### PR TITLE
feat: support HTTP_PROXY/HTTPS_PROXY env vars for all outbound requests

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,21 @@
+/**
+ * Next.js server instrumentation — runs once at server startup (Node.js runtime only).
+ * Sets a global undici ProxyAgent so ALL fetch() calls automatically use the proxy
+ * when HTTP_PROXY / HTTPS_PROXY environment variables are set.
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  if (!proxyUrl) return;
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ProxyAgent, setGlobalDispatcher } = require('undici');
+  setGlobalDispatcher(new ProxyAgent(proxyUrl));
+  console.log(`[Proxy] Global fetch proxy set: ${proxyUrl}`);
+}

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1009,11 +1009,20 @@ export function getModel(config: ModelConfig): ModelWithInfo {
         apiKey: effectiveApiKey,
         baseURL: effectiveBaseUrl,
       };
-      if (config.proxy) {
+      // Support per-provider proxy (config.proxy) or fall back to standard env vars.
+      // instrumentation.ts sets a global undici dispatcher for env-var proxy, so this
+      // explicit override is only needed when config.proxy differs from the global setting.
+      const proxyUrl =
+        config.proxy ||
+        process.env.HTTPS_PROXY ||
+        process.env.https_proxy ||
+        process.env.HTTP_PROXY ||
+        process.env.http_proxy;
+      if (proxyUrl) {
         // Dynamic require to avoid bundling undici on the client side
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { ProxyAgent, fetch: undiciFetch } = require('undici');
-        const agent = new ProxyAgent(config.proxy);
+        const agent = new ProxyAgent(proxyUrl);
         googleOptions.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
           undiciFetch(input as string, {
             ...(init as Record<string, unknown>),


### PR DESCRIPTION
## Problem

Node.js built-in `fetch` does **not** respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables. Users in regions where foreign AI APIs (Google, OpenAI, Anthropic) are blocked cannot use these providers even when a system-level proxy is configured.

The project already has `lib/server/proxy-fetch.ts` and a per-provider `proxy` field in `server-providers.yml`, but:
- `proxy-fetch.ts` is never called by any adapter (dead code)
- Only the Google LLM provider reads `config.proxy` from YAML — requiring manual YAML configuration
- All media adapters (Nano Banana, Veo, Kling, Seedance) and TTS providers use bare `fetch()` with no proxy support at all

## Solution

**Two minimal changes, zero impact for users who don't need a proxy.**

### 1. `instrumentation.ts` (new file)

Uses Next.js's server instrumentation hook to call `undici.setGlobalDispatcher()` at server startup. This makes **every** `fetch()` call on the server automatically route through the proxy — LLM, TTS, image generation, video generation, web search — with no per-adapter changes needed.

```
HTTP_PROXY=http://127.0.0.1:7897   # or HTTPS_PROXY
```

If neither env var is set, the function returns immediately — **zero behavior change** for users who don't need a proxy (domestic API users, overseas users, etc.).

### 2. `lib/ai/providers.ts` — Google LLM env var fallback

The existing `config.proxy` (from `server-providers.yml`) now also falls back to `HTTP_PROXY`/`HTTPS_PROXY` env vars, so users don't need to duplicate their proxy URL in YAML.

## Behavior Matrix

| Scenario | HTTP_PROXY set? | Result |
|----------|----------------|--------|
| Domestic user + domestic model (Qwen, DeepSeek, GLM) | No | Direct fetch, no change |
| Domestic user + foreign model (Google, OpenAI) | Yes (local proxy) | All fetch routed through proxy ✅ |
| Overseas user + foreign model | No | Direct fetch, no change |
| Mixed (domestic + foreign models) | Yes + rule-based proxy (e.g. Clash) | Proxy handles routing, domestic IPs bypass automatically |

## Files Changed

- `instrumentation.ts` — new, 20 lines
- `lib/ai/providers.ts` — 10 line change (env var fallback for Google proxy)