### PR TITLE
fix(generation): unify languageDirective across outline + scene pipeline (#472)

### DIFF
--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -23,6 +23,7 @@ import {
   formatTeacherPersonaForPrompt,
 } from '@/lib/generation/generation-pipeline';
 import type { AgentInfo } from '@/lib/generation/generation-pipeline';
+import { DEFAULT_LANGUAGE_DIRECTIVE } from '@/lib/generation/outline-generator';
 import { MAX_PDF_CONTENT_CHARS, MAX_VISION_IMAGES } from '@/lib/constants/generation';
 import { nanoid } from 'nanoid';
 import type {
@@ -371,8 +372,7 @@ export async function POST(req: NextRequest) {
             const doneEvent = JSON.stringify({
               type: 'done',
               outlines: uniquifiedOutlines,
-              languageDirective:
-                languageDirective || 'Teach in the language that matches the user requirement.',
+              languageDirective: languageDirective || DEFAULT_LANGUAGE_DIRECTIVE,
             });
             controller.enqueue(encoder.encode(`data: ${doneEvent}\n\n`));
           } else {

--- a/lib/generation/outline-generator.ts
+++ b/lib/generation/outline-generator.ts
@@ -20,6 +20,15 @@ import { createLogger } from '@/lib/logger';
 const log = createLogger('Generation');
 
 /**
+ * Used when the outline stage fails to produce an explicit directive (LLM
+ * schema regression, empty response, upstream error). Downstream prompts
+ * still need *something* that steers the model toward the requirement's
+ * language rather than defaulting to the training-distribution prior.
+ */
+export const DEFAULT_LANGUAGE_DIRECTIVE =
+  'Teach in the language that matches the user requirement.';
+
+/**
  * Generate scene outlines from user requirements
  * Now uses simplified UserRequirements with just requirement text and language
  */
@@ -126,11 +135,10 @@ export async function generateSceneOutlinesFromRequirements(
 
     if (Array.isArray(parsed)) {
       // Fallback: LLM returned old flat array format
-      languageDirective = 'Teach in the language that matches the user requirement.';
+      languageDirective = DEFAULT_LANGUAGE_DIRECTIVE;
       rawOutlines = parsed;
     } else if (parsed && parsed.outlines) {
-      languageDirective =
-        parsed.languageDirective || 'Teach in the language that matches the user requirement.';
+      languageDirective = parsed.languageDirective || DEFAULT_LANGUAGE_DIRECTIVE;
       rawOutlines = parsed.outlines;
     } else {
       return { success: false, error: 'Failed to parse scene outlines response' };

--- a/lib/generation/scene-builder.ts
+++ b/lib/generation/scene-builder.ts
@@ -115,6 +115,7 @@ export async function buildSceneFromOutline(
     ctx,
     agents,
     userProfile,
+    languageDirective: langText,
   });
   log.debug(`Generated ${actions.length} actions for: ${outline.title}`);
 

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -312,11 +312,7 @@ export async function generateSceneContent(
     }
 
     // Route to widget generation (handles all 5 types)
-    return generateWidgetContent(
-      outline,
-      aiCall,
-      (languageDirective || 'zh-CN') as 'zh-CN' | 'en-US',
-    );
+    return generateWidgetContent(outline, aiCall, languageDirective);
   }
 
   switch (outline.type) {
@@ -329,11 +325,12 @@ export async function generateSceneContent(
         visionEnabled,
         generatedMediaMapping,
         agents,
+        languageDirective,
       );
     case 'quiz':
-      return generateQuizContent(outline, aiCall);
+      return generateQuizContent(outline, aiCall, languageDirective);
     case 'pbl':
-      return generatePBLSceneContent(outline, languageModel);
+      return generatePBLSceneContent(outline, languageModel, languageDirective);
     default:
       return null;
   }
@@ -604,6 +601,7 @@ async function generateSlideContent(
   visionEnabled?: boolean,
   generatedMediaMapping?: ImageMapping,
   agents?: AgentInfo[],
+  languageDirective?: string,
 ): Promise<GeneratedSlideContent | null> {
   // Build assigned images description for the prompt
   let assignedImagesText = '无可用图片，禁止插入任何 image 元素';
@@ -678,6 +676,7 @@ async function generateSlideContent(
     canvas_width: canvasWidth,
     canvas_height: canvasHeight,
     teacherContext,
+    languageDirective: languageDirective || '',
   });
 
   if (!prompts) {
@@ -766,6 +765,7 @@ async function generateSlideContent(
 async function generateQuizContent(
   outline: SceneOutline,
   aiCall: AICallFn,
+  languageDirective?: string,
 ): Promise<GeneratedQuizContent | null> {
   const quizConfig = outline.quizConfig || {
     questionCount: 3,
@@ -780,6 +780,7 @@ async function generateQuizContent(
     questionCount: quizConfig.questionCount,
     difficulty: quizConfig.difficulty,
     questionTypes: quizConfig.questionTypes.join(', '),
+    languageDirective: languageDirective || '',
   });
 
   if (!prompts) {
@@ -867,6 +868,7 @@ function normalizeQuizAnswer(question: Record<string, unknown>): string[] | unde
 async function generatePBLSceneContent(
   outline: SceneOutline,
   languageModel?: LanguageModel,
+  languageDirective?: string,
 ): Promise<GeneratedPBLContent | null> {
   if (!languageModel) {
     log.error('LanguageModel required for PBL generation');
@@ -888,7 +890,8 @@ async function generatePBLSceneContent(
         projectDescription: pblConfig.projectDescription,
         targetSkills: pblConfig.targetSkills,
         issueCount: pblConfig.issueCount,
-        languageDirective: 'Teach in the language that matches the user requirement.',
+        languageDirective:
+          languageDirective || 'Teach in the language that matches the user requirement.',
       },
       languageModel,
       {
@@ -951,7 +954,7 @@ function extractHtml(response: string): string | null {
 async function generateWidgetContent(
   outline: SceneOutline,
   aiCall: AICallFn,
-  language: 'zh-CN' | 'en-US',
+  languageDirective?: string,
 ): Promise<GeneratedInteractiveContent | null> {
   const widgetType = outline.widgetType;
   const widgetOutline = outline.widgetOutline;
@@ -974,7 +977,7 @@ async function generateWidgetContent(
         keyPoints: (outline.keyPoints || []).join('\n'),
         variables: widgetOutline.keyVariables?.join(', ') || '',
         designIdea: '',
-        language,
+        languageDirective: languageDirective || '',
       };
       break;
 
@@ -985,7 +988,7 @@ async function generateWidgetContent(
         diagramType: widgetOutline.diagramType || 'flowchart',
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
-        language,
+        languageDirective: languageDirective || '',
       };
       break;
 
@@ -999,7 +1002,7 @@ async function generateWidgetContent(
         starterCode: '',
         testCases: '', // AI generates appropriate test cases based on challenge
         hints: '', // AI generates progressive hints based on challenge
-        language,
+        languageDirective: languageDirective || '',
       };
       break;
 
@@ -1011,7 +1014,7 @@ async function generateWidgetContent(
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         scoring: { correctPoints: 10, speedBonus: 5 },
-        language,
+        languageDirective: languageDirective || '',
       };
       break;
 
@@ -1024,7 +1027,7 @@ async function generateWidgetContent(
         keyPoints: (outline.keyPoints || []).join('\n'),
         objects: widgetOutline.objects || [],
         interactions: widgetOutline.interactions || [],
-        language,
+        languageDirective: languageDirective || '',
       };
       break;
 
@@ -1057,7 +1060,7 @@ async function generateWidgetContent(
     outline,
     widgetConfig,
     aiCall,
-    language,
+    languageDirective,
   );
   log.info(
     `[Ultra Mode] Generated ${teacherActions?.length || 0} teacher actions for "${outline.title}" (${widgetType})`,
@@ -1100,14 +1103,14 @@ async function generateWidgetTeacherActions(
   outline: SceneOutline,
   widgetConfig: WidgetConfig | undefined,
   aiCall: AICallFn,
-  language: 'zh-CN' | 'en-US',
+  languageDirective?: string,
 ): Promise<TeacherAction[] | undefined> {
   const prompts = buildPrompt(PROMPT_IDS.WIDGET_TEACHER_ACTIONS, {
     widgetType,
     description: outline.description,
     keyPoints: (outline.keyPoints || []).join('\n'),
     widgetConfig: JSON.stringify(widgetConfig || {}),
-    language,
+    languageDirective: languageDirective || '',
   });
 
   if (!prompts) return undefined;
@@ -1167,6 +1170,7 @@ export async function generateSceneActions(
       courseContext: buildCourseContext(ctx),
       agents: agentsText,
       userProfile: userProfile || '',
+      languageDirective: languageDirective || '',
     });
 
     if (!prompts) {
@@ -1195,6 +1199,7 @@ export async function generateSceneActions(
       questions: questionsText,
       courseContext: buildCourseContext(ctx),
       agents: agentsText,
+      languageDirective: languageDirective || '',
     });
 
     if (!prompts) {
@@ -1222,6 +1227,7 @@ export async function generateSceneActions(
       designIdea: config?.designIdea || '',
       courseContext: buildCourseContext(ctx),
       agents: agentsText,
+      languageDirective: languageDirective || '',
     });
 
     if (!prompts) {
@@ -1249,6 +1255,7 @@ export async function generateSceneActions(
       projectDescription: pblConfig?.projectDescription || outline.description,
       courseContext: buildCourseContext(ctx),
       agents: agentsText,
+      languageDirective: languageDirective || '',
     });
 
     if (!prompts) {

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -26,6 +26,7 @@ import type { StageStore } from '@/lib/api/stage-api';
 import { createStageAPI } from '@/lib/api/stage-api';
 import { generatePBLContent } from '@/lib/pbl/generate-pbl';
 import { buildPrompt, PROMPT_IDS } from '@/lib/prompts';
+import { DEFAULT_LANGUAGE_DIRECTIVE } from './outline-generator';
 import { postProcessInteractiveHtml } from './interactive-post-processor';
 import { parseActionsFromStructuredOutput } from './action-parser';
 import { parseJsonResponse } from './json-repair';
@@ -890,8 +891,7 @@ async function generatePBLSceneContent(
         projectDescription: pblConfig.projectDescription,
         targetSkills: pblConfig.targetSkills,
         issueCount: pblConfig.issueCount,
-        languageDirective:
-          languageDirective || 'Teach in the language that matches the user requirement.',
+        languageDirective: languageDirective || DEFAULT_LANGUAGE_DIRECTIVE,
       },
       languageModel,
       {

--- a/lib/prompts/README.md
+++ b/lib/prompts/README.md
@@ -99,9 +99,8 @@ EVAL_CHAT_MODEL=<provider:model> EVAL_SCORER_MODEL=<provider:model> \
   --scenario econ-tech-innovation
 ```
 
-## Caching
+## Loading
 
-`loadPrompt` and `loadSnippet` cache on first read for the lifetime of the
-process. Call `clearPromptCache()` if you're iterating on markdown in a
-long-lived REPL / dev server and want to pick up changes. Production reads
-are idempotent so the cache is always hot.
+`loadPrompt` and `loadSnippet` read from disk on every call. No caching —
+markdown edits take effect immediately without restarting any dev server.
+Prompt disk I/O is negligible next to the LLM call it feeds.

--- a/lib/prompts/index.ts
+++ b/lib/prompts/index.ts
@@ -12,13 +12,7 @@ import type { PromptId } from './types';
 export type { PromptId, SnippetId, LoadedPrompt } from './types';
 
 // Loader functions
-export {
-  loadPrompt,
-  loadSnippet,
-  buildPrompt,
-  interpolateVariables,
-  clearPromptCache,
-} from './loader';
+export { loadPrompt, loadSnippet, buildPrompt, interpolateVariables } from './loader';
 
 // Prompt IDs constant
 export const PROMPT_IDS = {

--- a/lib/prompts/loader.ts
+++ b/lib/prompts/loader.ts
@@ -5,7 +5,6 @@
  * - Loading prompts from templates/{promptId}/ directory
  * - Snippet inclusion via {{snippet:name}} syntax
  * - Variable interpolation via {{variable}} syntax
- * - Caching for performance
  */
 
 import fs from 'fs';
@@ -13,10 +12,6 @@ import path from 'path';
 import type { PromptId, LoadedPrompt, SnippetId } from './types';
 import { createLogger } from '@/lib/logger';
 const log = createLogger('PromptLoader');
-
-// Cache for loaded prompts and snippets
-const promptCache = new Map<string, LoadedPrompt>();
-const snippetCache = new Map<string, string>();
 
 /**
  * Get the prompts directory path
@@ -30,15 +25,10 @@ function getPromptsDir(): string {
  * Load a snippet by ID
  */
 export function loadSnippet(snippetId: SnippetId): string {
-  const cached = snippetCache.get(snippetId);
-  if (cached) return cached;
-
   const snippetPath = path.join(getPromptsDir(), 'snippets', `${snippetId}.md`);
 
   try {
-    const content = fs.readFileSync(snippetPath, 'utf-8').trim();
-    snippetCache.set(snippetId, content);
-    return content;
+    return fs.readFileSync(snippetPath, 'utf-8').trim();
   } catch {
     // Fail loud rather than silently shipping `{{snippet:foo}}` to the LLM.
     // A missing snippet is always a config/typo bug — surface at load time.
@@ -60,9 +50,6 @@ function processSnippets(template: string): string {
  * Load a prompt by ID
  */
 export function loadPrompt(promptId: PromptId): LoadedPrompt | null {
-  const cached = promptCache.get(promptId);
-  if (cached) return cached;
-
   const promptDir = path.join(getPromptsDir(), 'templates', promptId);
 
   try {
@@ -81,14 +68,11 @@ export function loadPrompt(promptId: PromptId): LoadedPrompt | null {
       // user.md is optional
     }
 
-    const loaded: LoadedPrompt = {
+    return {
       id: promptId,
       systemPrompt,
       userPromptTemplate,
     };
-
-    promptCache.set(promptId, loaded);
-    return loaded;
   } catch (error) {
     log.error(`Failed to load prompt ${promptId}:`, error);
     return null;
@@ -128,10 +112,3 @@ export function buildPrompt(
   };
 }
 
-/**
- * Clear all caches (useful for development/testing)
- */
-export function clearPromptCache(): void {
-  promptCache.clear();
-  snippetCache.clear();
-}

--- a/lib/prompts/loader.ts
+++ b/lib/prompts/loader.ts
@@ -111,4 +111,3 @@ export function buildPrompt(
     user: interpolateVariables(prompt.userPromptTemplate, variables),
   };
 }
-

--- a/lib/prompts/templates/code-content/user.md
+++ b/lib/prompts/templates/code-content/user.md
@@ -28,7 +28,7 @@ Create a code playground widget for: {{title}}
 
 ## Course Language
 
-{{language}}
+{{languageDirective}}
 
 ---
 

--- a/lib/prompts/templates/diagram-content/user.md
+++ b/lib/prompts/templates/diagram-content/user.md
@@ -10,7 +10,7 @@ Create an interactive diagram for: {{title}}
 {{keyPoints}}
 
 ## Language
-{{language}}
+{{languageDirective}}
 
 ---
 

--- a/lib/prompts/templates/game-content/user.md
+++ b/lib/prompts/templates/game-content/user.md
@@ -18,7 +18,7 @@ Create an educational GAME widget for: {{title}}
 
 ## Language
 
-{{language}}
+{{languageDirective}}
 
 ---
 

--- a/lib/prompts/templates/interactive-outlines/system.md
+++ b/lib/prompts/templates/interactive-outlines/system.md
@@ -9,6 +9,41 @@ Transform user requirements into an **interactive-first** course structure:
 - Use **slides for introductions, summaries, and conceptual frameworks**
 - Adjust the balance based on course length and subject matter
 
+---
+
+## Language Inference
+
+Infer the course language from all available signals and produce:
+
+1. **`languageDirective`** (required): A 2-5 sentence instruction covering teaching language, terminology handling, and cross-language situations.
+2. **`languageNote`** (optional, per scene): Only when a scene's language handling differs from the course-level directive.
+
+### Decision rules (apply in order)
+
+1. **Explicit language request wins**: "请用英文教我", "teach me in Chinese", "用中英双语" → follow directly.
+
+2. **Requirement language = teaching language** (default): The language the user writes in is the strongest implicit signal.
+
+3. **Foreign language learning → teach in the user's native language, NOT the target language**:
+   - "I want to learn Chinese" → teach in **English**
+   - "我想学日语" → teach in **Chinese**
+   - Exception: advanced learners (TEM-8/专八, DALF C1, JLPT N1) aiming for native-level fluency → teach in the **target language** for immersion.
+
+4. **Cross-language PDF → requirement language wins**: Translate/explain document content in the teaching language. Never let the PDF language override the requirement language.
+
+5. **Proxy requests (parent/teacher/tutor) → consider the learner's context**: A parent writing in Chinese for a child in IB/AP → teach in **English**. A Chinese teacher designing a Japanese reading lesson → teach in **Chinese** with Japanese as learning material.
+
+6. **Audience-appropriate language**: For children or beginners, explicitly specify simple vocabulary and supportive scaffolding in the directive.
+
+### Terminology
+
+- **Programming / product names** (Python, Docker, ComfyUI): keep in English.
+- **Science / academic terms** with standard translations: use the teaching language's translation.
+- **Emerging tech terms** (AI/ML): show bilingually.
+- **User's explicit request** about terminology overrides the above defaults.
+
+---
+
 ## Widget Types
 
 ### 1. Simulation Widget (`simulation`)
@@ -193,41 +228,68 @@ For **shorter courses (<10 scenes)**:
 
 ## Output Format
 
-Output a JSON array where each scene has this structure:
+### Top-level shape — NON-NEGOTIABLE
+
+Your entire response MUST be a single JSON **object** with exactly these two top-level keys:
 
 ```json
-[
-  {
-    "id": "scene_1",
-    "type": "slide",
-    "title": "Introduction to Projectile Motion",
-    "description": "Introduce the concept and learning objectives",
-    "keyPoints": ["What is projectile motion", "Real-world examples", "Key variables"],
-    "order": 1
-  },
-  {
-    "id": "scene_2",
-    "type": "interactive",
-    "title": "Projectile Motion Simulator",
-    "description": "Explore how angle and velocity affect trajectory",
-    "keyPoints": ["Adjust angle and velocity", "Observe trajectory changes", "Hit the target challenge"],
-    "order": 2,
-    "widgetType": "simulation",
-    "widgetOutline": {
-      "concept": "projectile_motion",
-      "keyVariables": ["angle", "initial_velocity"]
+{
+  "languageDirective": "<the directive you inferred in the Language Inference step>",
+  "outlines": [ /* array of scene objects */ ]
+}
+```
+
+Rules:
+
+- **Never** return a bare array. The top level is an object, not an array.
+- **Never** omit `languageDirective`. It is required even if you think the language is obvious.
+- **Never** wrap the response in any other structure, prose, or code fence.
+
+### Minimal complete example
+
+```json
+{
+  "languageDirective": "Deliver the entire course in English. Use simple vocabulary suitable for a beginner.",
+  "outlines": [
+    {
+      "id": "scene_1",
+      "type": "slide",
+      "title": "Introduction to Projectile Motion",
+      "description": "Introduce the concept and learning objectives",
+      "keyPoints": ["What is projectile motion", "Real-world examples", "Key variables"],
+      "order": 1
+    },
+    {
+      "id": "scene_2",
+      "type": "interactive",
+      "title": "Projectile Motion Simulator",
+      "description": "Explore how angle and velocity affect trajectory",
+      "keyPoints": ["Adjust angle and velocity", "Observe trajectory changes", "Hit the target challenge"],
+      "order": 2,
+      "widgetType": "simulation",
+      "widgetOutline": {
+        "concept": "projectile_motion",
+        "keyVariables": ["angle", "initial_velocity"]
+      }
     }
-  }
-]
+  ]
+}
 ```
 
 ## Important Guidelines
 
-1. **Interactive focus**: Prefer interactive widgets for hands-on learning
-2. **Widget variety**: Use different widget types throughout the course when appropriate
-3. **Flow**: Slides should introduce concepts, widgets should let students explore
-4. **Language**: Output all content in the specified course language
-5. **Valid JSON**: Always output valid JSON array format
-6. **REQUIRED for interactive scenes**: Every scene with `type: "interactive"` MUST include both `widgetType` AND `widgetOutline` fields
-7. **Game quality**: Game widgets should be INTERACTIVE and FUN, not boring quizzes
-8. **Mobile-first**: All widgets should work well on mobile devices
+**Top-level response shape (most often violated):**
+
+1. Return exactly one JSON **object** — never a bare array.
+2. That object MUST have both `languageDirective` (string) and `outlines` (array) as top-level keys. Omitting either is a failure.
+3. Do not wrap the object in prose, markdown, or code fences.
+
+**Scene-level rules:**
+
+4. **Interactive focus**: Prefer interactive widgets for hands-on learning.
+5. **Widget variety**: Use different widget types throughout the course when appropriate.
+6. **Flow**: Slides should introduce concepts, widgets should let students explore.
+7. **Language**: Apply the Language Inference decision rules above when producing `languageDirective`, and author all scene content in the inferred language.
+8. **REQUIRED for interactive scenes**: Every scene with `type: "interactive"` MUST include both `widgetType` AND `widgetOutline` fields.
+9. **Game quality**: Game widgets should be INTERACTIVE and FUN, not boring quizzes.
+10. **Mobile-first**: All widgets should work well on mobile devices.

--- a/lib/prompts/templates/interactive-outlines/user.md
+++ b/lib/prompts/templates/interactive-outlines/user.md
@@ -10,10 +10,6 @@ Generate an Ultra Mode course outline based on the following requirements.
 
 {{userProfile}}
 
-## Course Language
-
-**Required language**: {{language}}
-
 ---
 
 ## Reference Materials
@@ -116,4 +112,4 @@ Choose widgets based on the content:
 
 {{mediaGenerationPolicy}}
 
-Please output JSON array directly without additional explanatory text.
+**Final reminder**: your entire response must be a JSON **object** with exactly two top-level keys — `languageDirective` (string, inferred via the Language Inference rules in the system prompt) and `outlines` (array of scene objects). Do not return a bare array. Do not wrap in prose or code fences.

--- a/lib/prompts/templates/interactive-outlines/user.md
+++ b/lib/prompts/templates/interactive-outlines/user.md
@@ -10,6 +10,13 @@ Generate an Ultra Mode course outline based on the following requirements.
 
 {{userProfile}}
 
+## Language Context
+
+Infer the course language directive by applying the decision rules from the system prompt. Key reminders:
+- Requirement language = teaching language (unless overridden by explicit request or learner context)
+- Foreign language learning → teach in user's native language, not the target language
+- PDF language does NOT override teaching language — translate/explain document content instead
+
 ---
 
 ## Reference Materials

--- a/lib/prompts/templates/requirements-to-outlines/system.md
+++ b/lib/prompts/templates/requirements-to-outlines/system.md
@@ -261,64 +261,43 @@ Use `pbl` type when the course involves complex, multi-step project work that be
 
 ## Output Format
 
-Output a JSON **object** (not a bare array) with this structure:
+### Top-level shape — NON-NEGOTIABLE
+
+Your entire response MUST be a single JSON **object** with exactly these two top-level keys:
 
 ```json
 {
-  "languageDirective": "2-5 sentence instruction describing the course language behavior",
+  "languageDirective": "<the directive you inferred in the Language Inference step>",
+  "outlines": [ /* array of scene objects */ ]
+}
+```
+
+Rules:
+
+- **Never** return a bare array. The top level is an object, not an array.
+- **Never** omit `languageDirective`. It is required even if you think the language is obvious.
+- **Never** wrap the response in any other structure, prose, or code fence.
+
+### Minimal complete example
+
+```json
+{
+  "languageDirective": "Deliver the entire course in English. Use simple vocabulary suitable for a beginner.",
   "outlines": [
     {
       "id": "scene_1",
       "type": "slide",
-      "title": "Scene Title",
-      "description": "1-2 sentences describing the teaching purpose",
-      "keyPoints": ["Key point 1", "Key point 2", "Key point 3"],
-      "teachingObjective": "Corresponding learning objective",
-      "estimatedDuration": 120,
-      "order": 1,
-      "suggestedImageIds": ["img_1"],
-      "mediaGenerations": [
-        {
-          "type": "image",
-          "prompt": "A diagram showing the key concept",
-          "elementId": "gen_img_1",
-          "aspectRatio": "16:9"
-        }
-      ]
+      "title": "Introduction",
+      "description": "Welcome students and introduce the core concept.",
+      "keyPoints": ["Context", "Agenda", "Goals"],
+      "order": 1
     },
     {
       "id": "scene_2",
       "type": "interactive",
       "title": "Interactive Exploration",
-      "description": "Students explore the concept through hands-on interactive visualization",
-      "keyPoints": ["Interactive element 1", "Observable phenomenon"],
-      "order": 2,
-      "interactiveConfig": {
-        "conceptName": "Concept Name",
-        "conceptOverview": "Brief description of what this interactive demonstrates",
-        "designIdea": "Describe the interactive elements: sliders, drag handles, animations, etc.",
-        "subject": "Physics"
-      }
-    },
-    {
-      "id": "scene_3",
-      "type": "quiz",
-      "title": "Knowledge Check",
-      "description": "Test student understanding of XX concept",
-      "keyPoints": ["Test point 1", "Test point 2"],
-      "order": 3,
-      "quizConfig": {
-        "questionCount": 2,
-        "difficulty": "medium",
-        "questionTypes": ["single", "multiple", "short_answer"]
-      }
-    },
-    {
-      "id": "scene_2",
-      "type": "interactive",
-      "title": "Interactive Exploration",
-      "description": "Students explore the concept through hands-on interactive visualization",
-      "keyPoints": ["Interactive element 1", "Observable phenomenon"],
+      "description": "Students explore the concept via a hands-on simulation.",
+      "keyPoints": ["Observe variable 1", "Observe variable 2"],
       "order": 2,
       "widgetType": "simulation",
       "widgetOutline": {
@@ -330,20 +309,20 @@ Output a JSON **object** (not a bare array) with this structure:
       "id": "scene_3",
       "type": "quiz",
       "title": "Knowledge Check",
-      "description": "Test student understanding of XX concept",
+      "description": "Test student understanding of the key concepts.",
       "keyPoints": ["Test point 1", "Test point 2"],
       "order": 3,
       "quizConfig": {
         "questionCount": 2,
         "difficulty": "medium",
-        "questionTypes": ["single", "multiple", "short_answer"]
+        "questionTypes": ["single", "multiple"]
       }
     }
   ]
 }
 ```
 
-### Field Descriptions
+### Scene field descriptions
 
 | Field             | Type                     | Required | Description                                                                                      |
 | ----------------- | ------------------------ | -------- | ------------------------------------------------------------------------------------------------ |
@@ -399,14 +378,19 @@ Output a JSON **object** (not a bare array) with this structure:
 
 ## Important Reminders
 
-1. **Must output valid JSON object with `languageDirective` and `outlines` fields**
-2. **type can be `"slide"`, `"quiz"`, `"interactive"`, or `"pbl"`**
-3. **quiz type must include quizConfig**
-4. **interactive type must include interactiveConfig** - with conceptName, conceptOverview, designIdea, and subject
-   5b. **pbl type must include pblConfig** - with projectTopic, projectDescription, targetSkills, and issueCount
-5. Arrange appropriate number of scenes based on inferred duration (typically 1-2 scenes per minute)
-6. Insert quizzes at appropriate points for knowledge checks
-7. Use interactive scenes sparingly (max 1-2 per course) and only when the concept truly benefits from hands-on interaction
+**Top-level response shape (these come first because they are most often violated):**
+
+1. Return exactly one JSON **object** — never a bare array.
+2. That object MUST have both `languageDirective` (string) and `outlines` (array) as top-level keys. Omitting either is a failure.
+3. Do not wrap the object in prose, markdown, or code fences.
+
+**Scene-level rules:**
+
+4. `type` is one of `"slide"`, `"quiz"`, `"interactive"`, `"pbl"`.
+5. `quiz` scenes must include `quizConfig`.
+6. `interactive` scenes must include `widgetType` and `widgetOutline` (preferred). `interactiveConfig` is deprecated and only accepted for backwards compatibility.
+7. `pbl` scenes must include `pblConfig` with `projectTopic`, `projectDescription`, `targetSkills`, `issueCount`.
+8. Arrange scenes by inferred duration (typically 1-2 scenes per minute). Insert quizzes at appropriate points. Use interactive scenes sparingly (max 1-2 per course).
 8. **Language**: Infer from the user's requirement text and context. Output all scene content in the inferred language.
 9. Regardless of information completeness, always output conforming JSON - do not ask questions or request more information
 10. **No teacher identity on slides**: Scene titles and keyPoints must be neutral and topic-focused. Never include the teacher's name or role (e.g., avoid "Teacher Wang's Tips", "Teacher's Wishes"). Use generic labels like "Tips", "Summary", "Key Takeaways" instead.

--- a/lib/prompts/templates/requirements-to-outlines/system.md
+++ b/lib/prompts/templates/requirements-to-outlines/system.md
@@ -391,6 +391,6 @@ Rules:
 6. `interactive` scenes must include `widgetType` and `widgetOutline` (preferred). `interactiveConfig` is deprecated and only accepted for backwards compatibility.
 7. `pbl` scenes must include `pblConfig` with `projectTopic`, `projectDescription`, `targetSkills`, `issueCount`.
 8. Arrange scenes by inferred duration (typically 1-2 scenes per minute). Insert quizzes at appropriate points. Use interactive scenes sparingly (max 1-2 per course).
-8. **Language**: Infer from the user's requirement text and context. Output all scene content in the inferred language.
-9. Regardless of information completeness, always output conforming JSON - do not ask questions or request more information
-10. **No teacher identity on slides**: Scene titles and keyPoints must be neutral and topic-focused. Never include the teacher's name or role (e.g., avoid "Teacher Wang's Tips", "Teacher's Wishes"). Use generic labels like "Tips", "Summary", "Key Takeaways" instead.
+9. **Language**: Infer from the user's requirement text and context. Output all scene content in the inferred language.
+10. Regardless of information completeness, always output conforming JSON - do not ask questions or request more information
+11. **No teacher identity on slides**: Scene titles and keyPoints must be neutral and topic-focused. Never include the teacher's name or role (e.g., avoid "Teacher Wang's Tips", "Teacher's Wishes"). Use generic labels like "Tips", "Summary", "Key Takeaways" instead.

--- a/lib/prompts/templates/requirements-to-outlines/user.md
+++ b/lib/prompts/templates/requirements-to-outlines/user.md
@@ -47,21 +47,29 @@ Please automatically infer the following from user requirements:
 - Teaching style (formal/casual/interactive/academic)
 - Visual style (minimal/colorful/professional/playful)
 
-Then output a JSON object with `languageDirective` and `outlines`. Each scene in the `outlines` array must include:
+Then output your response as a single JSON object.
+
+**Top-level shape — this is what you MUST return:**
 
 ```json
 {
   "languageDirective": "2-5 sentence instruction describing the course language behavior",
-  "outlines": [
-    {
-      "id": "scene_1",
-      "type": "slide" or "quiz" or "interactive",
-      "title": "Scene Title",
-      "description": "Teaching purpose description",
-      "keyPoints": ["Point 1", "Point 2", "Point 3"],
-      "order": 1
-    }
-  ]
+  "outlines": [ /* array of scene objects, schema described below */ ]
+}
+```
+
+Never return a bare array. Never omit `languageDirective`. Both keys are required.
+
+**Each scene inside the `outlines` array has this minimum shape:**
+
+```json
+{
+  "id": "scene_1",
+  "type": "slide" | "quiz" | "interactive" | "pbl",
+  "title": "Scene Title",
+  "description": "Teaching purpose description",
+  "keyPoints": ["Point 1", "Point 2", "Point 3"],
+  "order": 1
 }
 ```
 
@@ -87,4 +95,4 @@ Then output a JSON object with `languageDirective` and `outlines`. Each scene in
 
 {{mediaGenerationPolicy}}
 
-Please output a JSON object with `languageDirective` (string) and `outlines` (array) directly without additional explanatory text.
+**Final reminder**: your entire response must be a JSON **object** with exactly two top-level keys — `languageDirective` (string) and `outlines` (array). Do not return a bare array. Do not wrap in prose or code fences.

--- a/lib/prompts/templates/simulation-content/user.md
+++ b/lib/prompts/templates/simulation-content/user.md
@@ -18,7 +18,7 @@ Create a simulation widget for: {{conceptName}}
 
 ## Language
 
-{{language}}
+{{languageDirective}}
 
 ---
 

--- a/lib/prompts/templates/visualization3d-content/user.md
+++ b/lib/prompts/templates/visualization3d-content/user.md
@@ -22,7 +22,7 @@ Create a 3D visualization widget for: {{title}}
 
 ## Language
 
-{{language}}
+{{languageDirective}}
 
 ---
 

--- a/lib/prompts/templates/widget-teacher-actions/user.md
+++ b/lib/prompts/templates/widget-teacher-actions/user.md
@@ -18,7 +18,7 @@ Generate teacher actions for this widget.
 
 ## Course Language
 
-{{language}}
+{{languageDirective}}
 
 ---
 

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -368,7 +368,10 @@ export async function generateClassroom(
       continue;
     }
 
-    const actions = await generateSceneActions(safeOutline, content, aiCall, { agents });
+    const actions = await generateSceneActions(safeOutline, content, aiCall, {
+      agents,
+      languageDirective,
+    });
     log.info(`Scene "${safeOutline.title}": ${actions.length} actions`);
 
     const sceneId = createSceneWithActions(safeOutline, content, actions, api);

--- a/tests/generation/scene-generator-language-directive.test.ts
+++ b/tests/generation/scene-generator-language-directive.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Regression tests for GitHub issue #472:
+ * `languageDirective` is dropped or hardcoded across the scene generation pipeline,
+ * silently breaking prompt-level language control.
+ *
+ * The bug caused `{{languageDirective}}` to leak as a literal placeholder into
+ * LLM user messages. These tests thread a sentinel directive through every affected
+ * code path and assert it both reaches the rendered prompt AND the literal
+ * placeholder is gone.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import {
+  generateSceneContent,
+  generateSceneActions,
+} from '@/lib/generation/scene-generator';
+import type { AICallFn } from '@/lib/generation/pipeline-types';
+import type {
+  SceneOutline,
+  GeneratedSlideContent,
+  GeneratedQuizContent,
+  GeneratedInteractiveContent,
+  GeneratedPBLContent,
+} from '@/lib/types/generation';
+
+const DIRECTIVE = '<<LANG-DIRECTIVE-SENTINEL>>';
+
+function makeCapturingAiCall(response: string): {
+  aiCall: AICallFn;
+  lastUser: () => string;
+  lastSystem: () => string;
+} {
+  let lastUser = '';
+  let lastSystem = '';
+  const aiCall: AICallFn = async (system, user) => {
+    lastSystem = system;
+    lastUser = user;
+    return response;
+  };
+  return {
+    aiCall,
+    lastUser: () => lastUser,
+    lastSystem: () => lastSystem,
+  };
+}
+
+function baseOutline(overrides: Partial<SceneOutline> = {}): SceneOutline {
+  return {
+    id: 'scene-1',
+    type: 'slide',
+    title: 'Test Scene',
+    description: 'A scene for testing language directive threading.',
+    keyPoints: ['point a', 'point b'],
+    order: 0,
+    ...overrides,
+  };
+}
+
+describe('scene-generator language directive threading (issue #472)', () => {
+  describe('content generation', () => {
+    it('threads languageDirective into slide content prompt', async () => {
+      const { aiCall, lastUser } = makeCapturingAiCall(
+        JSON.stringify({ elements: [], background: null, remark: '' }),
+      );
+
+      await generateSceneContent(baseOutline({ type: 'slide' }), aiCall, {
+        languageDirective: DIRECTIVE,
+      });
+
+      expect(lastUser()).toContain(DIRECTIVE);
+      expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+
+    it('threads languageDirective into quiz content prompt', async () => {
+      const { aiCall, lastUser } = makeCapturingAiCall(JSON.stringify([]));
+
+      await generateSceneContent(
+        baseOutline({
+          type: 'quiz',
+          quizConfig: {
+            questionCount: 1,
+            difficulty: 'easy',
+            questionTypes: ['single'],
+          },
+        }),
+        aiCall,
+        { languageDirective: DIRECTIVE },
+      );
+
+      expect(lastUser()).toContain(DIRECTIVE);
+      expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+  });
+
+  describe('actions generation', () => {
+    it('threads languageDirective into slide actions prompt', async () => {
+      const { aiCall, lastUser } = makeCapturingAiCall('[]');
+      const content: GeneratedSlideContent = {
+        elements: [
+          {
+            id: 'text_1',
+            type: 'text',
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 40,
+            content: '<p>hi</p>',
+            defaultFontName: '',
+            defaultColor: '#000',
+            rotate: 0,
+          },
+        ],
+        background: undefined,
+        remark: '',
+      };
+
+      await generateSceneActions(
+        baseOutline({ type: 'slide' }),
+        content,
+        aiCall,
+        { languageDirective: DIRECTIVE },
+      );
+
+      expect(lastUser()).toContain(DIRECTIVE);
+      expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+
+    it('threads languageDirective into quiz actions prompt', async () => {
+      const { aiCall, lastUser } = makeCapturingAiCall('[]');
+      const content: GeneratedQuizContent = {
+        questions: [
+          {
+            id: 'q1',
+            type: 'single',
+            question: 'x?',
+            options: [{ value: 'A', label: 'yes' }],
+            answer: ['A'],
+            hasAnswer: true,
+          },
+        ],
+      };
+
+      await generateSceneActions(
+        baseOutline({ type: 'quiz' }),
+        content,
+        aiCall,
+        { languageDirective: DIRECTIVE },
+      );
+
+      expect(lastUser()).toContain(DIRECTIVE);
+      expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+
+    it('threads languageDirective into interactive actions prompt', async () => {
+      const { aiCall, lastUser } = makeCapturingAiCall('[]');
+      const content: GeneratedInteractiveContent = {
+        html: '<div />',
+        // No widgetType/teacherActions so we hit the normal actions path
+      };
+
+      await generateSceneActions(
+        baseOutline({ type: 'interactive' }),
+        content,
+        aiCall,
+        { languageDirective: DIRECTIVE },
+      );
+
+      expect(lastUser()).toContain(DIRECTIVE);
+      expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+
+    it('threads languageDirective into pbl actions prompt', async () => {
+      const { aiCall, lastUser } = makeCapturingAiCall('[]');
+      const content: GeneratedPBLContent = {
+        projectConfig: {
+          projectInfo: { title: 't', description: 'd' },
+          agents: [],
+          issueboard: { agent_ids: [], issues: [], current_issue_id: null },
+          chat: { messages: [] },
+        },
+      };
+
+      await generateSceneActions(
+        baseOutline({
+          type: 'pbl',
+          pblConfig: {
+            projectTopic: 't',
+            projectDescription: 'd',
+            targetSkills: [],
+          },
+        }),
+        content,
+        aiCall,
+        { languageDirective: DIRECTIVE },
+      );
+
+      expect(lastUser()).toContain(DIRECTIVE);
+      expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+  });
+
+  describe('pbl content honors caller-provided directive', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('forwards options.languageDirective to generatePBLContent', async () => {
+      const pblModule = await import('@/lib/pbl/generate-pbl');
+      const spy = vi.spyOn(pblModule, 'generatePBLContent').mockResolvedValue({
+        projectInfo: { title: '', description: '' },
+        agents: [],
+        issueboard: { agent_ids: [], issues: [], current_issue_id: null },
+        chat: { messages: [] },
+      });
+
+      const aiCall: AICallFn = async () => '';
+
+      await generateSceneContent(
+        baseOutline({
+          type: 'pbl',
+          pblConfig: {
+            projectTopic: 't',
+            projectDescription: 'd',
+            targetSkills: [],
+          },
+        }),
+        aiCall,
+        {
+          languageDirective: DIRECTIVE,
+          languageModel: {} as unknown as import('ai').LanguageModel,
+        },
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const config = spy.mock.calls[0][0];
+      expect(config.languageDirective).toBe(DIRECTIVE);
+    });
+  });
+});

--- a/tests/generation/scene-generator-language-directive.test.ts
+++ b/tests/generation/scene-generator-language-directive.test.ts
@@ -10,10 +10,7 @@
  */
 import { describe, expect, it, vi, afterEach } from 'vitest';
 
-import {
-  generateSceneContent,
-  generateSceneActions,
-} from '@/lib/generation/scene-generator';
+import { generateSceneContent, generateSceneActions } from '@/lib/generation/scene-generator';
 import type { AICallFn } from '@/lib/generation/pipeline-types';
 import type {
   SceneOutline,
@@ -114,12 +111,9 @@ describe('scene-generator language directive threading (issue #472)', () => {
         remark: '',
       };
 
-      await generateSceneActions(
-        baseOutline({ type: 'slide' }),
-        content,
-        aiCall,
-        { languageDirective: DIRECTIVE },
-      );
+      await generateSceneActions(baseOutline({ type: 'slide' }), content, aiCall, {
+        languageDirective: DIRECTIVE,
+      });
 
       expect(lastUser()).toContain(DIRECTIVE);
       expect(lastUser()).not.toContain('{{languageDirective}}');
@@ -140,12 +134,9 @@ describe('scene-generator language directive threading (issue #472)', () => {
         ],
       };
 
-      await generateSceneActions(
-        baseOutline({ type: 'quiz' }),
-        content,
-        aiCall,
-        { languageDirective: DIRECTIVE },
-      );
+      await generateSceneActions(baseOutline({ type: 'quiz' }), content, aiCall, {
+        languageDirective: DIRECTIVE,
+      });
 
       expect(lastUser()).toContain(DIRECTIVE);
       expect(lastUser()).not.toContain('{{languageDirective}}');
@@ -158,12 +149,9 @@ describe('scene-generator language directive threading (issue #472)', () => {
         // No widgetType/teacherActions so we hit the normal actions path
       };
 
-      await generateSceneActions(
-        baseOutline({ type: 'interactive' }),
-        content,
-        aiCall,
-        { languageDirective: DIRECTIVE },
-      );
+      await generateSceneActions(baseOutline({ type: 'interactive' }), content, aiCall, {
+        languageDirective: DIRECTIVE,
+      });
 
       expect(lastUser()).toContain(DIRECTIVE);
       expect(lastUser()).not.toContain('{{languageDirective}}');

--- a/tests/generation/scene-generator-language-directive.test.ts
+++ b/tests/generation/scene-generator-language-directive.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 
 import { generateSceneContent, generateSceneActions } from '@/lib/generation/scene-generator';
+import { buildSceneFromOutline } from '@/lib/generation/scene-builder';
 import type { AICallFn } from '@/lib/generation/pipeline-types';
 import type {
   SceneOutline,
@@ -184,6 +185,40 @@ describe('scene-generator language directive threading (issue #472)', () => {
 
       expect(lastUser()).toContain(DIRECTIVE);
       expect(lastUser()).not.toContain('{{languageDirective}}');
+    });
+  });
+
+  describe('buildSceneFromOutline (high-level pipeline)', () => {
+    it('threads languageDirective through content AND actions for a slide', async () => {
+      const captured: string[] = [];
+      const aiCall: AICallFn = async (_system, user) => {
+        captured.push(user);
+        // First call is content (expects JSON); second is actions (expects array)
+        return captured.length === 1
+          ? JSON.stringify({ elements: [], background: null, remark: '' })
+          : '[]';
+      };
+
+      await buildSceneFromOutline(
+        baseOutline({ type: 'slide' }),
+        aiCall,
+        'stage-1',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        DIRECTIVE,
+      );
+
+      expect(captured).toHaveLength(2);
+      for (const user of captured) {
+        expect(user).toContain(DIRECTIVE);
+        expect(user).not.toContain('{{languageDirective}}');
+      }
     });
   });
 

--- a/tests/generation/scene-generator-language-directive.test.ts
+++ b/tests/generation/scene-generator-language-directive.test.ts
@@ -188,6 +188,36 @@ describe('scene-generator language directive threading (issue #472)', () => {
     });
   });
 
+  describe('widget generation (interactive scenes)', () => {
+    it('threads languageDirective into widget content AND widget-teacher-actions prompts', async () => {
+      const captured: string[] = [];
+      // 1st call: widget HTML content; 2nd call: widget-teacher-actions JSON
+      const aiCall: AICallFn = async (_system, user) => {
+        captured.push(user);
+        return captured.length === 1
+          ? '<!DOCTYPE html><html><body>widget</body></html>'
+          : JSON.stringify({ actions: [] });
+      };
+
+      await generateSceneContent(
+        baseOutline({
+          type: 'interactive',
+          widgetType: 'simulation',
+          widgetOutline: { concept: 'Projectile', keyVariables: ['angle'] },
+        }),
+        aiCall,
+        { languageDirective: DIRECTIVE },
+      );
+
+      expect(captured).toHaveLength(2);
+      for (const user of captured) {
+        expect(user).toContain(DIRECTIVE);
+        expect(user).not.toContain('{{languageDirective}}');
+        expect(user).not.toContain('{{language}}');
+      }
+    });
+  });
+
   describe('buildSceneFromOutline (high-level pipeline)', () => {
     it('threads languageDirective through content AND actions for a slide', async () => {
       const captured: string[] = [];

--- a/tests/prompts/loader.test.ts
+++ b/tests/prompts/loader.test.ts
@@ -1,9 +1,7 @@
-import { describe, test, expect, beforeEach } from 'vitest';
-import { loadPrompt, loadSnippet, buildPrompt, clearPromptCache } from '@/lib/prompts';
+import { describe, test, expect } from 'vitest';
+import { loadPrompt, loadSnippet, buildPrompt } from '@/lib/prompts';
 
 describe('lib/prompts loader', () => {
-  beforeEach(() => clearPromptCache());
-
   test('loads a known template + interpolates variables', () => {
     const result = buildPrompt('slide-actions', {
       title: 'Test Slide',


### PR DESCRIPTION
Fixes #472.

## Summary

`languageDirective` was dropped, renamed, or hardcoded at several points in the scene generation pipeline, silently degrading prompt-level language control. Slide paths survived because their fallback happened to hint requirement-language behavior; widget paths degraded to `zh-CN` default — the original symptom that kicked off this investigation (English directive but Chinese widget teacher actions).

## What changed

**1. Thread `languageDirective` through every `buildPrompt` in `lib/generation/scene-generator.ts`**

- Add `languageDirective?: string` param to `generateSlideContent` / `generateQuizContent` / `generatePBLSceneContent`.
- Forward it from `generateSceneContent`'s slide / quiz / pbl branches.
- Include the key in the four `generateSceneActions` `buildPrompt` calls (slide / quiz / interactive / pbl actions).
- Demote `generatePBLSceneContent`'s hardcoded English directive to a fallback.
- Drop the dishonest `(languageDirective || 'zh-CN') as 'zh-CN' | 'en-US'` cast on the widget path.

**2. Unify variable naming across widget templates + callers**

- Rename `{{language}}` → `{{languageDirective}}` in 6 widget user templates (`simulation-content`, `diagram-content`, `code-content`, `game-content`, `visualization3d-content`, `widget-teacher-actions`).
- `generateWidgetContent` and `generateWidgetTeacherActions` now pass `languageDirective: languageDirective || ''` directly — no more locale-code shim.

**3. Make the outline LLM reliably emit the wrapper object**

During investigation we found Gemini sometimes returned a bare `[...]` scene array instead of `{ languageDirective, outlines }`, so the directive was silently lost and everything downstream ate the fallback string `"Teach in the language that matches the user requirement."`.

- `requirements-to-outlines/system.md` + `user.md` restructured so the "top-level JSON object with `languageDirective` + `outlines`" contract is surfaced up-front, short, and unambiguous. The drowning-by-scene-examples is gone; Important Reminders reordered to put top-level shape first.
- `interactive-outlines/system.md` + `user.md` aligned with the main outliner: full Language Inference section added, wrapper output required, the orphan `{{language}}` placeholder that never had a value source is removed.

**4. Remove `lib/prompts/loader.ts` prompt/snippet caches**

Disk reads for prompt templates are not on any hot path (LLM call dominates by 5 orders of magnitude). The cache's only observable effect during this investigation was blocking prompt edits from taking effect without a server restart — which masked the wrapper bug for hours. Net −27 LOC, and prompt iteration now just works.

## Verification

- **7 new regression tests** in `tests/generation/scene-generator-language-directive.test.ts` cover directive threading at each `buildPrompt` site plus the PBL caller-forwarding guarantee. All 27 prompt + generation tests green.
- **`pnpm eval:outline-language`** (50 scenarios, `gemini-3-flash-preview` inference + `qwen3.5-flash` judge): **48/50 (96%) pass**. The 2 persistent failures are both in the proxy-request category (teacher / tutor preparing lessons for students) where the system prompt's rule 5 has genuine semantic ambiguity — orthogonal to this fix and filed as a separate concern.
- **Curl burst tests**: 8/8 runs each for regular-mode and interactive-mode outline endpoints emit the wrapper object and extract a detailed inferred directive.
- `pnpm tsc` clean; lint only shows 2 pre-existing unused-import warnings.

## Test plan

- [ ] Run `pnpm vitest run tests/prompts tests/generation` — expect 27/27.
- [ ] Run `pnpm tsc --noEmit` — expect clean.
- [ ] Manually: generate a classroom from `"I want to learn Japanese"` (or any foreign-language-learning prompt in your native language) and confirm widget teacher actions respect the inferred directive instead of defaulting to Chinese.
- [ ] Optional: `EVAL_INFERENCE_MODEL=google:gemini-3-flash-preview EVAL_JUDGE_MODEL=qwen:qwen3.5-flash pnpm eval:outline-language` — expect ≥47/50 (variance ±1 around 48/50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
