### PR TITLE
fix(i18n): add missing Ollama and Doubao provider names for ru-RU

### DIFF
--- a/components/settings/index.tsx
+++ b/components/settings/index.tsx
@@ -520,7 +520,12 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
                 <Box className="h-8 w-8 text-muted-foreground" />
               )}
               <div>
-                <h2 className="text-lg font-semibold">{selectedProvider.name}</h2>
+                <h2 className="text-lg font-semibold">
+                  {t(`settings.providerNames.${selectedProvider.id}`) !==
+                  `settings.providerNames.${selectedProvider.id}`
+                    ? t(`settings.providerNames.${selectedProvider.id}`)
+                    : selectedProvider.name}
+                </h2>
                 <p className="text-xs text-muted-foreground">
                   {getProviderTypeLabel(selectedProvider.type, t)}
                 </p>

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -403,7 +403,9 @@
       "kimi": "Kimi",
       "minimax": "MiniMax",
       "glm": "GLM",
-      "siliconflow": "SiliconFlow"
+      "siliconflow": "SiliconFlow",
+      "doubao": "Doubao",
+      "ollama": "Ollama (Локальный)"
     },
     "providerTypes": {
       "openai": "Протокол OpenAI",


### PR DESCRIPTION
## Summary
- Add missing `providerNames.ollama` and `providerNames.doubao` keys to `ru-RU.json`
- These were added to en-US, zh-CN, ja-JP in #94 but ru-RU was missed

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)