### PR TITLE
fix(e2e): add provider apiKey to test settings fixture

### DIFF
--- a/e2e/fixtures/test-data/settings.ts
+++ b/e2e/fixtures/test-data/settings.ts
@@ -4,6 +4,9 @@ export function createSettingsStorage(overrides: Record<string, unknown> = {}) {
     state: {
       modelId: 'gpt-4o',
       providerId: 'openai',
+      providersConfig: {
+        openai: { apiKey: 'test-key' },
+      },
       agentMode: 'preset',
       selectedAgentIds: [],
       ttsEnabled: false,


### PR DESCRIPTION
## Summary

Fixes #264

#232 added validation in `fetchServerProviders` that clears `modelId` when the selected provider has no `apiKey` and no server config. The E2E settings fixture only had `modelId` and `providerId` but no `providersConfig`, so on page load the validation cleared the model selection and `handleGenerate` bailed out before navigating.

One-line fix: add `providersConfig: { openai: { apiKey: 'test-key' } }` to the test fixture.

## Test plan

- [ ] CI E2E tests pass (previously 100% failing on main)