### PR TITLE
chore: add Claude Code directories to ESLint global ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,10 @@ const eslintConfig = defineConfig([
     'next-env.d.ts',
     // Vendored/generated code:
     'packages/**',
+    // Claude Code local files:
+    '.claude/**',
+    '.superpowers/**',
+    '.worktrees/**',
   ]),
   {
     rules: {


### PR DESCRIPTION
## Summary
- Add `.claude/**`, `.superpowers/**`, `.worktrees/**` to ESLint `globalIgnores` to prevent scanning local Claude Code worktree artifacts (`.next`, `node_modules`)

## Test plan
- [x] Verify `pnpm lint` no longer scans worktree directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)