### PR TITLE
fix: isolate settings API key autofill fields

### DIFF
--- a/components/settings/asr-settings.tsx
+++ b/components/settings/asr-settings.tsx
@@ -161,7 +161,12 @@ export function ASRSettings({ selectedProviderId }: ASRSettingsProps) {
               <Label className="text-sm">{t('settings.asrApiKey')}</Label>
               <div className="relative">
                 <Input
+                  name={`asr-api-key-${selectedProviderId}`}
                   type={showApiKey ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   placeholder={
                     isServerConfigured ? t('settings.optionalOverride') : t('settings.enterApiKey')
                   }
@@ -185,6 +190,11 @@ export function ASRSettings({ selectedProviderId }: ASRSettingsProps) {
             <div className="space-y-2">
               <Label className="text-sm">{t('settings.asrBaseUrl')}</Label>
               <Input
+                name={`asr-base-url-${selectedProviderId}`}
+                autoComplete="off"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
                 placeholder={asrProvider.defaultBaseUrl || t('settings.enterCustomBaseUrl')}
                 value={asrProvidersConfig[selectedProviderId]?.baseUrl || ''}
                 onChange={(e) =>

--- a/components/settings/image-settings.tsx
+++ b/components/settings/image-settings.tsx
@@ -154,7 +154,12 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
         <div className="flex gap-2">
           <div className="relative flex-1">
             <Input
+              name={`image-api-key-${selectedProviderId}`}
               type={showApiKey ? 'text' : 'password'}
+              autoComplete="new-password"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
               placeholder={
                 isServerConfigured ? t('settings.optionalOverride') : t('settings.enterApiKey')
               }
@@ -210,7 +215,12 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
       <div className="space-y-2">
         <Label>Base URL</Label>
         <Input
+          name={`image-base-url-${selectedProviderId}`}
           type="url"
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           value={currentConfig?.baseUrl || ''}
           onChange={(e) => handleBaseUrlChange(e.target.value)}
           placeholder={

--- a/components/settings/pdf-settings.tsx
+++ b/components/settings/pdf-settings.tsx
@@ -106,6 +106,11 @@ export function PDFSettings({ selectedProviderId }: PDFSettingsProps) {
               <Label className="text-sm">{t('settings.pdfBaseUrl')}</Label>
               <div className="flex gap-2">
                 <Input
+                  name={`pdf-base-url-${selectedProviderId}`}
+                  autoComplete="off"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   placeholder="http://localhost:8080"
                   value={providerConfig?.baseUrl || ''}
                   onChange={(e) =>
@@ -141,7 +146,12 @@ export function PDFSettings({ selectedProviderId }: PDFSettingsProps) {
               </Label>
               <div className="relative">
                 <Input
+                  name={`pdf-api-key-${selectedProviderId}`}
                   type={showApiKey ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   placeholder={
                     isServerConfigured ? t('settings.optionalOverride') : t('settings.enterApiKey')
                   }

--- a/components/settings/provider-config-panel.tsx
+++ b/components/settings/provider-config-panel.tsx
@@ -167,7 +167,12 @@ export function ProviderConfigPanel({
         <div className="flex gap-2">
           <div className="relative flex-1">
             <Input
+              name={`llm-api-key-${provider.id}`}
               type={showApiKey ? 'text' : 'password'}
+              autoComplete="new-password"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
               placeholder={isServerConfigured ? t('settings.optionalOverride') : 'sk-...'}
               value={apiKey}
               onChange={(e) => handleApiKeyChange(e.target.value)}
@@ -240,7 +245,12 @@ export function ProviderConfigPanel({
       <div className="space-y-2">
         <Label>{t('settings.apiHost')}</Label>
         <Input
+          name={`llm-base-url-${provider.id}`}
           type="url"
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           placeholder={provider.defaultBaseUrl || 'https://api.example.com/v1'}
           value={baseUrl}
           onChange={(e) => handleBaseUrlChange(e.target.value)}

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -155,7 +155,12 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
               <Label className="text-sm">{t('settings.ttsApiKey')}</Label>
               <div className="relative">
                 <Input
+                  name={`tts-api-key-${selectedProviderId}`}
                   type={showApiKey ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   placeholder={
                     isServerConfigured ? t('settings.optionalOverride') : t('settings.enterApiKey')
                   }
@@ -179,6 +184,11 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
             <div className="space-y-2">
               <Label className="text-sm">{t('settings.ttsBaseUrl')}</Label>
               <Input
+                name={`tts-base-url-${selectedProviderId}`}
+                autoComplete="off"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
                 placeholder={ttsProvider.defaultBaseUrl || t('settings.enterCustomBaseUrl')}
                 value={ttsProvidersConfig[selectedProviderId]?.baseUrl || ''}
                 onChange={(e) =>

--- a/components/settings/video-settings.tsx
+++ b/components/settings/video-settings.tsx
@@ -153,7 +153,12 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
         <div className="flex gap-2">
           <div className="relative flex-1">
             <Input
+              name={`video-api-key-${selectedProviderId}`}
               type={showApiKey ? 'text' : 'password'}
+              autoComplete="new-password"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
               placeholder={
                 isServerConfigured
                   ? t('settings.optionalOverride')
@@ -213,7 +218,12 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
       <div className="space-y-2">
         <Label>Base URL</Label>
         <Input
+          name={`video-base-url-${selectedProviderId}`}
           type="url"
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           value={currentConfig?.baseUrl || ''}
           onChange={(e) => handleBaseUrlChange(e.target.value)}
           placeholder={

--- a/components/settings/web-search-settings.tsx
+++ b/components/settings/web-search-settings.tsx
@@ -47,7 +47,12 @@ export function WebSearchSettings({ selectedProviderId }: WebSearchSettingsProps
               <Label className="text-sm">{t('settings.webSearchApiKey')}</Label>
               <div className="relative">
                 <Input
+                  name={`web-search-api-key-${selectedProviderId}`}
                   type={showApiKey ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   placeholder={
                     isServerConfigured ? t('settings.optionalOverride') : t('settings.enterApiKey')
                   }
@@ -73,6 +78,11 @@ export function WebSearchSettings({ selectedProviderId }: WebSearchSettingsProps
             <div className="space-y-2">
               <Label className="text-sm">{t('settings.webSearchBaseUrl')}</Label>
               <Input
+                name={`web-search-base-url-${selectedProviderId}`}
+                autoComplete="off"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
                 placeholder={provider.defaultBaseUrl || 'https://api.tavily.com'}
                 value={webSearchProvidersConfig[selectedProviderId]?.baseUrl || ''}
                 onChange={(e) =>


### PR DESCRIPTION
## Summary

<!-- Briefly describe the changes in this PR. -->
防止部分浏览器自动填充导致API Key互相覆盖

## Related Issues

<!-- Link related issues: "Closes #123", "Fixes #456", "Related to #789" -->
"Fixes #46 "

## Changes

<!-- List the key changes: -->
- components/settings/*-settings.tsx

## Type of Change

<!-- Check the relevant options: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1.打开设置
2.填写网络搜索API Key
3.点击保存，无法正常保存，会被语言模型的key覆盖

### What you personally verified

<!-- What did you test beyond CI? Include edge cases checked and anything you did NOT verify. -->

- 

### Evidence

<!-- Attach at least one: logs, screenshots, recordings, or before/after comparisons. -->

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
