### PR TITLE
fix(browser-tts): add zh-TW zh-HK locale mapping for TTS

### DIFF
--- a/lib/hooks/use-browser-tts.ts
+++ b/lib/hooks/use-browser-tts.ts
@@ -4,7 +4,7 @@
  * Completely free, no API key required
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 
 // Note: Window.SpeechSynthesis declaration is already in the global scope
 
@@ -29,15 +29,18 @@ export function useBrowserTTS(options: UseBrowserTTSOptions = {}) {
     lang = 'zh-CN',
   } = options;
 
-  const langMapping: Record<string, string> = {
-    'zh-TW': 'zh-TW',
-    'zh-HK': 'zh-HK',
-    'zh-Hant': 'zh-TW',
-    'zh-Hant-TW': 'zh-TW',
-    'zh-Hant-HK': 'zh-HK',
-    'yue': 'zh-HK',
-    'yue-HK': 'zh-HK',
-  };
+  const langMapping = useMemo(
+    (): Record<string, string> => ({
+      'zh-TW': 'zh-TW',
+      'zh-HK': 'zh-HK',
+      'zh-Hant': 'zh-TW',
+      'zh-Hant-TW': 'zh-TW',
+      'zh-Hant-HK': 'zh-HK',
+      'yue': 'zh-HK',
+      'yue-HK': 'zh-HK',
+    }),
+    [],
+  );
 
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
@@ -83,7 +86,7 @@ export function useBrowserTTS(options: UseBrowserTTSOptions = {}) {
       utterance.rate = rate;
       utterance.pitch = pitch;
       utterance.volume = volume;
-      utterance.lang = lang;
+      utterance.lang = langMapping[lang] || lang;
 
       // Set voice if specified
       if (voiceURI) {
@@ -124,7 +127,7 @@ export function useBrowserTTS(options: UseBrowserTTSOptions = {}) {
       utteranceRef.current = utterance;
       window.speechSynthesis.speak(utterance);
     },
-    [rate, pitch, volume, lang, availableVoices, onStart, onEnd, onError],
+    [rate, pitch, volume, lang, langMapping, availableVoices, onStart, onEnd, onError],
   );
 
   const pause = useCallback(() => {

--- a/lib/hooks/use-browser-tts.ts
+++ b/lib/hooks/use-browser-tts.ts
@@ -29,6 +29,16 @@ export function useBrowserTTS(options: UseBrowserTTSOptions = {}) {
     lang = 'zh-CN',
   } = options;
 
+  const langMapping: Record<string, string> = {
+    'zh-TW': 'zh-TW',
+    'zh-HK': 'zh-HK',
+    'zh-Hant': 'zh-TW',
+    'zh-Hant-TW': 'zh-TW',
+    'zh-Hant-HK': 'zh-HK',
+    'yue': 'zh-HK',
+    'yue-HK': 'zh-HK',
+  };
+
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [availableVoices, setAvailableVoices] = useState<SpeechSynthesisVoice[]>([]);

--- a/tests/eval/shared/run-dir.test.ts
+++ b/tests/eval/shared/run-dir.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { createRunDir } from '@/eval/shared/run-dir';
 
 describe('createRunDir', () => {
@@ -29,10 +29,11 @@ describe('createRunDir', () => {
 
   it('timestamp segment has no colons or dots', () => {
     const runDir = createRunDir(tempRoot, 'x');
-    const segments = runDir.split('/');
+    const segments = runDir.split(sep);
     const timestamp = segments[segments.length - 1];
-    expect(timestamp).not.toContain(':');
-    expect(timestamp).not.toContain('.');
+    const timestampWithoutDrive = timestamp.replace(/^[A-Za-z]:/, '');
+    expect(timestampWithoutDrive).not.toContain(':');
+    expect(timestampWithoutDrive).not.toContain('.');
     expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
   });
 });


### PR DESCRIPTION
## Summary
Fix browser TTS to properly support zh-TW and zh-HK locales.

## Changes
- Add locale mapping for Traditional Chinese (zh-TW)
- Add locale mapping for Cantonese (zh-HK)
- Fix browser TTS compatibility issues

## Testing
- Local testing passed
- CI checks passed (including Windows test fix)