### PR TITLE
fix(export): skip malformed SVG path shapes instead of aborting PPTX export

### DIFF
--- a/lib/export/svg-path-parser.ts
+++ b/lib/export/svg-path-parser.ts
@@ -1,5 +1,8 @@
 import { SVGPathData } from 'svg-pathdata';
 import arcToBezier from 'svg-arc-to-cubic-bezier';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('SvgPathParser');
 
 const typeMap = {
   1: 'Z',
@@ -32,9 +35,20 @@ export type SvgPath = ReturnType<typeof parseSvgPath>;
 /**
  * 解析SVG路径，并将圆弧（A）类型的路径转为三次贝塞尔（C）类型的路径
  * @param d SVG path d属性
+ *
+ * Returns an empty array if the path is malformed (e.g. unrecognised commands).
+ * Mirrors the defensive behaviour of {@link getSvgPathRange}: a single bad path
+ * (often produced by upstream LLM hallucinations) shouldn't take down the whole
+ * PPTX export.
  */
 export const toPoints = (d: string) => {
-  const pathData = new SVGPathData(d);
+  let pathData: SVGPathData;
+  try {
+    pathData = new SVGPathData(d);
+  } catch (err) {
+    log.warn(`Failed to parse SVG path "${d}":`, err);
+    return [];
+  }
 
   const points = [];
   for (const item of pathData.commands) {

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -581,7 +581,9 @@ async function buildPptxBlob(
             x: el.width / el.viewBox[0],
             y: el.height / el.viewBox[1],
           };
-          const points = formatPoints(toPoints(el.path), ratioPx2Inch, scale);
+          const rawPoints = toPoints(el.path);
+          if (!rawPoints.length) continue; // Malformed path — toPoints already logged.
+          const points = formatPoints(rawPoints, ratioPx2Inch, scale);
 
           let fillColor = formatColor(el.fill);
           if (el.gradient) {

--- a/tests/export/svg-path-parser.test.ts
+++ b/tests/export/svg-path-parser.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { toPoints, getSvgPathRange } from '@/lib/export/svg-path-parser';
+
+describe('toPoints', () => {
+  beforeEach(() => {
+    // Silence the parser's warn log for malformed-path cases.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  test('parses a valid M/L/Z path', () => {
+    const points = toPoints('M 0 0 L 1 0 L 1 1 L 0 1 Z');
+    expect(points.length).toBeGreaterThan(0);
+    expect(points[0]).toMatchObject({ type: 'M', x: 0, y: 0 });
+  });
+
+  test('returns [] for a malformed path so the export does not crash', () => {
+    // Real-world malformed path observed in an imported course manifest:
+    // upstream LLM produced "alert" instead of an "A" arc command.
+    const malformed = 'M 1 0.5 alert 0.5 0.5 0 1 1 0 0.5 A 0.5 0.5 0 1 1 1 0.5 Z';
+    expect(toPoints(malformed)).toEqual([]);
+  });
+});
+
+describe('getSvgPathRange', () => {
+  test('returns zero range for malformed path (existing tolerant behaviour)', () => {
+    expect(getSvgPathRange('not a path')).toEqual({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- Make `toPoints` (in `lib/export/svg-path-parser.ts`) mirror the tolerant pattern of its sibling `getSvgPathRange`: warn and return `[]` on parse failure, instead of letting `svg-pathdata`'s `SyntaxError` propagate.
- In the shape branch of `buildPptxBlob` (`lib/export/use-export-pptx.ts`), skip the element when `toPoints` returns no points so a single bad path no longer blocks the entire export.
- Add unit tests covering the happy path and the exact malformed input that triggered #504 (`M 1 0.5 alert 0.5 0.5 0 1 1 0 0.5 A 0.5 0.5 0 1 1 1 0.5 Z`).

Fixes #504.

## Test plan
- [x] `pnpm exec vitest run tests/export/svg-path-parser.test.ts` — 3/3 pass.
- [x] `pnpm exec tsc --noEmit` and `pnpm exec eslint` clean on touched files.
- [x] Playwright repro spec exercising the full UI flow (import affected `.maic.zip` → open classroom → click Export PPTX) captured the original `SyntaxError: Unexpected character "l" ...` in `Export failed:` console output before the fix, and "Export successful" toast after the fix.
- [ ] **Not yet verified manually in a browser** — reviewer should sanity-check by importing a problematic `.maic.zip` and clicking Export PPTX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)