### PR TITLE
fix: use provider-specific default voice when testing TTS in settings

### DIFF
--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -31,9 +31,7 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
 
   // Use the store voice only if it belongs to the selected provider; otherwise use the provider's default voice
   const effectiveVoice =
-    selectedProviderId === ttsProviderId
-      ? ttsVoice
-      : ttsProvider.voices[0]?.id || 'default';
+    selectedProviderId === ttsProviderId ? ttsVoice : ttsProvider.voices[0]?.id || 'default';
   const isServerConfigured = !!ttsProvidersConfig[selectedProviderId]?.isServerConfigured;
 
   const [showApiKey, setShowApiKey] = useState(false);
@@ -72,7 +70,9 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
         const utterance = new SpeechSynthesisUtterance(testText);
         utterance.rate = ttsSpeed;
         const voices = window.speechSynthesis.getVoices();
-        const selectedVoice = voices.find((v) => v.name === effectiveVoice || v.lang === effectiveVoice);
+        const selectedVoice = voices.find(
+          (v) => v.name === effectiveVoice || v.lang === effectiveVoice,
+        );
         if (selectedVoice) utterance.voice = selectedVoice;
         utterance.onend = () => {
           setTestStatus('success');


### PR DESCRIPTION
When testing a TTS provider different from the currently active one, the voice from the active provider was sent (e.g. OpenAI's 'alloy' sent to GLM API), causing error 1214. Now falls back to the selected provider's default voice.