### PR TITLE
feat(config): add GLM-5.1 and GLM-5V-Turbo to GLM preset models

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -451,7 +451,22 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     requiresApiKey: true,
     icon: '/logos/glm.svg',
     models: [
-      // GLM-5 Series - Latest flagship model
+      // GLM-5.1 Series - Latest flagship model
+      {
+        id: 'glm-5.1',
+        name: 'GLM-5.1',
+        contextWindow: 200000,
+        outputWindow: 128000,
+        capabilities: { streaming: true, tools: true, vision: false },
+      },
+      {
+        id: 'glm-5v-turbo',
+        name: 'GLM-5V-Turbo',
+        contextWindow: 200000,
+        outputWindow: 128000,
+        capabilities: { streaming: true, tools: true, vision: true },
+      },
+      // GLM-5 Series
       {
         id: 'glm-5',
         name: 'GLM-5',


### PR DESCRIPTION
## Summary
- Add GLM-5.1 and GLM-5V-Turbo to the GLM provider preset model list in `lib/ai/providers.ts`
- GLM-5.1: 200K context, 128K output, text-only reasoning model
- GLM-5V-Turbo: 200K context, 128K output, vision-enabled multimodal model

Closes #436

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

### Evidence
- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally

## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes do not introduce new warnings