### PR TITLE
fix: persist classroom to server for cross-device access

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -27,8 +27,27 @@ export default function ClassroomDetailPage() {
   const generationStartedRef = useRef(false);
 
   const { generateRemaining, retrySingleOutline, stop } = useSceneGenerator({
-    onComplete: () => {
+    onComplete: async () => {
       log.info('[Classroom] All scenes generated');
+      // Update server-side storage with all generated scenes
+      const state = useStageStore.getState();
+      if (state.stage && state.scenes.length > 0) {
+        try {
+          const resp = await fetch('/api/classroom', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              stage: state.stage,
+              scenes: state.scenes,
+            }),
+          });
+          if (resp.ok) {
+            log.info('[Classroom] Updated server-side storage with all scenes');
+          }
+        } catch (err) {
+          log.warn('[Classroom] Failed to update server-side storage:', err);
+        }
+      }
     },
   });
 

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -721,6 +721,29 @@ function GenerationPreviewContent() {
         }),
       );
 
+      // Persist classroom to server-side storage for cross-device access
+      const state = store;
+      try {
+        const persistResp = await fetch('/api/classroom', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            stage: state.stage,
+            scenes: state.scenes,
+          }),
+        });
+        if (persistResp.ok) {
+          const persistData = await persistResp.json();
+          log.info('[Generation] Classroom persisted to server:', persistData.url);
+        } else {
+          log.warn(
+            '[Generation] Failed to persist classroom to server, continuing with local-only storage',
+          );
+        }
+      } catch (persistErr) {
+        log.warn('[Generation] Error persisting classroom to server:', persistErr);
+      }
+
       sessionStorage.removeItem('generationSession');
       await store.saveToStorage();
       router.push(`/classroom/${stage.id}`);


### PR DESCRIPTION
## Summary

  Fixes 404 errors when accessing classrooms from different devices on the same network. Previously, classrooms were only stored in browser IndexedDB, making them inaccessible from other devices. This change persists classroom data to server-side storage, enabling cross-device access via the API.

  ## Related Issues

  N/A (new fix)

  ## Changes

  - **`app/generation-preview/page.tsx`**: Added server-side persistence call after first scene generation, before navigation to classroom page
  - **`app/classroom/[id]/page.tsx`**: Added server-side update call in `onComplete` callback when all scenes finish generation
  - Data is now saved to `data/classrooms/{id}.json` on the server filesystem
  - Falls back gracefully if server persistence fails (continues with local-only storage)

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Verification

  ### Steps to reproduce / test

  1. Start dev server: `pnpm dev`
  2. On Device A (localhost), create a new course and wait for first scene to complete
  3. On Device B (LAN), access `http://<Device-A-IP>:3000/classroom/<id>`
  4. Verify classroom loads successfully instead of 404
  5. Wait for all scenes to complete generation
  6. Refresh on Device B to verify full content is available

  ### What you personally verified

  - Code follows existing patterns in the codebase (uses existing `/api/classroom` endpoint)
  - Error handling is robust (try-catch with fallback behavior)
  - No breaking changes - existing single-device workflow unaffected
  - TypeScript types are correct

  ### Evidence

  - [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
  - [ ] Manually tested locally (pending user verification)
  - [ ] Screenshots / recordings attached (N/A - backend behavior change)

  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have performed a self-review of my code
  - [x] I have added/updated documentation as needed
  - [x] My changes do not introduce new warnings