### PR TITLE
fix(roundtable): use absolute px values in breathing bar CSS keyframes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -147,32 +147,32 @@
   }
 }
 
-/* Breathing bars for presentation speech bubbles */
+/* Breathing bars for presentation speech bubbles (parent is h-3.5 = 14px) */
 @keyframes breathing-bar-1 {
   0%,
   100% {
-    height: 20%;
+    height: 3px;
   }
   50% {
-    height: 100%;
+    height: 14px;
   }
 }
 @keyframes breathing-bar-2 {
   0%,
   100% {
-    height: 40%;
+    height: 6px;
   }
   50% {
-    height: 100%;
+    height: 14px;
   }
 }
 @keyframes breathing-bar-3 {
   0%,
   100% {
-    height: 20%;
+    height: 3px;
   }
   50% {
-    height: 80%;
+    height: 11px;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace CSS percentage `height` values with absolute pixel values in breathing bar `@keyframes`
- Percentage heights do not resolve on empty `div` flex items; framer-motion handled this internally but pure CSS does not

Closes #299

## Test plan

- [ ] Enter presentation mode, verify breathing bars on teacher bubble are visible and animate
- [ ] Verify breathing bars on student agent bubble are visible and animate
- [ ] Hover over bubble — bars hide, pause icon appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)