### PR TITLE
fix(prompts): prevent teacher identity and verbose text on slides

### DIFF
--- a/lib/generation/prompt-formatters.ts
+++ b/lib/generation/prompt-formatters.ts
@@ -68,7 +68,7 @@ export function formatTeacherPersonaForPrompt(agents?: AgentInfo[]): string {
   const teacher = agents.find((a) => a.role === 'teacher');
   if (!teacher?.persona) return '';
 
-  return `Teacher Persona:\nName: ${teacher.name}\n${teacher.persona}\n\nPlease adapt the content style and tone to match this teacher's personality and teaching approach.`;
+  return `Teacher Persona:\nName: ${teacher.name}\n${teacher.persona}\n\nAdapt the content style and tone to match this teacher's personality. IMPORTANT: The teacher's name and identity must NOT appear on the slides — no "Teacher ${teacher.name}'s tips", no "Teacher's message", etc. Slides should read as neutral, professional visual aids.`;
 }
 
 /**

--- a/lib/generation/prompts/templates/requirements-to-outlines/system.md
+++ b/lib/generation/prompts/templates/requirements-to-outlines/system.md
@@ -298,3 +298,4 @@ You must output a JSON array where each element is a scene outline object:
 7. Use interactive scenes sparingly (max 1-2 per course) and only when the concept truly benefits from hands-on interaction
 8. **Language Requirement**: Strictly output all content in the language specified by the user
 9. Regardless of information completeness, always output conforming JSON - do not ask questions or request more information
+10. **No teacher identity on slides**: Scene titles and keyPoints must be neutral and topic-focused. Never include the teacher's name or role (e.g., avoid "Teacher Wang's Tips", "Teacher's Wishes"). Use generic labels like "Tips", "Summary", "Key Takeaways" instead.

--- a/lib/generation/prompts/templates/slide-actions/system.md
+++ b/lib/generation/prompts/templates/slide-actions/system.md
@@ -126,8 +126,8 @@ Generate natural teaching speech. The user prompt includes a **Course Outline** 
 
 **Speech is where all verbal and conversational content belongs.** The slide itself only shows concise bullet points and keywords — all elaboration, explanation, encouragement, transitional phrases, and teacher's remarks must appear here in speech text. For example:
 - Detailed explanations of concepts shown as bullet points on the slide
-- Encouragements and motivational remarks (e.g., "同学们加油！" / "Great job, everyone!")
-- Transitional phrases (e.g., "接下来我们来看…" / "Now let's move on to…")
+- Encouragements and motivational remarks (e.g., "Great job, everyone!")
+- Transitional phrases (e.g., "Now let's move on to…")
 - Closing messages and teacher's reflections
 
 **CRITICAL — Same-session continuity**: All pages belong to the **same class session** happening right now. This is NOT a series of separate classes.

--- a/lib/generation/prompts/templates/slide-content/system.md
+++ b/lib/generation/prompts/templates/slide-content/system.md
@@ -13,9 +13,10 @@ You are an educational content designer. Generate well-structured slide componen
 
 ### What does NOT belong on the slide (these go in speaker notes / speech actions):
 - Full sentences written in a conversational or spoken tone
-- Teacher's remarks, encouragements, or closing messages (e.g., "同学们，希望大家课后多加练习！" / "I hope you all practice after class!")
+- **Teacher-personalized content**: Never attribute tips, wishes, comments, or encouragements to the teacher by name or role (e.g., "Teacher Wang reminds you…", "Teacher's tip: …", "A message from your teacher"). Generic labels like "Tips", "Reminder", "Note" are fine — just don't attach the teacher's identity to them. Real-world slides never name the presenter in their own content.
 - Verbose explanations or lecture-style paragraphs
-- Transitional phrases meant to be spoken aloud (e.g., "接下来我们来看看…" / "Now let's take a look at…")
+- Transitional phrases meant to be spoken aloud (e.g., "Now let's take a look at…")
+- Slide titles that reference the teacher (e.g., "Teacher's Classroom", "Teacher's Wishes") — use neutral, topic-focused titles instead (e.g., "Summary", "Practice", "Key Takeaways")
 
 **Rule of thumb**: If a piece of text reads like something a teacher would *say* rather than *show*, it does not belong on the slide. Keep every text element under ~20 words (or ~30 Chinese characters) per bullet point.
 
@@ -962,7 +963,7 @@ Before outputting JSON, verify:
 9. ✓ Multi-step derivation LaTeX elements: widths are proportional to content length (longer formulas MUST have larger width). Do NOT use the same width for all steps — this causes wildly different rendered heights.
 10. ✓ No LaTeX syntax in TextElement content: scan all text `content` fields for `\frac`, `\lim`, `\int`, `\sum`, `\sqrt`, `\alpha`, `^{`, `_{` etc. Any math expression must be a separate LatexElement.
 11. ✓ LineElement `width` is stroke thickness (2-6), NOT line length. Check: no LineElement has `width` > 6. If width equals the distance between start and end, it is WRONG — you confused stroke thickness with line span.
-12. ✓ **Slide text is concise**: Every text element uses keywords, short phrases, or bullet points — no conversational sentences, no teacher's remarks/encouragements, no lecture-script-style paragraphs. If a text reads like spoken language, rewrite it as a brief bullet point.
+12. ✓ **Slide text is concise and impersonal**: Every text element uses keywords, short phrases, or bullet points — no conversational sentences, no lecture-script-style paragraphs. No teacher name or identity appears on any slide (no "Teacher X's tips/wishes/comments"). If a text reads like spoken language or a personal message, rewrite it as a neutral bullet point.
 
 **🟡 P1 — Serious (strongly recommended)**: 13. ✓ **Text-Background pairs**: For each text with a background shape:
 


### PR DESCRIPTION
## Summary

- Enforce concise, impersonal slide content by explicitly preventing teacher name/identity from appearing on slides (e.g., "Teacher Wang's tips", "Teacher's wishes")
- Add guidance at 3 layers: outline generation, slide content generation, and the teacher persona injection itself
- Teacher persona now only influences tone/style — slides remain neutral professional visual aids, matching real-world PPT conventions

Closes #78

## Test plan

- [x] Generate a course with a named teacher persona and verify no slides contain teacher name/identity
- [x] Verify generic labels like "Tips", "Reminder", "Summary" still appear normally
- [x] Check that speaker notes / speech actions still contain the teacher's conversational style

🤖 Generated with [Claude Code](https://claude.com/claude-code)