### PR TITLE
chore: add Claude Code local files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+CLAUDE.local.md
+.claude
+.superpowers
+
 # dependencies
 /node_modules
 /openclaw/node_modules


### PR DESCRIPTION
## Summary
- Add `CLAUDE.local.md`, `.claude/`, `.superpowers/` to `.gitignore` to prevent local Claude Code configuration files from being tracked

## Test plan
- [x] Verify these paths are excluded from `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)