### PR TITLE
feat: add 1.25x playback speed option

### DIFF
--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -20,7 +20,7 @@ import { createLogger } from '@/lib/logger';
 const log = createLogger('Settings');
 
 /** Available playback speed tiers */
-export const PLAYBACK_SPEEDS = [1, 1.5, 2] as const;
+export const PLAYBACK_SPEEDS = [1, 1.25, 1.5, 2] as const;
 export type PlaybackSpeed = (typeof PLAYBACK_SPEEDS)[number];
 
 export interface SettingsState {


### PR DESCRIPTION
Closes #130

One-line change: adds `1.25` to the `PLAYBACK_SPEEDS` array.

```diff
-export const PLAYBACK_SPEEDS = [1, 1.5, 2] as const;
+export const PLAYBACK_SPEEDS = [1, 1.25, 1.5, 2] as const;
```

1.25x is one of the most commonly used speed tiers across media players (YouTube, podcast apps, etc.) and provides a gentle speed-up without making speech hard to follow. No UI changes needed — the toolbar renders `${playbackSpeed}x` dynamically.