### PR TITLE
feat(generation): depth-aware course scaffolding with coverage map

### DIFF
--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -34,6 +34,12 @@ import type {
 import { apiError } from '@/lib/server/api-response';
 import { createLogger } from '@/lib/logger';
 import { resolveModelFromHeaders } from '@/lib/server/resolve-model';
+import {
+  describeDepthProfile,
+  describeAudienceLevel,
+  defaultDepthLevelForOrder,
+} from '@/lib/generation/depth-profile';
+import type { DepthLevel } from '@/lib/types/generation';
 const log = createLogger('Outlines Stream');
 
 export const maxDuration = 300;
@@ -206,6 +212,9 @@ export async function POST(req: NextRequest) {
     // Build teacher context from agents (if available)
     const teacherContext = formatTeacherPersonaForPrompt(agents);
 
+    const depthProfile = requirements.depthProfile ?? 'standard';
+    const audienceLevel = requirements.audienceLevel ?? 'intermediate';
+
     const prompts = buildPrompt(PROMPT_IDS.REQUIREMENTS_TO_OUTLINES, {
       requirement: requirements.requirement,
       pdfContent: pdfText ? pdfText.substring(0, MAX_PDF_CONTENT_CHARS) : 'None',
@@ -214,6 +223,10 @@ export async function POST(req: NextRequest) {
       mediaGenerationPolicy,
       teacherContext,
       userProfile: userProfileText,
+      depthProfile,
+      audienceLevel,
+      depthProfileGuidance: describeDepthProfile(depthProfile),
+      audienceGuidance: describeAudienceLevel(audienceLevel),
     });
 
     if (!prompts) {
@@ -302,11 +315,17 @@ export async function POST(req: NextRequest) {
                 // Try to extract new outlines from the accumulated text
                 const newOutlines = extractNewOutlines(fullText, parsedOutlines.length);
                 for (const outline of newOutlines) {
-                  // Ensure ID and order
+                  // Ensure ID, order, and depthLevel default. Total scene count is
+                  // unknown mid-stream, so we use the running count as a best-effort
+                  // denominator — it's only used when the model omits depthLevel.
+                  const order = parsedOutlines.length + 1;
+                  const depthLevel: DepthLevel =
+                    outline.depthLevel ?? defaultDepthLevelForOrder(order, order);
                   const enriched = {
                     ...outline,
                     id: outline.id || nanoid(),
-                    order: parsedOutlines.length + 1,
+                    order,
+                    depthLevel,
                   };
                   parsedOutlines.push(enriched);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ import { AgentBar } from '@/components/agent/agent-bar';
 import { useTheme } from '@/lib/hooks/use-theme';
 import { nanoid } from 'nanoid';
 import { storePdfBlob } from '@/lib/utils/image-storage';
-import type { UserRequirements } from '@/lib/types/generation';
+import type { UserRequirements, DepthProfile, AudienceLevel } from '@/lib/types/generation';
 import { useSettingsStore } from '@/lib/store/settings';
 import { useUserProfileStore, AVATAR_OPTIONS } from '@/lib/store/user-profile';
 import {
@@ -54,18 +54,36 @@ import { useImportClassroom } from '@/lib/import/use-import-classroom';
 const log = createLogger('Home');
 
 const WEB_SEARCH_STORAGE_KEY = 'webSearchEnabled';
+const DEPTH_PROFILE_STORAGE_KEY = 'depthProfile';
+const AUDIENCE_LEVEL_STORAGE_KEY = 'audienceLevel';
 const RECENT_OPEN_STORAGE_KEY = 'recentClassroomsOpen';
+
+const DEPTH_PROFILE_VALUES: ReadonlyArray<DepthProfile> = [
+  'overview',
+  'standard',
+  'deep-dive',
+  'mastery',
+];
+const AUDIENCE_LEVEL_VALUES: ReadonlyArray<AudienceLevel> = [
+  'beginner',
+  'intermediate',
+  'advanced',
+];
 
 interface FormState {
   pdfFile: File | null;
   requirement: string;
   webSearch: boolean;
+  depthProfile: DepthProfile;
+  audienceLevel: AudienceLevel;
 }
 
 const initialFormState: FormState = {
   pdfFile: null,
   requirement: '',
   webSearch: false,
+  depthProfile: 'standard',
+  audienceLevel: 'intermediate',
 };
 
 function HomePage() {
@@ -97,8 +115,16 @@ function HomePage() {
     }
     try {
       const savedWebSearch = localStorage.getItem(WEB_SEARCH_STORAGE_KEY);
+      const savedDepth = localStorage.getItem(DEPTH_PROFILE_STORAGE_KEY);
+      const savedAudience = localStorage.getItem(AUDIENCE_LEVEL_STORAGE_KEY);
       const updates: Partial<FormState> = {};
       if (savedWebSearch === 'true') updates.webSearch = true;
+      if (savedDepth && DEPTH_PROFILE_VALUES.includes(savedDepth as DepthProfile)) {
+        updates.depthProfile = savedDepth as DepthProfile;
+      }
+      if (savedAudience && AUDIENCE_LEVEL_VALUES.includes(savedAudience as AudienceLevel)) {
+        updates.audienceLevel = savedAudience as AudienceLevel;
+      }
       if (Object.keys(updates).length > 0) {
         setForm((prev) => ({ ...prev, ...updates }));
       }
@@ -198,6 +224,9 @@ function HomePage() {
     setForm((prev) => ({ ...prev, [field]: value }));
     try {
       if (field === 'webSearch') localStorage.setItem(WEB_SEARCH_STORAGE_KEY, String(value));
+      if (field === 'depthProfile') localStorage.setItem(DEPTH_PROFILE_STORAGE_KEY, value as string);
+      if (field === 'audienceLevel')
+        localStorage.setItem(AUDIENCE_LEVEL_STORAGE_KEY, value as string);
       if (field === 'requirement') updateRequirementCache(value as string);
     } catch {
       /* ignore */
@@ -260,6 +289,8 @@ function HomePage() {
         userNickname: userProfile.nickname || undefined,
         userBio: userProfile.bio || undefined,
         webSearch: form.webSearch || undefined,
+        depthProfile: form.depthProfile,
+        audienceLevel: form.audienceLevel,
       };
 
       let pdfStorageKey: string | undefined;
@@ -512,6 +543,10 @@ function HomePage() {
                   pdfFile={form.pdfFile}
                   onPdfFileChange={(f) => updateForm('pdfFile', f)}
                   onPdfError={setError}
+                  depthProfile={form.depthProfile}
+                  onDepthProfileChange={(v) => updateForm('depthProfile', v)}
+                  audienceLevel={form.audienceLevel}
+                  onAudienceLevelChange={(v) => updateForm('audienceLevel', v)}
                 />
               </div>
 

--- a/components/generation/generation-toolbar.tsx
+++ b/components/generation/generation-toolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useMemo } from 'react';
-import { Bot, Check, ChevronLeft, Paperclip, FileText, X, Globe2 } from 'lucide-react';
+import { Bot, Check, ChevronLeft, Paperclip, FileText, X, Globe2, Layers } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
@@ -21,6 +21,7 @@ import type { WebSearchProviderId } from '@/lib/web-search/types';
 import type { ProviderId } from '@/lib/ai/providers';
 import { MONO_LOGO_PROVIDERS } from '@/lib/ai/providers';
 import type { SettingsSection } from '@/lib/types/settings';
+import type { DepthProfile, AudienceLevel } from '@/lib/types/generation';
 import { MediaPopover } from '@/components/generation/media-popover';
 
 // ─── Constants ───────────────────────────────────────────────
@@ -36,6 +37,11 @@ export interface GenerationToolbarProps {
   pdfFile: File | null;
   onPdfFileChange: (file: File | null) => void;
   onPdfError: (error: string | null) => void;
+  // Depth
+  depthProfile: DepthProfile;
+  onDepthProfileChange: (v: DepthProfile) => void;
+  audienceLevel: AudienceLevel;
+  onAudienceLevelChange: (v: AudienceLevel) => void;
 }
 
 // ─── Component ───────────────────────────────────────────────
@@ -46,6 +52,10 @@ export function GenerationToolbar({
   pdfFile,
   onPdfFileChange,
   onPdfError,
+  depthProfile,
+  onDepthProfileChange,
+  audienceLevel,
+  onAudienceLevelChange,
 }: GenerationToolbarProps) {
   const { t } = useI18n();
   const currentProviderId = useSettingsStore((s) => s.providerId);
@@ -359,10 +369,85 @@ export function GenerationToolbar({
       {/* ── Separator ── */}
       <div className="w-px h-4 bg-border/60 mx-1" />
 
+      {/* ── Depth profile + audience ── */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            className={
+              depthProfile === 'standard' && audienceLevel === 'intermediate' ? pillMuted : pillActive
+            }
+          >
+            <Layers className="size-3.5" />
+            <span>{depthProfileShortLabel(depthProfile)}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-72 p-3 space-y-3">
+          <div>
+            <p className="text-xs font-semibold mb-0.5">{t('toolbar.depth')}</p>
+            <p className="text-[10px] text-muted-foreground/70">{t('toolbar.depthDesc')}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground shrink-0 w-20">
+              {t('toolbar.depthProfile')}
+            </span>
+            <Select
+              value={depthProfile}
+              onValueChange={(v) => onDepthProfileChange(v as DepthProfile)}
+            >
+              <SelectTrigger className="h-7 text-xs flex-1 min-w-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="overview">{t('toolbar.depthProfileOverview')}</SelectItem>
+                <SelectItem value="standard">{t('toolbar.depthProfileStandard')}</SelectItem>
+                <SelectItem value="deep-dive">{t('toolbar.depthProfileDeepDive')}</SelectItem>
+                <SelectItem value="mastery">{t('toolbar.depthProfileMastery')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground shrink-0 w-20">
+              {t('toolbar.depthAudience')}
+            </span>
+            <Select
+              value={audienceLevel}
+              onValueChange={(v) => onAudienceLevelChange(v as AudienceLevel)}
+            >
+              <SelectTrigger className="h-7 text-xs flex-1 min-w-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="beginner">{t('toolbar.depthAudienceBeginner')}</SelectItem>
+                <SelectItem value="intermediate">
+                  {t('toolbar.depthAudienceIntermediate')}
+                </SelectItem>
+                <SelectItem value="advanced">{t('toolbar.depthAudienceAdvanced')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* ── Separator ── */}
+      <div className="w-px h-4 bg-border/60 mx-1" />
+
       {/* ── Media popover ── */}
       <MediaPopover onSettingsOpen={onSettingsOpen} />
     </div>
   );
+}
+
+function depthProfileShortLabel(profile: DepthProfile): string {
+  switch (profile) {
+    case 'overview':
+      return 'Overview';
+    case 'standard':
+      return 'Standard';
+    case 'deep-dive':
+      return 'Deep dive';
+    case 'mastery':
+      return 'Mastery';
+  }
 }
 
 // ─── ModelSelectorPopover (two-level: provider → model) ─────

--- a/lib/generation/depth-profile.ts
+++ b/lib/generation/depth-profile.ts
@@ -1,0 +1,109 @@
+/**
+ * Depth-tier helpers shared by the outline generator, validator, and scene-content prompts.
+ *
+ * These describe the cognitive scaffolding contract:
+ *   foundation → building → application → synthesis → mastery
+ * and provide profile-specific distribution targets so a course can be tuned
+ * from a quick overview to a research-level deep-dive.
+ */
+
+import type {
+  DepthLevel,
+  DepthProfile,
+  AudienceLevel,
+  SceneOutline,
+} from '@/lib/types/generation';
+
+export const DEPTH_LEVELS: readonly DepthLevel[] = [
+  'foundation',
+  'building',
+  'application',
+  'synthesis',
+  'mastery',
+] as const;
+
+export const DEFAULT_DEPTH_PROFILE: DepthProfile = 'standard';
+export const DEFAULT_AUDIENCE_LEVEL: AudienceLevel = 'intermediate';
+
+/**
+ * Target percentage of scenes at each depth tier per course profile.
+ * Values per row sum to 100. Used both as the prompt directive and
+ * as the validator's expected distribution (with a tolerance).
+ */
+export const DEPTH_DISTRIBUTION: Record<
+  DepthProfile,
+  Record<DepthLevel, number>
+> = {
+  overview: { foundation: 50, building: 30, application: 15, synthesis: 5, mastery: 0 },
+  standard: { foundation: 30, building: 35, application: 25, synthesis: 10, mastery: 0 },
+  'deep-dive': { foundation: 20, building: 30, application: 30, synthesis: 15, mastery: 5 },
+  mastery: { foundation: 15, building: 25, application: 30, synthesis: 20, mastery: 10 },
+};
+
+/** Tiers that must declare prerequisiteSceneIds. */
+export const TIERS_REQUIRING_PREREQUISITES: ReadonlySet<DepthLevel> = new Set([
+  'application',
+  'synthesis',
+  'mastery',
+]);
+
+/** Human-readable summary of the depth profile (injected into prompts). */
+export function describeDepthProfile(profile: DepthProfile): string {
+  const dist = DEPTH_DISTRIBUTION[profile];
+  const parts = DEPTH_LEVELS.filter((l) => dist[l] > 0).map((l) => `${l} ~${dist[l]}%`);
+  const summary: Record<DepthProfile, string> = {
+    overview: 'Quick survey: prioritize big picture and motivation; minimal advanced material.',
+    standard: 'Balanced course: solid foundation, worked examples, some application.',
+    'deep-dive':
+      'Deep dive: assume basics covered quickly, spend most time on application and synthesis.',
+    mastery: 'Mastery / research-level: rigorous derivations, edge cases, novel applications.',
+  };
+  return `${profile} — ${summary[profile]}\nTarget tier distribution: ${parts.join(', ')}.`;
+}
+
+export function describeAudienceLevel(level: AudienceLevel): string {
+  const summary: Record<AudienceLevel, string> = {
+    beginner:
+      'Beginner: assume no prior background. Define every term, use everyday analogies, avoid jargon.',
+    intermediate:
+      'Intermediate: assume comfortable with prerequisites. Move quickly through basics, focus on mechanisms and application.',
+    advanced:
+      'Advanced: assume strong background. Skip elementary review entirely; engage with nuance, tradeoffs, and edge cases.',
+  };
+  return `${level} — ${summary[level]}`;
+}
+
+/**
+ * Conservative default when the LLM forgets to emit `depthLevel` for a scene.
+ * Roughly maps scene order to a tier following the standard distribution.
+ */
+export function defaultDepthLevelForOrder(order: number, total: number): DepthLevel {
+  if (total <= 0) return 'building';
+  const pct = order / total;
+  if (pct <= 0.3) return 'foundation';
+  if (pct <= 0.65) return 'building';
+  if (pct <= 0.9) return 'application';
+  return 'synthesis';
+}
+
+/** Compute actual tier distribution percentages (rounded). */
+export function computeDepthDistribution(
+  outlines: Pick<SceneOutline, 'depthLevel'>[],
+): Record<DepthLevel, number> {
+  const dist: Record<DepthLevel, number> = {
+    foundation: 0,
+    building: 0,
+    application: 0,
+    synthesis: 0,
+    mastery: 0,
+  };
+  if (outlines.length === 0) return dist;
+  for (const o of outlines) {
+    const level = (o.depthLevel ?? 'building') as DepthLevel;
+    dist[level] += 1;
+  }
+  for (const k of DEPTH_LEVELS) {
+    dist[k] = Math.round((dist[k] / outlines.length) * 100);
+  }
+  return dist;
+}

--- a/lib/generation/outline-generator.ts
+++ b/lib/generation/outline-generator.ts
@@ -10,7 +10,17 @@ import type {
   SceneOutline,
   PdfImage,
   ImageMapping,
+  OutlineGenerationOutput,
+  CoverageMap,
+  DepthProfile,
+  AudienceLevel,
+  DepthLevel,
 } from '@/lib/types/generation';
+import {
+  defaultDepthLevelForOrder,
+  describeDepthProfile,
+  describeAudienceLevel,
+} from './depth-profile';
 import { buildPrompt, PROMPT_IDS } from './prompts';
 import { formatImageDescription, formatImagePlaceholder } from './prompt-formatters';
 import { parseJsonResponse } from './json-repair';
@@ -37,7 +47,9 @@ export async function generateSceneOutlinesFromRequirements(
     researchContext?: string;
     teacherContext?: string;
   },
-): Promise<GenerationResult<{ languageDirective: string; outlines: SceneOutline[] }>> {
+): Promise<GenerationResult<OutlineGenerationOutput>> {
+  const depthProfile: DepthProfile = requirements.depthProfile ?? 'standard';
+  const audienceLevel: AudienceLevel = requirements.audienceLevel ?? 'intermediate';
   // Build available images description for the prompt
   let availableImagesText = 'No images available';
   let visionImages: Array<{ id: string; src: string }> | undefined;
@@ -100,6 +112,10 @@ export async function generateSceneOutlinesFromRequirements(
     researchContext: options?.researchContext || 'None',
     // Server-side generation populates this via options; client-side populates via formatTeacherPersonaForPrompt
     teacherContext: options?.teacherContext || '',
+    depthProfile,
+    audienceLevel,
+    depthProfileGuidance: describeDepthProfile(depthProfile),
+    audienceGuidance: describeAudienceLevel(audienceLevel),
   });
 
   if (!prompts) {
@@ -118,11 +134,19 @@ export async function generateSceneOutlinesFromRequirements(
 
     const response = await aiCall(prompts.system, prompts.user, visionImages);
     const parsed = parseJsonResponse<
-      { languageDirective: string; outlines: SceneOutline[] } | SceneOutline[]
+      | {
+          languageDirective: string;
+          outlines: SceneOutline[];
+          coverageMap?: CoverageMap;
+          depthProfile?: DepthProfile;
+        }
+      | SceneOutline[]
     >(response);
 
     let languageDirective: string;
     let rawOutlines: SceneOutline[];
+    let coverageMap: CoverageMap = { topics: [] };
+    let returnedDepthProfile: DepthProfile = depthProfile;
 
     if (Array.isArray(parsed)) {
       // Fallback: LLM returned old flat array format
@@ -132,6 +156,8 @@ export async function generateSceneOutlinesFromRequirements(
       languageDirective =
         parsed.languageDirective || 'Teach in the language that matches the user requirement.';
       rawOutlines = parsed.outlines;
+      if (parsed.coverageMap?.topics) coverageMap = parsed.coverageMap;
+      if (parsed.depthProfile) returnedDepthProfile = parsed.depthProfile;
     } else {
       return { success: false, error: 'Failed to parse scene outlines response' };
     }
@@ -140,12 +166,15 @@ export async function generateSceneOutlinesFromRequirements(
       return { success: false, error: 'Failed to parse scene outlines response' };
     }
 
-    // Ensure IDs and order
-    const enriched = rawOutlines.map((outline, index) => ({
-      ...outline,
-      id: outline.id || nanoid(),
-      order: index + 1,
-    }));
+    // Ensure IDs and order; default depthLevel when the model omits it.
+    const totalScenes = rawOutlines.length;
+    const enriched: SceneOutline[] = rawOutlines.map((outline, index) => {
+      const id = outline.id || nanoid();
+      const order = index + 1;
+      const depthLevel: DepthLevel =
+        outline.depthLevel ?? defaultDepthLevelForOrder(order, totalScenes);
+      return { ...outline, id, order, depthLevel };
+    });
 
     // Replace sequential gen_img_N/gen_vid_N with globally unique IDs
     const result = uniquifyMediaElementIds(enriched);
@@ -159,7 +188,15 @@ export async function generateSceneOutlinesFromRequirements(
       totalScenes: result.length,
     });
 
-    return { success: true, data: { languageDirective, outlines: result } };
+    return {
+      success: true,
+      data: {
+        languageDirective,
+        outlines: result,
+        coverageMap,
+        depthProfile: returnedDepthProfile,
+      },
+    };
   } catch (error) {
     return { success: false, error: String(error) };
   }

--- a/lib/generation/outline-validator.ts
+++ b/lib/generation/outline-validator.ts
@@ -1,0 +1,133 @@
+/**
+ * Pure-function validators for the post-generation outline.
+ *
+ * The LLM is good at producing structurally-correct JSON but bad at honoring
+ * progression rules consistently. These checks let the pipeline (and tests)
+ * detect when an outline violates the depth-scaffolding contract — drop a
+ * `synthesis` scene before its prerequisite, miss the foundation tier
+ * entirely, or over/under-shoot the requested depth profile.
+ *
+ * The LLM-as-judge `validateCoverage` (free-text gap detection) is deliberately
+ * not in this file — it lives in a follow-up so this module stays free of
+ * AI calls and can be reasoned about with plain unit tests.
+ */
+
+import type { SceneOutline, DepthProfile, DepthLevel } from '@/lib/types/generation';
+import {
+  DEPTH_DISTRIBUTION,
+  DEPTH_LEVELS,
+  TIERS_REQUIRING_PREREQUISITES,
+  computeDepthDistribution,
+  DEFAULT_DEPTH_PROFILE,
+} from './depth-profile';
+
+/** A single violation of the progression contract. */
+export interface DepthValidationIssue {
+  code:
+    | 'EMPTY_OUTLINE'
+    | 'FIRST_NOT_FOUNDATION'
+    | 'PREREQUISITE_MISSING'
+    | 'PREREQUISITE_OUT_OF_ORDER'
+    | 'PREREQUISITE_REQUIRED'
+    | 'DISTRIBUTION_OFF';
+  message: string;
+  sceneId?: string;
+}
+
+export interface DepthValidationResult {
+  ok: boolean;
+  issues: DepthValidationIssue[];
+  /** Actual tier distribution (percentages summing to ~100). */
+  actualDistribution: Record<DepthLevel, number>;
+  expectedDistribution: Record<DepthLevel, number>;
+}
+
+/**
+ * How far each tier's actual % may drift from the target before it's flagged.
+ * Generous on purpose — small courses can't hit exact percentages.
+ */
+const DISTRIBUTION_TOLERANCE_PCT = 20;
+
+/** Validate a generated outline against the depth-scaffolding contract. */
+export function validateDepthProgression(
+  outlines: SceneOutline[],
+  profile: DepthProfile = DEFAULT_DEPTH_PROFILE,
+): DepthValidationResult {
+  const issues: DepthValidationIssue[] = [];
+  const expectedDistribution = DEPTH_DISTRIBUTION[profile];
+
+  if (outlines.length === 0) {
+    return {
+      ok: false,
+      issues: [{ code: 'EMPTY_OUTLINE', message: 'Outline contains no scenes.' }],
+      actualDistribution: emptyDistribution(),
+      expectedDistribution,
+    };
+  }
+
+  const sorted = [...outlines].sort((a, b) => a.order - b.order);
+  const idToOrder = new Map(sorted.map((o) => [o.id, o.order]));
+
+  // Rule 1: first scene must be foundation
+  if (sorted[0].depthLevel && sorted[0].depthLevel !== 'foundation') {
+    issues.push({
+      code: 'FIRST_NOT_FOUNDATION',
+      sceneId: sorted[0].id,
+      message: `First scene is "${sorted[0].depthLevel}" but must be "foundation" — students need a starting ramp.`,
+    });
+  }
+
+  // Rule 2: prerequisites must exist and come earlier
+  for (const scene of sorted) {
+    const tier = scene.depthLevel ?? 'building';
+    const prereqs = scene.prerequisiteSceneIds ?? [];
+
+    if (TIERS_REQUIRING_PREREQUISITES.has(tier) && prereqs.length === 0) {
+      issues.push({
+        code: 'PREREQUISITE_REQUIRED',
+        sceneId: scene.id,
+        message: `Scene "${scene.title}" is at tier "${tier}" but declares no prerequisiteSceneIds.`,
+      });
+    }
+
+    for (const pid of prereqs) {
+      const prereqOrder = idToOrder.get(pid);
+      if (prereqOrder === undefined) {
+        issues.push({
+          code: 'PREREQUISITE_MISSING',
+          sceneId: scene.id,
+          message: `Scene "${scene.title}" references unknown prerequisiteSceneId "${pid}".`,
+        });
+      } else if (prereqOrder >= scene.order) {
+        issues.push({
+          code: 'PREREQUISITE_OUT_OF_ORDER',
+          sceneId: scene.id,
+          message: `Scene "${scene.title}" (order ${scene.order}) references prerequisite "${pid}" with order ${prereqOrder} — prerequisites must come earlier.`,
+        });
+      }
+    }
+  }
+
+  // Rule 3: actual distribution roughly matches the profile
+  const actualDistribution = computeDepthDistribution(sorted);
+  for (const tier of DEPTH_LEVELS) {
+    const drift = Math.abs(actualDistribution[tier] - expectedDistribution[tier]);
+    if (drift > DISTRIBUTION_TOLERANCE_PCT) {
+      issues.push({
+        code: 'DISTRIBUTION_OFF',
+        message: `Depth tier "${tier}": actual ${actualDistribution[tier]}% vs expected ${expectedDistribution[tier]}% (${profile} profile).`,
+      });
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+    actualDistribution,
+    expectedDistribution,
+  };
+}
+
+function emptyDistribution(): Record<DepthLevel, number> {
+  return { foundation: 0, building: 0, application: 0, synthesis: 0, mastery: 0 };
+}

--- a/lib/generation/pipeline-types.ts
+++ b/lib/generation/pipeline-types.ts
@@ -2,7 +2,12 @@
  * Type definitions for the generation pipeline.
  */
 
-import type { GenerationProgress } from '@/lib/types/generation';
+import type {
+  GenerationProgress,
+  SceneOutline,
+  DepthLevel,
+  DepthProfile,
+} from '@/lib/types/generation';
 
 // ==================== Agent Info ====================
 
@@ -16,12 +21,23 @@ export interface AgentInfo {
 
 // ==================== Cross-Page Context ====================
 
+/** Compact prior-scene reference for content scaffolding (no actions/canvas). */
+export type PriorOutlineRef = Pick<
+  SceneOutline,
+  'id' | 'order' | 'title' | 'keyPoints' | 'depthLevel'
+>;
+
 /** Cross-page context for maintaining speech coherence across scenes */
 export interface SceneGenerationContext {
   pageIndex: number; // Current page (1-based)
   totalPages: number; // Total number of pages
   allTitles: string[]; // All page titles in order
   previousSpeeches: string[]; // Speech texts from the previous page only
+  // Depth scaffolding context (optional for backwards compat — older callers
+  // that don't yet thread these through still get a working speech context).
+  priorOutlines?: PriorOutlineRef[];
+  currentDepthLevel?: DepthLevel;
+  depthProfile?: DepthProfile;
 }
 
 // ==================== Generated Slide Data Interface ====================

--- a/lib/generation/prompt-formatters.ts
+++ b/lib/generation/prompt-formatters.ts
@@ -49,6 +49,45 @@ export function buildCourseContext(ctx?: SceneGenerationContext): string {
   return lines.join('\n');
 }
 
+/**
+ * Build a scaffolding context block that lists prior scenes and instructs the
+ * model on how this scene should build on them. Used by the slide / quiz /
+ * interactive content prompts to enforce progressive depth.
+ */
+export function buildContentScaffoldContext(ctx?: SceneGenerationContext): string {
+  if (!ctx || !ctx.priorOutlines || ctx.priorOutlines.length === 0) return '';
+
+  const lines: string[] = ['Already-established concepts (from earlier scenes in this course):'];
+  for (const o of ctx.priorOutlines) {
+    const points = o.keyPoints?.length ? o.keyPoints.join('; ') : '(no key points listed)';
+    const tier = o.depthLevel ? ` [${o.depthLevel}]` : '';
+    lines.push(`- Scene ${o.order}${tier} "${o.title}": ${points}`);
+  }
+
+  const currentTier = ctx.currentDepthLevel ?? 'building';
+  const profile = ctx.depthProfile ?? 'standard';
+  lines.push('');
+  lines.push(
+    `This scene is at depth tier **${currentTier}** in a **${profile}** course. Do NOT re-explain the established concepts above — reference them by name and build on them.`,
+  );
+
+  if (currentTier === 'application' || currentTier === 'synthesis' || currentTier === 'mastery') {
+    lines.push(
+      'Because this is an application+ tier scene: include at least one worked example, derivation step, comparison, or non-trivial edge case. Density and rigor matter more than brevity.',
+    );
+  } else if (currentTier === 'building') {
+    lines.push(
+      'Because this is a building tier scene: walk through the mechanism with a concrete worked example.',
+    );
+  } else {
+    lines.push(
+      'Because this is a foundation tier scene: motivate the concept, define terms clearly, and use the simplest possible example.',
+    );
+  }
+
+  return lines.join('\n');
+}
+
 /** Format agent list for injection into action prompts */
 export function formatAgentsForPrompt(agents?: AgentInfo[]): string {
   if (!agents || agents.length === 0) return '';

--- a/lib/generation/prompts/templates/quiz-content/system.md
+++ b/lib/generation/prompts/templates/quiz-content/system.md
@@ -96,6 +96,18 @@ Open-ended question requiring a written response. No options or predefined answe
 | medium     | Requires understanding and simple analysis           |
 | hard       | Requires synthesis, evaluation, or complex reasoning |
 
+### Depth-tier alignment
+
+The scene's overall depth tier is **`{{depthLevel}}`**. Difficulty MUST match this tier — never produce a recall question when the surrounding scenes are doing application/synthesis work.
+
+| Scene depth tier | Expected question difficulty                                       |
+| ---------------- | ------------------------------------------------------------------ |
+| foundation       | easy — definitions and one-step recall                             |
+| building         | easy / medium — recognise the mechanism in a simple scenario       |
+| application      | medium / hard — apply to a non-trivial case, compare options       |
+| synthesis        | hard — combine multiple prior concepts, evaluate tradeoffs         |
+| mastery          | hard — novel scenario, justify a choice with multi-step reasoning  |
+
 ## Output Format
 
 Output a JSON array of question objects. Every question must have `analysis` and `points`:

--- a/lib/generation/prompts/templates/quiz-content/user.md
+++ b/lib/generation/prompts/templates/quiz-content/user.md
@@ -1,7 +1,10 @@
 Title: {{title}}
 Description: {{description}}
+Depth Tier: {{depthLevel}}
 Test Points: {{keyPoints}}
 Question Count: {{questionCount}}, Difficulty: {{difficulty}}, Question Types: {{questionTypes}}
+
+{{scaffoldContext}}
 
 ## Language Directive
 {{languageDirective}}

--- a/lib/generation/prompts/templates/requirements-to-outlines/system.md
+++ b/lib/generation/prompts/templates/requirements-to-outlines/system.md
@@ -66,6 +66,71 @@ Infer the course language from all available signals and produce:
 
 ---
 
+## Coverage Planning (REQUIRED)
+
+Before writing scenes, **decompose the requested topic into 5–12 sub-topics** that together fully cover the user's goal. Each sub-topic must be addressed by at least one scene. Surface this plan as the top-level `coverageMap` field in the output:
+
+```json
+"coverageMap": {
+  "topics": [
+    {
+      "name": "Self-attention mechanism",
+      "rationale": "The foundational operation that makes Transformers work — without it learners cannot reason about anything else.",
+      "addressedBySceneIds": ["scene_3", "scene_4"]
+    }
+  ]
+}
+```
+
+Rules:
+- **Completeness over brevity.** If the user asks "teach me X", every standard sub-topic of X must appear, even if briefly. Don't skip a sub-topic just because the course is short — shorten its scene instead.
+- Every `addressedBySceneIds` entry must reference a scene that actually exists in `outlines`.
+- Every scene should map to at least one coverage topic (no orphan scenes).
+- Order topics roughly in the order they appear in the course.
+
+---
+
+## Progressive Depth Scaffolding (REQUIRED)
+
+Each scene has a **`depthLevel`** chosen from this ladder (loosely Bloom-aligned):
+
+| Tier          | Cognitive load                                                            |
+| ------------- | -------------------------------------------------------------------------- |
+| `foundation`  | Definitions, motivation, simplest examples. "What is X?"                  |
+| `building`    | Mechanisms, walkthroughs, worked examples. "How does X work?"             |
+| `application` | Non-trivial problems, comparisons, edge cases. "When/how do I use X?"     |
+| `synthesis`   | Combine multiple concepts, design tradeoffs. "How does X fit with Y, Z?"  |
+| `mastery`     | Novel scenarios, research-level depth. "What are X's frontiers?"          |
+
+**Order matters**: scenes must climb this ladder roughly monotonically. The first scene must be `foundation`. Never put a `synthesis`/`mastery` scene before its prerequisites have been established.
+
+### Depth Profile
+
+The course depth profile is **`{{depthProfile}}`** ({{depthProfileGuidance}}).
+
+Match this distribution as closely as the topic allows. A `deep-dive` course is **noticeably heavier in `application`/`synthesis`** than a `standard` course — do NOT default to a shallow overview.
+
+### Prerequisites
+
+For every scene at `application`, `synthesis`, or `mastery`, set `prerequisiteSceneIds` to the scene IDs whose concepts this scene builds on. Each prerequisite ID must reference a scene with **strictly smaller `order`**. Foundation/building scenes may omit `prerequisiteSceneIds`.
+
+### Depth, not length
+
+A higher depth tier means **denser concepts and more rigor**, not just more words. Application+ scenes should:
+- Reference a specific prior scene by ID and extend its idea
+- Include at least one worked example, derivation step, comparison, or edge case
+- Avoid re-explaining anything already established in earlier scenes
+
+---
+
+## Audience Level
+
+The audience level is **`{{audienceLevel}}`** ({{audienceGuidance}}).
+
+This shifts where the foundation tier lands. Advanced audiences need only minimal foundation scenes; beginners need more.
+
+---
+
 ## Default Assumption Rules
 
 When user requirements don't specify, use these defaults:
@@ -218,6 +283,16 @@ Output a JSON **object** (not a bare array) with this structure:
 ```json
 {
   "languageDirective": "2-5 sentence instruction describing the course language behavior",
+  "depthProfile": "standard",
+  "coverageMap": {
+    "topics": [
+      {
+        "name": "Sub-topic name",
+        "rationale": "Why this sub-topic matters for the course goal",
+        "addressedBySceneIds": ["scene_1", "scene_2"]
+      }
+    ]
+  },
   "outlines": [
     {
       "id": "scene_1",
@@ -226,6 +301,7 @@ Output a JSON **object** (not a bare array) with this structure:
       "description": "1-2 sentences describing the teaching purpose",
       "keyPoints": ["Key point 1", "Key point 2", "Key point 3"],
       "teachingObjective": "Corresponding learning objective",
+      "depthLevel": "foundation",
       "estimatedDuration": 120,
       "order": 1,
       "suggestedImageIds": ["img_1"],
@@ -258,6 +334,8 @@ Output a JSON **object** (not a bare array) with this structure:
       "title": "Knowledge Check",
       "description": "Test student understanding of XX concept",
       "keyPoints": ["Test point 1", "Test point 2"],
+      "depthLevel": "application",
+      "prerequisiteSceneIds": ["scene_1", "scene_2"],
       "order": 3,
       "quizConfig": {
         "questionCount": 2,
@@ -287,6 +365,8 @@ Output a JSON **object** (not a bare array) with this structure:
 | interactiveConfig | object                   | ❌       | Required for interactive type, contains conceptName/conceptOverview/designIdea/subject           |
 | languageNote      | string                   | ❌       | Optional. Only include when this scene has language considerations not covered by the course-level languageDirective. |
 | pblConfig         | object                   | ❌       | Required for pbl type, contains projectTopic/projectDescription/targetSkills/issueCount |
+| depthLevel        | string                   | ✅       | One of `foundation`/`building`/`application`/`synthesis`/`mastery` (see Progressive Depth Scaffolding) |
+| prerequisiteSceneIds | string[]              | conditional | Required when `depthLevel` is `application`/`synthesis`/`mastery`. Each ID must reference a scene with smaller `order`. |
 
 ### quizConfig Structure
 
@@ -324,14 +404,15 @@ Output a JSON **object** (not a bare array) with this structure:
 
 ## Important Reminders
 
-1. **Must output valid JSON object with `languageDirective` and `outlines` fields**
+1. **Must output valid JSON object with `languageDirective`, `coverageMap`, `depthProfile`, and `outlines` fields**
 2. **type can be `"slide"`, `"quiz"`, `"interactive"`, or `"pbl"`**
 3. **quiz type must include quizConfig**
 4. **interactive type must include interactiveConfig** - with conceptName, conceptOverview, designIdea, and subject
    5b. **pbl type must include pblConfig** - with projectTopic, projectDescription, targetSkills, and issueCount
-5. Arrange appropriate number of scenes based on inferred duration (typically 1-2 scenes per minute)
-6. Insert quizzes at appropriate points for knowledge checks
+5. **Scene count is depth-driven, not just duration-driven.** Standard courses run ~1-2 scenes per minute; `deep-dive` and `mastery` courses can run 1.5-3× longer to give application/synthesis tiers room to breathe. Don't truncate the curriculum to hit a duration target — extend the duration instead.
+6. Insert quizzes at appropriate points for knowledge checks. Quiz `depthLevel` should match the surrounding material (a quiz after `application` scenes should itself be `application`).
 7. Use interactive scenes sparingly (max 1-2 per course) and only when the concept truly benefits from hands-on interaction
 8. **Language**: Infer from the user's requirement text and context. Output all scene content in the inferred language.
 9. Regardless of information completeness, always output conforming JSON - do not ask questions or request more information
 10. **No teacher identity on slides**: Scene titles and keyPoints must be neutral and topic-focused. Never include the teacher's name or role (e.g., avoid "Teacher Wang's Tips", "Teacher's Wishes"). Use generic labels like "Tips", "Summary", "Key Takeaways" instead.
+11. **Every scene must declare `depthLevel`**, scenes ≥ application must declare `prerequisiteSceneIds`, and the top-level `coverageMap` must list every sub-topic with the scenes that address it.

--- a/lib/generation/prompts/templates/requirements-to-outlines/user.md
+++ b/lib/generation/prompts/templates/requirements-to-outlines/user.md
@@ -37,21 +37,38 @@ Infer the course language directive by applying the decision rules from the syst
 
 ---
 
+## Course Depth Configuration
+
+**Depth profile:** {{depthProfileGuidance}}
+
+**Audience level:** {{audienceGuidance}}
+
+Honor these settings strictly. A `deep-dive` or `mastery` profile must produce a course that is **noticeably deeper** than `standard` — more application/synthesis scenes, denser key points per scene, and explicit prerequisite chains. Do not collapse to a generic survey.
+
+---
+
 ## Output Requirements
 
 Please automatically infer the following from user requirements:
 
 - Course topic and core content
-- Target audience and difficulty level
-- Course duration (default 15-30 minutes if not specified)
+- Course duration (default 15-30 minutes for `standard`; longer for `deep-dive`/`mastery`)
 - Teaching style (formal/casual/interactive/academic)
 - Visual style (minimal/colorful/professional/playful)
 
-Then output a JSON object with `languageDirective` and `outlines`. Each scene in the `outlines` array must include:
+The audience level and depth profile are already specified above — do NOT re-infer them.
+
+Then output a JSON object with `languageDirective`, `depthProfile`, `coverageMap`, and `outlines`:
 
 ```json
 {
   "languageDirective": "2-5 sentence instruction describing the course language behavior",
+  "depthProfile": "{{depthProfile}}",
+  "coverageMap": {
+    "topics": [
+      { "name": "Sub-topic", "rationale": "Why it matters", "addressedBySceneIds": ["scene_1"] }
+    ]
+  },
   "outlines": [
     {
       "id": "scene_1",
@@ -59,11 +76,14 @@ Then output a JSON object with `languageDirective` and `outlines`. Each scene in
       "title": "Scene Title",
       "description": "Teaching purpose description",
       "keyPoints": ["Point 1", "Point 2", "Point 3"],
+      "depthLevel": "foundation",
       "order": 1
     }
   ]
 }
 ```
+
+`coverageMap` MUST list every sub-topic of the requested course; every scene MUST declare `depthLevel`; scenes at `application`/`synthesis`/`mastery` MUST declare `prerequisiteSceneIds` referencing earlier scenes.
 
 ### Special Notes
 
@@ -77,7 +97,7 @@ Then output a JSON object with `languageDirective` and `outlines`. Each scene in
    ```
 2. **If images are available**, add `suggestedImageIds` to relevant slide scenes
 3. **Interactive scenes**: If a concept benefits from hands-on simulation/visualization, use `"type": "interactive"` with an `interactiveConfig` object containing `conceptName`, `conceptOverview`, `designIdea`, and `subject`. Limit to 1-2 per course.
-4. **Scene count**: Based on inferred duration, typically 1-2 scenes per minute
+4. **Scene count**: Standard courses ~1-2 scenes/min; deep-dive/mastery courses 1.5-3× more scenes to give application/synthesis tiers room. Don't truncate the curriculum to hit a duration target.
 5. **Quiz placement**: Recommend inserting a quiz every 3-5 slides for assessment
 6. **Language**: Infer from the user's requirement text and context, then output all content in the inferred language
 7. **If no suitable PDF images exist** for a slide scene that would benefit from visuals, add `mediaGenerations` array with image generation prompts. Write prompts in English. Use `elementId` format like "gen_img_1", "gen_img_2" — IDs must be **globally unique across all scenes** (do NOT restart numbering per scene). To reuse a generated image in a different scene, reference the same elementId without re-declaring it in mediaGenerations. Each generated image should be visually distinct — avoid near-identical media across slides.

--- a/lib/generation/prompts/templates/slide-content/system.md
+++ b/lib/generation/prompts/templates/slide-content/system.md
@@ -18,7 +18,21 @@ You are an educational content designer. Generate well-structured slide componen
 - Transitional phrases meant to be spoken aloud (e.g., "Now let's take a look at…")
 - Slide titles that reference the teacher (e.g., "Teacher's Classroom", "Teacher's Wishes") — use neutral, topic-focused titles instead (e.g., "Summary", "Practice", "Key Takeaways")
 
-**Rule of thumb**: If a piece of text reads like something a teacher would *say* rather than *show*, it does not belong on the slide. Keep every text element under ~20 words (or ~30 Chinese characters) per bullet point.
+**Rule of thumb**: If a piece of text reads like something a teacher would *say* rather than *show*, it does not belong on the slide. Bullets should be scannable, not lectured.
+
+**Depth-aware text density** — adjust max length per bullet to this slide's depth tier:
+
+| Depth tier   | Max per bullet (English / Chinese) | Notes                                                                      |
+| ------------ | ---------------------------------- | -------------------------------------------------------------------------- |
+| foundation   | ~20 words / ~30 chars              | Keep it crisp — definitions and motivation.                                |
+| building     | ~25 words / ~35 chars              | Include short worked-example fragments and compact diagrams.               |
+| application  | ~35 words / ~50 chars              | Allow non-trivial bullets — comparisons, edge cases, formula annotations.  |
+| synthesis    | ~50 words / ~75 chars              | Allow dense formulae, derivation steps, or multi-line tradeoff statements. |
+| mastery      | ~50 words / ~75 chars              | Same as synthesis; lean on charts/equations over prose.                    |
+
+Higher depth tiers also allow **more elements per slide** (densely-annotated diagrams, multiple sub-figures, supporting equations) — match the rigor the speaker is delivering.
+
+This slide's depth tier: **{{depthLevel}}** — apply the corresponding cap.
 
 ---
 

--- a/lib/generation/prompts/templates/slide-content/user.md
+++ b/lib/generation/prompts/templates/slide-content/user.md
@@ -4,8 +4,11 @@
 
 - **Title**: {{title}}
 - **Description**: {{description}}
+- **Depth Tier**: {{depthLevel}}
 - **Key Points**:
   {{keyPoints}}
+
+{{scaffoldContext}}
 
 {{teacherContext}}
 

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -28,6 +28,7 @@ import { parseActionsFromStructuredOutput } from './action-parser';
 import { parseJsonResponse } from './json-repair';
 import {
   buildCourseContext,
+  buildContentScaffoldContext,
   buildLanguageText,
   formatAgentsForPrompt,
   formatTeacherPersonaForPrompt,
@@ -58,6 +59,8 @@ export interface SceneContentOptions {
   generatedMediaMapping?: ImageMapping;
   agents?: AgentInfo[];
   languageDirective?: string;
+  /** Cross-scene scaffolding context — prior outlines + this scene's depth tier. */
+  ctx?: SceneGenerationContext;
 }
 
 export interface SceneActionsOptions {
@@ -98,11 +101,29 @@ export async function generateFullScenes(
     totalScenes,
   });
 
+  // Build a compact prior-outline list once; each scene slices into it.
+  const allTitles = sceneOutlines.map((o) => o.title);
+  const priorRefs = sceneOutlines.map((o) => ({
+    id: o.id,
+    order: o.order,
+    title: o.title,
+    keyPoints: o.keyPoints,
+    depthLevel: o.depthLevel,
+  }));
+
   // Generate all scenes in parallel
   const results = await Promise.all(
     sceneOutlines.map(async (outline, index) => {
       try {
-        const sceneId = await generateSingleScene(outline, api, aiCall, languageDirective);
+        const ctx: SceneGenerationContext = {
+          pageIndex: index + 1,
+          totalPages: totalScenes,
+          allTitles,
+          previousSpeeches: [],
+          priorOutlines: priorRefs.slice(0, index),
+          currentDepthLevel: outline.depthLevel,
+        };
+        const sceneId = await generateSingleScene(outline, api, aiCall, languageDirective, ctx);
 
         // Update progress (not atomic, but sufficient for UI display)
         completedCount++;
@@ -147,10 +168,11 @@ async function generateSingleScene(
   api: ReturnType<typeof createStageAPI>,
   aiCall: AICallFn,
   languageDirective?: string,
+  ctx?: SceneGenerationContext,
 ): Promise<string | null> {
   // Step 3.1: Generate content
   log.info(`Step 3.1: Generating content for: ${outline.title}`);
-  const content = await generateSceneContent(outline, aiCall, { languageDirective });
+  const content = await generateSceneContent(outline, aiCall, { languageDirective, ctx });
   if (!content) {
     log.error(`Failed to generate content for: ${outline.title}`);
     return null;
@@ -158,7 +180,7 @@ async function generateSingleScene(
 
   // Step 3.2: Generate Actions
   log.info(`Step 3.2: Generating actions for: ${outline.title}`);
-  const actions = await generateSceneActions(outline, content, aiCall, { languageDirective });
+  const actions = await generateSceneActions(outline, content, aiCall, { languageDirective, ctx });
   log.info(`Generated ${actions.length} actions for: ${outline.title}`);
 
   // Create complete Scene
@@ -187,6 +209,7 @@ export async function generateSceneContent(
     generatedMediaMapping,
     agents,
     languageDirective,
+    ctx,
   } = options;
   // If outline is interactive but missing interactiveConfig, fall back to slide
   if (outline.type === 'interactive' && !outline.interactiveConfig) {
@@ -203,6 +226,7 @@ export async function generateSceneContent(
       generatedMediaMapping,
       agents,
       languageDirective,
+      ctx,
     );
   }
 
@@ -217,9 +241,10 @@ export async function generateSceneContent(
         generatedMediaMapping,
         agents,
         languageDirective,
+        ctx,
       );
     case 'quiz':
-      return generateQuizContent(outline, aiCall, languageDirective);
+      return generateQuizContent(outline, aiCall, languageDirective, ctx);
     case 'interactive':
       return generateInteractiveContent(outline, aiCall, languageDirective);
     case 'pbl':
@@ -495,6 +520,7 @@ async function generateSlideContent(
   generatedMediaMapping?: ImageMapping,
   agents?: AgentInfo[],
   languageDirective?: string,
+  ctx?: SceneGenerationContext,
 ): Promise<GeneratedSlideContent | null> {
   // Build assigned images description for the prompt
   let assignedImagesText = 'No images available. Do NOT insert any image elements.';
@@ -560,6 +586,11 @@ async function generateSlideContent(
 
   const teacherContext = formatTeacherPersonaForPrompt(agents);
 
+  const sceneCtx: SceneGenerationContext | undefined = ctx
+    ? { ...ctx, currentDepthLevel: outline.depthLevel ?? ctx.currentDepthLevel }
+    : undefined;
+  const scaffoldContext = buildContentScaffoldContext(sceneCtx);
+
   const prompts = buildPrompt(PROMPT_IDS.SLIDE_CONTENT, {
     title: outline.title,
     description: outline.description,
@@ -569,6 +600,8 @@ async function generateSlideContent(
     canvas_width: canvasWidth,
     canvas_height: canvasHeight,
     teacherContext,
+    scaffoldContext,
+    depthLevel: outline.depthLevel ?? 'building',
     languageDirective: buildLanguageText(languageDirective, outline.languageNote),
   });
 
@@ -659,6 +692,7 @@ async function generateQuizContent(
   outline: SceneOutline,
   aiCall: AICallFn,
   languageDirective?: string,
+  ctx?: SceneGenerationContext,
 ): Promise<GeneratedQuizContent | null> {
   const quizConfig = outline.quizConfig || {
     questionCount: 3,
@@ -666,12 +700,32 @@ async function generateQuizContent(
     questionTypes: ['single'],
   };
 
+  // Map scene depth tier → quiz difficulty when explicit difficulty is "medium"
+  // (the legacy default). Scenes with an authored quizConfig.difficulty win.
+  const depthLevel = outline.depthLevel ?? ctx?.currentDepthLevel ?? 'building';
+  const tierToDifficulty: Record<string, 'easy' | 'medium' | 'hard'> = {
+    foundation: 'easy',
+    building: 'easy',
+    application: 'medium',
+    synthesis: 'hard',
+    mastery: 'hard',
+  };
+  const effectiveDifficulty: 'easy' | 'medium' | 'hard' =
+    outline.quizConfig?.difficulty ?? tierToDifficulty[depthLevel] ?? 'medium';
+
+  const sceneCtx: SceneGenerationContext | undefined = ctx
+    ? { ...ctx, currentDepthLevel: depthLevel }
+    : undefined;
+  const scaffoldContext = buildContentScaffoldContext(sceneCtx);
+
   const prompts = buildPrompt(PROMPT_IDS.QUIZ_CONTENT, {
     title: outline.title,
     description: outline.description,
     keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
     questionCount: quizConfig.questionCount,
-    difficulty: quizConfig.difficulty,
+    difficulty: effectiveDifficulty,
+    depthLevel,
+    scaffoldContext,
     questionTypes: quizConfig.questionTypes.join(', '),
     languageDirective: buildLanguageText(languageDirective, outline.languageNote),
   });

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -26,7 +26,18 @@
     "ttsTitle": "تحويل النص إلى كلام",
     "ttsHint": "اختر صوتًا للمعلم الذكي",
     "ttsPreview": "معاينة",
-    "ttsPreviewing": "جارٍ التشغيل..."
+    "ttsPreviewing": "جارٍ التشغيل...",
+    "depth": "العمق",
+    "depthDesc": "اضبط مستوى عمق الدورة والجمهور المستهدف",
+    "depthProfile": "ملف العمق",
+    "depthAudience": "مستوى الجمهور",
+    "depthProfileOverview": "نظرة عامة — واسعة وسطحية",
+    "depthProfileStandard": "قياسي — متوازن",
+    "depthProfileDeepDive": "تعمق — تدرّج كامل",
+    "depthProfileMastery": "إتقان — تركيب متقدم",
+    "depthAudienceBeginner": "مبتدئ",
+    "depthAudienceIntermediate": "متوسط",
+    "depthAudienceAdvanced": "متقدم"
   },
   "export": {
     "pptx": "تصدير PPTX",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -26,7 +26,18 @@
     "ttsTitle": "Text-to-Speech",
     "ttsHint": "Choose a voice for the AI teacher",
     "ttsPreview": "Preview",
-    "ttsPreviewing": "Playing..."
+    "ttsPreviewing": "Playing...",
+    "depth": "Depth",
+    "depthDesc": "Tune how deep the course goes and who it's for",
+    "depthProfile": "Depth profile",
+    "depthAudience": "Audience level",
+    "depthProfileOverview": "Overview — broad and shallow",
+    "depthProfileStandard": "Standard — balanced",
+    "depthProfileDeepDive": "Deep dive — thorough scaffolding",
+    "depthProfileMastery": "Mastery — advanced synthesis",
+    "depthAudienceBeginner": "Beginner",
+    "depthAudienceIntermediate": "Intermediate",
+    "depthAudienceAdvanced": "Advanced"
   },
   "export": {
     "pptx": "Export PPTX",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -26,7 +26,18 @@
     "ttsTitle": "音声合成",
     "ttsHint": "AI教師の声を選択",
     "ttsPreview": "プレビュー",
-    "ttsPreviewing": "再生中..."
+    "ttsPreviewing": "再生中...",
+    "depth": "深度",
+    "depthDesc": "コースの深さと対象者を調整",
+    "depthProfile": "深度プロファイル",
+    "depthAudience": "対象レベル",
+    "depthProfileOverview": "概要 — 広く浅く",
+    "depthProfileStandard": "標準 — バランス型",
+    "depthProfileDeepDive": "深掘り — 段階的に厚く",
+    "depthProfileMastery": "熟達 — 高度な統合",
+    "depthAudienceBeginner": "初級",
+    "depthAudienceIntermediate": "中級",
+    "depthAudienceAdvanced": "上級"
   },
   "export": {
     "pptx": "PPTXエクスポート",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -26,7 +26,18 @@
     "ttsTitle": "Синтез речи",
     "ttsHint": "Выберите голос для AI-учителя",
     "ttsPreview": "Прослушать",
-    "ttsPreviewing": "Воспроизведение..."
+    "ttsPreviewing": "Воспроизведение...",
+    "depth": "Глубина",
+    "depthDesc": "Настройте глубину курса и уровень аудитории",
+    "depthProfile": "Профиль глубины",
+    "depthAudience": "Уровень аудитории",
+    "depthProfileOverview": "Обзор — широко и поверхностно",
+    "depthProfileStandard": "Стандарт — сбалансированно",
+    "depthProfileDeepDive": "Углубленно — пошагово и подробно",
+    "depthProfileMastery": "Мастерство — продвинутый синтез",
+    "depthAudienceBeginner": "Начинающий",
+    "depthAudienceIntermediate": "Средний",
+    "depthAudienceAdvanced": "Продвинутый"
   },
   "export": {
     "pptx": "Экспорт PPTX",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -26,7 +26,18 @@
     "ttsTitle": "语音合成",
     "ttsHint": "选择 AI 教师的朗读音色",
     "ttsPreview": "试听",
-    "ttsPreviewing": "播放中..."
+    "ttsPreviewing": "播放中...",
+    "depth": "深度",
+    "depthDesc": "调整课程的深度与受众",
+    "depthProfile": "深度模式",
+    "depthAudience": "受众水平",
+    "depthProfileOverview": "概览 — 广而浅",
+    "depthProfileStandard": "标准 — 平衡",
+    "depthProfileDeepDive": "深入 — 充分递进",
+    "depthProfileMastery": "精通 — 高阶综合",
+    "depthAudienceBeginner": "入门",
+    "depthAudienceIntermediate": "中级",
+    "depthAudienceAdvanced": "进阶"
   },
   "export": {
     "pptx": "导出 PPTX",

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -350,6 +350,17 @@ export async function generateClassroom(
   log.info('Stage 2: Generating scene content and actions...');
   let generatedScenes = 0;
 
+  // Build prior-outline refs once; each scene slices into it for scaffolding.
+  const allTitles = outlines.map((o) => o.title);
+  const priorRefs = outlines.map((o) => ({
+    id: o.id,
+    order: o.order,
+    title: o.title,
+    keyPoints: o.keyPoints,
+    depthLevel: o.depthLevel,
+  }));
+  const depthProfile = outlinesResult.data.depthProfile;
+
   for (const [index, outline] of outlines.entries()) {
     const safeOutline = applyOutlineFallbacks(outline, true);
     const progressStart = 30 + Math.floor((index / Math.max(outlines.length, 1)) * 60);
@@ -362,7 +373,21 @@ export async function generateClassroom(
       totalScenes: outlines.length,
     });
 
-    const content = await generateSceneContent(safeOutline, aiCall, { agents, languageDirective });
+    const ctx = {
+      pageIndex: index + 1,
+      totalPages: outlines.length,
+      allTitles,
+      previousSpeeches: [],
+      priorOutlines: priorRefs.slice(0, index),
+      currentDepthLevel: safeOutline.depthLevel,
+      depthProfile,
+    };
+
+    const content = await generateSceneContent(safeOutline, aiCall, {
+      agents,
+      languageDirective,
+      ctx,
+    });
     if (!content) {
       log.warn(`Skipping scene "${safeOutline.title}" — content generation failed`);
       continue;
@@ -371,6 +396,7 @@ export async function generateClassroom(
     const actions = await generateSceneActions(safeOutline, content, aiCall, {
       agents,
       languageDirective,
+      ctx,
     });
     log.info(`Scene "${safeOutline.title}": ${actions.length} actions`);
 

--- a/lib/types/generation.ts
+++ b/lib/types/generation.ts
@@ -51,6 +51,57 @@ export interface UserRequirements {
   userNickname?: string; // Student nickname for personalization
   userBio?: string; // Student background for personalization
   webSearch?: boolean; // Enable web search for richer context
+  // How deeply to cover the topic. Drives the depth-tier distribution in outline generation.
+  // Defaults to 'standard'.
+  depthProfile?: DepthProfile;
+  // Audience prior knowledge level. Influences foundation density and terminology pacing.
+  // Defaults to 'intermediate'.
+  audienceLevel?: AudienceLevel;
+}
+
+// ==================== Depth & Coverage Model ====================
+
+/** Per-scene cognitive depth tier (loosely mapped to Bloom's taxonomy). */
+export type DepthLevel =
+  | 'foundation' // Remember/Understand: definitions, motivation, simple examples
+  | 'building' // Understand/Apply: walkthroughs, mechanisms, worked examples
+  | 'application' // Apply/Analyze: non-trivial problems, comparisons, edge cases
+  | 'synthesis' // Analyze/Evaluate: integrate multiple concepts, design tradeoffs
+  | 'mastery'; // Evaluate/Create: novel scenarios, research-level depth
+
+/** Course-wide depth profile selected by the user (or inferred). */
+export type DepthProfile = 'overview' | 'standard' | 'deep-dive' | 'mastery';
+
+/** Audience prior knowledge. */
+export type AudienceLevel = 'beginner' | 'intermediate' | 'advanced';
+
+/** Optional fine-grained Bloom tier for downstream eval / analytics. */
+export type BloomLevel =
+  | 'remember'
+  | 'understand'
+  | 'apply'
+  | 'analyze'
+  | 'evaluate'
+  | 'create';
+
+/** A topic the model planned to cover and which scenes address it. */
+export interface CoverageTopic {
+  name: string;
+  rationale: string; // Why this sub-topic matters for the course goal
+  addressedBySceneIds: string[]; // Must be non-empty in a complete outline
+}
+
+/** Top-level coverage map returned alongside outlines. */
+export interface CoverageMap {
+  topics: CoverageTopic[];
+}
+
+/** Outline generation result envelope. */
+export interface OutlineGenerationOutput {
+  languageDirective: string;
+  outlines: SceneOutline[];
+  coverageMap: CoverageMap;
+  depthProfile: DepthProfile;
 }
 
 // ==================== Stage 1 Output: Scene Outlines (Simplified) ====================
@@ -69,6 +120,15 @@ export interface SceneOutline {
   estimatedDuration?: number; // seconds
   order: number;
   languageNote?: string; // LLM-inferred language note for this scene
+  // Cognitive depth tier. Optional in the type for backwards compatibility,
+  // but the outline generator fills it in (defaulting to 'building') so downstream
+  // code can rely on it being present after generateSceneOutlinesFromRequirements.
+  depthLevel?: DepthLevel;
+  // Scene IDs whose concepts this scene depends on. Required for application/synthesis/mastery.
+  // All entries must reference scenes with strictly smaller `order`.
+  prerequisiteSceneIds?: string[];
+  // Optional fine-grained Bloom tier when the model wants to be specific.
+  bloomLevel?: BloomLevel;
   // Suggested image IDs (from PDF-extracted images)
   suggestedImageIds?: string[]; // e.g., ["img_1", "img_3"]
   // AI-generated media requests (when PDF images are insufficient)


### PR DESCRIPTION
## Summary

Addresses user feedback that generated courses are "too shallow" and outlines miss sub-topics. Introduces an explicit depth ladder (`foundation → building → application → synthesis → mastery`) plus a coverage map, threaded end-to-end through outline → scene generation.

## What changed

**Types & shared helpers**
- `SceneOutline` gains optional `depthLevel` / `prerequisiteSceneIds` / `bloomLevel` (back-compat — code defaults missing tiers via `defaultDepthLevelForOrder`).
- `UserRequirements` gains `depthProfile` (`overview` | `standard` | `deep-dive` | `mastery`) and `audienceLevel` (`beginner` | `intermediate` | `advanced`).
- Outline generator output now includes `coverageMap` + `depthProfile`.
- New `lib/generation/depth-profile.ts` centralises distribution targets, prerequisite-required tiers, and describer helpers.

**Outline prompt rewrite**
- Two REQUIRED new sections in `requirements-to-outlines/system.md`: **Coverage Planning** (sub-topic decomposition with rationale) and **Progressive Depth Scaffolding** (profile-driven distribution + prerequisite rules).
- Scene-count rule no longer fixed to "1–2/min" — now driven by depth profile and topic complexity.

**Scene generation scaffolding**
- `SceneGenerationContext` carries `priorOutlines`, `currentDepthLevel`, `depthProfile`. Built once and sliced per scene so each slide knows what's already established.
- New `buildContentScaffoldContext` formatter injects "do not re-explain X / go deeper than tier (N-1)" guidance.
- Slide system prompt drops the hard 20-word cap in favor of a depth-aware density table; quiz system prompt maps tier → expected difficulty.

**Validation**
- `lib/generation/outline-validator.ts` — pure function `validateDepthProgression`: empty outline, first-must-be-foundation, prerequisite existence + ordering, distribution drift (±20%).
- LLM-as-judge coverage validator + retry are intentionally deferred to PR 2 so this module stays unit-testable with no AI calls.

**UI**
- New "Depth" pill in `GenerationToolbar` (profile + audience selectors) — persisted to `localStorage`, threaded into `UserRequirements` from `app/page.tsx`.
- i18n keys added to all 5 locales.

## Why

Two diagnosed root causes from the user complaint:
1. The outline prompt only enforced "1–2 scenes per minute" — no coverage check, no progression contract.
2. Each scene was generated in isolation, so the model re-explained foundations every slide and never visibly "deepened".

This PR addresses both at the prompt + data-model level. The remaining items in the original plan (LLM coverage judge + fill-gap retry, scene retry-once + manifest, regenerate-scene API, `CourseQualityPanel`, eval harness) are scoped to **PR 2 (resilience + UI)** to keep this PR reviewable.

## Test plan

- [x] `pnpm check:i18n-keys` — passes (5 locales aligned)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual E2E: generate a course with `deep-dive` profile and verify mid/late scenes are visibly thicker than openings, and that the outline lists explicit `depthLevel` per scene
- [ ] Manual E2E: same topic with `overview` profile — confirm shorter, shallower output
- [ ] Spot-check a generated outline JSON for `coverageMap` + `prerequisiteSceneIds` correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)