### PR TITLE
feat(home): inline search for recent classrooms

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'motion/react';
 import {
@@ -12,6 +12,7 @@ import {
   ImagePlus,
   Pencil,
   Trash2,
+  Search,
   Settings,
   Sun,
   Moon,
@@ -21,11 +22,17 @@ import {
   Upload,
   Sparkles,
   Atom,
+  X,
 } from 'lucide-react';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { LanguageSwitcher } from '@/components/language-switcher';
 import { createLogger } from '@/lib/logger';
 import { Button } from '@/components/ui/button';
+import {
+  InputGroup,
+  InputGroupInput,
+  InputGroupButton,
+} from '@/components/ui/input-group';
 import { Textarea as UITextarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import { SettingsDialog } from '@/components/settings';
@@ -129,6 +136,10 @@ function HomePage() {
   const [classrooms, setClassrooms] = useState<StageListItem[]>([]);
   const [thumbnails, setThumbnails] = useState<Record<string, Slide>>({});
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchButtonRef = useRef<HTMLButtonElement>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -200,6 +211,16 @@ function HomePage() {
       toast.error(t('classroom.renameFailed'));
     }
   };
+
+  const filteredClassrooms = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return classrooms;
+    return classrooms.filter((c) => {
+      const name = c.name?.toLowerCase() ?? '';
+      const desc = c.description?.toLowerCase() ?? '';
+      return name.includes(q) || desc.includes(q);
+    });
+  }, [classrooms, searchQuery]);
 
   const updateForm = <K extends keyof FormState>(field: K, value: FormState[K]) => {
     setForm((prev) => ({ ...prev, [field]: value }));

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -97,6 +97,14 @@ function HomePage() {
   // Model setup state
   const currentModelId = useSettingsStore((s) => s.modelId);
   const [recentOpen, setRecentOpen] = useState(true);
+  const persistRecentOpen = (next: boolean) => {
+    setRecentOpen(next);
+    try {
+      localStorage.setItem(RECENT_OPEN_STORAGE_KEY, String(next));
+    } catch {
+      /* ignore */
+    }
+  };
 
   // Hydrate client-only state after mount (avoids SSR mismatch)
   /* eslint-disable react-hooks/set-state-in-effect -- Hydration from localStorage must happen in effect */
@@ -648,15 +656,7 @@ function HomePage() {
             <div className="flex-1 h-px bg-border/40 group-hover:bg-border/70 transition-colors" />
             <div className="shrink-0 flex items-center gap-3 text-[13px] text-muted-foreground/60 select-none">
               <button
-                onClick={() => {
-                  const next = !recentOpen;
-                  setRecentOpen(next);
-                  try {
-                    localStorage.setItem(RECENT_OPEN_STORAGE_KEY, String(next));
-                  } catch {
-                    /* ignore */
-                  }
-                }}
+                onClick={() => persistRecentOpen(!recentOpen)}
                 className="flex items-center gap-2 hover:text-foreground/70 transition-colors cursor-pointer"
               >
                 <Clock className="size-3.5" />
@@ -680,14 +680,7 @@ function HomePage() {
                     aria-label={t('classroom.searchAriaLabel')}
                     onClick={() => {
                       setSearchOpen(true);
-                      if (!recentOpen) {
-                        setRecentOpen(true);
-                        try {
-                          localStorage.setItem(RECENT_OPEN_STORAGE_KEY, 'true');
-                        } catch {
-                          /* ignore */
-                        }
-                      }
+                      if (!recentOpen) persistRecentOpen(true);
                       requestAnimationFrame(() => searchInputRef.current?.focus());
                     }}
                     initial={{ opacity: 0 }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -677,7 +677,6 @@ function HomePage() {
                     ref={searchButtonRef}
                     type="button"
                     aria-label={t('classroom.searchAriaLabel')}
-                    aria-expanded={false}
                     onClick={() => {
                       setSearchOpen(true);
                       if (!recentOpen) {
@@ -732,7 +731,7 @@ function HomePage() {
                         }}
                         placeholder={t('classroom.searchPlaceholder')}
                         aria-label={t('classroom.searchAriaLabel')}
-                        className="h-7 text-[12px]"
+                        className="h-7"
                       />
                       {searchQuery && (
                         <InputGroupButton
@@ -776,7 +775,7 @@ function HomePage() {
                 transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
                 className="w-full overflow-hidden"
               >
-                {filteredClassrooms.length === 0 ? (
+                {searchQuery.trim() && filteredClassrooms.length === 0 ? (
                   <div className="pt-8 pb-2 text-center text-[13px] text-muted-foreground/60">
                     {t('classroom.searchEmpty')}
                   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,11 +28,7 @@ import { useI18n } from '@/lib/hooks/use-i18n';
 import { LanguageSwitcher } from '@/components/language-switcher';
 import { createLogger } from '@/lib/logger';
 import { Button } from '@/components/ui/button';
-import {
-  InputGroup,
-  InputGroupInput,
-  InputGroupButton,
-} from '@/components/ui/input-group';
+import { InputGroup, InputGroupInput, InputGroupButton } from '@/components/ui/input-group';
 import { Textarea as UITextarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import { SettingsDialog } from '@/components/settings';
@@ -721,9 +717,7 @@ function HomePage() {
                               setSearchQuery('');
                             } else {
                               setSearchOpen(false);
-                              requestAnimationFrame(() =>
-                                searchButtonRef.current?.focus(),
-                              );
+                              requestAnimationFrame(() => searchButtonRef.current?.focus());
                             }
                           }
                         }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -670,7 +670,7 @@ function HomePage() {
               </button>
 
               {/* Search toggle — icon that expands into an input in place */}
-              <AnimatePresence initial={false} mode="wait">
+              <AnimatePresence initial={false}>
                 {!searchOpen ? (
                   <motion.button
                     key="search-icon"
@@ -689,10 +689,10 @@ function HomePage() {
                       }
                       requestAnimationFrame(() => searchInputRef.current?.focus());
                     }}
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.9 }}
-                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.12, ease: 'easeOut' }}
                     className="flex items-center justify-center size-6 rounded-full text-muted-foreground/50 hover:text-foreground/70 hover:bg-muted/50 transition-colors cursor-pointer"
                   >
                     <Search className="size-3.5" />
@@ -703,10 +703,19 @@ function HomePage() {
                     initial={{ opacity: 0, width: 0 }}
                     animate={{ opacity: 1, width: 200 }}
                     exit={{ opacity: 0, width: 0 }}
-                    transition={{ duration: 0.2, ease: 'easeOut' }}
+                    transition={{ duration: 0.18, ease: [0.25, 0.1, 0.25, 1] }}
                     className="overflow-hidden"
                   >
-                    <InputGroup className="h-7 text-[12px]">
+                    <InputGroup
+                      className={cn(
+                        'h-7 text-[12px] rounded-full bg-muted/40 border-transparent shadow-none',
+                        'transition-colors',
+                        'hover:bg-muted/60',
+                        'has-[[data-slot=input-group-control]:focus-visible]:bg-muted/60',
+                        'has-[[data-slot=input-group-control]:focus-visible]:border-transparent',
+                        'has-[[data-slot=input-group-control]:focus-visible]:ring-0',
+                      )}
+                    >
                       <InputGroupInput
                         ref={searchInputRef}
                         value={searchQuery}
@@ -731,7 +740,7 @@ function HomePage() {
                         }}
                         placeholder={t('classroom.searchPlaceholder')}
                         aria-label={t('classroom.searchAriaLabel')}
-                        className="h-7"
+                        className="h-7 pl-3 placeholder:text-muted-foreground/50"
                       />
                       {searchQuery && (
                         <InputGroupButton

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -668,6 +668,90 @@ function HomePage() {
                   <ChevronDown className="size-3.5" />
                 </motion.div>
               </button>
+
+              {/* Search toggle — icon that expands into an input in place */}
+              <AnimatePresence initial={false} mode="wait">
+                {!searchOpen ? (
+                  <motion.button
+                    key="search-icon"
+                    ref={searchButtonRef}
+                    type="button"
+                    aria-label={t('classroom.searchAriaLabel')}
+                    aria-expanded={false}
+                    onClick={() => {
+                      setSearchOpen(true);
+                      if (!recentOpen) {
+                        setRecentOpen(true);
+                        try {
+                          localStorage.setItem(RECENT_OPEN_STORAGE_KEY, 'true');
+                        } catch {
+                          /* ignore */
+                        }
+                      }
+                      requestAnimationFrame(() => searchInputRef.current?.focus());
+                    }}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.9 }}
+                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                    className="flex items-center justify-center size-6 rounded-full text-muted-foreground/50 hover:text-foreground/70 hover:bg-muted/50 transition-colors cursor-pointer"
+                  >
+                    <Search className="size-3.5" />
+                  </motion.button>
+                ) : (
+                  <motion.div
+                    key="search-input"
+                    initial={{ opacity: 0, width: 0 }}
+                    animate={{ opacity: 1, width: 200 }}
+                    exit={{ opacity: 0, width: 0 }}
+                    transition={{ duration: 0.2, ease: 'easeOut' }}
+                    className="overflow-hidden"
+                  >
+                    <InputGroup className="h-7 text-[12px]">
+                      <InputGroupInput
+                        ref={searchInputRef}
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Escape') {
+                            e.preventDefault();
+                            if (searchQuery) {
+                              setSearchQuery('');
+                            } else {
+                              setSearchOpen(false);
+                              requestAnimationFrame(() =>
+                                searchButtonRef.current?.focus(),
+                              );
+                            }
+                          }
+                        }}
+                        onBlur={() => {
+                          if (!searchQuery) {
+                            setSearchOpen(false);
+                          }
+                        }}
+                        placeholder={t('classroom.searchPlaceholder')}
+                        aria-label={t('classroom.searchAriaLabel')}
+                        className="h-7 text-[12px]"
+                      />
+                      {searchQuery && (
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={t('classroom.clearSearch')}
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => {
+                            setSearchQuery('');
+                            searchInputRef.current?.focus();
+                          }}
+                        >
+                          <X />
+                        </InputGroupButton>
+                      )}
+                    </InputGroup>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
               <button
                 onClick={triggerFileSelect}
                 disabled={importing}
@@ -692,32 +776,38 @@ function HomePage() {
                 transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
                 className="w-full overflow-hidden"
               >
-                <div className="pt-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-5 gap-y-8">
-                  {classrooms.map((classroom, i) => (
-                    <motion.div
-                      key={classroom.id}
-                      initial={{ opacity: 0, y: 16 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{
-                        delay: i * 0.04,
-                        duration: 0.35,
-                        ease: 'easeOut',
-                      }}
-                    >
-                      <ClassroomCard
-                        classroom={classroom}
-                        slide={thumbnails[classroom.id]}
-                        formatDate={formatDate}
-                        onDelete={handleDelete}
-                        onRename={handleRename}
-                        confirmingDelete={pendingDeleteId === classroom.id}
-                        onConfirmDelete={() => confirmDelete(classroom.id)}
-                        onCancelDelete={() => setPendingDeleteId(null)}
-                        onClick={() => router.push(`/classroom/${classroom.id}`)}
-                      />
-                    </motion.div>
-                  ))}
-                </div>
+                {filteredClassrooms.length === 0 ? (
+                  <div className="pt-8 pb-2 text-center text-[13px] text-muted-foreground/60">
+                    {t('classroom.searchEmpty')}
+                  </div>
+                ) : (
+                  <div className="pt-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-5 gap-y-8">
+                    {filteredClassrooms.map((classroom, i) => (
+                      <motion.div
+                        key={classroom.id}
+                        initial={{ opacity: 0, y: 16 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{
+                          delay: i * 0.04,
+                          duration: 0.35,
+                          ease: 'easeOut',
+                        }}
+                      >
+                        <ClassroomCard
+                          classroom={classroom}
+                          slide={thumbnails[classroom.id]}
+                          formatDate={formatDate}
+                          onDelete={handleDelete}
+                          onRename={handleRename}
+                          confirmingDelete={pendingDeleteId === classroom.id}
+                          onConfirmDelete={() => confirmDelete(classroom.id)}
+                          onCancelDelete={() => setPendingDeleteId(null)}
+                          onClick={() => router.push(`/classroom/${classroom.id}`)}
+                        />
+                      </motion.div>
+                    ))}
+                  </div>
+                )}
               </motion.div>
             )}
           </AnimatePresence>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useDeferredValue } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'motion/react';
 import {
@@ -212,15 +212,16 @@ function HomePage() {
     }
   };
 
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const filteredClassrooms = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase();
+    const q = deferredSearchQuery.trim().toLowerCase();
     if (!q) return classrooms;
     return classrooms.filter((c) => {
       const name = c.name?.toLowerCase() ?? '';
       const desc = c.description?.toLowerCase() ?? '';
       return name.includes(q) || desc.includes(q);
     });
-  }, [classrooms, searchQuery]);
+  }, [classrooms, deferredSearchQuery]);
 
   const updateForm = <K extends keyof FormState>(field: K, value: FormState[K]) => {
     setForm((prev) => ({ ...prev, [field]: value }));

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -280,7 +280,11 @@
     "delete": "حذف",
     "rename": "إعادة تسمية",
     "renamePlaceholder": "أدخل اسم الفصل",
-    "renameFailed": "فشلت إعادة تسمية الفصل"
+    "renameFailed": "فشلت إعادة تسمية الفصل",
+    "searchPlaceholder": "البحث عن الدروس...",
+    "searchAriaLabel": "البحث عن الدروس",
+    "clearSearch": "مسح",
+    "searchEmpty": "لا توجد دروس مطابقة"
   },
   "upload": {
     "pdfSizeLimit": "يدعم ملفات PDF حتى 50 ميغابايت",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -280,7 +280,11 @@
     "delete": "Delete",
     "rename": "Rename",
     "renamePlaceholder": "Enter classroom name",
-    "renameFailed": "Failed to rename classroom"
+    "renameFailed": "Failed to rename classroom",
+    "searchPlaceholder": "Search courses...",
+    "searchAriaLabel": "Search courses",
+    "clearSearch": "Clear",
+    "searchEmpty": "No courses match your search"
   },
   "upload": {
     "pdfSizeLimit": "Supports PDF files up to 50MB",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -280,7 +280,11 @@
     "delete": "削除",
     "rename": "名前を変更",
     "renamePlaceholder": "教室名を入力",
-    "renameFailed": "教室名の変更に失敗しました"
+    "renameFailed": "教室名の変更に失敗しました",
+    "searchPlaceholder": "コースを検索...",
+    "searchAriaLabel": "コースを検索",
+    "clearSearch": "クリア",
+    "searchEmpty": "該当するコースが見つかりません"
   },
   "upload": {
     "pdfSizeLimit": "50MBまでのPDFファイルに対応しています",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -280,7 +280,11 @@
     "delete": "Удалить",
     "rename": "Переименовать",
     "renamePlaceholder": "Введите название класса",
-    "renameFailed": "Не удалось переименовать класс"
+    "renameFailed": "Не удалось переименовать класс",
+    "searchPlaceholder": "Поиск курсов...",
+    "searchAriaLabel": "Поиск курсов",
+    "clearSearch": "Очистить",
+    "searchEmpty": "Курсы не найдены"
   },
   "upload": {
     "pdfSizeLimit": "Поддержка PDF до 50 МБ",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -280,7 +280,11 @@
     "delete": "删除",
     "rename": "重命名",
     "renamePlaceholder": "输入课堂名称",
-    "renameFailed": "重命名失败"
+    "renameFailed": "重命名失败",
+    "searchPlaceholder": "搜索课程...",
+    "searchAriaLabel": "搜索课程",
+    "clearSearch": "清空",
+    "searchEmpty": "没有找到匹配的课程"
   },
   "upload": {
     "pdfSizeLimit": "支持最大50MB的PDF文件",


### PR DESCRIPTION
Closes #475.

## Summary

- Add a minimal inline search to the Home page's "Recent" classroom section — a Search icon button in the title row that expands in-place into a pill-style input and filters the list by name + description.
- Case-insensitive substring match, real-time filtering. Clearing via the inline ✕ keeps the input open; Escape clears or collapses; blur with an empty query auto-collapses.
- Grid re-render is deferred via `useDeferredValue` so fast typing stays snappy even with many classroom cards.

## Changes

- `app/page.tsx` — new `searchOpen` / `searchQuery` local state, `filteredClassrooms = useMemo(...)` driven by `useDeferredValue(searchQuery)`, `AnimatePresence`-based icon ↔ input toggle, pill-style `InputGroup`, empty-state row in the expanded grid.
- `lib/i18n/locales/{en-US,zh-CN,ja-JP,ru-RU,ar-SA}.json` — new keys under `classroom.*`: `searchPlaceholder`, `searchAriaLabel`, `clearSearch`, `searchEmpty`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

Manual (verified locally via \`pnpm dev\`):

- [x] Default state shows only the 🔍 icon; other UI unchanged.
- [x] Click 🔍 → input expands in place, auto-focuses, and auto-expands the collapsed section.
- [x] Real-time filtering by name and description is case-insensitive.
- [x] Typing with many classrooms does not lag the input (deferred grid render).
- [x] No match → empty-state text shown.
- [x] ✕ clears but keeps input open and focused; Escape clears, then collapses + restores focus to the toggle; blur with empty query collapses.
- [x] Existing open / rename / delete / import flows still work.
- [x] Language switch (en/zh/ja/ru/ar) — placeholder, empty state, aria labels all translated.