### PR TITLE
fix(export): use latest classroom name from IndexedDB for ZIP filename (#434)

### DIFF
--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -5,7 +5,7 @@ import { saveAs } from 'file-saver';
 import { toast } from 'sonner';
 import { useStageStore } from '@/lib/store/stage';
 import { useI18n } from '@/lib/hooks/use-i18n';
-import { getGeneratedAgentsByStageId } from '@/lib/utils/database';
+import { db, getGeneratedAgentsByStageId } from '@/lib/utils/database';
 import {
   CLASSROOM_ZIP_FORMAT_VERSION,
   CLASSROOM_ZIP_EXTENSION,
@@ -36,24 +36,28 @@ export function useExportClassroom() {
       const JSZip = (await import('jszip')).default;
       const zip = new JSZip();
 
-      // 1. Collect agents from DB
+      // 1. Read latest stage name from IndexedDB (may have been renamed on home page)
+      const freshStage = await db.stages.get(stage.id);
+      const latestName = freshStage?.name || stage.name;
+
+      // 2. Collect agents from DB
       const agentRecords = await getGeneratedAgentsByStageId(stage.id);
 
-      // 2. Collect audio files
+      // 3. Collect audio files
       const audioFiles = await collectAudioFiles(scenes);
 
-      // 3. Collect media files (generated images/videos)
+      // 4. Collect media files (generated images/videos)
       const mediaFiles = await collectMediaFiles(stage.id);
 
-      // 4. Build audioId → zipPath mapping for manifest
+      // 5. Build audioId → zipPath mapping for manifest
       const audioIdToPath = new Map<string, string>();
       for (const af of audioFiles) {
         audioIdToPath.set(af.record.id, af.zipPath);
       }
 
-      // 5. Build manifest
+      // 6. Build manifest
       const manifestStage: ManifestStage = {
-        name: stage.name,
+        name: latestName,
         description: stage.description,
         language: stage.languageDirective,
         style: stage.style,
@@ -111,7 +115,7 @@ export function useExportClassroom() {
           : {}),
       }));
 
-      // 6. Build mediaIndex
+      // 7. Build mediaIndex
       const mediaIndex: Record<string, MediaIndexEntry> = {};
 
       for (const af of audioFiles) {
@@ -144,7 +148,7 @@ export function useExportClassroom() {
         }
       }
 
-      // 7. Assemble manifest
+      // 8. Assemble manifest
       const manifest: ClassroomManifest = {
         formatVersion: CLASSROOM_ZIP_FORMAT_VERSION,
         exportedAt: new Date().toISOString(),
@@ -157,7 +161,7 @@ export function useExportClassroom() {
 
       zip.file('manifest.json', JSON.stringify(manifest, null, 2));
 
-      // 8. Add media blobs to ZIP
+      // 9. Add media blobs to ZIP
       for (const af of audioFiles) {
         zip.file(af.zipPath, af.record.blob);
       }
@@ -168,9 +172,9 @@ export function useExportClassroom() {
         }
       }
 
-      // 9. Generate and download
+      // 10. Generate and download
       const zipBlob = await zip.generateAsync({ type: 'blob' });
-      const safeName = stage.name.replace(/[\\/:*?"<>|]/g, '_') || 'classroom';
+      const safeName = latestName.replace(/[\\/:*?"<>|]/g, '_') || 'classroom';
       saveAs(zipBlob, `${safeName}${CLASSROOM_ZIP_EXTENSION}`);
 
       toast.success(t('export.exportSuccess'), { id: toastId });


### PR DESCRIPTION
## Summary
- Read the latest `stage.name` from IndexedDB before generating ZIP, instead of relying on the potentially stale Zustand store cache
- Fixes the issue where renaming a classroom on the home page had no effect on the exported ZIP filename

## Test plan
- [x] `pnpm check` (Prettier) passed
- [x] `pnpm lint` (ESLint) 0 errors
- [x] `npx tsc --noEmit` passed
- [x] `vitest run tests/export/` 5/5 passed
- [ ] Manual: rename a classroom on home page → re-enter → export ZIP → verify filename uses the new name

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)