### PR TITLE
fix: resolve DNS before SSRF validation to prevent rebinding bypass

### DIFF
--- a/app/api/azure-voices/route.ts
+++ b/app/api/azure-voices/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Validate baseUrl against SSRF
-    const ssrfError = validateUrlForSSRF(baseUrl);
+    const ssrfError = await validateUrlForSSRF(baseUrl);
     if (ssrfError) {
       return apiError('INVALID_URL', 403, ssrfError);
     }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -68,7 +68,7 @@ export async function POST(req: NextRequest) {
       model: languageModel,
       apiKey: resolvedApiKey,
       providerId,
-    } = resolveModel({
+    } = await resolveModel({
       modelString: body.model,
       apiKey: body.apiKey,
       baseUrl: body.baseUrl,

--- a/app/api/generate/agent-profiles/route.ts
+++ b/app/api/generate/agent-profiles/route.ts
@@ -66,7 +66,7 @@ export async function POST(req: NextRequest) {
     }
 
     // ── Model resolution from request headers ──
-    const { model: languageModel, modelString: _modelString } = resolveModelFromHeaders(req);
+    const { model: languageModel, modelString: _modelString } = await resolveModelFromHeaders(req);
     modelString = _modelString;
 
     // ── Build prompt ──

--- a/app/api/generate/image/route.ts
+++ b/app/api/generate/image/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
     const clientModel = request.headers.get('x-image-model') || undefined;
 
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/generate/scene-actions/route.ts
+++ b/app/api/generate/scene-actions/route.ts
@@ -77,7 +77,7 @@ export async function POST(req: NextRequest) {
     }
 
     // ── Model resolution from request headers ──
-    const { model: languageModel, modelInfo, modelString } = resolveModelFromHeaders(req);
+    const { model: languageModel, modelInfo, modelString } = await resolveModelFromHeaders(req);
     outlineTitle = outline?.title;
     resolvedModelString = modelString;
 

--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -73,7 +73,7 @@ export async function POST(req: NextRequest) {
     };
 
     // ── Model resolution from request headers ──
-    const { model: languageModel, modelInfo, modelString } = resolveModelFromHeaders(req);
+    const { model: languageModel, modelInfo, modelString } = await resolveModelFromHeaders(req);
     outlineTitle = rawOutline?.title;
     resolvedModelString = modelString;
 

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
 
     // Get API configuration from request headers
-    const { model: languageModel, modelInfo, modelString } = resolveModelFromHeaders(req);
+    const { model: languageModel, modelInfo, modelString } = await resolveModelFromHeaders(req);
     resolvedModelString = modelString;
 
     if (!body.requirements) {

--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: NextRequest) {
 
     const clientBaseUrl = ttsBaseUrl || undefined;
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/generate/video/route.ts
+++ b/app/api/generate/video/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
     const clientModel = request.headers.get('x-video-model') || undefined;
 
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/parse-pdf/route.ts
+++ b/app/api/parse-pdf/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
 
     const clientBaseUrl = baseUrl || undefined;
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/pbl/chat/route.ts
+++ b/app/api/pbl/chat/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Get model config from headers
-    const { model } = resolveModelFromHeaders(req);
+    const { model } = await resolveModelFromHeaders(req);
 
     // Build context for the agent, differentiating question vs judge
     let issueContext = '';

--- a/app/api/proxy-media/route.ts
+++ b/app/api/proxy-media/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Block local/private network URLs to prevent SSRF
-    const ssrfError = validateUrlForSSRF(url);
+    const ssrfError = await validateUrlForSSRF(url);
     if (ssrfError) {
       return apiError('INVALID_URL', 403, ssrfError);
     }

--- a/app/api/quiz-grade/route.ts
+++ b/app/api/quiz-grade/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Resolve model from request headers
-    const { model: languageModel } = resolveModelFromHeaders(req);
+    const { model: languageModel } = await resolveModelFromHeaders(req);
 
     const isZh = language === 'zh-CN';
 

--- a/app/api/transcription/route.ts
+++ b/app/api/transcription/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
 
     const clientBaseUrl = baseUrl || undefined;
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/verify-image-provider/route.ts
+++ b/app/api/verify-image-provider/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
     const clientBaseUrl = request.headers.get('x-base-url') || undefined;
 
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/verify-model/route.ts
+++ b/app/api/verify-model/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
     // Parse model string and resolve server-side fallback
     let languageModel;
     try {
-      const result = resolveModel({
+      const result = await resolveModel({
         modelString: model,
         apiKey: apiKey || '',
         baseUrl: baseUrl || undefined,

--- a/app/api/verify-pdf-provider/route.ts
+++ b/app/api/verify-pdf-provider/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
 
     const clientBaseUrl = (baseUrl as string | undefined) || undefined;
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/verify-video-provider/route.ts
+++ b/app/api/verify-video-provider/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
     const clientBaseUrl = request.headers.get('x-base-url') || undefined;
 
     if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-      const ssrfError = validateUrlForSSRF(clientBaseUrl);
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }

--- a/app/api/web-search/route.ts
+++ b/app/api/web-search/route.ts
@@ -53,7 +53,7 @@ export async function POST(req: NextRequest) {
 
     let aiCall: AICallFn | undefined;
     try {
-      const { model: languageModel } = resolveModelFromHeaders(req);
+      const { model: languageModel } = await resolveModelFromHeaders(req);
       aiCall = async (systemPrompt, userPrompt) => {
         const result = await callLLM(
           {

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -177,7 +177,13 @@ export async function generateClassroom(
     scenesGenerated: 0,
   });
 
-  const { model: languageModel, modelInfo, modelString, providerId, apiKey } = resolveModel({});
+  const {
+    model: languageModel,
+    modelInfo,
+    modelString,
+    providerId,
+    apiKey,
+  } = await resolveModel({});
   log.info(`Using server-configured model: ${modelString}`);
 
   // Fail fast if the resolved provider has no API key configured

--- a/lib/server/resolve-model.ts
+++ b/lib/server/resolve-model.ts
@@ -24,12 +24,12 @@ export interface ResolvedModel extends ModelWithInfo {
  *
  * Use this when model config comes from the request body.
  */
-export function resolveModel(params: {
+export async function resolveModel(params: {
   modelString?: string;
   apiKey?: string;
   baseUrl?: string;
   providerType?: string;
-}): ResolvedModel {
+}): Promise<ResolvedModel> {
   const modelString = params.modelString || process.env.DEFAULT_MODEL || 'gpt-4o-mini';
   const { providerId, modelId } = parseModelString(modelString);
 
@@ -38,7 +38,7 @@ export function resolveModel(params: {
   // resolveBaseUrl() and bypass this check — they're trusted by the operator.
   const clientBaseUrl = params.baseUrl || undefined;
   if (clientBaseUrl && process.env.NODE_ENV === 'production') {
-    const ssrfError = validateUrlForSSRF(clientBaseUrl);
+    const ssrfError = await validateUrlForSSRF(clientBaseUrl);
     if (ssrfError) {
       throw new Error(ssrfError);
     }
@@ -68,7 +68,7 @@ export function resolveModel(params: {
  * Note: requiresApiKey is derived server-side from the provider registry,
  * never from client headers, to prevent auth bypass.
  */
-export function resolveModelFromHeaders(req: NextRequest): ResolvedModel {
+export async function resolveModelFromHeaders(req: NextRequest): Promise<ResolvedModel> {
   return resolveModel({
     modelString: req.headers.get('x-model') || undefined,
     apiKey: req.headers.get('x-api-key') || undefined,

--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -4,19 +4,169 @@
  * Validates URLs to prevent requests to internal/private network addresses.
  * Used by any API route that fetches a user-supplied URL server-side.
  */
+import { promises as dns } from 'node:dns';
+import { isIP } from 'node:net';
 
-/** Check if hostname is in the 172.16.0.0 - 172.31.255.255 private range */
-function isPrivate172(hostname: string): boolean {
-  if (!hostname.startsWith('172.')) return false;
-  const second = parseInt(hostname.split('.')[1], 10);
-  return second >= 16 && second <= 31;
+function normalizeAddress(value: string): string {
+  let normalized = value.trim().toLowerCase();
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.slice(1, -1);
+  }
+  return normalized.replace(/\.+$/, '');
+}
+
+function parseIPv4(ip: string): number[] | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) {
+      return Number.NaN;
+    }
+    return Number.parseInt(part, 10);
+  });
+
+  if (octets.some((octet) => Number.isNaN(octet) || octet < 0 || octet > 255)) {
+    return null;
+  }
+
+  return octets;
+}
+
+function extractMappedIPv4(ip: string): string | null {
+  const normalized = normalizeAddress(ip);
+  if (!normalized.startsWith('::ffff:')) {
+    return null;
+  }
+
+  const suffix = normalized.slice('::ffff:'.length);
+  const dottedIPv4 = parseIPv4(suffix);
+  if (dottedIPv4) {
+    return dottedIPv4.join('.');
+  }
+
+  const parts = suffix.split(':');
+  if (parts.length !== 2 || parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) {
+    return null;
+  }
+
+  const [high, low] = parts.map((part) => Number.parseInt(part, 16));
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join('.');
+}
+
+function getFirstIPv6Hextet(ip: string): number | null {
+  const normalized = normalizeAddress(ip);
+  if (!normalized.includes(':')) {
+    return null;
+  }
+
+  if (normalized.startsWith('::')) {
+    return 0;
+  }
+
+  const [firstHextet] = normalized.split(':');
+  if (!firstHextet || !/^[0-9a-f]{1,4}$/.test(firstHextet)) {
+    return null;
+  }
+
+  return Number.parseInt(firstHextet, 16);
+}
+
+/** Expand an IPv6 address into 8 numeric hextets. Returns null for invalid input. */
+function expandIPv6(ip: string): number[] | null {
+  const normalized = normalizeAddress(ip);
+  if (!normalized.includes(':')) return null;
+
+  // Skip IPv4-suffix forms (handled separately by extractMappedIPv4)
+  const lastPart = normalized.split(':').pop() || '';
+  if (lastPart.includes('.')) return null;
+
+  const sides = normalized.split('::');
+  if (sides.length > 2) return null;
+
+  let parts: string[];
+  if (sides.length === 2) {
+    const left = sides[0] ? sides[0].split(':') : [];
+    const right = sides[1] ? sides[1].split(':') : [];
+    const missing = 8 - left.length - right.length;
+    if (missing < 0) return null;
+    parts = [...left, ...Array(missing).fill('0'), ...right];
+  } else {
+    parts = normalized.split(':');
+  }
+
+  if (parts.length !== 8) return null;
+  if (parts.some((p) => !/^[0-9a-f]{1,4}$/.test(p))) return null;
+
+  return parts.map((p) => Number.parseInt(p, 16));
+}
+
+export function isPrivateIP(ip: string): boolean {
+  const normalized = normalizeAddress(ip);
+  const mappedIPv4 = extractMappedIPv4(normalized);
+  if (mappedIPv4) {
+    return isPrivateIP(mappedIPv4);
+  }
+
+  const ipv4 = parseIPv4(normalized);
+  if (ipv4) {
+    const [first, second, third, fourth] = ipv4;
+    return (
+      first === 0 ||
+      first === 10 ||
+      first === 127 ||
+      (first === 169 && second === 254) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168) ||
+      (first === 0 && second === 0 && third === 0 && fourth === 0)
+    );
+  }
+
+  const ipv6FirstHextet = getFirstIPv6Hextet(normalized);
+  if (ipv6FirstHextet === null) {
+    return false;
+  }
+
+  if (normalized === '::' || normalized === '::1') {
+    return true;
+  }
+
+  if (
+    (ipv6FirstHextet & 0xfe00) === 0xfc00 || // fc00::/7 unique local
+    (ipv6FirstHextet & 0xffc0) === 0xfe80 || // fe80::/10 link-local
+    (ipv6FirstHextet & 0xffc0) === 0xfec0 // fec0::/10 site-local (deprecated)
+  ) {
+    return true;
+  }
+
+  // 6to4 tunnel: 2002::/16 — embedded IPv4 sits in bits 16-47
+  if (ipv6FirstHextet === 0x2002) {
+    const hextets = expandIPv6(normalized);
+    if (hextets) {
+      const embedded = `${hextets[1] >> 8}.${hextets[1] & 0xff}.${hextets[2] >> 8}.${hextets[2] & 0xff}`;
+      if (isPrivateIP(embedded)) return true;
+    }
+  }
+
+  // Teredo tunnel: 2001:0000::/32 — client IPv4 in last 32 bits, XOR-inverted
+  if (ipv6FirstHextet === 0x2001) {
+    const hextets = expandIPv6(normalized);
+    if (hextets && hextets[1] === 0x0000) {
+      const high = hextets[6] ^ 0xffff;
+      const low = hextets[7] ^ 0xffff;
+      const embedded = `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+      if (isPrivateIP(embedded)) return true;
+    }
+  }
+
+  return false;
 }
 
 /**
  * Validate a URL against SSRF attacks.
  * Returns null if the URL is safe, or an error message string if blocked.
  */
-export function validateUrlForSSRF(url: string): string | null {
+export async function validateUrlForSSRF(url: string): Promise<string | null> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -34,20 +184,33 @@ export function validateUrlForSSRF(url: string): string | null {
     return null;
   }
 
-  const hostname = parsed.hostname.toLowerCase();
+  const hostname = normalizeAddress(parsed.hostname);
   if (
     hostname === 'localhost' ||
-    hostname === '127.0.0.1' ||
-    hostname === '::1' ||
-    hostname === '0.0.0.0' ||
-    hostname.startsWith('10.') ||
-    hostname.startsWith('192.168.') ||
-    hostname.startsWith('169.254.') ||
-    isPrivate172(hostname) ||
     hostname.endsWith('.local') ||
-    hostname.startsWith('fd') ||
-    hostname.startsWith('fe80')
+    hostname === '0.0.0.0' ||
+    hostname === '::1' ||
+    isPrivateIP(hostname)
   ) {
+    return 'Local/private network URLs are not allowed';
+  }
+
+  if (isIP(hostname)) {
+    return null;
+  }
+
+  let resolvedAddresses: Array<{ address: string; family: number }>;
+  try {
+    resolvedAddresses = await dns.lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    return 'Unable to verify hostname safety';
+  }
+
+  if (resolvedAddresses.length === 0) {
+    return 'Unable to verify hostname safety';
+  }
+
+  if (resolvedAddresses.some(({ address }) => isPrivateIP(address))) {
     return 'Local/private network URLs are not allowed';
   }
 

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { lookupMock } = vi.hoisted(() => ({
+  lookupMock: vi.fn(),
+}));
+
+vi.mock('node:dns', () => ({
+  promises: {
+    lookup: lookupMock,
+  },
+}));
+
+describe('validateUrlForSSRF', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    lookupMock.mockReset();
+  });
+
+  it('allows a public hostname when DNS resolves to a public IP', async () => {
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://api.openai.com')).resolves.toBeNull();
+    expect(lookupMock).toHaveBeenCalledWith('api.openai.com', { all: true, verbatim: true });
+  });
+
+  it('allows a public IP literal without DNS lookup', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://8.8.8.8')).resolves.toBeNull();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('allows a public IPv6 literal without DNS lookup', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://[2606:4700:4700::1111]')).resolves.toBeNull();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid URLs and non-http protocols', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('not-a-url')).resolves.toBe('Invalid URL');
+    await expect(validateUrlForSSRF('ftp://example.com')).resolves.toBe(
+      'Only HTTP(S) URLs are allowed',
+    );
+    await expect(validateUrlForSSRF('file:///etc/passwd')).resolves.toBe(
+      'Only HTTP(S) URLs are allowed',
+    );
+    await expect(validateUrlForSSRF('javascript:alert(1)')).resolves.toBe(
+      'Only HTTP(S) URLs are allowed',
+    );
+  });
+
+  it('rejects blocked hostnames immediately', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('http://localhost')).resolves.toBe(
+      'Local/private network URLs are not allowed',
+    );
+    await expect(validateUrlForSSRF('http://printer.local')).resolves.toBe(
+      'Local/private network URLs are not allowed',
+    );
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects private IPv4 literals', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    const urls = [
+      'http://127.0.0.1',
+      'http://10.0.0.42',
+      'http://172.16.5.4',
+      'http://172.31.255.255',
+      'http://192.168.1.10',
+      'http://169.254.169.254',
+      'http://0.0.0.0',
+    ];
+
+    for (const url of urls) {
+      await expect(validateUrlForSSRF(url)).resolves.toBe(
+        'Local/private network URLs are not allowed',
+      );
+    }
+
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects private IPv6 literals and mapped loopback addresses', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    const urls = [
+      'http://[::1]',
+      'http://[fd00::1234]',
+      'http://[fe80::1]',
+      'http://[fec0::1]',
+      'http://[::ffff:127.0.0.1]',
+    ];
+
+    for (const url of urls) {
+      await expect(validateUrlForSSRF(url)).resolves.toBe(
+        'Local/private network URLs are not allowed',
+      );
+    }
+
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects 6to4 tunnel addresses embedding private IPv4', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    // 2002:7f00:0001:: embeds 127.0.0.1
+    await expect(validateUrlForSSRF('http://[2002:7f00:0001::]')).resolves.toBe(
+      'Local/private network URLs are not allowed',
+    );
+    // 2002:0a00:0001:: embeds 10.0.0.1
+    await expect(validateUrlForSSRF('http://[2002:0a00:0001::]')).resolves.toBe(
+      'Local/private network URLs are not allowed',
+    );
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('allows 6to4 tunnel addresses embedding public IPv4', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    // 2002:0808:0808:: embeds 8.8.8.8
+    await expect(validateUrlForSSRF('http://[2002:0808:0808::]')).resolves.toBeNull();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects Teredo tunnel addresses embedding private IPv4', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    // Client IPv4 127.0.0.1 XOR 0xFFFFFFFF = 0x80FFFFFE → hextets 80ff:fffe
+    await expect(
+      validateUrlForSSRF('http://[2001:0000:4136:e378:8000:63bf:80ff:fffe]'),
+    ).resolves.toBe('Local/private network URLs are not allowed');
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('allows Teredo tunnel addresses embedding public IPv4', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    // Client IPv4 8.8.8.8 XOR 0xFFFFFFFF = 0xF7F7F7F7 → hextets f7f7:f7f7
+    await expect(
+      validateUrlForSSRF('http://[2001:0000:4136:e378:8000:63bf:f7f7:f7f7]'),
+    ).resolves.toBeNull();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects hostnames that resolve to a private IP', async () => {
+    lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://attacker.com')).resolves.toBe(
+      'Local/private network URLs are not allowed',
+    );
+  });
+
+  it('rejects hostnames when any DNS answer is private', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '192.168.1.10', family: 4 },
+    ]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://mixed.example')).resolves.toBe(
+      'Local/private network URLs are not allowed',
+    );
+  });
+
+  it('fails closed when DNS lookup errors', async () => {
+    lookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://missing.example')).resolves.toBe(
+      'Unable to verify hostname safety',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fix SSRF guard DNS rebinding bypass by resolving hostnames to IP addresses before validation.

Closes #378

## Problem

The SSRF guard in `lib/server/ssrf-guard.ts` only checked hostname strings (e.g. `localhost`, `192.168.*`), allowing attackers to register a domain resolving to a private IP and bypass all private-network checks. This could expose cloud instance metadata (`169.254.169.254`), internal APIs, and other local services.

## Changes

### Core Fix (`lib/server/ssrf-guard.ts`)

- **`validateUrlForSSRF` is now `async`** — resolves hostnames via `dns.promises.lookup` with `{ all: true, verbatim: true }` and rejects if **any** returned address is private/local
- **`isPrivateIP()` helper** covers:
  - IPv4: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `0.0.0.0`
  - IPv6: `::1`, `::`, `fc00::/7` (ULA), `fe80::/10` (link-local), `fec0::/10` (deprecated site-local)
  - IPv4-mapped IPv6: `::ffff:127.0.0.1`, `::ffff:7f00:0001`
  - **6to4 tunnel** (`2002::/16`): extracts embedded IPv4 from bits 16-47
  - **Teredo tunnel** (`2001:0000::/32`): extracts XOR-inverted client IPv4 from bits 96-127
- **IP literals detected via `net.isIP()`** — validated directly without DNS lookup, avoiding false positives from "DNS failure = block"
- **Fail-closed** — DNS resolution errors or empty results reject the request

### Async Propagation (20+ files)

- `resolveModel()` and `resolveModelFromHeaders()` in `lib/server/resolve-model.ts` are now `async`
- All direct `validateUrlForSSRF()` callers and indirect callers via `resolveModel`/`resolveModelFromHeaders` updated with `await`
- **No behavioral changes** — existing production-only gating (`NODE_ENV === 'production'`) and per-route SSRF policies are preserved

### Tests (`tests/server/ssrf-guard.test.ts`)

14 test cases covering:
| Category | Cases |
|----------|-------|
| Public pass-through | Public hostname, IPv4 literal, IPv6 literal |
| Protocol blocking | Invalid URL, `ftp://`, `file://`, `javascript:` |
| Hostname fast-path | `localhost`, `.local` |
| Private IPv4 literals | `127.0.0.1`, `10.x`, `172.16-31.x`, `192.168.x`, `169.254.x`, `0.0.0.0` |
| Private IPv6 literals | `::1`, `fd00::`, `fe80::`, `fec0::`, `::ffff:127.0.0.1` |
| 6to4 tunnel | Private embedded (blocked) + public embedded (allowed) |
| Teredo tunnel | Private embedded (blocked) + public embedded (allowed) |
| DNS rebinding | Mocked lookup → `127.0.0.1` → blocked |
| Mixed DNS answers | Public + private → blocked |
| DNS failure | Lookup throws → blocked (fail-closed) |

## Verification

-  `pnpm vitest run tests/server/ssrf-guard.test.ts` — 14/14 passed
-  `pnpm build` — no type errors

## Out of Scope

- **TOCTOU / IP pinning**: The resolved IP at validation time could differ from the IP at fetch time. Mitigating this requires connecting directly by resolved IP, which is a larger change. Tracked separately.
- **ISATAP tunnel**: Extremely rare in practice, deferred.

*Assisted by Claude Opus 4.6 and GPT-5.4.*