### PR TITLE
fix: normalize Tavily queries before search

### DIFF
--- a/lib/web-search/tavily.ts
+++ b/lib/web-search/tavily.ts
@@ -6,9 +6,29 @@
  */
 
 import { proxyFetch } from '@/lib/server/proxy-fetch';
+import { createLogger } from '@/lib/logger';
 import type { WebSearchResult, WebSearchSource } from '@/lib/types/web-search';
 
 const TAVILY_API_URL = 'https://api.tavily.com/search';
+const TAVILY_MAX_QUERY_LENGTH = 400;
+const log = createLogger('WebSearch');
+
+function normalizeTavilyQuery(query: string): string {
+  const normalized = query.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length > TAVILY_MAX_QUERY_LENGTH) {
+    log.warn(
+      `[WebSearch] Tavily query truncated: ${normalized.length} → ${TAVILY_MAX_QUERY_LENGTH} chars`,
+    );
+
+    return normalized
+      .slice(0, TAVILY_MAX_QUERY_LENGTH)
+      .replace(/\s+\S*$/, '')
+      .trim();
+  }
+
+  return normalized;
+}
 
 /**
  * Search the web using Tavily REST API and return structured results.
@@ -19,6 +39,7 @@ export async function searchWithTavily(params: {
   maxResults?: number;
 }): Promise<WebSearchResult> {
   const { query, apiKey, maxResults = 5 } = params;
+  const normalizedQuery = normalizeTavilyQuery(query);
 
   const res = await proxyFetch(TAVILY_API_URL, {
     method: 'POST',
@@ -27,7 +48,7 @@ export async function searchWithTavily(params: {
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      query,
+      query: normalizedQuery,
       search_depth: 'basic',
       max_results: maxResults,
       include_answer: 'basic',


### PR DESCRIPTION
## Summary
Fixes web search failures when Tavily receives overly long queries by normalizing and truncating Tavily queries before sending the request. This keeps the Tavily integration aligned with Tavily’s documented guidance to keep queries under 400 characters and prevents long lesson requirement text from causing search failures.

## Related Issues
<!-- Link related issues: "Closes #123", "Fixes #456", "Related to #789" -->
Fixes #119

## Changes
<!-- List the key changes: -->
- Added centralized Tavily query normalization in `lib/web-search/tavily.ts`
- Collapsed repeated whitespace and trimmed query input before sending requests
- Enforced a 400-character Tavily query cap at the integration boundary
- Avoided truncating in the middle of a trailing word when shortening long queries
- Logged a warning when query truncation occurs

## Type of Change
<!-- Check the relevant options: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification
### Steps to reproduce / test
1. Enable web search and provide a Tavily API key
2. Enter a lesson/classroom requirement longer than 400 characters
3. Trigger a Tavily-backed search flow such as generation preview or classroom generation
4. Confirm the request no longer fails due to an oversized Tavily query

### What you personally verified
<!-- What did you test beyond CI? Include edge cases checked and anything you did NOT verify. -->
- Verified that both known Tavily call paths funnel through `searchWithTavily()`
- Verified Tavily query handling is now centralized in `lib/web-search/tavily.ts`
- Ran `pnpm exec tsc --noEmit` and`pnpm lint lib/web-search/tavily.ts`
- Verified normalization behavior for:
  - extra whitespace and newlines
  - exactly 400-character queries
  - queries longer than 400 characters
  - truncation without leaving trailing spaces
  - truncation that avoids cutting the trailing word fragment when possible
- Ran a live end-to-end test with a 494-char requirement and Tavily API key configured locally
- Confirmed 500 error before fix, 200 after fix
- Warn log confirmed: `Tavily query truncated: 494 → 400 chars`
### Evidence
<!-- Attach at least one: logs, screenshots, recordings, or before/after comparisons. -->
- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots / recordings attached (if UI changes)
before:
<img width="819" height="809" alt="Screenshot 2026-03-19 at 3 13 10 PM" src="https://github.com/user-attachments/assets/4151e5d5-7851-4507-807b-82dbb7103d5c" />

after: 
[2026-03-19T09:43:51.109Z] [WARN] [WebSearch] [WebSearch] Tavily query truncated: 494 → 400 chars
[2026-03-19T09:43:51.111Z] [INFO] [ProxyFetch] No proxy configured, using direct fetch for: https://api.tavily.com/search


## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings