### PR TITLE
feat(playback): add browser TTS mute detection and notification

### DIFF
--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { AlertTriangle } from 'lucide-react';
 import { VisuallyHidden } from 'radix-ui';
+import { toast } from 'sonner';
 
 /**
  * Stage Component
@@ -527,6 +528,12 @@ export function Stage({
             }
           }, 1500);
         }
+      },
+      onBrowserTTSMuted: () => {
+        toast.warning(t('playback.browserTtsMuted'), {
+          duration: 5000,
+          id: 'browser-tts-muted',
+        });
       },
     });
 

--- a/lib/i18n/common.ts
+++ b/lib/i18n/common.ts
@@ -37,6 +37,9 @@ export const commonZhCN = {
     exportSuccess: '导出成功',
     exportFailed: '导出失败',
   },
+  playback: {
+    browserTtsMuted: '当前浏览器处于静音状态，无法听到语音。请打开系统或浏览器音量。',
+  },
 } as const;
 
 export const commonEnUS = {
@@ -77,5 +80,8 @@ export const commonEnUS = {
     exporting: 'Exporting...',
     exportSuccess: 'Export successful',
     exportFailed: 'Export failed',
+  },
+  playback: {
+    browserTtsMuted: 'Browser is muted. Please unmute your system or browser to hear the audio.',
   },
 } as const;

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -663,7 +663,19 @@ export class PlaybackEngine {
       utterance.lang = cjkRatio > CJK_LANG_THRESHOLD ? 'zh-CN' : 'en-US';
     }
 
+    // Track start time to detect abnormally fast completion (likely due to mute)
+    const startTime = performance.now();
+    const MIN_NORMAL_DURATION = 200; // ms - anything faster is suspicious
+
     utterance.onend = () => {
+      const duration = performance.now() - startTime;
+      
+      // Detect abnormally fast completion - likely browser/system is muted
+      if (duration < MIN_NORMAL_DURATION && chunkText.trim().length > 0) {
+        log.warn(`Browser TTS chunk ended too quickly (${duration}ms) - possible mute state`);
+        this.callbacks.onBrowserTTSMuted?.();
+      }
+      
       this.browserTTSChunkIndex++;
       if (this.mode === 'playing') {
         this.playBrowserTTSChunk(); // next chunk

--- a/lib/playback/types.ts
+++ b/lib/playback/types.ts
@@ -59,4 +59,7 @@ export interface PlaybackEngineCallbacks {
   getPlaybackSpeed?: () => number;
 
   onComplete?: () => void;
+
+  /** Browser TTS is muted - prompt user to unmute */
+  onBrowserTTSMuted?: () => void;
 }


### PR DESCRIPTION
feat(playback): add browser TTS mute detection and notification

## Summary

Add browser TTS mute state detection that displays a notification when the browser is muted.

## Related Issues

Closes #<issue-number>

## Changes

- Detect abnormally fast TTS completion in playback engine (indicating muted state)
- Show toast notification when mute is detected
- Add bilingual prompts for Chinese and English users

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Start the app and navigate to the playback interface
2. Mute your system or browser
3. Play content with TTS enabled
4. Observe if the mute notification toast appears

### What you personally verified

- TTS correctly triggers notification when muted
- No false positives during normal volume playback
- Chinese and English UI display correct prompt text

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots / recordings attached (if UI changes)

<img width="1170" height="614" alt="image" src="https://github.com/user-attachments/assets/ee438576-7ee2-4be6-86b9-95e741aecd49" />

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
