### PR TITLE
[codex] Fix Claude Haiku 4.5 thinking controls

### DIFF
--- a/lib/ai/llm.ts
+++ b/lib/ai/llm.ts
@@ -148,6 +148,14 @@ function buildThinkingProviderOptions(
 
     case 'anthropic': {
       if (mode === 'disabled') return { anthropic: { thinking: { type: 'disabled' } } };
+
+      if (thinking.control === 'toggle-budget' || thinking.control === 'budget-only') {
+        const budget = pickThinkingBudget(thinking, config);
+        return budget === undefined
+          ? undefined
+          : { anthropic: { thinking: { type: 'enabled', budgetTokens: budget } } };
+      }
+
       const effort = getAnthropicEffort(thinking, config);
       if (!effort) return undefined;
 

--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -129,6 +129,13 @@ const anthropicAdaptiveEffort: ThinkingCapability = {
   anthropicThinking: { type: 'adaptive' },
 };
 
+const anthropicBudget: ThinkingCapability = toggleBudgetCapability(
+  'anthropic',
+  { min: 1024, max: 64000, step: 1024 },
+  false,
+  1024,
+);
+
 const anthropicOpus47Effort: ThinkingCapability = {
   ...anthropicAdaptiveEffort,
   effortValues: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
@@ -232,7 +239,7 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('anthropic', 'claude-opus-4-6')]: anthropicAdaptiveEffort,
   [getModelMetadataKey('anthropic', 'claude-sonnet-4-6')]: anthropicAdaptiveEffort,
   [getModelMetadataKey('anthropic', 'claude-sonnet-4-5')]: anthropicManualEffort,
-  [getModelMetadataKey('anthropic', 'claude-haiku-4-5')]: anthropicManualEffort,
+  [getModelMetadataKey('anthropic', 'claude-haiku-4-5')]: anthropicBudget,
 
   [getModelMetadataKey('google', 'gemini-3.1-pro-preview')]: levelCapability(
     ['minimal', 'low', 'medium', 'high'],

--- a/tests/ai/anthropic-serialization.test.ts
+++ b/tests/ai/anthropic-serialization.test.ts
@@ -1,0 +1,54 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { describe, expect, it, vi } from 'vitest';
+
+import { callLLM } from '@/lib/ai/llm';
+
+describe('Anthropic request serialization', () => {
+  it('serializes Claude Haiku 4.5 thinking budget without effort', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({
+          type: 'message',
+          id: 'msg_test',
+          model: 'claude-haiku-4-5',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    const anthropic = createAnthropic({
+      apiKey: 'test-key',
+      fetch: fetchMock,
+    });
+
+    await callLLM(
+      {
+        model: anthropic.chat('claude-haiku-4-5'),
+        prompt: 'hi',
+        maxOutputTokens: 10,
+      } as Parameters<typeof callLLM>[0],
+      'serialization-test',
+      undefined,
+      { mode: 'enabled', budgetTokens: 4096 },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(captured).toMatchObject({
+      model: 'claude-haiku-4-5',
+      max_tokens: 4106,
+      thinking: {
+        type: 'enabled',
+        budget_tokens: 4096,
+      },
+    });
+    expect(captured?.output_config).toBeUndefined();
+  });
+});

--- a/tests/ai/llm-thinking-options.test.ts
+++ b/tests/ai/llm-thinking-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const aiMock = vi.hoisted(() => ({
+  generateText: vi.fn(async (params: unknown) => ({ text: 'ok', params })),
+  streamText: vi.fn(),
+}));
+
+vi.mock('ai', () => ({
+  generateText: aiMock.generateText,
+  streamText: aiMock.streamText,
+}));
+
+import { callLLM } from '@/lib/ai/llm';
+
+describe('LLM thinking provider options', () => {
+  it('sends Claude Haiku 4.5 thinking budget without effort', async () => {
+    await callLLM(
+      {
+        model: {
+          provider: 'anthropic.messages',
+          modelId: 'claude-haiku-4-5',
+        },
+        prompt: 'hi',
+      } as Parameters<typeof callLLM>[0],
+      'test',
+      undefined,
+      { mode: 'enabled', budgetTokens: 4096 },
+    );
+
+    expect(aiMock.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          anthropic: {
+            thinking: { type: 'enabled', budgetTokens: 4096 },
+          },
+        },
+      }),
+    );
+    const params = aiMock.generateText.mock.calls[0]?.[0] as {
+      providerOptions?: { anthropic?: Record<string, unknown> };
+    };
+    expect(params.providerOptions?.anthropic).not.toHaveProperty('effort');
+  });
+});

--- a/tests/ai/thinking-config.test.ts
+++ b/tests/ai/thinking-config.test.ts
@@ -33,6 +33,23 @@ describe('thinking config metadata', () => {
     expect(supportsConfigurableThinking(minimaxThinking)).toBe(false);
   });
 
+  it('exposes Claude Haiku 4.5 thinking as budget-only, not effort', () => {
+    const thinking = getThinking('anthropic', 'claude-haiku-4-5');
+
+    expect(supportsConfigurableThinking(thinking)).toBe(true);
+    expect(thinking?.control).toBe('toggle-budget');
+    expect(thinking?.requestAdapter).toBe('anthropic');
+    expect(thinking?.effortValues).toBeUndefined();
+    expect(getDefaultThinkingConfig(thinking)).toEqual({
+      mode: 'disabled',
+      budgetTokens: 1024,
+    });
+    expect(normalizeThinkingConfig(thinking, { mode: 'enabled', budgetTokens: 4096 })).toEqual({
+      mode: 'enabled',
+      budgetTokens: 4096,
+    });
+  });
+
   it('removes deprecated and legacy models from the built-in catalog', () => {
     const openaiModels = getProvider('openai')?.models.map((item) => item.id);
     const glmModels = getProvider('glm')?.models.map((item) => item.id);


### PR DESCRIPTION
## Summary

- Change `claude-haiku-4-5` from Anthropic manual effort levels to a budget-based Anthropic thinking capability.
- Map Anthropic budget controls to `thinking: { type: 'enabled', budgetTokens }` without sending `effort` / `output_config.effort`.
- Add metadata, providerOptions, and Anthropic request serialization tests for Claude Haiku 4.5.

## Context

Fixes #497.

Claude Haiku 4.5 supports extended thinking, but the supported control is Anthropic thinking budget (`thinking.budget_tokens`), not the manual effort selector exposed by the previous `anthropicManualEffort` metadata.

## Validation

- `pnpm exec vitest run tests/ai/thinking-config.test.ts tests/ai/llm-thinking-options.test.ts tests/ai/anthropic-serialization.test.ts`

The serialization test uses a mocked `fetch` and does not send any real Anthropic API request.