### PR TITLE
Feat/export scorm12

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -10,16 +10,19 @@ import {
   Download,
   FileDown,
   Package,
+  BookOpen,
 } from 'lucide-react';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useTheme } from '@/lib/hooks/use-theme';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { SettingsDialog } from './settings';
+import { ScormExportDialog } from './scorm-export-dialog';
 import { cn } from '@/lib/utils';
 import { useStageStore } from '@/lib/store/stage';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import { useExportPPTX } from '@/lib/export/use-export-pptx';
+import { useExportScorm } from '@/lib/export/scorm';
 
 interface HeaderProps {
   readonly currentSceneTitle: string;
@@ -35,12 +38,16 @@ export function Header({ currentSceneTitle }: HeaderProps) {
 
   // Export
   const { exporting: isExporting, exportPPTX, exportResourcePack } = useExportPPTX();
+  const { exporting: isExportingScorm, exportScorm } = useExportScorm();
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const [scormDialogOpen, setScormDialogOpen] = useState(false);
   const exportRef = useRef<HTMLDivElement>(null);
   const scenes = useStageStore((s) => s.scenes);
   const generatingOutlines = useStageStore((s) => s.generatingOutlines);
   const failedOutlines = useStageStore((s) => s.failedOutlines);
   const mediaTasks = useMediaGenerationStore((s) => s.tasks);
+
+  const anyExporting = isExporting || isExportingScorm;
 
   const canExport =
     scenes.length > 0 &&
@@ -222,31 +229,31 @@ export function Header({ currentSceneTitle }: HeaderProps) {
         <div className="relative" ref={exportRef}>
           <button
             onClick={() => {
-              if (canExport && !isExporting) setExportMenuOpen(!exportMenuOpen);
+              if (canExport && !anyExporting) setExportMenuOpen(!exportMenuOpen);
             }}
-            disabled={!canExport || isExporting}
+            disabled={!canExport || anyExporting}
             title={
               canExport
-                ? isExporting
+                ? anyExporting
                   ? t('export.exporting')
                   : t('export.pptx')
                 : t('share.notReady')
             }
             className={cn(
               'shrink-0 p-2 rounded-full transition-all',
-              canExport && !isExporting
+              canExport && !anyExporting
                 ? 'text-gray-400 dark:text-gray-500 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200 hover:shadow-sm'
                 : 'text-gray-300 dark:text-gray-600 cursor-not-allowed opacity-50',
             )}
           >
-            {isExporting ? (
+            {anyExporting ? (
               <Loader2 className="w-4 h-4 animate-spin" />
             ) : (
               <Download className="w-4 h-4" />
             )}
           </button>
           {exportMenuOpen && (
-            <div className="absolute top-full mt-2 right-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg overflow-hidden z-50 min-w-[200px]">
+            <div className="absolute top-full mt-2 right-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg overflow-hidden z-50 min-w-[220px]">
               <button
                 onClick={() => {
                   setExportMenuOpen(false);
@@ -272,11 +279,32 @@ export function Header({ currentSceneTitle }: HeaderProps) {
                   </div>
                 </div>
               </button>
+              <div className="border-t border-gray-100 dark:border-gray-700" />
+              <button
+                onClick={() => {
+                  setExportMenuOpen(false);
+                  setScormDialogOpen(true);
+                }}
+                className="w-full px-4 py-2.5 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2.5"
+              >
+                <BookOpen className="w-4 h-4 text-gray-400 shrink-0" />
+                <div>
+                  <div>{t('export.scorm')}</div>
+                  <div className="text-[11px] text-gray-400 dark:text-gray-500">
+                    {t('export.scormDesc')}
+                  </div>
+                </div>
+              </button>
             </div>
           )}
         </div>
       </header>
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+      <ScormExportDialog
+        open={scormDialogOpen}
+        onOpenChange={setScormDialogOpen}
+        onConfirm={(opts) => exportScorm(opts)}
+      />
     </>
   );
 }

--- a/components/scorm-export-dialog.tsx
+++ b/components/scorm-export-dialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { BookOpen } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/hooks/use-i18n';
+import type { ScormExportOptions } from '@/lib/export/scorm';
+
+interface ScormExportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (options: ScormExportOptions) => void;
+}
+
+export function ScormExportDialog({ open, onOpenChange, onConfirm }: ScormExportDialogProps) {
+  const { t } = useI18n();
+  const [includeVideos, setIncludeVideos] = useState(false);
+
+  function handleConfirm() {
+    onOpenChange(false);
+    onConfirm({ includeVideos });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-2 mb-1">
+            <BookOpen className="w-5 h-5 text-purple-500" />
+            <DialogTitle>{t('export.scormDialogTitle')}</DialogTitle>
+          </div>
+          <DialogDescription>{t('export.scormDialogDesc')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <label
+            className={`flex items-start gap-3 p-3.5 rounded-lg border-2 cursor-pointer transition-colors ${
+              !includeVideos
+                ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20'
+                : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+            }`}
+          >
+            <input
+              type="radio"
+              name="video-option"
+              className="mt-0.5 accent-purple-500"
+              checked={!includeVideos}
+              onChange={() => setIncludeVideos(false)}
+            />
+            <div>
+              <div className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                {t('export.scormReplacePoster')}
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                ✓ Recommended
+              </div>
+            </div>
+          </label>
+
+          <label
+            className={`flex items-start gap-3 p-3.5 rounded-lg border-2 cursor-pointer transition-colors ${
+              includeVideos
+                ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20'
+                : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+            }`}
+          >
+            <input
+              type="radio"
+              name="video-option"
+              className="mt-0.5 accent-purple-500"
+              checked={includeVideos}
+              onChange={() => setIncludeVideos(true)}
+            />
+            <div>
+              <div className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                {t('export.scormIncludeVideos')}
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                ⚠ May exceed LMS upload limits (100–300 MB)
+              </div>
+            </div>
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleConfirm} className="bg-purple-600 hover:bg-purple-700 text-white">
+            {t('export.scormExport')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/export/scorm/asset-collector.ts
+++ b/lib/export/scorm/asset-collector.ts
@@ -1,0 +1,248 @@
+import { isMediaPlaceholder, useMediaGenerationStore } from '@/lib/store/media-generation';
+import type { Scene, SlideContent } from '@/lib/types/stage';
+import type { SpeechAction } from '@/lib/types/action';
+
+export interface AssetEntry {
+  zipPath: string;
+  blob: Blob;
+  mimeType: string;
+}
+
+export interface AssetMap {
+  /** Returns the ZIP-relative path for a given original src, or undefined if not collected */
+  get(src: string): string | undefined;
+  /** All collected assets */
+  entries(): AssetEntry[];
+}
+
+// ── Internal map implementation ──
+
+class AssetMapImpl implements AssetMap {
+  private _srcToZipPath = new Map<string, string>();
+  private _entries: AssetEntry[] = [];
+
+  set(src: string, zipPath: string, blob: Blob, mimeType: string) {
+    if (this._srcToZipPath.has(src)) return; // deduplicate
+    this._srcToZipPath.set(src, zipPath);
+    this._entries.push({ zipPath, blob, mimeType });
+  }
+
+  get(src: string): string | undefined {
+    return this._srcToZipPath.get(src);
+  }
+
+  entries(): AssetEntry[] {
+    return this._entries;
+  }
+}
+
+// ── Fetch helpers ──
+
+function dataUriToBlob(dataUri: string): { blob: Blob; mimeType: string } {
+  const [header, b64] = dataUri.split(',');
+  const mimeType = header.match(/:(.*?);/)?.[1] ?? 'application/octet-stream';
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return { blob: new Blob([bytes], { type: mimeType }), mimeType };
+}
+
+async function fetchToBlob(src: string): Promise<{ blob: Blob; mimeType: string } | null> {
+  try {
+    if (src.startsWith('data:')) {
+      return dataUriToBlob(src);
+    }
+    const resp = await fetch(src);
+    if (!resp.ok) return null;
+    const blob = await resp.blob();
+    return { blob, mimeType: blob.type || 'application/octet-stream' };
+  } catch {
+    return null;
+  }
+}
+
+function mimeToExt(mimeType: string, fallback = 'bin'): string {
+  const map: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'image/svg+xml': 'svg',
+    'audio/mpeg': 'mp3',
+    'audio/mp3': 'mp3',
+    'audio/wav': 'wav',
+    'audio/ogg': 'ogg',
+    'audio/aac': 'aac',
+    'video/mp4': 'mp4',
+    'video/webm': 'webm',
+    'video/ogg': 'ogv',
+  };
+  return map[mimeType] ?? fallback;
+}
+
+function pad2(n: number): string {
+  return String(n + 1).padStart(2, '0');
+}
+
+// ── Resolve a src that may be a media placeholder ──
+
+function resolveSrc(src: string): { src: string; poster?: string } | null {
+  if (!isMediaPlaceholder(src)) return { src };
+  const task = useMediaGenerationStore.getState().tasks[src];
+  if (task?.status === 'done' && task.objectUrl) {
+    return { src: task.objectUrl, poster: task.poster };
+  }
+  return null; // not ready, skip
+}
+
+// ── Main export ──
+
+/**
+ * Collects all media assets from exportable scenes into an AssetMap.
+ *
+ * - Slide scenes: image/video/audio element srcs + background image + TTS audio
+ * - Quiz/Interactive scenes: no media assets
+ * - When includeVideos=false, video elements are replaced by their poster image.
+ *   If no poster is available, the video element is skipped entirely.
+ *
+ * Returns an AssetMap that maps original src → zipPath, and iterable AssetEntry[].
+ */
+export async function collectAssets(
+  scenes: Scene[],
+  includeVideos: boolean,
+): Promise<AssetMap> {
+  const map = new AssetMapImpl();
+
+  const add = async (
+    originalSrc: string,
+    category: 'images' | 'audio' | 'videos',
+    sceneIdx: number,
+    suffix: string,
+  ) => {
+    if (!originalSrc || map.get(originalSrc) !== undefined) return; // already queued or empty
+    const result = await fetchToBlob(originalSrc);
+    if (!result) return;
+    const ext = mimeToExt(result.mimeType, category === 'audio' ? 'mp3' : category === 'videos' ? 'mp4' : 'png');
+    const zipPath = `assets/${category}/scene_${pad2(sceneIdx)}_${suffix}.${ext}`;
+    map.set(originalSrc, zipPath, result.blob, result.mimeType);
+  };
+
+  for (let i = 0; i < scenes.length; i++) {
+    const scene = scenes[i];
+
+    // ── Slide scenes ──
+    if (scene.content.type === 'slide') {
+      const canvas = (scene.content as SlideContent).canvas;
+
+      // Background image
+      if (canvas.background?.type === 'image' && canvas.background.image?.src) {
+        await add(canvas.background.image.src, 'images', i, 'bg');
+      }
+
+      // Elements
+      let elIdx = 0;
+      for (const el of canvas.elements) {
+        const elSuffix = `el_${el.id}`;
+
+        if (el.type === 'image') {
+          const resolved = resolveSrc(el.src);
+          if (resolved) await add(resolved.src, 'images', i, elSuffix);
+
+        } else if (el.type === 'video') {
+          const resolved = resolveSrc(el.src);
+          const resolvedPoster = el.poster ? resolveSrc(el.poster) : null;
+
+          if (includeVideos && resolved) {
+            await add(resolved.src, 'videos', i, elSuffix);
+            // Also collect poster (used as fallback thumbnail in HTML)
+            const posterSrc = resolvedPoster?.src ?? resolved.poster;
+            if (posterSrc) await add(posterSrc, 'images', i, `${elSuffix}_poster`);
+          } else {
+            // Replace video with poster image
+            const posterSrc =
+              resolvedPoster?.src ??
+              (resolved?.poster) ??
+              // Also check media generation store poster
+              (isMediaPlaceholder(el.src)
+                ? useMediaGenerationStore.getState().tasks[el.src]?.poster
+                : undefined);
+            if (posterSrc) await add(posterSrc, 'images', i, `${elSuffix}_poster`);
+          }
+
+        } else if (el.type === 'audio') {
+          const resolved = resolveSrc(el.src);
+          if (resolved) await add(resolved.src, 'audio', i, elSuffix);
+        }
+
+        elIdx++;
+      }
+
+      // TTS narration from SpeechActions
+      if (scene.actions) {
+        let speechIdx = 0;
+        for (const action of scene.actions) {
+          if (action.type === 'speech') {
+            const speech = action as SpeechAction;
+            if (speech.audioUrl) {
+              await add(speech.audioUrl, 'audio', i, `speech_${speechIdx}`);
+              speechIdx++;
+            }
+          }
+        }
+      }
+    }
+
+    // Quiz and Interactive scenes have no media assets to collect
+  }
+
+  return map;
+}
+
+/**
+ * Returns all ZIP asset paths referenced by a specific scene.
+ * Used to populate <file> entries in imsmanifest.xml.
+ */
+export function getSceneAssetHrefs(scene: Scene, sceneIdx: number, assetMap: AssetMap, includeVideos: boolean): string[] {
+  const hrefs: string[] = [];
+
+  if (scene.content.type !== 'slide') return hrefs;
+
+  const canvas = (scene.content as SlideContent).canvas;
+
+  const collect = (src: string) => {
+    if (!src) return;
+    const resolved = resolveSrc(src);
+    if (resolved) {
+      const p = assetMap.get(resolved.src);
+      if (p) hrefs.push(p);
+    }
+  };
+
+  if (canvas.background?.type === 'image' && canvas.background.image?.src) {
+    collect(canvas.background.image.src);
+  }
+
+  for (const el of canvas.elements) {
+    if (el.type === 'image') collect(el.src);
+    else if (el.type === 'video') {
+      if (includeVideos) {
+        collect(el.src);
+        if (el.poster) collect(el.poster);
+      } else if (el.poster) {
+        collect(el.poster);
+      }
+    } else if (el.type === 'audio') collect(el.src);
+  }
+
+  if (scene.actions) {
+    for (const action of scene.actions) {
+      if (action.type === 'speech') {
+        const speech = action as SpeechAction;
+        if (speech.audioUrl) collect(speech.audioUrl);
+      }
+    }
+  }
+
+  return [...new Set(hrefs)];
+}

--- a/lib/export/scorm/asset-collector.ts
+++ b/lib/export/scorm/asset-collector.ts
@@ -1,6 +1,7 @@
 import { isMediaPlaceholder, useMediaGenerationStore } from '@/lib/store/media-generation';
 import type { Scene, SlideContent } from '@/lib/types/stage';
 import type { SpeechAction } from '@/lib/types/action';
+import { db } from '@/lib/utils/database';
 
 export interface AssetEntry {
   zipPath: string;
@@ -179,6 +180,7 @@ export async function collectAssets(
       }
 
       // TTS narration from SpeechActions
+      // Primary: use server-hosted audioUrl (if set). Fallback: read blob from IndexedDB by audioId.
       if (scene.actions) {
         let speechIdx = 0;
         for (const action of scene.actions) {
@@ -187,6 +189,19 @@ export async function collectAssets(
             if (speech.audioUrl) {
               await add(speech.audioUrl, 'audio', i, `speech_${speechIdx}`);
               speechIdx++;
+            } else if (speech.audioId) {
+              try {
+                const record = await db.audioFiles.get(speech.audioId);
+                if (record) {
+                  const ext = record.format || 'mp3';
+                  const mimeType = ext === 'mp3' ? 'audio/mpeg' : `audio/${ext}`;
+                  const zipPath = `assets/audio/scene_${pad2(i)}_speech_${speechIdx}.${ext}`;
+                  map.set(`idb:${speech.audioId}`, zipPath, record.blob, mimeType);
+                  speechIdx++;
+                }
+              } catch {
+                // IndexedDB access failed — skip this audio
+              }
             }
           }
         }

--- a/lib/export/scorm/course-builder.ts
+++ b/lib/export/scorm/course-builder.ts
@@ -1,0 +1,452 @@
+/**
+ * course-builder.ts
+ * Assembles all scene fragments into a single SCORM 1.2 SCO HTML file (index.html).
+ *
+ * Architecture: single SCO with internal JS navigation.
+ * - All scenes are <section> elements; only the current one is visible.
+ * - Navigation (Prev/Next) is handled entirely in JS.
+ * - Slide canvases scale responsively via transform:scale() with a wrapper
+ *   that tracks the visual (scaled) dimensions so flex centering works correctly.
+ * - Narration audio plays automatically on slide load; user can pause/resume/restart.
+ * - SCORM completion is set only when the user reaches the last scene.
+ * - Quiz sections call window.onQuizSubmitted(sceneIdx, score) on submit.
+ */
+import type { SlideSceneMeta } from './slide-sco';
+import type { QuizSceneMeta } from './quiz-sco';
+import type { InteractiveSceneMeta } from './interactive-sco';
+import { QUIZ_PASS_THRESHOLD } from './quiz-sco';
+
+export type SceneMeta = SlideSceneMeta | QuizSceneMeta | InteractiveSceneMeta;
+
+export interface CourseHtmlOptions {
+  courseName: string;
+  sections: Array<{ html: string; meta: SceneMeta }>;
+  needsKatex: boolean;
+}
+
+const NAV_HEIGHT = 52; // px — fixed bottom nav bar height
+
+/** Serialise scene metadata for the JS runtime (avoids any TS types in output) */
+function serializeMeta(metas: SceneMeta[]): string {
+  return JSON.stringify(
+    metas.map((m) => {
+      if (m.type === 'slide') {
+        return {
+          type: 'slide', id: m.sceneId,
+          canvasId: m.canvasId, scalerId: m.scalerId,
+          cw: m.cw, ch: m.ch, narrIds: m.narrIds,
+        };
+      }
+      if (m.type === 'quiz') {
+        return { type: 'quiz', id: m.sceneId, questionCount: m.questionCount };
+      }
+      return { type: 'interactive', id: m.sceneId };
+    }),
+  );
+}
+
+export function buildCourseHtml(opts: CourseHtmlOptions): string {
+  const { courseName, sections, needsKatex } = opts;
+  const metas = sections.map((s) => s.meta);
+  const totalScenes = sections.length;
+  const hasQuiz = metas.some((m) => m.type === 'quiz');
+
+  const sceneSections = sections.map((s) => s.html).join('\n\n');
+  const metasJson = serializeMeta(metas);
+
+  const katexLink = needsKatex
+    ? `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous" onerror="this.remove()">`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${courseName.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</title>
+  <script src="scorm_bridge.js"></script>
+  ${katexLink}
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body {
+      width: 100%; height: 100%;
+      overflow: hidden;
+      font-family: 'Segoe UI', Arial, sans-serif;
+      background: #111;
+    }
+
+    /* ── Scene container ── */
+    .scene {
+      position: fixed;
+      inset: 0;
+      bottom: ${NAV_HEIGHT}px;
+    }
+
+    /* ── Slide scenes ── */
+    .scene-slide {
+      background: #1a1a1a;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    /* slide-scaler: sized to VISUAL (scaled) dimensions — flex lays out around this */
+    .slide-scaler {
+      position: relative;
+      flex-shrink: 0;
+    }
+    /* slide-canvas: full 960×N canvas, scaled from top-left inside .slide-scaler */
+    .slide-canvas {
+      position: absolute;
+      top: 0; left: 0;
+      transform-origin: top left;
+      overflow: hidden;
+    }
+
+    /* ── Quiz scenes ── */
+    .scene-quiz {
+      background: #f5f5f7;
+      overflow-y: auto;
+    }
+    .quiz-scroll {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+    .quiz-title {
+      font-size: 1.4rem;
+      font-weight: 700;
+      margin-bottom: 1.5rem;
+      color: #1d1d1f;
+    }
+    .question-block {
+      background: #fff;
+      border-radius: 10px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1.25rem;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    }
+    .question-text {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      line-height: 1.5;
+    }
+    .q-num { color: #6e6e73; margin-right: 4px; }
+    .q-multi-hint { font-size: 0.8rem; font-weight: 400; color: #6e6e73; }
+    .options-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .option-label {
+      display: flex; align-items: flex-start; gap: 10px;
+      padding: 0.6rem 0.75rem;
+      border-radius: 6px; cursor: pointer;
+      border: 1.5px solid #e0e0e5;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .option-label:hover { border-color: #0071e3; background: #f0f6ff; }
+    .option-label input { margin-top: 2px; accent-color: #0071e3; }
+    .option-value { font-weight: 600; min-width: 20px; color: #6e6e73; }
+    .option-text { flex: 1; }
+    .option-label.opt-correct  { border-color: #34c759; background: #f0faf3; }
+    .option-label.opt-incorrect { border-color: #ff3b30; background: #fff5f4; }
+    .option-label.opt-missed   { border-color: #34c759; background: #f0faf3; border-style: dashed; }
+    .analysis {
+      margin-top: 0.75rem; padding: 0.6rem 0.75rem;
+      background: #f9f9fb; border-left: 3px solid #0071e3;
+      font-size: 0.9rem; color: #444; border-radius: 0 4px 4px 0;
+      display: none;
+    }
+    .result-bar {
+      margin: 1rem 0; padding: 0.75rem 1rem;
+      border-radius: 8px; font-weight: 600; font-size: 1rem;
+    }
+    .result-pass { background: #f0faf3; color: #1a7f37; border: 1.5px solid #34c759; }
+    .result-fail { background: #fff5f4; color: #c0392b; border: 1.5px solid #ff3b30; }
+    .submit-btn {
+      display: block; width: 100%; padding: 0.8rem;
+      background: #0071e3; color: #fff; border: none;
+      border-radius: 8px; font-size: 1rem; font-weight: 600; cursor: pointer;
+      margin-top: 1rem;
+    }
+    .submit-btn:hover:not(:disabled) { background: #0077ed; }
+    .submit-btn:disabled { background: #b0c8e8; cursor: not-allowed; }
+
+    /* ── Interactive scenes ── */
+    .scene-interactive { background: #fff; }
+    .interactive-frame { width: 100%; height: 100%; border: none; }
+
+    /* ── Navigation bar (fixed bottom) ── */
+    #nav-bar {
+      position: fixed;
+      bottom: 0; left: 0; right: 0;
+      height: ${NAV_HEIGHT}px;
+      background: #fff;
+      border-top: 1px solid #e0e0e5;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 1rem;
+      gap: 0.5rem;
+      z-index: 1000;
+    }
+    .nav-btn {
+      background: #f5f5f7; border: 1.5px solid #d0d0d5;
+      padding: 6px 14px; border-radius: 6px;
+      cursor: pointer; font-size: 0.85rem; font-weight: 500;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .nav-btn:hover:not(:disabled) { background: #e8e8ed; }
+    .nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    #nav-center {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      min-width: 0;
+    }
+    #scene-title {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #1d1d1f;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    #scene-counter {
+      font-size: 0.8rem;
+      color: #6e6e73;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* ── Audio control (inline with nav) ── */
+    #narr-ctrl { display: none; align-items: center; gap: 6px; flex-shrink: 0; }
+    #narr-play-btn {
+      background: #f0f0f5; border: 1.5px solid #c0c0c8;
+      padding: 5px 10px; border-radius: 6px; cursor: pointer;
+      font-size: 0.8rem; white-space: nowrap;
+    }
+    #narr-play-btn:hover { background: #e4e4ec; }
+  </style>
+</head>
+<body>
+
+<!-- ── All scene sections ── -->
+${sceneSections}
+
+<!-- ── Fixed navigation bar ── -->
+<div id="nav-bar">
+  <button class="nav-btn" id="prev-btn" onclick="prevScene()" disabled>&#8592; Prev</button>
+
+  <div id="nav-center">
+    <span id="scene-title"></span>
+    <span id="scene-counter"></span>
+  </div>
+
+  <!-- Narration audio controls (only visible for slide scenes with TTS) -->
+  <div id="narr-ctrl">
+    <button id="narr-play-btn" onclick="toggleNarration()">&#9654; Play</button>
+    <button class="nav-btn" onclick="restartNarration()" title="Restart narration">&#8635;</button>
+  </div>
+
+  <button class="nav-btn" id="next-btn" onclick="nextScene()">Next &#8594;</button>
+</div>
+
+<script>
+// ── Scene definitions ──
+var SCENES = ${metasJson};
+var TOTAL = ${totalScenes};
+var currentIdx = 0;
+var quizScores = {}; // sceneIdx → 0-100
+
+// ── Narration state ──
+var narrEls = [];
+var narrIdx = 0;
+var narrPlaying = false;
+
+function stopNarration() {
+  narrEls.forEach(function(a) {
+    a.pause();
+    a.currentTime = 0;
+    a.onended = null;
+  });
+  narrEls = [];
+  narrIdx = 0;
+  narrPlaying = false;
+  document.getElementById('narr-play-btn').textContent = '\\u25B6 Play';
+}
+
+function playNarrFrom(idx) {
+  if (idx >= narrEls.length) {
+    narrPlaying = false;
+    document.getElementById('narr-play-btn').textContent = '\\u25B6 Play';
+    return;
+  }
+  narrIdx = idx;
+  narrPlaying = true;
+  document.getElementById('narr-play-btn').textContent = '\\u23F8 Pause';
+  narrEls[idx].onended = function() { playNarrFrom(idx + 1); };
+  narrEls[idx].play().catch(function() {
+    narrPlaying = false;
+    document.getElementById('narr-play-btn').textContent = '\\u25B6 Play';
+  });
+}
+
+function startNarration(scene) {
+  stopNarration();
+  if (!scene.narrIds || !scene.narrIds.length) return;
+  narrEls = scene.narrIds.map(function(id) {
+    return document.getElementById(id);
+  }).filter(Boolean);
+  if (narrEls.length) playNarrFrom(0);
+}
+
+function toggleNarration() {
+  if (!narrEls.length) return;
+  var el = narrEls[narrIdx] || narrEls[0];
+  if (!el) return;
+  if (el.paused) {
+    narrPlaying = true;
+    el.play().catch(function(){});
+    document.getElementById('narr-play-btn').textContent = '\\u23F8 Pause';
+  } else {
+    el.pause();
+    narrPlaying = false;
+    document.getElementById('narr-play-btn').textContent = '\\u25B6 Play';
+  }
+}
+
+function restartNarration() {
+  var scene = SCENES[currentIdx];
+  if (scene && scene.type === 'slide') startNarration(scene);
+}
+
+// ── Slide scaling ──
+function rescaleSlide(scene) {
+  var sectionEl = document.getElementById(scene.id);
+  var availW = sectionEl.offsetWidth;
+  var availH = sectionEl.offsetHeight;
+  if (!availW || !availH) return;
+  var s = Math.min(availW / scene.cw, availH / scene.ch);
+  var scaler = document.getElementById(scene.scalerId);
+  var canvas = document.getElementById(scene.canvasId);
+  scaler.style.width  = (scene.cw * s) + 'px';
+  scaler.style.height = (scene.ch * s) + 'px';
+  canvas.style.transform = 'scale(' + s + ')';
+}
+
+window.addEventListener('resize', function() {
+  var s = SCENES[currentIdx];
+  if (s && s.type === 'slide') rescaleSlide(s);
+});
+
+// ── Scene navigation ──
+function showScene(idx) {
+  stopNarration();
+
+  // Hide all, show target
+  SCENES.forEach(function(s) {
+    var el = document.getElementById(s.id);
+    if (el) el.style.display = 'none';
+  });
+  var scene = SCENES[idx];
+  var sceneEl = document.getElementById(scene.id);
+  if (sceneEl) sceneEl.style.display = '';
+  currentIdx = idx;
+
+  // Update nav bar text
+  document.getElementById('scene-title').textContent = scene.title || '';
+  document.getElementById('scene-counter').textContent = (idx + 1) + ' / ' + TOTAL;
+
+  // Prev button
+  document.getElementById('prev-btn').disabled = (idx === 0);
+
+  // Next button: disabled on last scene, or quiz not yet submitted
+  var isLast = (idx === TOTAL - 1);
+  var isQuizNotDone = scene.type === 'quiz' && quizScores[idx] === undefined;
+  document.getElementById('next-btn').disabled = isLast || isQuizNotDone;
+
+  // Narration controls
+  var narrCtrl = document.getElementById('narr-ctrl');
+  if (scene.type === 'slide' && scene.narrIds && scene.narrIds.length) {
+    narrCtrl.style.display = 'flex';
+    startNarration(scene);
+  } else {
+    narrCtrl.style.display = 'none';
+  }
+
+  // Rescale slides
+  if (scene.type === 'slide') {
+    // small timeout to let the browser render first
+    setTimeout(function() { rescaleSlide(scene); }, 0);
+  }
+
+  // SCORM: report progress
+  var progress = Math.round(((idx + 1) / TOTAL) * 100);
+  SCORM.setValue('cmi.core.score.raw', progress);
+  SCORM.setValue('cmi.core.score.min', '0');
+  SCORM.setValue('cmi.core.score.max', '100');
+  SCORM.commit();
+
+  // SCORM: complete only on last scene
+  if (isLast) {
+    SCORM.setCompleted();
+  }
+}
+
+function prevScene() {
+  if (currentIdx > 0) showScene(currentIdx - 1);
+}
+
+function nextScene() {
+  if (currentIdx < TOTAL - 1) showScene(currentIdx + 1);
+}
+
+// Called by quiz sections after submit
+window.onQuizSubmitted = function(sceneIdx, score) {
+  quizScores[sceneIdx] = score;
+  // Enable Next (unless it was the last scene)
+  if (sceneIdx < TOTAL - 1) {
+    document.getElementById('next-btn').disabled = false;
+  } else {
+    // Last scene is a quiz — complete now
+    SCORM.setScore(score, 0, 100);
+    if (score >= ${QUIZ_PASS_THRESHOLD}) {
+      SCORM.setPassed();
+    } else {
+      SCORM.setFailed();
+    }
+  }
+};
+
+// ── Init ──
+window.addEventListener('load', function() {
+  SCORM.init();
+  SCORM.setValue('cmi.core.lesson_status', 'incomplete');
+
+  // Set title on each scene (used in showScene)
+  var sceneTitles = ${JSON.stringify(sections.map((s) => s.meta.type === 'slide'
+    ? '' // title comes from scene data passed via JS — we embed it differently
+    : ''))};
+  // Titles are embedded directly in the SCENES array below:
+  // (done at build time, no runtime injection needed)
+
+  showScene(0);
+});
+
+window.addEventListener('beforeunload', function() {
+  SCORM.finish();
+});
+
+// Patch scene titles from DOM (each section has a data-title attribute)
+(function() {
+  SCENES.forEach(function(s, i) {
+    var el = document.getElementById(s.id);
+    if (el) s.title = el.getAttribute('data-title') || s.id;
+  });
+})();
+</script>
+</body>
+</html>`;
+}

--- a/lib/export/scorm/course-builder.ts
+++ b/lib/export/scorm/course-builder.ts
@@ -1,15 +1,14 @@
 /**
  * course-builder.ts
- * Assembles all scene fragments into a single SCORM 1.2 SCO HTML file (index.html).
+ * Assembles all scene fragments into a single SCORM 1.2 SCO (index.html).
  *
- * Architecture: single SCO with internal JS navigation.
- * - All scenes are <section> elements; only the current one is visible.
- * - Navigation (Prev/Next) is handled entirely in JS.
- * - Slide canvases scale responsively via transform:scale() with a wrapper
- *   that tracks the visual (scaled) dimensions so flex centering works correctly.
- * - Narration audio plays automatically on slide load; user can pause/resume/restart.
- * - SCORM completion is set only when the user reaches the last scene.
- * - Quiz sections call window.onQuizSubmitted(sceneIdx, score) on submit.
+ * Layout:
+ *   - Fixed 240px left sidebar with scene list and progress indicator
+ *   - Scene area fills the remaining right space (position:fixed, left:240px)
+ *   - Fixed 52px nav bar at the bottom (also right of sidebar)
+ *
+ * CSS: all class names prefixed with "om-" to avoid conflicts with LMS stylesheets
+ * (Bootstrap, Moodle, etc. commonly define .scene, .option-label, .submit-btn, etc.)
  */
 import type { SlideSceneMeta } from './slide-sco';
 import type { QuizSceneMeta } from './quiz-sco';
@@ -20,13 +19,18 @@ export type SceneMeta = SlideSceneMeta | QuizSceneMeta | InteractiveSceneMeta;
 
 export interface CourseHtmlOptions {
   courseName: string;
-  sections: Array<{ html: string; meta: SceneMeta }>;
+  /** Each section includes the pre-built HTML fragment, its metadata, and the scene title. */
+  sections: Array<{ html: string; meta: SceneMeta; title: string }>;
   needsKatex: boolean;
 }
 
-const NAV_HEIGHT = 52; // px — fixed bottom nav bar height
+const SIDEBAR_W = 240; // px
+const NAV_H = 52;      // px
 
-/** Serialise scene metadata for the JS runtime (avoids any TS types in output) */
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 function serializeMeta(metas: SceneMeta[]): string {
   return JSON.stringify(
     metas.map((m) => {
@@ -58,45 +62,144 @@ export function buildCourseHtml(opts: CourseHtmlOptions): string {
     ? `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous" onerror="this.remove()">`
     : '';
 
+  const sidebarItems = sections
+    .map((s, i) => `    <li id="om-nav-${i}" class="om-nav-item" onclick="sidebarGo(${i})" title="${escHtml(s.title)}">
+      <span class="om-nav-dot"></span>
+      <span class="om-nav-label">${escHtml(s.title)}</span>
+    </li>`)
+    .join('\n');
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${courseName.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</title>
+  <title>${escHtml(courseName)}</title>
   <script src="scorm_bridge.js"></script>
   ${katexLink}
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body {
-      width: 100%; height: 100%;
+    html, body { width: 100%; height: 100%; overflow: hidden; font-family: 'Segoe UI', Arial, sans-serif; background: #111; }
+
+    /* ── Sidebar ── */
+    #om-sidebar {
+      position: fixed;
+      left: 0; top: 0; bottom: 0;
+      width: ${SIDEBAR_W}px;
+      background: #0d1b2a;
+      border-right: 1px solid rgba(255,255,255,0.08);
+      display: flex;
+      flex-direction: column;
+      z-index: 200;
       overflow: hidden;
-      font-family: 'Segoe UI', Arial, sans-serif;
-      background: #111;
     }
+    #om-sidebar-header {
+      padding: 1.2rem 1rem 1rem;
+      flex-shrink: 0;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+    }
+    #om-course-title {
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: #fff;
+      line-height: 1.35;
+      margin-bottom: 0.6rem;
+    }
+    #om-progress-label {
+      font-size: 0.68rem;
+      color: #8090a8;
+      margin-bottom: 0.35rem;
+    }
+    #om-progress-bar {
+      height: 3px;
+      background: rgba(255,255,255,0.12);
+      border-radius: 2px;
+    }
+    #om-progress-fill {
+      height: 100%;
+      background: #0071e3;
+      border-radius: 2px;
+      width: 0%;
+      transition: width 0.4s ease;
+    }
+    #om-scene-list {
+      list-style: none;
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.5rem 0;
+    }
+    #om-scene-list::-webkit-scrollbar { width: 4px; }
+    #om-scene-list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 2px; }
+    .om-nav-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 0.55rem 1rem;
+      cursor: pointer;
+      border-left: 3px solid transparent;
+      transition: background 0.12s, border-color 0.12s;
+    }
+    .om-nav-item:hover { background: rgba(255,255,255,0.06); }
+    .om-nav-item.om-active {
+      background: rgba(0,113,227,0.18);
+      border-left-color: #0071e3;
+    }
+    .om-nav-dot {
+      width: 16px; height: 16px;
+      border-radius: 50%;
+      border: 1.5px solid #4a5a6a;
+      flex-shrink: 0;
+      margin-top: 2px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 9px;
+      font-weight: bold;
+      color: transparent;
+      transition: all 0.2s;
+    }
+    .om-nav-item.om-visited .om-nav-dot {
+      background: #34c759;
+      border-color: #34c759;
+      color: #fff;
+    }
+    .om-nav-item.om-active .om-nav-dot { border-color: #0071e3; }
+    .om-nav-item.om-active.om-visited .om-nav-dot {
+      background: #0071e3;
+      border-color: #0071e3;
+      color: #fff;
+    }
+    .om-nav-label {
+      font-size: 0.76rem;
+      color: #9aa8ba;
+      line-height: 1.35;
+    }
+    .om-nav-item.om-active .om-nav-label { color: #e0e8f0; }
 
     /* ── Scene container ── */
-    .scene {
+    .om-scene {
       position: fixed;
-      inset: 0;
-      bottom: ${NAV_HEIGHT}px;
+      left: ${SIDEBAR_W}px;
+      right: 0;
+      top: 0;
+      bottom: ${NAV_H}px;
     }
 
     /* ── Slide scenes ── */
-    .scene-slide {
+    .om-slide {
       background: #1a1a1a;
       display: flex;
       align-items: center;
       justify-content: center;
       overflow: hidden;
     }
-    /* slide-scaler: sized to VISUAL (scaled) dimensions — flex lays out around this */
-    .slide-scaler {
+    /* om-scaler: sized to VISUAL (scaled) dimensions — flex lays out around this */
+    .om-scaler {
       position: relative;
       flex-shrink: 0;
     }
-    /* slide-canvas: full 960×N canvas, scaled from top-left inside .slide-scaler */
-    .slide-canvas {
+    /* om-canvas: full-resolution canvas, scaled from top-left inside .om-scaler */
+    .om-canvas {
       position: absolute;
       top: 0; left: 0;
       transform-origin: top left;
@@ -104,81 +207,100 @@ export function buildCourseHtml(opts: CourseHtmlOptions): string {
     }
 
     /* ── Quiz scenes ── */
-    .scene-quiz {
+    .om-quiz {
       background: #f5f5f7;
       overflow-y: auto;
     }
-    .quiz-scroll {
+    .om-quiz-scroll {
       max-width: 760px;
       margin: 0 auto;
       padding: 2rem 1.5rem;
     }
-    .quiz-title {
+    .om-quiz-title {
       font-size: 1.4rem;
       font-weight: 700;
       margin-bottom: 1.5rem;
       color: #1d1d1f;
     }
-    .question-block {
+    .om-qblock {
       background: #fff;
       border-radius: 10px;
       padding: 1.25rem 1.5rem;
       margin-bottom: 1.25rem;
       box-shadow: 0 1px 4px rgba(0,0,0,0.08);
     }
-    .question-text {
+    .om-qtext {
       font-size: 1rem;
       font-weight: 600;
       margin-bottom: 1rem;
       line-height: 1.5;
     }
-    .q-num { color: #6e6e73; margin-right: 4px; }
-    .q-multi-hint { font-size: 0.8rem; font-weight: 400; color: #6e6e73; }
-    .options-list { display: flex; flex-direction: column; gap: 0.5rem; }
-    .option-label {
-      display: flex; align-items: flex-start; gap: 10px;
+    .om-qnum { color: #6e6e73; margin-right: 4px; }
+    .om-qhint { font-size: 0.8rem; font-weight: 400; color: #6e6e73; }
+    .om-opts { display: flex; flex-direction: column; gap: 0.5rem; }
+    .om-opt {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
       padding: 0.6rem 0.75rem;
-      border-radius: 6px; cursor: pointer;
+      border-radius: 6px;
+      cursor: pointer;
       border: 1.5px solid #e0e0e5;
       transition: border-color 0.15s, background 0.15s;
     }
-    .option-label:hover { border-color: #0071e3; background: #f0f6ff; }
-    .option-label input { margin-top: 2px; accent-color: #0071e3; }
-    .option-value { font-weight: 600; min-width: 20px; color: #6e6e73; }
-    .option-text { flex: 1; }
-    .option-label.opt-correct  { border-color: #34c759; background: #f0faf3; }
-    .option-label.opt-incorrect { border-color: #ff3b30; background: #fff5f4; }
-    .option-label.opt-missed   { border-color: #34c759; background: #f0faf3; border-style: dashed; }
-    .analysis {
-      margin-top: 0.75rem; padding: 0.6rem 0.75rem;
-      background: #f9f9fb; border-left: 3px solid #0071e3;
-      font-size: 0.9rem; color: #444; border-radius: 0 4px 4px 0;
+    .om-opt:hover { border-color: #0071e3; background: #f0f6ff; }
+    .om-opt input { margin-top: 2px; accent-color: #0071e3; }
+    .om-optval { font-weight: 600; min-width: 20px; color: #6e6e73; }
+    .om-opttext { flex: 1; }
+    .om-opt.om-correct  { border-color: #34c759; background: #f0faf3; }
+    .om-opt.om-wrong    { border-color: #ff3b30; background: #fff5f4; }
+    .om-opt.om-missed   { border-color: #34c759; background: #f0faf3; border-style: dashed; }
+    .om-analysis {
+      margin-top: 0.75rem;
+      padding: 0.6rem 0.75rem;
+      background: #f9f9fb;
+      border-left: 3px solid #0071e3;
+      font-size: 0.9rem;
+      color: #444;
+      border-radius: 0 4px 4px 0;
       display: none;
     }
-    .result-bar {
-      margin: 1rem 0; padding: 0.75rem 1rem;
-      border-radius: 8px; font-weight: 600; font-size: 1rem;
+    .om-result {
+      margin: 1rem 0;
+      padding: 0.75rem 1rem;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 1rem;
     }
-    .result-pass { background: #f0faf3; color: #1a7f37; border: 1.5px solid #34c759; }
-    .result-fail { background: #fff5f4; color: #c0392b; border: 1.5px solid #ff3b30; }
-    .submit-btn {
-      display: block; width: 100%; padding: 0.8rem;
-      background: #0071e3; color: #fff; border: none;
-      border-radius: 8px; font-size: 1rem; font-weight: 600; cursor: pointer;
+    .om-pass { background: #f0faf3; color: #1a7f37; border: 1.5px solid #34c759; }
+    .om-fail { background: #fff5f4; color: #c0392b; border: 1.5px solid #ff3b30; }
+    .om-submit {
+      display: block;
+      width: 100%;
+      padding: 0.8rem;
+      background: #0071e3;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
       margin-top: 1rem;
     }
-    .submit-btn:hover:not(:disabled) { background: #0077ed; }
-    .submit-btn:disabled { background: #b0c8e8; cursor: not-allowed; }
+    .om-submit:hover:not(:disabled) { background: #0077ed; }
+    .om-submit:disabled { background: #b0c8e8; cursor: not-allowed; }
 
     /* ── Interactive scenes ── */
-    .scene-interactive { background: #fff; }
-    .interactive-frame { width: 100%; height: 100%; border: none; }
+    .om-interactive { background: #fff; }
+    .om-iframe { width: 100%; height: 100%; border: none; }
 
-    /* ── Navigation bar (fixed bottom) ── */
+    /* ── Navigation bar (fixed bottom, right of sidebar) ── */
     #nav-bar {
       position: fixed;
-      bottom: 0; left: 0; right: 0;
-      height: ${NAV_HEIGHT}px;
+      bottom: 0;
+      left: ${SIDEBAR_W}px;
+      right: 0;
+      height: ${NAV_H}px;
       background: #fff;
       border-top: 1px solid #e0e0e5;
       display: flex;
@@ -188,15 +310,19 @@ export function buildCourseHtml(opts: CourseHtmlOptions): string {
       gap: 0.5rem;
       z-index: 1000;
     }
-    .nav-btn {
-      background: #f5f5f7; border: 1.5px solid #d0d0d5;
-      padding: 6px 14px; border-radius: 6px;
-      cursor: pointer; font-size: 0.85rem; font-weight: 500;
+    .om-nav-btn {
+      background: #f5f5f7;
+      border: 1.5px solid #d0d0d5;
+      padding: 6px 14px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      font-weight: 500;
       white-space: nowrap;
       flex-shrink: 0;
     }
-    .nav-btn:hover:not(:disabled) { background: #e8e8ed; }
-    .nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .om-nav-btn:hover:not(:disabled) { background: #e8e8ed; }
+    .om-nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
     #nav-center {
       flex: 1;
       display: flex;
@@ -205,52 +331,57 @@ export function buildCourseHtml(opts: CourseHtmlOptions): string {
       gap: 0.75rem;
       min-width: 0;
     }
-    #scene-title {
-      font-size: 0.85rem;
-      font-weight: 600;
-      color: #1d1d1f;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
     #scene-counter {
       font-size: 0.8rem;
       color: #6e6e73;
       white-space: nowrap;
       flex-shrink: 0;
     }
-
-    /* ── Audio control (inline with nav) ── */
     #narr-ctrl { display: none; align-items: center; gap: 6px; flex-shrink: 0; }
     #narr-play-btn {
-      background: #f0f0f5; border: 1.5px solid #c0c0c8;
-      padding: 5px 10px; border-radius: 6px; cursor: pointer;
-      font-size: 0.8rem; white-space: nowrap;
+      background: #f0f0f5;
+      border: 1.5px solid #c0c0c8;
+      padding: 5px 10px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.8rem;
+      white-space: nowrap;
     }
     #narr-play-btn:hover { background: #e4e4ec; }
   </style>
 </head>
 <body>
 
+<!-- ── Sidebar ── -->
+<nav id="om-sidebar">
+  <div id="om-sidebar-header">
+    <div id="om-course-title">${escHtml(courseName)}</div>
+    <div id="om-progress-label">0 / ${totalScenes} completades</div>
+    <div id="om-progress-bar"><div id="om-progress-fill"></div></div>
+  </div>
+  <ul id="om-scene-list">
+${sidebarItems}
+  </ul>
+</nav>
+
 <!-- ── All scene sections ── -->
 ${sceneSections}
 
 <!-- ── Fixed navigation bar ── -->
 <div id="nav-bar">
-  <button class="nav-btn" id="prev-btn" onclick="prevScene()" disabled>&#8592; Prev</button>
+  <button class="om-nav-btn" id="prev-btn" onclick="prevScene()" disabled>&#8592; Prev</button>
 
   <div id="nav-center">
-    <span id="scene-title"></span>
-    <span id="scene-counter"></span>
+    <span id="scene-counter">1 / ${totalScenes}</span>
   </div>
 
-  <!-- Narration audio controls (only visible for slide scenes with TTS) -->
+  <!-- Narration controls (visible only for slides with TTS) -->
   <div id="narr-ctrl">
     <button id="narr-play-btn" onclick="toggleNarration()">&#9654; Play</button>
-    <button class="nav-btn" onclick="restartNarration()" title="Restart narration">&#8635;</button>
+    <button class="om-nav-btn" onclick="restartNarration()" title="Restart narration">&#8635;</button>
   </div>
 
-  <button class="nav-btn" id="next-btn" onclick="nextScene()">Next &#8594;</button>
+  <button class="om-nav-btn" id="next-btn" onclick="nextScene()">Next &#8594;</button>
 </div>
 
 <script>
@@ -258,7 +389,11 @@ ${sceneSections}
 var SCENES = ${metasJson};
 var TOTAL = ${totalScenes};
 var currentIdx = 0;
-var quizScores = {}; // sceneIdx → 0-100
+var quizScores = {};
+
+// ── Visit tracking ──
+var visitedArr = [];
+for (var _vi = 0; _vi < TOTAL; _vi++) visitedArr.push(false);
 
 // ── Narration state ──
 var narrEls = [];
@@ -331,6 +466,7 @@ function rescaleSlide(scene) {
   var s = Math.min(availW / scene.cw, availH / scene.ch);
   var scaler = document.getElementById(scene.scalerId);
   var canvas = document.getElementById(scene.canvasId);
+  if (!scaler || !canvas) return;
   scaler.style.width  = (scene.cw * s) + 'px';
   scaler.style.height = (scene.ch * s) + 'px';
   canvas.style.transform = 'scale(' + s + ')';
@@ -340,6 +476,34 @@ window.addEventListener('resize', function() {
   var s = SCENES[currentIdx];
   if (s && s.type === 'slide') rescaleSlide(s);
 });
+
+// ── Sidebar ──
+function updateSidebar(idx) {
+  var visitedCount = 0;
+  for (var i = 0; i < TOTAL; i++) {
+    if (visitedArr[i]) visitedCount++;
+    var item = document.getElementById('om-nav-' + i);
+    if (!item) continue;
+    var cls = 'om-nav-item';
+    if (visitedArr[i]) cls += ' om-visited';
+    if (i === idx) cls += ' om-active';
+    item.className = cls;
+    var dot = item.querySelector('.om-nav-dot');
+    if (dot) dot.textContent = visitedArr[i] ? '\\u2713' : '';
+    // Scroll active item into view
+    if (i === idx) {
+      item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }
+  document.getElementById('om-progress-label').textContent =
+    visitedCount + ' / ' + TOTAL + ' completades';
+  document.getElementById('om-progress-fill').style.width =
+    Math.round((visitedCount / TOTAL) * 100) + '%';
+}
+
+function sidebarGo(idx) {
+  showScene(idx);
+}
 
 // ── Scene navigation ──
 function showScene(idx) {
@@ -355,14 +519,15 @@ function showScene(idx) {
   if (sceneEl) sceneEl.style.display = '';
   currentIdx = idx;
 
-  // Update nav bar text
-  document.getElementById('scene-title').textContent = scene.title || '';
+  // Mark visited
+  visitedArr[idx] = true;
+
+  // Sidebar + counter
+  updateSidebar(idx);
   document.getElementById('scene-counter').textContent = (idx + 1) + ' / ' + TOTAL;
 
-  // Prev button
+  // Prev / Next buttons
   document.getElementById('prev-btn').disabled = (idx === 0);
-
-  // Next button: disabled on last scene, or quiz not yet submitted
   var isLast = (idx === TOTAL - 1);
   var isQuizNotDone = scene.type === 'quiz' && quizScores[idx] === undefined;
   document.getElementById('next-btn').disabled = isLast || isQuizNotDone;
@@ -378,18 +543,18 @@ function showScene(idx) {
 
   // Rescale slides
   if (scene.type === 'slide') {
-    // small timeout to let the browser render first
     setTimeout(function() { rescaleSlide(scene); }, 0);
   }
 
-  // SCORM: report progress
-  var progress = Math.round(((idx + 1) / TOTAL) * 100);
+  // SCORM: report progress as % scenes visited
+  var visitedCount = 0;
+  for (var j = 0; j < TOTAL; j++) if (visitedArr[j]) visitedCount++;
+  var progress = Math.round((visitedCount / TOTAL) * 100);
   SCORM.setValue('cmi.core.score.raw', progress);
   SCORM.setValue('cmi.core.score.min', '0');
   SCORM.setValue('cmi.core.score.max', '100');
   SCORM.commit();
 
-  // SCORM: complete only on last scene
   if (isLast) {
     SCORM.setCompleted();
   }
@@ -406,11 +571,9 @@ function nextScene() {
 // Called by quiz sections after submit
 window.onQuizSubmitted = function(sceneIdx, score) {
   quizScores[sceneIdx] = score;
-  // Enable Next (unless it was the last scene)
   if (sceneIdx < TOTAL - 1) {
     document.getElementById('next-btn').disabled = false;
   } else {
-    // Last scene is a quiz — complete now
     SCORM.setScore(score, 0, 100);
     if (score >= ${QUIZ_PASS_THRESHOLD}) {
       SCORM.setPassed();
@@ -424,28 +587,12 @@ window.onQuizSubmitted = function(sceneIdx, score) {
 window.addEventListener('load', function() {
   SCORM.init();
   SCORM.setValue('cmi.core.lesson_status', 'incomplete');
-
-  // Set title on each scene (used in showScene)
-  var sceneTitles = ${JSON.stringify(sections.map((s) => s.meta.type === 'slide'
-    ? '' // title comes from scene data passed via JS — we embed it differently
-    : ''))};
-  // Titles are embedded directly in the SCENES array below:
-  // (done at build time, no runtime injection needed)
-
   showScene(0);
 });
 
 window.addEventListener('beforeunload', function() {
   SCORM.finish();
 });
-
-// Patch scene titles from DOM (each section has a data-title attribute)
-(function() {
-  SCENES.forEach(function(s, i) {
-    var el = document.getElementById(s.id);
-    if (el) s.title = el.getAttribute('data-title') || s.id;
-  });
-})();
 </script>
 </body>
 </html>`;

--- a/lib/export/scorm/course-builder.ts
+++ b/lib/export/scorm/course-builder.ts
@@ -601,42 +601,61 @@ window.onQuizSubmitted = function(sceneIdx, score) {
 window.addEventListener('load', function() {
   SCORM.init();
 
-  // Restore suspend_data (visited scenes + quiz scores)
-  var savedData = SCORM.getValue('cmi.suspend_data');
-  if (savedData) {
-    try {
-      var state = JSON.parse(savedData);
-      if (state.v) {
-        for (var i = 0; i < state.v.length && i < TOTAL; i++) {
-          visitedArr[i] = state.v[i] === '1';
-        }
-      }
-      if (state.q) {
-        var keys = Object.keys(state.q);
-        for (var ki = 0; ki < keys.length; ki++) {
-          quizScores[parseInt(keys[ki], 10)] = state.q[keys[ki]];
-        }
-      }
-    } catch (e) {}
-  }
+  // Some LMS bridges load state asynchronously after LMSInitialize returns.
+  // We retry reading suspend_data up to 10 times (50ms apart, max ~500ms)
+  // so that resume works even when the LMS fetch takes a moment to complete.
+  var resumeAttempts = 0;
 
-  // Do not overwrite 'completed'/'passed' with 'incomplete'
-  var currentStatus = SCORM.getValue('cmi.core.lesson_status');
-  if (currentStatus !== 'completed' && currentStatus !== 'passed') {
-    SCORM.setValue('cmi.core.lesson_status', 'incomplete');
-  }
+  function applyResume() {
+    var savedData = SCORM.getValue('cmi.suspend_data');
+    var savedLocation = SCORM.getValue('cmi.core.lesson_location');
 
-  // Resume at last saved position
-  var startIdx = 0;
-  var savedLocation = SCORM.getValue('cmi.core.lesson_location');
-  if (savedLocation) {
-    var parsed = parseInt(savedLocation, 10);
-    if (!isNaN(parsed) && parsed >= 0 && parsed < TOTAL) {
-      startIdx = parsed;
+    // If data looks empty and we haven't exhausted retries, wait and retry.
+    // (A fresh first-time enrolment will also have empty data, but retrying
+    //  is harmless — we just end up at scene 0 after the last attempt.)
+    if (!savedData && !savedLocation && resumeAttempts < 10) {
+      resumeAttempts++;
+      setTimeout(applyResume, 50);
+      return;
     }
+
+    // Restore visited scenes + quiz scores from suspend_data
+    if (savedData) {
+      try {
+        var state = JSON.parse(savedData);
+        if (state.v) {
+          for (var i = 0; i < state.v.length && i < TOTAL; i++) {
+            visitedArr[i] = state.v[i] === '1';
+          }
+        }
+        if (state.q) {
+          var keys = Object.keys(state.q);
+          for (var ki = 0; ki < keys.length; ki++) {
+            quizScores[parseInt(keys[ki], 10)] = state.q[keys[ki]];
+          }
+        }
+      } catch (e) {}
+    }
+
+    // Do not overwrite 'completed'/'passed' with 'incomplete'
+    var currentStatus = SCORM.getValue('cmi.core.lesson_status');
+    if (currentStatus !== 'completed' && currentStatus !== 'passed') {
+      SCORM.setValue('cmi.core.lesson_status', 'incomplete');
+    }
+
+    // Resume at last saved position
+    var startIdx = 0;
+    if (savedLocation) {
+      var parsed = parseInt(savedLocation, 10);
+      if (!isNaN(parsed) && parsed >= 0 && parsed < TOTAL) {
+        startIdx = parsed;
+      }
+    }
+
+    showScene(startIdx);
   }
 
-  showScene(startIdx);
+  applyResume();
 });
 
 window.addEventListener('beforeunload', function() {

--- a/lib/export/scorm/course-builder.ts
+++ b/lib/export/scorm/course-builder.ts
@@ -505,6 +505,17 @@ function sidebarGo(idx) {
   showScene(idx);
 }
 
+// ── SCORM suspend_data persistence ──
+function saveSuspendData() {
+  var visitedStr = '';
+  for (var i = 0; i < TOTAL; i++) {
+    visitedStr += visitedArr[i] ? '1' : '0';
+  }
+  var suspendData = JSON.stringify({ v: visitedStr, q: quizScores });
+  SCORM.setValue('cmi.core.lesson_location', String(currentIdx));
+  SCORM.setValue('cmi.suspend_data', suspendData);
+}
+
 // ── Scene navigation ──
 function showScene(idx) {
   stopNarration();
@@ -553,6 +564,7 @@ function showScene(idx) {
   SCORM.setValue('cmi.core.score.raw', progress);
   SCORM.setValue('cmi.core.score.min', '0');
   SCORM.setValue('cmi.core.score.max', '100');
+  saveSuspendData();
   SCORM.commit();
 
   if (isLast) {
@@ -571,6 +583,8 @@ function nextScene() {
 // Called by quiz sections after submit
 window.onQuizSubmitted = function(sceneIdx, score) {
   quizScores[sceneIdx] = score;
+  saveSuspendData();
+  SCORM.commit();
   if (sceneIdx < TOTAL - 1) {
     document.getElementById('next-btn').disabled = false;
   } else {
@@ -586,8 +600,43 @@ window.onQuizSubmitted = function(sceneIdx, score) {
 // ── Init ──
 window.addEventListener('load', function() {
   SCORM.init();
-  SCORM.setValue('cmi.core.lesson_status', 'incomplete');
-  showScene(0);
+
+  // Restore suspend_data (visited scenes + quiz scores)
+  var savedData = SCORM.getValue('cmi.suspend_data');
+  if (savedData) {
+    try {
+      var state = JSON.parse(savedData);
+      if (state.v) {
+        for (var i = 0; i < state.v.length && i < TOTAL; i++) {
+          visitedArr[i] = state.v[i] === '1';
+        }
+      }
+      if (state.q) {
+        var keys = Object.keys(state.q);
+        for (var ki = 0; ki < keys.length; ki++) {
+          quizScores[parseInt(keys[ki], 10)] = state.q[keys[ki]];
+        }
+      }
+    } catch (e) {}
+  }
+
+  // Do not overwrite 'completed'/'passed' with 'incomplete'
+  var currentStatus = SCORM.getValue('cmi.core.lesson_status');
+  if (currentStatus !== 'completed' && currentStatus !== 'passed') {
+    SCORM.setValue('cmi.core.lesson_status', 'incomplete');
+  }
+
+  // Resume at last saved position
+  var startIdx = 0;
+  var savedLocation = SCORM.getValue('cmi.core.lesson_location');
+  if (savedLocation) {
+    var parsed = parseInt(savedLocation, 10);
+    if (!isNaN(parsed) && parsed >= 0 && parsed < TOTAL) {
+      startIdx = parsed;
+    }
+  }
+
+  showScene(startIdx);
 });
 
 window.addEventListener('beforeunload', function() {

--- a/lib/export/scorm/course-builder.ts
+++ b/lib/export/scorm/course-builder.ts
@@ -175,6 +175,11 @@ export function buildCourseHtml(opts: CourseHtmlOptions): string {
       line-height: 1.35;
     }
     .om-nav-item.om-active .om-nav-label { color: #e0e8f0; }
+    .om-nav-item.om-locked {
+      opacity: 0.4;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
 
     /* ── Scene container ── */
     .om-scene {
@@ -289,6 +294,21 @@ export function buildCourseHtml(opts: CourseHtmlOptions): string {
     }
     .om-submit:hover:not(:disabled) { background: #0077ed; }
     .om-submit:disabled { background: #b0c8e8; cursor: not-allowed; }
+    .om-qblock--warn { border: 2px solid #ff9500; }
+    .om-retry {
+      display: block;
+      width: 100%;
+      padding: 0.8rem;
+      background: #f5f5f7;
+      color: #1d1d1f;
+      border: 1.5px solid #d0d0d5;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 0.5rem;
+    }
+    .om-retry:hover { background: #e8e8ed; }
 
     /* ── Interactive scenes ── */
     .om-interactive { background: #fff; }
@@ -390,6 +410,7 @@ var SCENES = ${metasJson};
 var TOTAL = ${totalScenes};
 var currentIdx = 0;
 var quizScores = {};
+var unlockedUpTo = 0; // highest scene index the student may access
 
 // ── Visit tracking ──
 var visitedArr = [];
@@ -487,6 +508,7 @@ function updateSidebar(idx) {
     var cls = 'om-nav-item';
     if (visitedArr[i]) cls += ' om-visited';
     if (i === idx) cls += ' om-active';
+    if (i > unlockedUpTo) cls += ' om-locked';
     item.className = cls;
     var dot = item.querySelector('.om-nav-dot');
     if (dot) dot.textContent = visitedArr[i] ? '\\u2713' : '';
@@ -502,6 +524,7 @@ function updateSidebar(idx) {
 }
 
 function sidebarGo(idx) {
+  if (idx > unlockedUpTo) return;
   showScene(idx);
 }
 
@@ -511,7 +534,7 @@ function saveSuspendData() {
   for (var i = 0; i < TOTAL; i++) {
     visitedStr += visitedArr[i] ? '1' : '0';
   }
-  var suspendData = JSON.stringify({ v: visitedStr, q: quizScores });
+  var suspendData = JSON.stringify({ v: visitedStr, q: quizScores, u: unlockedUpTo });
   SCORM.setValue('cmi.core.lesson_location', String(currentIdx));
   SCORM.setValue('cmi.suspend_data', suspendData);
 }
@@ -533,6 +556,11 @@ function showScene(idx) {
   // Mark visited
   visitedArr[idx] = true;
 
+  // Unlock next scene for non-quiz scenes (quiz unlocks only on pass)
+  if (scene.type !== 'quiz') {
+    unlockedUpTo = Math.max(unlockedUpTo, Math.min(idx + 1, TOTAL - 1));
+  }
+
   // Sidebar + counter
   updateSidebar(idx);
   document.getElementById('scene-counter').textContent = (idx + 1) + ' / ' + TOTAL;
@@ -540,8 +568,8 @@ function showScene(idx) {
   // Prev / Next buttons
   document.getElementById('prev-btn').disabled = (idx === 0);
   var isLast = (idx === TOTAL - 1);
-  var isQuizNotDone = scene.type === 'quiz' && quizScores[idx] === undefined;
-  document.getElementById('next-btn').disabled = isLast || isQuizNotDone;
+  var nextLocked = isLast || (idx + 1 > unlockedUpTo);
+  document.getElementById('next-btn').disabled = nextLocked;
 
   // Narration controls
   var narrCtrl = document.getElementById('narr-ctrl');
@@ -583,11 +611,15 @@ function nextScene() {
 // Called by quiz sections after submit
 window.onQuizSubmitted = function(sceneIdx, score) {
   quizScores[sceneIdx] = score;
+  if (score >= ${QUIZ_PASS_THRESHOLD}) {
+    unlockedUpTo = Math.max(unlockedUpTo, Math.min(sceneIdx + 1, TOTAL - 1));
+    if (sceneIdx === currentIdx && sceneIdx < TOTAL - 1) {
+      document.getElementById('next-btn').disabled = false;
+    }
+  }
   saveSuspendData();
   SCORM.commit();
-  if (sceneIdx < TOTAL - 1) {
-    document.getElementById('next-btn').disabled = false;
-  } else {
+  if (sceneIdx === TOTAL - 1) {
     SCORM.setScore(score, 0, 100);
     if (score >= ${QUIZ_PASS_THRESHOLD}) {
       SCORM.setPassed();
@@ -611,15 +643,15 @@ window.addEventListener('load', function() {
     var savedLocation = SCORM.getValue('cmi.core.lesson_location');
 
     // If data looks empty and we haven't exhausted retries, wait and retry.
-    // (A fresh first-time enrolment will also have empty data, but retrying
-    //  is harmless — we just end up at scene 0 after the last attempt.)
-    if (!savedData && !savedLocation && resumeAttempts < 10) {
+    // Safety net for LMS bridges that load state asynchronously after LMSInitialize.
+    // (A fresh first-time enrolment also has empty data — retrying is harmless.)
+    if (!savedData && !savedLocation && resumeAttempts < 5) {
       resumeAttempts++;
-      setTimeout(applyResume, 50);
+      setTimeout(applyResume, 100);
       return;
     }
 
-    // Restore visited scenes + quiz scores from suspend_data
+    // Restore visited scenes, quiz scores, and unlock level from suspend_data
     if (savedData) {
       try {
         var state = JSON.parse(savedData);
@@ -633,6 +665,9 @@ window.addEventListener('load', function() {
           for (var ki = 0; ki < keys.length; ki++) {
             quizScores[parseInt(keys[ki], 10)] = state.q[keys[ki]];
           }
+        }
+        if (typeof state.u === 'number') {
+          unlockedUpTo = Math.min(state.u, TOTAL - 1);
         }
       } catch (e) {}
     }

--- a/lib/export/scorm/index.ts
+++ b/lib/export/scorm/index.ts
@@ -1,0 +1,2 @@
+export { useExportScorm } from './use-export-scorm';
+export type { ScormExportOptions } from './use-export-scorm';

--- a/lib/export/scorm/interactive-sco.ts
+++ b/lib/export/scorm/interactive-sco.ts
@@ -30,8 +30,8 @@ export function buildInteractiveSection(scene: Scene, sceneIndex: number): Inter
   // Escape HTML for srcdoc attribute (must escape " and &)
   const srcdoc = (content.html ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 
-  const html = `<section id="${sceneId}" class="scene scene-interactive" data-title="${escHtml(scene.title)}" style="display:none">
-  <iframe class="interactive-frame"
+  const html = `<section id="${sceneId}" class="om-scene om-interactive" data-title="${escHtml(scene.title)}" style="display:none">
+  <iframe class="om-iframe"
     srcdoc="${srcdoc}"
     sandbox="allow-scripts allow-same-origin allow-forms"
     title="${escHtml(scene.title)}"></iframe>

--- a/lib/export/scorm/interactive-sco.ts
+++ b/lib/export/scorm/interactive-sco.ts
@@ -1,0 +1,94 @@
+import type { Scene, InteractiveContent } from '@/lib/types/stage';
+
+export interface InteractiveScoOptions {
+  scene: Scene;
+  sceneIndex: number;
+  totalScenes: number;
+  allScoHrefs: string[];
+}
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Builds the full HTML string for an interactive SCO page.
+ *
+ * The interactive HTML is embedded in an isolated <iframe srcdoc="..."> so its
+ * own scripts cannot interfere with the SCORM bridge on the parent frame.
+ * SCORM completion is set immediately on load (no grading for interactive scenes).
+ */
+export function buildInteractiveSco(opts: InteractiveScoOptions): string {
+  const { scene, sceneIndex, totalScenes, allScoHrefs } = opts;
+
+  if (scene.content.type !== 'interactive') return '';
+  const content = scene.content as InteractiveContent;
+
+  if (!content.html) return '';
+
+  // Escape the HTML for use as a srcdoc attribute value
+  const srcdoc = content.html.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+
+  const myHref = allScoHrefs[sceneIndex];
+  const hasPrev = sceneIndex > 0;
+  const hasNext = sceneIndex < totalScenes - 1;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escHtml(scene.title)}</title>
+  <script src="../scorm_bridge.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: sans-serif; background: #1a1a1a; }
+    .page-wrapper { display: flex; flex-direction: column; height: 100%; }
+    .content-frame {
+      flex: 1;
+      border: none;
+      width: 100%;
+      background: #fff;
+    }
+    .nav-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 8px 16px;
+      background: #fff;
+      border-top: 1px solid #e0e0e5;
+      flex-shrink: 0;
+    }
+    .nav-bar button {
+      background: #f5f5f7; border: 1.5px solid #d0d0d5;
+      padding: 6px 18px; border-radius: 6px;
+      cursor: pointer; font-size: 0.9rem; font-weight: 500;
+    }
+    .nav-bar button:hover { background: #e8e8ed; }
+    .scene-counter { font-size: 0.85rem; color: #6e6e73; }
+  </style>
+</head>
+<body>
+<div class="page-wrapper">
+  <iframe class="content-frame" srcdoc="${srcdoc}" sandbox="allow-scripts allow-same-origin allow-forms" title="${escHtml(scene.title)}"></iframe>
+  <div class="nav-bar">
+    ${hasPrev ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','prev')">&#8592; Prev</button>` : '<span></span>'}
+    <span class="scene-counter">${sceneIndex + 1} / ${totalScenes}</span>
+    ${hasNext ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','next')">Next &#8594;</button>` : '<span></span>'}
+  </div>
+</div>
+<script>
+var ALL_SCOS = ${JSON.stringify(allScoHrefs)};
+window.addEventListener('load', function() {
+  SCORM.init();
+  SCORM.setCompleted();
+});
+window.addEventListener('beforeunload', function() {
+  SCORM.finish();
+});
+</script>
+</body>
+</html>`;
+}

--- a/lib/export/scorm/interactive-sco.ts
+++ b/lib/export/scorm/interactive-sco.ts
@@ -1,94 +1,44 @@
+/**
+ * interactive-sco.ts
+ * Builds the HTML fragment (a <section> element) for an interactive scene.
+ * The interactive HTML is embedded in an isolated <iframe srcdoc="...">.
+ */
 import type { Scene, InteractiveContent } from '@/lib/types/stage';
 
-export interface InteractiveScoOptions {
-  scene: Scene;
-  sceneIndex: number;
-  totalScenes: number;
-  allScoHrefs: string[];
+export interface InteractiveSceneMeta {
+  type: 'interactive';
+  sceneId: string;
+}
+
+export interface InteractiveSectionResult {
+  html: string;
+  meta: InteractiveSceneMeta;
 }
 
 function escHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 /**
- * Builds the full HTML string for an interactive SCO page.
- *
- * The interactive HTML is embedded in an isolated <iframe srcdoc="..."> so its
- * own scripts cannot interfere with the SCORM bridge on the parent frame.
- * SCORM completion is set immediately on load (no grading for interactive scenes).
+ * Builds the HTML <section> fragment for an interactive scene.
+ * The interactive HTML is sandboxed in an iframe (allow-scripts + allow-same-origin).
  */
-export function buildInteractiveSco(opts: InteractiveScoOptions): string {
-  const { scene, sceneIndex, totalScenes, allScoHrefs } = opts;
-
-  if (scene.content.type !== 'interactive') return '';
+export function buildInteractiveSection(scene: Scene, sceneIndex: number): InteractiveSectionResult {
   const content = scene.content as InteractiveContent;
+  const sceneId = `scene-${sceneIndex}`;
 
-  if (!content.html) return '';
+  // Escape HTML for srcdoc attribute (must escape " and &)
+  const srcdoc = (content.html ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 
-  // Escape the HTML for use as a srcdoc attribute value
-  const srcdoc = content.html.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  const html = `<section id="${sceneId}" class="scene scene-interactive" data-title="${escHtml(scene.title)}" style="display:none">
+  <iframe class="interactive-frame"
+    srcdoc="${srcdoc}"
+    sandbox="allow-scripts allow-same-origin allow-forms"
+    title="${escHtml(scene.title)}"></iframe>
+</section>`;
 
-  const myHref = allScoHrefs[sceneIndex];
-  const hasPrev = sceneIndex > 0;
-  const hasNext = sceneIndex < totalScenes - 1;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escHtml(scene.title)}</title>
-  <script src="../scorm_bridge.js"></script>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: sans-serif; background: #1a1a1a; }
-    .page-wrapper { display: flex; flex-direction: column; height: 100%; }
-    .content-frame {
-      flex: 1;
-      border: none;
-      width: 100%;
-      background: #fff;
-    }
-    .nav-bar {
-      display: flex; align-items: center; justify-content: space-between;
-      padding: 8px 16px;
-      background: #fff;
-      border-top: 1px solid #e0e0e5;
-      flex-shrink: 0;
-    }
-    .nav-bar button {
-      background: #f5f5f7; border: 1.5px solid #d0d0d5;
-      padding: 6px 18px; border-radius: 6px;
-      cursor: pointer; font-size: 0.9rem; font-weight: 500;
-    }
-    .nav-bar button:hover { background: #e8e8ed; }
-    .scene-counter { font-size: 0.85rem; color: #6e6e73; }
-  </style>
-</head>
-<body>
-<div class="page-wrapper">
-  <iframe class="content-frame" srcdoc="${srcdoc}" sandbox="allow-scripts allow-same-origin allow-forms" title="${escHtml(scene.title)}"></iframe>
-  <div class="nav-bar">
-    ${hasPrev ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','prev')">&#8592; Prev</button>` : '<span></span>'}
-    <span class="scene-counter">${sceneIndex + 1} / ${totalScenes}</span>
-    ${hasNext ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','next')">Next &#8594;</button>` : '<span></span>'}
-  </div>
-</div>
-<script>
-var ALL_SCOS = ${JSON.stringify(allScoHrefs)};
-window.addEventListener('load', function() {
-  SCORM.init();
-  SCORM.setCompleted();
-});
-window.addEventListener('beforeunload', function() {
-  SCORM.finish();
-});
-</script>
-</body>
-</html>`;
+  return {
+    html,
+    meta: { type: 'interactive', sceneId },
+  };
 }

--- a/lib/export/scorm/manifest.ts
+++ b/lib/export/scorm/manifest.ts
@@ -1,50 +1,34 @@
-export interface ScoEntry {
-  id: string;     // e.g. "scene_01"
-  title: string;
-  href: string;   // e.g. "scos/scene_01.html"
-  isQuiz: boolean;
-  assetHrefs: string[]; // all asset paths referenced by this SCO
+export interface ScormManifestOptions {
+  courseId: string;
+  courseTitle: string;
+  /** All asset zip paths referenced by the single SCO */
+  assetHrefs: string[];
+  /** Pass threshold (0-100). Set only if course has quiz scenes. */
+  masteryScore?: number;
 }
 
-const PASS_SCORE = 80;
-
 /**
- * Builds the imsmanifest.xml string for a SCORM 1.2 package.
+ * Builds the imsmanifest.xml string for a single-SCO SCORM 1.2 package.
+ * All course content lives in one index.html file at the package root.
  */
-export function buildManifest(
-  courseId: string,
-  courseTitle: string,
-  scos: ScoEntry[],
-): string {
+export function buildManifest(opts: ScormManifestOptions): string {
+  const { courseId, courseTitle, assetHrefs, masteryScore } = opts;
+
   const escXml = (s: string) =>
     s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
   const orgId = `${courseId}_org`;
 
-  const items = scos
-    .map(
-      (sco) => `
-      <item identifier="item_${sco.id}" identifierref="res_${sco.id}">
-        <title>${escXml(sco.title)}</title>${sco.isQuiz ? `\n        <adlcp:masteryscore>${PASS_SCORE}</adlcp:masteryscore>` : ''}
-      </item>`,
-    )
-    .join('');
+  const masteryLine =
+    masteryScore !== undefined
+      ? `\n        <adlcp:masteryscore>${masteryScore}</adlcp:masteryscore>`
+      : '';
 
-  const resources = scos
-    .map((sco) => {
-      const files = [`<file href="${escXml(sco.href)}"/>`, `<file href="scorm_bridge.js"/>`];
-      for (const asset of sco.assetHrefs) {
-        files.push(`<file href="${escXml(asset)}"/>`);
-      }
-      return `
-    <resource identifier="res_${sco.id}"
-              type="webcontent"
-              adlcp:scormtype="sco"
-              href="${escXml(sco.href)}">
-      ${files.join('\n      ')}
-    </resource>`;
-    })
-    .join('');
+  const fileEntries = [
+    `<file href="index.html"/>`,
+    `<file href="scorm_bridge.js"/>`,
+    ...assetHrefs.map((h) => `<file href="${escXml(h)}"/>`),
+  ].join('\n      ');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <manifest identifier="${escXml(courseId)}"
@@ -61,11 +45,20 @@ export function buildManifest(
 
   <organizations default="${escXml(orgId)}">
     <organization identifier="${escXml(orgId)}">
-      <title>${escXml(courseTitle)}</title>${items}
+      <title>${escXml(courseTitle)}</title>
+      <item identifier="item_1" identifierref="res_1">
+        <title>${escXml(courseTitle)}</title>${masteryLine}
+      </item>
     </organization>
   </organizations>
 
-  <resources>${resources}
+  <resources>
+    <resource identifier="res_1"
+              type="webcontent"
+              adlcp:scormtype="sco"
+              href="index.html">
+      ${fileEntries}
+    </resource>
   </resources>
 
 </manifest>`;

--- a/lib/export/scorm/manifest.ts
+++ b/lib/export/scorm/manifest.ts
@@ -1,0 +1,72 @@
+export interface ScoEntry {
+  id: string;     // e.g. "scene_01"
+  title: string;
+  href: string;   // e.g. "scos/scene_01.html"
+  isQuiz: boolean;
+  assetHrefs: string[]; // all asset paths referenced by this SCO
+}
+
+const PASS_SCORE = 80;
+
+/**
+ * Builds the imsmanifest.xml string for a SCORM 1.2 package.
+ */
+export function buildManifest(
+  courseId: string,
+  courseTitle: string,
+  scos: ScoEntry[],
+): string {
+  const escXml = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+  const orgId = `${courseId}_org`;
+
+  const items = scos
+    .map(
+      (sco) => `
+      <item identifier="item_${sco.id}" identifierref="res_${sco.id}">
+        <title>${escXml(sco.title)}</title>${sco.isQuiz ? `\n        <adlcp:masteryscore>${PASS_SCORE}</adlcp:masteryscore>` : ''}
+      </item>`,
+    )
+    .join('');
+
+  const resources = scos
+    .map((sco) => {
+      const files = [`<file href="${escXml(sco.href)}"/>`, `<file href="scorm_bridge.js"/>`];
+      for (const asset of sco.assetHrefs) {
+        files.push(`<file href="${escXml(asset)}"/>`);
+      }
+      return `
+    <resource identifier="res_${sco.id}"
+              type="webcontent"
+              adlcp:scormtype="sco"
+              href="${escXml(sco.href)}">
+      ${files.join('\n      ')}
+    </resource>`;
+    })
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<manifest identifier="${escXml(courseId)}"
+  version="1.0"
+  xmlns="http://www.imsproject.org/xsd/imscp_rootv1p1p2"
+  xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_rootv1p2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.imsproject.org/xsd/imscp_rootv1p1p2 imscp_rootv1p1p2.xsd http://www.adlnet.org/xsd/adlcp_rootv1p2 adlcp_rootv1p2.xsd">
+
+  <metadata>
+    <schema>ADL SCORM</schema>
+    <schemaversion>1.2</schemaversion>
+  </metadata>
+
+  <organizations default="${escXml(orgId)}">
+    <organization identifier="${escXml(orgId)}">
+      <title>${escXml(courseTitle)}</title>${items}
+    </organization>
+  </organizations>
+
+  <resources>${resources}
+  </resources>
+
+</manifest>`;
+}

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -105,6 +105,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       var allAnswered = true;
       QUESTIONS_${sceneIndex}.forEach(function(q) {
         var block = document.getElementById('qblock_' + q.id);
+        if (!block) return;
         var hasAnswer = q.type === 'single'
           ? !!block.querySelector('input[type=radio]:checked')
           : !!block.querySelector('input[type=checkbox]:checked');
@@ -182,6 +183,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
 
       QUESTIONS_${sceneIndex}.forEach(function(q) {
         var block = document.getElementById('qblock_' + q.id);
+        if (!block) return;
         block.querySelectorAll('input').forEach(function(inp) {
           inp.disabled = false;
           inp.checked = false;
@@ -191,6 +193,17 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
         });
         var analysisEl = document.getElementById('analysis_' + q.id);
         if (analysisEl) analysisEl.style.display = 'none';
+      });
+    });
+
+    // Clear orange warning in real time when user selects an answer
+    QUESTIONS_${sceneIndex}.forEach(function(q) {
+      var block = document.getElementById('qblock_' + q.id);
+      if (!block) return;
+      block.querySelectorAll('input').forEach(function(inp) {
+        inp.addEventListener('change', function() {
+          block.classList.remove('om-qblock--warn');
+        });
       });
     });
   })();

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -27,16 +27,19 @@ function escHtml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function renderQuestion(q: QuizQuestion, idx: number): string {
+function renderQuestion(q: QuizQuestion, idx: number, sceneIndex: number): string {
   if (q.type === 'short_answer' || !q.options?.length) return '';
   const inputType = q.type === 'multiple' ? 'checkbox' : 'radio';
   const multiHint = q.type === 'multiple' ? ' <span class="om-qhint">(select all that apply)</span>' : '';
+  // Prefix IDs with sceneIndex to avoid conflicts when multiple quizzes share question IDs
+  const blockId = `qblock_${sceneIndex}_${escHtml(q.id)}`;
+  const analysisId = `analysis_${sceneIndex}_${escHtml(q.id)}`;
 
   const options = q.options
     .map(
       (opt) => `
       <label class="om-opt" data-value="${escHtml(opt.value)}">
-        <input type="${inputType}" name="q_${escHtml(q.id)}" value="${escHtml(opt.value)}">
+        <input type="${inputType}" name="q_${sceneIndex}_${escHtml(q.id)}" value="${escHtml(opt.value)}">
         <span class="om-optval">${escHtml(opt.value)}.</span>
         <span class="om-opttext">${escHtml(opt.label)}</span>
       </label>`,
@@ -44,10 +47,10 @@ function renderQuestion(q: QuizQuestion, idx: number): string {
     .join('');
 
   const analysis = q.analysis
-    ? `<div class="om-analysis" id="analysis_${escHtml(q.id)}">${escHtml(q.analysis)}</div>`
+    ? `<div class="om-analysis" id="${analysisId}">${escHtml(q.analysis)}</div>`
     : '';
 
-  return `<div class="om-qblock" id="qblock_${escHtml(q.id)}"
+  return `<div class="om-qblock" id="${blockId}"
      data-qid="${escHtml(q.id)}" data-type="${q.type}"
      data-answer="${escHtml((q.answer ?? []).join(','))}">
   <div class="om-qtext"><span class="om-qnum">${idx + 1}.</span> ${escHtml(q.question)}${multiHint}</div>
@@ -69,7 +72,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
     (q) => (q.type === 'single' || q.type === 'multiple') && q.options?.length && q.answer?.length,
   );
 
-  const questionsHtml = exportable.map((q, i) => renderQuestion(q, i)).join('\n');
+  const questionsHtml = exportable.map((q, i) => renderQuestion(q, i, sceneIndex)).join('\n');
 
   // Serialize question data for inline JS
   const questionsJson = JSON.stringify(
@@ -104,7 +107,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       // Require at least one answer per question
       var allAnswered = true;
       QUESTIONS_${sceneIndex}.forEach(function(q) {
-        var block = document.getElementById('qblock_' + q.id);
+        var block = document.getElementById('qblock_${sceneIndex}_' + q.id);
         if (!block) return;
         var hasAnswer = q.type === 'single'
           ? !!block.querySelector('input[type=radio]:checked')
@@ -119,7 +122,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
 
       var correct = 0;
       QUESTIONS_${sceneIndex}.forEach(function(q, iIdx) {
-        var block = document.getElementById('qblock_' + q.id);
+        var block = document.getElementById('qblock_${sceneIndex}_' + q.id);
         if (!block) return;
         var studentResponse = '';
         var isCorrect = false;
@@ -148,7 +151,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
           else if (!inAnswer && input.checked) label.classList.add('om-wrong');
         });
 
-        var analysisEl = document.getElementById('analysis_' + q.id);
+        var analysisEl = document.getElementById('analysis_${sceneIndex}_' + q.id);
         if (analysisEl) analysisEl.style.display = 'block';
 
         // SCORM interaction
@@ -184,7 +187,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       document.getElementById('result_${sceneIndex}').style.display = 'none';
 
       QUESTIONS_${sceneIndex}.forEach(function(q) {
-        var block = document.getElementById('qblock_' + q.id);
+        var block = document.getElementById('qblock_${sceneIndex}_' + q.id);
         if (!block) return;
         Array.from(block.querySelectorAll('input')).forEach(function(inp) {
           inp.disabled = false;
@@ -193,14 +196,14 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
         Array.from(block.querySelectorAll('.om-opt')).forEach(function(lbl) {
           lbl.className = 'om-opt';
         });
-        var analysisEl = document.getElementById('analysis_' + q.id);
+        var analysisEl = document.getElementById('analysis_${sceneIndex}_' + q.id);
         if (analysisEl) analysisEl.style.display = 'none';
       });
     });
 
     // Clear orange warning in real time when user selects an answer
     QUESTIONS_${sceneIndex}.forEach(function(q) {
-      var block = document.getElementById('qblock_' + q.id);
+      var block = document.getElementById('qblock_${sceneIndex}_' + q.id);
       if (!block) return;
       Array.from(block.querySelectorAll('input')).forEach(function(inp) {
         inp.addEventListener('change', function() {

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -1,0 +1,235 @@
+import type { Scene, QuizContent, QuizQuestion } from '@/lib/types/stage';
+
+export interface QuizScoOptions {
+  scene: Scene;
+  sceneIndex: number;
+  totalScenes: number;
+  allScoHrefs: string[];
+}
+
+const PASS_THRESHOLD = 80;
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderQuestion(q: QuizQuestion, idx: number): string {
+  // short_answer questions are excluded from SCORM export
+  if (q.type === 'short_answer' || !q.options?.length) return '';
+
+  const inputType = q.type === 'multiple' ? 'checkbox' : 'radio';
+  const typeLabel = q.type === 'multiple' ? ' <span class="q-multi-hint">(select all that apply)</span>' : '';
+
+  const options = q.options
+    .map(
+      (opt) => `
+      <label class="option-label" data-value="${escHtml(opt.value)}">
+        <input type="${inputType}" name="q_${escHtml(q.id)}" value="${escHtml(opt.value)}">
+        <span class="option-value">${escHtml(opt.value)}.</span>
+        <span class="option-text">${escHtml(opt.label)}</span>
+      </label>`,
+    )
+    .join('');
+
+  const analysis = q.analysis
+    ? `<div class="analysis" id="analysis_${escHtml(q.id)}">${escHtml(q.analysis)}</div>`
+    : '';
+
+  return `
+<div class="question-block" id="q_block_${escHtml(q.id)}"
+     data-qid="${escHtml(q.id)}"
+     data-type="${q.type}"
+     data-answer="${escHtml((q.answer ?? []).join(','))}">
+  <div class="question-text">
+    <span class="q-num">${idx + 1}.</span> ${escHtml(q.question)}${typeLabel}
+  </div>
+  <div class="options-list">
+    ${options}
+  </div>
+  ${analysis}
+</div>`;
+}
+
+/**
+ * Builds the full HTML string for a quiz SCO page.
+ *
+ * Only single and multiple choice questions are exported.
+ * Short-answer questions are skipped.
+ * SCORM scoring: score.raw = (correct / total) * 100, pass threshold = 80.
+ */
+export function buildQuizSco(opts: QuizScoOptions): string {
+  const { scene, sceneIndex, totalScenes, allScoHrefs } = opts;
+
+  if (scene.content.type !== 'quiz') return '';
+  const content = scene.content as QuizContent;
+
+  // Only exportable questions: single or multiple with options and answers
+  const exportable = content.questions.filter(
+    (q) => (q.type === 'single' || q.type === 'multiple') && q.options?.length && q.answer?.length,
+  );
+
+  const questionsHtml = exportable.map((q, i) => renderQuestion(q, i)).join('');
+
+  const myHref = allScoHrefs[sceneIndex];
+  const hasPrev = sceneIndex > 0;
+  const hasNext = sceneIndex < totalScenes - 1;
+
+  // Serialise question data for the JS runtime
+  const questionsJson = JSON.stringify(
+    exportable.map((q) => ({
+      id: q.id,
+      type: q.type,
+      answer: q.answer ?? [],
+    })),
+  );
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escHtml(scene.title)}</title>
+  <script src="../scorm_bridge.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { margin: 0; padding: 0; font-family: 'Segoe UI', Arial, sans-serif; background: #f5f5f7; color: #1d1d1f; min-height: 100vh; }
+    .page-wrapper { max-width: 760px; margin: 0 auto; padding: 2rem 1.5rem 5rem; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 1.5rem; color: #1d1d1f; }
+    .question-block { background: #fff; border-radius: 10px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+    .question-text { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; line-height: 1.5; }
+    .q-num { color: #6e6e73; margin-right: 4px; }
+    .q-multi-hint { font-size: 0.8rem; font-weight: 400; color: #6e6e73; }
+    .options-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .option-label {
+      display: flex; align-items: flex-start; gap: 10px;
+      padding: 0.6rem 0.75rem;
+      border-radius: 6px; cursor: pointer;
+      border: 1.5px solid #e0e0e5;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .option-label:hover { border-color: #0071e3; background: #f0f6ff; }
+    .option-label input { margin-top: 2px; accent-color: #0071e3; }
+    .option-value { font-weight: 600; min-width: 20px; color: #6e6e73; }
+    .option-text { flex: 1; }
+    .option-label.correct  { border-color: #34c759; background: #f0faf3; }
+    .option-label.incorrect { border-color: #ff3b30; background: #fff5f4; }
+    .option-label.missed   { border-color: #34c759; background: #f0faf3; border-style: dashed; }
+    .analysis { margin-top: 0.75rem; padding: 0.6rem 0.75rem; background: #f9f9fb; border-left: 3px solid #0071e3; font-size: 0.9rem; color: #444; border-radius: 0 4px 4px 0; display: none; }
+    #result-bar { margin: 1rem 0; padding: 0.75rem 1rem; border-radius: 8px; font-weight: 600; font-size: 1rem; display: none; }
+    #result-bar.pass { background: #f0faf3; color: #1a7f37; border: 1.5px solid #34c759; }
+    #result-bar.fail { background: #fff5f4; color: #c0392b; border: 1.5px solid #ff3b30; }
+    #submit-btn {
+      display: block; width: 100%; padding: 0.8rem; margin: 1rem 0 0;
+      background: #0071e3; color: #fff; border: none; border-radius: 8px;
+      font-size: 1rem; font-weight: 600; cursor: pointer;
+    }
+    #submit-btn:hover:not(:disabled) { background: #0077ed; }
+    #submit-btn:disabled { background: #b0c8e8; cursor: not-allowed; }
+    .nav-bar { position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #e0e0e5; display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 1.5rem; gap: 1rem; }
+    .nav-bar button { background: #f5f5f7; border: 1.5px solid #d0d0d5; padding: 0.5rem 1.25rem; border-radius: 6px; cursor: pointer; font-size: 0.9rem; font-weight: 500; }
+    .nav-bar button:hover { background: #e8e8ed; }
+    .scene-counter { font-size: 0.85rem; color: #6e6e73; }
+  </style>
+</head>
+<body>
+<div class="page-wrapper">
+  <h1>${escHtml(scene.title)}</h1>
+  ${questionsHtml.trim() || '<p style="color:#6e6e73;">No gradable questions in this section.</p>'}
+  <div id="result-bar"></div>
+  <button id="submit-btn"${exportable.length === 0 ? ' disabled' : ''}>Submit</button>
+</div>
+
+<div class="nav-bar">
+  ${hasPrev ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','prev')">&#8592; Prev</button>` : '<span></span>'}
+  <span class="scene-counter">${sceneIndex + 1} / ${totalScenes}</span>
+  ${hasNext ? `<button id="next-btn" onclick="SCORM.navigate(ALL_SCOS,'${myHref}','next')">Next &#8594;</button>` : '<span></span>'}
+</div>
+
+<script>
+var ALL_SCOS = ${JSON.stringify(allScoHrefs)};
+var QUESTIONS = ${questionsJson};
+var PASS_THRESHOLD = ${PASS_THRESHOLD};
+var submitted = false;
+
+window.addEventListener('load', function() {
+  SCORM.init();
+  SCORM.setValue('cmi.core.lesson_status', 'incomplete');
+});
+window.addEventListener('beforeunload', function() {
+  if (!submitted) SCORM.finish();
+});
+
+document.getElementById('submit-btn').addEventListener('click', function() {
+  if (submitted || QUESTIONS.length === 0) return;
+  submitted = true;
+  this.disabled = true;
+
+  var correct = 0;
+
+  QUESTIONS.forEach(function(q, interactionIdx) {
+    var block = document.getElementById('q_block_' + q.id);
+    var studentResponse = '';
+    var isCorrect = false;
+
+    if (q.type === 'single') {
+      var sel = block.querySelector('input[type=radio]:checked');
+      studentResponse = sel ? sel.value : '';
+      isCorrect = studentResponse === q.answer[0];
+    } else {
+      var checked = Array.from(block.querySelectorAll('input[type=checkbox]:checked'))
+                        .map(function(c) { return c.value; })
+                        .sort();
+      studentResponse = checked.join('[,]');
+      var correctSorted = q.answer.slice().sort().join('[,]');
+      isCorrect = studentResponse === correctSorted;
+    }
+
+    if (isCorrect) correct++;
+
+    // Visual feedback on options
+    var labels = block.querySelectorAll('.option-label');
+    labels.forEach(function(label) {
+      var input = label.querySelector('input');
+      var val = input.value;
+      var inAnswer = q.answer.indexOf(val) !== -1;
+      var isSelected = input.checked;
+      input.disabled = true;
+      if (inAnswer && isSelected) label.classList.add('correct');
+      else if (inAnswer && !isSelected) label.classList.add('missed');
+      else if (!inAnswer && isSelected) label.classList.add('incorrect');
+    });
+
+    // Show analysis
+    var analysis = document.getElementById('analysis_' + q.id);
+    if (analysis) analysis.style.display = 'block';
+
+    // Log SCORM interaction
+    var correctPattern = q.type === 'single' ? q.answer[0] : q.answer.slice().sort().join('[,]');
+    SCORM.logInteraction(interactionIdx, q.id, 'choice', studentResponse, correctPattern, isCorrect ? 'correct' : 'wrong');
+  });
+
+  // Score
+  var pct = QUESTIONS.length > 0 ? Math.round((correct / QUESTIONS.length) * 100) : 0;
+  SCORM.setScore(pct, 0, 100);
+
+  var resultBar = document.getElementById('result-bar');
+  resultBar.style.display = 'block';
+  resultBar.textContent = 'Score: ' + correct + ' / ' + QUESTIONS.length + ' (' + pct + '%)';
+
+  if (pct >= PASS_THRESHOLD) {
+    SCORM.setPassed();
+    resultBar.className = 'pass';
+  } else {
+    SCORM.setFailed();
+    resultBar.className = 'fail';
+    resultBar.textContent += ' — minimum passing score is ' + PASS_THRESHOLD + '%';
+  }
+});
+</script>
+</body>
+</html>`;
+}

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -1,13 +1,22 @@
+/**
+ * quiz-sco.ts
+ * Builds the HTML fragment (a <section> element) for a quiz scene.
+ * Only single/multiple choice questions are exported (short_answer excluded).
+ */
 import type { Scene, QuizContent, QuizQuestion } from '@/lib/types/stage';
 
-export interface QuizScoOptions {
-  scene: Scene;
-  sceneIndex: number;
-  totalScenes: number;
-  allScoHrefs: string[];
+export const QUIZ_PASS_THRESHOLD = 80;
+
+export interface QuizSceneMeta {
+  type: 'quiz';
+  sceneId: string;
+  questionCount: number; // exportable questions count
 }
 
-const PASS_THRESHOLD = 80;
+export interface QuizSectionResult {
+  html: string;
+  meta: QuizSceneMeta;
+}
 
 function escHtml(s: string): string {
   return s
@@ -18,11 +27,9 @@ function escHtml(s: string): string {
 }
 
 function renderQuestion(q: QuizQuestion, idx: number): string {
-  // short_answer questions are excluded from SCORM export
   if (q.type === 'short_answer' || !q.options?.length) return '';
-
   const inputType = q.type === 'multiple' ? 'checkbox' : 'radio';
-  const typeLabel = q.type === 'multiple' ? ' <span class="q-multi-hint">(select all that apply)</span>' : '';
+  const multiHint = q.type === 'multiple' ? ' <span class="q-multi-hint">(select all that apply)</span>' : '';
 
   const options = q.options
     .map(
@@ -39,197 +46,117 @@ function renderQuestion(q: QuizQuestion, idx: number): string {
     ? `<div class="analysis" id="analysis_${escHtml(q.id)}">${escHtml(q.analysis)}</div>`
     : '';
 
-  return `
-<div class="question-block" id="q_block_${escHtml(q.id)}"
-     data-qid="${escHtml(q.id)}"
-     data-type="${q.type}"
+  return `<div class="question-block" id="qblock_${escHtml(q.id)}"
+     data-qid="${escHtml(q.id)}" data-type="${q.type}"
      data-answer="${escHtml((q.answer ?? []).join(','))}">
-  <div class="question-text">
-    <span class="q-num">${idx + 1}.</span> ${escHtml(q.question)}${typeLabel}
-  </div>
-  <div class="options-list">
-    ${options}
-  </div>
+  <div class="question-text"><span class="q-num">${idx + 1}.</span> ${escHtml(q.question)}${multiHint}</div>
+  <div class="options-list">${options}</div>
   ${analysis}
 </div>`;
 }
 
 /**
- * Builds the full HTML string for a quiz SCO page.
- *
- * Only single and multiple choice questions are exported.
- * Short-answer questions are skipped.
- * SCORM scoring: score.raw = (correct / total) * 100, pass threshold = 80.
+ * Builds the HTML <section> fragment for a quiz scene.
+ * Scoring is reported via the global onQuizSubmitted(sceneIdx, score) callback
+ * defined in course-builder.ts.
  */
-export function buildQuizSco(opts: QuizScoOptions): string {
-  const { scene, sceneIndex, totalScenes, allScoHrefs } = opts;
-
-  if (scene.content.type !== 'quiz') return '';
+export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionResult {
   const content = scene.content as QuizContent;
+  const sceneId = `scene-${sceneIndex}`;
 
-  // Only exportable questions: single or multiple with options and answers
   const exportable = content.questions.filter(
     (q) => (q.type === 'single' || q.type === 'multiple') && q.options?.length && q.answer?.length,
   );
 
-  const questionsHtml = exportable.map((q, i) => renderQuestion(q, i)).join('');
+  const questionsHtml = exportable.map((q, i) => renderQuestion(q, i)).join('\n');
 
-  const myHref = allScoHrefs[sceneIndex];
-  const hasPrev = sceneIndex > 0;
-  const hasNext = sceneIndex < totalScenes - 1;
-
-  // Serialise question data for the JS runtime
+  // Serialize question data for inline JS
   const questionsJson = JSON.stringify(
-    exportable.map((q) => ({
-      id: q.id,
-      type: q.type,
-      answer: q.answer ?? [],
-    })),
+    exportable.map((q) => ({ id: q.id, type: q.type, answer: q.answer ?? [] })),
   );
 
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escHtml(scene.title)}</title>
-  <script src="../scorm_bridge.js"></script>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; }
-    body { margin: 0; padding: 0; font-family: 'Segoe UI', Arial, sans-serif; background: #f5f5f7; color: #1d1d1f; min-height: 100vh; }
-    .page-wrapper { max-width: 760px; margin: 0 auto; padding: 2rem 1.5rem 5rem; }
-    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 1.5rem; color: #1d1d1f; }
-    .question-block { background: #fff; border-radius: 10px; padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
-    .question-text { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; line-height: 1.5; }
-    .q-num { color: #6e6e73; margin-right: 4px; }
-    .q-multi-hint { font-size: 0.8rem; font-weight: 400; color: #6e6e73; }
-    .options-list { display: flex; flex-direction: column; gap: 0.5rem; }
-    .option-label {
-      display: flex; align-items: flex-start; gap: 10px;
-      padding: 0.6rem 0.75rem;
-      border-radius: 6px; cursor: pointer;
-      border: 1.5px solid #e0e0e5;
-      transition: border-color 0.15s, background 0.15s;
+  const noQuestions = exportable.length === 0;
+
+  const html = `<section id="${sceneId}" class="scene scene-quiz" data-title="${escHtml(scene.title)}" style="display:none">
+  <div class="quiz-scroll">
+    <h2 class="quiz-title">${escHtml(scene.title)}</h2>
+    ${noQuestions
+      ? '<p style="color:#6e6e73;">No gradable questions in this section.</p>'
+      : questionsHtml
     }
-    .option-label:hover { border-color: #0071e3; background: #f0f6ff; }
-    .option-label input { margin-top: 2px; accent-color: #0071e3; }
-    .option-value { font-weight: 600; min-width: 20px; color: #6e6e73; }
-    .option-text { flex: 1; }
-    .option-label.correct  { border-color: #34c759; background: #f0faf3; }
-    .option-label.incorrect { border-color: #ff3b30; background: #fff5f4; }
-    .option-label.missed   { border-color: #34c759; background: #f0faf3; border-style: dashed; }
-    .analysis { margin-top: 0.75rem; padding: 0.6rem 0.75rem; background: #f9f9fb; border-left: 3px solid #0071e3; font-size: 0.9rem; color: #444; border-radius: 0 4px 4px 0; display: none; }
-    #result-bar { margin: 1rem 0; padding: 0.75rem 1rem; border-radius: 8px; font-weight: 600; font-size: 1rem; display: none; }
-    #result-bar.pass { background: #f0faf3; color: #1a7f37; border: 1.5px solid #34c759; }
-    #result-bar.fail { background: #fff5f4; color: #c0392b; border: 1.5px solid #ff3b30; }
-    #submit-btn {
-      display: block; width: 100%; padding: 0.8rem; margin: 1rem 0 0;
-      background: #0071e3; color: #fff; border: none; border-radius: 8px;
-      font-size: 1rem; font-weight: 600; cursor: pointer;
-    }
-    #submit-btn:hover:not(:disabled) { background: #0077ed; }
-    #submit-btn:disabled { background: #b0c8e8; cursor: not-allowed; }
-    .nav-bar { position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #e0e0e5; display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 1.5rem; gap: 1rem; }
-    .nav-bar button { background: #f5f5f7; border: 1.5px solid #d0d0d5; padding: 0.5rem 1.25rem; border-radius: 6px; cursor: pointer; font-size: 0.9rem; font-weight: 500; }
-    .nav-bar button:hover { background: #e8e8ed; }
-    .scene-counter { font-size: 0.85rem; color: #6e6e73; }
-  </style>
-</head>
-<body>
-<div class="page-wrapper">
-  <h1>${escHtml(scene.title)}</h1>
-  ${questionsHtml.trim() || '<p style="color:#6e6e73;">No gradable questions in this section.</p>'}
-  <div id="result-bar"></div>
-  <button id="submit-btn"${exportable.length === 0 ? ' disabled' : ''}>Submit</button>
-</div>
+    <div id="result_${sceneIndex}" class="result-bar" style="display:none"></div>
+    <button id="submit_${sceneIndex}" class="submit-btn"${noQuestions ? ' disabled' : ''}>
+      Submit
+    </button>
+  </div>
+  <script>
+  (function() {
+    var QUESTIONS_${sceneIndex} = ${questionsJson};
+    var submitted_${sceneIndex} = false;
 
-<div class="nav-bar">
-  ${hasPrev ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','prev')">&#8592; Prev</button>` : '<span></span>'}
-  <span class="scene-counter">${sceneIndex + 1} / ${totalScenes}</span>
-  ${hasNext ? `<button id="next-btn" onclick="SCORM.navigate(ALL_SCOS,'${myHref}','next')">Next &#8594;</button>` : '<span></span>'}
-</div>
+    document.getElementById('submit_${sceneIndex}').addEventListener('click', function() {
+      if (submitted_${sceneIndex} || QUESTIONS_${sceneIndex}.length === 0) return;
+      submitted_${sceneIndex} = true;
+      this.disabled = true;
 
-<script>
-var ALL_SCOS = ${JSON.stringify(allScoHrefs)};
-var QUESTIONS = ${questionsJson};
-var PASS_THRESHOLD = ${PASS_THRESHOLD};
-var submitted = false;
+      var correct = 0;
+      QUESTIONS_${sceneIndex}.forEach(function(q, iIdx) {
+        var block = document.getElementById('qblock_' + q.id);
+        var studentResponse = '';
+        var isCorrect = false;
 
-window.addEventListener('load', function() {
-  SCORM.init();
-  SCORM.setValue('cmi.core.lesson_status', 'incomplete');
-});
-window.addEventListener('beforeunload', function() {
-  if (!submitted) SCORM.finish();
-});
+        if (q.type === 'single') {
+          var sel = block.querySelector('input[type=radio]:checked');
+          studentResponse = sel ? sel.value : '';
+          isCorrect = studentResponse === q.answer[0];
+        } else {
+          var checked = Array.from(block.querySelectorAll('input[type=checkbox]:checked'))
+                            .map(function(c) { return c.value; }).sort();
+          studentResponse = checked.join('[,]');
+          isCorrect = studentResponse === q.answer.slice().sort().join('[,]');
+        }
 
-document.getElementById('submit-btn').addEventListener('click', function() {
-  if (submitted || QUESTIONS.length === 0) return;
-  submitted = true;
-  this.disabled = true;
+        if (isCorrect) correct++;
 
-  var correct = 0;
+        // Visual feedback
+        block.querySelectorAll('.option-label').forEach(function(label) {
+          var input = label.querySelector('input');
+          input.disabled = true;
+          var inAnswer = q.answer.indexOf(input.value) !== -1;
+          if (inAnswer && input.checked) label.classList.add('opt-correct');
+          else if (inAnswer && !input.checked) label.classList.add('opt-missed');
+          else if (!inAnswer && input.checked) label.classList.add('opt-incorrect');
+        });
 
-  QUESTIONS.forEach(function(q, interactionIdx) {
-    var block = document.getElementById('q_block_' + q.id);
-    var studentResponse = '';
-    var isCorrect = false;
+        var analysisEl = document.getElementById('analysis_' + q.id);
+        if (analysisEl) analysisEl.style.display = 'block';
 
-    if (q.type === 'single') {
-      var sel = block.querySelector('input[type=radio]:checked');
-      studentResponse = sel ? sel.value : '';
-      isCorrect = studentResponse === q.answer[0];
-    } else {
-      var checked = Array.from(block.querySelectorAll('input[type=checkbox]:checked'))
-                        .map(function(c) { return c.value; })
-                        .sort();
-      studentResponse = checked.join('[,]');
-      var correctSorted = q.answer.slice().sort().join('[,]');
-      isCorrect = studentResponse === correctSorted;
-    }
+        // SCORM interaction
+        var correctPattern = q.type === 'single' ? q.answer[0] : q.answer.slice().sort().join('[,]');
+        if (typeof SCORM !== 'undefined') {
+          SCORM.logInteraction(iIdx, q.id, 'choice', studentResponse, correctPattern, isCorrect ? 'correct' : 'wrong');
+        }
+      });
 
-    if (isCorrect) correct++;
+      var pct = QUESTIONS_${sceneIndex}.length > 0
+        ? Math.round((correct / QUESTIONS_${sceneIndex}.length) * 100) : 0;
 
-    // Visual feedback on options
-    var labels = block.querySelectorAll('.option-label');
-    labels.forEach(function(label) {
-      var input = label.querySelector('input');
-      var val = input.value;
-      var inAnswer = q.answer.indexOf(val) !== -1;
-      var isSelected = input.checked;
-      input.disabled = true;
-      if (inAnswer && isSelected) label.classList.add('correct');
-      else if (inAnswer && !isSelected) label.classList.add('missed');
-      else if (!inAnswer && isSelected) label.classList.add('incorrect');
+      var bar = document.getElementById('result_${sceneIndex}');
+      bar.style.display = 'block';
+      bar.textContent = 'Score: ' + correct + ' / ' + QUESTIONS_${sceneIndex}.length + ' (' + pct + '%)';
+      bar.className = 'result-bar ' + (pct >= ${QUIZ_PASS_THRESHOLD} ? 'result-pass' : 'result-fail');
+
+      // Notify course controller
+      if (typeof window.onQuizSubmitted === 'function') {
+        window.onQuizSubmitted(${sceneIndex}, pct);
+      }
     });
+  })();
+  </script>
+</section>`;
 
-    // Show analysis
-    var analysis = document.getElementById('analysis_' + q.id);
-    if (analysis) analysis.style.display = 'block';
-
-    // Log SCORM interaction
-    var correctPattern = q.type === 'single' ? q.answer[0] : q.answer.slice().sort().join('[,]');
-    SCORM.logInteraction(interactionIdx, q.id, 'choice', studentResponse, correctPattern, isCorrect ? 'correct' : 'wrong');
-  });
-
-  // Score
-  var pct = QUESTIONS.length > 0 ? Math.round((correct / QUESTIONS.length) * 100) : 0;
-  SCORM.setScore(pct, 0, 100);
-
-  var resultBar = document.getElementById('result-bar');
-  resultBar.style.display = 'block';
-  resultBar.textContent = 'Score: ' + correct + ' / ' + QUESTIONS.length + ' (' + pct + '%)';
-
-  if (pct >= PASS_THRESHOLD) {
-    SCORM.setPassed();
-    resultBar.className = 'pass';
-  } else {
-    SCORM.setFailed();
-    resultBar.className = 'fail';
-    resultBar.textContent += ' — minimum passing score is ' + PASS_THRESHOLD + '%';
-  }
-});
-</script>
-</body>
-</html>`;
+  return {
+    html,
+    meta: { type: 'quiz', sceneId, questionCount: exportable.length },
+  };
 }

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -89,6 +89,9 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
     <button id="submit_${sceneIndex}" class="om-submit"${noQuestions ? ' disabled' : ''}>
       Submit
     </button>
+    <button id="retry_${sceneIndex}" class="om-retry" style="display:none">
+      Torna-ho a intentar
+    </button>
   </div>
   <script>
   (function() {
@@ -97,6 +100,19 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
 
     document.getElementById('submit_${sceneIndex}').addEventListener('click', function() {
       if (submitted_${sceneIndex} || QUESTIONS_${sceneIndex}.length === 0) return;
+
+      // Require at least one answer per question
+      var allAnswered = true;
+      QUESTIONS_${sceneIndex}.forEach(function(q) {
+        var block = document.getElementById('qblock_' + q.id);
+        var hasAnswer = q.type === 'single'
+          ? !!block.querySelector('input[type=radio]:checked')
+          : !!block.querySelector('input[type=checkbox]:checked');
+        if (!hasAnswer) { allAnswered = false; block.classList.add('om-qblock--warn'); }
+        else { block.classList.remove('om-qblock--warn'); }
+      });
+      if (!allAnswered) return;
+
       submitted_${sceneIndex} = true;
       this.disabled = true;
 
@@ -147,10 +163,35 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       bar.textContent = 'Score: ' + correct + ' / ' + QUESTIONS_${sceneIndex}.length + ' (' + pct + '%)';
       bar.className = 'om-result ' + (pct >= ${QUIZ_PASS_THRESHOLD} ? 'om-pass' : 'om-fail');
 
+      // Show retry button if failed
+      if (pct < ${QUIZ_PASS_THRESHOLD}) {
+        document.getElementById('retry_${sceneIndex}').style.display = 'block';
+      }
+
       // Notify course controller
       if (typeof window.onQuizSubmitted === 'function') {
         window.onQuizSubmitted(${sceneIndex}, pct);
       }
+    });
+
+    document.getElementById('retry_${sceneIndex}').addEventListener('click', function() {
+      submitted_${sceneIndex} = false;
+      this.style.display = 'none';
+      document.getElementById('submit_${sceneIndex}').disabled = false;
+      document.getElementById('result_${sceneIndex}').style.display = 'none';
+
+      QUESTIONS_${sceneIndex}.forEach(function(q) {
+        var block = document.getElementById('qblock_' + q.id);
+        block.querySelectorAll('input').forEach(function(inp) {
+          inp.disabled = false;
+          inp.checked = false;
+        });
+        block.querySelectorAll('.om-opt').forEach(function(lbl) {
+          lbl.className = 'om-opt';
+        });
+        var analysisEl = document.getElementById('analysis_' + q.id);
+        if (analysisEl) analysisEl.style.display = 'none';
+      });
     });
   })();
   </script>

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -120,6 +120,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       var correct = 0;
       QUESTIONS_${sceneIndex}.forEach(function(q, iIdx) {
         var block = document.getElementById('qblock_' + q.id);
+        if (!block) return;
         var studentResponse = '';
         var isCorrect = false;
 
@@ -137,8 +138,9 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
         if (isCorrect) correct++;
 
         // Visual feedback
-        block.querySelectorAll('.om-opt').forEach(function(label) {
+        Array.from(block.querySelectorAll('.om-opt')).forEach(function(label) {
           var input = label.querySelector('input');
+          if (!input) return;
           input.disabled = true;
           var inAnswer = q.answer.indexOf(input.value) !== -1;
           if (inAnswer && input.checked) label.classList.add('om-correct');
@@ -151,7 +153,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
 
         // SCORM interaction
         var correctPattern = q.type === 'single' ? q.answer[0] : q.answer.slice().sort().join('[,]');
-        if (typeof SCORM !== 'undefined') {
+        if (typeof SCORM !== 'undefined' && typeof SCORM.logInteraction === 'function') {
           SCORM.logInteraction(iIdx, q.id, 'choice', studentResponse, correctPattern, isCorrect ? 'correct' : 'wrong');
         }
       });
@@ -184,11 +186,11 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       QUESTIONS_${sceneIndex}.forEach(function(q) {
         var block = document.getElementById('qblock_' + q.id);
         if (!block) return;
-        block.querySelectorAll('input').forEach(function(inp) {
+        Array.from(block.querySelectorAll('input')).forEach(function(inp) {
           inp.disabled = false;
           inp.checked = false;
         });
-        block.querySelectorAll('.om-opt').forEach(function(lbl) {
+        Array.from(block.querySelectorAll('.om-opt')).forEach(function(lbl) {
           lbl.className = 'om-opt';
         });
         var analysisEl = document.getElementById('analysis_' + q.id);
@@ -200,7 +202,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
     QUESTIONS_${sceneIndex}.forEach(function(q) {
       var block = document.getElementById('qblock_' + q.id);
       if (!block) return;
-      block.querySelectorAll('input').forEach(function(inp) {
+      Array.from(block.querySelectorAll('input')).forEach(function(inp) {
         inp.addEventListener('change', function() {
           block.classList.remove('om-qblock--warn');
         });

--- a/lib/export/scorm/quiz-sco.ts
+++ b/lib/export/scorm/quiz-sco.ts
@@ -2,6 +2,7 @@
  * quiz-sco.ts
  * Builds the HTML fragment (a <section> element) for a quiz scene.
  * Only single/multiple choice questions are exported (short_answer excluded).
+ * CSS classes use the "om-" prefix to avoid conflicts with LMS stylesheets.
  */
 import type { Scene, QuizContent, QuizQuestion } from '@/lib/types/stage';
 
@@ -29,28 +30,28 @@ function escHtml(s: string): string {
 function renderQuestion(q: QuizQuestion, idx: number): string {
   if (q.type === 'short_answer' || !q.options?.length) return '';
   const inputType = q.type === 'multiple' ? 'checkbox' : 'radio';
-  const multiHint = q.type === 'multiple' ? ' <span class="q-multi-hint">(select all that apply)</span>' : '';
+  const multiHint = q.type === 'multiple' ? ' <span class="om-qhint">(select all that apply)</span>' : '';
 
   const options = q.options
     .map(
       (opt) => `
-      <label class="option-label" data-value="${escHtml(opt.value)}">
+      <label class="om-opt" data-value="${escHtml(opt.value)}">
         <input type="${inputType}" name="q_${escHtml(q.id)}" value="${escHtml(opt.value)}">
-        <span class="option-value">${escHtml(opt.value)}.</span>
-        <span class="option-text">${escHtml(opt.label)}</span>
+        <span class="om-optval">${escHtml(opt.value)}.</span>
+        <span class="om-opttext">${escHtml(opt.label)}</span>
       </label>`,
     )
     .join('');
 
   const analysis = q.analysis
-    ? `<div class="analysis" id="analysis_${escHtml(q.id)}">${escHtml(q.analysis)}</div>`
+    ? `<div class="om-analysis" id="analysis_${escHtml(q.id)}">${escHtml(q.analysis)}</div>`
     : '';
 
-  return `<div class="question-block" id="qblock_${escHtml(q.id)}"
+  return `<div class="om-qblock" id="qblock_${escHtml(q.id)}"
      data-qid="${escHtml(q.id)}" data-type="${q.type}"
      data-answer="${escHtml((q.answer ?? []).join(','))}">
-  <div class="question-text"><span class="q-num">${idx + 1}.</span> ${escHtml(q.question)}${multiHint}</div>
-  <div class="options-list">${options}</div>
+  <div class="om-qtext"><span class="om-qnum">${idx + 1}.</span> ${escHtml(q.question)}${multiHint}</div>
+  <div class="om-opts">${options}</div>
   ${analysis}
 </div>`;
 }
@@ -77,15 +78,15 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
 
   const noQuestions = exportable.length === 0;
 
-  const html = `<section id="${sceneId}" class="scene scene-quiz" data-title="${escHtml(scene.title)}" style="display:none">
-  <div class="quiz-scroll">
-    <h2 class="quiz-title">${escHtml(scene.title)}</h2>
+  const html = `<section id="${sceneId}" class="om-scene om-quiz" data-title="${escHtml(scene.title)}" style="display:none">
+  <div class="om-quiz-scroll">
+    <h2 class="om-quiz-title">${escHtml(scene.title)}</h2>
     ${noQuestions
       ? '<p style="color:#6e6e73;">No gradable questions in this section.</p>'
       : questionsHtml
     }
-    <div id="result_${sceneIndex}" class="result-bar" style="display:none"></div>
-    <button id="submit_${sceneIndex}" class="submit-btn"${noQuestions ? ' disabled' : ''}>
+    <div id="result_${sceneIndex}" class="om-result" style="display:none"></div>
+    <button id="submit_${sceneIndex}" class="om-submit"${noQuestions ? ' disabled' : ''}>
       Submit
     </button>
   </div>
@@ -119,13 +120,13 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
         if (isCorrect) correct++;
 
         // Visual feedback
-        block.querySelectorAll('.option-label').forEach(function(label) {
+        block.querySelectorAll('.om-opt').forEach(function(label) {
           var input = label.querySelector('input');
           input.disabled = true;
           var inAnswer = q.answer.indexOf(input.value) !== -1;
-          if (inAnswer && input.checked) label.classList.add('opt-correct');
-          else if (inAnswer && !input.checked) label.classList.add('opt-missed');
-          else if (!inAnswer && input.checked) label.classList.add('opt-incorrect');
+          if (inAnswer && input.checked) label.classList.add('om-correct');
+          else if (inAnswer && !input.checked) label.classList.add('om-missed');
+          else if (!inAnswer && input.checked) label.classList.add('om-wrong');
         });
 
         var analysisEl = document.getElementById('analysis_' + q.id);
@@ -144,7 +145,7 @@ export function buildQuizSection(scene: Scene, sceneIndex: number): QuizSectionR
       var bar = document.getElementById('result_${sceneIndex}');
       bar.style.display = 'block';
       bar.textContent = 'Score: ' + correct + ' / ' + QUESTIONS_${sceneIndex}.length + ' (' + pct + '%)';
-      bar.className = 'result-bar ' + (pct >= ${QUIZ_PASS_THRESHOLD} ? 'result-pass' : 'result-fail');
+      bar.className = 'om-result ' + (pct >= ${QUIZ_PASS_THRESHOLD} ? 'om-pass' : 'om-fail');
 
       // Notify course controller
       if (typeof window.onQuizSubmitted === 'function') {

--- a/lib/export/scorm/scorm-bridge.ts
+++ b/lib/export/scorm/scorm-bridge.ts
@@ -1,0 +1,130 @@
+/**
+ * Returns the scorm_bridge.js source string — a self-contained SCORM 1.2 API
+ * wrapper embedded verbatim into every SCORM package.
+ */
+export function getScormBridgeJs(): string {
+  return `
+(function (root) {
+  'use strict';
+
+  var API = null;
+
+  function findAPI(win) {
+    var attempts = 0;
+    while (win.API == null && win.parent != null && win.parent !== win) {
+      attempts++;
+      if (attempts > 7) return null;
+      win = win.parent;
+    }
+    return win.API || null;
+  }
+
+  function getAPI() {
+    if (API) return API;
+    API = findAPI(window);
+    if (!API && window.opener) API = findAPI(window.opener);
+    return API;
+  }
+
+  root.SCORM = {
+    initialized: false,
+
+    init: function () {
+      var api = getAPI();
+      if (!api) {
+        // No LMS present — running standalone, silently continue
+        this.initialized = true;
+        return true;
+      }
+      var result = api.LMSInitialize('');
+      this.initialized = (result === 'true' || result === true);
+      return this.initialized;
+    },
+
+    finish: function () {
+      var api = getAPI();
+      if (!api || !this.initialized) return;
+      api.LMSFinish('');
+      this.initialized = false;
+    },
+
+    getValue: function (key) {
+      var api = getAPI();
+      if (!api || !this.initialized) return '';
+      return api.LMSGetValue(key) || '';
+    },
+
+    setValue: function (key, value) {
+      var api = getAPI();
+      if (!api || !this.initialized) return;
+      api.LMSSetValue(key, String(value));
+    },
+
+    commit: function () {
+      var api = getAPI();
+      if (!api || !this.initialized) return;
+      api.LMSCommit('');
+    },
+
+    // ── High-level helpers ──
+
+    setCompleted: function () {
+      this.setValue('cmi.core.lesson_status', 'completed');
+      this.commit();
+    },
+
+    setPassed: function () {
+      this.setValue('cmi.core.lesson_status', 'passed');
+      this.commit();
+    },
+
+    setFailed: function () {
+      this.setValue('cmi.core.lesson_status', 'failed');
+      this.commit();
+    },
+
+    setScore: function (raw, min, max) {
+      this.setValue('cmi.core.score.raw', raw);
+      this.setValue('cmi.core.score.min', min);
+      this.setValue('cmi.core.score.max', max);
+      this.commit();
+    },
+
+    // Log a single interaction (question response)
+    // index: 0-based interaction index
+    // type: 'choice' for single/multiple select
+    // response: student answer string (values joined by '[,]' for multiple)
+    // correct: correct answer pattern string
+    // result: 'correct' | 'wrong'
+    logInteraction: function (index, id, type, response, correct, result) {
+      var pre = 'cmi.interactions.' + index + '.';
+      this.setValue(pre + 'id', id);
+      this.setValue(pre + 'type', type);
+      this.setValue(pre + 'student_response', response);
+      this.setValue(pre + 'correct_responses.0.pattern', correct);
+      this.setValue(pre + 'result', result);
+    },
+
+    // ── Navigation ──
+    // sceneHrefs: JSON array of all SCO href strings (relative to ZIP root)
+    // currentHref: this SCO's href (e.g. 'scos/scene_01.html')
+    // direction: 'next' | 'prev'
+    navigate: function (sceneHrefs, currentHref, direction) {
+      var idx = sceneHrefs.indexOf(currentHref);
+      var next = direction === 'next' ? idx + 1 : idx - 1;
+      if (next < 0 || next >= sceneHrefs.length) return;
+      this.finish();
+      // Try parent frame first (LMS frameset), fall back to self
+      if (window.parent && window.parent !== window) {
+        try {
+          window.parent.location.href = sceneHrefs[next];
+          return;
+        } catch (e) { /* cross-origin, fall through */ }
+      }
+      window.location.href = sceneHrefs[next];
+    }
+  };
+
+})(window);
+`.trim();
+}

--- a/lib/export/scorm/slide-sco.ts
+++ b/lib/export/scorm/slide-sco.ts
@@ -174,7 +174,7 @@ function renderShape(el: PPTShapeElement): string {
   }
   const { defs, fillRef } = svgGradientDef(el);
   return `<div style="${elBaseStyle(el)}${opacity}overflow:visible;">
-  <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;"${svgTransform}>
+  <svg viewBox="0 0 ${vw} ${vh}" preserveAspectRatio="none" style="width:100%;height:100%;"${svgTransform}>
     ${defs}<path d="${escHtml(el.path)}" fill="${fillRef}" ${outline} fill-rule="nonzero"/>
   </svg>${text}
 </div>`;

--- a/lib/export/scorm/slide-sco.ts
+++ b/lib/export/scorm/slide-sco.ts
@@ -358,12 +358,10 @@ export function buildSlideSection(opts: SlideSectionOptions): SlideSectionResult
     }
   }
 
-  const html = `<section id="${sceneId}" class="scene scene-slide" data-title="${escHtml(scene.title)}" style="display:none">
-  <div class="slide-stage">
-    <div class="slide-scaler" id="${scalerId}">
-      <div class="slide-canvas" id="${canvasId}" style="width:${cw}px;height:${ch}px;background:${bgFallback};${bgCss}">
-        ${elements}
-      </div>
+  const html = `<section id="${sceneId}" class="om-scene om-slide" data-title="${escHtml(scene.title)}" style="display:none">
+  <div class="om-scaler" id="${scalerId}">
+    <div class="om-canvas" id="${canvasId}" style="width:${cw}px;height:${ch}px;background:${bgFallback};${bgCss}">
+      ${elements}
     </div>
   </div>
   ${narrTags}</section>`;

--- a/lib/export/scorm/slide-sco.ts
+++ b/lib/export/scorm/slide-sco.ts
@@ -137,9 +137,28 @@ function renderImage(el: PPTImageElement, assetMap: AssetMap): string {
 </div>`;
 }
 
+/**
+ * Build an SVG <defs> gradient block and return the fill reference.
+ * SVG fill attribute does not support CSS gradient syntax — must use <defs>.
+ */
+function svgGradientDef(el: PPTShapeElement): { defs: string; fillRef: string } {
+  if (!el.gradient) return { defs: '', fillRef: escHtml(el.fill || 'none') };
+  const gradId = `grad-${el.id}`;
+  const stops = el.gradient.colors
+    .map((c) => `<stop offset="${c.pos}%" stop-color="${escHtml(c.color)}"/>`)
+    .join('');
+  let defs: string;
+  if (el.gradient.type === 'radial') {
+    defs = `<defs><radialGradient id="${gradId}" cx="50%" cy="50%" r="50%" gradientUnits="objectBoundingBox">${stops}</radialGradient></defs>`;
+  } else {
+    // Linear: default direction left→right, rotated by el.gradient.rotate around center
+    defs = `<defs><linearGradient id="${gradId}" x1="0" y1="0.5" x2="1" y2="0.5" gradientUnits="objectBoundingBox" gradientTransform="rotate(${el.gradient.rotate},0.5,0.5)">${stops}</linearGradient></defs>`;
+  }
+  return { defs, fillRef: `url(#${gradId})` };
+}
+
 function renderShape(el: PPTShapeElement): string {
   const [vw, vh] = el.viewBox;
-  const fill = el.gradient ? gradientCss(el.gradient) : el.fill;
   const opacity = el.opacity !== undefined ? `opacity:${el.opacity};` : '';
   const flipH = el.flipH ? 'scale(-1,1)' : '';
   const flipV = el.flipV ? 'scale(1,-1)' : '';
@@ -153,9 +172,10 @@ function renderShape(el: PPTShapeElement): string {
     const va = t.align === 'top' ? 'flex-start' : t.align === 'bottom' ? 'flex-end' : 'center';
     text = `<div style="position:absolute;inset:0;display:flex;align-items:${va};justify-content:center;padding:4px;overflow:hidden;font-family:${escHtml(t.defaultFontName || 'sans-serif')};color:${t.defaultColor || '#000'};line-height:${t.lineHeight ?? 1.5};">${t.content}</div>`;
   }
+  const { defs, fillRef } = svgGradientDef(el);
   return `<div style="${elBaseStyle(el)}${opacity}overflow:visible;">
   <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;"${svgTransform}>
-    <path d="${escHtml(el.path)}" fill="${escHtml(fill)}" ${outline} fill-rule="nonzero"/>
+    ${defs}<path d="${escHtml(el.path)}" fill="${fillRef}" ${outline} fill-rule="nonzero"/>
   </svg>${text}
 </div>`;
 }
@@ -316,6 +336,7 @@ export function buildSlideSection(opts: SlideSectionOptions): SlideSectionResult
     .join('\n    ');
 
   // TTS narration audio elements
+  // Look up by audioUrl first, then by idb:{audioId} (for IndexedDB-stored audio)
   const narrIds: string[] = [];
   let narrTags = '';
   if (scene.actions) {
@@ -323,8 +344,9 @@ export function buildSlideSection(opts: SlideSectionOptions): SlideSectionResult
     for (const action of scene.actions) {
       if (action.type === 'speech') {
         const speech = action as SpeechAction;
-        if (speech.audioUrl) {
-          const p = assetMap.get(speech.audioUrl);
+        const mapKey = speech.audioUrl || (speech.audioId ? `idb:${speech.audioId}` : '');
+        if (mapKey) {
+          const p = assetMap.get(mapKey);
           if (p) {
             const id = `narr-${sceneIndex}-${idx}`;
             narrIds.push(id);

--- a/lib/export/scorm/slide-sco.ts
+++ b/lib/export/scorm/slide-sco.ts
@@ -1,0 +1,452 @@
+import type { Scene, SlideContent } from '@/lib/types/stage';
+import type {
+  PPTElement,
+  PPTTextElement,
+  PPTImageElement,
+  PPTShapeElement,
+  PPTLineElement,
+  PPTChartElement,
+  PPTTableElement,
+  PPTLatexElement,
+  PPTVideoElement,
+  PPTAudioElement,
+  SlideBackground,
+  Gradient,
+} from '@/lib/types/slides';
+import type { SpeechAction } from '@/lib/types/action';
+import { isMediaPlaceholder, useMediaGenerationStore } from '@/lib/store/media-generation';
+import type { AssetMap } from './asset-collector';
+
+export interface SlideScoOptions {
+  scene: Scene;
+  sceneIndex: number;
+  totalScenes: number;
+  allScoHrefs: string[];
+  assetMap: AssetMap;
+  includeVideos: boolean;
+}
+
+// ── Helpers ──
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function resolvedSrc(src: string, assetMap: AssetMap): string {
+  // If the src was collected as an asset, return the relative ZIP path
+  const stored = assetMap.get(src);
+  if (stored) return `../${stored}`;
+  // Media placeholder that was resolved
+  if (isMediaPlaceholder(src)) {
+    const task = useMediaGenerationStore.getState().tasks[src];
+    if (task?.objectUrl) {
+      const stored2 = assetMap.get(task.objectUrl);
+      if (stored2) return `../${stored2}`;
+    }
+    return ''; // not available
+  }
+  // Absolute URL or data URI — use directly
+  return src;
+}
+
+function buildBackgroundCss(bg: SlideBackground | undefined, assetMap: AssetMap): string {
+  if (!bg) return '';
+  if (bg.type === 'solid' && bg.color) return `background-color: ${bg.color};`;
+  if (bg.type === 'image' && bg.image?.src) {
+    const src = resolvedSrc(bg.image.src, assetMap);
+    if (!src) return '';
+    const size = bg.image.size === 'repeat' ? 'auto' : bg.image.size;
+    const repeat = bg.image.size === 'repeat' ? 'repeat' : 'no-repeat';
+    return `background-image: url('${src}'); background-size: ${size}; background-repeat: ${repeat}; background-position: center;`;
+  }
+  if (bg.type === 'gradient' && bg.gradient) {
+    return `background: ${buildGradientCss(bg.gradient)};`;
+  }
+  return '';
+}
+
+function buildGradientCss(g: Gradient): string {
+  const stops = g.colors.map((c) => `${c.color} ${c.pos}%`).join(', ');
+  if (g.type === 'radial') return `radial-gradient(circle, ${stops})`;
+  return `linear-gradient(${g.rotate}deg, ${stops})`;
+}
+
+function elStyle(el: PPTElement & { rotate: number }): string {
+  return `position:absolute;left:${el.left}px;top:${el.top}px;width:${el.width}px;height:${el.height}px;${el.rotate ? `transform:rotate(${el.rotate}deg);` : ''}`;
+}
+
+// ── Element renderers ──
+
+function renderText(el: PPTTextElement): string {
+  const fill = el.fill ? `background:${el.fill};` : '';
+  const opacity = el.opacity !== undefined ? `opacity:${el.opacity};` : '';
+  const lineH = el.lineHeight ?? 1.5;
+  const wordSp = el.wordSpace ?? 0;
+  const overflow = el.vertical ? 'writing-mode:vertical-rl;' : '';
+  return `<div style="${elStyle(el)}overflow:hidden;font-family:${escHtml(el.defaultFontName || 'sans-serif')};color:${el.defaultColor || '#000'};line-height:${lineH};letter-spacing:${wordSp}px;${fill}${opacity}${overflow}">${el.content}</div>`;
+}
+
+function renderImage(el: PPTImageElement, assetMap: AssetMap): string {
+  const src = resolvedSrc(el.src, assetMap);
+  if (!src) return '';
+
+  const filters: string[] = [];
+  if (el.filters) {
+    if (el.filters.blur) filters.push(`blur(${el.filters.blur})`);
+    if (el.filters.brightness) filters.push(`brightness(${el.filters.brightness})`);
+    if (el.filters.contrast) filters.push(`contrast(${el.filters.contrast})`);
+    if (el.filters.grayscale) filters.push(`grayscale(${el.filters.grayscale})`);
+    if (el.filters.saturate) filters.push(`saturate(${el.filters.saturate})`);
+    if (el.filters['hue-rotate']) filters.push(`hue-rotate(${el.filters['hue-rotate']})`);
+    if (el.filters.sepia) filters.push(`sepia(${el.filters.sepia})`);
+    if (el.filters.invert) filters.push(`invert(${el.filters.invert})`);
+    if (el.filters.opacity) filters.push(`opacity(${el.filters.opacity})`);
+  }
+  const filterCss = filters.length ? `filter:${filters.join(' ')};` : '';
+
+  let clipCss = '';
+  let borderRadius = '';
+  if (el.clip) {
+    const [[x1, y1], [x2, y2]] = el.clip.range;
+    clipCss = `clip-path:inset(${y1}% ${100 - x2}% ${100 - y2}% ${x1}%);`;
+    if (el.clip.shape === 'ellipse') borderRadius = 'border-radius:50%;';
+  }
+
+  const flipH = el.flipH ? 'scaleX(-1)' : '';
+  const flipV = el.flipV ? 'scaleY(-1)' : '';
+  const flipCss = flipH || flipV ? `transform-origin:center;${el.rotate ? `transform:rotate(${el.rotate}deg) ${flipH} ${flipV};` : `transform:${flipH} ${flipV};`}` : '';
+
+  const colorMask = el.colorMask
+    ? `<div style="position:absolute;inset:0;background:${el.colorMask};pointer-events:none;"></div>`
+    : '';
+
+  const base = el.rotate ? `transform:rotate(${el.rotate}deg);` : '';
+  const style = `position:absolute;left:${el.left}px;top:${el.top}px;width:${el.width}px;height:${el.height}px;${flipCss || base}overflow:hidden;${borderRadius}`;
+
+  return `<div style="${style}">${colorMask}<img src="${src}" style="width:100%;height:100%;object-fit:cover;${filterCss}${clipCss}" loading="lazy" alt=""/></div>`;
+}
+
+function renderShape(el: PPTShapeElement): string {
+  const [vw, vh] = el.viewBox;
+  const fill = el.gradient ? buildGradientCss(el.gradient) : el.fill;
+  const opacity = el.opacity !== undefined ? `opacity:${el.opacity};` : '';
+  const flipH = el.flipH ? 'scale(-1,1)' : '';
+  const flipV = el.flipV ? 'scale(1,-1)' : '';
+  const transform = (flipH || flipV) ? ` transform="${flipH || flipV}"` : '';
+  const outline = el.outline?.color && el.outline.width
+    ? `stroke="${el.outline.color}" stroke-width="${el.outline.width}" stroke-dasharray="${el.outline.style === 'dashed' ? '8 4' : el.outline.style === 'dotted' ? '2 4' : 'none'}"`
+    : 'stroke="none"';
+
+  let textOverlay = '';
+  if (el.text?.content) {
+    const t = el.text;
+    textOverlay = `<div style="position:absolute;inset:0;display:flex;align-items:${t.align === 'top' ? 'flex-start' : t.align === 'bottom' ? 'flex-end' : 'center'};justify-content:center;padding:4px;overflow:hidden;font-family:${escHtml(t.defaultFontName || 'sans-serif')};color:${t.defaultColor || '#000'};line-height:${t.lineHeight ?? 1.5};">${t.content}</div>`;
+  }
+
+  return `<div style="${elStyle(el)}${opacity}overflow:visible;">
+  <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;"${transform}>
+    <path d="${escHtml(el.path)}" fill="${escHtml(fill)}" ${outline} fill-rule="nonzero"/>
+  </svg>${textOverlay}
+</div>`;
+}
+
+function renderLine(el: PPTLineElement): string {
+  const [sx, sy] = el.start;
+  const [ex, ey] = el.end;
+  const minX = Math.min(sx, ex);
+  const minY = Math.min(sy, ey);
+  const maxX = Math.max(sx, ex);
+  const maxY = Math.max(sy, ey);
+  const w = maxX - minX || 2;
+  const h = maxY - minY || 2;
+  const dash = el.style === 'dashed' ? 'stroke-dasharray="8 4"' : el.style === 'dotted' ? 'stroke-dasharray="2 4"' : '';
+  return `<div style="position:absolute;left:${minX}px;top:${minY}px;width:${w}px;height:${h}px;overflow:visible;">
+  <svg viewBox="${minX} ${minY} ${w} ${h}" style="overflow:visible;width:${w}px;height:${h}px;">
+    <line x1="${sx}" y1="${sy}" x2="${ex}" y2="${ey}" stroke="${el.color}" stroke-width="2" ${dash}/>
+  </svg>
+</div>`;
+}
+
+function renderChart(el: PPTChartElement): string {
+  // NOTE: ECharts cannot render without a DOM/canvas at build time.
+  // We emit a data table as a SCORM-compatible fallback.
+  // Future enhancement: pre-render to SVG using headless ECharts.
+  const { labels, legends, series } = el.data;
+  const fill = el.fill ? `background:${el.fill};` : '';
+
+  let rows = `<tr><th></th>${labels.map((l) => `<th>${escHtml(l)}</th>`).join('')}</tr>`;
+  for (let i = 0; i < legends.length; i++) {
+    rows += `<tr><th>${escHtml(legends[i])}</th>${(series[i] ?? []).map((v) => `<td>${v}</td>`).join('')}</tr>`;
+  }
+
+  return `<div style="${elStyle(el)}overflow:auto;${fill}font-size:11px;">
+  <table style="border-collapse:collapse;width:100%;">
+    ${rows}
+  </table>
+</div>`;
+}
+
+function renderTable(el: PPTTableElement): string {
+  let colGroup = '<colgroup>';
+  for (const w of el.colWidths) {
+    colGroup += `<col style="width:${(w * 100).toFixed(1)}%"/>`;
+  }
+  colGroup += '</colgroup>';
+
+  let tbody = '<tbody>';
+  for (let ri = 0; ri < el.data.length; ri++) {
+    tbody += '<tr>';
+    for (const cell of el.data[ri]) {
+      if (!cell) continue;
+      const s = cell.style ?? {};
+      const css = [
+        s.bold ? 'font-weight:bold' : '',
+        s.em ? 'font-style:italic' : '',
+        s.underline ? 'text-decoration:underline' : '',
+        s.strikethrough ? 'text-decoration:line-through' : '',
+        s.color ? `color:${s.color}` : '',
+        s.backcolor ? `background:${s.backcolor}` : '',
+        s.fontsize ? `font-size:${s.fontsize}` : '',
+        s.align ? `text-align:${s.align}` : '',
+      ]
+        .filter(Boolean)
+        .join(';');
+      const cs = cell.colspan > 1 ? ` colspan="${cell.colspan}"` : '';
+      const rs = cell.rowspan > 1 ? ` rowspan="${cell.rowspan}"` : '';
+      tbody += `<td${cs}${rs} style="border:1px solid ${el.outline.color ?? '#ccc'};padding:4px;${css}">${cell.text}</td>`;
+    }
+    tbody += '</tr>';
+  }
+  tbody += '</tbody>';
+
+  return `<div style="${elStyle(el)}overflow:auto;">
+  <table style="border-collapse:collapse;width:100%;height:100%;">${colGroup}${tbody}</table>
+</div>`;
+}
+
+function renderLatex(el: PPTLatexElement): string {
+  if (el.html) {
+    return `<div style="${elStyle(el)}overflow:hidden;display:flex;align-items:center;justify-content:${el.align ?? 'center'};">${el.html}</div>`;
+  }
+  // Legacy SVG path fallback
+  if (el.path && el.viewBox) {
+    const [vw, vh] = el.viewBox;
+    return `<div style="${elStyle(el)}overflow:hidden;">
+  <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;">
+    <path d="${escHtml(el.path)}" fill="${el.color ?? '#000'}" stroke-width="${el.strokeWidth ?? 0}"/>
+  </svg>
+</div>`;
+  }
+  return '';
+}
+
+function renderVideo(el: PPTVideoElement, assetMap: AssetMap, includeVideos: boolean): string {
+  if (includeVideos) {
+    const src = resolvedSrc(el.src, assetMap);
+    if (!src) return '';
+    const posterSrc = el.poster ? resolvedSrc(el.poster, assetMap) : '';
+    const posterAttr = posterSrc ? ` poster="${posterSrc}"` : '';
+    return `<div style="${elStyle(el)}overflow:hidden;"><video controls style="width:100%;height:100%;" src="${src}"${posterAttr}></video></div>`;
+  } else {
+    // Show poster image instead of video
+    const posterSrc =
+      el.poster
+        ? resolvedSrc(el.poster, assetMap)
+        : (() => {
+            // Fallback: check media generation store poster via original src
+            if (isMediaPlaceholder(el.src)) {
+              const task = useMediaGenerationStore.getState().tasks[el.src];
+              return task?.poster ? resolvedSrc(task.poster, assetMap) : '';
+            }
+            return '';
+          })();
+    if (!posterSrc) return ''; // no poster available, skip element
+    return `<div style="${elStyle(el)}overflow:hidden;"><img src="${posterSrc}" style="width:100%;height:100%;object-fit:cover;" alt=""/></div>`;
+  }
+}
+
+function renderAudio(el: PPTAudioElement, assetMap: AssetMap): string {
+  const src = resolvedSrc(el.src, assetMap);
+  if (!src) return '';
+  return `<div style="${elStyle(el)}overflow:hidden;display:flex;align-items:center;"><audio controls${el.loop ? ' loop' : ''} style="width:100%;" src="${src}"></audio></div>`;
+}
+
+function renderElement(el: PPTElement, assetMap: AssetMap, includeVideos: boolean): string {
+  switch (el.type) {
+    case 'text': return renderText(el as PPTTextElement);
+    case 'image': return renderImage(el as PPTImageElement, assetMap);
+    case 'shape': return renderShape(el as PPTShapeElement);
+    case 'line': return renderLine(el as PPTLineElement);
+    case 'chart': return renderChart(el as PPTChartElement);
+    case 'table': return renderTable(el as PPTTableElement);
+    case 'latex': return renderLatex(el as PPTLatexElement);
+    case 'video': return renderVideo(el as PPTVideoElement, assetMap, includeVideos);
+    case 'audio': return renderAudio(el as PPTAudioElement, assetMap);
+    default: return '';
+  }
+}
+
+// ── Check if any latex element is present (need KaTeX CSS) ──
+
+function hasLatexWithHtml(els: PPTElement[]): boolean {
+  return els.some((el) => el.type === 'latex' && (el as PPTLatexElement).html);
+}
+
+// ── Build narration audio tags and chain script ──
+
+function buildNarrationHtml(scene: Scene, assetMap: AssetMap): { tags: string; script: string } {
+  if (!scene.actions) return { tags: '', script: '' };
+
+  const speechUrls: string[] = [];
+  for (const action of scene.actions) {
+    if (action.type === 'speech') {
+      const speech = action as SpeechAction;
+      if (speech.audioUrl) {
+        const stored = assetMap.get(speech.audioUrl);
+        if (stored) speechUrls.push(`../${stored}`);
+      }
+    }
+  }
+
+  if (speechUrls.length === 0) return { tags: '', script: '' };
+
+  const tags = speechUrls
+    .map((url, i) => `<audio id="narr_${i}" src="${url}"${i === 0 ? ' style="display:none"' : ' style="display:none"'}></audio>`)
+    .join('\n');
+
+  const script = `
+var _narrIdx = 0;
+var _narrUrls = ${JSON.stringify(speechUrls)};
+function _playNarr(i) {
+  if (i >= _narrUrls.length) return;
+  var a = document.getElementById('narr_' + i);
+  if (!a) return;
+  a.onended = function() { _playNarr(i + 1); };
+  a.play().catch(function(){});
+}
+// Auto-play narration when page loads (requires user interaction policy may block)
+document.addEventListener('DOMContentLoaded', function() { _playNarr(0); });
+`;
+
+  return { tags, script };
+}
+
+// ── Main ──
+
+/**
+ * Builds the full HTML string for a slide SCO page.
+ *
+ * The slide canvas is rendered as absolutely-positioned elements inside a
+ * 960×(960*viewportRatio) container that scales responsively via CSS transform.
+ * TTS narration audio plays automatically on load.
+ * SCORM completion is set immediately on page load (slides are self-completing).
+ */
+export function buildSlideSco(opts: SlideScoOptions): string {
+  const { scene, sceneIndex, totalScenes, allScoHrefs, assetMap, includeVideos } = opts;
+
+  if (scene.content.type !== 'slide') return '';
+  const canvas = (scene.content as SlideContent).canvas;
+
+  const canvasW = canvas.viewportSize ?? 960;
+  const canvasH = Math.round(canvasW * (canvas.viewportRatio ?? 0.5625));
+  const bgCss = buildBackgroundCss(canvas.background, assetMap);
+  const bgFallback = canvas.theme?.backgroundColor ?? '#ffffff';
+
+  const elements = canvas.elements
+    .map((el) => renderElement(el, assetMap, includeVideos))
+    .filter(Boolean)
+    .join('\n');
+
+  const { tags: narrTags, script: narrScript } = buildNarrationHtml(scene, assetMap);
+
+  const needsKatex = hasLatexWithHtml(canvas.elements);
+  // Minimal KaTeX CSS — inlined to ensure offline use (no CDN dependency)
+  const katexCss = needsKatex
+    ? `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous" onerror="this.remove()">`
+    : '';
+
+  const myHref = allScoHrefs[sceneIndex];
+  const hasPrev = sceneIndex > 0;
+  const hasNext = sceneIndex < totalScenes - 1;
+
+  const navButtons = `
+<div class="nav-bar">
+  ${hasPrev ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','prev')">&#8592; Prev</button>` : '<span></span>'}
+  <span class="scene-counter">${sceneIndex + 1} / ${totalScenes}</span>
+  ${hasNext ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','next')">Next &#8594;</button>` : '<span></span>'}
+</div>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escHtml(scene.title)}</title>
+  <script src="../scorm_bridge.js"></script>
+  ${katexCss}
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; overflow: hidden; background: #1a1a1a; height: 100%; font-family: sans-serif; }
+    .stage-wrapper { position: fixed; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; }
+    .slide-canvas {
+      position: relative;
+      width: ${canvasW}px;
+      height: ${canvasH}px;
+      transform-origin: center center;
+      background: ${bgFallback};
+      ${bgCss}
+      overflow: hidden;
+    }
+    .nav-bar {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 4px 0;
+    }
+    .nav-bar button {
+      background: rgba(255,255,255,0.15);
+      border: 1px solid rgba(255,255,255,0.3);
+      color: #fff;
+      padding: 6px 16px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    .nav-bar button:hover { background: rgba(255,255,255,0.25); }
+    .scene-counter { color: rgba(255,255,255,0.6); font-size: 13px; min-width: 60px; text-align: center; }
+  </style>
+</head>
+<body>
+<div class="stage-wrapper">
+  <div class="slide-canvas" id="slide-canvas">
+    ${elements}
+  </div>
+  ${navButtons}
+</div>
+${narrTags}
+<script>
+var ALL_SCOS = ${JSON.stringify(allScoHrefs)};
+window.addEventListener('load', function() {
+  SCORM.init();
+  SCORM.setCompleted();
+  rescale();
+});
+window.addEventListener('beforeunload', function() {
+  SCORM.finish();
+});
+function rescale() {
+  var vw = window.innerWidth;
+  var vh = window.innerHeight - 48; // leave room for nav bar
+  var s = Math.min(vw / ${canvasW}, vh / ${canvasH});
+  document.getElementById('slide-canvas').style.transform = 'scale(' + s + ')';
+}
+window.addEventListener('resize', rescale);
+${narrScript}
+</script>
+</body>
+</html>`;
+}

--- a/lib/export/scorm/slide-sco.ts
+++ b/lib/export/scorm/slide-sco.ts
@@ -1,3 +1,8 @@
+/**
+ * slide-sco.ts
+ * Builds the HTML fragment (a <section> element) for a slide scene.
+ * Assets use paths relative to the ZIP root (no "../").
+ */
 import type { Scene, SlideContent } from '@/lib/types/stage';
 import type {
   PPTElement,
@@ -17,13 +22,21 @@ import type { SpeechAction } from '@/lib/types/action';
 import { isMediaPlaceholder, useMediaGenerationStore } from '@/lib/store/media-generation';
 import type { AssetMap } from './asset-collector';
 
-export interface SlideScoOptions {
-  scene: Scene;
-  sceneIndex: number;
-  totalScenes: number;
-  allScoHrefs: string[];
-  assetMap: AssetMap;
-  includeVideos: boolean;
+export interface SlideSceneMeta {
+  type: 'slide';
+  sceneId: string;        // e.g. "scene-0"
+  canvasId: string;       // e.g. "canvas-0"
+  scalerId: string;       // e.g. "scaler-0"
+  cw: number;             // canvas width px
+  ch: number;             // canvas height px
+  narrIds: string[];      // IDs of <audio> narration elements to chain-play
+  hasNarration: boolean;
+}
+
+export interface SlideSectionResult {
+  html: string;
+  meta: SlideSceneMeta;
+  needsKatex: boolean;
 }
 
 // ── Helpers ──
@@ -36,46 +49,45 @@ function escHtml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function resolvedSrc(src: string, assetMap: AssetMap): string {
-  // If the src was collected as an asset, return the relative ZIP path
+/** Resolve a src to a ZIP-root-relative path. */
+function assetPath(src: string, assetMap: AssetMap): string {
+  if (!src) return '';
   const stored = assetMap.get(src);
-  if (stored) return `../${stored}`;
-  // Media placeholder that was resolved
+  if (stored) return stored; // e.g. "assets/images/..."
   if (isMediaPlaceholder(src)) {
     const task = useMediaGenerationStore.getState().tasks[src];
     if (task?.objectUrl) {
-      const stored2 = assetMap.get(task.objectUrl);
-      if (stored2) return `../${stored2}`;
+      const s2 = assetMap.get(task.objectUrl);
+      if (s2) return s2;
     }
-    return ''; // not available
+    return '';
   }
-  // Absolute URL or data URI — use directly
+  // Absolute URL or data URI — use as-is
   return src;
 }
 
 function buildBackgroundCss(bg: SlideBackground | undefined, assetMap: AssetMap): string {
   if (!bg) return '';
-  if (bg.type === 'solid' && bg.color) return `background-color: ${bg.color};`;
+  if (bg.type === 'solid' && bg.color) return `background-color:${bg.color};`;
   if (bg.type === 'image' && bg.image?.src) {
-    const src = resolvedSrc(bg.image.src, assetMap);
-    if (!src) return '';
+    const p = assetPath(bg.image.src, assetMap);
+    if (!p) return '';
     const size = bg.image.size === 'repeat' ? 'auto' : bg.image.size;
     const repeat = bg.image.size === 'repeat' ? 'repeat' : 'no-repeat';
-    return `background-image: url('${src}'); background-size: ${size}; background-repeat: ${repeat}; background-position: center;`;
+    return `background-image:url('${p}');background-size:${size};background-repeat:${repeat};background-position:center;`;
   }
-  if (bg.type === 'gradient' && bg.gradient) {
-    return `background: ${buildGradientCss(bg.gradient)};`;
-  }
+  if (bg.type === 'gradient' && bg.gradient) return `background:${gradientCss(bg.gradient)};`;
   return '';
 }
 
-function buildGradientCss(g: Gradient): string {
+function gradientCss(g: Gradient): string {
   const stops = g.colors.map((c) => `${c.color} ${c.pos}%`).join(', ');
-  if (g.type === 'radial') return `radial-gradient(circle, ${stops})`;
-  return `linear-gradient(${g.rotate}deg, ${stops})`;
+  return g.type === 'radial'
+    ? `radial-gradient(circle, ${stops})`
+    : `linear-gradient(${g.rotate}deg, ${stops})`;
 }
 
-function elStyle(el: PPTElement & { rotate: number }): string {
+function elBaseStyle(el: { left: number; top: number; width: number; height: number; rotate: number }): string {
   return `position:absolute;left:${el.left}px;top:${el.top}px;width:${el.width}px;height:${el.height}px;${el.rotate ? `transform:rotate(${el.rotate}deg);` : ''}`;
 }
 
@@ -84,16 +96,15 @@ function elStyle(el: PPTElement & { rotate: number }): string {
 function renderText(el: PPTTextElement): string {
   const fill = el.fill ? `background:${el.fill};` : '';
   const opacity = el.opacity !== undefined ? `opacity:${el.opacity};` : '';
-  const lineH = el.lineHeight ?? 1.5;
-  const wordSp = el.wordSpace ?? 0;
-  const overflow = el.vertical ? 'writing-mode:vertical-rl;' : '';
-  return `<div style="${elStyle(el)}overflow:hidden;font-family:${escHtml(el.defaultFontName || 'sans-serif')};color:${el.defaultColor || '#000'};line-height:${lineH};letter-spacing:${wordSp}px;${fill}${opacity}${overflow}">${el.content}</div>`;
+  const lh = el.lineHeight ?? 1.5;
+  const ws = el.wordSpace ?? 0;
+  const vert = el.vertical ? 'writing-mode:vertical-rl;' : '';
+  return `<div style="${elBaseStyle(el)}overflow:hidden;font-family:${escHtml(el.defaultFontName || 'sans-serif')};color:${el.defaultColor || '#000'};line-height:${lh};letter-spacing:${ws}px;${fill}${opacity}${vert}">${el.content}</div>`;
 }
 
 function renderImage(el: PPTImageElement, assetMap: AssetMap): string {
-  const src = resolvedSrc(el.src, assetMap);
-  if (!src) return '';
-
+  const p = assetPath(el.src, assetMap);
+  if (!p) return '';
   const filters: string[] = [];
   if (el.filters) {
     if (el.filters.blur) filters.push(`blur(${el.filters.blur})`);
@@ -107,50 +118,45 @@ function renderImage(el: PPTImageElement, assetMap: AssetMap): string {
     if (el.filters.opacity) filters.push(`opacity(${el.filters.opacity})`);
   }
   const filterCss = filters.length ? `filter:${filters.join(' ')};` : '';
-
   let clipCss = '';
-  let borderRadius = '';
+  let br = '';
   if (el.clip) {
     const [[x1, y1], [x2, y2]] = el.clip.range;
     clipCss = `clip-path:inset(${y1}% ${100 - x2}% ${100 - y2}% ${x1}%);`;
-    if (el.clip.shape === 'ellipse') borderRadius = 'border-radius:50%;';
+    if (el.clip.shape === 'ellipse') br = 'border-radius:50%;';
   }
-
   const flipH = el.flipH ? 'scaleX(-1)' : '';
   const flipV = el.flipV ? 'scaleY(-1)' : '';
-  const flipCss = flipH || flipV ? `transform-origin:center;${el.rotate ? `transform:rotate(${el.rotate}deg) ${flipH} ${flipV};` : `transform:${flipH} ${flipV};`}` : '';
-
+  const flipT = (flipH || flipV) && !el.rotate ? `transform:${[flipH, flipV].filter(Boolean).join(' ')};` : '';
   const colorMask = el.colorMask
     ? `<div style="position:absolute;inset:0;background:${el.colorMask};pointer-events:none;"></div>`
     : '';
-
-  const base = el.rotate ? `transform:rotate(${el.rotate}deg);` : '';
-  const style = `position:absolute;left:${el.left}px;top:${el.top}px;width:${el.width}px;height:${el.height}px;${flipCss || base}overflow:hidden;${borderRadius}`;
-
-  return `<div style="${style}">${colorMask}<img src="${src}" style="width:100%;height:100%;object-fit:cover;${filterCss}${clipCss}" loading="lazy" alt=""/></div>`;
+  const rot = el.rotate ? `transform:rotate(${el.rotate}deg);` : '';
+  return `<div style="position:absolute;left:${el.left}px;top:${el.top}px;width:${el.width}px;height:${el.height}px;${rot}overflow:hidden;${br}">
+  ${colorMask}<img src="${p}" style="width:100%;height:100%;object-fit:cover;${filterCss}${clipCss}${flipT}" loading="lazy" alt=""/>
+</div>`;
 }
 
 function renderShape(el: PPTShapeElement): string {
   const [vw, vh] = el.viewBox;
-  const fill = el.gradient ? buildGradientCss(el.gradient) : el.fill;
+  const fill = el.gradient ? gradientCss(el.gradient) : el.fill;
   const opacity = el.opacity !== undefined ? `opacity:${el.opacity};` : '';
   const flipH = el.flipH ? 'scale(-1,1)' : '';
   const flipV = el.flipV ? 'scale(1,-1)' : '';
-  const transform = (flipH || flipV) ? ` transform="${flipH || flipV}"` : '';
+  const svgTransform = (flipH || flipV) ? ` transform="${[flipH, flipV].filter(Boolean).join(' ')}"` : '';
   const outline = el.outline?.color && el.outline.width
-    ? `stroke="${el.outline.color}" stroke-width="${el.outline.width}" stroke-dasharray="${el.outline.style === 'dashed' ? '8 4' : el.outline.style === 'dotted' ? '2 4' : 'none'}"`
+    ? `stroke="${escHtml(el.outline.color)}" stroke-width="${el.outline.width}" stroke-dasharray="${el.outline.style === 'dashed' ? '8 4' : el.outline.style === 'dotted' ? '2 4' : 'none'}"`
     : 'stroke="none"';
-
-  let textOverlay = '';
+  let text = '';
   if (el.text?.content) {
     const t = el.text;
-    textOverlay = `<div style="position:absolute;inset:0;display:flex;align-items:${t.align === 'top' ? 'flex-start' : t.align === 'bottom' ? 'flex-end' : 'center'};justify-content:center;padding:4px;overflow:hidden;font-family:${escHtml(t.defaultFontName || 'sans-serif')};color:${t.defaultColor || '#000'};line-height:${t.lineHeight ?? 1.5};">${t.content}</div>`;
+    const va = t.align === 'top' ? 'flex-start' : t.align === 'bottom' ? 'flex-end' : 'center';
+    text = `<div style="position:absolute;inset:0;display:flex;align-items:${va};justify-content:center;padding:4px;overflow:hidden;font-family:${escHtml(t.defaultFontName || 'sans-serif')};color:${t.defaultColor || '#000'};line-height:${t.lineHeight ?? 1.5};">${t.content}</div>`;
   }
-
-  return `<div style="${elStyle(el)}${opacity}overflow:visible;">
-  <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;"${transform}>
+  return `<div style="${elBaseStyle(el)}${opacity}overflow:visible;">
+  <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;"${svgTransform}>
     <path d="${escHtml(el.path)}" fill="${escHtml(fill)}" ${outline} fill-rule="nonzero"/>
-  </svg>${textOverlay}
+  </svg>${text}
 </div>`;
 }
 
@@ -159,48 +165,38 @@ function renderLine(el: PPTLineElement): string {
   const [ex, ey] = el.end;
   const minX = Math.min(sx, ex);
   const minY = Math.min(sy, ey);
-  const maxX = Math.max(sx, ex);
-  const maxY = Math.max(sy, ey);
-  const w = maxX - minX || 2;
-  const h = maxY - minY || 2;
+  const w = Math.max(Math.abs(ex - sx), 2);
+  const h = Math.max(Math.abs(ey - sy), 2);
   const dash = el.style === 'dashed' ? 'stroke-dasharray="8 4"' : el.style === 'dotted' ? 'stroke-dasharray="2 4"' : '';
   return `<div style="position:absolute;left:${minX}px;top:${minY}px;width:${w}px;height:${h}px;overflow:visible;">
-  <svg viewBox="${minX} ${minY} ${w} ${h}" style="overflow:visible;width:${w}px;height:${h}px;">
-    <line x1="${sx}" y1="${sy}" x2="${ex}" y2="${ey}" stroke="${el.color}" stroke-width="2" ${dash}/>
+  <svg style="overflow:visible;width:${w}px;height:${h}px;" viewBox="${minX} ${minY} ${w} ${h}">
+    <line x1="${sx}" y1="${sy}" x2="${ex}" y2="${ey}" stroke="${escHtml(el.color)}" stroke-width="2" ${dash}/>
   </svg>
 </div>`;
 }
 
 function renderChart(el: PPTChartElement): string {
-  // NOTE: ECharts cannot render without a DOM/canvas at build time.
-  // We emit a data table as a SCORM-compatible fallback.
-  // Future enhancement: pre-render to SVG using headless ECharts.
+  // NOTE: ECharts cannot render at build time. Fallback: data table.
+  // Future improvement: pre-render to SVG using headless ECharts.
   const { labels, legends, series } = el.data;
   const fill = el.fill ? `background:${el.fill};` : '';
-
   let rows = `<tr><th></th>${labels.map((l) => `<th>${escHtml(l)}</th>`).join('')}</tr>`;
   for (let i = 0; i < legends.length; i++) {
-    rows += `<tr><th>${escHtml(legends[i])}</th>${(series[i] ?? []).map((v) => `<td>${v}</td>`).join('')}</tr>`;
+    rows += `<tr><th>${escHtml(legends[i])}</th>${(series[i] ?? []).map((v) => `<td style="text-align:right">${v}</td>`).join('')}</tr>`;
   }
-
-  return `<div style="${elStyle(el)}overflow:auto;${fill}font-size:11px;">
-  <table style="border-collapse:collapse;width:100%;">
-    ${rows}
-  </table>
+  return `<div style="${elBaseStyle(el)}overflow:auto;${fill}font-size:11px;">
+  <table style="border-collapse:collapse;width:100%;">${rows}</table>
 </div>`;
 }
 
 function renderTable(el: PPTTableElement): string {
   let colGroup = '<colgroup>';
-  for (const w of el.colWidths) {
-    colGroup += `<col style="width:${(w * 100).toFixed(1)}%"/>`;
-  }
+  for (const w of el.colWidths) colGroup += `<col style="width:${(w * 100).toFixed(1)}%"/>`;
   colGroup += '</colgroup>';
-
   let tbody = '<tbody>';
-  for (let ri = 0; ri < el.data.length; ri++) {
+  for (const row of el.data) {
     tbody += '<tr>';
-    for (const cell of el.data[ri]) {
+    for (const cell of row) {
       if (!cell) continue;
       const s = cell.style ?? {};
       const css = [
@@ -212,30 +208,26 @@ function renderTable(el: PPTTableElement): string {
         s.backcolor ? `background:${s.backcolor}` : '',
         s.fontsize ? `font-size:${s.fontsize}` : '',
         s.align ? `text-align:${s.align}` : '',
-      ]
-        .filter(Boolean)
-        .join(';');
+      ].filter(Boolean).join(';');
       const cs = cell.colspan > 1 ? ` colspan="${cell.colspan}"` : '';
       const rs = cell.rowspan > 1 ? ` rowspan="${cell.rowspan}"` : '';
-      tbody += `<td${cs}${rs} style="border:1px solid ${el.outline.color ?? '#ccc'};padding:4px;${css}">${cell.text}</td>`;
+      tbody += `<td${cs}${rs} style="border:1px solid ${escHtml(el.outline.color ?? '#ccc')};padding:4px;${css}">${cell.text}</td>`;
     }
     tbody += '</tr>';
   }
   tbody += '</tbody>';
-
-  return `<div style="${elStyle(el)}overflow:auto;">
+  return `<div style="${elBaseStyle(el)}overflow:auto;">
   <table style="border-collapse:collapse;width:100%;height:100%;">${colGroup}${tbody}</table>
 </div>`;
 }
 
 function renderLatex(el: PPTLatexElement): string {
   if (el.html) {
-    return `<div style="${elStyle(el)}overflow:hidden;display:flex;align-items:center;justify-content:${el.align ?? 'center'};">${el.html}</div>`;
+    return `<div style="${elBaseStyle(el)}overflow:hidden;display:flex;align-items:center;justify-content:${el.align ?? 'center'};">${el.html}</div>`;
   }
-  // Legacy SVG path fallback
   if (el.path && el.viewBox) {
     const [vw, vh] = el.viewBox;
-    return `<div style="${elStyle(el)}overflow:hidden;">
+    return `<div style="${elBaseStyle(el)}overflow:hidden;">
   <svg viewBox="0 0 ${vw} ${vh}" style="width:100%;height:100%;">
     <path d="${escHtml(el.path)}" fill="${el.color ?? '#000'}" stroke-width="${el.strokeWidth ?? 0}"/>
   </svg>
@@ -246,33 +238,30 @@ function renderLatex(el: PPTLatexElement): string {
 
 function renderVideo(el: PPTVideoElement, assetMap: AssetMap, includeVideos: boolean): string {
   if (includeVideos) {
-    const src = resolvedSrc(el.src, assetMap);
-    if (!src) return '';
-    const posterSrc = el.poster ? resolvedSrc(el.poster, assetMap) : '';
-    const posterAttr = posterSrc ? ` poster="${posterSrc}"` : '';
-    return `<div style="${elStyle(el)}overflow:hidden;"><video controls style="width:100%;height:100%;" src="${src}"${posterAttr}></video></div>`;
-  } else {
-    // Show poster image instead of video
-    const posterSrc =
-      el.poster
-        ? resolvedSrc(el.poster, assetMap)
-        : (() => {
-            // Fallback: check media generation store poster via original src
-            if (isMediaPlaceholder(el.src)) {
-              const task = useMediaGenerationStore.getState().tasks[el.src];
-              return task?.poster ? resolvedSrc(task.poster, assetMap) : '';
-            }
-            return '';
-          })();
-    if (!posterSrc) return ''; // no poster available, skip element
-    return `<div style="${elStyle(el)}overflow:hidden;"><img src="${posterSrc}" style="width:100%;height:100%;object-fit:cover;" alt=""/></div>`;
+    const p = assetPath(el.src, assetMap);
+    if (!p) return '';
+    const posterP = el.poster ? assetPath(el.poster, assetMap) : '';
+    const posterAttr = posterP ? ` poster="${posterP}"` : '';
+    return `<div style="${elBaseStyle(el)}overflow:hidden;"><video controls style="width:100%;height:100%;" src="${p}"${posterAttr}></video></div>`;
   }
+  // Video replaced by poster
+  const posterSrc = el.poster
+    ? assetPath(el.poster, assetMap)
+    : (() => {
+        if (isMediaPlaceholder(el.src)) {
+          const task = useMediaGenerationStore.getState().tasks[el.src];
+          return task?.poster ? assetPath(task.poster, assetMap) : '';
+        }
+        return '';
+      })();
+  if (!posterSrc) return '';
+  return `<div style="${elBaseStyle(el)}overflow:hidden;"><img src="${posterSrc}" style="width:100%;height:100%;object-fit:cover;" alt=""/></div>`;
 }
 
 function renderAudio(el: PPTAudioElement, assetMap: AssetMap): string {
-  const src = resolvedSrc(el.src, assetMap);
-  if (!src) return '';
-  return `<div style="${elStyle(el)}overflow:hidden;display:flex;align-items:center;"><audio controls${el.loop ? ' loop' : ''} style="width:100%;" src="${src}"></audio></div>`;
+  const p = assetPath(el.src, assetMap);
+  if (!p) return '';
+  return `<div style="${elBaseStyle(el)}overflow:hidden;display:flex;align-items:center;"><audio controls${el.loop ? ' loop' : ''} style="width:100%;" src="${p}"></audio></div>`;
 }
 
 function renderElement(el: PPTElement, assetMap: AssetMap, includeVideos: boolean): string {
@@ -290,163 +279,85 @@ function renderElement(el: PPTElement, assetMap: AssetMap, includeVideos: boolea
   }
 }
 
-// ── Check if any latex element is present (need KaTeX CSS) ──
-
-function hasLatexWithHtml(els: PPTElement[]): boolean {
+function hasLatex(els: PPTElement[]): boolean {
   return els.some((el) => el.type === 'latex' && (el as PPTLatexElement).html);
 }
 
-// ── Build narration audio tags and chain script ──
+// ── Public API ──
 
-function buildNarrationHtml(scene: Scene, assetMap: AssetMap): { tags: string; script: string } {
-  if (!scene.actions) return { tags: '', script: '' };
-
-  const speechUrls: string[] = [];
-  for (const action of scene.actions) {
-    if (action.type === 'speech') {
-      const speech = action as SpeechAction;
-      if (speech.audioUrl) {
-        const stored = assetMap.get(speech.audioUrl);
-        if (stored) speechUrls.push(`../${stored}`);
-      }
-    }
-  }
-
-  if (speechUrls.length === 0) return { tags: '', script: '' };
-
-  const tags = speechUrls
-    .map((url, i) => `<audio id="narr_${i}" src="${url}"${i === 0 ? ' style="display:none"' : ' style="display:none"'}></audio>`)
-    .join('\n');
-
-  const script = `
-var _narrIdx = 0;
-var _narrUrls = ${JSON.stringify(speechUrls)};
-function _playNarr(i) {
-  if (i >= _narrUrls.length) return;
-  var a = document.getElementById('narr_' + i);
-  if (!a) return;
-  a.onended = function() { _playNarr(i + 1); };
-  a.play().catch(function(){});
+export interface SlideSectionOptions {
+  scene: Scene;
+  sceneIndex: number;
+  assetMap: AssetMap;
+  includeVideos: boolean;
 }
-// Auto-play narration when page loads (requires user interaction policy may block)
-document.addEventListener('DOMContentLoaded', function() { _playNarr(0); });
-`;
-
-  return { tags, script };
-}
-
-// ── Main ──
 
 /**
- * Builds the full HTML string for a slide SCO page.
- *
- * The slide canvas is rendered as absolutely-positioned elements inside a
- * 960×(960*viewportRatio) container that scales responsively via CSS transform.
- * TTS narration audio plays automatically on load.
- * SCORM completion is set immediately on page load (slides are self-completing).
+ * Builds the HTML <section> fragment for a slide scene.
+ * Asset paths are relative to the ZIP root (no "../").
  */
-export function buildSlideSco(opts: SlideScoOptions): string {
-  const { scene, sceneIndex, totalScenes, allScoHrefs, assetMap, includeVideos } = opts;
+export function buildSlideSection(opts: SlideSectionOptions): SlideSectionResult {
+  const { scene, sceneIndex, assetMap, includeVideos } = opts;
 
-  if (scene.content.type !== 'slide') return '';
   const canvas = (scene.content as SlideContent).canvas;
+  const cw = canvas.viewportSize ?? 960;
+  const ch = Math.round(cw * (canvas.viewportRatio ?? 0.5625));
 
-  const canvasW = canvas.viewportSize ?? 960;
-  const canvasH = Math.round(canvasW * (canvas.viewportRatio ?? 0.5625));
+  const sceneId = `scene-${sceneIndex}`;
+  const canvasId = `canvas-${sceneIndex}`;
+  const scalerId = `scaler-${sceneIndex}`;
+
   const bgCss = buildBackgroundCss(canvas.background, assetMap);
   const bgFallback = canvas.theme?.backgroundColor ?? '#ffffff';
 
   const elements = canvas.elements
     .map((el) => renderElement(el, assetMap, includeVideos))
     .filter(Boolean)
-    .join('\n');
+    .join('\n    ');
 
-  const { tags: narrTags, script: narrScript } = buildNarrationHtml(scene, assetMap);
-
-  const needsKatex = hasLatexWithHtml(canvas.elements);
-  // Minimal KaTeX CSS — inlined to ensure offline use (no CDN dependency)
-  const katexCss = needsKatex
-    ? `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous" onerror="this.remove()">`
-    : '';
-
-  const myHref = allScoHrefs[sceneIndex];
-  const hasPrev = sceneIndex > 0;
-  const hasNext = sceneIndex < totalScenes - 1;
-
-  const navButtons = `
-<div class="nav-bar">
-  ${hasPrev ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','prev')">&#8592; Prev</button>` : '<span></span>'}
-  <span class="scene-counter">${sceneIndex + 1} / ${totalScenes}</span>
-  ${hasNext ? `<button onclick="SCORM.navigate(ALL_SCOS,'${myHref}','next')">Next &#8594;</button>` : '<span></span>'}
-</div>`;
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escHtml(scene.title)}</title>
-  <script src="../scorm_bridge.js"></script>
-  ${katexCss}
-  <style>
-    *, *::before, *::after { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; overflow: hidden; background: #1a1a1a; height: 100%; font-family: sans-serif; }
-    .stage-wrapper { position: fixed; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; }
-    .slide-canvas {
-      position: relative;
-      width: ${canvasW}px;
-      height: ${canvasH}px;
-      transform-origin: center center;
-      background: ${bgFallback};
-      ${bgCss}
-      overflow: hidden;
+  // TTS narration audio elements
+  const narrIds: string[] = [];
+  let narrTags = '';
+  if (scene.actions) {
+    let idx = 0;
+    for (const action of scene.actions) {
+      if (action.type === 'speech') {
+        const speech = action as SpeechAction;
+        if (speech.audioUrl) {
+          const p = assetMap.get(speech.audioUrl);
+          if (p) {
+            const id = `narr-${sceneIndex}-${idx}`;
+            narrIds.push(id);
+            narrTags += `<audio id="${id}" src="${p}" style="display:none"></audio>\n  `;
+            idx++;
+          }
+        }
+      }
     }
-    .nav-bar {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      padding: 4px 0;
-    }
-    .nav-bar button {
-      background: rgba(255,255,255,0.15);
-      border: 1px solid rgba(255,255,255,0.3);
-      color: #fff;
-      padding: 6px 16px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-size: 14px;
-    }
-    .nav-bar button:hover { background: rgba(255,255,255,0.25); }
-    .scene-counter { color: rgba(255,255,255,0.6); font-size: 13px; min-width: 60px; text-align: center; }
-  </style>
-</head>
-<body>
-<div class="stage-wrapper">
-  <div class="slide-canvas" id="slide-canvas">
-    ${elements}
+  }
+
+  const html = `<section id="${sceneId}" class="scene scene-slide" data-title="${escHtml(scene.title)}" style="display:none">
+  <div class="slide-stage">
+    <div class="slide-scaler" id="${scalerId}">
+      <div class="slide-canvas" id="${canvasId}" style="width:${cw}px;height:${ch}px;background:${bgFallback};${bgCss}">
+        ${elements}
+      </div>
+    </div>
   </div>
-  ${navButtons}
-</div>
-${narrTags}
-<script>
-var ALL_SCOS = ${JSON.stringify(allScoHrefs)};
-window.addEventListener('load', function() {
-  SCORM.init();
-  SCORM.setCompleted();
-  rescale();
-});
-window.addEventListener('beforeunload', function() {
-  SCORM.finish();
-});
-function rescale() {
-  var vw = window.innerWidth;
-  var vh = window.innerHeight - 48; // leave room for nav bar
-  var s = Math.min(vw / ${canvasW}, vh / ${canvasH});
-  document.getElementById('slide-canvas').style.transform = 'scale(' + s + ')';
+  ${narrTags}</section>`;
+
+  const meta: SlideSceneMeta = {
+    type: 'slide',
+    sceneId,
+    canvasId,
+    scalerId,
+    cw,
+    ch,
+    narrIds,
+    hasNarration: narrIds.length > 0,
+  };
+
+  return { html, meta, needsKatex: hasLatex(canvas.elements) };
 }
-window.addEventListener('resize', rescale);
-${narrScript}
-</script>
-</body>
-</html>`;
-}
+
+export type { PPTElement };

--- a/lib/export/scorm/use-export-scorm.ts
+++ b/lib/export/scorm/use-export-scorm.ts
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import { saveAs } from 'file-saver';
+import { toast } from 'sonner';
+
+import { useStageStore } from '@/lib/store';
+import { useI18n } from '@/lib/hooks/use-i18n';
+import { createLogger } from '@/lib/logger';
+import type { Scene, InteractiveContent } from '@/lib/types/stage';
+
+import { collectAssets, getSceneAssetHrefs } from './asset-collector';
+import { buildManifest, type ScoEntry } from './manifest';
+import { getScormBridgeJs } from './scorm-bridge';
+import { buildSlideSco } from './slide-sco';
+import { buildQuizSco } from './quiz-sco';
+import { buildInteractiveSco } from './interactive-sco';
+
+const log = createLogger('ExportSCORM');
+
+export interface ScormExportOptions {
+  includeVideos: boolean;
+}
+
+function sanitizeId(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64) || 'course';
+}
+
+function pad2(n: number): string {
+  return String(n + 1).padStart(2, '0');
+}
+
+function isExportableScene(scene: Scene): boolean {
+  if (scene.content.type === 'pbl') return false;
+  if (scene.content.type === 'interactive') {
+    return Boolean((scene.content as InteractiveContent).html);
+  }
+  return true;
+}
+
+/**
+ * React hook for SCORM 1.2 export.
+ *
+ * Mirrors the useExportPPTX pattern: guard against concurrent exports,
+ * show toast on success/failure, lazy-import JSZip for code splitting.
+ *
+ * What gets exported:
+ * - slide scenes → HTML SCO with absolutepositioned canvas + TTS narration
+ * - quiz scenes  → HTML SCO with single/multiple choice questions + SCORM scoring
+ * - interactive scenes (with html) → HTML SCO wrapping content in an iframe
+ *
+ * Excluded: pbl scenes, interactive scenes without html,
+ *           whiteboards, multi-agent chat, short-answer questions.
+ */
+export function useExportScorm(): {
+  exporting: boolean;
+  exportScorm: (options: ScormExportOptions) => void;
+} {
+  const [exporting, setExporting] = useState(false);
+  const exportingRef = useRef(false);
+  const { t } = useI18n();
+
+  const scenes = useStageStore((s) => s.scenes);
+  const stage = useStageStore((s) => s.stage);
+
+  const withExportGuard = useCallback(
+    (action: () => Promise<void>) => {
+      if (exportingRef.current) return;
+      exportingRef.current = true;
+      setExporting(true);
+      setTimeout(async () => {
+        try {
+          await action();
+        } catch (err) {
+          log.error('SCORM export failed:', err);
+          toast.error(t('export.exportFailed'));
+        } finally {
+          exportingRef.current = false;
+          setExporting(false);
+        }
+      }, 100);
+    },
+    [t],
+  );
+
+  const exportScorm = useCallback(
+    (options: ScormExportOptions) => {
+      withExportGuard(async () => {
+        const JSZip = (await import('jszip')).default;
+        const zip = new JSZip();
+
+        const fileName = stage?.name || 'course';
+        const courseId = sanitizeId(fileName);
+
+        // 1. Filter to exportable scenes only
+        const exportableScenes = scenes.filter(isExportableScene);
+
+        if (exportableScenes.length === 0) {
+          toast.error(t('export.exportFailed'));
+          return;
+        }
+
+        // 2. Build SCO href list (used in every SCO for navigation)
+        const allScoHrefs = exportableScenes.map(
+          (_, i) => `scos/scene_${pad2(i)}.html`,
+        );
+
+        // 3. Collect all media assets (fetch blobs, resolve placeholders)
+        const assetMap = await collectAssets(exportableScenes, options.includeVideos);
+
+        // 4. Write asset blobs into ZIP
+        for (const entry of assetMap.entries()) {
+          zip.file(entry.zipPath, entry.blob);
+        }
+
+        // 5. Build SCO HTML pages + collect ScoEntry metadata for manifest
+        const scoEntries: ScoEntry[] = [];
+
+        for (let i = 0; i < exportableScenes.length; i++) {
+          const scene = exportableScenes[i];
+          const href = allScoHrefs[i];
+          const sceneId = `scene_${pad2(i)}`;
+          let html = '';
+
+          if (scene.content.type === 'slide') {
+            html = buildSlideSco({
+              scene,
+              sceneIndex: i,
+              totalScenes: exportableScenes.length,
+              allScoHrefs,
+              assetMap,
+              includeVideos: options.includeVideos,
+            });
+          } else if (scene.content.type === 'quiz') {
+            html = buildQuizSco({
+              scene,
+              sceneIndex: i,
+              totalScenes: exportableScenes.length,
+              allScoHrefs,
+            });
+          } else if (scene.content.type === 'interactive') {
+            html = buildInteractiveSco({
+              scene,
+              sceneIndex: i,
+              totalScenes: exportableScenes.length,
+              allScoHrefs,
+            });
+          }
+
+          if (!html) continue;
+
+          zip.file(href, html);
+
+          const assetHrefs = getSceneAssetHrefs(scene, i, assetMap, options.includeVideos);
+
+          scoEntries.push({
+            id: sceneId,
+            title: scene.title,
+            href,
+            isQuiz: scene.content.type === 'quiz',
+            assetHrefs,
+          });
+        }
+
+        // 6. Write scorm_bridge.js
+        zip.file('scorm_bridge.js', getScormBridgeJs());
+
+        // 7. Write imsmanifest.xml
+        const manifest = buildManifest(courseId, stage?.name ?? fileName, scoEntries);
+        zip.file('imsmanifest.xml', manifest);
+
+        // 8. Generate ZIP and trigger download
+        const zipBlob = await zip.generateAsync({
+          type: 'blob',
+          compression: 'DEFLATE',
+          compressionOptions: { level: 6 },
+        });
+        saveAs(zipBlob, `${fileName}_scorm.zip`);
+        toast.success(t('export.exportSuccess'));
+      });
+    },
+    [withExportGuard, scenes, stage, t],
+  );
+
+  return { exporting, exportScorm };
+}

--- a/lib/export/scorm/use-export-scorm.ts
+++ b/lib/export/scorm/use-export-scorm.ts
@@ -107,7 +107,7 @@ export function useExportScorm(): {
         }
 
         // 4. Build scene section fragments
-        const sectionResults: Array<{ html: string; meta: SceneMeta }> = [];
+        const sectionResults: Array<{ html: string; meta: SceneMeta; title: string }> = [];
         let needsKatex = false;
         let hasQuiz = false;
 
@@ -116,15 +116,15 @@ export function useExportScorm(): {
 
           if (scene.content.type === 'slide') {
             const res = buildSlideSection({ scene, sceneIndex: i, assetMap, includeVideos: options.includeVideos });
-            sectionResults.push({ html: res.html, meta: res.meta });
+            sectionResults.push({ html: res.html, meta: res.meta, title: scene.title });
             if (res.needsKatex) needsKatex = true;
           } else if (scene.content.type === 'quiz') {
             const res = buildQuizSection(scene, i);
-            sectionResults.push({ html: res.html, meta: res.meta });
+            sectionResults.push({ html: res.html, meta: res.meta, title: scene.title });
             hasQuiz = true;
           } else if (scene.content.type === 'interactive') {
             const res = buildInteractiveSection(scene, i);
-            sectionResults.push({ html: res.html, meta: res.meta });
+            sectionResults.push({ html: res.html, meta: res.meta, title: scene.title });
           }
         }
 

--- a/lib/export/scorm/use-export-scorm.ts
+++ b/lib/export/scorm/use-export-scorm.ts
@@ -8,6 +8,7 @@ import { useStageStore } from '@/lib/store';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { createLogger } from '@/lib/logger';
 import type { Scene, InteractiveContent } from '@/lib/types/stage';
+import type { SpeechAction } from '@/lib/types/action';
 
 import { collectAssets, getSceneAssetHrefs } from './asset-collector';
 import { buildManifest } from './manifest';
@@ -151,7 +152,27 @@ export function useExportScorm(): {
         });
         zip.file('imsmanifest.xml', manifest);
 
-        // 8. Generate ZIP and trigger download
+        // 8. Generate notes.txt (scene titles + TTS narration text)
+        const notesLines: string[] = [courseTitle, '='.repeat(courseTitle.length), ''];
+        for (let i = 0; i < exportableScenes.length; i++) {
+          const scene = exportableScenes[i];
+          notesLines.push(`[${i + 1}] ${scene.title}`);
+          notesLines.push('');
+          if (scene.content.type === 'slide' && scene.actions?.length) {
+            for (const action of scene.actions) {
+              if (action.type === 'speech') {
+                const text = (action as SpeechAction).text;
+                if (text) {
+                  notesLines.push(text);
+                  notesLines.push('');
+                }
+              }
+            }
+          }
+        }
+        zip.file('notes.txt', notesLines.join('\n'));
+
+        // 9. Generate ZIP and trigger download
         const zipBlob = await zip.generateAsync({
           type: 'blob',
           compression: 'DEFLATE',

--- a/lib/export/scorm/use-export-scorm.ts
+++ b/lib/export/scorm/use-export-scorm.ts
@@ -10,11 +10,12 @@ import { createLogger } from '@/lib/logger';
 import type { Scene, InteractiveContent } from '@/lib/types/stage';
 
 import { collectAssets, getSceneAssetHrefs } from './asset-collector';
-import { buildManifest, type ScoEntry } from './manifest';
+import { buildManifest } from './manifest';
 import { getScormBridgeJs } from './scorm-bridge';
-import { buildSlideSco } from './slide-sco';
-import { buildQuizSco } from './quiz-sco';
-import { buildInteractiveSco } from './interactive-sco';
+import { buildSlideSection } from './slide-sco';
+import { buildQuizSection } from './quiz-sco';
+import { buildInteractiveSection } from './interactive-sco';
+import { buildCourseHtml, type SceneMeta } from './course-builder';
 
 const log = createLogger('ExportSCORM');
 
@@ -24,10 +25,6 @@ export interface ScormExportOptions {
 
 function sanitizeId(name: string): string {
   return name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64) || 'course';
-}
-
-function pad2(n: number): string {
-  return String(n + 1).padStart(2, '0');
 }
 
 function isExportableScene(scene: Scene): boolean {
@@ -41,13 +38,13 @@ function isExportableScene(scene: Scene): boolean {
 /**
  * React hook for SCORM 1.2 export.
  *
- * Mirrors the useExportPPTX pattern: guard against concurrent exports,
- * show toast on success/failure, lazy-import JSZip for code splitting.
+ * Generates a single-SCO package: all scenes in one index.html with internal
+ * JS navigation. Fixes LMS iframe navigation issues from multi-SCO approach.
  *
  * What gets exported:
- * - slide scenes → HTML SCO with absolutepositioned canvas + TTS narration
- * - quiz scenes  → HTML SCO with single/multiple choice questions + SCORM scoring
- * - interactive scenes (with html) → HTML SCO wrapping content in an iframe
+ * - slide scenes → <section> with absolute-positioned canvas + TTS narration
+ * - quiz scenes  → <section> with single/multiple choice questions + SCORM scoring
+ * - interactive scenes (with html) → <section> wrapping content in an iframe
  *
  * Excluded: pbl scenes, interactive scenes without html,
  *           whiteboards, multi-agent chat, short-answer questions.
@@ -91,6 +88,7 @@ export function useExportScorm(): {
 
         const fileName = stage?.name || 'course';
         const courseId = sanitizeId(fileName);
+        const courseTitle = stage?.name ?? fileName;
 
         // 1. Filter to exportable scenes only
         const exportableScenes = scenes.filter(isExportableScene);
@@ -100,73 +98,57 @@ export function useExportScorm(): {
           return;
         }
 
-        // 2. Build SCO href list (used in every SCO for navigation)
-        const allScoHrefs = exportableScenes.map(
-          (_, i) => `scos/scene_${pad2(i)}.html`,
-        );
-
-        // 3. Collect all media assets (fetch blobs, resolve placeholders)
+        // 2. Collect all media assets (fetch blobs, resolve placeholders)
         const assetMap = await collectAssets(exportableScenes, options.includeVideos);
 
-        // 4. Write asset blobs into ZIP
+        // 3. Write asset blobs into ZIP
         for (const entry of assetMap.entries()) {
           zip.file(entry.zipPath, entry.blob);
         }
 
-        // 5. Build SCO HTML pages + collect ScoEntry metadata for manifest
-        const scoEntries: ScoEntry[] = [];
+        // 4. Build scene section fragments
+        const sectionResults: Array<{ html: string; meta: SceneMeta }> = [];
+        let needsKatex = false;
+        let hasQuiz = false;
 
         for (let i = 0; i < exportableScenes.length; i++) {
           const scene = exportableScenes[i];
-          const href = allScoHrefs[i];
-          const sceneId = `scene_${pad2(i)}`;
-          let html = '';
 
           if (scene.content.type === 'slide') {
-            html = buildSlideSco({
-              scene,
-              sceneIndex: i,
-              totalScenes: exportableScenes.length,
-              allScoHrefs,
-              assetMap,
-              includeVideos: options.includeVideos,
-            });
+            const res = buildSlideSection({ scene, sceneIndex: i, assetMap, includeVideos: options.includeVideos });
+            sectionResults.push({ html: res.html, meta: res.meta });
+            if (res.needsKatex) needsKatex = true;
           } else if (scene.content.type === 'quiz') {
-            html = buildQuizSco({
-              scene,
-              sceneIndex: i,
-              totalScenes: exportableScenes.length,
-              allScoHrefs,
-            });
+            const res = buildQuizSection(scene, i);
+            sectionResults.push({ html: res.html, meta: res.meta });
+            hasQuiz = true;
           } else if (scene.content.type === 'interactive') {
-            html = buildInteractiveSco({
-              scene,
-              sceneIndex: i,
-              totalScenes: exportableScenes.length,
-              allScoHrefs,
-            });
+            const res = buildInteractiveSection(scene, i);
+            sectionResults.push({ html: res.html, meta: res.meta });
           }
-
-          if (!html) continue;
-
-          zip.file(href, html);
-
-          const assetHrefs = getSceneAssetHrefs(scene, i, assetMap, options.includeVideos);
-
-          scoEntries.push({
-            id: sceneId,
-            title: scene.title,
-            href,
-            isQuiz: scene.content.type === 'quiz',
-            assetHrefs,
-          });
         }
+
+        // 5. Assemble single index.html
+        const courseHtml = buildCourseHtml({
+          courseName: courseTitle,
+          sections: sectionResults,
+          needsKatex,
+        });
+        zip.file('index.html', courseHtml);
 
         // 6. Write scorm_bridge.js
         zip.file('scorm_bridge.js', getScormBridgeJs());
 
-        // 7. Write imsmanifest.xml
-        const manifest = buildManifest(courseId, stage?.name ?? fileName, scoEntries);
+        // 7. Write imsmanifest.xml (single-SCO pointing to index.html)
+        const allAssetHrefs = exportableScenes.flatMap((scene, i) =>
+          getSceneAssetHrefs(scene, i, assetMap, options.includeVideos),
+        );
+        const manifest = buildManifest({
+          courseId,
+          courseTitle,
+          assetHrefs: allAssetHrefs,
+          masteryScore: hasQuiz ? 80 : undefined,
+        });
         zip.file('imsmanifest.xml', manifest);
 
         // 8. Generate ZIP and trigger download

--- a/lib/i18n/common.ts
+++ b/lib/i18n/common.ts
@@ -36,6 +36,13 @@ export const commonZhCN = {
     exporting: '正在导出...',
     exportSuccess: '导出成功',
     exportFailed: '导出失败',
+    scorm: '导出 SCORM 1.2',
+    scormDesc: '用于 LMS 的标准化课程包',
+    scormDialogTitle: '导出 SCORM 1.2',
+    scormDialogDesc: '请选择视频处理方式',
+    scormIncludeVideos: '包含视频（完整包，文件较大）',
+    scormReplacePoster: '用封面图替换视频（文件更小）',
+    scormExport: '导出',
   },
 } as const;
 
@@ -77,5 +84,12 @@ export const commonEnUS = {
     exporting: 'Exporting...',
     exportSuccess: 'Export successful',
     exportFailed: 'Export failed',
+    scorm: 'Export SCORM 1.2',
+    scormDesc: 'Standardized course package for LMS',
+    scormDialogTitle: 'Export SCORM 1.2',
+    scormDialogDesc: 'Choose how to handle video content',
+    scormIncludeVideos: 'Include videos (complete package, may be large)',
+    scormReplacePoster: 'Replace videos with poster images (smaller download)',
+    scormExport: 'Export',
   },
 } as const;


### PR DESCRIPTION
## Summary

Adds a complete SCORM 1.2 export pipeline to OpenMAIC. Instructors can export any course as a standards-compliant `.zip` package that can be uploaded to any SCORM 1.2 LMS (Moodle, SCORM Cloud, etc.). The package is a single-SCO design: all scenes live in one `index.html` with internal JS navigation, which avoids the iframe navigation failures that multi-SCO approaches suffer in most LMSes.

## Related Issues

No related issues.

## Changes

- **New export pipeline** — `lib/export/scorm/` with dedicated modules: `course-builder.ts`, `slide-sco.ts`, `quiz-sco.ts`, `interactive-sco.ts`, `asset-collector.ts`, `manifest.ts`, `scorm-bridge.ts`, `use-export-scorm.ts`
- **Single-SCO architecture** — all scenes as `<section>` elements in one `index.html`; internal JS navigation replaces inter-SCO redirects
- **Slide rendering** — absolute-positioned canvas with `transform: scale()` fit; SVG shapes use `preserveAspectRatio="none"` and inline `<linearGradient>`/`<radialGradient>` defs to match editor appearance
- **TTS audio export** — speech audio fetched from IndexedDB (`db.audioFiles`) when no server URL is available; included in `assets/audio/` inside the ZIP
- **Quiz scenes** — single and multiple choice questions with immediate visual feedback (correct / wrong / missed); submit requires all questions answered; failed attempts show a retry button with infinite retries
- **Interactive scenes** — embedded in a sandboxed `<iframe srcdoc>`
- **Left sidebar** — fixed 240 px navigation panel listing all scenes with visited state (green checkmark) and a progress bar; locked scenes are dimmed until unlocked
- **Sequential navigation** — slide/interactive scenes unlock the next scene on visit; quiz scenes only unlock the next scene after passing (≥ 80 %); sidebar and Next button enforce this
- **SCORM progress reporting** — `cmi.core.lesson_location` + `cmi.suspend_data` saved on every navigation and quiz submit; on re-entry the course resumes at the last scene with visited state and quiz scores restored; `completed`/`passed` status is never downgraded to `incomplete`
- **CSS isolation** — all class names use the `om-` prefix to prevent collisions with LMS stylesheets (Bootstrap, Moodle, etc.)
- **`notes.txt`** — plain-text file included in the ZIP with each scene's title and its TTS narration text, mirroring the notes panel in the OpenMAIC editor
- **Export dialog** — new `ScormExportDialog` component with an "include videos" toggle, accessible from the header

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Verification

### Steps to reproduce / test

1. Open a course in OpenMAIC that contains at least one slide with TTS narration, one quiz (single/multiple choice), and one interactive scene.
2. Click **Export → SCORM 1.2** in the header and confirm the download.
3. Unzip the package and verify the structure: `imsmanifest.xml`, `index.html`, `scorm_bridge.js`, `notes.txt`, and an `assets/` folder with audio files.
4. Open `index.html` locally in a browser: verify sidebar navigation, slide scaling, audio playback, quiz submission with visual feedback, and retry on failure.
5. Upload the ZIP to a SCORM 1.2 LMS (e.g. SCORM Cloud or Moodle): verify that navigation, scoring, and completion status are recorded correctly.
6. Exit the course mid-way and re-enter: verify the course resumes at the correct scene with visited state and quiz scores preserved.

### What you personally verified

- Slides render correctly at all window sizes (scale fit, no letterboxing of SVG shapes including gradient fills)
- TTS audio files are included in the ZIP and play back in the correct order
- Quiz submit is blocked until all questions are answered; orange warning highlights unanswered questions and clears in real time when an answer is selected
- Failed quiz shows a "Torna-ho a intentar" retry button that fully resets the form; passing unlocks the Next button and the next scene in the sidebar
- Two quizzes in the same course work independently (duplicate question IDs across quizzes no longer conflict — each block ID is prefixed with the scene index)
- Resume/bookmark works against LMS: re-entering the course navigates to the last scene and restores visited state and quiz scores
- `notes.txt` contains the correct narration text for each slide scene (not needed, but as a bonus)
- Not verified: behaviour on Moodle or other LMSes beyond a custom developed LMS compatible with SCORM v1.2

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

### Development

Development realized by Claude Code, under supervision of Author.

