### PR TITLE
fix(audio): prevent Qwen ASR from returning placeholder text

### DIFF
--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -265,6 +265,9 @@ async function transcribeQwenASR(
             {
               audio: `data:audio/wav;base64,${base64Audio}`,
             },
+            {
+              text: "Please transcribe the audio into text exactly as spoken without any other comments.",
+            },
           ],
         },
       ],


### PR DESCRIPTION
Fixes #76.

### Description

When using Qwen ASR (阿里云百炼) endpoints (`model: 'qwen3-asr-flash'`) through the `messages` array, sending audio without a text prompt causes the model to output conversational filler like `"嗯。"` rather than transcribing the audio.

By explicitly adding a transcription instruction (`{ text: "Please transcribe the audio into text exactly as spoken without any other comments." }`), the model correctly processes the audio as a transcription task.

*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*