### PR TITLE
fix(tts): delegate discussion TTS pause/resume to browser speech API

### DIFF
--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -36,6 +36,8 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
   const queueRef = useRef<QueueItem[]>([]);
   const isPlayingRef = useRef(false);
   const pausedRef = useRef(false);
+  /** Tracks which TTS provider is currently speaking (for pause/resume delegation) */
+  const currentProviderRef = useRef<TTSProviderId | null>(null);
   const segmentDoneCounterRef = useRef(0);
   const abortControllerRef = useRef<AbortController | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -43,19 +45,31 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
   onAudioStateChangeRef.current = onAudioStateChange;
   const processQueueRef = useRef<() => void>(() => {});
 
-  const { speak: browserSpeak, cancel: browserCancel } = useBrowserTTS({
+  const {
+    speak: browserSpeak,
+    pause: browserPause,
+    resume: browserResume,
+    cancel: browserCancel,
+  } = useBrowserTTS({
     rate: ttsSpeed,
     onEnd: () => {
       isPlayingRef.current = false;
       segmentDoneCounterRef.current++;
       onAudioStateChangeRef.current?.(null, 'idle');
-      processQueueRef.current();
+      // Don't advance queue while paused — resume() will kick-start it
+      if (!pausedRef.current) {
+        processQueueRef.current();
+      }
     },
   });
   const browserCancelRef = useRef(browserCancel);
   browserCancelRef.current = browserCancel;
   const browserSpeakRef = useRef(browserSpeak);
   browserSpeakRef.current = browserSpeak;
+  const browserPauseRef = useRef(browserPause);
+  browserPauseRef.current = browserPause;
+  const browserResumeRef = useRef(browserResume);
+  browserResumeRef.current = browserResume;
 
   // Build agent index map for deterministic voice resolution
   const agentIndexMap = useRef<Map<string, number>>(new Map());
@@ -98,6 +112,7 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
   );
 
   const processQueue = useCallback(async () => {
+    if (pausedRef.current) return; // Don't advance while paused
     if (isPlayingRef.current || queueRef.current.length === 0) return;
     if (!enabled || ttsMuted) {
       queueRef.current = [];
@@ -109,12 +124,14 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
 
     // Browser TTS
     if (item.providerId === 'browser-native-tts') {
+      currentProviderRef.current = item.providerId;
       onAudioStateChangeRef.current?.(item.agentId, 'playing');
       browserSpeakRef.current(item.text, item.voiceId);
       return;
     }
 
     // Server TTS — use the item's provider, not the global one
+    currentProviderRef.current = item.providerId;
     onAudioStateChangeRef.current?.(item.agentId, 'generating');
     const controller = new AbortController();
     abortControllerRef.current = controller;
@@ -198,6 +215,8 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
   );
 
   const cleanup = useCallback(() => {
+    pausedRef.current = false;
+    currentProviderRef.current = null;
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
     if (audioRef.current) {
@@ -208,22 +227,32 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
     browserCancelRef.current();
     queueRef.current = [];
     isPlayingRef.current = false;
-    pausedRef.current = false;
     segmentDoneCounterRef.current = 0;
     onAudioStateChangeRef.current?.(null, 'idle');
   }, []);
 
+  /** Pause TTS audio (browser-native or server). Does NOT stop the SSE stream. */
   const pause = useCallback(() => {
+    if (pausedRef.current) return;
     pausedRef.current = true;
-    if (audioRef.current && !audioRef.current.paused) {
+    if (currentProviderRef.current === 'browser-native-tts') {
+      browserPauseRef.current();
+    } else if (audioRef.current && !audioRef.current.paused) {
       audioRef.current.pause();
     }
   }, []);
 
+  /** Resume TTS audio. If the previous utterance already ended while paused, advance the queue. */
   const resume = useCallback(() => {
+    if (!pausedRef.current) return;
     pausedRef.current = false;
-    if (audioRef.current && audioRef.current.paused && audioRef.current.src) {
-      audioRef.current.play().catch(() => {});
+    if (currentProviderRef.current === 'browser-native-tts') {
+      browserResumeRef.current();
+    } else if (audioRef.current && audioRef.current.paused) {
+      audioRef.current.play();
+    } else if (!isPlayingRef.current) {
+      // Audio finished while paused — kick-start the queue
+      processQueueRef.current();
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes #245 — Browser-native TTS (`speechSynthesis`) could not be paused or resumed during discussion mode. The `useDiscussionTTS` hook exposed `pause()`/`resume()` methods but they only controlled the server TTS `HTMLAudioElement`, ignoring browser-native speech entirely.

## Root Cause

`useDiscussionTTS` destructured only `speak` and `cancel` from `useBrowserTTS`, missing `pause` and `resume`. The existing `pause()`/`resume()` only handled `audioRef` (server TTS), leaving `speechSynthesis` running when users paused a discussion.

## Changes

### `lib/hooks/use-discussion-tts.ts`

- **`currentProviderRef`** — tracks which TTS provider is active (`'browser-native-tts'` vs server providers) so `pause()`/`resume()` can delegate to the correct backend
- Destructure `pause`/`resume` from `useBrowserTTS` and store in stable refs
- **`pause()`** — delegates to `browserPauseRef` or `audioRef.pause()` based on `currentProviderRef`
- **`resume()`** — delegates to `browserResumeRef`, `audioRef.play()`, or `processQueue()` (if audio ended while paused)
- Guard `processQueue` and `onEnd` callback against queue advancement while paused
- Set `currentProviderRef` before playing each item in `processQueue`
- Reset refs in `cleanup()`

## Edge Cases

| Scenario | Behavior |
|----------|----------|
| Pause during browser TTS | Delegates to `speechSynthesis.pause()` |
| Pause during server TTS | `audioRef.pause()` |
| Audio ends while paused | `onEnd` won't advance queue; `resume()` kick-starts it |
| New segments arrive while paused | Pushed to queue but guarded by `pausedRef` |

## Related

- #249 — Perceived ~300ms delay with `speechSynthesis.pause()` (follow-up)
- #250 — Lecture/discussion resume from sentence start (follow-up)

> 🤖 AI-assisted and reviewed by Claude Opus 4.6