### PR TITLE
fix(storage): local disk persistence for classroom data generated via browser UI flow (#53)

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -52,6 +52,14 @@ export default function ClassroomDetailPage() {
         isCurrent,
         loadFromStorage,
         getCurrentStage: () => useStageStore.getState().stage,
+        getLocalDeck: () => {
+          const state = useStageStore.getState();
+          return {
+            sceneCount: state.scenes.length,
+            outlineCount: state.outlines.length,
+            generationComplete: state.generationComplete,
+          };
+        },
         fetchClassroom: defaultClassroomLoadDeps.fetchClassroom,
         applyFallbackScenes: (args) =>
           defaultClassroomLoadDeps.applyFallbackScenes({

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -47,6 +47,7 @@ import type {
   SessionDocumentSource,
 } from '@/lib/types/generation';
 import { AgentRevealModal } from '@/components/agent/agent-reveal-modal';
+import { persistClassroomToServer } from '@/lib/hooks/classroom-persistence';
 import { createLogger } from '@/lib/logger';
 import {
   type GenerationSessionState,
@@ -1076,6 +1077,23 @@ function GenerationPreviewContent() {
 
       sessionStorage.removeItem('generationSession');
       await store.saveToStorage();
+
+      // Persist to server disk so the URL resolves cross-browser during generation (#53).
+      // Fresh snapshot: `store` predates addScene, its scenes are stale.
+      const fresh = useStageStore.getState();
+      if (fresh.stage) {
+        void persistClassroomToServer(fresh.stage, fresh.scenes).then((result) => {
+          if (result.success) {
+            log.info('[GenerationPreview] First scene persisted to server disk:', fresh.stage?.id);
+          } else {
+            log.warn(
+              '[GenerationPreview] Failed to persist first scene to server disk:',
+              result.error,
+            );
+          }
+        });
+      }
+
       router.push(`/classroom/${stage.id}`);
     } catch (err) {
       setIsOutlineStreaming(false);

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -39,6 +39,11 @@ export interface RunClassroomLoadArgs<TMediaTasks = unknown, TGeneratedAgentReco
   isCurrent: () => boolean;
   loadFromStorage: (classroomId: string, loadToken: StageSceneLoadToken) => Promise<void>;
   getCurrentStage: () => Stage | null;
+  getLocalDeck: () => {
+    sceneCount: number;
+    outlineCount: number;
+    generationComplete: boolean;
+  };
   fetchClassroom: (classroomId: string) => Promise<ClassroomPayload | null>;
   applyFallbackScenes: (args: {
     loadToken: StageSceneLoadToken;
@@ -68,6 +73,7 @@ export async function runClassroomLoad<TMediaTasks = unknown, TGeneratedAgentRec
   isCurrent,
   loadFromStorage,
   getCurrentStage,
+  getLocalDeck,
   fetchClassroom,
   applyFallbackScenes,
   saveGeneratedAgents,
@@ -87,12 +93,28 @@ export async function runClassroomLoad<TMediaTasks = unknown, TGeneratedAgentRec
     await loadFromStorage(classroomId, loadToken);
     if (!isCurrent()) return;
 
-    if (!getCurrentStage()) {
-      log.info('No IndexedDB data, trying server-side storage for:', classroomId);
+    // a browser that loads a classroom mid-generation caches the partial deck
+    // in IndexedDB (debounced store saves) and would otherwise keep re-reading
+    // its own stale copy forever — so re-check server-side storage for cached
+    // viewer copies (no outlines to resume, never marked complete) too, not
+    // just when IndexedDB was empty (#53)
+    const cachedStage = getCurrentStage();
+    const localDeck = getLocalDeck();
+    const staleViewerCopy =
+      !!cachedStage && !localDeck.generationComplete && localDeck.outlineCount === 0;
+
+    if (!cachedStage || staleViewerCopy) {
+      log.info(
+        cachedStage
+          ? 'Cached deck is a viewer snapshot, re-checking server-side storage for:'
+          : 'No IndexedDB data, trying server-side storage for:',
+        classroomId,
+      );
       const classroom = await fetchClassroom(classroomId);
       if (!isCurrent()) return;
 
-      if (classroom) {
+      // never downgrade — adopt the server deck only when it is fuller than the cache
+      if (classroom && (!cachedStage || classroom.scenes.length > localDeck.sceneCount)) {
         const { stage, scenes } = classroom;
         const applied = await applyFallbackScenes({ loadToken, stage, scenes });
         if (!isCurrent()) return;

--- a/lib/hooks/classroom-persistence.ts
+++ b/lib/hooks/classroom-persistence.ts
@@ -1,0 +1,44 @@
+import type { Stage, Scene } from '@/lib/types/stage';
+
+export interface PersistClassroomResult {
+  success: boolean;
+  url?: string;
+  error?: string;
+}
+
+async function sendPersist(stage: Stage, scenes: Scene[]): Promise<PersistClassroomResult> {
+  try {
+    const response = await fetch('/api/classroom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stage, scenes }),
+    });
+
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok || data.success === false) {
+      return { success: false, error: data.error || `HTTP ${response.status}` };
+    }
+
+    return { success: true, url: data.url };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// serialize writes per stage id so a slow first-scene POST can't land after the
+// completion POST and clobber the full deck with a stale one-scene snapshot (#53)
+const persistChains = new Map<string, Promise<PersistClassroomResult>>();
+
+export function persistClassroomToServer(
+  stage: Stage,
+  scenes: Scene[],
+): Promise<PersistClassroomResult> {
+  const prev = persistChains.get(stage.id) ?? Promise.resolve();
+  const next = prev.catch(() => undefined).then(() => sendPersist(stage, scenes));
+  persistChains.set(stage.id, next);
+  void next.finally(() => {
+    if (persistChains.get(stage.id) === next) persistChains.delete(stage.id);
+  });
+  return next;
+}

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -13,7 +13,7 @@ import type {
   UserRequirements,
 } from '@/lib/types/generation';
 import type { AgentInfo } from '@/lib/generation/generation-pipeline';
-import type { Scene } from '@/lib/types/stage';
+import type { Scene, Stage } from '@/lib/types/stage';
 import type { SpeechAction } from '@/lib/types/action';
 import { splitLongSpeechActions } from '@/lib/audio/tts-utils';
 import { measureAudioDuration } from '@/lib/audio/audio-duration';
@@ -28,8 +28,25 @@ import {
   withGenerationRetry,
   type GenerationRetryOptions,
 } from '@/lib/generation/generation-retry';
+import { persistClassroomToServer } from '@/lib/hooks/classroom-persistence';
 
 const log = createLogger('SceneGenerator');
+
+// Mirror browser-generated classrooms to the server disk so they load
+// cross-browser (#53). Non-fatal: on failure we log and generation continues.
+async function persistClassroomIfReady(
+  stage: Stage | null,
+  scenes: Scene[],
+  phase: string,
+): Promise<void> {
+  if (!stage || scenes.length === 0) return;
+  const result = await persistClassroomToServer(stage, scenes);
+  if (result.success) {
+    log.info(`Classroom persisted to server disk (${phase}):`, stage.id);
+  } else {
+    log.warn(`Failed to persist classroom to server disk (${phase}):`, result.error);
+  }
+}
 
 interface SceneContentResult {
   success: boolean;
@@ -658,6 +675,13 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
             store.getState().addScene(scene);
             options.onSceneGenerated?.(scene, outline.order);
             previousSpeeches = actionsResult.previousSpeeches || [];
+
+            // Persist as soon as the first scene lands so the classroom URL
+            // resolves cross-browser early; a full re-persist runs on completion.
+            const afterAdd = store.getState();
+            if (afterAdd.scenes.length === 1) {
+              void persistClassroomIfReady(afterAdd.stage, afterAdd.scenes, 'first scene');
+            }
           } else {
             if (abortRef.current || store.getState().generationEpoch !== startEpoch) {
               pausedByFailureOrAbort = true;
@@ -680,6 +704,10 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
             store.getState().setGenerationStatus('completed');
             store.getState().setGeneratingOutlines([]);
             store.getState().setGenerationComplete(true);
+
+            const finalState = store.getState();
+            await persistClassroomIfReady(finalState.stage, finalState.scenes, 'completion');
+
             options.onComplete?.();
           }
         }
@@ -834,6 +862,13 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
           // so mark completion here too — otherwise a later delete would treat
           // the orphaned outline as pending and regenerate it.
           store.getState().markGenerationCompleteIfDone();
+
+          // If that retry actually finished the deck, mirror it to disk too —
+          // otherwise a deck completed via retry would never reach the server.
+          if (store.getState().generationComplete) {
+            const finalState = store.getState();
+            void persistClassroomIfReady(finalState.stage, finalState.scenes, 'retry completion');
+          }
         }
       } catch (err) {
         if (!isAbortError(err)) {

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -76,6 +76,7 @@ function deferred<T>() {
 function makeDeps(overrides: Partial<Parameters<typeof runClassroomLoad>[0]> = {}) {
   let current = true;
   let stage: Stage | null = null;
+  let localDeck = { sceneCount: 0, outlineCount: 0, generationComplete: false };
   const settings = {
     agentMode: 'auto' as const,
     selectedAgentIds: [] as string[],
@@ -90,6 +91,7 @@ function makeDeps(overrides: Partial<Parameters<typeof runClassroomLoad>[0]> = {
     isCurrent: () => current,
     loadFromStorage: vi.fn().mockResolvedValue(undefined),
     getCurrentStage: () => stage,
+    getLocalDeck: () => localDeck,
     fetchClassroom: vi.fn().mockResolvedValue(null),
     applyFallbackScenes: vi.fn().mockResolvedValue(false),
     saveGeneratedAgents: vi.fn().mockResolvedValue([]),
@@ -121,6 +123,9 @@ function makeDeps(overrides: Partial<Parameters<typeof runClassroomLoad>[0]> = {
     },
     setStage(next: Stage | null) {
       stage = next;
+    },
+    setLocalDeck(next: typeof localDeck) {
+      localDeck = next;
     },
   };
 }
@@ -296,6 +301,61 @@ describe('runClassroomLoad', () => {
     expect(deps.applyGeneratedAgentRecords).toHaveBeenCalledWith([{ id: 'agent-a' }]);
     expect(settings.setSelectedAgentIds).toHaveBeenCalledWith(['agent-a']);
     expect(deps.setLoading).toHaveBeenCalledWith(false);
+  });
+
+  // #53: a viewer browser that cached a mid-generation deck must pick up the
+  // finished deck from the server on the next load instead of staying stale
+  it('re-checks the server for a cached viewer snapshot and adopts a fuller deck', async () => {
+    const stage = makeStage('stage-a');
+    const scenes = [makeScene('scene-a', 'stage-a'), makeScene('scene-b', 'stage-a')];
+    const { deps, setStage, setLocalDeck } = makeDeps({
+      fetchClassroom: vi.fn().mockResolvedValue({ stage, scenes }),
+      applyFallbackScenes: vi.fn().mockResolvedValue(true),
+    });
+    setStage(stage);
+    setLocalDeck({ sceneCount: 1, outlineCount: 0, generationComplete: false });
+
+    await runClassroomLoad(deps);
+
+    expect(deps.fetchClassroom).toHaveBeenCalledWith('stage-a');
+    expect(deps.applyFallbackScenes).toHaveBeenCalledWith({ loadToken: 1, stage, scenes });
+  });
+
+  it('keeps the cached deck when the server copy has no more scenes', async () => {
+    const stage = makeStage('stage-a');
+    const { deps, setStage, setLocalDeck } = makeDeps({
+      fetchClassroom: vi.fn().mockResolvedValue({
+        stage,
+        scenes: [makeScene('scene-a', 'stage-a')],
+      }),
+    });
+    setStage(stage);
+    setLocalDeck({ sceneCount: 1, outlineCount: 0, generationComplete: false });
+
+    await runClassroomLoad(deps);
+
+    expect(deps.fetchClassroom).toHaveBeenCalled();
+    expect(deps.applyFallbackScenes).not.toHaveBeenCalled();
+  });
+
+  it('does not consult the server in the generating browser (outlines pending)', async () => {
+    const { deps, setStage, setLocalDeck } = makeDeps();
+    setStage(makeStage('stage-a'));
+    setLocalDeck({ sceneCount: 1, outlineCount: 4, generationComplete: false });
+
+    await runClassroomLoad(deps);
+
+    expect(deps.fetchClassroom).not.toHaveBeenCalled();
+  });
+
+  it('does not consult the server for a deck already marked complete', async () => {
+    const { deps, setStage, setLocalDeck } = makeDeps();
+    setStage(makeStage('stage-a'));
+    setLocalDeck({ sceneCount: 4, outlineCount: 0, generationComplete: true });
+
+    await runClassroomLoad(deps);
+
+    expect(deps.fetchClassroom).not.toHaveBeenCalled();
   });
 
   it('stops side effects when the component unmounts while loading', async () => {

--- a/tests/lib/hooks/classroom-persistence.test.ts
+++ b/tests/lib/hooks/classroom-persistence.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { persistClassroomToServer } from '@/lib/hooks/classroom-persistence';
+import type { Stage, Scene } from '@/lib/types/stage';
+
+const stage = { id: 'abc' } as unknown as Stage;
+const scenes = [] as unknown as Scene[];
+
+function mockFetchOnce(response: Partial<Response> & { json: () => Promise<unknown> }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => response as Response),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('persistClassroomToServer', () => {
+  it('returns success on a 2xx response', async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ success: true, id: 'abc', url: '/classroom/abc' }),
+    });
+
+    const result = await persistClassroomToServer(stage, scenes);
+
+    expect(result.success).toBe(true);
+    expect(result.url).toBe('/classroom/abc');
+  });
+
+  it('returns failure on a non-2xx response instead of reporting success', async () => {
+    // fetch() resolves normally for 4xx/5xx, so the helper must check response.ok.
+    mockFetchOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ success: false, error: 'disk write failed' }),
+    });
+
+    const result = await persistClassroomToServer(stage, scenes);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('disk write failed');
+  });
+
+  it('treats an API body with success:false as a failure even on a 2xx status', async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: false, error: 'validation failed' }),
+    });
+
+    const result = await persistClassroomToServer(stage, scenes);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('validation failed');
+  });
+
+  it('falls back to the HTTP status when the error body has no message', async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('not json');
+      },
+    });
+
+    const result = await persistClassroomToServer(stage, scenes);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('HTTP 502');
+  });
+
+  it('returns failure instead of throwing when fetch itself rejects', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+
+    const result = await persistClassroomToServer(stage, scenes);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('network down');
+  });
+
+  // #53: a slow first-scene write must never overwrite the completed deck. We gate the
+  // one-scene fetch so it resolves after the completion fetch is issued; the per-stage
+  // chain must still commit them in order (one scene, then the full deck).
+  it('serializes writes per stage so a deferred first-scene POST cannot overwrite the final deck', async () => {
+    const raceStage = { id: 'race' } as unknown as Stage;
+    const oneScene = [{}] as unknown as Scene[];
+    const fullDeck = [{}, {}, {}] as unknown as Scene[];
+
+    const committed: number[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: RequestInit) => {
+        const body = JSON.parse(init.body as string) as { scenes: unknown[] };
+        const count = body.scenes.length;
+        if (count === 1) await firstGate;
+        committed.push(count);
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ success: true, url: '/classroom/race' }),
+        } as Response;
+      }),
+    );
+
+    const first = persistClassroomToServer(raceStage, oneScene);
+    const completion = persistClassroomToServer(raceStage, fullDeck);
+
+    // completion must wait behind the still-gated first-scene write
+    await Promise.resolve();
+    expect(committed).toEqual([]);
+
+    releaseFirst();
+    await Promise.all([first, completion]);
+
+    // full deck is the last snapshot the server sees, never the stale one-scene payload
+    expect(committed).toEqual([1, 3]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #53 — classrooms generated via the browser UI are now persisted to `data/classrooms/{id}.json` on the server disk, so the classroom URL resolves in any browser/device, not just the one that generated it.

## Related Issues

Closes #53

## Root Cause

OpenMAIC has two generation flows:

- **API/OpenClaw flow** — runs server-side via `classroom-generation.ts`, already called `persistClassroom()` correctly
- **Browser UI flow** — runs client-side, saved to IndexedDB only and never wrote to disk

This meant every classroom created through the normal browser UI was only accessible in the browser that generated it — switching to another browser shows "Classroom not found" because IndexedDB is local to each browser.

## Changes

- `lib/hooks/classroom-persistence.ts` — new `persistClassroomToServer()` helper wrapping `POST /api/classroom` (which triggers the existing atomic `persistClassroom()` disk write). A write is only reported successful after checking `response.ok` **and** the API body — non-2xx, `success: false`, and network errors all return a failure result.
- `app/generation-preview/page.tsx` — persists right after the first scene lands, before navigating to the classroom, so the URL resolves cross-browser *during* generation. Reads a fresh store snapshot after `addScene` so the payload always contains the new scene.
- `lib/hooks/use-scene-generator.ts` — re-persists the full deck on main generation completion and on retry-driven completion (integrated with the current generation state machine: `generationEpoch`, `markGenerationCompleteIfDone`).
- `tests/lib/hooks/classroom-persistence.test.ts` — vitest coverage: 2xx success, non-2xx failure, `success: false` on a 2xx status, HTTP-status fallback when the body isn't JSON, and fetch rejection.

## Persistence policy

Persistence is best-effort and non-fatal: generation never fails because of a failed write; failures are logged as warnings. Success is never reported without validating the response.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

**Steps to reproduce / test**

1. Generate a course via the browser UI
2. As soon as the app navigates to `/classroom/{id}`, check that `data/classrooms/{id}.json` exists on disk (before generation finishes)
3. Open the classroom URL in a different browser — should load mid-generation
4. After completion, refresh the second browser — full deck is available

**What I personally verified**

- Generated course in Chrome — `data/classrooms/{id}.json` created with full course data
- Opened same URL in Edge — loaded correctly from disk
- Failed writes log a warning and generation completes normally

**Evidence**

- [x] `pnpm lint`, `npx tsc --noEmit`, and vitest pass
- [x] Manually tested locally

## Notes

Zero new dependencies. No schema changes.

Opening a persisted course in another browser requires pasting the direct classroom URL (e.g. `http://localhost:3000/classroom/{id}`). The home page course list still reads from IndexedDB only — showing disk-persisted courses on the home page is a separate improvement.
