### PR TITLE
feat: add Russian support for generation and PBL runtime flows

### DIFF
--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
       allOutlines,
       pdfImages,
       imageMapping,
-      stageInfo: _stageInfo,
+      stageInfo,
       stageId,
       agents,
       languageDirective,
@@ -45,6 +45,7 @@ export async function POST(req: NextRequest) {
       stageInfo: {
         name: string;
         description?: string;
+        language?: string;
         style?: string;
       };
       stageId: string;
@@ -67,7 +68,16 @@ export async function POST(req: NextRequest) {
       return apiError('MISSING_REQUIRED_FIELD', 400, 'stageId is required');
     }
 
-    const outline: SceneOutline = { ...rawOutline };
+    const outline: SceneOutline = {
+      ...rawOutline,
+      language:
+        rawOutline.language ||
+        (stageInfo?.language === 'en-US'
+          ? 'en-US'
+          : stageInfo?.language === 'ru-RU'
+            ? 'ru-RU'
+            : 'zh-CN'),
+    };
 
     // ── Model resolution from request headers ──
     const { model: languageModel, modelInfo, modelString } = await resolveModelFromHeaders(req);

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -47,6 +47,12 @@ function getLocalizedEmpty(language: string, kind: 'images' | 'content' | 'resea
   return kind === 'images' ? 'No images available' : 'None';
 }
 
+function resolveRequirementLanguage(language?: string): 'zh-CN' | 'en-US' | 'ru-RU' {
+  if (language === 'en-US') return 'en-US';
+  if (language === 'ru-RU') return 'ru-RU';
+  return 'zh-CN';
+}
+
 /**
  * Incremental JSON array parser.
  * Extracts complete top-level objects from a partially-streamed JSON array.
@@ -132,9 +138,10 @@ export async function POST(req: NextRequest) {
 
     // Detect vision capability
     const hasVision = !!modelInfo?.capabilities?.vision;
+    const requirementLanguage = resolveRequirementLanguage(requirements.language);
 
     // Build prompt (same logic as generateSceneOutlinesFromRequirements)
-    let availableImagesText = getLocalizedEmpty(requirements.language, 'images');
+    let availableImagesText = getLocalizedEmpty(requirementLanguage, 'images');
     let visionImages: Array<{ id: string; src: string }> | undefined;
 
     if (pdfImages && pdfImages.length > 0) {
@@ -146,10 +153,10 @@ export async function POST(req: NextRequest) {
         const noSrcImages = pdfImages.filter((img) => !imageMapping[img.id]);
 
         const visionDescriptions = visionSlice.map((img) =>
-          formatImagePlaceholder(img, requirements.language),
+          formatImagePlaceholder(img, requirementLanguage),
         );
         const textDescriptions = [...textOnlySlice, ...noSrcImages].map((img) =>
-          formatImageDescription(img, requirements.language),
+          formatImageDescription(img, requirementLanguage),
         );
         availableImagesText = [...visionDescriptions, ...textDescriptions].join('\n');
 
@@ -162,7 +169,7 @@ export async function POST(req: NextRequest) {
       } else {
         // Text-only mode: full descriptions
         availableImagesText = pdfImages
-          .map((img) => formatImageDescription(img, requirements.language))
+          .map((img) => formatImageDescription(img, requirementLanguage))
           .join('\n');
       }
     }
@@ -187,12 +194,12 @@ export async function POST(req: NextRequest) {
 
     const prompts = buildPrompt(PROMPT_IDS.REQUIREMENTS_TO_OUTLINES, {
       requirement: requirements.requirement,
-      language: requirements.language,
+      language: requirementLanguage,
       pdfContent: pdfText
         ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS)
-        : getLocalizedEmpty(requirements.language, 'content'),
+        : getLocalizedEmpty(requirementLanguage, 'content'),
       availableImages: availableImagesText,
-      researchContext: researchContext || getLocalizedEmpty(requirements.language, 'research'),
+      researchContext: researchContext || getLocalizedEmpty(requirementLanguage, 'research'),
       mediaGenerationPolicy,
       teacherContext,
     });

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -6,9 +6,8 @@
  * so the frontend can display them incrementally.
  *
  * SSE events:
- *   { type: 'languageDirective', data: string }
  *   { type: 'outline', data: SceneOutline, index: number }
- *   { type: 'done', outlines: SceneOutline[], languageDirective: string }
+ *   { type: 'done', outlines: SceneOutline[] }
  *   { type: 'error', error: string }
  */
 
@@ -38,45 +37,27 @@ const log = createLogger('Outlines Stream');
 
 export const maxDuration = 300;
 
-/**
- * Extract the languageDirective from the streamed wrapper JSON.
- * Matches `"languageDirective":"<value>"` in partial JSON like:
- *   {"languageDirective":"用中文授课...","outlines":[...
- */
-function extractLanguageDirective(buffer: string): string | null {
-  const match = buffer.match(/"languageDirective"\s*:\s*"((?:[^"\\]|\\.)*)"/);
-  if (!match) return null;
-  try {
-    return JSON.parse(`"${match[1]}"`);
-  } catch {
-    return match[1];
+function getLocalizedEmpty(language: string, kind: 'images' | 'content' | 'research'): string {
+  if (language === 'zh-CN') {
+    return kind === 'images' ? '无可用图片' : '无';
   }
+  if (language === 'ru-RU') {
+    return kind === 'images' ? 'Нет доступных изображений' : 'Нет';
+  }
+  return kind === 'images' ? 'No images available' : 'None';
 }
 
 /**
  * Incremental JSON array parser.
  * Extracts complete top-level objects from a partially-streamed JSON array.
- * Supports both a flat array `[{...},{...}]` and a wrapper object
- * `{"languageDirective":"...","outlines":[{...},{...}]}`.
  * Returns newly found objects (skipping `alreadyParsed` count).
  */
 function extractNewOutlines(buffer: string, alreadyParsed: number): SceneOutline[] {
   const results: SceneOutline[] = [];
 
-  // Strip markdown fencing if present
-  const stripped = buffer.replace(/^[\s\S]*?(?=[\[{])/, '');
-
-  // Find the outlines array — either nested in {"outlines": [...]} or a flat array
-  let arrayStart = -1;
-  const outlinesKeyIdx = stripped.indexOf('"outlines"');
-  if (outlinesKeyIdx >= 0) {
-    // Wrapper format: find [ after "outlines":
-    arrayStart = stripped.indexOf('[', outlinesKeyIdx);
-  } else {
-    // Flat array fallback
-    arrayStart = stripped.indexOf('[');
-  }
-
+  // Find the start of the JSON array (skip any markdown fencing)
+  const stripped = buffer.replace(/^[\s\S]*?(?=\[)/, '');
+  const arrayStart = stripped.indexOf('[');
   if (arrayStart === -1) return results;
 
   let depth = 0;
@@ -149,17 +130,11 @@ export async function POST(req: NextRequest) {
     };
     requirementSnippet = requirements?.requirement?.substring(0, 60);
 
-    // Build user profile string for language inference context
-    const userProfileText =
-      requirements.userNickname || requirements.userBio
-        ? `## Student Profile\n\nStudent: ${requirements.userNickname || 'Unknown'}${requirements.userBio ? ` — ${requirements.userBio}` : ''}\n\nConsider this student's background when designing the course. Adapt difficulty, examples, and teaching approach accordingly.\n\n---`
-        : '';
-
     // Detect vision capability
     const hasVision = !!modelInfo?.capabilities?.vision;
 
     // Build prompt (same logic as generateSceneOutlinesFromRequirements)
-    let availableImagesText = 'No images available';
+    let availableImagesText = getLocalizedEmpty(requirements.language, 'images');
     let visionImages: Array<{ id: string; src: string }> | undefined;
 
     if (pdfImages && pdfImages.length > 0) {
@@ -170,9 +145,11 @@ export async function POST(req: NextRequest) {
         const textOnlySlice = allWithSrc.slice(MAX_VISION_IMAGES);
         const noSrcImages = pdfImages.filter((img) => !imageMapping[img.id]);
 
-        const visionDescriptions = visionSlice.map((img) => formatImagePlaceholder(img));
+        const visionDescriptions = visionSlice.map((img) =>
+          formatImagePlaceholder(img, requirements.language),
+        );
         const textDescriptions = [...textOnlySlice, ...noSrcImages].map((img) =>
-          formatImageDescription(img),
+          formatImageDescription(img, requirements.language),
         );
         availableImagesText = [...visionDescriptions, ...textDescriptions].join('\n');
 
@@ -184,7 +161,9 @@ export async function POST(req: NextRequest) {
         }));
       } else {
         // Text-only mode: full descriptions
-        availableImagesText = pdfImages.map((img) => formatImageDescription(img)).join('\n');
+        availableImagesText = pdfImages
+          .map((img) => formatImageDescription(img, requirements.language))
+          .join('\n');
       }
     }
 
@@ -208,12 +187,14 @@ export async function POST(req: NextRequest) {
 
     const prompts = buildPrompt(PROMPT_IDS.REQUIREMENTS_TO_OUTLINES, {
       requirement: requirements.requirement,
-      pdfContent: pdfText ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS) : 'None',
+      language: requirements.language,
+      pdfContent: pdfText
+        ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS)
+        : getLocalizedEmpty(requirements.language, 'content'),
       availableImages: availableImagesText,
-      researchContext: researchContext || 'None',
+      researchContext: researchContext || getLocalizedEmpty(requirements.language, 'research'),
       mediaGenerationPolicy,
       teacherContext,
-      userProfile: userProfileText,
     });
 
     if (!prompts) {
@@ -273,7 +254,6 @@ export async function POST(req: NextRequest) {
               };
 
           let parsedOutlines: SceneOutline[] = [];
-          let languageDirective: string | null = null;
           let lastError: string | undefined;
 
           for (let attempt = 1; attempt <= MAX_STREAM_RETRIES + 1; attempt++) {
@@ -282,22 +262,9 @@ export async function POST(req: NextRequest) {
 
               let fullText = '';
               parsedOutlines = [];
-              languageDirective = null;
 
               for await (const chunk of result.textStream) {
                 fullText += chunk;
-
-                // Try to extract language directive early
-                if (!languageDirective) {
-                  languageDirective = extractLanguageDirective(fullText);
-                  if (languageDirective) {
-                    const ldEvent = JSON.stringify({
-                      type: 'languageDirective',
-                      data: languageDirective,
-                    });
-                    controller.enqueue(encoder.encode(`data: ${ldEvent}\n\n`));
-                  }
-                }
 
                 // Try to extract new outlines from the accumulated text
                 const newOutlines = extractNewOutlines(fullText, parsedOutlines.length);
@@ -365,8 +332,6 @@ export async function POST(req: NextRequest) {
             const doneEvent = JSON.stringify({
               type: 'done',
               outlines: uniquifiedOutlines,
-              languageDirective:
-                languageDirective || 'Teach in the language that matches the user requirement.',
             });
             controller.enqueue(encoder.encode(`data: ${doneEvent}\n\n`));
           } else {

--- a/app/api/quiz-grade/route.ts
+++ b/app/api/quiz-grade/route.ts
@@ -47,12 +47,17 @@ export async function POST(req: NextRequest) {
     const { model: languageModel } = await resolveModelFromHeaders(req);
 
     const isZh = language === 'zh-CN';
+    const isRu = language === 'ru-RU';
 
     const systemPrompt = isZh
       ? `你是一位专业的教育评估专家。请根据题目和学生答案进行评分并给出简短评语。
 必须以如下 JSON 格式回复（不要包含其他内容）：
 {"score": <0到${points}的整数>, "comment": "<一两句评语>"}`
-      : `You are a professional educational assessor. Grade the student's answer and provide brief feedback.
+      : isRu
+        ? `Ты профессиональный эксперт по образовательной оценке. Оцени ответ студента и дай краткий комментарий.
+Ты должен ответить только в следующем JSON-формате, без любого другого текста:
+{"score": <целое число от 0 до ${points}>, "comment": "<одно-два предложения обратной связи>"}`
+        : `You are a professional educational assessor. Grade the student's answer and provide brief feedback.
 You must reply in the following JSON format only (no other content):
 {"score": <integer from 0 to ${points}>, "comment": "<one or two sentences of feedback>"}`;
 
@@ -60,7 +65,11 @@ You must reply in the following JSON format only (no other content):
       ? `题目：${question}
 满分：${points}分
 ${commentPrompt ? `评分要点：${commentPrompt}\n` : ''}学生答案：${userAnswer}`
-      : `Question: ${question}
+      : isRu
+        ? `Вопрос: ${question}
+Максимум: ${points} баллов
+${commentPrompt ? `Критерии оценивания: ${commentPrompt}\n` : ''}Ответ студента: ${userAnswer}`
+        : `Question: ${question}
 Full marks: ${points} points
 ${commentPrompt ? `Grading guidance: ${commentPrompt}\n` : ''}Student answer: ${userAnswer}`;
 
@@ -92,7 +101,9 @@ ${commentPrompt ? `Grading guidance: ${commentPrompt}\n` : ''}Student answer: ${
         score: Math.round(points * 0.5),
         comment: isZh
           ? '已作答，请参考标准答案。'
-          : 'Answer received. Please refer to the standard answer.',
+          : isRu
+            ? 'Ответ получен. Сверьтесь с эталонным ответом.'
+            : 'Answer received. Please refer to the standard answer.',
       };
     }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,17 +54,20 @@ import { useImportClassroom } from '@/lib/import/use-import-classroom';
 const log = createLogger('Home');
 
 const WEB_SEARCH_STORAGE_KEY = 'webSearchEnabled';
+const LANGUAGE_STORAGE_KEY = 'generationLanguage';
 const RECENT_OPEN_STORAGE_KEY = 'recentClassroomsOpen';
 
 interface FormState {
   pdfFile: File | null;
   requirement: string;
+  language: 'zh-CN' | 'en-US' | 'ru-RU';
   webSearch: boolean;
 }
 
 const initialFormState: FormState = {
   pdfFile: null,
   requirement: '',
+  language: 'zh-CN',
   webSearch: false,
 };
 
@@ -97,8 +100,19 @@ function HomePage() {
     }
     try {
       const savedWebSearch = localStorage.getItem(WEB_SEARCH_STORAGE_KEY);
+      const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
       const updates: Partial<FormState> = {};
       if (savedWebSearch === 'true') updates.webSearch = true;
+      if (savedLanguage === 'zh-CN' || savedLanguage === 'en-US' || savedLanguage === 'ru-RU') {
+        updates.language = savedLanguage;
+      } else {
+        const navLang = navigator.language?.toLowerCase() || '';
+        updates.language = navLang.startsWith('zh')
+          ? 'zh-CN'
+          : navLang.startsWith('ru')
+            ? 'ru-RU'
+            : 'en-US';
+      }
       if (Object.keys(updates).length > 0) {
         setForm((prev) => ({ ...prev, ...updates }));
       }
@@ -198,6 +212,7 @@ function HomePage() {
     setForm((prev) => ({ ...prev, [field]: value }));
     try {
       if (field === 'webSearch') localStorage.setItem(WEB_SEARCH_STORAGE_KEY, String(value));
+      if (field === 'language') localStorage.setItem(LANGUAGE_STORAGE_KEY, String(value));
       if (field === 'requirement') updateRequirementCache(value as string);
     } catch {
       /* ignore */
@@ -257,6 +272,7 @@ function HomePage() {
       const userProfile = useUserProfileStore.getState();
       const requirements: UserRequirements = {
         requirement: form.requirement,
+        language: form.language,
         userNickname: userProfile.nickname || undefined,
         userBio: userProfile.bio || undefined,
         webSearch: form.webSearch || undefined,
@@ -503,6 +519,8 @@ function HomePage() {
             <div className="px-3 pb-3 flex items-end gap-2">
               <div className="flex-1 min-w-0">
                 <GenerationToolbar
+                  language={form.language}
+                  onLanguageChange={(lang) => updateForm('language', lang)}
                   webSearch={form.webSearch}
                   onWebSearchChange={(v) => updateForm('webSearch', v)}
                   onSettingsOpen={(section) => {

--- a/components/generation/generation-toolbar.tsx
+++ b/components/generation/generation-toolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useMemo } from 'react';
-import { Bot, Check, ChevronLeft, Paperclip, FileText, X, Globe2 } from 'lucide-react';
+import { Bot, Check, ChevronLeft, Globe, Paperclip, FileText, X, Globe2 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
@@ -29,6 +29,8 @@ const MAX_PDF_SIZE_BYTES = MAX_PDF_SIZE_MB * 1024 * 1024;
 
 // ─── Types ───────────────────────────────────────────────────
 export interface GenerationToolbarProps {
+  language: 'zh-CN' | 'en-US' | 'ru-RU';
+  onLanguageChange: (lang: 'zh-CN' | 'en-US' | 'ru-RU') => void;
   webSearch: boolean;
   onWebSearchChange: (v: boolean) => void;
   onSettingsOpen: (section?: SettingsSection) => void;
@@ -40,6 +42,8 @@ export interface GenerationToolbarProps {
 
 // ─── Component ───────────────────────────────────────────────
 export function GenerationToolbar({
+  language,
+  onLanguageChange,
   webSearch,
   onWebSearchChange,
   onSettingsOpen,
@@ -355,6 +359,24 @@ export function GenerationToolbar({
           <TooltipContent>{t('toolbar.webSearchNoProvider')}</TooltipContent>
         </Tooltip>
       )}
+
+      {/* ── Language pill ── */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={() =>
+              onLanguageChange(
+                language === 'zh-CN' ? 'ru-RU' : language === 'ru-RU' ? 'en-US' : 'zh-CN',
+              )
+            }
+            className={pillMuted}
+          >
+            <Globe className="size-3.5" />
+            <span>{language === 'zh-CN' ? '中文' : language === 'ru-RU' ? 'RU' : 'EN'}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Generation language</TooltipContent>
+      </Tooltip>
 
       {/* ── Separator ── */}
       <div className="w-px h-4 bg-border/60 mx-1" />

--- a/components/scene-renderers/quiz-view.tsx
+++ b/components/scene-renderers/quiz-view.tsx
@@ -129,7 +129,9 @@ async function gradeShortAnswerQuestion(
       aiComment:
         language === 'zh-CN'
           ? '评分服务暂时不可用，已给予基础分。'
-          : 'Grading service unavailable. Base score given.',
+          : language === 'ru-RU'
+            ? 'Сервис оценки временно недоступен. Начислен базовый балл.'
+            : 'Grading service unavailable. Base score given.',
     };
   }
 }

--- a/lib/generation/outline-generator.ts
+++ b/lib/generation/outline-generator.ts
@@ -29,6 +29,12 @@ function getLocalizedEmpty(language: string, kind: 'images' | 'content' | 'resea
   return kind === 'images' ? 'No images available' : 'None';
 }
 
+function resolveRequirementLanguage(language?: string): 'zh-CN' | 'en-US' | 'ru-RU' {
+  if (language === 'en-US') return 'en-US';
+  if (language === 'ru-RU') return 'ru-RU';
+  return 'zh-CN';
+}
+
 /**
  * Generate scene outlines from user requirements
  * Now uses simplified UserRequirements with just requirement text and language
@@ -48,8 +54,10 @@ export async function generateSceneOutlinesFromRequirements(
     teacherContext?: string;
   },
 ): Promise<GenerationResult<{ languageDirective: string; outlines: SceneOutline[] }>> {
+  const requirementLanguage = resolveRequirementLanguage(requirements.language);
+
   // Build available images description for the prompt
-  let availableImagesText = getLocalizedEmpty(requirements.language, 'images');
+  let availableImagesText = getLocalizedEmpty(requirementLanguage, 'images');
   let visionImages: Array<{ id: string; src: string }> | undefined;
 
   if (pdfImages && pdfImages.length > 0) {
@@ -61,10 +69,10 @@ export async function generateSceneOutlinesFromRequirements(
       const noSrcImages = pdfImages.filter((img) => !options.imageMapping![img.id]);
 
       const visionDescriptions = visionSlice.map((img) =>
-        formatImagePlaceholder(img, requirements.language),
+        formatImagePlaceholder(img, requirementLanguage),
       );
       const textDescriptions = [...textOnlySlice, ...noSrcImages].map((img) =>
-        formatImageDescription(img, requirements.language),
+        formatImageDescription(img, requirementLanguage),
       );
       availableImagesText = [...visionDescriptions, ...textDescriptions].join('\n');
 
@@ -77,7 +85,7 @@ export async function generateSceneOutlinesFromRequirements(
     } else {
       // Text-only mode: full descriptions
       availableImagesText = pdfImages
-        .map((img) => formatImageDescription(img, requirements.language))
+        .map((img) => formatImageDescription(img, requirementLanguage))
         .join('\n');
     }
   }
@@ -107,15 +115,14 @@ export async function generateSceneOutlinesFromRequirements(
   const prompts = buildPrompt(PROMPT_IDS.REQUIREMENTS_TO_OUTLINES, {
     // New simplified variables
     requirement: requirements.requirement,
-    language: requirements.language,
+    language: requirementLanguage,
     pdfContent: pdfText
       ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS)
-      : getLocalizedEmpty(requirements.language, 'content'),
+      : getLocalizedEmpty(requirementLanguage, 'content'),
     availableImages: availableImagesText,
     userProfile: userProfileText,
     mediaGenerationPolicy,
-    researchContext:
-      options?.researchContext || getLocalizedEmpty(requirements.language, 'research'),
+    researchContext: options?.researchContext || getLocalizedEmpty(requirementLanguage, 'research'),
     // Server-side generation populates this via options; client-side populates via formatTeacherPersonaForPrompt
     teacherContext: options?.teacherContext || '',
   });
@@ -160,7 +167,7 @@ export async function generateSceneOutlinesFromRequirements(
       ...outline,
       id: outline.id || nanoid(),
       order: index + 1,
-      language: outline.language || requirements.language,
+      language: outline.language || requirementLanguage,
     }));
 
     // Replace sequential gen_img_N/gen_vid_N with globally unique IDs

--- a/lib/generation/outline-generator.ts
+++ b/lib/generation/outline-generator.ts
@@ -19,6 +19,16 @@ import type { AICallFn, GenerationResult, GenerationCallbacks } from './pipeline
 import { createLogger } from '@/lib/logger';
 const log = createLogger('Generation');
 
+function getLocalizedEmpty(language: string, kind: 'images' | 'content' | 'research'): string {
+  if (language === 'zh-CN') {
+    return kind === 'images' ? '无可用图片' : '无';
+  }
+  if (language === 'ru-RU') {
+    return kind === 'images' ? 'Нет доступных изображений' : 'Нет';
+  }
+  return kind === 'images' ? 'No images available' : 'None';
+}
+
 /**
  * Generate scene outlines from user requirements
  * Now uses simplified UserRequirements with just requirement text and language
@@ -39,7 +49,7 @@ export async function generateSceneOutlinesFromRequirements(
   },
 ): Promise<GenerationResult<{ languageDirective: string; outlines: SceneOutline[] }>> {
   // Build available images description for the prompt
-  let availableImagesText = 'No images available';
+  let availableImagesText = getLocalizedEmpty(requirements.language, 'images');
   let visionImages: Array<{ id: string; src: string }> | undefined;
 
   if (pdfImages && pdfImages.length > 0) {
@@ -50,9 +60,11 @@ export async function generateSceneOutlinesFromRequirements(
       const textOnlySlice = allWithSrc.slice(MAX_VISION_IMAGES);
       const noSrcImages = pdfImages.filter((img) => !options.imageMapping![img.id]);
 
-      const visionDescriptions = visionSlice.map((img) => formatImagePlaceholder(img));
+      const visionDescriptions = visionSlice.map((img) =>
+        formatImagePlaceholder(img, requirements.language),
+      );
       const textDescriptions = [...textOnlySlice, ...noSrcImages].map((img) =>
-        formatImageDescription(img),
+        formatImageDescription(img, requirements.language),
       );
       availableImagesText = [...visionDescriptions, ...textDescriptions].join('\n');
 
@@ -64,7 +76,9 @@ export async function generateSceneOutlinesFromRequirements(
       }));
     } else {
       // Text-only mode: full descriptions
-      availableImagesText = pdfImages.map((img) => formatImageDescription(img)).join('\n');
+      availableImagesText = pdfImages
+        .map((img) => formatImageDescription(img, requirements.language))
+        .join('\n');
     }
   }
 
@@ -93,11 +107,15 @@ export async function generateSceneOutlinesFromRequirements(
   const prompts = buildPrompt(PROMPT_IDS.REQUIREMENTS_TO_OUTLINES, {
     // New simplified variables
     requirement: requirements.requirement,
-    pdfContent: pdfText ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS) : 'None',
+    language: requirements.language,
+    pdfContent: pdfText
+      ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS)
+      : getLocalizedEmpty(requirements.language, 'content'),
     availableImages: availableImagesText,
     userProfile: userProfileText,
     mediaGenerationPolicy,
-    researchContext: options?.researchContext || 'None',
+    researchContext:
+      options?.researchContext || getLocalizedEmpty(requirements.language, 'research'),
     // Server-side generation populates this via options; client-side populates via formatTeacherPersonaForPrompt
     teacherContext: options?.teacherContext || '',
   });
@@ -125,7 +143,6 @@ export async function generateSceneOutlinesFromRequirements(
     let rawOutlines: SceneOutline[];
 
     if (Array.isArray(parsed)) {
-      // Fallback: LLM returned old flat array format
       languageDirective = 'Teach in the language that matches the user requirement.';
       rawOutlines = parsed;
     } else if (parsed && parsed.outlines) {
@@ -133,18 +150,17 @@ export async function generateSceneOutlinesFromRequirements(
         parsed.languageDirective || 'Teach in the language that matches the user requirement.';
       rawOutlines = parsed.outlines;
     } else {
-      return { success: false, error: 'Failed to parse scene outlines response' };
+      return {
+        success: false,
+        error: 'Failed to parse scene outlines response',
+      };
     }
 
-    if (!Array.isArray(rawOutlines)) {
-      return { success: false, error: 'Failed to parse scene outlines response' };
-    }
-
-    // Ensure IDs and order
     const enriched = rawOutlines.map((outline, index) => ({
       ...outline,
       id: outline.id || nanoid(),
       order: index + 1,
+      language: outline.language || requirements.language,
     }));
 
     // Replace sequential gen_img_N/gen_vid_N with globally unique IDs

--- a/lib/generation/prompt-formatters.ts
+++ b/lib/generation/prompt-formatters.ts
@@ -75,27 +75,45 @@ export function formatTeacherPersonaForPrompt(agents?: AgentInfo[]): string {
  * Format a single PdfImage description for prompt inclusion.
  * Includes dimension/aspect-ratio info when available.
  */
-export function formatImageDescription(img: PdfImage): string {
+export function formatImageDescription(img: PdfImage, language: string = 'en-US'): string {
   let dimInfo = '';
   if (img.width && img.height) {
     const ratio = (img.width / img.height).toFixed(2);
-    dimInfo = ` | size: ${img.width}×${img.height} (aspect ratio ${ratio})`;
+    dimInfo =
+      language === 'zh-CN'
+        ? ` | 尺寸: ${img.width}×${img.height} (宽高比${ratio})`
+        : language === 'ru-RU'
+          ? ` | Размер: ${img.width}×${img.height} (соотношение ${ratio})`
+          : ` | Size: ${img.width}×${img.height} (aspect ratio ${ratio})`;
   }
   const desc = img.description ? ` | ${img.description}` : '';
-  return `- **${img.id}**: from PDF page ${img.pageNumber}${dimInfo}${desc}`;
+  return language === 'zh-CN'
+    ? `- **${img.id}**: 来自PDF第${img.pageNumber}页${dimInfo}${desc}`
+    : language === 'ru-RU'
+      ? `- **${img.id}**: из PDF, страница ${img.pageNumber}${dimInfo}${desc}`
+      : `- **${img.id}**: from PDF page ${img.pageNumber}${dimInfo}${desc}`;
 }
 
 /**
  * Format a short image placeholder for vision mode.
  * Only ID + page + dimensions + aspect ratio (no description), since the model can see the actual image.
  */
-export function formatImagePlaceholder(img: PdfImage): string {
+export function formatImagePlaceholder(img: PdfImage, language: string = 'en-US'): string {
   let dimInfo = '';
   if (img.width && img.height) {
     const ratio = (img.width / img.height).toFixed(2);
-    dimInfo = ` | size: ${img.width}×${img.height} (aspect ratio ${ratio})`;
+    dimInfo =
+      language === 'zh-CN'
+        ? ` | 尺寸: ${img.width}×${img.height} (宽高比${ratio})`
+        : language === 'ru-RU'
+          ? ` | Размер: ${img.width}×${img.height} (соотношение ${ratio})`
+          : ` | Size: ${img.width}×${img.height} (aspect ratio ${ratio})`;
   }
-  return `- **${img.id}**: image from PDF page ${img.pageNumber}${dimInfo} [see attached]`;
+  return language === 'zh-CN'
+    ? `- **${img.id}**: PDF第${img.pageNumber}页的图片${dimInfo} [参见附图]`
+    : language === 'ru-RU'
+      ? `- **${img.id}**: изображение из PDF, страница ${img.pageNumber}${dimInfo} [см. вложение]`
+      : `- **${img.id}**: image from PDF page ${img.pageNumber}${dimInfo} [see attached]`;
 }
 
 /**

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -876,8 +876,7 @@ async function generatePBLSceneContent(
         projectDescription: pblConfig.projectDescription,
         targetSkills: pblConfig.targetSkills,
         issueCount: pblConfig.issueCount,
-        languageDirective:
-          languageDirective || 'Teach in the language that matches the user requirement.',
+        language: pblConfig.language || outline.language || 'en-US',
       },
       languageModel,
       {

--- a/lib/orchestration/prompt-builder.ts
+++ b/lib/orchestration/prompt-builder.ts
@@ -163,9 +163,11 @@ Personalize your teaching based on their background when relevant. Address them 
 
   const roleGuideline = ROLE_GUIDELINES[agentConfig.role] || ROLE_GUIDELINES.student;
 
-  // Build language constraint from stage language directive
-  const langDirective = storeState.stage?.languageDirective;
-  const languageConstraint = langDirective ? `\n# Language (CRITICAL)\n${langDirective}\n` : '';
+  // Build language constraint from stage language
+  const courseLanguage = storeState.stage?.language;
+  const languageConstraint = courseLanguage
+    ? `\n# Language (CRITICAL)\nYou MUST speak in ${courseLanguage === 'zh-CN' ? 'Chinese (Simplified)' : courseLanguage === 'en-US' ? 'English' : courseLanguage === 'ru-RU' ? 'Russian' : courseLanguage}. ALL text content in your response MUST be in this language.\n`
+    : '';
 
   return `# Role
 You are ${agentConfig.name}.
@@ -221,10 +223,9 @@ ${buildWhiteboardGuidelines(agentConfig.role)}
 ${actionDescriptions}
 
 ## Action Usage Guidelines
-${slideActionGuidelines}- Whiteboard actions (wb_open, wb_draw_text, wb_draw_shape, wb_draw_chart, wb_draw_latex, wb_draw_table, wb_draw_line, wb_draw_code, wb_edit_code, wb_delete, wb_clear, wb_close): Use when explaining concepts that benefit from diagrams, formulas, data charts, tables, connecting lines, code demonstrations, or step-by-step derivations. Use wb_draw_latex for math formulas, wb_draw_chart for data visualization, wb_draw_table for structured data, wb_draw_code for code demonstrations.
+${slideActionGuidelines}- Whiteboard actions (wb_open, wb_draw_text, wb_draw_shape, wb_draw_chart, wb_draw_latex, wb_draw_table, wb_draw_line, wb_delete, wb_clear, wb_close): Use when explaining concepts that benefit from diagrams, formulas, data charts, tables, connecting lines, or step-by-step derivations. Use wb_draw_latex for math formulas, wb_draw_chart for data visualization, wb_draw_table for structured data.
 - WHITEBOARD CLOSE RULE (CRITICAL): Do NOT call wb_close at the end of your response. Leave the whiteboard OPEN so students can read what you drew. Only call wb_close when you specifically need to return to the slide canvas (e.g., to use spotlight or laser on slide elements). Frequent open/close is distracting.
 - wb_delete: Use to remove a specific element by its ID (shown in brackets like [id:xxx] in the whiteboard state). Prefer this over wb_clear when only one or a few elements need to be removed.
-- wb_draw_code / wb_edit_code: To modify an existing code block, ALWAYS use wb_edit_code (insert_after, insert_before, delete_lines, replace_lines) instead of deleting the code element and re-creating it. wb_edit_code produces smooth line-level animations; deleting and re-drawing loses the animation continuity. Only use wb_draw_code for creating a brand-new code block.
 ${mutualExclusionNote}
 
 # Current State
@@ -333,7 +334,6 @@ This project uses KaTeX for formula rendering, which supports virtually all stan
 - Use chart elements for data visualization (bar charts, line graphs, pie charts, etc.).
 - Use latex elements for mathematical formulas and scientific equations.
 - Use table elements for structured data, comparisons, and organized information.
-- Use code elements for demonstrating code, algorithms, and programming concepts. Code blocks have syntax highlighting and support line-by-line editing.
 - Use shape elements sparingly — only for simple diagrams. Do not add large numbers of meaningless shapes.
 - Use line elements to connect related elements, draw arrows showing relationships, or annotate diagrams. Specify arrow markers via the points parameter.
 - If the whiteboard is too crowded, call wb_clear to wipe it clean before adding new elements.
@@ -373,12 +373,6 @@ The whiteboard canvas is 1000 × 562 pixels. Follow these rules to prevent eleme
 - Check existing elements' positions in the whiteboard state
 - Ensure your new element's bounding box does not overlap with any existing element
 - If space is insufficient, use wb_delete to remove unneeded elements or wb_clear to start fresh
-
-### Code Element Layout & Usage
-- Code blocks have a **header bar (~32px)** showing the file name and language. The actual code content starts below the header. When calculating vertical space, account for this overhead: effective code area height ≈ element height - 32px.
-- Each code line is ~22px tall (at default fontSize 14). Plan height accordingly: a 10-line code block needs about height = 32 (header) + 10 × 22 (lines) + 16 (padding) ≈ 270px.
-- Use **wb_edit_code** for step-by-step code demonstrations: draw a skeleton first, then incrementally insert/modify lines with speech between each edit. This creates a "live coding" effect.
-- When editing code, reference lines by their stable IDs (L1, L2, ...) shown in the whiteboard state. Do NOT guess line IDs — always check the current whiteboard state first.
 ${latexGuidelines}
 ${common}`;
   }
@@ -454,18 +448,6 @@ function summarizeElement(el: any): string {
       const ex = el.end?.[0] ?? 0;
       const ey = el.end?.[1] ?? 0;
       return `${id} line: (${lx + sx},${ly + sy}) → (${lx + ex},${ly + ey})`;
-    }
-    case 'code': {
-      const lang = el.language || 'unknown';
-      const lineCount = el.lines?.length || 0;
-      const codeFn = el.fileName ? ` "${el.fileName}"` : '';
-      const linePreview = (el.lines || [])
-        .slice(0, 10)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map((l: any) => `    ${l.id}: ${l.content}`)
-        .join('\n');
-      const moreLines = lineCount > 10 ? `\n    ... and ${lineCount - 10} more lines` : '';
-      return `${id} code${codeFn} (${lang}, ${lineCount} lines) ${pos}${size}\n${linePreview}${moreLines}`;
     }
     case 'video':
       return `${id} video ${pos}${size}`;
@@ -606,30 +588,6 @@ function buildVirtualWhiteboardContext(
         elements.push({
           agentName: record.agentName,
           summary: `line${hasArrow}: (${sx},${sy}) → (${ex},${ey})`,
-        });
-        break;
-      }
-      case 'wb_draw_code': {
-        const lang = String(record.params.language || '');
-        const codeFileName = record.params.fileName ? ` "${record.params.fileName}"` : '';
-        const x = record.params.x ?? '?';
-        const y = record.params.y ?? '?';
-        const w = record.params.width ?? 500;
-        const h = record.params.height ?? 300;
-        const code = String(record.params.code || '');
-        const lineCount = code.split('\n').length;
-        elements.push({
-          agentName: record.agentName,
-          summary: `code block${codeFileName} (${lang}, ${lineCount} lines) at (${x},${y}), size ${w}x${h}`,
-        });
-        break;
-      }
-      case 'wb_edit_code': {
-        const op = record.params.operation || 'edit';
-        const targetId = record.params.elementId || '?';
-        elements.push({
-          agentName: record.agentName,
-          summary: `edited code "${targetId}" (${op})`,
         });
         break;
       }

--- a/lib/pbl/generate-pbl.ts
+++ b/lib/pbl/generate-pbl.ts
@@ -25,7 +25,7 @@ export interface GeneratePBLConfig {
   projectDescription: string;
   targetSkills: string[];
   issueCount?: number;
-  languageDirective: string;
+  language: string;
 }
 
 export interface GeneratePBLCallbacks {
@@ -44,7 +44,7 @@ export async function generatePBLContent(
   model: LanguageModel,
   callbacks?: GeneratePBLCallbacks,
 ): Promise<PBLProjectConfig> {
-  const { languageDirective } = config;
+  const { language } = config;
 
   // Initialize shared state
   const projectConfig: PBLProjectConfig = {
@@ -61,9 +61,15 @@ export async function generatePBLContent(
   );
   const projectMCP = new ProjectMCP(projectConfig);
   const agentMCP = new AgentMCP(projectConfig);
-  const issueboardMCP = new IssueboardMCP(projectConfig, agentMCP, languageDirective);
+  const issueboardMCP = new IssueboardMCP(projectConfig, agentMCP, language);
 
-  callbacks?.onProgress?.('Starting PBL project generation...');
+  callbacks?.onProgress?.(
+    language === 'zh-CN'
+      ? '开始生成 PBL 项目...'
+      : language === 'ru-RU'
+        ? 'Запускаю генерацию PBL-проекта...'
+        : 'Starting PBL project generation...',
+  );
 
   // Define tools with Zod schemas, delegating to MCP instances
   const pblTools = {
@@ -287,16 +293,33 @@ export async function generatePBLContent(
     {
       model,
       system: systemPrompt,
-      prompt: `Design a PBL project. Start in project_info mode by setting the project title and description.`,
+      prompt:
+        language === 'zh-CN'
+          ? `请设计一个PBL项目。现在从 project_info 模式开始，先设置项目标题和描述。`
+          : language === 'ru-RU'
+            ? `Спроектируй PBL-проект. Начни с режима project_info и сначала задай название и описание проекта.`
+            : `Design a PBL project. Start in project_info mode by setting the project title and description.`,
       tools: pblTools,
       stopWhen: stepCountIs(30),
       onStepFinish: ({ toolCalls, text }) => {
         if (text) {
-          callbacks?.onProgress?.(`Thinking: ${text.slice(0, 100)}...`);
+          callbacks?.onProgress?.(
+            language === 'zh-CN'
+              ? `思考中: ${text.slice(0, 100)}...`
+              : language === 'ru-RU'
+                ? `Думаю: ${text.slice(0, 100)}...`
+                : `Thinking: ${text.slice(0, 100)}...`,
+          );
         }
         if (toolCalls) {
           for (const tc of toolCalls) {
-            callbacks?.onProgress?.(`Tool: ${tc.toolName}`);
+            callbacks?.onProgress?.(
+              language === 'zh-CN'
+                ? `工具: ${tc.toolName}`
+                : language === 'ru-RU'
+                  ? `Инструмент: ${tc.toolName}`
+                  : `Tool: ${tc.toolName}`,
+            );
           }
         }
       },
@@ -307,16 +330,32 @@ export async function generatePBLContent(
   // Check if mode reached idle; if not, the LLM may have stopped early
   if (modeMCP.getCurrentMode() !== 'idle') {
     callbacks?.onProgress?.(
-      'Warning: Generation did not reach idle mode. Project may be incomplete.',
+      language === 'zh-CN'
+        ? '警告：生成流程未进入 idle 模式，项目可能不完整。'
+        : language === 'ru-RU'
+          ? 'Предупреждение: генерация не дошла до режима idle, проект может быть неполным.'
+          : 'Warning: Generation did not reach idle mode. Project may be incomplete.',
     );
   }
 
-  callbacks?.onProgress?.('PBL structure generated. Running post-processing...');
+  callbacks?.onProgress?.(
+    language === 'zh-CN'
+      ? 'PBL 结构已生成，开始后处理...'
+      : language === 'ru-RU'
+        ? 'PBL-структура создана, запускаю постобработку...'
+        : 'PBL structure generated. Running post-processing...',
+  );
 
   // Post-processing: activate first issue and generate initial questions
-  await postProcessPBL(projectConfig, model, languageDirective, callbacks);
+  await postProcessPBL(projectConfig, model, language, callbacks);
 
-  callbacks?.onProgress?.('PBL project generation complete!');
+  callbacks?.onProgress?.(
+    language === 'zh-CN'
+      ? 'PBL 项目生成完成！'
+      : language === 'ru-RU'
+        ? 'Генерация PBL-проекта завершена!'
+        : 'PBL project generation complete!',
+  );
 
   return projectConfig;
 }
@@ -330,7 +369,7 @@ export async function generatePBLContent(
 async function postProcessPBL(
   config: PBLProjectConfig,
   model: LanguageModel,
-  languageDirective: string,
+  language: string,
   callbacks?: GeneratePBLCallbacks,
 ): Promise<void> {
   const { issueboard, agents } = config;
@@ -345,19 +384,74 @@ async function postProcessPBL(
   firstIssue.is_active = true;
   issueboard.current_issue_id = firstIssue.id;
 
-  callbacks?.onProgress?.(`Activating first issue: ${firstIssue.title}`);
+  callbacks?.onProgress?.(
+    language === 'zh-CN'
+      ? `激活第一个任务: ${firstIssue.title}`
+      : language === 'ru-RU'
+        ? `Активирую первую задачу: ${firstIssue.title}`
+        : `Activating first issue: ${firstIssue.title}`,
+  );
 
   // Generate initial questions for the first issue
   const questionAgent = agents.find((a) => a.name === firstIssue.question_agent_name);
   if (!questionAgent) {
-    callbacks?.onProgress?.('Warning: Question agent not found for first issue.');
+    callbacks?.onProgress?.(
+      language === 'zh-CN'
+        ? '警告：未找到首个任务的 Question Agent。'
+        : language === 'ru-RU'
+          ? 'Предупреждение: для первой задачи не найден Question Agent.'
+          : 'Warning: Question agent not found for first issue.',
+    );
     return;
   }
 
   try {
-    callbacks?.onProgress?.('Generating initial questions for first issue...');
+    callbacks?.onProgress?.(
+      language === 'zh-CN'
+        ? '为首个任务生成初始问题...'
+        : language === 'ru-RU'
+          ? 'Генерирую стартовые вопросы для первой задачи...'
+          : 'Generating initial questions for first issue...',
+    );
 
-    const context = `## Issue Information
+    const context =
+      language === 'zh-CN'
+        ? `## 任务信息
+
+**标题**: ${firstIssue.title}
+**描述**: ${firstIssue.description}
+**负责人**: ${firstIssue.person_in_charge}
+${firstIssue.participants.length > 0 ? `**参与者**: ${firstIssue.participants.join('、')}` : ''}
+${firstIssue.notes ? `**备注**: ${firstIssue.notes}` : ''}
+
+## 你的任务
+
+根据以上任务信息，生成1-3个具体、可操作的引导问题，帮助学生理解和完成这个任务。每个问题应：
+- 引导学生达成关键学习目标
+- 具体且可操作
+- 帮助分解问题
+- 鼓励批判性思考
+
+请以编号列表格式回答。`
+        : language === 'ru-RU'
+          ? `## Информация по задаче
+
+**Заголовок**: ${firstIssue.title}
+**Описание**: ${firstIssue.description}
+**Ответственный**: ${firstIssue.person_in_charge}
+${firstIssue.participants.length > 0 ? `**Участники**: ${firstIssue.participants.join(', ')}` : ''}
+${firstIssue.notes ? `**Примечания**: ${firstIssue.notes}` : ''}
+
+## Твоя задача
+
+На основе информации выше сгенерируй 1-3 конкретных и практичных вопроса, которые помогут студенту понять и выполнить эту задачу. Каждый вопрос должен:
+- вести к ключевым учебным целям
+- быть конкретным и применимым
+- помогать разбить проблему на части
+- стимулировать критическое мышление
+
+Ответь нумерованным списком.`
+          : `## Issue Information
 
 **Title**: ${firstIssue.title}
 **Description**: ${firstIssue.description}
@@ -367,16 +461,13 @@ ${firstIssue.notes ? `**Notes**: ${firstIssue.notes}` : ''}
 
 ## Your Task
 
-Generate a welcome message for the student working on this issue. The message should:
-1. Start with a friendly greeting introducing yourself as the guiding assistant for this issue (use a natural, localized title — do NOT use the English term "Question Agent" directly in non-English contexts)
-2. Present 1-3 specific, actionable guiding questions based on the issue information above, each question should:
-   - Guide students toward key learning objectives
-   - Be specific and actionable
-   - Help break down the problem
-   - Encourage critical thinking
-3. End by encouraging the student to type \`@question\` anytime for help (keep the literal \`@question\` as-is since it triggers the agent system)
+Based on the issue information above, generate 1-3 specific, actionable questions that will help students understand and complete this issue. Each question should:
+- Guide students toward key learning objectives
+- Be specific and actionable
+- Help break down the problem
+- Encourage critical thinking
 
-Format the questions as a numbered list.`;
+Format your response as a numbered list.`;
 
     const questionResult = await callLLM(
       {
@@ -390,18 +481,34 @@ Format the questions as a numbered list.`;
     const generatedQuestions = questionResult.text;
     firstIssue.generated_questions = generatedQuestions;
 
+    // Add welcome message to chat
+    const welcomeMessage =
+      language === 'zh-CN'
+        ? `你好！我是这个任务的提问助手："${firstIssue.title}"\n\n为了引导你的学习，我准备了一些问题：\n\n${generatedQuestions}\n\n随时 @question 我来获取帮助或澄清！`
+        : `Hello! I'm your Question Agent for this issue: "${firstIssue.title}"\n\nTo help guide your work, I've prepared some questions for you:\n\n${generatedQuestions}\n\nFeel free to @question me anytime if you need help or clarification!`;
+
     config.chat.messages.push({
       id: `msg_welcome_${Date.now()}`,
       agent_name: firstIssue.question_agent_name,
-      message: generatedQuestions,
+      message: welcomeMessage,
       timestamp: Date.now(),
       read_by: [],
     });
 
-    callbacks?.onProgress?.('Initial questions generated and welcome message added.');
+    callbacks?.onProgress?.(
+      language === 'zh-CN'
+        ? '已生成初始问题并写入欢迎消息。'
+        : language === 'ru-RU'
+          ? 'Стартовые вопросы сгенерированы, приветственное сообщение добавлено.'
+          : 'Initial questions generated and welcome message added.',
+    );
   } catch (error) {
     callbacks?.onProgress?.(
-      `Warning: Failed to generate initial questions: ${error instanceof Error ? error.message : String(error)}`,
+      language === 'zh-CN'
+        ? `警告：生成初始问题失败: ${error instanceof Error ? error.message : String(error)}`
+        : language === 'ru-RU'
+          ? `Предупреждение: не удалось сгенерировать стартовые вопросы: ${error instanceof Error ? error.message : String(error)}`
+          : `Warning: Failed to generate initial questions: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }

--- a/lib/pbl/mcp/agent-templates.ts
+++ b/lib/pbl/mcp/agent-templates.ts
@@ -1,14 +1,30 @@
 /**
  * Agent template prompts for PBL Question and Judge agents.
  *
- * Uses languageDirective for multi-language support.
+ * Migrated from PBL-Nano with multi-language support.
  */
 
-export function getQuestionAgentPrompt(languageDirective: string): string {
-  const languageSection = languageDirective
-    ? `\n## Language\n\n${languageDirective}\n\nAll responses must follow this language directive.`
-    : '';
-  return `You are a Question Agent in a Project-Based Learning platform. Your role is to help students understand and complete their assigned issue.
+export function getQuestionAgentPrompt(language: string = 'en-US'): string {
+  if (language === 'zh-CN') {
+    return QUESTION_AGENT_TEMPLATE_PROMPT_ZH;
+  }
+  if (language === 'ru-RU') {
+    return QUESTION_AGENT_TEMPLATE_PROMPT_RU;
+  }
+  return QUESTION_AGENT_TEMPLATE_PROMPT;
+}
+
+export function getJudgeAgentPrompt(language: string = 'en-US'): string {
+  if (language === 'zh-CN') {
+    return JUDGE_AGENT_TEMPLATE_PROMPT_ZH;
+  }
+  if (language === 'ru-RU') {
+    return JUDGE_AGENT_TEMPLATE_PROMPT_RU;
+  }
+  return JUDGE_AGENT_TEMPLATE_PROMPT;
+}
+
+export const QUESTION_AGENT_TEMPLATE_PROMPT = `You are a Question Agent in a Project-Based Learning platform. Your role is to help students understand and complete their assigned issue.
 
 ## Your Responsibilities:
 
@@ -24,14 +40,9 @@ export function getQuestionAgentPrompt(languageDirective: string): string {
 - Be encouraging and supportive
 - Focus on learning process, not just answers
 - Help students break down complex problems
-- Guide them to relevant resources or thinking approaches${languageSection}`;
-}
+- Guide them to relevant resources or thinking approaches`;
 
-export function getJudgeAgentPrompt(languageDirective: string): string {
-  const languageSection = languageDirective
-    ? `\n## Language\n\n${languageDirective}\n\nAll responses must follow this language directive.`
-    : '';
-  return `You are a Judge Agent in a Project-Based Learning platform. Your role is to evaluate whether students have completed their assigned issue successfully.
+export const JUDGE_AGENT_TEMPLATE_PROMPT = `You are a Judge Agent in a Project-Based Learning platform. Your role is to evaluate whether students have completed their assigned issue successfully.
 
 ## Your Responsibilities:
 
@@ -51,5 +62,84 @@ export function getJudgeAgentPrompt(languageDirective: string): string {
 - Be fair but encouraging
 - Provide specific, actionable feedback
 - Focus on learning outcomes, not perfection
-- Celebrate successes while identifying growth areas${languageSection}`;
-}
+- Celebrate successes while identifying growth areas`;
+
+const QUESTION_AGENT_TEMPLATE_PROMPT_ZH = `你是项目式学习平台中的提问助手（Question Agent）。你的职责是帮助学生理解并完成分配给他们的任务。
+
+## 你的职责：
+
+1. **生成初始问题**：当任务被激活时，根据任务标题和描述生成1-3个具体、可操作的引导问题。
+
+2. **回答学生疑问**：当学生 @mention 你时：
+   - 提供有用的提示和引导
+   - 通过反问帮助他们批判性思考
+   - 不直接给出答案——帮助他们自己发现解决方案
+   - 围绕生成的引导问题保持方向
+
+## 准则：
+- 鼓励和支持学生
+- 关注学习过程，而非仅关注答案
+- 帮助学生分解复杂问题
+- 引导他们找到相关资源或思路`;
+
+const JUDGE_AGENT_TEMPLATE_PROMPT_ZH = `你是项目式学习平台中的评判助手（Judge Agent）。你的职责是评估学生是否成功完成了分配的任务。
+
+## 你的职责：
+
+1. **评估完成度**：当学生 @mention 你时：
+   - 请他们解释完成了什么
+   - 对照任务描述和引导问题审核他们的工作
+   - 提供建设性反馈
+   - 判断任务是否完成或需要改进
+
+2. **反馈格式**：
+   - 突出做得好的地方
+   - 指出不足和改进空间
+   - 如果未完成，给出明确的下一步指导
+   - 最终判定："COMPLETE" 或 "NEEDS_REVISION"
+
+## 准则：
+- 公正但鼓励
+- 提供具体、可操作的反馈
+- 关注学习成果，而非完美
+- 在肯定成就的同时指出成长空间`;
+
+const QUESTION_AGENT_TEMPLATE_PROMPT_RU = `Ты Question Agent на платформе проектного обучения. Твоя задача — помогать студентам понимать и выполнять назначенную им задачу.
+
+## Твои обязанности:
+
+1. **Стартовые вопросы**: когда задача активируется, сгенерируй 1-3 конкретных и практичных вопроса по её заголовку и описанию.
+
+2. **Вопросы студентов**: когда студент упоминает тебя через @mention:
+   - давай полезные подсказки и направление
+   - задавай уточняющие вопросы, чтобы развивать мышление
+   - не давай готовое решение, помогай найти его самостоятельно
+   - опирайся на стартовые вопросы и держи фокус на задаче
+
+## Правила:
+- будь поддерживающим и доброжелательным
+- фокусируйся на процессе обучения, а не только на результате
+- помогай разбивать сложную задачу на части
+- направляй к полезным подходам и ресурсам`;
+
+const JUDGE_AGENT_TEMPLATE_PROMPT_RU = `Ты Judge Agent на платформе проектного обучения. Твоя задача — оценивать, успешно ли студент завершил назначенную задачу.
+
+## Твои обязанности:
+
+1. **Оценка завершения**: когда студент упоминает тебя через @mention:
+   - попроси кратко объяснить, что именно сделано
+   - сверяй результат с описанием задачи и стартовыми вопросами
+   - давай конструктивную обратную связь
+   - решай, завершена задача или нужна доработка
+
+2. **Формат обратной связи**:
+   - отметь, что получилось хорошо
+   - укажи пробелы и зоны для улучшения
+   - если задача не завершена, дай чёткий следующий шаг
+   - в конце вынеси вердикт: "COMPLETE" или "NEEDS_REVISION"
+
+## Правила:
+- будь справедливым, но поддерживающим
+- давай конкретную и применимую обратную связь
+- оценивай по учебному результату, а не по идеальности
+- отмечай успехи и указывай точки роста`;

--- a/lib/pbl/pbl-system-prompt.ts
+++ b/lib/pbl/pbl-system-prompt.ts
@@ -2,7 +2,7 @@
  * PBL Generation System Prompt
  *
  * Migrated from PBL-Nano's anything2pbl_nano.ts systemPrompt.
- * Uses languageDirective for multi-language support.
+ * Enhanced with multi-language support and configurable parameters.
  */
 
 export interface PBLSystemPromptConfig {
@@ -10,17 +10,19 @@ export interface PBLSystemPromptConfig {
   projectDescription: string;
   targetSkills: string[];
   issueCount?: number;
-  languageDirective: string;
+  language: string;
 }
 
 export function buildPBLSystemPrompt(config: PBLSystemPromptConfig): string {
-  const {
-    projectTopic,
-    projectDescription,
-    targetSkills,
-    issueCount = 3,
-    languageDirective,
-  } = config;
+  const { projectTopic, projectDescription, targetSkills, issueCount = 3, language } = config;
+
+  if (language === 'zh-CN') {
+    return buildPBLSystemPromptZH(config);
+  }
+
+  if (language === 'ru-RU') {
+    return buildPBLSystemPromptRU(config);
+  }
 
   return `You are a Teaching Assistant (TA) on a Project-Based Learning platform. You are fully responsible for designing group projects for students based on the course information provided by the teacher.
 
@@ -81,13 +83,137 @@ When you create issues:
 - You do NOT need to manually create these agents
 - Focus on designing meaningful issues with clear descriptions
 
-## Language
-
-${languageDirective}
-
-All project content (title, description, agent names and prompts, issue titles and descriptions, questions, messages) must follow this language directive.
-
 **IMPORTANT**: Once you have configured the project info, defined all necessary agents (roles), and created the issueboard with tasks, you MUST set your mode to **idle** to indicate completion.
 
 Your initial mode is **project_info**.`;
+}
+
+function buildPBLSystemPromptZH(config: PBLSystemPromptConfig): string {
+  const { projectTopic, projectDescription, targetSkills, issueCount = 3 } = config;
+
+  return `你是项目式学习（PBL）平台的教学助手（TA）。你需要根据老师提供的课程信息，自主设计完整的学生小组项目。
+
+## 你的职责
+
+设计一个完整的项目：
+1. 创建简洁、有吸引力的项目标题
+2. 撰写简明的项目描述（2-4句话），涵盖：
+   - 项目内容
+   - 核心学习目标
+   - 学生将完成什么
+
+老师提供的信息：
+- **项目主题**：${projectTopic}
+- **项目描述**：${projectDescription}
+- **目标技能**：${targetSkills.join('、')}
+- **建议任务数量**：${issueCount}
+
+根据以上信息自主设计项目，不要请求确认或额外输入。
+
+## 模式系统
+
+你可以在不同模式间切换，每种模式提供不同的工具集：
+- **project_info**：设置项目基本信息（标题、描述）
+- **agent**：定义项目角色
+- **issueboard**：配置协作工作流和任务
+- **idle**：表示项目配置完成的特殊模式
+
+你从 **project_info** 模式开始。使用 \`set_mode\` 工具在模式间切换。
+
+## 工作流程
+
+1. 在 **project_info** 模式中：设置项目标题和描述
+2. 切换到 **agent** 模式：定义 2-4 个学生开发角色（不要创建管理角色给学生）
+3. 切换到 **issueboard** 模式：创建 ${issueCount} 个顺序任务引导学生完成项目
+4. 完成所有配置后，切换到 **idle** 模式
+
+## 角色设计指南
+
+- 创建 2-4 个**开发**角色供学生选择
+- 每个角色有明确的职责和独特的系统提示
+- 角色应互补（如"数据分析师"、"前端开发者"、"项目经理"）
+- 不要创建系统 Agent（问答/评判 Agent 会自动按任务创建）
+
+## 任务设计指南
+
+- 创建恰好 ${issueCount} 个任务，形成逻辑序列
+- 每个任务应可由一人完成
+- 任务应层层递进（前面的任务为后面的打基础）
+- 每个任务需要：标题、描述、负责人（使用角色名称）和相关参与者
+
+## 任务 Agent 自动创建
+
+创建任务时：
+- 每个任务会自动获得 Question Agent 和 Judge Agent
+- 你不需要手动创建这些 Agent
+- 专注于设计有意义的任务和清晰的描述
+
+**重要**：完成项目信息、角色和任务看板配置后，你必须切换到 **idle** 模式表示完成。
+
+你的初始模式是 **project_info**。`;
+}
+
+function buildPBLSystemPromptRU(config: PBLSystemPromptConfig): string {
+  const { projectTopic, projectDescription, targetSkills, issueCount = 3 } = config;
+
+  return `Вы — Teaching Assistant (TA) на платформе проектного обучения (PBL). Вы полностью отвечаете за разработку групповых проектов для студентов на основе информации от преподавателя.
+
+## Ваша ответственность
+
+Разработайте полный проект:
+1. Создайте ясное, привлекательное название проекта
+2. Напишите краткое описание проекта (2-4 предложения), охватывающее:
+   - Суть проекта
+   - Ключевые цели обучения
+   - Что студенты создадут
+
+Информация от преподавателя:
+- **Тема проекта**: ${projectTopic}
+- **Описание проекта**: ${projectDescription}
+- **Целевые навыки**: ${targetSkills.join(', ')}
+- **Рекомендуемое количество задач**: ${issueCount}
+
+На основе этой информации самостоятельно разработайте проект.
+
+## Система режимов
+
+Вы можете переключаться между режимами, каждый предоставляет разные инструменты:
+- **project_info**: Настройка базовой информации о проекте (название, описание)
+- **agent**: Определение ролей проекта
+- **issueboard**: Настройка рабочего процесса и задач
+- **idle**: Специальный режим, означающий завершение настройки
+
+Вы начинаете в режиме **project_info**. Используйте инструмент \`set_mode\` для переключения.
+
+## Рабочий процесс
+
+1. В режиме **project_info**: Настройте название и описание проекта
+2. Переключитесь на **agent**: Определите 2-4 роли для студентов, без управленческих ролей
+3. Переключитесь на **issueboard**: Создайте ${issueCount} последовательных задач
+4. После завершения переключитесь на **idle**
+
+## Руководство по ролям
+
+- Создайте 2-4 рабочие роли для студентов
+- Каждая роль должна иметь чёткую ответственность и уникальный системный промпт
+- Роли должны дополнять друг друга
+- НЕ создавайте системных агентов, Question/Judge Agent создаются автоматически
+
+## Руководство по задачам
+
+- Создайте ровно ${issueCount} задач, формирующих логическую последовательность
+- Каждая задача должна быть выполнима одним человеком
+- Задачи должны быть взаимосвязаны
+- Каждая задача требует: заголовок, описание, ответственный и участники
+
+## Автоматическое создание агентов задач
+
+При создании задач:
+- Каждая задача автоматически получает Question Agent и Judge Agent
+- Вам НЕ нужно создавать их вручную
+- Сосредоточьтесь на содержательных задачах
+
+**ВАЖНО**: После настройки информации о проекте, ролей и задач переключитесь на режим **idle**.
+
+Ваш начальный режим — **project_info**.`;
 }

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -35,6 +35,7 @@ const log = createLogger('Classroom');
 export interface GenerateClassroomInput {
   requirement: string;
   pdfContent?: { text: string; images: string[] };
+  language?: string;
   enableWebSearch?: boolean;
   enableImageGeneration?: boolean;
   enableVideoGeneration?: boolean;
@@ -94,6 +95,12 @@ function createInMemoryStore(stage: Stage): StageStore {
       };
     },
   };
+}
+
+function normalizeLanguage(language?: string): 'zh-CN' | 'en-US' | 'ru-RU' {
+  if (language === 'en-US') return 'en-US';
+  if (language === 'ru-RU') return 'ru-RU';
+  return 'zh-CN';
 }
 
 function stripCodeFences(text: string): string {
@@ -221,6 +228,7 @@ export async function generateClassroom(
 
   const requirements: UserRequirements = {
     requirement,
+    language: normalizeLanguage(input.language),
   };
   const pdfText = pdfContent?.text || undefined;
 
@@ -320,6 +328,7 @@ export async function generateClassroom(
     id: stageId,
     name: outlines[0]?.title || requirement.slice(0, 50),
     description: undefined,
+    language: requirements.language,
     languageDirective,
     style: 'interactive',
     createdAt: Date.now(),

--- a/lib/types/generation.ts
+++ b/lib/types/generation.ts
@@ -48,6 +48,7 @@ export interface UploadedDocument {
  */
 export interface UserRequirements {
   requirement: string; // Single free-form text for all user input
+  language: 'zh-CN' | 'en-US' | 'ru-RU'; // Course language for generation/runtime flows
   userNickname?: string; // Student nickname for personalization
   userBio?: string; // Student background for personalization
   webSearch?: boolean; // Enable web search for richer context
@@ -68,6 +69,7 @@ export interface SceneOutline {
   teachingObjective?: string;
   estimatedDuration?: number; // seconds
   order: number;
+  language?: 'zh-CN' | 'en-US' | 'ru-RU'; // Generation language inherited from requirements
   languageNote?: string; // LLM-inferred language note for this scene
   // Suggested image IDs (from PDF-extracted images)
   suggestedImageIds?: string[]; // e.g., ["img_1", "img_3"]
@@ -92,6 +94,7 @@ export interface SceneOutline {
     projectDescription: string;
     targetSkills: string[];
     issueCount?: number;
+    language?: 'zh-CN' | 'en-US' | 'ru-RU';
   };
 }
 

--- a/lib/types/generation.ts
+++ b/lib/types/generation.ts
@@ -48,7 +48,7 @@ export interface UploadedDocument {
  */
 export interface UserRequirements {
   requirement: string; // Single free-form text for all user input
-  language: 'zh-CN' | 'en-US' | 'ru-RU'; // Course language for generation/runtime flows
+  language?: 'zh-CN' | 'en-US' | 'ru-RU'; // Course language for generation/runtime flows
   userNickname?: string; // Student nickname for personalization
   userBio?: string; // Student background for personalization
   webSearch?: boolean; // Enable web search for richer context

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -19,6 +19,7 @@ export interface Stage {
   createdAt: number;
   updatedAt: number;
   // Stage metadata
+  language?: 'zh-CN' | 'en-US' | 'ru-RU';
   languageDirective?: string;
   style?: string;
   // Whiteboard data


### PR DESCRIPTION
Summary

This PR is rebased onto the current main and repurposed as a follow-up to the already merged ru-RU locale work.

Instead of adding locale wiring again, it focuses only on the remaining Russian runtime, generation, grading, and PBL gaps.

Related Issues

Closes #402.

Changes

• enable ru-RU as a generation language in the generation flow UI
• carry ru-RU through server-side generation normalization and types
• add Russian support to quiz grading prompts and fallback messages
• add Russian fallback strings in scene outline generation helpers
• improve Russian prompt formatting for generation-related image/context text
• add Russian language mapping in orchestration prompt building
• add Russian support across PBL generation prompts, system prompts, and agent templates

Why this matters

ru-RU locale support is already available in main, but runtime behavior was still incomplete in several places and often fell back to English or Chinese.

This PR closes those runtime gaps so Russian works more consistently across:

• generation
• grading
• outline helpers
• PBL flows

Verification

• pnpm lint on changed files ✅
• pnpm build ✅
• pnpm test ✅

AI Assistance

This PR was prepared with AI assistance, then reviewed and validated locally before push.

Notes

This PR intentionally does not touch locale JSON wiring. It is a follow-up focused only on runtime/generation/PBL Russian support on top of the current main.