### PR TITLE
Add quiz assessment context MVP

### DIFF
--- a/app/api/quiz-grade/route.ts
+++ b/app/api/quiz-grade/route.ts
@@ -6,9 +6,9 @@
  */
 
 import { NextRequest } from 'next/server';
-import { callLLM } from '@/lib/ai/llm';
 import { createLogger } from '@/lib/logger';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
+import { gradeShortAnswerQuestion } from '@/lib/server/quiz-assessment';
 import { resolveModelFromHeaders } from '@/lib/server/resolve-model';
 const log = createLogger('Quiz Grade');
 
@@ -18,11 +18,6 @@ interface GradeRequest {
   points: number;
   commentPrompt?: string;
   language?: string;
-}
-
-interface GradeResponse {
-  score: number;
-  comment: string;
 }
 
 export async function POST(req: NextRequest) {
@@ -37,57 +32,23 @@ export async function POST(req: NextRequest) {
     // Resolve model from request headers
     const { model: languageModel } = resolveModelFromHeaders(req);
 
-    const isZh = language === 'zh-CN';
-
-    const systemPrompt = isZh
-      ? `你是一位专业的教育评估专家。请根据题目和学生答案进行评分并给出简短评语。
-必须以如下 JSON 格式回复（不要包含其他内容）：
-{"score": <0到${points}的整数>, "comment": "<一两句评语>"}`
-      : `You are a professional educational assessor. Grade the student's answer and provide brief feedback.
-You must reply in the following JSON format only (no other content):
-{"score": <integer from 0 to ${points}>, "comment": "<one or two sentences of feedback>"}`;
-
-    const userPrompt = isZh
-      ? `题目：${question}
-满分：${points}分
-${commentPrompt ? `评分要点：${commentPrompt}\n` : ''}学生答案：${userAnswer}`
-      : `Question: ${question}
-Full marks: ${points} points
-${commentPrompt ? `Grading guidance: ${commentPrompt}\n` : ''}Student answer: ${userAnswer}`;
-
-    const result = await callLLM(
-      {
-        model: languageModel,
-        system: systemPrompt,
-        prompt: userPrompt,
+    const result = await gradeShortAnswerQuestion({
+      question: {
+        id: 'short-answer',
+        type: 'short_answer',
+        question,
+        points,
+        commentPrompt,
       },
-      'quiz-grade',
-    );
+      userAnswer,
+      language: language || 'en-US',
+      languageModel,
+    });
 
-    // Parse the LLM response as JSON
-    const text = result.text.trim();
-    let gradeResult: GradeResponse;
-
-    try {
-      // Try to extract JSON from the response
-      const jsonMatch = text.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) throw new Error('No JSON found');
-      const parsed = JSON.parse(jsonMatch[0]);
-      gradeResult = {
-        score: Math.max(0, Math.min(points, Math.round(Number(parsed.score)))),
-        comment: String(parsed.comment || ''),
-      };
-    } catch {
-      // Fallback: give partial credit with a generic comment
-      gradeResult = {
-        score: Math.round(points * 0.5),
-        comment: isZh
-          ? '已作答，请参考标准答案。'
-          : 'Answer received. Please refer to the standard answer.',
-      };
-    }
-
-    return apiSuccess({ ...gradeResult });
+    return apiSuccess({
+      score: result.earned,
+      comment: result.aiComment || '',
+    });
   } catch (error) {
     log.error('Error:', error);
     return apiError('INTERNAL_ERROR', 500, 'Failed to grade answer');

--- a/app/api/quiz-submit/route.ts
+++ b/app/api/quiz-submit/route.ts
@@ -1,0 +1,65 @@
+import { nanoid } from 'nanoid';
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/server/api-response';
+import { buildQuizAttemptFromSubmission } from '@/lib/server/quiz-assessment';
+import { isShortAnswer } from '@/lib/quiz/assessment';
+import { resolveModelFromHeaders } from '@/lib/server/resolve-model';
+import type { QuizAnswerMap } from '@/lib/types/assessment';
+import type { QuizQuestion } from '@/lib/types/stage';
+
+interface QuizSubmitRequest {
+  stageId: string;
+  sceneId: string;
+  questions: QuizQuestion[];
+  answers: QuizAnswerMap;
+  language?: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as QuizSubmitRequest;
+    const { stageId, sceneId, questions, answers, language } = body;
+
+    if (!stageId || !sceneId) {
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'stageId and sceneId are required');
+    }
+    if (!questions || questions.length === 0) {
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'questions are required');
+    }
+    if (!answers || Object.keys(answers).length === 0) {
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'answers are required');
+    }
+
+    const requiresShortAnswerModel = questions.some(isShortAnswer);
+    let languageModel: ReturnType<typeof resolveModelFromHeaders>['model'] | undefined;
+    if (requiresShortAnswerModel) {
+      try {
+        languageModel = resolveModelFromHeaders(req).model;
+      } catch {
+        languageModel = undefined;
+      }
+    }
+    const submittedAt = Date.now();
+    const attempt = await buildQuizAttemptFromSubmission({
+      attemptId: nanoid(),
+      stageId,
+      sceneId,
+      questions,
+      answers,
+      language: language || 'en-US',
+      languageModel,
+      submittedAt,
+    });
+
+    return apiSuccess({
+      attempt,
+      assessmentContext: attempt.assessmentContext,
+    });
+  } catch (error) {
+    return apiError(
+      'INTERNAL_ERROR',
+      500,
+      error instanceof Error ? error.message : 'Failed to submit quiz',
+    );
+  }
+}

--- a/components/chat/use-chat-sessions.ts
+++ b/components/chat/use-chat-sessions.ts
@@ -395,6 +395,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
           currentSceneId: freshState.currentSceneId,
           mode: freshState.mode,
           whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+          assessmentContext: freshState.latestAssessmentContext,
         };
 
         const response = await fetch('/api/chat', {
@@ -759,6 +760,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              assessmentContext: currentState.latestAssessmentContext,
             },
             config: {
               agentIds,
@@ -994,6 +996,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              assessmentContext: currentState.latestAssessmentContext,
             },
             config: {
               agentIds,
@@ -1147,6 +1150,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              assessmentContext: currentState.latestAssessmentContext,
             },
             config: {
               agentIds,

--- a/components/scene-renderers/quiz-view.tsx
+++ b/components/scene-renderers/quiz-view.tsx
@@ -17,6 +17,13 @@ import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { getCurrentModelConfig } from '@/lib/utils/model-config';
 import { createLogger } from '@/lib/logger';
+import { useStageStore } from '@/lib/store';
+import {
+  deleteQuizAttemptsForScene,
+  getLatestQuizAttemptForScene,
+  saveQuizAttempt,
+} from '@/lib/utils/assessment-storage';
+import type { QuizAnswerMap, QuizQuestionResult } from '@/lib/types/assessment';
 
 const log = createLogger('QuizView');
 import type { QuizQuestion } from '@/lib/types/stage';
@@ -27,112 +34,11 @@ import { SpeechButton } from '@/components/audio/speech-button';
 
 type Phase = 'not_started' | 'answering' | 'grading' | 'reviewing';
 
-interface QuestionResult {
-  questionId: string;
-  correct: boolean | null;
-  status: 'correct' | 'incorrect';
-  earned: number;
-  aiComment?: string;
-}
+type QuestionResult = QuizQuestionResult;
 
 interface QuizViewProps {
   readonly questions: QuizQuestion[];
   readonly sceneId: string;
-}
-
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-function arraysEqual(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  const sa = [...a].sort();
-  const sb = [...b].sort();
-  return sa.every((v, i) => v === sb[i]);
-}
-
-function toArray(v: string | string[] | undefined): string[] {
-  if (!v) return [];
-  return Array.isArray(v) ? v : [v];
-}
-
-function isShortAnswer(q: QuizQuestion): boolean {
-  return q.type === 'short_answer' || (!q.hasAnswer && (!q.answer || q.answer.length === 0));
-}
-
-/** Grade choice questions locally. Returns results only for non-short-answer questions. */
-function gradeChoiceQuestions(
-  questions: QuizQuestion[],
-  answers: Record<string, string | string[]>,
-): QuestionResult[] {
-  return questions
-    .filter((q) => !isShortAnswer(q))
-    .map((q) => {
-      const pts = q.points ?? 1;
-      const userAnswer = toArray(answers[q.id]);
-      const correctAnswer = toArray(q.answer);
-      const correct = arraysEqual(userAnswer, correctAnswer);
-      return {
-        questionId: q.id,
-        correct,
-        status: correct ? ('correct' as const) : ('incorrect' as const),
-        earned: correct ? pts : 0,
-      };
-    });
-}
-
-/** Call /api/quiz-grade for a single short-answer question. */
-async function gradeShortAnswerQuestion(
-  q: QuizQuestion,
-  userAnswer: string,
-  language: string,
-): Promise<QuestionResult> {
-  const pts = q.points ?? 1;
-  try {
-    const modelConfig = getCurrentModelConfig();
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      'x-model': modelConfig.modelString,
-      'x-api-key': modelConfig.apiKey,
-    };
-    if (modelConfig.baseUrl) headers['x-base-url'] = modelConfig.baseUrl;
-    if (modelConfig.providerType) headers['x-provider-type'] = modelConfig.providerType;
-    if (modelConfig.requiresApiKey) headers['x-requires-api-key'] = 'true';
-
-    const res = await fetch('/api/quiz-grade', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        question: q.question,
-        userAnswer,
-        points: pts,
-        commentPrompt: q.commentPrompt,
-        language,
-      }),
-    });
-
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = (await res.json()) as { score: number; comment: string };
-    const earned = Math.max(0, Math.min(pts, data.score));
-    return {
-      questionId: q.id,
-      correct: earned >= pts * 0.8,
-      status: earned >= pts * 0.8 ? 'correct' : 'incorrect',
-      earned,
-      aiComment: data.comment,
-    };
-  } catch (err) {
-    log.error('[quiz-view] AI grading failed for', q.id, err);
-    // Fallback: give half credit
-    return {
-      questionId: q.id,
-      correct: null,
-      status: 'incorrect',
-      earned: Math.round(pts * 0.5),
-      aiComment:
-        language === 'zh-CN'
-          ? '评分服务暂时不可用，已给予基础分。'
-          : 'Grading service unavailable. Base score given.',
-    };
-  }
 }
 
 // ─── Sub-components ─────────────────────────────────────────────────────────
@@ -687,8 +593,10 @@ function ScoreBanner({
 
 export function QuizView({ questions, sceneId }: QuizViewProps) {
   const { t, locale } = useI18n();
+  const stageId = useStageStore((state) => state.stage?.id);
+  const setLatestAssessmentContext = useStageStore((state) => state.setLatestAssessmentContext);
   const [phase, setPhase] = useState<Phase>('not_started');
-  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+  const [answers, setAnswers] = useState<QuizAnswerMap>({});
   const [results, setResults] = useState<QuestionResult[]>([]);
 
   // Draft cache for quiz answers, keyed by sceneId to isolate across classrooms
@@ -709,6 +617,25 @@ export function QuizView({ questions, sceneId }: QuizViewProps) {
       setPhase('answering');
     }
   }
+
+  useEffect(() => {
+    if (!stageId) return;
+    let cancelled = false;
+
+    void (async () => {
+      const attempt = await getLatestQuizAttemptForScene(stageId, sceneId);
+      if (!attempt || cancelled) return;
+
+      setAnswers(attempt.answers);
+      setResults(attempt.results);
+      setPhase('reviewing');
+      setLatestAssessmentContext(attempt.assessmentContext);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sceneId, setLatestAssessmentContext, stageId]);
 
   const totalPoints = useMemo(
     () => questions.reduce((sum, q) => sum + (q.points ?? 1), 0),
@@ -735,53 +662,93 @@ export function QuizView({ questions, sceneId }: QuizViewProps) {
     [updateAnswersCache],
   );
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
+    if (!stageId) return;
+
     setPhase('grading');
-    clearAnswersCache();
-  }, [clearAnswersCache]);
 
-  // When entering grading phase, grade choice questions locally + call API for short-answer
-  useEffect(() => {
-    if (phase !== 'grading') return;
-    let cancelled = false;
+    try {
+      const modelConfig = getCurrentModelConfig();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'x-model': modelConfig.modelString,
+        'x-api-key': modelConfig.apiKey,
+      };
+      if (modelConfig.baseUrl) headers['x-base-url'] = modelConfig.baseUrl;
+      if (modelConfig.providerType) headers['x-provider-type'] = modelConfig.providerType;
+      if (modelConfig.requiresApiKey) headers['x-requires-api-key'] = 'true';
 
-    (async () => {
-      // 1. Grade choice questions locally (instant)
-      const choiceResults = gradeChoiceQuestions(questions, answers);
+      const res = await fetch('/api/quiz-submit', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          stageId,
+          sceneId,
+          questions,
+          answers,
+          language: locale,
+        }),
+      });
 
-      // 2. Grade short-answer questions via AI API (parallel)
-      const shortAnswerQs = questions.filter(isShortAnswer);
-      const aiResults = await Promise.all(
-        shortAnswerQs.map((q) =>
-          gradeShortAnswerQuestion(q, (answers[q.id] as string) ?? '', locale),
-        ),
-      );
-
-      if (cancelled) return;
-
-      // 3. Merge results in original question order
-      const allResultsMap = new Map<string, QuestionResult>();
-      for (const r of [...choiceResults, ...aiResults]) {
-        allResultsMap.set(r.questionId, r);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
       }
-      const ordered = questions.map((q) => allResultsMap.get(q.id)!).filter(Boolean);
 
-      setResults(ordered);
+      const payload = (await res.json()) as {
+        success?: boolean;
+        attempt?: {
+          attemptId: string;
+          stageId: string;
+          sceneId: string;
+          answers: QuizAnswerMap;
+          results: QuestionResult[];
+          totalScore: number;
+          maxScore: number;
+          assessmentContext: {
+            attemptId: string;
+            stageId: string;
+            sceneId: string;
+            latestQuizScore: number;
+            maxScore: number;
+            incorrectQuestions: string[];
+            weakConcepts: string[];
+            masteryLevel: 'high' | 'medium' | 'low';
+            recommendedNextStep: 'advance' | 'review' | 'remediate';
+            submittedAt: number;
+          };
+          submittedAt: number;
+        };
+      };
 
+      if (!payload.attempt) {
+        throw new Error('Missing quiz attempt in response');
+      }
+
+      await saveQuizAttempt({
+        ...payload.attempt,
+        questions,
+      });
+
+      setResults(payload.attempt.results);
+      setLatestAssessmentContext(payload.attempt.assessmentContext);
+      clearAnswersCache();
       setPhase('reviewing');
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [phase, questions, answers, locale]);
+    } catch (error) {
+      log.error('[quiz-view] quiz submit failed', error);
+      setPhase('answering');
+    }
+  }, [answers, clearAnswersCache, locale, questions, sceneId, setLatestAssessmentContext, stageId]);
 
   const handleRetry = useCallback(() => {
+    if (stageId) {
+      void deleteQuizAttemptsForScene(stageId, sceneId);
+    }
     setPhase('not_started');
     setAnswers({});
     setResults([]);
     clearAnswersCache();
-  }, [clearAnswersCache]);
+    setLatestAssessmentContext(null);
+  }, [clearAnswersCache, sceneId, setLatestAssessmentContext, stageId]);
 
   const earnedScore = useMemo(() => results.reduce((sum, r) => sum + r.earned, 0), [results]);
 

--- a/lib/orchestration/prompt-builder.ts
+++ b/lib/orchestration/prompt-builder.ts
@@ -617,7 +617,7 @@ DO NOT redraw content that already exists. Check positions above before adding n
  * Build context string from store state
  */
 function buildStateContext(storeState: StatelessChatRequest['storeState']): string {
-  const { stage, scenes, currentSceneId, mode, whiteboardOpen } = storeState;
+  const { stage, scenes, currentSceneId, mode, whiteboardOpen, assessmentContext } = storeState;
 
   const lines: string[] = [];
 
@@ -685,6 +685,26 @@ function buildStateContext(storeState: StatelessChatRequest['storeState']): stri
     const wbElements = lastWb.elements || [];
     lines.push(
       `Whiteboard (last of ${stage.whiteboard.length}, ${wbElements.length} elements):\n${summarizeElements(wbElements)}`,
+    );
+  }
+
+  if (assessmentContext) {
+    lines.push(
+      [
+        'Latest assessment context:',
+        `  Scene ID: ${assessmentContext.sceneId}`,
+        `  Score: ${assessmentContext.latestQuizScore}/${assessmentContext.maxScore}`,
+        `  Mastery: ${assessmentContext.masteryLevel}`,
+        `  Recommended next step: ${assessmentContext.recommendedNextStep}`,
+        assessmentContext.weakConcepts.length > 0
+          ? `  Weak concepts: ${assessmentContext.weakConcepts.join('; ')}`
+          : null,
+        assessmentContext.incorrectQuestions.length > 0
+          ? `  Incorrect questions: ${assessmentContext.incorrectQuestions.join(' | ')}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join('\n'),
     );
   }
 

--- a/lib/quiz/assessment.ts
+++ b/lib/quiz/assessment.ts
@@ -1,0 +1,131 @@
+import type { AssessmentContext, QuizAnswerMap, QuizAttempt, QuizQuestionResult } from '@/lib/types/assessment';
+import type { QuizQuestion } from '@/lib/types/stage';
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+export function toArray(v: string | string[] | undefined): string[] {
+  if (!v) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+export function isShortAnswer(question: QuizQuestion): boolean {
+  return (
+    question.type === 'short_answer' ||
+    (!question.hasAnswer && (!question.answer || question.answer.length === 0))
+  );
+}
+
+export function gradeChoiceQuestions(
+  questions: QuizQuestion[],
+  answers: QuizAnswerMap,
+): QuizQuestionResult[] {
+  return questions
+    .filter((q) => !isShortAnswer(q))
+    .map((q) => {
+      const pts = q.points ?? 1;
+      const userAnswer = toArray(answers[q.id]);
+      const correctAnswer = toArray(q.answer);
+      const correct = arraysEqual(userAnswer, correctAnswer);
+      return {
+        questionId: q.id,
+        correct,
+        status: correct ? 'correct' : 'incorrect',
+        earned: correct ? pts : 0,
+      };
+    });
+}
+
+function deriveWeakConcepts(questions: QuizQuestion[], results: QuizQuestionResult[]): string[] {
+  const incorrectIds = new Set(
+    results.filter((result) => result.status === 'incorrect').map((result) => result.questionId),
+  );
+  return questions
+    .filter((question) => incorrectIds.has(question.id))
+    .map((question) => question.analysis?.trim() || question.question.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+}
+
+function deriveMasteryLevel(scoreRatio: number): AssessmentContext['masteryLevel'] {
+  if (scoreRatio >= 0.85) return 'high';
+  if (scoreRatio >= 0.6) return 'medium';
+  return 'low';
+}
+
+function deriveRecommendedNextStep(
+  masteryLevel: AssessmentContext['masteryLevel'],
+): AssessmentContext['recommendedNextStep'] {
+  if (masteryLevel === 'high') return 'advance';
+  if (masteryLevel === 'medium') return 'review';
+  return 'remediate';
+}
+
+export function buildAssessmentContext(params: {
+  attemptId: string;
+  stageId: string;
+  sceneId: string;
+  questions: QuizQuestion[];
+  results: QuizQuestionResult[];
+  submittedAt: number;
+}): AssessmentContext {
+  const { attemptId, stageId, sceneId, questions, results, submittedAt } = params;
+  const maxScore = questions.reduce((sum, question) => sum + (question.points ?? 1), 0);
+  const latestQuizScore = results.reduce((sum, result) => sum + result.earned, 0);
+  const scoreRatio = maxScore > 0 ? latestQuizScore / maxScore : 0;
+  const masteryLevel = deriveMasteryLevel(scoreRatio);
+  const incorrectQuestions = questions
+    .filter((question) => results.some((result) => result.questionId === question.id && result.status === 'incorrect'))
+    .map((question) => question.question)
+    .slice(0, 5);
+
+  return {
+    attemptId,
+    stageId,
+    sceneId,
+    latestQuizScore,
+    maxScore,
+    incorrectQuestions,
+    weakConcepts: deriveWeakConcepts(questions, results),
+    masteryLevel,
+    recommendedNextStep: deriveRecommendedNextStep(masteryLevel),
+    submittedAt,
+  };
+}
+
+export function buildQuizAttempt(params: {
+  attemptId: string;
+  stageId: string;
+  sceneId: string;
+  questions: QuizQuestion[];
+  answers: QuizAnswerMap;
+  results: QuizQuestionResult[];
+  submittedAt: number;
+}): QuizAttempt {
+  const { attemptId, stageId, sceneId, questions, answers, results, submittedAt } = params;
+  const assessmentContext = buildAssessmentContext({
+    attemptId,
+    stageId,
+    sceneId,
+    questions,
+    results,
+    submittedAt,
+  });
+
+  return {
+    attemptId,
+    stageId,
+    sceneId,
+    answers,
+    results,
+    totalScore: assessmentContext.latestQuizScore,
+    maxScore: assessmentContext.maxScore,
+    questions,
+    assessmentContext,
+    submittedAt,
+  };
+}

--- a/lib/server/quiz-assessment.ts
+++ b/lib/server/quiz-assessment.ts
@@ -1,0 +1,123 @@
+import { callLLM } from '@/lib/ai/llm';
+import { buildQuizAttempt, gradeChoiceQuestions, isShortAnswer } from '@/lib/quiz/assessment';
+import type { QuizAnswerMap, QuizAttempt, QuizQuestionResult } from '@/lib/types/assessment';
+import type { QuizQuestion } from '@/lib/types/stage';
+import type { LanguageModel } from 'ai';
+
+function fallbackShortAnswerResult(language: string, question: QuizQuestion): QuizQuestionResult {
+  const points = question.points ?? 1;
+  return {
+    questionId: question.id,
+    correct: null,
+    status: 'incorrect',
+    earned: Math.round(points * 0.5),
+    aiComment:
+      language === 'zh-CN'
+        ? '评分服务暂时不可用，已给予基础分。'
+        : 'Grading service unavailable. Base score given.',
+  };
+}
+
+export async function gradeShortAnswerQuestion(params: {
+  question: QuizQuestion;
+  userAnswer: string;
+  language: string;
+  languageModel?: LanguageModel;
+}): Promise<QuizQuestionResult> {
+  const { question, userAnswer, language, languageModel } = params;
+  const points = question.points ?? 1;
+  const isZh = language === 'zh-CN';
+
+  if (!languageModel) {
+    return fallbackShortAnswerResult(language, question);
+  }
+
+  const systemPrompt = isZh
+    ? `你是一位专业的教育评估专家。请根据题目和学生答案进行评分并给出简短评语。
+必须以如下 JSON 格式回复（不要包含其他内容）：
+{"score": <0到${points}的整数>, "comment": "<一两句评语>"}`
+    : `You are a professional educational assessor. Grade the student's answer and provide brief feedback.
+You must reply in the following JSON format only (no other content):
+{"score": <integer from 0 to ${points}>, "comment": "<one or two sentences of feedback>"}`;
+
+  const userPrompt = isZh
+    ? `题目：${question.question}
+满分：${points}分
+${question.commentPrompt ? `评分要点：${question.commentPrompt}\n` : ''}学生答案：${userAnswer}`
+    : `Question: ${question.question}
+Full marks: ${points} points
+${question.commentPrompt ? `Grading guidance: ${question.commentPrompt}\n` : ''}Student answer: ${userAnswer}`;
+
+  try {
+    const result = await callLLM(
+      {
+        model: languageModel,
+        system: systemPrompt,
+        prompt: userPrompt,
+      },
+      'quiz-grade',
+    );
+
+    const text = result.text.trim();
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new Error('No JSON found');
+    const parsed = JSON.parse(jsonMatch[0]) as { score?: number; comment?: string };
+    const earned = Math.max(0, Math.min(points, Math.round(Number(parsed.score))));
+
+    return {
+      questionId: question.id,
+      correct: earned >= points * 0.8,
+      status: earned >= points * 0.8 ? 'correct' : 'incorrect',
+      earned,
+      aiComment: String(parsed.comment || ''),
+    };
+  } catch {
+    return fallbackShortAnswerResult(language, question);
+  }
+}
+
+export async function buildQuizAttemptFromSubmission(params: {
+  attemptId: string;
+  stageId: string;
+  sceneId: string;
+  questions: QuizQuestion[];
+  answers: QuizAnswerMap;
+  language: string;
+  languageModel?: LanguageModel;
+  submittedAt: number;
+}): Promise<QuizAttempt> {
+  const { attemptId, stageId, sceneId, questions, answers, language, languageModel, submittedAt } =
+    params;
+
+  const choiceResults = gradeChoiceQuestions(questions, answers);
+  const shortAnswerQuestions = questions.filter(isShortAnswer);
+  const shortAnswerResults = await Promise.all(
+    shortAnswerQuestions.map((question) =>
+      gradeShortAnswerQuestion({
+        question,
+        userAnswer: String(answers[question.id] || ''),
+        language,
+        languageModel,
+      }),
+    ),
+  );
+
+  const resultsById = new Map<string, QuizQuestionResult>();
+  for (const result of [...choiceResults, ...shortAnswerResults]) {
+    resultsById.set(result.questionId, result);
+  }
+
+  const orderedResults = questions
+    .map((question) => resultsById.get(question.id))
+    .filter((result): result is QuizQuestionResult => result != null);
+
+  return buildQuizAttempt({
+    attemptId,
+    stageId,
+    sceneId,
+    questions,
+    answers,
+    results: orderedResults,
+    submittedAt,
+  });
+}

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { Stage, Scene, StageMode } from '@/lib/types/stage';
+import type { AssessmentContext } from '@/lib/types/assessment';
 import { createSelectors } from '@/lib/utils/create-selectors';
 import type { ChatSession } from '@/lib/types/chat';
 import type { SceneOutline } from '@/lib/types/generation';
@@ -59,6 +60,9 @@ interface StageState {
   // Persisted outlines for resume-on-refresh
   outlines: SceneOutline[];
 
+  // Latest quiz-derived learning signal for downstream orchestration
+  latestAssessmentContext: AssessmentContext | null;
+
   // Transient generation tracking (not persisted)
   generationEpoch: number;
   generationStatus: 'idle' | 'generating' | 'paused' | 'completed' | 'error';
@@ -77,6 +81,7 @@ interface StageState {
   setToolbarState: (state: ToolbarState) => void;
   setGeneratingOutlines: (outlines: SceneOutline[]) => void;
   setOutlines: (outlines: SceneOutline[]) => void;
+  setLatestAssessmentContext: (context: AssessmentContext | null) => void;
   setGenerationStatus: (status: 'idle' | 'generating' | 'paused' | 'completed' | 'error') => void;
   setCurrentGeneratingOrder: (order: number) => void;
   bumpGenerationEpoch: () => void;
@@ -105,6 +110,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
   toolbarState: 'ai',
   generatingOutlines: [],
   outlines: [],
+  latestAssessmentContext: null,
   generationEpoch: 0,
   generationStatus: 'idle' as const,
   currentGeneratingOrder: -1,
@@ -117,6 +123,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       scenes: [],
       currentSceneId: null,
       chats: [],
+      latestAssessmentContext: null,
       generationEpoch: s.generationEpoch + 1,
     }));
     debouncedSave();
@@ -211,6 +218,8 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     }
   },
 
+  setLatestAssessmentContext: (latestAssessmentContext) => set({ latestAssessmentContext }),
+
   setGenerationStatus: (generationStatus) => set({ generationStatus }),
 
   setCurrentGeneratingOrder: (currentGeneratingOrder) => set({ currentGeneratingOrder }),
@@ -282,8 +291,10 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
 
       // Load outlines for resume-on-refresh
       const { db } = await import('@/lib/utils/database');
+      const { getLatestAssessmentContextForStage } = await import('@/lib/utils/assessment-storage');
       const outlinesRecord = await db.stageOutlines.get(stageId);
       const outlines = outlinesRecord?.outlines || [];
+      const latestAssessmentContext = await getLatestAssessmentContextForStage(stageId);
 
       if (data) {
         set({
@@ -292,6 +303,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
           currentSceneId: data.currentSceneId,
           chats: data.chats,
           outlines,
+          latestAssessmentContext,
           // Compute generatingOutlines from persisted outlines minus completed scenes
           generatingOutlines: outlines.filter((o) => !data.scenes.some((s) => s.order === o.order)),
         });
@@ -312,6 +324,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       currentSceneId: null,
       chats: [],
       outlines: [],
+      latestAssessmentContext: null,
       generationEpoch: s.generationEpoch + 1,
       generationStatus: 'idle' as const,
       currentGeneratingOrder: -1,

--- a/lib/types/assessment.ts
+++ b/lib/types/assessment.ts
@@ -1,0 +1,37 @@
+import type { QuizQuestion } from '@/lib/types/stage';
+
+export type QuizAnswerMap = Record<string, string | string[]>;
+
+export interface QuizQuestionResult {
+  questionId: string;
+  correct: boolean | null;
+  status: 'correct' | 'incorrect';
+  earned: number;
+  aiComment?: string;
+}
+
+export interface AssessmentContext {
+  attemptId: string;
+  stageId: string;
+  sceneId: string;
+  latestQuizScore: number;
+  maxScore: number;
+  incorrectQuestions: string[];
+  weakConcepts: string[];
+  masteryLevel: 'high' | 'medium' | 'low';
+  recommendedNextStep: 'advance' | 'review' | 'remediate';
+  submittedAt: number;
+}
+
+export interface QuizAttempt {
+  attemptId: string;
+  stageId: string;
+  sceneId: string;
+  answers: QuizAnswerMap;
+  results: QuizQuestionResult[];
+  totalScore: number;
+  maxScore: number;
+  questions?: QuizQuestion[];
+  assessmentContext: AssessmentContext;
+  submittedAt: number;
+}

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UIMessage } from 'ai';
+import type { AssessmentContext } from '@/lib/types/assessment';
 
 // Session Types
 export type SessionType = 'qa' | 'discussion' | 'lecture';
@@ -154,6 +155,7 @@ export interface SendMessageRequest {
     currentSceneId: string | null;
     mode: 'autonomous' | 'playback';
     whiteboardOpen: boolean;
+    assessmentContext?: AssessmentContext | null;
   };
 }
 
@@ -243,6 +245,7 @@ export interface StatelessChatRequest {
     currentSceneId: string | null;
     mode: StageMode;
     whiteboardOpen: boolean;
+    assessmentContext?: AssessmentContext | null;
   };
   /** Agent configuration */
   config: {

--- a/lib/utils/assessment-storage.ts
+++ b/lib/utils/assessment-storage.ts
@@ -1,0 +1,59 @@
+import type { AssessmentContext, QuizAttempt } from '@/lib/types/assessment';
+import { db } from '@/lib/utils/database';
+
+export async function saveQuizAttempt(attempt: QuizAttempt): Promise<void> {
+  await db.quizAttempts.put({
+    attemptId: attempt.attemptId,
+    stageId: attempt.stageId,
+    sceneId: attempt.sceneId,
+    answers: attempt.answers,
+    results: attempt.results,
+    totalScore: attempt.totalScore,
+    maxScore: attempt.maxScore,
+    assessmentContext: attempt.assessmentContext,
+    submittedAt: attempt.submittedAt,
+    createdAt: attempt.submittedAt,
+  });
+}
+
+export async function getLatestQuizAttemptForScene(
+  stageId: string,
+  sceneId: string,
+): Promise<QuizAttempt | null> {
+  const attempts = await db.quizAttempts
+    .where('[stageId+sceneId]')
+    .equals([stageId, sceneId])
+    .toArray();
+
+  const latest = attempts.sort((a, b) => b.submittedAt - a.submittedAt)[0];
+  if (!latest) return null;
+
+  return {
+    attemptId: latest.attemptId,
+    stageId: latest.stageId,
+    sceneId: latest.sceneId,
+    answers: latest.answers,
+    results: latest.results,
+    totalScore: latest.totalScore,
+    maxScore: latest.maxScore,
+    questions: [],
+    assessmentContext: latest.assessmentContext,
+    submittedAt: latest.submittedAt,
+  };
+}
+
+export async function deleteQuizAttemptsForScene(stageId: string, sceneId: string): Promise<void> {
+  const attempts = await db.quizAttempts.where('[stageId+sceneId]').equals([stageId, sceneId]).toArray();
+  if (attempts.length === 0) return;
+  await db.quizAttempts.bulkDelete(attempts.map((attempt) => attempt.attemptId));
+}
+
+export async function getLatestAssessmentContextForStage(
+  stageId: string,
+): Promise<AssessmentContext | null> {
+  const attempts = await db.quizAttempts.where('stageId').equals(stageId).toArray();
+  if (attempts.length === 0) return null;
+
+  const latest = attempts.sort((a, b) => b.submittedAt - a.submittedAt)[0];
+  return latest?.assessmentContext || null;
+}

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -1,6 +1,7 @@
 import Dexie, { type EntityTable } from 'dexie';
 import type { Scene, SceneType, SceneContent, Whiteboard } from '@/lib/types/stage';
 import type { Action } from '@/lib/types/action';
+import type { AssessmentContext, QuizAnswerMap, QuizQuestionResult } from '@/lib/types/assessment';
 import type {
   SessionType,
   SessionStatus,
@@ -166,6 +167,22 @@ export interface GeneratedAgentRecord {
   createdAt: number;
 }
 
+/**
+ * QuizAttempt table - Persisted quiz submissions and derived assessment summary
+ */
+export interface QuizAttemptRecord {
+  attemptId: string; // Primary key
+  stageId: string; // FK -> stages.id
+  sceneId: string; // FK -> scenes.id
+  answers: QuizAnswerMap;
+  results: QuizQuestionResult[];
+  totalScore: number;
+  maxScore: number;
+  assessmentContext: AssessmentContext;
+  submittedAt: number;
+  createdAt: number;
+}
+
 /** Build the compound primary key for mediaFiles: `${stageId}:${elementId}` */
 export function mediaFileKey(stageId: string, elementId: string): string {
   return `${stageId}:${elementId}`;
@@ -191,6 +208,7 @@ class MAICDatabase extends Dexie {
   stageOutlines!: EntityTable<StageOutlinesRecord, 'stageId'>;
   mediaFiles!: EntityTable<MediaFileRecord, 'id'>;
   generatedAgents!: EntityTable<GeneratedAgentRecord, 'id'>;
+  quizAttempts!: EntityTable<QuizAttemptRecord, 'attemptId'>;
 
   constructor() {
     super(DATABASE_NAME);
@@ -308,6 +326,21 @@ class MAICDatabase extends Dexie {
       mediaFiles: 'id, stageId, [stageId+type]',
       generatedAgents: 'id, stageId',
     });
+
+    // Version 9: Add quizAttempts table for persisted quiz submissions
+    this.version(9).stores({
+      stages: 'id, updatedAt',
+      scenes: 'id, stageId, order, [stageId+order]',
+      audioFiles: 'id, createdAt',
+      imageFiles: 'id, createdAt',
+      snapshots: '++id',
+      chatSessions: 'id, stageId, [stageId+createdAt]',
+      playbackState: 'stageId',
+      stageOutlines: 'stageId',
+      mediaFiles: 'id, stageId, [stageId+type]',
+      generatedAgents: 'id, stageId',
+      quizAttempts: 'attemptId, stageId, sceneId, [stageId+sceneId], submittedAt',
+    });
   }
 }
 
@@ -350,12 +383,14 @@ export async function exportDatabase(): Promise<{
   scenes: SceneRecord[];
   chatSessions: ChatSessionRecord[];
   playbackState: PlaybackStateRecord[];
+  quizAttempts: QuizAttemptRecord[];
 }> {
   return {
     stages: await db.stages.toArray(),
     scenes: await db.scenes.toArray(),
     chatSessions: await db.chatSessions.toArray(),
     playbackState: await db.playbackState.toArray(),
+    quizAttempts: await db.quizAttempts.toArray(),
   };
 }
 
@@ -367,15 +402,17 @@ export async function importDatabase(data: {
   scenes?: SceneRecord[];
   chatSessions?: ChatSessionRecord[];
   playbackState?: PlaybackStateRecord[];
+  quizAttempts?: QuizAttemptRecord[];
 }): Promise<void> {
   await db.transaction(
     'rw',
-    [db.stages, db.scenes, db.chatSessions, db.playbackState],
+    [db.stages, db.scenes, db.chatSessions, db.playbackState, db.quizAttempts],
     async () => {
       if (data.stages) await db.stages.bulkPut(data.stages);
       if (data.scenes) await db.scenes.bulkPut(data.scenes);
       if (data.chatSessions) await db.chatSessions.bulkPut(data.chatSessions);
       if (data.playbackState) await db.playbackState.bulkPut(data.playbackState);
+      if (data.quizAttempts) await db.quizAttempts.bulkPut(data.quizAttempts);
     },
   );
   log.info('Database imported successfully');
@@ -404,6 +441,7 @@ export async function deleteStageWithRelatedData(stageId: string): Promise<void>
       db.stageOutlines,
       db.mediaFiles,
       db.generatedAgents,
+      db.quizAttempts,
     ],
     async () => {
       await db.stages.delete(stageId);
@@ -413,6 +451,7 @@ export async function deleteStageWithRelatedData(stageId: string): Promise<void>
       await db.stageOutlines.delete(stageId);
       await db.mediaFiles.where('stageId').equals(stageId).delete();
       await db.generatedAgents.where('stageId').equals(stageId).delete();
+      await db.quizAttempts.where('stageId').equals(stageId).delete();
     },
   );
 }

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -123,6 +123,7 @@ export async function deleteStageData(stageId: string): Promise<void> {
     // Delete chat sessions and playback state
     await deleteChatSessions(stageId);
     await clearPlaybackState(stageId);
+    await db.quizAttempts.where('stageId').equals(stageId).delete();
 
     log.info(`Deleted stage: ${stageId}`);
   } catch (error) {


### PR DESCRIPTION
Closes #57

## Summary

This PR implements the MVP for quiz assessment context so quiz results can become a durable runtime signal instead of staying inside component-local state.

### What it adds

- `QuizAttempt` / `AssessmentContext` domain types
- local IndexedDB persistence for quiz attempts
- new `POST /api/quiz-submit` endpoint for full-quiz submission
- shared server-side quiz assessment logic
- `QuizView` integration for submit, restore, and retry cleanup
- `assessmentContext` injection into chat `storeState`
- prompt context exposure so downstream agent behavior can see the latest quiz outcome

## Scope of this MVP

Included:
- local persistence only
- full-quiz submit flow
- lightweight assessment summary
- chat/runtime integration via `/api/chat`

Not included:
- server-side persistence
- scene regeneration / branching generation
- broader learner profile modeling beyond latest quiz attempt summary

## Verification

### Automated
- `pnpm lint`
- `pnpm build`

### Manual
- created a minimal quiz classroom via `/api/classroom`
- completed quiz submission through the UI
- confirmed the report renders correctly
- refreshed `/classroom/[id]` and confirmed the latest quiz result restores automatically
- confirmed `quizAttempts` is persisted in IndexedDB with `assessmentContext`

## Notes

- short-answer grading now degrades gracefully when no model is configured, instead of blocking the whole quiz submission path
- `/api/quiz-grade` remains available as a per-question helper, while `/api/quiz-submit` handles the full quiz lifecycle
