### PR TITLE
docs: tighten VoxCPM2 README section

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -220,9 +220,9 @@ docker compose up --build
 
 ### 可选：VoxCPM2（自托管 TTS，支持音色克隆）
 
-[VoxCPM2](https://github.com/OpenBMB/VoxCPM) 是 OpenBMB 开源的 TTS 模型，音色克隆能力强。OpenMAIC 作为适配层接入：你在自己的硬件上跑 VoxCPM 后端，OpenMAIC 负责调用。音色档案（包括参考音频克隆）存在浏览器本地，保持纯前端的部署模型。
+[VoxCPM2](https://github.com/OpenBMB/VoxCPM) 是 OpenBMB 开源的 TTS 模型，支持声音克隆。OpenMAIC 自带适配器，把 VoxCPM 跑在自己机器上即可对接。
 
-**1. 部署 VoxCPM 后端。** OpenMAIC 支持三种部署形态，按你的环境选一种即可：
+**1. 部署 VoxCPM 后端。** 三种部署形态，背后是同一套 OpenMAIC 适配器，在设置里切换即可。
 
 | 后端 | 接口 | 适用场景 |
 | --- | --- | --- |
@@ -230,9 +230,9 @@ docker compose up --build
 | **Python API** | `/tts/upload` | 官方 VoxCPM Python 运行时（FastAPI） |
 | **Nano-vLLM** | `/generate` | 轻量级 Nano-vLLM FastAPI 部署 |
 
-每种后端的部署步骤详见 [VoxCPM 仓库](https://github.com/OpenBMB/VoxCPM)。
+每种后端的具体启动步骤见 [VoxCPM 仓库](https://github.com/OpenBMB/VoxCPM)。
 
-**2. 在 OpenMAIC 中配置。** 打开 设置 → **语音合成** → **VoxCPM2**，选择后端类型并填入 Base URL，下方的 Request URL 预览会确认实际调用地址：
+**2. 在 OpenMAIC 中配置。** 打开 设置 → **语音合成** → **VoxCPM2**，选择后端类型并填入 Base URL，下方的 Request URL 预览会显示实际请求地址。
 
 <img src="assets/voxcpm/voxcpm-connection.png" width="85%" alt="VoxCPM2 连接设置：后端选择、Base URL、模型名" />
 
@@ -242,15 +242,13 @@ docker compose up --build
 TTS_VOXCPM_BASE_URL=http://localhost:8000/v1
 ```
 
-**3. 管理音色。** 音色管理器支持构建一个浏览器本地的音色池，Agent Bar 会自动接入：
+**3. 管理音色。** 三种音色模式，都在 **设置 → 语音合成 → VoxCPM2 → VoxCPM 音色** 里。
 
-<img src="assets/voxcpm/voxcpm-voice-manager.png" width="85%" alt="VoxCPM2 音色管理器：音色池、Prompt 与 Clone 创建" />
+<img src="assets/voxcpm/voxcpm-voice-manager.png" width="85%" alt="VoxCPM2 音色管理：Auto / Prompt / Clone 三种模式" />
 
-- **Auto Voice**（默认）—— 在合成时根据每个智能体的人设自动生成 voice prompt，零配置。
-- **Prompt 音色** —— 用自然语言描述音色（例如 *"温暖的女性教师嗓音，平静而鼓励，中等音调"*）。
-- **Clone 音色** —— 上传一段参考音频或在浏览器里录一段，OpenMAIC 会把参考音频传给后端作为克隆样本。音色克隆需要后端支持参考音频（vLLM-Omni / Python API / Nano-vLLM 都支持）。
-
-> 音色档案存放在浏览器 IndexedDB 中，不会同步到服务端。
+- **Auto Voice**（默认）：合成时根据每个智能体的人设动态生成 voice prompt，零配置。
+- **Prompt 音色**：用自然语言描述音色，例如 *"温暖的女性教师嗓音，平静而鼓励，中等音调"*。
+- **Clone 音色**：上传一段参考音频或在浏览器里录一段。音频存在 IndexedDB 中，每次合成时发给后端。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ Set `PDF_MINERU_BASE_URL` (and `PDF_MINERU_API_KEY` if needed) in `.env.local`.
 
 ### Optional: VoxCPM2 (Self-Hosted TTS with Voice Cloning)
 
-[VoxCPM2](https://github.com/OpenBMB/VoxCPM) is an open-source TTS model from OpenBMB with strong voice cloning. OpenMAIC ships an adapter — you bring up VoxCPM on your own hardware, and OpenMAIC speaks to it. Voice profiles (including reference-audio clones) live in your browser, so the serverless setup model is preserved.
+[VoxCPM2](https://github.com/OpenBMB/VoxCPM) is an open-source TTS model from OpenBMB with voice cloning. OpenMAIC ships an adapter; run VoxCPM on your own hardware and OpenMAIC will talk to it.
 
-**1. Run a VoxCPM backend.** OpenMAIC supports three deployment styles — pick whichever your environment fits:
+**1. Run a VoxCPM backend.** Three deployment styles, all behind the same OpenMAIC adapter. You toggle which one in Settings.
 
 | Backend | Endpoint | When to use |
 | --- | --- | --- |
@@ -230,27 +230,25 @@ Set `PDF_MINERU_BASE_URL` (and `PDF_MINERU_API_KEY` if needed) in `.env.local`.
 | **Python API** | `/tts/upload` | Official VoxCPM Python runtime via FastAPI |
 | **Nano-vLLM** | `/generate` | Lightweight Nano-vLLM FastAPI deployment |
 
-See the [VoxCPM repo](https://github.com/OpenBMB/VoxCPM) for setup instructions for each backend.
+See the [VoxCPM repo](https://github.com/OpenBMB/VoxCPM) for backend setup.
 
-**2. Point OpenMAIC at it.** Open Settings → **Text-to-Speech** → **VoxCPM2**, pick the backend, and paste your Base URL. The Request URL preview confirms OpenMAIC will hit the right endpoint:
+**2. Point OpenMAIC at it.** Open Settings → **Text-to-Speech** → **VoxCPM2**, pick the backend, and paste your Base URL. The Request URL preview confirms OpenMAIC will hit the right endpoint.
 
 <img src="assets/voxcpm/voxcpm-connection.png" width="85%" alt="VoxCPM2 connection settings: backend selector, Base URL, model" />
 
-You can also pre-configure it via env vars (no API key required):
+Or pre-configure it via env var (no API key required):
 
 ```env
 TTS_VOXCPM_BASE_URL=http://localhost:8000/v1
 ```
 
-**3. Manage voices.** The voice manager lets you build a per-browser voice pool that the Agent Bar picks up automatically:
+**3. Manage voices.** Three voice modes, all under **Settings → Text-to-Speech → VoxCPM2 → VoxCPM Voices**.
 
-<img src="assets/voxcpm/voxcpm-voice-manager.png" width="85%" alt="VoxCPM2 voice manager with Voice Pool, Prompt and Clone tabs" />
+<img src="assets/voxcpm/voxcpm-voice-manager.png" width="85%" alt="VoxCPM2 VoxCPM Voices section with Auto, Prompt and Clone modes" />
 
-- **Auto Voice** (default) — generates a voice prompt from each agent's persona at synthesis time. No setup required.
-- **Prompt voice** — describe the voice in natural language (e.g. *"Warm female teacher voice, calm and encouraging, mid-pitch"*).
-- **Clone voice** — upload a short reference audio clip or record one in the browser; OpenMAIC sends it to your backend as the cloning reference. Voice cloning requires a backend that supports reference audio (vLLM-Omni, Python API, or Nano-vLLM).
-
-> Voice profiles are stored in your browser's IndexedDB and are not synced to the server.
+- **Auto Voice** (default): OpenMAIC generates a voice prompt from each agent's persona at synthesis time. No setup required.
+- **Prompt voice**: describe the voice in natural language, e.g. *"warm female teacher voice, calm and encouraging, mid-pitch"*.
+- **Clone voice**: upload a short reference audio clip or record one in the browser. The clip is stored in IndexedDB and sent to your VoxCPM backend on each synthesis.
 
 ---
 


### PR DESCRIPTION
## What

Small tone + accuracy pass on the VoxCPM2 section in `README.md` / `README-zh.md`.

## Why

A few claims in the current section don't quite hold up against the code:

1. **"Voice profiles live in your browser, so the serverless setup model is preserved"** / **"Voice profiles are stored in your browser's IndexedDB and are not synced to the server"** — overclaims the privacy story. The voice library *catalog* lives in IndexedDB, but cloning is not zero-data: the reference audio clip is sent to the VoxCPM backend on every synthesis. Better to just say what actually happens.
2. **"Voice cloning requires a backend that supports reference audio (vLLM-Omni, Python API, or Nano-vLLM)"** — all three shipped backends already support reference audio (`voxCPMBackendSupportsReferenceAudio` returns `true` for each). And when the capability check returns false, `voice-resolver.ts` filters clone profiles out of the picker entirely (and the settings UI shows them disabled with a warning) — there is no silent fallback. So the warning is misleading on both counts.
3. **"voice manager" / "Voice Pool, Prompt and Clone tabs"** — the actual settings section is **VoxCPM Voices** / **VoxCPM 音色** (`voxcpmVoicesTitle`); "Voice Pool" isn't a label that ships in the UI.

Also dropped a couple of stacked em-dash chains and AI-flavored phrasing that crept in.

## Changes

- `README.md` (en): VoxCPM2 section, ~10 lines
- `README-zh.md` (zh): same section, ~10 lines

No code changes, no asset changes.