### PR TITLE
Add community prebuilt Docker image reference and note on local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,53 @@ cp .env.example .env.local
 docker compose up --build
 ```
 
+---
+### Community Prebuilt Docker Image
+
+For users who prefer not to build locally, a prebuilt Docker image is available:
+
+#### Run directly (30 seconds setup)
+
+```bash
+docker run -p 3000:3000 --env-file .env.local devprincekumar/openmaic:latest
+```
+
+#### Or using docker compose
+
+```yaml
+services:
+  openmaic:
+    image: devprincekumar/openmaic:latest
+    env_file:
+      - .env.local
+    ports:
+      - "3000:3000"
+```
+
+Full deployment guide:
+
+https://github.com/855princekumar/openmaic-docker
+
+This image provides:
+
+* No local build requirement
+* Faster onboarding
+* Simplified setup using environment configuration
+
+---
+
+### Note on Local LLM Support
+
+Currently, OpenMAIC relies on external LLM providers.
+
+Local LLM support (e.g., via Ollama or OpenAI-compatible endpoints) would significantly enhance usability for:
+
+* Offline environments
+* Cost-sensitive deployments
+* Privacy-focused use cases
+
+A community effort is underway to explore local LLM integration, with potential future contributions once validated.
+
 ### Optional: MinerU (Advanced Document Parsing)
 
 [MinerU](https://github.com/opendatalab/MinerU) provides enhanced parsing for complex tables, formulas, and OCR. You can use the [MinerU official API](https://mineru.net/) or [self-host your own instance](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/).

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ services:
       - "3000:3000"
 ```
 
-Full deployment guide:
+Full deployment guide (community-maintained):
 
 https://github.com/855princekumar/openmaic-docker
 
@@ -218,6 +218,7 @@ Local LLM support (e.g., via Ollama or OpenAI-compatible endpoints) would signif
 * Privacy-focused use cases
 
 A community effort is underway to explore local LLM integration, with potential future contributions once validated.
+This is a community-maintained deployment option and is not officially maintained by the OpenMAIC team.
 
 ### Optional: MinerU (Advanced Document Parsing)
 


### PR DESCRIPTION
## Summary

Adds a reference to a community-maintained prebuilt Docker image to simplify OpenMAIC deployment without requiring a local build.

## Related Issues

N/A

## Changes

* Added optional prebuilt Docker image usage under Docker section
* Included `docker run` and compose examples
* Linked external deployment guide
* Added note on potential local LLM support

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Follow existing Docker setup
2. Run using provided prebuilt image command
3. Verify application loads on localhost

### What you personally verified

* Verified container runs successfully using prebuilt image
* Confirmed application loads and responds correctly
* Ensured no changes to existing setup flow

### Evidence

* [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
* [x] Manually tested locally
* [ ] Screenshots / recordings attached (if UI changes)


## Checklist

* [x] My code follows the project's coding style
* [x] I have performed a self-review of my code
* [x] I have added/updated documentation as needed
* [x] My changes do not introduce new warnings
