### PR TITLE
fix: prevent auto-generated agents from bleeding into preset classrooms

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -61,7 +61,8 @@ export default function ClassroomDetailPage() {
       // Restore completed media generation tasks from IndexedDB
       await useMediaGenerationStore.getState().restoreFromDB(classroomId);
       // Restore agents for this stage
-      const { loadGeneratedAgentsForStage } = await import('@/lib/orchestration/registry/store');
+      const { loadGeneratedAgentsForStage, useAgentRegistry } =
+        await import('@/lib/orchestration/registry/store');
       const generatedAgentIds = await loadGeneratedAgentsForStage(classroomId);
       const { useSettingsStore } = await import('@/lib/store/settings');
       if (generatedAgentIds.length > 0) {
@@ -69,16 +70,21 @@ export default function ClassroomDetailPage() {
         useSettingsStore.getState().setAgentMode('auto');
         useSettingsStore.getState().setSelectedAgentIds(generatedAgentIds);
       } else {
-        // Preset mode — restore agent IDs saved in the stage at creation time
+        // Preset mode — restore agent IDs saved in the stage at creation time.
+        // Filter out any stale generated IDs that may have been persisted before
+        // the bleed-fix, so they don't resolve against a leftover registry entry.
         const stage = useStageStore.getState().stage;
         const stageAgentIds = stage?.agentIds;
+        const registry = useAgentRegistry.getState();
+        const cleanIds = stageAgentIds?.filter((id) => {
+          const a = registry.getAgent(id);
+          return a && !a.isGenerated;
+        });
         useSettingsStore.getState().setAgentMode('preset');
         useSettingsStore
           .getState()
           .setSelectedAgentIds(
-            stageAgentIds && stageAgentIds.length > 0
-              ? stageAgentIds
-              : ['default-1', 'default-2', 'default-3'],
+            cleanIds && cleanIds.length > 0 ? cleanIds : ['default-1', 'default-2', 'default-3'],
           );
       }
     } catch (error) {

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -484,7 +484,11 @@ function GenerationPreviewContent() {
         } catch (err: unknown) {
           log.warn('[Generation] Agent generation failed, falling back to presets:', err);
           const registry = useAgentRegistry.getState();
-          agents = settings.selectedAgentIds
+          const fallbackIds = settings.selectedAgentIds.filter((id) => {
+            const a = registry.getAgent(id);
+            return a && !a.isGenerated;
+          });
+          agents = fallbackIds
             .map((id) => registry.getAgent(id))
             .filter(Boolean)
             .map((a) => ({
@@ -493,12 +497,17 @@ function GenerationPreviewContent() {
               role: a!.role,
               persona: a!.persona,
             }));
-          stage.agentIds = settings.selectedAgentIds;
+          stage.agentIds = fallbackIds;
         }
       } else {
         // Preset mode — use selected agents (include persona)
+        // Filter out stale generated agent IDs that may linger in settings
         const registry = useAgentRegistry.getState();
-        agents = settings.selectedAgentIds
+        const presetAgentIds = settings.selectedAgentIds.filter((id) => {
+          const a = registry.getAgent(id);
+          return a && !a.isGenerated;
+        });
+        agents = presetAgentIds
           .map((id) => registry.getAgent(id))
           .filter(Boolean)
           .map((a) => ({
@@ -507,7 +516,7 @@ function GenerationPreviewContent() {
             role: a!.role,
             persona: a!.persona,
           }));
-        stage.agentIds = settings.selectedAgentIds;
+        stage.agentIds = presetAgentIds;
       }
 
       // ── Generate outlines (with agent personas for teacher context) ──

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -508,13 +508,18 @@ export function AgentBar() {
   const handleModeChange = (mode: 'preset' | 'auto') => {
     setAgentMode(mode);
     if (mode === 'preset') {
-      const hasTeacherSelected = selectedAgentIds.some((id) => {
+      // Remove stale auto-generated agent IDs that may linger from a previous auto classroom
+      const presetIds = selectedAgentIds.filter((id) => agents.some((a) => a.id === id));
+      const hasTeacher = presetIds.some((id) => {
         const a = agents.find((agent) => agent.id === id);
         return a?.role === 'teacher';
       });
-      if (!hasTeacherSelected && teacherAgent) {
-        setSelectedAgentIds([teacherAgent.id, ...selectedAgentIds]);
+      if (!hasTeacher && teacherAgent) {
+        presetIds.unshift(teacherAgent.id);
       }
+      setSelectedAgentIds(
+        presetIds.length > 0 ? presetIds : ['default-1', 'default-2', 'default-3'],
+      );
     }
   };
 

--- a/lib/orchestration/registry/store.ts
+++ b/lib/orchestration/registry/store.ts
@@ -334,17 +334,19 @@ export async function loadGeneratedAgentsForStage(stageId: string): Promise<stri
   const { getGeneratedAgentsByStageId } = await import('@/lib/utils/database');
   const records = await getGeneratedAgentsByStageId(stageId);
 
-  if (records.length === 0) return [];
-
   const registry = useAgentRegistry.getState();
 
-  // Clear previously loaded generated agents
+  // Always clear previously loaded generated agents — even when the new stage
+  // has none — to prevent stale agents from a prior auto-classroom leaking
+  // into the current preset classroom.
   const currentAgents = registry.listAgents();
   for (const agent of currentAgents) {
     if (agent.isGenerated) {
       registry.deleteAgent(agent.id);
     }
   }
+
+  if (records.length === 0) return [];
 
   // Add new ones
   const ids: string[] = [];


### PR DESCRIPTION
## Summary

- Fix three independent bugs that combined to leak auto-generated agents across classrooms
- Add defense-in-depth filtering at four layers: mode switch, generation save, stage load, and registry cleanup
- Handle backward compatibility with pre-fix IndexedDB data that may contain mixed agent IDs

Closes #247

## Root Cause

| Bug | Location | Issue |
|-----|----------|-------|
| 1 | `agent-bar.tsx` `handleModeChange` | Switching to preset mode only added teacher, never removed stale generated IDs |
| 2 | `registry/store.ts` `loadGeneratedAgentsForStage` | Early return on empty result skipped clearing stale generated agents from registry |
| 3 | `generation-preview/page.tsx` | Saved raw `selectedAgentIds` (with stale generated IDs) into `stage.agentIds` |
| 4 | `classroom/[id]/page.tsx` | Trusted `stage.agentIds` from IndexedDB without filtering generated IDs |

## Test plan

- [x] Create an auto-generated agent classroom, then switch to preset mode and create a preset classroom
- [x] Open the auto classroom, then open the preset classroom — verify only preset agents appear
- [x] Alternate between classrooms multiple times — verify no agent bleed in either direction
- [x] Create a fresh preset classroom — verify no stale generated agent IDs in `stage.agentIds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)