### PR TITLE
fix(roundtable): render confirmation dialog inside fullscreen container

### DIFF
--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -1191,7 +1191,10 @@ export function Stage({
           if (!open) cancelSceneSwitch();
         }}
       >
-        <AlertDialogContent className="max-w-sm rounded-2xl p-0 overflow-hidden border-0 shadow-[0_25px_60px_-12px_rgba(0,0,0,0.15)] dark:shadow-[0_25px_60px_-12px_rgba(0,0,0,0.5)]">
+        <AlertDialogContent
+          container={isPresenting ? stageRef.current : undefined}
+          className="max-w-sm rounded-2xl p-0 overflow-hidden border-0 shadow-[0_25px_60px_-12px_rgba(0,0,0,0.15)] dark:shadow-[0_25px_60px_-12px_rgba(0,0,0,0.5)]"
+        >
           <VisuallyHidden.Root>
             <AlertDialogTitle>{t('stage.confirmSwitchTitle')}</AlertDialogTitle>
           </VisuallyHidden.Root>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -39,12 +39,14 @@ function AlertDialogOverlay({
 function AlertDialogContent({
   className,
   size = 'default',
+  container,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: 'default' | 'sm';
+  container?: HTMLElement | null;
 }) {
   return (
-    <AlertDialogPortal>
+    <AlertDialogPortal container={container}>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"


### PR DESCRIPTION
## Summary

- Fixed scene-switch confirmation dialog being invisible during fullscreen presentation mode
- The AlertDialog was portaled to `document.body` by default, which is outside the fullscreen element and therefore hidden
- Added optional `container` prop to `AlertDialogContent` and pass `stageRef.current` when in fullscreen mode

Closes #304

## Test plan

- [x] Enter a roundtable discussion
- [x] Switch to fullscreen presentation mode
- [x] Click "Next Page" while discussion is active
- [x] Confirmation dialog appears correctly inside the fullscreen view
- [x] Clicking confirm advances to the next page
- [x] Normal (non-fullscreen) mode still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)