### PR TITLE
fix: remove invalid bodyParser config in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,10 +5,7 @@
   "buildCommand": "pnpm build",
   "functions": {
     "app/api/**/*.ts": {
-      "maxDuration": 300,
-      "bodyParser": {
-        "sizeLimit": "50mb"
-      }
+      "maxDuration": 300
     }
   }
 }


### PR DESCRIPTION
bodyParser is not a valid property inside the functions block of vercel.json, causing deployment to fail. Removed it as this config is not supported by Vercel.