### PR TITLE
fix: add missing i18n keys pdfLoadFailed, pdfParseFailed, streamNotReadable

### DIFF
--- a/lib/i18n/generation.ts
+++ b/lib/i18n/generation.ts
@@ -21,6 +21,9 @@ export const generationZhCN = {
     // Progress steps (used dynamically via activeStep)
     analyzingPdf: '解析 PDF 文档',
     analyzingPdfDesc: '正在提取文档结构和内容...',
+    pdfLoadFailed: '无法加载 PDF 文件，请重试',
+    pdfParseFailed: 'PDF 解析失败',
+    streamNotReadable: '无法读取生成数据流',
     generatingOutlines: '生成课程大纲',
     generatingOutlinesDesc: '正在构建学习路径...',
     generatingSlideContent: '生成页面内容',
@@ -85,6 +88,9 @@ export const generationEnUS = {
     // Progress steps (used dynamically via activeStep)
     analyzingPdf: 'Analyzing PDF Document',
     analyzingPdfDesc: 'Extracting document structure and content...',
+    pdfLoadFailed: 'Failed to load PDF file, please try again',
+    pdfParseFailed: 'PDF parsing failed',
+    streamNotReadable: 'Unable to read generation stream',
     generatingOutlines: 'Drafting Course Outline',
     generatingOutlinesDesc: 'Structuring the learning path...',
     generatingSlideContent: 'Generating Page Content',


### PR DESCRIPTION
## Summary

Adds 3 missing i18n keys (`pdfLoadFailed`, `pdfParseFailed`, `streamNotReadable`) that are referenced via `t()` in `app/generation-preview/page.tsx` but were never defined in the i18n files.

Without these keys, users see raw key strings like `generation.pdfLoadFailed` instead of localized error messages when errors occur.

## Changes

Added to both `generationZhCN` and `generationEnUS` in `lib/i18n/generation.ts`:

| Key | zh-CN | en-US |
|-----|-------|-------|
| `pdfLoadFailed` | 无法加载 PDF 文件，请重试 | Failed to load PDF file, please try again |
| `pdfParseFailed` | PDF 解析失败 | PDF parsing failed |
| `streamNotReadable` | 无法读取生成数据流 | Unable to read generation stream |

## Impact

- Error messages now display in user's language instead of raw key strings
- Only affects error paths — no change to normal usage

Closes #166