### PR TITLE
fix: pass providerType to chat api

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -97,6 +97,7 @@ export async function POST(req: NextRequest) {
       apiKey: effectiveApiKey,
       baseUrl: effectiveBaseUrl,
       proxy,
+      providerType: body.providerType,
     });
 
     // Use the native request signal for abort propagation

--- a/components/chat/use-chat-sessions.ts
+++ b/components/chat/use-chat-sessions.ts
@@ -353,6 +353,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
         apiKey: string;
         baseUrl?: string;
         model?: string;
+        providerType?: string;
       },
       controller: AbortController,
       sessionType: SessionType,
@@ -771,6 +772,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
             apiKey: mc.apiKey,
             baseUrl: mc.baseUrl,
             model: mc.modelString,
+            providerType: mc.providerType,
           },
           controller,
           session.type,
@@ -1006,6 +1008,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
             apiKey: mc.apiKey,
             baseUrl: mc.baseUrl,
             model: mc.modelString,
+            providerType: mc.providerType,
           },
           controller,
           sessionType,
@@ -1162,6 +1165,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
             apiKey: mc.apiKey,
             baseUrl: mc.baseUrl,
             model: mc.modelString,
+            providerType: mc.providerType,
           },
           controller,
           'discussion',

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -279,6 +279,8 @@ export interface StatelessChatRequest {
   apiKey: string;
   baseUrl?: string;
   model?: string;
+  /** Provider adapter type for custom providers (e.g. openai, anthropic, google) */
+  providerType?: 'openai' | 'anthropic' | 'google';
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes chat requests for custom providers by passing `providerType` from the client to `/api/chat` and through server model resolution.

## Related Issues

None.

## Changes

- Added `providerType` to the stateless chat request type.
- Passed `providerType` from `use-chat-sessions` when sending chat requests.
- Forwarded `providerType` into `getModel()` in `/api/chat`.
- Keeps custom providers from failing with `Unknown provider ... Please provide providerType.`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Configure a custom provider.
2. Send a chat message through the chat session flow.
3. Confirm the request no longer fails with `Unknown provider ... Please provide providerType.`

### What you personally verified

- Confirmed the code path that builds `/api/chat` requests now includes `providerType`.
- Ran `pnpm exec tsc --noEmit` successfully.
- I did not run a full browser end-to-end test in this session.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings