### PR TITLE
fix: prevent modifier-key combos (Ctrl+C, Ctrl+S) from triggering single-key shortcuts

### DIFF
--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -788,6 +788,8 @@ export function Stage({
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
+      // Let modifier-key combos (Ctrl+C, Ctrl+S, etc.) pass through to the browser
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
       if (
         isPresentationShortcutTarget(event.target) ||
         isPresentationShortcutTarget(document.activeElement)


### PR DESCRIPTION
## Summary

Fixes #358 — `Ctrl+C` (copy), `Ctrl+S` (save), and other modifier-key combinations were incorrectly intercepted by the global keyboard shortcut handler in `Stage`, toggling UI panels instead of performing their native browser actions.

## Problem

The `onKeyDown` handler in `components/stage.tsx` matches single-letter keys (`c`, `s`, `m`) without checking for modifier keys. When a user presses `Ctrl+C`:

1. `event.key` → `'c'` ✅ matches the `case 'c'` branch
2. `event.ctrlKey` → `true` ⚠️ **not checked**
3. `event.preventDefault()` blocks the native copy action
4. `setChatAreaCollapsed(!chatAreaCollapsed)` toggles the chat sidebar

| Combination | Expected | Actual (before fix) |
|---|---|---|
| `Ctrl+C` | Copy | Toggles chat sidebar |
| `Ctrl+S` | Save | Toggles scene sidebar |
| `Ctrl+M` | Browser shortcut | Toggles TTS mute |
| `⌘+C` / `⌘+S` (macOS) | Copy / Save | Same issue via `metaKey` |

## Fix

Add a single modifier-key guard at the top of the `onKeyDown` handler:

```typescript
if (event.ctrlKey || event.metaKey || event.altKey) return;
```

This lets all modifier-key combinations pass through to the browser while preserving bare-key shortcuts (`c`, `s`, `m`, arrows, space, escape).

## Risk Assessment

**Minimal.** No existing shortcut in this handler is designed to work with `Ctrl`/`Meta`/`Alt`. The guard only affects key events that were never intended to be captured.