### PR TITLE
fix(tts): use provider's default voice when testing non-active provider

### DIFF
--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useSettingsStore } from '@/lib/store/settings';
-import { TTS_PROVIDERS } from '@/lib/audio/constants';
+import { TTS_PROVIDERS, DEFAULT_TTS_VOICES } from '@/lib/audio/constants';
 import type { TTSProviderId } from '@/lib/audio/types';
 import { Volume2, Loader2, CheckCircle2, XCircle, Eye, EyeOff } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -25,6 +25,14 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
   const ttsSpeed = useSettingsStore((state) => state.ttsSpeed);
   const ttsProvidersConfig = useSettingsStore((state) => state.ttsProvidersConfig);
   const setTTSProviderConfig = useSettingsStore((state) => state.setTTSProviderConfig);
+  const activeProviderId = useSettingsStore((state) => state.ttsProviderId);
+
+  // When testing a non-active provider, use that provider's default voice
+  // instead of the active provider's voice (which may be incompatible)
+  const effectiveVoice =
+    selectedProviderId === activeProviderId
+      ? ttsVoice
+      : DEFAULT_TTS_VOICES[selectedProviderId] || 'default';
 
   const ttsProvider = TTS_PROVIDERS[selectedProviderId] ?? TTS_PROVIDERS['openai-tts'];
   const isServerConfigured = !!ttsProvidersConfig[selectedProviderId]?.isServerConfigured;
@@ -65,7 +73,9 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
         const utterance = new SpeechSynthesisUtterance(testText);
         utterance.rate = ttsSpeed;
         const voices = window.speechSynthesis.getVoices();
-        const selectedVoice = voices.find((v) => v.name === ttsVoice || v.lang === ttsVoice);
+        const selectedVoice = voices.find(
+          (v) => v.name === effectiveVoice || v.lang === effectiveVoice,
+        );
         if (selectedVoice) utterance.voice = selectedVoice;
         utterance.onend = () => {
           setTestStatus('success');
@@ -85,7 +95,7 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
         text: testText,
         audioId: 'tts-test',
         ttsProviderId: selectedProviderId,
-        ttsVoice: ttsVoice,
+        ttsVoice: effectiveVoice,
         ttsSpeed: ttsSpeed,
       };
       const apiKeyValue = ttsProvidersConfig[selectedProviderId]?.apiKey;

--- a/lib/audio/constants.ts
+++ b/lib/audio/constants.ts
@@ -825,6 +825,18 @@ export function getTTSProvider(providerId: TTSProviderId): TTSProviderConfig | u
 }
 
 /**
+ * Default voice for each TTS provider.
+ * Used when switching providers or testing a non-active provider.
+ */
+export const DEFAULT_TTS_VOICES: Record<TTSProviderId, string> = {
+  'openai-tts': 'alloy',
+  'azure-tts': 'zh-CN-XiaoxiaoNeural',
+  'glm-tts': 'tongtong',
+  'qwen-tts': 'Cherry',
+  'browser-native-tts': 'default',
+};
+
+/**
  * Get voices for a specific TTS provider
  */
 export function getTTSVoices(providerId: TTSProviderId): TTSVoiceInfo[] {

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -9,6 +9,7 @@ import type { ProviderId } from '@/lib/ai/providers';
 import type { ProvidersConfig } from '@/lib/types/settings';
 import { PROVIDERS } from '@/lib/ai/providers';
 import type { TTSProviderId, ASRProviderId } from '@/lib/audio/types';
+import { DEFAULT_TTS_VOICES } from '@/lib/audio/constants';
 import type { PDFProviderId } from '@/lib/pdf/types';
 import type { ImageProviderId, VideoProviderId } from '@/lib/media/types';
 import { IMAGE_PROVIDERS } from '@/lib/media/image-providers';
@@ -515,20 +516,11 @@ export const useSettingsStore = create<SettingsState>()(
         // Audio actions
         setTTSProvider: (providerId) =>
           set((state) => {
-            // Define default voices for each provider
-            const defaultVoices: Record<TTSProviderId, string> = {
-              'openai-tts': 'alloy',
-              'azure-tts': 'zh-CN-XiaoxiaoNeural', // Xiaoxiao - Chinese Mandarin female
-              'glm-tts': 'tongtong',
-              'qwen-tts': 'Cherry',
-              'browser-native-tts': 'default',
-            };
-
             // If switching provider, set default voice for that provider
             const shouldUpdateVoice = state.ttsProviderId !== providerId;
             return {
               ttsProviderId: providerId,
-              ...(shouldUpdateVoice && { ttsVoice: defaultVoices[providerId] }),
+              ...(shouldUpdateVoice && { ttsVoice: DEFAULT_TTS_VOICES[providerId] }),
             };
           }),
 
@@ -838,14 +830,7 @@ export const useSettingsStore = create<SettingsState>()(
                   !newTTSConfig[state.ttsProviderId]?.isServerConfigured
                 ) {
                   autoTtsProvider = serverTtsIds[0];
-                  const defaultVoices: Record<TTSProviderId, string> = {
-                    'openai-tts': 'alloy',
-                    'azure-tts': 'zh-CN-XiaoxiaoNeural',
-                    'glm-tts': 'tongtong',
-                    'qwen-tts': 'Cherry',
-                    'browser-native-tts': 'default',
-                  };
-                  autoTtsVoice = defaultVoices[autoTtsProvider] || 'default';
+                  autoTtsVoice = DEFAULT_TTS_VOICES[autoTtsProvider] || 'default';
                 }
 
                 // ASR: select first server provider if current is not server-configured


### PR DESCRIPTION
## Summary
- When testing a TTS provider different from the currently active one, the voice from the active provider was sent (e.g. OpenAI's `alloy` sent to GLM API), causing error 1214
- Now falls back to the selected provider's default voice when testing a non-active provider
- Extracted duplicated `defaultVoices` mappings into a shared `DEFAULT_TTS_VOICES` constant in `lib/audio/constants.ts`

Closes #6

## Test plan
- [x] Set active TTS provider to OpenAI, then test GLM provider — should use `tongtong` instead of `alloy`
- [x] Set active TTS provider to GLM, then test Qwen provider — should use `Cherry` instead of `tongtong`
- [x] Test the active provider — should still use the currently selected voice from the store
- [x] Verify provider switching in settings still auto-sets the correct default voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)