### PR TITLE
Fix SSRF/credential forwarding via client-supplied baseUrl

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -73,8 +73,12 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const effectiveApiKey = clientBaseUrl ? body.apiKey || '' : resolveApiKey(providerId, body.apiKey);
-    const effectiveBaseUrl = clientBaseUrl ? clientBaseUrl : resolveBaseUrl(providerId, body.baseUrl);
+    const effectiveApiKey = clientBaseUrl
+      ? body.apiKey || ''
+      : resolveApiKey(providerId, body.apiKey);
+    const effectiveBaseUrl = clientBaseUrl
+      ? clientBaseUrl
+      : resolveBaseUrl(providerId, body.baseUrl);
     const proxy = resolveProxy(providerId);
 
     if (!effectiveApiKey) {

--- a/app/api/generate/image/route.ts
+++ b/app/api/generate/image/route.ts
@@ -47,7 +47,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const apiKey = clientBaseUrl ? clientApiKey || '' : resolveImageApiKey(providerId, clientApiKey);
+    const apiKey = clientBaseUrl
+      ? clientApiKey || ''
+      : resolveImageApiKey(providerId, clientApiKey);
     if (!apiKey) {
       return apiError(
         'MISSING_API_KEY',

--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -54,8 +54,12 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const apiKey = clientBaseUrl ? ttsApiKey || '' : resolveTTSApiKey(ttsProviderId, ttsApiKey || undefined);
-    const baseUrl = clientBaseUrl ? clientBaseUrl : resolveTTSBaseUrl(ttsProviderId, ttsBaseUrl || undefined);
+    const apiKey = clientBaseUrl
+      ? ttsApiKey || ''
+      : resolveTTSApiKey(ttsProviderId, ttsApiKey || undefined);
+    const baseUrl = clientBaseUrl
+      ? clientBaseUrl
+      : resolveTTSBaseUrl(ttsProviderId, ttsBaseUrl || undefined);
 
     // Build TTS config
     const config = {

--- a/app/api/generate/video/route.ts
+++ b/app/api/generate/video/route.ts
@@ -48,7 +48,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const apiKey = clientBaseUrl ? clientApiKey || '' : resolveVideoApiKey(providerId, clientApiKey);
+    const apiKey = clientBaseUrl
+      ? clientApiKey || ''
+      : resolveVideoApiKey(providerId, clientApiKey);
     if (!apiKey) {
       return apiError(
         'MISSING_API_KEY',

--- a/app/api/parse-pdf/route.ts
+++ b/app/api/parse-pdf/route.ts
@@ -43,8 +43,12 @@ export async function POST(req: NextRequest) {
 
     const config = {
       providerId: effectiveProviderId,
-      apiKey: clientBaseUrl ? apiKey || '' : resolvePDFApiKey(effectiveProviderId, apiKey || undefined),
-      baseUrl: clientBaseUrl ? clientBaseUrl : resolvePDFBaseUrl(effectiveProviderId, baseUrl || undefined),
+      apiKey: clientBaseUrl
+        ? apiKey || ''
+        : resolvePDFApiKey(effectiveProviderId, apiKey || undefined),
+      baseUrl: clientBaseUrl
+        ? clientBaseUrl
+        : resolvePDFBaseUrl(effectiveProviderId, baseUrl || undefined),
     };
 
     // Convert PDF to buffer

--- a/app/api/transcription/route.ts
+++ b/app/api/transcription/route.ts
@@ -36,8 +36,12 @@ export async function POST(req: NextRequest) {
     const config = {
       providerId: effectiveProviderId,
       language: language || 'auto',
-      apiKey: clientBaseUrl ? apiKey || '' : resolveASRApiKey(effectiveProviderId, apiKey || undefined),
-      baseUrl: clientBaseUrl ? clientBaseUrl : resolveASRBaseUrl(effectiveProviderId, baseUrl || undefined),
+      apiKey: clientBaseUrl
+        ? apiKey || ''
+        : resolveASRApiKey(effectiveProviderId, apiKey || undefined),
+      baseUrl: clientBaseUrl
+        ? clientBaseUrl
+        : resolveASRBaseUrl(effectiveProviderId, baseUrl || undefined),
     };
 
     // Convert audio file to buffer

--- a/app/api/verify-image-provider/route.ts
+++ b/app/api/verify-image-provider/route.ts
@@ -38,7 +38,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const apiKey = clientBaseUrl ? clientApiKey || '' : resolveImageApiKey(providerId, clientApiKey);
+    const apiKey = clientBaseUrl
+      ? clientApiKey || ''
+      : resolveImageApiKey(providerId, clientApiKey);
     const baseUrl = clientBaseUrl ? clientBaseUrl : resolveImageBaseUrl(providerId, clientBaseUrl);
 
     if (!apiKey) {

--- a/app/api/verify-pdf-provider/route.ts
+++ b/app/api/verify-pdf-provider/route.ts
@@ -27,7 +27,9 @@ export async function POST(req: NextRequest) {
       return apiError('MISSING_REQUIRED_FIELD', 400, 'Base URL is required');
     }
 
-    const resolvedApiKey = clientBaseUrl ? (apiKey as string | undefined) || '' : resolvePDFApiKey(providerId, apiKey);
+    const resolvedApiKey = clientBaseUrl
+      ? (apiKey as string | undefined) || ''
+      : resolvePDFApiKey(providerId, apiKey);
 
     const headers: Record<string, string> = {};
     if (resolvedApiKey) {

--- a/app/api/verify-video-provider/route.ts
+++ b/app/api/verify-video-provider/route.ts
@@ -38,7 +38,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const apiKey = clientBaseUrl ? clientApiKey || '' : resolveVideoApiKey(providerId, clientApiKey);
+    const apiKey = clientBaseUrl
+      ? clientApiKey || ''
+      : resolveVideoApiKey(providerId, clientApiKey);
     const baseUrl = clientBaseUrl ? clientBaseUrl : resolveVideoBaseUrl(providerId, clientBaseUrl);
 
     if (!apiKey) {

--- a/lib/server/resolve-model.ts
+++ b/lib/server/resolve-model.ts
@@ -38,7 +38,9 @@ export function resolveModel(params: {
     }
   }
 
-  const apiKey = clientBaseUrl ? params.apiKey || '' : resolveApiKey(providerId, params.apiKey || '');
+  const apiKey = clientBaseUrl
+    ? params.apiKey || ''
+    : resolveApiKey(providerId, params.apiKey || '');
   const baseUrl = clientBaseUrl ? clientBaseUrl : resolveBaseUrl(providerId, params.baseUrl);
   const proxy = resolveProxy(providerId);
   const { model, modelInfo } = getModel({


### PR DESCRIPTION
问题：当前实现允许客户端传入 baseUrl，同时在未提供 apiKey 时会回退使用服务器环境变量 key，导致服务器可能携带自己的 key 请求攻击者控制的地址（凭据泄露/SSRF）。

修复：禁止 ‘server key + client baseUrl’ 组合：只要自定义 baseUrl，就必须显式提供客户端 key；生产环境增加 SSRF 校验，并对连通性检查禁用重定向。

EN：Description:
Currently, the system allows clients to provide a custom baseUrl. If no apiKey is provided, it falls back to the server's environment variable, which could lead to API key leakage to attacker-controlled endpoints (Credential Leakage/SSRF).
 Fixes: 1. Prohibit the combination of 'server-side key + client-provided baseUrl'. 2. Integrated SSRF validation in production environments. 3. Disabled redirects in connectivity checks to further mitigate SSRF risks.