### PR TITLE
[codex] Fix MiniMax TTS fallback and HTML extraction

### DIFF
--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -20,6 +20,11 @@ const log = createLogger('TTS API');
 
 export const maxDuration = 30;
 
+function normalizeBaseUrl(baseUrl: string | undefined): string | undefined {
+  const trimmed = baseUrl?.trim();
+  return trimmed ? trimmed.replace(/\/+$/, '') : undefined;
+}
+
 export async function POST(req: NextRequest) {
   let ttsProviderId: string | undefined;
   let ttsVoice: string | undefined;
@@ -69,20 +74,24 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const clientBaseUrl = ttsBaseUrl || undefined;
-    if (clientBaseUrl) {
-      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
+    const clientApiKey = ttsApiKey?.trim() ? ttsApiKey : undefined;
+    const requestedBaseUrl = normalizeBaseUrl(ttsBaseUrl);
+    const serverBaseUrl = normalizeBaseUrl(resolveTTSBaseUrl(ttsProviderId));
+    const useClientBaseUrl =
+      !!requestedBaseUrl &&
+      (!!clientApiKey || normalizeBaseUrl(requestedBaseUrl) !== normalizeBaseUrl(serverBaseUrl));
+
+    if (useClientBaseUrl) {
+      const ssrfError = await validateUrlForSSRF(requestedBaseUrl);
       if (ssrfError) {
         return apiError('INVALID_URL', 403, ssrfError);
       }
     }
 
-    const apiKey = clientBaseUrl
-      ? ttsApiKey || ''
-      : resolveTTSApiKey(ttsProviderId, ttsApiKey || undefined);
-    const baseUrl = clientBaseUrl
-      ? clientBaseUrl
-      : resolveTTSBaseUrl(ttsProviderId, ttsBaseUrl || undefined);
+    const apiKey = useClientBaseUrl
+      ? clientApiKey || ''
+      : resolveTTSApiKey(ttsProviderId, clientApiKey);
+    const baseUrl = useClientBaseUrl ? requestedBaseUrl : serverBaseUrl || requestedBaseUrl;
 
     // Build TTS config
     const config = {

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -164,9 +164,8 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
         speed: ttsSpeed,
         apiKey: ttsProvidersConfig[selectedProviderId]?.apiKey,
         baseUrl:
-          ttsProvidersConfig[selectedProviderId]?.serverBaseUrl ||
           ttsProvidersConfig[selectedProviderId]?.baseUrl ||
-          providerConfig?.customDefaultBaseUrl ||
+          (!isServerConfigured ? providerConfig?.customDefaultBaseUrl : '') ||
           '',
         providerOptions,
       });

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -924,36 +924,49 @@ async function generatePBLSceneContent(
   }
 }
 
+function stripTrailingCodeFence(html: string): string {
+  return html.replace(/\s*```\s*$/g, '').trim();
+}
+
 /**
  * Extract HTML document from AI response.
  * Tries to find <!DOCTYPE html>...</html> first, then falls back to code block extraction.
  */
-function extractHtml(response: string): string | null {
+export function extractHtml(response: string): string | null {
   // Strategy 1: Find complete HTML document
-  const doctypeStart = response.indexOf('<!DOCTYPE html>');
-  const htmlTagStart = response.indexOf('<html');
-  const start = doctypeStart !== -1 ? doctypeStart : htmlTagStart;
+  const htmlStartMatch = /<!doctype\s+html>|<html\b/i.exec(response);
+  const start = htmlStartMatch?.index ?? -1;
 
   if (start !== -1) {
-    const htmlEnd = response.lastIndexOf('</html>');
-    if (htmlEnd !== -1) {
+    const htmlEnd = response.toLowerCase().lastIndexOf('</html>');
+    if (htmlEnd >= start) {
       return response.substring(start, htmlEnd + 7);
     }
+    return stripTrailingCodeFence(response.substring(start));
   }
 
   // Strategy 2: Extract from code block
   const codeBlockMatch = response.match(/```(?:html)?\s*([\s\S]*?)```/);
   if (codeBlockMatch) {
-    const content = codeBlockMatch[1].trim();
+    const content = stripTrailingCodeFence(codeBlockMatch[1]);
     if (content.includes('<html') || content.includes('<!DOCTYPE')) {
       return content;
     }
   }
 
-  // Strategy 3: If response itself looks like HTML
+  // Strategy 3: Extract from an unterminated HTML code block
+  const unterminatedCodeBlockMatch = response.match(/```(?:html)?\s*([\s\S]*)$/);
+  if (unterminatedCodeBlockMatch) {
+    const content = stripTrailingCodeFence(unterminatedCodeBlockMatch[1]);
+    if (/<html\b/i.test(content) || /<!doctype\s+html>/i.test(content)) {
+      return content;
+    }
+  }
+
+  // Strategy 4: If response itself looks like HTML
   const trimmed = response.trim();
-  if (trimmed.startsWith('<!DOCTYPE') || trimmed.startsWith('<html')) {
-    return trimmed;
+  if (/^<!doctype/i.test(trimmed) || /^<html\b/i.test(trimmed)) {
+    return stripTrailingCodeFence(trimmed);
   }
 
   log.error('Could not extract HTML from response');

--- a/tests/generation/scene-generator-language-directive.test.ts
+++ b/tests/generation/scene-generator-language-directive.test.ts
@@ -10,7 +10,11 @@
  */
 import { describe, expect, it, vi, afterEach } from 'vitest';
 
-import { generateSceneContent, generateSceneActions } from '@/lib/generation/scene-generator';
+import {
+  extractHtml,
+  generateSceneContent,
+  generateSceneActions,
+} from '@/lib/generation/scene-generator';
 import { buildSceneFromOutline } from '@/lib/generation/scene-builder';
 import type { AICallFn } from '@/lib/generation/pipeline-types';
 import type {
@@ -288,5 +292,19 @@ describe('scene-generator language directive threading (issue #472)', () => {
       const config = spy.mock.calls[0][0];
       expect(config.languageDirective).toBe(DIRECTIVE);
     });
+  });
+});
+
+describe('interactive HTML extraction', () => {
+  it('accepts an unterminated HTML code block when the model response is truncated', () => {
+    const html = extractHtml(`\`\`\`html
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head><title>Codex 命令全景图</title></head>
+<body><main>visible widget</main>`);
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('visible widget');
+    expect(html).not.toContain('```');
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes two provider-integration issues found while running OpenMAIC with a server-configured MiniMax setup:

- allow server-configured TTS credentials to be reused when clients echo the provider's server base URL back to `/api/generate/tts`
- make interactive HTML extraction tolerant of truncated or unterminated fenced HTML responses from non-default LLM providers

## Root cause

The TTS API previously treated any request-level `ttsBaseUrl` as a fully client-supplied provider configuration. When the UI sent the server-synced MiniMax `serverBaseUrl`, the route skipped the server API key fallback and failed with `API key required for TTS provider: minimax-tts`.

Interactive widget generation also required a complete `</html>` document or a closed Markdown code fence. Some model responses start with valid HTML inside a ```html block but may omit the final `</html>` or closing fence, causing scene-content generation to fail even though usable HTML was present.

## Changes

- Normalize and compare requested TTS base URLs against the server-configured provider URL before deciding whether to require client credentials.
- Avoid passing server-only TTS base URLs from the settings preview path as client custom URLs.
- Export and harden `extractHtml` so valid started HTML can be extracted even when the model response is truncated.
- Add regression coverage for unterminated HTML code blocks.

## Validation

```bash
pnpm test tests/generation/scene-generator-language-directive.test.ts tests/audio/minimax-tts-models.test.ts tests/server/provider-config.test.ts tests/store/settings-server-sync.test.ts
```

Result: 4 test files passed, 82 tests passed.