### PR TITLE
fix(spotlight): restore cutout for text and add element-content for image/video

### DIFF
--- a/components/slide-renderer/Editor/SpotlightOverlay.tsx
+++ b/components/slide-renderer/Editor/SpotlightOverlay.tsx
@@ -122,13 +122,17 @@ export function SpotlightOverlay() {
                 </mask>
               </defs>
 
-              {/* Dimmed Background */}
+              {/* Dimmed Background. No backdrop-filter: combined with SVG <mask>
+                 it breaks compositing (backdrop bypasses the mask cutout) in some
+                 browsers, leaving the focused area dimmed despite the cutout.
+                 Tailwind 3 silently dropped `backdrop-blur-[1.5px]` on SVG via
+                 --tw-* variables; Tailwind 4 emits the property directly and
+                 surfaced the bug. */}
               <rect
                 width="100"
                 height="100"
                 fill={`rgba(0,0,0,${dimness})`}
                 mask={`url(#mask-${spotlightElementId})`}
-                className="backdrop-blur-[1.5px]"
               />
 
               {/* THE ONE BORDER - white border */}

--- a/components/slide-renderer/components/element/ImageElement/BaseImageElement.tsx
+++ b/components/slide-renderer/components/element/ImageElement/BaseImageElement.tsx
@@ -51,7 +51,7 @@ export function BaseImageElement({ elementInfo }: BaseImageElementProps) {
 
   return (
     <div
-      className="absolute"
+      className="element-content absolute"
       style={{
         top: `${elementInfo.top}px`,
         left: `${elementInfo.left}px`,

--- a/components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx
+++ b/components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx
@@ -92,7 +92,7 @@ export function BaseVideoElement({ elementInfo }: BaseVideoElementProps) {
 
   return (
     <div
-      className="absolute"
+      className="element-content absolute"
       data-video-element
       style={{
         top: `${elementInfo.top}px`,


### PR DESCRIPTION
## Summary

Fixes #456.

- **Drop `backdrop-blur-[1.5px]` from the dim SVG `<rect>`** in `SpotlightOverlay`. The class compiles to `backdrop-filter: blur(1.5px)`, which composites in the wrong order with SVG `<mask>` and bypasses the cutout, leaving the focused area dimmed. The 1.5px blur is visually negligible on a translucent overlay; removing it fully restores the cutout.
- **Add `element-content` class to `BaseImageElement` and `BaseVideoElement`.** `SpotlightOverlay.measure()` walks `#screen-element-{id} → .element-content`, falling back to the outer wrapper when the class is missing. The other 7 `Base*Element` components carry it; image and video did not. The fallback hit a static `<div>` whose absolutely-positioned children do not contribute to its bounding box, so the measured rect was `{w: <slide>, h: 0}` — the cutout collapsed to a zero-height strip pinned to the slide top, reading as a full black overlay.

Diff is 3 files / +8 / -4. The original `motion.rect` cutout animation is preserved.

## Test plan

- [ ] `pnpm check`, `pnpm lint`, `npx tsc --noEmit` all pass
- [ ] Spotlight on a text title (transparent fill) shows clear focus area + thin white border
- [ ] Spotlight on an image element shows the image clearly, dim everywhere else, with the white border around the image
- [ ] Spotlight on a video element behaves the same as image
- [ ] Cutout opening animation (mask shrinks from larger to tight) still plays