### PR TITLE
test(e2e): add end-to-end generation happy path test

### DIFF
--- a/e2e/fixtures/mock-api.ts
+++ b/e2e/fixtures/mock-api.ts
@@ -44,13 +44,24 @@ export class MockApi {
     });
   }
 
-  /** Mock the scene actions generation endpoint */
-  async mockSceneActions(stageId = 'test-stage') {
-    await this.page.route('**/api/generate/scene-actions', (route) => {
-      route.fulfill({
+  /** Mock the scene actions generation endpoint.
+   *  When no stageId is provided, it is extracted from the request body
+   *  so the mock response matches the dynamically-generated stage id. */
+  async mockSceneActions(stageId?: string) {
+    await this.page.route('**/api/generate/scene-actions', async (route) => {
+      let id = stageId ?? 'test-stage';
+      if (!stageId) {
+        try {
+          const body = route.request().postDataJSON();
+          if (body?.stageId) id = body.stageId;
+        } catch {
+          // fallback to default
+        }
+      }
+      await route.fulfill({
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(createMockSceneActionsResponse(stageId)),
+        body: JSON.stringify(createMockSceneActionsResponse(id)),
       });
     });
   }
@@ -67,7 +78,7 @@ export class MockApi {
   }
 
   /** Set up API mocks for the generation flow. Note: server-providers is already mocked by the base fixture. */
-  async setupGenerationMocks(stageId = 'test-stage') {
+  async setupGenerationMocks(stageId?: string) {
     await this.mockSceneOutlinesStream();
     await this.mockSceneContent();
     await this.mockSceneActions(stageId);

--- a/e2e/tests/full-happy-path.spec.ts
+++ b/e2e/tests/full-happy-path.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '../fixtures/base';
+import { HomePage } from '../pages/home.page';
+import { GenerationPreviewPage } from '../pages/generation-preview.page';
+import { ClassroomPage } from '../pages/classroom.page';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+test.describe('Full Happy Path', () => {
+  test.beforeEach(async ({ page, mockApi }) => {
+    // Pre-seed settings in localStorage (all tests do this)
+    await page.addInitScript((settings) => {
+      localStorage.setItem('settings-storage', settings);
+    }, SETTINGS_STORAGE);
+
+    // Set up generation API mocks BEFORE any navigation —
+    // generation auto-starts when generation-preview mounts.
+    await mockApi.setupGenerationMocks();
+  });
+
+  test('home → generation-preview → classroom with scene navigation', async ({ page }) => {
+    // ── Phase 1: Home page ──────────────────────────────────────────────
+    const home = new HomePage(page);
+    await home.goto();
+
+    // Core UI elements visible
+    await expect(home.logo).toBeVisible();
+    await expect(home.textarea).toBeVisible();
+    await expect(home.enterButton).toBeDisabled();
+
+    // Fill requirement text → submit button activates
+    await home.fillRequirement('讲解光合作用');
+    await expect(home.enterButton).toBeEnabled();
+
+    // Submit → navigate to generation-preview
+    await home.submit();
+    await page.waitForURL(/\/generation-preview/);
+
+    // ── Phase 2: Generation preview ─────────────────────────────────────
+    const preview = new GenerationPreviewPage(page);
+
+    // Generation progress UI should be visible
+    await expect(preview.stepTitle).toBeVisible();
+
+    // Wait for mocked generation to complete and auto-redirect to classroom
+    await preview.waitForRedirectToClassroom();
+    expect(page.url()).toMatch(/\/classroom\//);
+
+    // ── Phase 3: Classroom ──────────────────────────────────────────────
+    const classroom = new ClassroomPage(page);
+    await classroom.waitForLoaded();
+
+    // At least one scene should be visible in the sidebar
+    await expect(classroom.sidebarScenes.first()).toBeVisible({ timeout: 10_000 });
+
+    // First scene title should match mock data
+    await expect(classroom.getSceneTitle(0)).toContainText('光合作用');
+
+    // If more than one scene item is rendered, verify scene switching works
+    const sceneCount = await classroom.sidebarScenes.count();
+    if (sceneCount > 1) {
+      await classroom.clickScene(1);
+      // Verify the clicked scene is visible (active)
+      await expect(classroom.sidebarScenes.nth(1)).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a full happy-path E2E test covering Home → Generation Preview → Classroom without pre-seeding intermediate state (closes #401)
- Fix latent bug in `MockApi.mockSceneActions`: hardcoded `stageId="test-stage"` caused `store.addScene()` to silently drop the scene due to stageId mismatch validation in the Zustand store. The mock now dynamically extracts the actual stageId from the request body.

## Changes
- `e2e/tests/full-happy-path.spec.ts` (new) — ~67 lines, reuses existing page objects, MockApi, and test data fixtures
- `e2e/fixtures/mock-api.ts` — `mockSceneActions()` now reads stageId from request body when none is provided; `setupGenerationMocks()` signature updated accordingly

## Bug found during development
The existing `generation-flow.spec.ts` test passes but has a latent issue: `mockSceneActions` returns a scene with `stageId="test-stage"`, while the actual stage created by `generation-preview` uses a random `nanoid(10)`. The store's `addScene()` validates this match and silently ignores mismatched scenes. The existing test only checks for redirect URL, not classroom content, so it doesn't catch this.

## Test plan
- [x] `pnpm exec playwright test` — all 4 tests pass (3 existing + 1 new)
- [x] `pnpm check` — Prettier passes
- [x] `pnpm lint` — 0 errors
- [x] `npx tsc --noEmit` — TypeScript passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)