### PR TITLE
fix: wrap mml2omml() return with String() for type safety

### DIFF
--- a/lib/export/latex-to-omml.ts
+++ b/lib/export/latex-to-omml.ts
@@ -71,7 +71,7 @@ export function latexToOmml(latex: string, fontSize?: number): string | null {
   try {
     const mathml = temml.renderToString(latex);
     const cleaned = stripUnsupportedMathML(mathml);
-    const omml = mml2omml(cleaned);
+    const omml = String(mml2omml(cleaned));
     const szHundredths = fontSize ? Math.round(fontSize * 100) : undefined;
     return postProcessOmml(omml, szHundredths);
   } catch {


### PR DESCRIPTION
## Summary

Fixes a TypeScript type error in `lib/export/latex-to-omml.ts` where `mml2omml()` returns a non-`string` type but its result is passed directly to `postProcessOmml()` which expects `string`.

## Fix

```diff
- const omml = mml2omml(cleaned);
+ const omml = String(mml2omml(cleaned));
```

## Impact

- `tsc --noEmit` now passes for this file
- Zero runtime behavior change (`String()` on a string is a no-op)

Closes #165