### PR TITLE
fix(roundtable): prevent TTS segments from overlapping on rapid pause/resume

### DIFF
--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -164,16 +164,22 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
       audio.volume = ttsMuted ? 0 : ttsVolume;
       audioRef.current = audio;
       audio.addEventListener('ended', () => {
+        audioRef.current = null;
         isPlayingRef.current = false;
         segmentDoneCounterRef.current++;
         onAudioStateChangeRef.current?.(item.agentId, 'idle');
-        queueMicrotask(() => processQueueRef.current());
+        if (!pausedRef.current) {
+          queueMicrotask(() => processQueueRef.current());
+        }
       });
       audio.addEventListener('error', () => {
+        audioRef.current = null;
         isPlayingRef.current = false;
         segmentDoneCounterRef.current++;
         onAudioStateChangeRef.current?.(item.agentId, 'idle');
-        queueMicrotask(() => processQueueRef.current());
+        if (!pausedRef.current) {
+          queueMicrotask(() => processQueueRef.current());
+        }
       });
 
       // If paused during TTS generation, keep audio ready but don't play
@@ -189,10 +195,13 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
       if ((err as Error).name !== 'AbortError') {
         console.error('[DiscussionTTS] TTS generation failed:', err);
       }
+      audioRef.current = null;
       isPlayingRef.current = false;
       segmentDoneCounterRef.current++;
       onAudioStateChangeRef.current?.(item.agentId, 'idle');
-      queueMicrotask(() => processQueueRef.current());
+      if (!pausedRef.current) {
+        queueMicrotask(() => processQueueRef.current());
+      }
     }
   }, [enabled, ttsMuted, ttsVolume, ttsProvidersConfig, ttsSpeed, playbackSpeed]);
 


### PR DESCRIPTION
Closes #285

## Summary

- Null `audioRef.current` in server TTS `ended`/`error`/`catch` handlers to prevent
  stale Audio elements from being replayed by subsequent pause/resume calls
- Add `if (!pausedRef.current)` guard before scheduling `processQueue()`, consistent
  with the browser TTS path

## Test plan

- [ ] Start roundtable with server TTS, rapidly press Space during segment transitions
  — no overlapping audio
- [ ] Pause mid-segment, wait for it to "end" silently, resume — next segment plays
  correctly
- [ ] Pause during TTS generation (fetch in-flight), resume — audio plays normally
- [ ] Browser TTS path unaffected (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)