### PR TITLE
feat(security): add anti-framing headers (X-Frame-Options + CSP frame-ancestors)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,25 @@ const nextConfig: NextConfig = {
   experimental: {
     proxyClientMaxBodySize: '200mb',
   },
+  async headers() {
+    const extraAncestors = process.env.ALLOWED_FRAME_ANCESTORS?.trim();
+    const frameAncestors = extraAncestors ? `'self' ${extraAncestors}` : "'self'";
+
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          // X-Frame-Options only supports SAMEORIGIN (no allow-list),
+          // so we omit it when custom ancestors are configured.
+          ...(!extraAncestors ? [{ key: 'X-Frame-Options', value: 'SAMEORIGIN' }] : []),
+          {
+            key: 'Content-Security-Policy',
+            value: `frame-ancestors ${frameAncestors}`,
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/tests/server/security-headers.test.ts
+++ b/tests/server/security-headers.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NextConfig } from 'next';
+
+async function loadConfig(): Promise<NextConfig> {
+  vi.resetModules();
+  const mod = await import('@/next.config');
+  return mod.default;
+}
+
+describe('Security response headers', () => {
+  afterEach(() => {
+    delete process.env.ALLOWED_FRAME_ANCESTORS;
+  });
+
+  describe('default (no ALLOWED_FRAME_ANCESTORS)', () => {
+    it('nextConfig.headers() is defined', async () => {
+      const config = await loadConfig();
+      expect(config.headers).toBeDefined();
+      expect(typeof config.headers).toBe('function');
+    });
+
+    it('includes X-Frame-Options SAMEORIGIN on all routes', async () => {
+      const config = await loadConfig();
+      const headerGroups = await config.headers!();
+      const allRouteGroup = headerGroups.find((g) => g.source === '/(.*)')!;
+
+      expect(allRouteGroup).toBeDefined();
+      expect(allRouteGroup.headers).toContainEqual({
+        key: 'X-Frame-Options',
+        value: 'SAMEORIGIN',
+      });
+    });
+
+    it("includes Content-Security-Policy frame-ancestors 'self'", async () => {
+      const config = await loadConfig();
+      const headerGroups = await config.headers!();
+      const allRouteGroup = headerGroups.find((g) => g.source === '/(.*)')!;
+
+      expect(allRouteGroup).toBeDefined();
+      expect(allRouteGroup.headers).toContainEqual({
+        key: 'Content-Security-Policy',
+        value: "frame-ancestors 'self'",
+      });
+    });
+  });
+
+  describe('with ALLOWED_FRAME_ANCESTORS', () => {
+    it('appends allowed origins to frame-ancestors', async () => {
+      process.env.ALLOWED_FRAME_ANCESTORS = 'https://partner.example.com';
+      const config = await loadConfig();
+      const headerGroups = await config.headers!();
+      const allRouteGroup = headerGroups.find((g) => g.source === '/(.*)')!;
+
+      expect(allRouteGroup.headers).toContainEqual({
+        key: 'Content-Security-Policy',
+        value: "frame-ancestors 'self' https://partner.example.com",
+      });
+    });
+
+    it('omits X-Frame-Options when custom ancestors are set', async () => {
+      process.env.ALLOWED_FRAME_ANCESTORS = 'https://partner.example.com';
+      const config = await loadConfig();
+      const headerGroups = await config.headers!();
+      const allRouteGroup = headerGroups.find((g) => g.source === '/(.*)')!;
+
+      const xfo = allRouteGroup.headers.find((h) => h.key === 'X-Frame-Options');
+      expect(xfo).toBeUndefined();
+    });
+
+    it('supports multiple space-separated origins', async () => {
+      process.env.ALLOWED_FRAME_ANCESTORS = 'https://a.example.com https://b.example.com';
+      const config = await loadConfig();
+      const headerGroups = await config.headers!();
+      const allRouteGroup = headerGroups.find((g) => g.source === '/(.*)')!;
+
+      expect(allRouteGroup.headers).toContainEqual({
+        key: 'Content-Security-Policy',
+        value: "frame-ancestors 'self' https://a.example.com https://b.example.com",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `X-Frame-Options: SAMEORIGIN` and `Content-Security-Policy: frame-ancestors 'self'` response headers to prevent clickjacking and unauthorized third-party embedding of the application.

Supports an optional `ALLOWED_FRAME_ANCESTORS` environment variable to whitelist trusted origins (e.g., for partner sites that need to embed OpenMAIC).

## Changes

### `next.config.ts`
- Added `headers()` function that applies anti-framing headers to all routes via the `/(.*)`  source pattern.
- `X-Frame-Options: SAMEORIGIN` — legacy header for older browser compatibility (omitted when custom ancestors are configured, since X-Frame-Options doesn't support allow-lists).
- `Content-Security-Policy: frame-ancestors 'self'` — modern standard that restricts which origins can embed this site in an iframe.
- Reads optional `ALLOWED_FRAME_ANCESTORS` env var to append trusted origins (space-separated).

### `tests/server/security-headers.test.ts` (new)
- Verifies that `headers()` is defined in the Next.js config.
- Asserts both `X-Frame-Options` and `Content-Security-Policy: frame-ancestors` are present with default config.
- Tests that `ALLOWED_FRAME_ANCESTORS` correctly appends origins to the CSP directive.
- Tests that `X-Frame-Options` is omitted when custom ancestors are set.
- Tests multiple space-separated origins.

## Configuration

By default, only same-origin framing is allowed. To whitelist additional origins:

```env
# .env or Vercel environment variables
ALLOWED_FRAME_ANCESTORS=https://partner.example.com https://another.example.com
```

## Verification

```bash
# All 100 tests pass, zero regressions
npx vitest run
# Test Files  8 passed (8)
#      Tests  100 passed (100)
```

After deployment, the headers can be verified with:
```bash
curl -sI https://open.maic.chat/ | grep -iE "x-frame|content-security"
# Expected:
# X-Frame-Options: SAMEORIGIN
# Content-Security-Policy: frame-ancestors 'self'
```

Closes THU-MAIC/OpenMAIC#428
Closes THU-MAIC/OpenMAIC#429