### PR TITLE
feat: add generated video manifest refs

### DIFF
--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -23,6 +23,7 @@ import {
 import { getCurrentModelConfig } from '@/lib/utils/model-config';
 import { db } from '@/lib/utils/database';
 import { MAX_PDF_CONTENT_CHARS, MAX_VISION_IMAGES } from '@/lib/constants/generation';
+import { buildVideoManifestFromOutlines } from '@/lib/media/video-manifest';
 import { nanoid } from 'nanoid';
 import type { Stage } from '@/lib/types/stage';
 import type { SceneOutline, PdfImage, ImageMapping } from '@/lib/types/generation';
@@ -673,6 +674,7 @@ function GenerationPreviewContent() {
 
       // Store stage and outlines
       const store = useStageStore.getState();
+      stage.videoManifest = buildVideoManifestFromOutlines(outlines);
       store.setStage(stage);
       store.setOutlines(outlines);
 

--- a/components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx
+++ b/components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx
@@ -8,6 +8,7 @@ import { useMediaGenerationStore, isMediaPlaceholder } from '@/lib/store/media-g
 import { useSettingsStore } from '@/lib/store/settings';
 import { useMediaStageId } from '@/lib/contexts/media-stage-context';
 import { retryMediaTask } from '@/lib/media/media-orchestrator';
+import { getVideoMediaRefForElement } from '@/lib/media/video-manifest';
 import { RotateCcw, Film, ShieldAlert, VideoOff } from 'lucide-react';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { createLogger } from '@/lib/logger';
@@ -32,22 +33,26 @@ export function BaseVideoElement({ elementInfo }: BaseVideoElementProps) {
 
   // Only subscribe to media store when inside a classroom (stageId provided via context).
   const stageId = useMediaStageId();
-  const isPlaceholder = isMediaPlaceholder(elementInfo.src);
+  const mediaRef = getVideoMediaRefForElement(elementInfo);
+  const concreteSrc =
+    elementInfo.src && !isMediaPlaceholder(elementInfo.src) ? elementInfo.src : undefined;
+  const isPlaceholder = !!mediaRef;
   const task = useMediaGenerationStore((s) => {
-    if (!isPlaceholder) return undefined;
-    const t = s.tasks[elementInfo.src];
+    if (!mediaRef) return undefined;
+    const t = s.tasks[mediaRef];
     if (t && t.stageId !== stageId) return undefined;
     return t;
   });
   const videoGenerationEnabled = useSettingsStore((s) => s.videoGenerationEnabled);
-  const resolvedSrc = task?.status === 'done' && task.objectUrl ? task.objectUrl : elementInfo.src;
-  const showDisabled = isPlaceholder && !task && !videoGenerationEnabled;
+  const resolvedSrc = task?.status === 'done' && task.objectUrl ? task.objectUrl : concreteSrc;
+  const showDisabled = isPlaceholder && !concreteSrc && !task && !videoGenerationEnabled;
   const showSkeleton =
     isPlaceholder &&
+    !concreteSrc &&
     !showDisabled &&
     (!task || task.status === 'pending' || task.status === 'generating');
-  const showError = isPlaceholder && task?.status === 'failed';
-  const isReady = !isPlaceholder || task?.status === 'done';
+  const showError = isPlaceholder && !concreteSrc && task?.status === 'failed';
+  const isReady = !!resolvedSrc;
 
   // Ensure video is paused on mount — prevents browser autoplay from user gesture context
   useEffect(() => {
@@ -149,7 +154,7 @@ export function BaseVideoElement({ elementInfo }: BaseVideoElementProps) {
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  retryMediaTask(elementInfo.src);
+                  if (mediaRef) retryMediaTask(mediaRef);
                 }}
                 onPointerDown={(e) => e.stopPropagation()}
                 className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40 rounded hover:bg-red-200 dark:hover:bg-red-900/60 transition-colors"
@@ -159,8 +164,7 @@ export function BaseVideoElement({ elementInfo }: BaseVideoElementProps) {
               </button>
             )}
           </div>
-        ) : (isReady && resolvedSrc && !isPlaceholder) ||
-          (isPlaceholder && task?.status === 'done') ? (
+        ) : isReady && resolvedSrc ? (
           <video
             ref={videoRef}
             className="w-full h-full"

--- a/lib/action/engine.ts
+++ b/lib/action/engine.ts
@@ -229,9 +229,9 @@ export class ActionEngine {
   // ==================== Synchronous — Video ====================
 
   private async executePlayVideo(action: PlayVideoAction): Promise<void> {
-    // Resolve the video element's src to a media placeholder ID (e.g. gen_vid_1).
+    // Resolve the video element to a generated media reference.
     // action.elementId is the slide element ID (e.g. video_abc123), but the media
-    // store is keyed by placeholder IDs, so we need to bridge the two.
+    // store is keyed by generated media refs, so we need to bridge the two.
     const placeholderId = this.resolveMediaPlaceholderId(action.elementId);
 
     if (placeholderId) {
@@ -291,8 +291,8 @@ export class ActionEngine {
   // ==================== Helpers — Media Resolution ====================
 
   /**
-   * Look up a video/image element's src in the current stage's scenes.
-   * Returns the src if it's a media placeholder ID (gen_vid_*, gen_img_*), null otherwise.
+   * Look up a video/image element's generated media reference in the current stage's scenes.
+   * Returns mediaRef first, then legacy src if it's a media placeholder ID.
    */
   private resolveMediaPlaceholderId(elementId: string): string | null {
     const { scenes, currentSceneId } = this.stageStore.getState();
@@ -309,12 +309,15 @@ export class ActionEngine {
       if (!scene || scene.type !== 'slide') continue;
       const elements = (
         scene.content as {
-          canvas?: { elements?: Array<{ id: string; src?: string }> };
+          canvas?: { elements?: Array<{ id: string; src?: string; mediaRef?: string }> };
         }
       )?.canvas?.elements;
       if (!Array.isArray(elements)) continue;
       const el = elements.find((e: { id: string }) => e.id === elementId);
-      if (el && 'src' in el && typeof el.src === 'string' && isMediaPlaceholder(el.src)) {
+      if (el && typeof el.mediaRef === 'string') {
+        return el.mediaRef;
+      }
+      if (el && typeof el.src === 'string' && isMediaPlaceholder(el.src)) {
         return el.src;
       }
     }

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -955,7 +955,8 @@ async function buildPptxBlob(
         let resolvedSrc = el.src;
         const mediaRef = el.type === 'video' ? el.mediaRef : undefined;
         const mediaLookupKey =
-          mediaRef || (typeof el.src === 'string' && isMediaPlaceholder(el.src) ? el.src : undefined);
+          mediaRef ||
+          (typeof el.src === 'string' && isMediaPlaceholder(el.src) ? el.src : undefined);
         if (mediaLookupKey) {
           const task = useMediaGenerationStore.getState().tasks[mediaLookupKey];
           if (task?.status === 'done' && task.objectUrl) {

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -951,16 +951,21 @@ async function buildPptxBlob(
 
       // ── VIDEO / AUDIO ──
       else if (el.type === 'video' || el.type === 'audio') {
-        // Resolve placeholder src → blob URL from media generation store
+        // Resolve generated video mediaRef or legacy placeholder src → blob URL.
         let resolvedSrc = el.src;
-        if (isMediaPlaceholder(el.src)) {
-          const task = useMediaGenerationStore.getState().tasks[el.src];
+        const mediaRef = el.type === 'video' ? el.mediaRef : undefined;
+        const mediaLookupKey =
+          mediaRef || (typeof el.src === 'string' && isMediaPlaceholder(el.src) ? el.src : undefined);
+        if (mediaLookupKey) {
+          const task = useMediaGenerationStore.getState().tasks[mediaLookupKey];
           if (task?.status === 'done' && task.objectUrl) {
             resolvedSrc = task.objectUrl;
-          } else {
+          } else if (!resolvedSrc || isMediaPlaceholder(resolvedSrc)) {
             continue; // Media not ready, skip
           }
         }
+
+        if (!resolvedSrc) continue;
 
         // Fetch blob and convert to base64 for embedding in PPTX
         // (blob: URLs and remote URLs won't work in offline PPTX)
@@ -995,8 +1000,8 @@ async function buildPptxBlob(
 
             // 1. Try poster from element or media generation store
             let posterUrl = 'poster' in el && el.poster ? el.poster : undefined;
-            if (!posterUrl && isMediaPlaceholder(el.src)) {
-              const task = useMediaGenerationStore.getState().tasks[el.src];
+            if (!posterUrl && mediaLookupKey) {
+              const task = useMediaGenerationStore.getState().tasks[mediaLookupKey];
               if (task?.poster) posterUrl = task.poster;
             }
             if (posterUrl) {

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -369,11 +369,6 @@ function isGeneratedImageId(value: string): boolean {
   return /^gen_(img|vid)_[\w-]+$/i.test(value);
 }
 
-function isGeneratedVideoId(value: string): boolean {
-  if (!value) return false;
-  return /^gen_vid_[\w-]+$/i.test(value);
-}
-
 /**
  * Resolve image ID references in src field to actual base64 URLs
  *
@@ -452,7 +447,6 @@ function normalizeGeneratedVideoRefs(
   const validRefs = generatedVideoEntries
     .filter((mg) => mg.type === 'video')
     .map((mg) => mg.elementId);
-  if (validRefs.length === 0) return elements;
 
   const validRefSet = new Set(validRefs);
   const onlyRef = validRefs.length === 1 ? validRefs[0] : undefined;
@@ -464,9 +458,16 @@ function normalizeGeneratedVideoRefs(
       const videoEl = { ...el } as Record<string, unknown>;
       const mediaRef = typeof videoEl.mediaRef === 'string' ? videoEl.mediaRef : undefined;
       const src = typeof videoEl.src === 'string' ? videoEl.src : undefined;
+      const hasGeneratedSrc = !!src && isGeneratedImageId(src);
+      const hasDirectSrc = !!src && !hasGeneratedSrc;
+
+      if (hasDirectSrc) {
+        if (mediaRef) delete videoEl.mediaRef;
+        return videoEl as typeof el;
+      }
 
       if (mediaRef && validRefSet.has(mediaRef)) {
-        if (src && isGeneratedVideoId(src)) delete videoEl.src;
+        if (hasGeneratedSrc) delete videoEl.src;
         return videoEl as typeof el;
       }
 
@@ -476,14 +477,14 @@ function normalizeGeneratedVideoRefs(
         return videoEl as typeof el;
       }
 
-      if ((mediaRef || (src && isGeneratedVideoId(src))) && onlyRef) {
+      if ((mediaRef || hasGeneratedSrc) && onlyRef) {
         log.warn(`Correcting generated video reference "${mediaRef || src}" to "${onlyRef}"`);
         videoEl.mediaRef = onlyRef;
-        if (src && isGeneratedVideoId(src)) delete videoEl.src;
+        if (hasGeneratedSrc) delete videoEl.src;
         return videoEl as typeof el;
       }
 
-      if (mediaRef || (src && isGeneratedVideoId(src))) {
+      if (mediaRef || hasGeneratedSrc) {
         log.warn(`Invalid generated video reference "${mediaRef || src}", removing element`);
         return null;
       }

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -369,6 +369,11 @@ function isGeneratedImageId(value: string): boolean {
   return /^gen_(img|vid)_[\w-]+$/i.test(value);
 }
 
+function isGeneratedVideoId(value: string): boolean {
+  if (!value) return false;
+  return /^gen_vid_[\w-]+$/i.test(value);
+}
+
 /**
  * Resolve image ID references in src field to actual base64 URLs
  *
@@ -418,7 +423,8 @@ function resolveImageIds(
       }
 
       if (el.type === 'video') {
-        if (!('src' in el)) {
+        const mediaRef = (el as Record<string, unknown>).mediaRef;
+        if (!('src' in el) && typeof mediaRef !== 'string') {
           log.warn(`Video element missing src, removing element`);
           return null;
         }
@@ -432,6 +438,54 @@ function resolveImageIds(
           log.debug(`Keeping generated video placeholder: ${src}`);
           return el;
         }
+      }
+
+      return el;
+    })
+    .filter((el): el is NonNullable<typeof el> => el !== null);
+}
+
+function normalizeGeneratedVideoRefs(
+  elements: GeneratedSlideData['elements'],
+  generatedVideoEntries: SceneOutline['mediaGenerations'] = [],
+): GeneratedSlideData['elements'] {
+  const validRefs = generatedVideoEntries
+    .filter((mg) => mg.type === 'video')
+    .map((mg) => mg.elementId);
+  if (validRefs.length === 0) return elements;
+
+  const validRefSet = new Set(validRefs);
+  const onlyRef = validRefs.length === 1 ? validRefs[0] : undefined;
+
+  return elements
+    .map((el) => {
+      if (el.type !== 'video') return el;
+
+      const videoEl = { ...el } as Record<string, unknown>;
+      const mediaRef = typeof videoEl.mediaRef === 'string' ? videoEl.mediaRef : undefined;
+      const src = typeof videoEl.src === 'string' ? videoEl.src : undefined;
+
+      if (mediaRef && validRefSet.has(mediaRef)) {
+        if (src && isGeneratedVideoId(src)) delete videoEl.src;
+        return videoEl as typeof el;
+      }
+
+      if (src && validRefSet.has(src)) {
+        videoEl.mediaRef = src;
+        delete videoEl.src;
+        return videoEl as typeof el;
+      }
+
+      if ((mediaRef || (src && isGeneratedVideoId(src))) && onlyRef) {
+        log.warn(`Correcting generated video reference "${mediaRef || src}" to "${onlyRef}"`);
+        videoEl.mediaRef = onlyRef;
+        if (src && isGeneratedVideoId(src)) delete videoEl.src;
+        return videoEl as typeof el;
+      }
+
+      if (mediaRef || (src && isGeneratedVideoId(src))) {
+        log.warn(`Invalid generated video reference "${mediaRef || src}", removing element`);
+        return null;
       }
 
       return el;
@@ -658,7 +712,7 @@ async function generateSlideContent(
       mediaParts.push(`AI-Generated Images (use these IDs as image element src):\n${genImgDescs}`);
     }
     if (genVidDescs) {
-      mediaParts.push(`AI-Generated Videos (use these IDs as video element src):\n${genVidDescs}`);
+      mediaParts.push(`AI-Generated Videos (use these IDs as video element mediaRef):\n${genVidDescs}`);
     }
 
     if (mediaParts.length > 0) {
@@ -746,8 +800,11 @@ async function generateSlideContent(
   );
   log.debug(`After image resolution: ${resolvedElements.length} elements`);
 
+  const videoNormalizedElements = normalizeGeneratedVideoRefs(resolvedElements, outline.mediaGenerations);
+  log.debug(`After video reference normalization: ${videoNormalizedElements.length} elements`);
+
   // Process elements, assign unique IDs
-  const processedElements: PPTElement[] = resolvedElements.map((el) => ({
+  const processedElements: PPTElement[] = videoNormalizedElements.map((el) => ({
     ...el,
     id: `${el.type}_${nanoid(8)}`,
     rotate: 0,

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -712,7 +712,9 @@ async function generateSlideContent(
       mediaParts.push(`AI-Generated Images (use these IDs as image element src):\n${genImgDescs}`);
     }
     if (genVidDescs) {
-      mediaParts.push(`AI-Generated Videos (use these IDs as video element mediaRef):\n${genVidDescs}`);
+      mediaParts.push(
+        `AI-Generated Videos (use these IDs as video element mediaRef):\n${genVidDescs}`,
+      );
     }
 
     if (mediaParts.length > 0) {
@@ -800,7 +802,10 @@ async function generateSlideContent(
   );
   log.debug(`After image resolution: ${resolvedElements.length} elements`);
 
-  const videoNormalizedElements = normalizeGeneratedVideoRefs(resolvedElements, outline.mediaGenerations);
+  const videoNormalizedElements = normalizeGeneratedVideoRefs(
+    resolvedElements,
+    outline.mediaGenerations,
+  );
   log.debug(`After video reference normalization: ${videoNormalizedElements.length} elements`);
 
   // Process elements, assign unique IDs

--- a/lib/media/video-manifest.ts
+++ b/lib/media/video-manifest.ts
@@ -1,0 +1,40 @@
+import type { SceneOutline } from '@/lib/types/generation';
+import type { PPTVideoElement } from '@/lib/types/slides';
+import type { Stage, VideoManifest, VideoManifestEntry } from '@/lib/types/stage';
+
+function isGeneratedVideoRef(value: string): boolean {
+  return /^gen_vid_[\w-]+$/i.test(value);
+}
+
+export function buildVideoManifestFromOutlines(outlines: SceneOutline[]): VideoManifest {
+  const manifest: VideoManifest = {};
+
+  for (const outline of outlines) {
+    for (const request of outline.mediaGenerations ?? []) {
+      if (request.type !== 'video') continue;
+      manifest[request.elementId] = {
+        type: 'video',
+        prompt: request.prompt,
+        aspectRatio: request.aspectRatio,
+        status: 'pending',
+      };
+    }
+  }
+
+  return manifest;
+}
+
+export function getVideoMediaRefForElement(element: PPTVideoElement): string | undefined {
+  if (element.mediaRef) return element.mediaRef;
+  if (element.src && isGeneratedVideoRef(element.src)) return element.src;
+  return undefined;
+}
+
+export function resolveVideoManifestEntry(
+  stage: Stage | null | undefined,
+  element: PPTVideoElement,
+): VideoManifestEntry | undefined {
+  const mediaRef = getVideoMediaRefForElement(element);
+  if (!mediaRef) return undefined;
+  return stage?.videoManifest?.[mediaRef];
+}

--- a/lib/media/video-manifest.ts
+++ b/lib/media/video-manifest.ts
@@ -16,7 +16,6 @@ export function buildVideoManifestFromOutlines(outlines: SceneOutline[]): VideoM
         type: 'video',
         prompt: request.prompt,
         aspectRatio: request.aspectRatio,
-        status: 'pending',
       };
     }
   }

--- a/lib/prompts/snippets/slide-video-instructions.md
+++ b/lib/prompts/snippets/slide-video-instructions.md
@@ -8,16 +8,16 @@
   "top": 150,
   "width": 500,
   "height": 281,
-  "src": "gen_vid_1",
+  "mediaRef": "<VIDEO_MEDIA_REF_FROM_ASSIGNED_MEDIA>",
   "autoplay": false
 }
 ```
 
-**Required Fields**: `id`, `type`, `left`, `top`, `width`, `height`, `src` (generated video ID like "gen_vid_1"), `autoplay` (boolean)
+**Required Fields**: `id`, `type`, `left`, `top`, `width`, `height`, `mediaRef` (generated video media ref copied exactly from the assigned media list), `autoplay` (boolean)
 
 **Video Sizing Rules**:
 
-- `src` must be a generated video ID from the assigned media list (for example, "gen_vid_1")
+- `mediaRef` must be copied exactly from the assigned video media list
 - Default aspect ratio: 16:9 -> `height = width / 1.778`
 - Typical video width: 400-600px (prominent on slide)
 - Position video as a focal element, usually centered or in the main content area

--- a/lib/prompts/templates/slide-content/system.md
+++ b/lib/prompts/templates/slide-content/system.md
@@ -908,8 +908,8 @@ Before outputting JSON, verify:
 - ✓ [gen-image-ratio] Generated image aspect ratio is preserved, usually 16:9 unless a different ratio is listed
 {{/if}}
 {{#if generatedVideoEnabled}}
-- ✓ [video-id] Video `src` values only use generated video IDs from the assigned media list (for example, "gen_vid_1")
-  - Do not invent video IDs or URLs not listed in the available media
+- ✓ [video-media-ref] Video `mediaRef` values only use generated video media refs from the assigned media list
+  - Do not invent video refs or URLs not listed in the available media
 {{/if}}
 - ✓ [latex-fields] LatexElement does NOT include `path`, `viewBox`, `strokeWidth`, or `fixedRatio` (system auto-generates these)
 - ✓ [latex-width] LatexElement width is appropriate for the formula category (standalone fractions: 30-80, NOT 200+; inline equations: 200-400). Check the LaTeX width guide table above.

--- a/lib/prompts/templates/slide-content/user.md
+++ b/lib/prompts/templates/slide-content/user.md
@@ -11,7 +11,7 @@
 
 ## Available Resources
 
-{{#if imageElementEnabled}}
+{{#if mediaElementEnabled}}
 - **Available Media**: {{assignedImages}}
 {{/if}}
 - **Canvas Size**: {{canvas_width}} × {{canvas_height}} px
@@ -33,7 +33,7 @@ Based on the scene information above, generate a complete Canvas/PPT component f
 - Use only the provided image IDs (for example, `img_1`) for source image `src` fields
 {{/if}}
 {{#if generatedVideoEnabled}}
-- Use only the provided generated video IDs (for example, `gen_vid_1`) for video `src` fields
+- Use only the provided generated video media refs for video `mediaRef` fields
 {{/if}}
 5. All TextElement `height` values must be selected from the quick reference table in the system prompt
 

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -418,13 +418,6 @@ export async function generateClassroom(
     try {
       const mediaMap = await generateMediaForClassroom(outlines, stageId, options.baseUrl);
       replaceMediaPlaceholders(scenes, mediaMap);
-      for (const [mediaRef, url] of Object.entries(mediaMap)) {
-        const entry = stage.videoManifest?.[mediaRef];
-        if (entry) {
-          entry.status = 'done';
-          entry.url = url;
-        }
-      }
       log.info(`Media generation complete: ${Object.keys(mediaMap).length} files`);
     } catch (err) {
       log.warn('Media generation phase failed, continuing:', err);

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -27,6 +27,7 @@ import {
   replaceMediaPlaceholders,
   generateTTSForClassroom,
 } from '@/lib/server/classroom-media-generation';
+import { buildVideoManifestFromOutlines } from '@/lib/media/video-manifest';
 import type { UserRequirements } from '@/lib/types/generation';
 import type { Scene, Stage } from '@/lib/types/stage';
 import { AGENT_COLOR_PALETTE, AGENT_DEFAULT_AVATARS } from '@/lib/constants/agent-defaults';
@@ -326,6 +327,7 @@ export async function generateClassroom(
     name: outlines[0]?.title || requirement.slice(0, 50),
     description: undefined,
     languageDirective,
+    videoManifest: buildVideoManifestFromOutlines(outlines),
     style: 'interactive',
     createdAt: Date.now(),
     updatedAt: Date.now(),
@@ -416,6 +418,13 @@ export async function generateClassroom(
     try {
       const mediaMap = await generateMediaForClassroom(outlines, stageId, options.baseUrl);
       replaceMediaPlaceholders(scenes, mediaMap);
+      for (const [mediaRef, url] of Object.entries(mediaMap)) {
+        const entry = stage.videoManifest?.[mediaRef];
+        if (entry) {
+          entry.status = 'done';
+          entry.url = url;
+        }
+      }
       log.info(`Media generation complete: ${Object.keys(mediaMap).length} files`);
     } catch (err) {
       log.warn('Media generation phase failed, continuing:', err);

--- a/lib/server/classroom-media-generation.ts
+++ b/lib/server/classroom-media-generation.ts
@@ -180,12 +180,16 @@ export function replaceMediaPlaceholders(scenes: Scene[], mediaMap: Record<strin
     if (scene.type !== 'slide') continue;
     const canvas = (
       scene.content as {
-        canvas?: { elements?: Array<{ id: string; src?: string; type?: string }> };
+        canvas?: { elements?: Array<{ id: string; src?: string; mediaRef?: string; type?: string }> };
       }
     )?.canvas;
     if (!canvas?.elements) continue;
 
     for (const el of canvas.elements) {
+      if (el.type === 'video' && typeof el.mediaRef === 'string' && mediaMap[el.mediaRef]) {
+        el.src = mediaMap[el.mediaRef];
+        continue;
+      }
       if (
         (el.type === 'image' || el.type === 'video') &&
         typeof el.src === 'string' &&

--- a/lib/server/classroom-media-generation.ts
+++ b/lib/server/classroom-media-generation.ts
@@ -188,7 +188,12 @@ export function replaceMediaPlaceholders(scenes: Scene[], mediaMap: Record<strin
     if (!canvas?.elements) continue;
 
     for (const el of canvas.elements) {
-      if (el.type === 'video' && typeof el.mediaRef === 'string' && mediaMap[el.mediaRef]) {
+      if (
+        el.type === 'video' &&
+        typeof el.mediaRef === 'string' &&
+        mediaMap[el.mediaRef] &&
+        (!el.src || isMediaPlaceholder(el.src))
+      ) {
         el.src = mediaMap[el.mediaRef];
         continue;
       }

--- a/lib/server/classroom-media-generation.ts
+++ b/lib/server/classroom-media-generation.ts
@@ -180,7 +180,9 @@ export function replaceMediaPlaceholders(scenes: Scene[], mediaMap: Record<strin
     if (scene.type !== 'slide') continue;
     const canvas = (
       scene.content as {
-        canvas?: { elements?: Array<{ id: string; src?: string; mediaRef?: string; type?: string }> };
+        canvas?: {
+          elements?: Array<{ id: string; src?: string; mediaRef?: string; type?: string }>;
+        };
       }
     )?.canvas;
     if (!canvas?.elements) continue;

--- a/lib/types/slides.ts
+++ b/lib/types/slides.ts
@@ -631,7 +631,8 @@ export interface PPTLatexElement extends PPTBaseElement {
  */
 export interface PPTVideoElement extends PPTBaseElement {
   type: 'video';
-  src: string;
+  src?: string;
+  mediaRef?: string;
   autoplay: boolean;
   poster?: string;
   ext?: string;

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -14,10 +14,6 @@ export interface VideoManifestEntry {
   type: 'video';
   prompt: string;
   aspectRatio?: string;
-  status: 'pending' | 'generating' | 'done' | 'failed';
-  url?: string;
-  poster?: string;
-  error?: string;
 }
 
 export type VideoManifest = Record<string, VideoManifestEntry>;
@@ -36,7 +32,8 @@ export interface Stage {
   style?: string;
   // Whiteboard data
   whiteboard?: Whiteboard[];
-  // Generated videos keyed by the mediaRef used by PPTVideoElement.
+  // Generated video requests keyed by the mediaRef used by PPTVideoElement.
+  // Runtime media state lives in the media task store / persisted media files.
   videoManifest?: VideoManifest;
   // Agent IDs selected when this classroom was created
   agentIds?: string[];

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -10,6 +10,18 @@ export type StageMode = 'autonomous' | 'playback';
 
 export type Whiteboard = Omit<Slide, 'theme' | 'turningMode' | 'sectionTag' | 'type'>;
 
+export interface VideoManifestEntry {
+  type: 'video';
+  prompt: string;
+  aspectRatio?: string;
+  status: 'pending' | 'generating' | 'done' | 'failed';
+  url?: string;
+  poster?: string;
+  error?: string;
+}
+
+export type VideoManifest = Record<string, VideoManifestEntry>;
+
 /**
  * Stage - Represents the entire classroom/course
  */
@@ -24,6 +36,8 @@ export interface Stage {
   style?: string;
   // Whiteboard data
   whiteboard?: Whiteboard[];
+  // Generated videos keyed by the mediaRef used by PPTVideoElement.
+  videoManifest?: VideoManifest;
   // Agent IDs selected when this classroom was created
   agentIds?: string[];
   /**

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -1,5 +1,5 @@
 import Dexie, { type EntityTable } from 'dexie';
-import type { Scene, SceneType, SceneContent, Whiteboard } from '@/lib/types/stage';
+import type { Scene, SceneType, SceneContent, Whiteboard, VideoManifest } from '@/lib/types/stage';
 import type { Action } from '@/lib/types/action';
 import type {
   SessionType,
@@ -48,6 +48,7 @@ export interface StageRecord {
   style?: string;
   currentSceneId?: string;
   agentIds?: string[]; // Agent IDs selected at creation time
+  videoManifest?: VideoManifest; // Generated video manifest; non-indexed
   interactiveMode?: boolean; // Interactive Mode flag; non-indexed
 }
 

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -48,7 +48,7 @@ export interface StageRecord {
   style?: string;
   currentSceneId?: string;
   agentIds?: string[]; // Agent IDs selected at creation time
-  videoManifest?: VideoManifest; // Generated video manifest; non-indexed
+  videoManifest?: VideoManifest; // Generated video request manifest; non-indexed
   interactiveMode?: boolean; // Interactive Mode flag; non-indexed
 }
 

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -50,6 +50,7 @@ export async function saveStageData(stageId: string, data: StageStoreData): Prom
       style: data.stage.style,
       currentSceneId: data.currentSceneId || undefined,
       agentIds: data.stage.agentIds,
+      videoManifest: data.stage.videoManifest,
       interactiveMode: data.stage.interactiveMode,
     });
 

--- a/tests/generation/media-prompt-wiring.test.ts
+++ b/tests/generation/media-prompt-wiring.test.ts
@@ -68,7 +68,7 @@ describe('media prompt condition wiring', () => {
         {
           type: 'video',
           prompt: 'Animation of water molecules evaporating',
-          elementId: 'gen_vid_1',
+          elementId: 'gen_vid_unique1',
           aspectRatio: '16:9',
         },
       ],
@@ -78,7 +78,9 @@ describe('media prompt condition wiring', () => {
 
     expect(result).not.toBeNull();
     expect(capturedPrompt).toContain('VideoElement');
-    expect(capturedPrompt).toContain('gen_vid_1');
+    expect(capturedPrompt).toContain('mediaRef');
+    expect(capturedPrompt).toContain('gen_vid_unique1');
+    expect(capturedPrompt).not.toContain('"src": "gen_vid_1"');
     expect(capturedPrompt).not.toContain('ImageElement');
     expect(capturedPrompt).not.toContain('gen_img_');
     expect(capturedPrompt).not.toContain('{{');

--- a/tests/generation/video-manifest-wiring.test.ts
+++ b/tests/generation/video-manifest-wiring.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+import { generateSceneContent } from '@/lib/generation/scene-generator';
+import type { AICallFn } from '@/lib/generation/pipeline-types';
+import type { GeneratedSlideContent, SceneOutline } from '@/lib/types/generation';
+
+describe('video manifest wiring', () => {
+  test('corrects an invalid generated video src to the only available mediaRef', async () => {
+    const outline: SceneOutline = {
+      id: 'scene_1',
+      type: 'slide',
+      title: 'Horse Motion',
+      description: 'Show a happy horse running',
+      keyPoints: ['horse gait', 'motion'],
+      order: 1,
+      mediaGenerations: [
+        {
+          type: 'video',
+          prompt: 'A happy horse running in a sunny field',
+          elementId: 'gen_vid_real123',
+          aspectRatio: '16:9',
+        },
+      ],
+    };
+
+    const aiCall: AICallFn = async () =>
+      JSON.stringify({
+        background: { type: 'solid', color: '#ffffff' },
+        elements: [
+          {
+            id: 'video_001',
+            type: 'video',
+            left: 120,
+            top: 120,
+            width: 640,
+            height: 360,
+            src: 'gen_vid_1',
+            autoplay: false,
+          },
+        ],
+      });
+
+    const content = await generateSceneContent(outline, aiCall);
+
+    expect(content).not.toBeNull();
+    const slideContent = content as GeneratedSlideContent;
+    const video = slideContent.elements.find((el) => el.type === 'video');
+    expect(video).toMatchObject({
+      type: 'video',
+      mediaRef: 'gen_vid_real123',
+    });
+    expect(Object.prototype.hasOwnProperty.call(video, 'src')).toBe(false);
+  });
+});

--- a/tests/generation/video-manifest-wiring.test.ts
+++ b/tests/generation/video-manifest-wiring.test.ts
@@ -50,4 +50,86 @@ describe('video manifest wiring', () => {
     });
     expect(Object.prototype.hasOwnProperty.call(video, 'src')).toBe(false);
   });
+
+  test('removes hallucinated generated video refs when no generated videos are available', async () => {
+    const outline: SceneOutline = {
+      id: 'scene_1',
+      type: 'slide',
+      title: 'Text-only scene',
+      description: 'Explain without generated media',
+      keyPoints: ['no media'],
+      order: 1,
+    };
+
+    const aiCall: AICallFn = async () =>
+      JSON.stringify({
+        background: { type: 'solid', color: '#ffffff' },
+        elements: [
+          {
+            id: 'video_001',
+            type: 'video',
+            left: 120,
+            top: 120,
+            width: 640,
+            height: 360,
+            mediaRef: 'gen_vid_fake',
+            autoplay: false,
+          },
+        ],
+      });
+
+    const content = await generateSceneContent(outline, aiCall);
+
+    expect(content).not.toBeNull();
+    const slideContent = content as GeneratedSlideContent;
+    expect(slideContent.elements.some((el) => el.type === 'video')).toBe(false);
+  });
+
+  test('preserves direct video src and drops generated mediaRef', async () => {
+    const outline: SceneOutline = {
+      id: 'scene_1',
+      type: 'slide',
+      title: 'Existing video',
+      description: 'Use a direct video URL',
+      keyPoints: ['direct video'],
+      order: 1,
+      mediaGenerations: [
+        {
+          type: 'video',
+          prompt: 'A generated fallback video',
+          elementId: 'gen_vid_real123',
+          aspectRatio: '16:9',
+        },
+      ],
+    };
+
+    const aiCall: AICallFn = async () =>
+      JSON.stringify({
+        background: { type: 'solid', color: '#ffffff' },
+        elements: [
+          {
+            id: 'video_001',
+            type: 'video',
+            left: 120,
+            top: 120,
+            width: 640,
+            height: 360,
+            src: 'https://example.com/direct.mp4',
+            mediaRef: 'gen_vid_real123',
+            autoplay: false,
+          },
+        ],
+      });
+
+    const content = await generateSceneContent(outline, aiCall);
+
+    expect(content).not.toBeNull();
+    const slideContent = content as GeneratedSlideContent;
+    const video = slideContent.elements.find((el) => el.type === 'video');
+    expect(video).toMatchObject({
+      type: 'video',
+      src: 'https://example.com/direct.mp4',
+    });
+    expect(Object.prototype.hasOwnProperty.call(video, 'mediaRef')).toBe(false);
+  });
 });

--- a/tests/media/video-manifest.test.ts
+++ b/tests/media/video-manifest.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import { buildVideoManifestFromOutlines, getVideoMediaRefForElement } from '@/lib/media/video-manifest';
+import {
+  buildVideoManifestFromOutlines,
+  getVideoMediaRefForElement,
+} from '@/lib/media/video-manifest';
 import type { SceneOutline } from '@/lib/types/generation';
 
 describe('video manifest', () => {

--- a/tests/media/video-manifest.test.ts
+++ b/tests/media/video-manifest.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest';
+import { buildVideoManifestFromOutlines, getVideoMediaRefForElement } from '@/lib/media/video-manifest';
+import type { SceneOutline } from '@/lib/types/generation';
+
+describe('video manifest', () => {
+  test('collects only generated video requests from outlines', () => {
+    const outlines: SceneOutline[] = [
+      {
+        id: 'scene_1',
+        type: 'slide',
+        title: 'Motion',
+        description: 'Explain a motion concept',
+        keyPoints: ['motion'],
+        order: 1,
+        mediaGenerations: [
+          {
+            type: 'image',
+            elementId: 'gen_img_abc123',
+            prompt: 'A still diagram',
+            aspectRatio: '16:9',
+          },
+          {
+            type: 'video',
+            elementId: 'gen_vid_unique1',
+            prompt: 'A short animation of the motion concept',
+            aspectRatio: '16:9',
+          },
+        ],
+      },
+      {
+        id: 'scene_2',
+        type: 'slide',
+        title: 'No media',
+        description: 'Explain without media',
+        keyPoints: ['text only'],
+        order: 2,
+      },
+    ];
+
+    expect(buildVideoManifestFromOutlines(outlines)).toEqual({
+      gen_vid_unique1: {
+        type: 'video',
+        prompt: 'A short animation of the motion concept',
+        aspectRatio: '16:9',
+        status: 'pending',
+      },
+    });
+  });
+
+  test('uses mediaRef before legacy placeholder src when resolving video references', () => {
+    expect(
+      getVideoMediaRefForElement({
+        id: 'video_1',
+        type: 'video',
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 56,
+        rotate: 0,
+        mediaRef: 'gen_vid_manifest',
+        src: 'gen_vid_legacy',
+        autoplay: false,
+      }),
+    ).toBe('gen_vid_manifest');
+
+    expect(
+      getVideoMediaRefForElement({
+        id: 'video_2',
+        type: 'video',
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 56,
+        rotate: 0,
+        src: 'gen_vid_legacy',
+        autoplay: false,
+      }),
+    ).toBe('gen_vid_legacy');
+
+    expect(
+      getVideoMediaRefForElement({
+        id: 'video_3',
+        type: 'video',
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 56,
+        rotate: 0,
+        src: 'https://example.com/video.mp4',
+        autoplay: false,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/tests/media/video-manifest.test.ts
+++ b/tests/media/video-manifest.test.ts
@@ -45,7 +45,6 @@ describe('video manifest', () => {
         type: 'video',
         prompt: 'A short animation of the motion concept',
         aspectRatio: '16:9',
-        status: 'pending',
       },
     });
   });

--- a/tests/prompts/media-conditional.test.ts
+++ b/tests/prompts/media-conditional.test.ts
@@ -131,7 +131,8 @@ describe('slide-content media prompt conditions', () => {
     const text = combined(buildSlidePrompt({ generatedVideoEnabled: true }));
 
     expect(text).toContain('VideoElement');
-    expect(text).toContain('gen_vid_1');
+    expect(text).toContain('mediaRef');
+    expect(text).not.toContain('"src": "gen_vid_1"');
     expect(text).not.toContain('ImageElement');
     expect(text).not.toContain('gen_img_');
     expect(text).not.toContain('{{');

--- a/tests/server/classroom-media-generation.test.ts
+++ b/tests/server/classroom-media-generation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { replaceMediaPlaceholders } from '@/lib/server/classroom-media-generation';
+import type { Scene } from '@/lib/types/stage';
+
+function slideScene(
+  elements: Array<{ id: string; type: string; src?: string; mediaRef?: string }>,
+) {
+  return {
+    id: 'scene_1',
+    stageId: 'stage_1',
+    type: 'slide',
+    title: 'Scene',
+    order: 1,
+    content: {
+      type: 'slide',
+      canvas: {
+        id: 'canvas_1',
+        elements,
+      },
+    },
+  } as unknown as Scene;
+}
+
+describe('classroom media placeholder replacement', () => {
+  test('preserves direct video src when mediaRef is also present', () => {
+    const scene = slideScene([
+      {
+        id: 'video_1',
+        type: 'video',
+        src: 'https://example.com/direct.mp4',
+        mediaRef: 'gen_vid_real123',
+      },
+    ]);
+
+    replaceMediaPlaceholders([scene], {
+      gen_vid_real123: 'https://cdn.example.com/generated.mp4',
+    });
+
+    const content = scene.content as {
+      canvas: { elements: Array<{ src?: string }> };
+    };
+    const video = content.canvas.elements[0];
+    expect(video.src).toBe('https://example.com/direct.mp4');
+  });
+});


### PR DESCRIPTION
## Summary

- Introduce a video-only manifest helper and `mediaRef` support for generated video elements.
- Update slide video prompts and post-processing so generated videos use validated `mediaRef` values instead of `src: gen_vid_*`.
- Resolve generated videos through `mediaRef` in renderer, actions, PPT export, and hosted classroom media replacement while preserving legacy `src: gen_vid_*` fallback.

Related: #539

## Test Plan

- `pnpm exec tsc --noEmit`
- `ALLOW_LOCAL_NETWORKS=false pnpm test`
- `pnpm lint` (0 errors, existing warnings remain)