### PR TITLE
Add built-in TTS voice selector

### DIFF
--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -8,7 +8,11 @@ import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useSettingsStore } from '@/lib/store/settings';
 import { useAgentRegistry } from '@/lib/orchestration/registry/store';
-import { resolveAgentVoice, getSelectableProvidersWithVoices } from '@/lib/audio/voice-resolver';
+import {
+  applySelectableVoiceChoice,
+  getSelectableProvidersWithVoices,
+  resolveAgentVoice,
+} from '@/lib/audio/voice-resolver';
 import { playBrowserTTSPreview } from '@/lib/audio/browser-tts-preview';
 import { useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
 import { resolveAgentVoiceOptions } from '@/lib/audio/agent-voice';
@@ -562,11 +566,14 @@ function TeacherVoicePill({
                       <button
                         type="button"
                         onClick={() => {
-                          setTTSProvider(provider.providerId);
-                          setTTSVoice(voice.id);
-                          if (group.modelId) {
-                            setTTSProviderConfig(provider.providerId, { modelId: group.modelId });
-                          }
+                          applySelectableVoiceChoice(
+                            {
+                              providerId: provider.providerId,
+                              voiceId: voice.id,
+                              ...(group.modelId && { modelId: group.modelId }),
+                            },
+                            { setTTSProvider, setTTSVoice, setTTSProviderConfig },
+                          );
                           setPopoverOpen(false);
                         }}
                         className={cn(

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -50,6 +50,11 @@ import { toast } from 'sonner';
 import { createLogger } from '@/lib/logger';
 import { useTTSPreview } from '@/lib/audio/use-tts-preview';
 import { isTTSProviderConfigured, isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
+import {
+  applySelectableVoiceChoice,
+  getSelectableProvidersWithVoices,
+  resolveSelectableVoiceChoice,
+} from '@/lib/audio/voice-resolver';
 import { isCustomTTSProvider } from '@/lib/audio/types';
 import {
   getVoxCPMProviderOptions,
@@ -81,6 +86,7 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
   const ttsVoice = useSettingsStore((state) => state.ttsVoice);
   const ttsSpeed = useSettingsStore((state) => state.ttsSpeed);
   const ttsProvidersConfig = useSettingsStore((state) => state.ttsProvidersConfig);
+  const setTTSProvider = useSettingsStore((state) => state.setTTSProvider);
   const setTTSProviderConfig = useSettingsStore((state) => state.setTTSProviderConfig);
   const activeProviderId = useSettingsStore((state) => state.ttsProviderId);
   const setTTSVoice = useSettingsStore((state) => state.setTTSVoice);
@@ -114,6 +120,28 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
         ? ((providerConfig?.customVoices as Array<{ id: string }> | undefined) || [])[0]?.id ||
           'default'
         : DEFAULT_TTS_VOICES[selectedProviderId as keyof typeof DEFAULT_TTS_VOICES] || 'default';
+
+  // Keep this control on the same enabled-provider and compatible-voice source
+  // as AgentBar and generation. Custom providers and VoxCPM retain their
+  // dedicated voice-management flows below.
+  const selectableProvider = getSelectableProvidersWithVoices(ttsProvidersConfig).find(
+    (provider) => provider.providerId === selectedProviderId,
+  );
+  const selectedSelectableVoiceId = (() => {
+    if (!selectableProvider) return '';
+    if (
+      selectedProviderId === activeProviderId &&
+      selectableProvider.voices.some((voice) => voice.id === ttsVoice)
+    ) {
+      return ttsVoice;
+    }
+    const defaultVoice = DEFAULT_TTS_VOICES[selectedProviderId as keyof typeof DEFAULT_TTS_VOICES];
+    return (
+      selectableProvider.voices.find((voice) => voice.id === defaultVoice)?.id ||
+      selectableProvider.voices[0]?.id ||
+      ''
+    );
+  })();
 
   const [showApiKey, setShowApiKey] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -481,6 +509,40 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
             )}
           </>
         ))}
+
+      {!isCustom && !isVoxCPM && selectableProvider && selectedSelectableVoiceId && (
+        <div className="space-y-2">
+          <Label className="text-sm">{t('settings.ttsVoice')}</Label>
+          <Select
+            value={selectedSelectableVoiceId}
+            onValueChange={(voiceId) => {
+              const choice = resolveSelectableVoiceChoice(
+                [selectableProvider],
+                selectedProviderId,
+                voiceId,
+                ttsProvidersConfig[selectedProviderId]?.modelId || '',
+              );
+              if (!choice) return;
+              applySelectableVoiceChoice(choice, {
+                setTTSProvider,
+                setTTSVoice,
+                setTTSProviderConfig,
+              });
+            }}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {selectableProvider.voices.map((voice) => (
+                <SelectItem key={voice.id} value={voice.id}>
+                  {voice.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
       {/* Test TTS */}
       <div className="space-y-2">

--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -125,6 +125,55 @@ export interface ProviderWithVoices {
   modelGroups: ModelVoiceGroup[]; // voices grouped by model
 }
 
+export interface SelectableVoiceChoice {
+  providerId: TTSProviderId;
+  voiceId: string;
+  modelId?: string;
+}
+
+/**
+ * Resolve a picker selection from the shared selectable provider list. Keeping
+ * this lookup here prevents Settings and AgentBar from inventing separate
+ * provider/model compatibility rules.
+ */
+export function resolveSelectableVoiceChoice(
+  providers: ProviderWithVoices[],
+  providerId: TTSProviderId,
+  voiceId: string,
+  currentModelId = '',
+): SelectableVoiceChoice | null {
+  const provider = providers.find((candidate) => candidate.providerId === providerId);
+  if (!provider?.voices.some((voice) => voice.id === voiceId)) return null;
+
+  const modelGroup =
+    provider.modelGroups.find(
+      (group) =>
+        group.modelId === currentModelId && group.voices.some((voice) => voice.id === voiceId),
+    ) || provider.modelGroups.find((group) => group.voices.some((voice) => voice.id === voiceId));
+
+  return {
+    providerId,
+    voiceId,
+    ...(modelGroup?.modelId && { modelId: modelGroup.modelId }),
+  };
+}
+
+/** Shared global TTS selection write used by Settings and AgentBar. */
+export function applySelectableVoiceChoice(
+  choice: SelectableVoiceChoice,
+  actions: {
+    setTTSProvider: (providerId: TTSProviderId) => void;
+    setTTSVoice: (voiceId: string) => void;
+    setTTSProviderConfig: (providerId: TTSProviderId, config: { modelId: string }) => void;
+  },
+) {
+  actions.setTTSProvider(choice.providerId);
+  if (choice.modelId) {
+    actions.setTTSProviderConfig(choice.providerId, { modelId: choice.modelId });
+  }
+  actions.setTTSVoice(choice.voiceId);
+}
+
 /**
  * Get all ENABLED providers and their voices for the voice picker UI and for
  * deterministic auto-assignment.

--- a/tests/config/settings-tts-voice-selection.test.ts
+++ b/tests/config/settings-tts-voice-selection.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  applySelectableVoiceChoice,
+  getSelectableProvidersWithVoices,
+  resolveSelectableVoiceChoice,
+} from '@/lib/audio/voice-resolver';
+
+const storage = new Map<string, string>();
+const localStorageStub = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => void storage.set(key, value),
+  removeItem: (key: string) => void storage.delete(key),
+  clear: () => void storage.clear(),
+  key: () => null,
+  length: 0,
+};
+
+vi.stubGlobal('localStorage', localStorageStub);
+vi.stubGlobal('window', { localStorage: localStorageStub });
+
+async function freshStore() {
+  vi.resetModules();
+  storage.clear();
+  const { useSettingsStore } = await import('@/lib/store/settings');
+  return useSettingsStore;
+}
+
+describe('Settings TTS voice selection', () => {
+  beforeEach(() => storage.clear());
+
+  it('switches from a non-active provider and selects a compatible voice from the shared list', async () => {
+    const store = await freshStore();
+    store.setState({
+      ttsProviderId: 'browser-native-tts',
+      ttsVoice: 'default',
+      ttsProvidersConfig: {
+        'openai-tts': { apiKey: 'test-key', modelId: 'tts-1' },
+      },
+    });
+
+    const providers = getSelectableProvidersWithVoices(store.getState().ttsProvidersConfig);
+    const choice = resolveSelectableVoiceChoice(providers, 'openai-tts', 'marin', 'tts-1');
+
+    expect(choice).toEqual({
+      providerId: 'openai-tts',
+      voiceId: 'marin',
+      modelId: 'gpt-4o-mini-tts',
+    });
+
+    applySelectableVoiceChoice(choice!, store.getState());
+
+    expect(store.getState().ttsProviderId).toBe('openai-tts');
+    expect(store.getState().ttsVoice).toBe('marin');
+    expect(store.getState().ttsProvidersConfig['openai-tts']?.modelId).toBe('gpt-4o-mini-tts');
+  });
+});

--- a/tests/config/settings-tts-voice-selection.test.ts
+++ b/tests/config/settings-tts-voice-selection.test.ts
@@ -34,7 +34,13 @@ describe('Settings TTS voice selection', () => {
       ttsProviderId: 'browser-native-tts',
       ttsVoice: 'default',
       ttsProvidersConfig: {
-        'openai-tts': { apiKey: 'test-key', modelId: 'tts-1' },
+        ...store.getState().ttsProvidersConfig,
+        'openai-tts': {
+          ...store.getState().ttsProvidersConfig['openai-tts'],
+          apiKey: 'test-key',
+          enabled: true,
+          modelId: 'tts-1',
+        },
       },
     });
 


### PR DESCRIPTION
## Summary

Rebuild the built-in TTS voice selector as a small current-`main` delta.

## Details

- Use the shared selectable provider/voice source in `lib/audio/voice-resolver.ts` for Settings and AgentBar.
- Selecting a voice on a non-active provider switches the active provider and selects a compatible model when needed.
- Preserve the existing custom TTS and VoxCPM management flows.
- Do not retain backup copies of the previous settings component.

## Test

- `pnpm exec prettier --check tests/config/settings-tts-voice-selection.test.ts`
- `pnpm exec vitest run tests/config/settings-tts-voice-selection.test.ts`
- GitHub Actions: **Lint, Typecheck & Unit Tests** and **E2E Tests** passed.