### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment Method
+      options:
+        - Local development (npm run dev / pnpm dev / yarn dev)
+        - Vercel deployment
+        - Docker
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Which browser are you using?
+      placeholder: e.g. Chrome 120, Firefox 121, Safari 17
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g. macOS 14.2, Windows 11, Ubuntu 22.04
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Screenshots
+      description: Paste any error messages, console logs, or screenshots.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/PtZaaTbH
+    about: Ask questions and discuss with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area of the project does this relate to?
+      options:
+        - Classroom generation
+        - Multi-agent interaction
+        - Slides / Whiteboard
+        - Quiz / Assessment
+        - TTS / Voice
+        - Interactive simulations
+        - OpenClaw integration
+        - UI / UX
+        - API / Backend
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any mockups, screenshots, or references that help explain the feature.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+## Summary
+
+<!-- Briefly describe the changes in this PR. -->
+
+## Related Issues
+
+<!-- Link related issues: "Closes #123", "Fixes #456", "Related to #789" -->
+
+## Changes
+
+<!-- List the key changes: -->
+-
+
+## Type of Change
+
+<!-- Check the relevant options: -->
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD or build changes
+
+## Verification
+
+### Steps to reproduce / test
+
+1.
+2.
+3.
+
+### What you personally verified
+
+<!-- What did you test beyond CI? Include edge cases checked and anything you did NOT verify. -->
+
+-
+
+### Evidence
+
+<!-- Attach at least one: logs, screenshots, recordings, or before/after comparisons. -->
+
+- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
+- [ ] Manually tested locally
+- [ ] Screenshots / recordings attached (if UI changes)
+
+## Checklist
+
+- [ ] My code follows the project's coding style
+- [ ] I have performed a self-review of my code
+- [ ] I have added/updated documentation as needed
+- [ ] My changes do not introduce new warnings


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates (bug report & feature request) using YAML forms
- Add PR template with verification checklist and evidence requirements
- Configure issue template chooser with Discord community link

## Test plan

- [x] Verify issue templates render correctly on GitHub (New Issue page)
- [x] Verify PR template auto-fills when creating a new PR
- [x] Confirm Discord link in issue template config works

🤖 Generated with [Claude Code](https://claude.com/claude-code)