### PR TITLE
ui: enlarge TTS voice pill in agent bar

### DIFF
--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -140,9 +140,9 @@ function AgentVoicePill({
       <div
         onClick={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
-        className="flex items-center gap-1 h-5 w-[88px] rounded-full bg-muted/40 px-2 text-[10px] text-muted-foreground/30 shrink-0 cursor-not-allowed"
+        className="flex items-center gap-1.5 h-6 w-[100px] rounded-full bg-muted/40 px-2.5 text-[11px] text-muted-foreground/30 shrink-0 cursor-not-allowed"
       >
-        <VolumeX className="size-2.5 shrink-0" />
+        <VolumeX className="size-3 shrink-0" />
         <span className="truncate flex-1 text-left">{displayName}</span>
       </div>
     );
@@ -161,24 +161,24 @@ function AgentVoicePill({
           type="button"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
-          className="flex items-center gap-1 h-5 w-[88px] rounded-full bg-primary/10 hover:bg-primary/20 dark:bg-primary/25 dark:hover:bg-primary/35 px-2 text-[10px] text-primary/80 hover:text-primary dark:text-primary/90 transition-colors shrink-0 cursor-pointer"
+          className="flex items-center gap-1.5 h-6 w-[100px] rounded-full bg-primary/10 hover:bg-primary/20 dark:bg-primary/25 dark:hover:bg-primary/35 px-2.5 text-[11px] text-primary/80 hover:text-primary dark:text-primary/90 transition-colors shrink-0 cursor-pointer"
         >
-          <Volume2 className="size-2.5 shrink-0" />
+          <Volume2 className="size-3 shrink-0" />
           <span className="truncate flex-1 text-left">{displayName}</span>
-          <ChevronDown className="size-2.5 shrink-0 opacity-50" />
+          <ChevronDown className="size-3 shrink-0 opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent
         side="bottom"
         align="end"
         sideOffset={4}
-        className="w-52 px-1 pb-1 pt-0 max-h-64 overflow-y-auto"
+        className="w-56 px-1 pb-1 pt-0 max-h-64 overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
       >
         {availableProviders.map((provider) => (
           <div key={provider.providerId}>
-            <div className="text-[10px] text-muted-foreground/60 font-medium px-2 py-1 sticky top-0 bg-popover">
+            <div className="text-[11px] text-muted-foreground/60 font-medium px-2 py-1 sticky top-0 bg-popover">
               {provider.providerName}
             </div>
             {provider.voices.map((voice) => {
@@ -190,7 +190,7 @@ function AgentVoicePill({
                 <div
                   key={previewKey}
                   className={cn(
-                    'flex items-center gap-1 rounded-sm transition-colors',
+                    'flex items-center gap-1.5 rounded-sm transition-colors',
                     isActive ? 'bg-primary/10' : 'hover:bg-muted',
                   )}
                 >
@@ -203,7 +203,7 @@ function AgentVoicePill({
                       setPopoverOpen(false);
                     }}
                     className={cn(
-                      'flex-1 text-left text-xs px-2 py-1 min-w-0 truncate',
+                      'flex-1 text-left text-[13px] px-2 py-1.5 min-w-0 truncate',
                       isActive ? 'text-primary font-medium' : 'text-foreground',
                     )}
                   >
@@ -216,16 +216,16 @@ function AgentVoicePill({
                       handlePreview(provider.providerId, voice.id);
                     }}
                     className={cn(
-                      'shrink-0 size-5 flex items-center justify-center rounded-sm transition-colors',
+                      'shrink-0 size-6 flex items-center justify-center rounded-sm transition-colors',
                       isPreviewing
                         ? 'text-primary'
                         : 'text-muted-foreground/40 hover:text-muted-foreground',
                     )}
                   >
                     {isPreviewing ? (
-                      <Loader2 className="size-3 animate-spin" />
+                      <Loader2 className="size-3.5 animate-spin" />
                     ) : (
-                      <Volume2 className="size-3" />
+                      <Volume2 className="size-3.5" />
                     )}
                   </button>
                 </div>
@@ -350,9 +350,9 @@ function TeacherVoicePill({
       <div
         onClick={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
-        className="flex items-center gap-1 h-5 w-[88px] rounded-full bg-muted/40 px-2 text-[10px] text-muted-foreground/30 shrink-0 cursor-not-allowed"
+        className="flex items-center gap-1.5 h-6 w-[100px] rounded-full bg-muted/40 px-2.5 text-[11px] text-muted-foreground/30 shrink-0 cursor-not-allowed"
       >
-        <VolumeX className="size-2.5 shrink-0" />
+        <VolumeX className="size-3 shrink-0" />
         <span className="truncate flex-1 text-left">{displayName}</span>
       </div>
     );
@@ -371,24 +371,24 @@ function TeacherVoicePill({
           type="button"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
-          className="flex items-center gap-1 h-5 w-[88px] rounded-full bg-primary/10 hover:bg-primary/20 dark:bg-primary/25 dark:hover:bg-primary/35 px-2 text-[10px] text-primary/80 hover:text-primary dark:text-primary/90 transition-colors shrink-0 cursor-pointer"
+          className="flex items-center gap-1.5 h-6 w-[100px] rounded-full bg-primary/10 hover:bg-primary/20 dark:bg-primary/25 dark:hover:bg-primary/35 px-2.5 text-[11px] text-primary/80 hover:text-primary dark:text-primary/90 transition-colors shrink-0 cursor-pointer"
         >
-          <Volume2 className="size-2.5 shrink-0" />
+          <Volume2 className="size-3 shrink-0" />
           <span className="truncate flex-1 text-left">{displayName}</span>
-          <ChevronDown className="size-2.5 shrink-0 opacity-50" />
+          <ChevronDown className="size-3 shrink-0 opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent
         side="bottom"
         align="end"
         sideOffset={4}
-        className="w-52 px-1 pb-1 pt-0 max-h-64 overflow-y-auto"
+        className="w-56 px-1 pb-1 pt-0 max-h-64 overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
       >
         {availableProviders.map((provider) => (
           <div key={provider.providerId}>
-            <div className="text-[10px] text-muted-foreground/60 font-medium px-2 py-1 sticky top-0 bg-popover">
+            <div className="text-[11px] text-muted-foreground/60 font-medium px-2 py-1 sticky top-0 bg-popover">
               {provider.providerName}
             </div>
             {provider.voices.map((voice) => {
@@ -399,7 +399,7 @@ function TeacherVoicePill({
                 <div
                   key={previewKey}
                   className={cn(
-                    'flex items-center gap-1 rounded-sm transition-colors',
+                    'flex items-center gap-1.5 rounded-sm transition-colors',
                     isActive ? 'bg-primary/10' : 'hover:bg-muted',
                   )}
                 >
@@ -411,7 +411,7 @@ function TeacherVoicePill({
                       setPopoverOpen(false);
                     }}
                     className={cn(
-                      'flex-1 text-left text-xs px-2 py-1 min-w-0 truncate',
+                      'flex-1 text-left text-[13px] px-2 py-1.5 min-w-0 truncate',
                       isActive ? 'text-primary font-medium' : 'text-foreground',
                     )}
                   >
@@ -424,16 +424,16 @@ function TeacherVoicePill({
                       handlePreview(provider.providerId, voice.id);
                     }}
                     className={cn(
-                      'shrink-0 size-5 flex items-center justify-center rounded-sm transition-colors',
+                      'shrink-0 size-6 flex items-center justify-center rounded-sm transition-colors',
                       isPreviewing
                         ? 'text-primary'
                         : 'text-muted-foreground/40 hover:text-muted-foreground',
                     )}
                   >
                     {isPreviewing ? (
-                      <Loader2 className="size-3 animate-spin" />
+                      <Loader2 className="size-3.5 animate-spin" />
                     ) : (
-                      <Volume2 className="size-3" />
+                      <Volume2 className="size-3.5" />
                     )}
                   </button>
                 </div>


### PR DESCRIPTION
## Summary
- Increase TTS voice selection pill size (height, width, font, icons) for better usability
- Enlarge popover menu items and preview buttons accordingly
- Applies to both `AgentVoicePill` and `TeacherVoicePill`

Closes #272

## Test plan
- [ ] Open homepage, expand agent bar
- [ ] Verify voice pill buttons are visibly larger and text is readable
- [ ] Click voice pill, verify popover items are comfortably sized
- [ ] Check both teacher and agent voice pills
- [ ] Verify disabled state styling is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)