### PR TITLE
fix: improve browser TTS preview and dedupe provider options

### DIFF
--- a/components/audio/tts-config-popover.tsx
+++ b/components/audio/tts-config-popover.tsx
@@ -14,6 +14,7 @@ import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/hooks/use-i18n';
+import { useBrowserTTS } from '@/lib/hooks/use-browser-tts';
 import { useSettingsStore } from '@/lib/store/settings';
 import { getTTSVoices } from '@/lib/audio/constants';
 
@@ -40,6 +41,12 @@ export function TtsConfigPopover() {
   const setTTSVoice = useSettingsStore((s) => s.setTTSVoice);
 
   const voices = getTTSVoices(ttsProviderId);
+  const { speak: speakBrowserTTS, cancel: cancelBrowserTTS } = useBrowserTTS({
+    rate: 1.0,
+    lang: locale || (typeof navigator !== 'undefined' ? navigator.language : 'zh-CN'),
+    onEnd: () => setPreviewing(false),
+    onError: () => setPreviewing(false),
+  });
   const localizedVoices = useMemo(
     () =>
       voices.map((v) => ({
@@ -56,12 +63,18 @@ export function TtsConfigPopover() {
     if (previewing) {
       audioRef.current?.pause();
       audioRef.current = null;
+      cancelBrowserTTS();
       setPreviewing(false);
       return;
     }
 
     setPreviewing(true);
     try {
+      if (ttsProviderId === 'browser-native-tts') {
+        speakBrowserTTS('你好，欢迎来到AI课堂！让我们一起学习吧。', ttsVoice);
+        return;
+      }
+
       const providerConfig = ttsProvidersConfig[ttsProviderId];
       const res = await fetch('/api/generate/tts', {
         method: 'POST',
@@ -95,7 +108,7 @@ export function TtsConfigPopover() {
     } catch {
       setPreviewing(false);
     }
-  }, [ttsProviderId, ttsVoice, ttsProvidersConfig, previewing]);
+  }, [cancelBrowserTTS, previewing, speakBrowserTTS, ttsProviderId, ttsProvidersConfig, ttsVoice]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/components/generation/media-popover.tsx
+++ b/components/generation/media-popover.tsx
@@ -27,6 +27,7 @@ import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/hooks/use-i18n';
+import { useBrowserTTS } from '@/lib/hooks/use-browser-tts';
 import { useSettingsStore } from '@/lib/store/settings';
 import { IMAGE_PROVIDERS } from '@/lib/media/image-providers';
 import { VIDEO_PROVIDERS } from '@/lib/media/video-providers';
@@ -134,6 +135,12 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
   ) => !needsKey || !!configs[id]?.apiKey || !!configs[id]?.isServerConfigured;
 
   const ttsSpeedRange = TTS_PROVIDERS[ttsProviderId]?.speedRange;
+  const { speak: speakBrowserTTS, cancel: cancelBrowserTTS } = useBrowserTTS({
+    rate: ttsSpeed,
+    lang: locale || (typeof navigator !== 'undefined' ? navigator.language : 'zh-CN'),
+    onEnd: () => setPreviewing(false),
+    onError: () => setPreviewing(false),
+  });
 
   // ─── Grouped select data (only available providers) ───
   const imageGroups = useMemo(
@@ -145,10 +152,14 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
           groupName: p.name,
           groupIcon: IMAGE_PROVIDER_ICONS[p.id],
           available: true,
-          items: [...p.models, ...(imageProvidersConfig[p.id]?.customModels || [])].map((m) => ({
-            id: m.id,
-            name: m.name,
-          })),
+          items: Array.from(
+            new Map(
+              [...p.models, ...(imageProvidersConfig[p.id]?.customModels || [])].map((m) => [
+                m.id,
+                { id: m.id, name: m.name },
+              ]),
+            ).values(),
+          ),
         })),
     [imageProvidersConfig],
   );
@@ -162,10 +173,14 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
           groupName: p.name,
           groupIcon: VIDEO_PROVIDER_ICONS[p.id],
           available: true,
-          items: [...p.models, ...(videoProvidersConfig[p.id]?.customModels || [])].map((m) => ({
-            id: m.id,
-            name: m.name,
-          })),
+          items: Array.from(
+            new Map(
+              [...p.models, ...(videoProvidersConfig[p.id]?.customModels || [])].map((m) => [
+                m.id,
+                { id: m.id, name: m.name },
+              ]),
+            ).values(),
+          ),
         })),
     [videoProvidersConfig],
   );
@@ -185,11 +200,17 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
     if (previewing) {
       audioRef.current?.pause();
       audioRef.current = null;
+      cancelBrowserTTS();
       setPreviewing(false);
       return;
     }
     setPreviewing(true);
     try {
+      if (ttsProviderId === 'browser-native-tts') {
+        speakBrowserTTS('你好，欢迎来到AI课堂！让我们一起学习吧。', ttsVoice);
+        return;
+      }
+
       const providerConfig = ttsProvidersConfig[ttsProviderId];
       const res = await fetch('/api/generate/tts', {
         method: 'POST',
@@ -221,7 +242,7 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
     } catch {
       setPreviewing(false);
     }
-  }, [ttsProviderId, ttsVoice, ttsProvidersConfig, previewing]);
+  }, [cancelBrowserTTS, previewing, speakBrowserTTS, ttsProviderId, ttsProvidersConfig, ttsVoice]);
 
   // ASR: only available providers
   const asrGroups = useMemo(

--- a/components/settings/audio-settings.tsx
+++ b/components/settings/audio-settings.tsx
@@ -64,7 +64,7 @@ interface AudioSettingsProps {
 }
 
 export function AudioSettings({ onSave }: AudioSettingsProps = {}) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
 
   // TTS state
   const ttsProviderId = useSettingsStore((state) => state.ttsProviderId);
@@ -270,14 +270,18 @@ export function AudioSettings({ onSave }: AudioSettingsProps = {}) {
           return;
         }
 
+        window.speechSynthesis.cancel();
+
         const utterance = new SpeechSynthesisUtterance(testText);
         utterance.rate = ttsSpeed;
+        utterance.lang = locale || navigator.language || 'zh-CN';
 
         // Try to find matching voice
         const voices = window.speechSynthesis.getVoices();
         const selectedVoice = voices.find((v) => v.name === ttsVoice || v.lang === ttsVoice);
         if (selectedVoice) {
           utterance.voice = selectedVoice;
+          utterance.lang = selectedVoice.lang || utterance.lang;
         }
 
         utterance.onend = () => {

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -19,7 +19,7 @@ interface TTSSettingsProps {
 }
 
 export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
 
   const ttsVoice = useSettingsStore((state) => state.ttsVoice);
   const ttsSpeed = useSettingsStore((state) => state.ttsSpeed);
@@ -70,13 +70,19 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
           return;
         }
 
+        window.speechSynthesis.cancel();
+
         const utterance = new SpeechSynthesisUtterance(testText);
         utterance.rate = ttsSpeed;
+        utterance.lang = locale || navigator.language || 'zh-CN';
         const voices = window.speechSynthesis.getVoices();
         const selectedVoice = voices.find(
           (v) => v.name === effectiveVoice || v.lang === effectiveVoice,
         );
-        if (selectedVoice) utterance.voice = selectedVoice;
+        if (selectedVoice) {
+          utterance.voice = selectedVoice;
+          utterance.lang = selectedVoice.lang || utterance.lang;
+        }
 
         await new Promise<void>((resolve, reject) => {
           utterance.onend = () => resolve();


### PR DESCRIPTION
## Summary

This PR improves the browser-native TTS preview experience in settings/popovers and removes duplicate media model options that were causing duplicate React key warnings.

## Related Issues

Related to browser-native TTS preview behavior and duplicate provider/model option rendering.

## Changes

- cancel any existing browser speech before starting a new preview
- set a `zh-CN` fallback language for browser speech synthesis previews
- support browser-native preview in the TTS config popover and media popover
- dedupe built-in and custom image/video model options in the media popover

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open audio/TTS settings or the media popover
2. Select `browser-native-tts` and test preview playback
3. Verify repeated preview actions do not overlap and media model options do not render duplicate entries

### What you personally verified

- verified browser-native TTS preview works in settings and popovers
- verified previews cancel the previous utterance before replaying
- verified duplicate model entries no longer trigger React key warnings
- ran project checks locally

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings