### PR TITLE
fix(roundtable): use inline style for breathing bar background color (#306)

### DIFF
--- a/components/roundtable/presentation-speech-overlay.tsx
+++ b/components/roundtable/presentation-speech-overlay.tsx
@@ -307,7 +307,7 @@ export function PresentationBubbleCard({
         buttonState &&
         buttonState !== 'none' &&
         (() => {
-          const barsColor = bubble.role === 'agent' ? 'bg-blue-500' : 'bg-purple-500';
+          const barsColor = bubble.role === 'agent' ? '#3b82f6' : '#a855f7';
 
           if (buttonState === 'play') {
             return (
@@ -353,16 +353,25 @@ export function PresentationBubbleCard({
                   {/* Breathing bars — visible by default, hidden on hover */}
                   <div className="flex gap-0.5 items-end justify-center h-3.5 w-3.5 group-hover/bubble:hidden">
                     <div
-                      className={cn('w-1 rounded-full', barsColor)}
-                      style={{ animation: 'breathing-bar-1 0.6s ease-in-out infinite' }}
+                      className="w-1 rounded-full"
+                      style={{
+                        backgroundColor: barsColor,
+                        animation: 'breathing-bar-1 0.6s ease-in-out infinite',
+                      }}
                     />
                     <div
-                      className={cn('w-1 rounded-full', barsColor)}
-                      style={{ animation: 'breathing-bar-2 0.4s ease-in-out infinite' }}
+                      className="w-1 rounded-full"
+                      style={{
+                        backgroundColor: barsColor,
+                        animation: 'breathing-bar-2 0.4s ease-in-out infinite',
+                      }}
                     />
                     <div
-                      className={cn('w-1 rounded-full', barsColor)}
-                      style={{ animation: 'breathing-bar-3 0.5s ease-in-out infinite' }}
+                      className="w-1 rounded-full"
+                      style={{
+                        backgroundColor: barsColor,
+                        animation: 'breathing-bar-3 0.5s ease-in-out infinite',
+                      }}
                     />
                   </div>
                   {/* Pause icon on hover */}


### PR DESCRIPTION
## Summary

Fix invisible breathing bars in presentation speech bubbles by switching from dynamic Tailwind classes to inline styles.

## Related Issues

Fixes #306

## Changes

- Replace dynamic `cn('w-1 rounded-full', barsColor)` with static `className="w-1 rounded-full"` + `style={{ backgroundColor: barsColor }}`
- Change `barsColor` from Tailwind class names (`'bg-blue-500'` / `'bg-purple-500'`) to hex values (`'#3b82f6'` / `'#a855f7'`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

### Steps to reproduce / test

1. Open a classroom with TTS enabled
2. Enter presentation/immersive mode via fullscreen button
3. Play a lecture — observe the bottom-right corner of speech bubbles
4. Before: bars are invisible. After: colored bars animate correctly.

### What you personally verified

- Tested on Chrome and Safari in dev mode
- Verified bars show correct colors (blue for agent, purple for others)
- Verified hover state still shows pause icon
- Verified breathing animation timing unchanged

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots / recordings attached (if UI changes) — visual bug, fix is self-evident from the code

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings