### PR TITLE
feat: add language selector to generation toolbar

### DIFF
--- a/components/generation/generation-toolbar.tsx
+++ b/components/generation/generation-toolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useMemo } from 'react';
-import { Bot, Brain, Check, Paperclip, FileText, X, Globe2, Search } from 'lucide-react';
+import { Bot, Brain, Check, Paperclip, FileText, X, Globe2, Globe, Search } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
@@ -41,7 +41,11 @@ const MAX_PDF_SIZE_MB = 50;
 const MAX_PDF_SIZE_BYTES = MAX_PDF_SIZE_MB * 1024 * 1024;
 
 // ─── Types ───────────────────────────────────────────────────
+export type CourseLanguage = 'zh-CN' | 'zh-TW' | 'en-US';
+
 export interface GenerationToolbarProps {
+  language: CourseLanguage;
+  onLanguageChange: (lang: CourseLanguage) => void;
   webSearch: boolean;
   onWebSearchChange: (v: boolean) => void;
   onSettingsOpen: (section?: SettingsSection) => void;
@@ -53,6 +57,8 @@ export interface GenerationToolbarProps {
 
 // ─── Component ───────────────────────────────────────────────
 export function GenerationToolbar({
+  language,
+  onLanguageChange,
   webSearch,
   onWebSearchChange,
   onSettingsOpen,
@@ -385,6 +391,28 @@ export function GenerationToolbar({
             <TooltipContent>{t('toolbar.webSearchNoProvider')}</TooltipContent>
           </Tooltip>
         )}
+
+        {/* ── Separator ── */}
+        <div className="w-px h-4 bg-border/60 mx-1" />
+
+        {/* ── Language pill ── */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => {
+                const languages: CourseLanguage[] = ['zh-CN', 'zh-TW', 'en-US'];
+                const currentIndex = languages.indexOf(language);
+                const nextIndex = (currentIndex + 1) % languages.length;
+                onLanguageChange(languages[nextIndex]);
+              }}
+              className={pillMuted}
+            >
+              <Globe className="size-3.5" />
+              <span>{language === 'zh-CN' ? '中文' : language === 'zh-TW' ? '繁中' : 'EN'}</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{t('toolbar.languageHint')}</TooltipContent>
+        </Tooltip>
 
         {/* ── Separator ── */}
         <div className="w-px h-4 bg-border/60 mx-1" />

--- a/tests/eval/shared/run-dir.test.ts
+++ b/tests/eval/shared/run-dir.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { createRunDir } from '@/eval/shared/run-dir';
 
 describe('createRunDir', () => {
@@ -29,10 +29,11 @@ describe('createRunDir', () => {
 
   it('timestamp segment has no colons or dots', () => {
     const runDir = createRunDir(tempRoot, 'x');
-    const segments = runDir.split('/');
+    const segments = runDir.split(sep);
     const timestamp = segments[segments.length - 1];
-    expect(timestamp).not.toContain(':');
-    expect(timestamp).not.toContain('.');
+    const timestampWithoutDrive = timestamp.replace(/^[A-Za-z]:/, '');
+    expect(timestampWithoutDrive).not.toContain(':');
+    expect(timestampWithoutDrive).not.toContain('.');
     expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
   });
 });


### PR DESCRIPTION
## Summary
Add language selector to the generation toolbar for specifying course language.

## Changes
- Add language selector component to generation toolbar
- Support locale selection (en-US, zh-CN, zh-TW, etc.)

## Testing
- Local testing passed
- CI checks passed (including Windows test fix)