### PR TITLE
feat(rebrand): Taluss Med design tokens, brand text & component restyling [TALA-4]

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,15 +48,18 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
+  --background: oklch(0.985 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: #722ed1;
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
+  /* Taluss Med teal primary (#0F766E teal-700) */
+  --primary: oklch(0.47 0.09 183);
+  --primary-light: oklch(0.62 0.11 183);
+  --primary-dark: oklch(0.40 0.08 183);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.97 0.01 183);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
@@ -65,55 +68,74 @@
   --destructive: oklch(0.58 0.22 27);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
+  --ring: oklch(0.67 0.11 183);
+  /* Semantic tokens */
+  --success: oklch(0.72 0.19 145);
+  --warning: oklch(0.77 0.17 70);
+  --info: oklch(0.62 0.19 255);
+  /* Radius scale */
+  --radius-card: 1rem;
+  --radius-button: 0.75rem;
+  --radius-badge: 9999px;
+  --chart-1: oklch(0.62 0.11 183);
+  --chart-2: oklch(0.72 0.19 145);
+  --chart-3: oklch(0.77 0.17 70);
+  --chart-4: oklch(0.47 0.09 183);
+  --chart-5: oklch(0.40 0.08 183);
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-primary: oklch(0.47 0.09 183);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.97 0.01 183);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: oklch(0.67 0.11 183);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.11 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.16 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.16 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: #8b47ea;
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
+  /* Lighter teal for dark mode contrast */
+  --primary: oklch(0.62 0.11 183);
+  --primary-light: oklch(0.72 0.12 183);
+  --primary-dark: oklch(0.52 0.10 183);
+  --primary-foreground: oklch(0.11 0 0);
+  --secondary: oklch(0.22 0.02 183);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
+  --muted: oklch(0.22 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.371 0 0);
+  --accent: oklch(0.28 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.205 0 0);
+  --ring: oklch(0.67 0.11 183);
+  /* Semantic tokens dark */
+  --success: oklch(0.72 0.19 145);
+  --warning: oklch(0.77 0.17 70);
+  --info: oklch(0.62 0.19 255);
+  /* Radius scale (same for dark) */
+  --radius-card: 1rem;
+  --radius-button: 0.75rem;
+  --radius-badge: 9999px;
+  --chart-1: oklch(0.72 0.12 183);
+  --chart-2: oklch(0.72 0.19 145);
+  --chart-3: oklch(0.77 0.17 70);
+  --chart-4: oklch(0.62 0.11 183);
+  --chart-5: oklch(0.52 0.10 183);
+  --sidebar: oklch(0.16 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-primary: oklch(0.62 0.11 183);
+  --sidebar-primary-foreground: oklch(0.11 0 0);
+  --sidebar-accent: oklch(0.22 0.02 183);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.67 0.11 183);
 }
 
 @layer base {
@@ -122,6 +144,8 @@
   }
   body {
     @apply bg-background text-foreground;
+    hyphens: none;
+    word-break: keep-all;
   }
 }
 /* ProseMirror Editor Styles */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,8 @@ const inter = localFont({
 });
 
 export const metadata: Metadata = {
-  title: 'OpenMAIC',
-  description:
-    'The open-source AI interactive classroom. Upload a PDF to instantly generate an immersive, multi-agent learning experience.',
+  title: 'Taluss Med',
+  description: 'Dein KI-Lernpartner für medizinische Prüfungen',
 };
 
 export default function RootLayout({
@@ -28,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={inter.variable} suppressHydrationWarning>
+    <html lang="de" className={inter.variable} suppressHydrationWarning>
       <body
         className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
         suppressHydrationWarning

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -476,9 +476,7 @@ function HomePage() {
         )}
       >
         {/* ── Logo ── */}
-        <motion.img
-          src="/logo-horizontal.png"
-          alt="OpenMAIC"
+        <motion.span
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{
@@ -487,8 +485,10 @@ function HomePage() {
             stiffness: 200,
             damping: 20,
           }}
-          className="h-12 md:h-16 mb-2 -ml-2 md:-ml-3"
-        />
+          className="font-bold text-primary text-3xl md:text-4xl mb-2"
+        >
+          Taluss Med
+        </motion.span>
 
         {/* ── Slogan ── */}
         <motion.p
@@ -669,7 +669,7 @@ function HomePage() {
 
       {/* Footer — flows with content, at the very end */}
       <div className="mt-auto pt-12 pb-4 text-center text-xs text-muted-foreground/40">
-        OpenMAIC Open Source Project
+        Taluss Med
       </div>
     </div>
   );

--- a/components/stage/scene-sidebar.tsx
+++ b/components/stage/scene-sidebar.tsx
@@ -126,7 +126,7 @@ export function SceneSidebar({
             className="flex items-center gap-2 cursor-pointer rounded-lg px-1.5 -mx-1.5 py-1 -my-1 hover:bg-gray-100/80 dark:hover:bg-gray-800/60 active:scale-[0.97] transition-all duration-150"
             title={t('generation.backToHome')}
           >
-            <img src="/logo-horizontal.png" alt="OpenMAIC" className="h-6" />
+            <span className="font-bold text-primary">Taluss Med</span>
           </button>
           <button
             onClick={() => onCollapseChange(true)}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -16,6 +16,10 @@ const badgeVariants = cva(
         outline: 'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
         ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
         link: 'text-primary underline-offset-4 hover:underline',
+        success:
+          'bg-[var(--success)]/15 text-[var(--success)] dark:bg-[var(--success)]/20 border-[var(--success)]/20',
+        warning:
+          'bg-[var(--warning)]/15 text-[var(--warning)] dark:bg-[var(--warning)]/20 border-[var(--warning)]/20',
       },
     },
     defaultVariants: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-[var(--radius-button)] border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        'ring-foreground/10 bg-card text-card-foreground gap-6 overflow-hidden rounded-xl py-6 text-sm shadow-xs ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col',
+        'ring-foreground/10 bg-card text-card-foreground gap-6 overflow-hidden rounded-[var(--radius-card)] py-6 text-sm shadow-sm ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-[var(--radius-card)] *:[img:last-child]:rounded-b-[var(--radius-card)] group/card flex flex-col',
         className,
       )}
       {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-11 rounded-[var(--radius-button)] border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openmaic",
+  "name": "taluss-med",
   "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

Implements Steps 1–4 of the Taluss Med rebrand per [TALA-3 plan](/TALA/issues/TALA-3#document-plan).

- **Design tokens** (`app/globals.css`): replaced purple primary with teal `oklch(0.47 0.09 183)` (#0F766E) in `:root` and `.dark`; added `--primary-light`, `--primary-dark`, `--success`, `--warning`, `--info` semantic tokens; added `--radius-card: 1rem`, `--radius-button: 0.75rem`, `--radius-badge: 9999px`; set `--ring` to teal-400 `oklch(0.67 0.11 183)`; added `hyphens: none; word-break: keep-all` to body for German compound nouns
- **Brand text**: `package.json` name → `taluss-med`; `app/layout.tsx` title → `Taluss Med`, description → DE tagline, `lang="de"`; page.tsx footer → `Taluss Med`; sidebar/home logo replaced with `<span class="font-bold text-primary">Taluss Med</span>`
- **Component restyling**: `button.tsx` uses `rounded-[var(--radius-button)]`; `card.tsx` uses `rounded-[var(--radius-card)]` + `shadow-sm`; `input.tsx` uses `h-11` + `rounded-[var(--radius-button)]`; `badge.tsx` gains `success` and `warning` CVA variants
- **Verification**: zero `OpenMAIC` hits in `app/`, `components/`, `package.json`; compilation passes (`✓ Compiled successfully`)

## Test plan

- [ ] Toggle dark mode — verify teal primary renders correctly, no purple bleed
- [ ] Check home page logo renders as "Taluss Med" text in teal
- [ ] Check sidebar logo is "Taluss Med" text
- [ ] Verify page title in browser tab shows "Taluss Med"
- [ ] Confirm `<html lang="de">` in page source
- [ ] Inspect card radius (16px), button radius (12px), input height (44px)
- [ ] Verify badge `success`/`warning` variants render with correct semantic colors
- [ ] `grep -r "OpenMAIC" app/ components/ package.json` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)