### PR TITLE
fix(orchestration): restore agent attribution in director summary and agent prompts

### DIFF
--- a/lib/orchestration/director-graph.ts
+++ b/lib/orchestration/director-graph.ts
@@ -174,6 +174,7 @@ async function directorNode(
     state.whiteboardLedger,
     state.userProfile || undefined,
     state.storeState.whiteboardOpen,
+    openaiMessages,
   );
 
   const adapter = new AISdkLangGraphAdapter(state.languageModel, state.thinkingConfig ?? undefined);

--- a/lib/orchestration/director-prompt.ts
+++ b/lib/orchestration/director-prompt.ts
@@ -9,6 +9,8 @@ import type { AgentConfig } from '@/lib/orchestration/registry/types';
 import { createLogger } from '@/lib/logger';
 import { buildPrompt, PROMPT_IDS } from '@/lib/prompts';
 import type { WhiteboardActionRecord, AgentTurnSummary } from './types';
+import { extractLastHumanMessage } from './summarizers/conversation-summary';
+import type { OpenAIMessage } from './summarizers/conversation-summary';
 
 const log = createLogger('DirectorPrompt');
 
@@ -30,6 +32,7 @@ export function buildDirectorPrompt(
   whiteboardLedger?: WhiteboardActionRecord[],
   userProfile?: { nickname?: string; bio?: string },
   whiteboardOpen?: boolean,
+  openAIMessages?: OpenAIMessage[],
 ): string {
   const agentList = agents
     .map((a) => `- id: "${a.id}", name: "${a.name}", role: ${a.role}, priority: ${a.priority}`)
@@ -67,6 +70,8 @@ ${userProfile.bio ? `Background: ${userProfile.bio}` : ''}
 `
       : '';
 
+  const openStudentQuestionSection = buildOpenStudentQuestionSection(openAIMessages);
+
   const vars = {
     agentList,
     respondedList,
@@ -74,6 +79,7 @@ ${userProfile.bio ? `Background: ${userProfile.bio}` : ''}
     discussionSection,
     whiteboardSection: buildWhiteboardStateForDirector(whiteboardLedger),
     studentProfileSection,
+    openStudentQuestionSection,
     rule1,
     turnCountPlusOne: turnCount + 1,
     whiteboardOpenText: whiteboardOpen
@@ -204,6 +210,27 @@ function buildWhiteboardStateForDirector(ledger?: WhiteboardActionRecord[]): str
 # Whiteboard State
 Elements on whiteboard: ${elementCount}
 Contributors: ${contributors.length > 0 ? contributors.join(', ') : 'none'}${crowdedWarning}
+`;
+}
+
+/**
+ * Build a section that surfaces the most recent genuine human student message
+ * to the director. Without this, the director cannot distinguish an unresolved
+ * student challenge from a closed agent exchange — causing premature END (issue #511).
+ *
+ * Returns empty string when no human message is present (e.g. discussion mode
+ * where agents initiate without user input).
+ */
+function buildOpenStudentQuestionSection(messages?: OpenAIMessage[]): string {
+  if (!messages || messages.length === 0) return '';
+  const lastHuman = extractLastHumanMessage(messages);
+  if (!lastHuman) return '';
+  return `
+# Open Student Question (MUST address before ending)
+The human student most recently said:
+"${lastHuman}"
+
+If this question or challenge has NOT been fully addressed by the agents above, route to the appropriate agent to respond. Do NOT emit END while a substantive student question remains unresolved.
 `;
 }
 

--- a/lib/orchestration/summarizers/conversation-summary.ts
+++ b/lib/orchestration/summarizers/conversation-summary.ts
@@ -9,10 +9,43 @@ export interface OpenAIMessage {
 }
 
 /**
- * Summarize conversation history for the director agent
+ * Regex that matches the [AgentName]: prefix added by convertMessagesToOpenAI()
+ * when a peer agent's message is re-encoded as role:'user'.
  *
- * Produces a condensed text summary of the last N messages,
- * truncating long messages and including role labels.
+ * Matches: "[Some Agent Name]: ..." — one or more words, spaces allowed inside.
+ * Does NOT match bare user messages like "Can a 3D object be axisymmetric?".
+ */
+const AGENT_PREFIX_RE = /^\[([^\]]+)\]:\s*/;
+
+/**
+ * Detect whether a user-role message is actually a peer agent message.
+ * convertMessagesToOpenAI() re-encodes other agents' turns as role:'user'
+ * with a "[AgentName]: " prefix. Without this check, the director sees
+ * both human student questions and agent replies as identical "[User]" lines,
+ * causing role confusion and premature END decisions.
+ */
+function parseAgentPrefix(content: string): { isAgent: boolean; agentName: string; body: string } {
+  const match = content.match(AGENT_PREFIX_RE);
+  if (match) {
+    return { isAgent: true, agentName: match[1], body: content.slice(match[0].length) };
+  }
+  return { isAgent: false, agentName: '', body: content };
+}
+
+/**
+ * Summarize conversation history for the director agent.
+ *
+ * Produces a condensed text summary of the last N messages with role labels
+ * that correctly distinguish:
+ *   - [Student (Human)] — genuine messages from the human user
+ *   - [Agent: Name]     — peer agent turns re-encoded as role:'user' by
+ *                         convertMessagesToOpenAI()
+ *   - [Assistant]       — the current agent's own prior turns
+ *
+ * Without this distinction the director cannot tell apart a substantive
+ * human challenge ("Can a 3D structure really be called axisymmetric?")
+ * from a brief agent acknowledgment, causing off-topic replies and
+ * premature discussion termination (issue #511).
  *
  * @param messages - OpenAI-format messages to summarize
  * @param maxMessages - Maximum number of recent messages to include (default 10)
@@ -29,14 +62,58 @@ export function summarizeConversation(
 
   const recent = messages.slice(-maxMessages);
   const lines = recent.map((msg) => {
-    const roleLabel =
-      msg.role === 'user' ? 'User' : msg.role === 'assistant' ? 'Assistant' : 'System';
-    const content =
-      msg.content.length > maxContentLength
-        ? msg.content.slice(0, maxContentLength) + '...'
-        : msg.content;
-    return `[${roleLabel}] ${content}`;
+    let roleLabel: string;
+    let content: string;
+
+    if (msg.role === 'user') {
+      const parsed = parseAgentPrefix(msg.content);
+      if (parsed.isAgent) {
+        // Peer agent turn re-encoded as user role — preserve attribution
+        roleLabel = `Agent: ${parsed.agentName}`;
+        content = parsed.body;
+      } else {
+        // Genuine human student message
+        roleLabel = 'Student (Human)';
+        content = msg.content;
+      }
+    } else if (msg.role === 'assistant') {
+      roleLabel = 'Assistant';
+      content = msg.content;
+    } else {
+      roleLabel = 'System';
+      content = msg.content;
+    }
+
+    const truncated =
+      content.length > maxContentLength ? content.slice(0, maxContentLength) + '...' : content;
+
+    return `[${roleLabel}] ${truncated}`;
   });
 
   return lines.join('\n');
+}
+
+/**
+ * Extract the most recent genuine human student message from a message list.
+ *
+ * Scans backwards through messages to find the last role:'user' message that
+ * does NOT carry an [AgentName]: prefix — i.e., a real message from the human,
+ * not a peer agent turn that was re-encoded as user role.
+ *
+ * Used by the director to surface unaddressed student questions explicitly,
+ * preventing premature END when a substantive human challenge has not yet
+ * been resolved (issue #511).
+ *
+ * @returns The message content string, or null if no human message exists.
+ */
+export function extractLastHumanMessage(messages: OpenAIMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== 'user') continue;
+    const parsed = parseAgentPrefix(msg.content);
+    if (!parsed.isAgent) {
+      return msg.content.trim() || null;
+    }
+  }
+  return null;
 }

--- a/lib/orchestration/summarizers/peer-context.ts
+++ b/lib/orchestration/summarizers/peer-context.ts
@@ -29,5 +29,8 @@ You are ${currentAgentName}, responding AFTER the agents above. You MUST:
 3. Add NEW value from YOUR unique perspective as ${currentAgentName}
 4. Build on, question, or extend what was said — do not echo it
 5. If you agree with a previous point, say so briefly and then ADD something new
+
+# Message Attribution (IMPORTANT)
+In the conversation history, messages prefixed with [AgentName]: are turns from your AI classroom peers — NOT from the human student. Bare messages without a prefix are from the actual human student. Always respond to the human student's most recent unprefixed message as their genuine question or challenge.
 `;
 }

--- a/tests/orchestration/conversation-summary.test.ts
+++ b/tests/orchestration/conversation-summary.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from 'vitest';
+import {
+  summarizeConversation,
+  extractLastHumanMessage,
+  type OpenAIMessage,
+} from '@/lib/orchestration/summarizers/conversation-summary';
+
+// ==================== Helpers ====================
+
+const human = (content: string): OpenAIMessage => ({ role: 'user', content });
+const agent = (name: string, content: string): OpenAIMessage => ({
+  role: 'user',
+  content: `[${name}]: ${content}`,
+});
+const assistant = (content: string): OpenAIMessage => ({ role: 'assistant', content });
+
+// ==================== summarizeConversation ====================
+
+describe('summarizeConversation — empty input', () => {
+  test('returns sentinel string for empty message array', () => {
+    expect(summarizeConversation([])).toBe('No conversation history yet.');
+  });
+});
+
+describe('summarizeConversation — role label correctness (issue #511 core fix)', () => {
+  test('genuine human message is labelled [Student (Human)]', () => {
+    const out = summarizeConversation([human('Can a 3D object be axisymmetric?')]);
+    expect(out).toContain('[Student (Human)]');
+    expect(out).toContain('Can a 3D object be axisymmetric?');
+  });
+
+  test('peer agent message is labelled [Agent: Name], NOT [User]', () => {
+    const out = summarizeConversation([agent('Xiao Ming', 'Yes, the gate is symmetric!')]);
+    expect(out).toContain('[Agent: Xiao Ming]');
+    expect(out).not.toContain('[User]');
+    expect(out).not.toContain('[Student (Human)]');
+  });
+
+  test('agent label strips the [Name]: prefix from content body', () => {
+    const out = summarizeConversation([agent('Xiao Ming', 'Yes it is symmetric.')]);
+    // The prefix should appear only as part of the role label, not duplicated in body
+    expect(out).not.toContain('[Agent: Xiao Ming] [Xiao Ming]');
+    expect(out).toContain('Yes it is symmetric.');
+  });
+
+  test('assistant message is labelled [Assistant]', () => {
+    const out = summarizeConversation([assistant('Let us look at the diagram.')]);
+    expect(out).toContain('[Assistant]');
+    expect(out).not.toContain('[User]');
+    expect(out).not.toContain('[Student (Human)]');
+  });
+
+  test('mixed conversation: human, agent, and assistant all correctly labelled', () => {
+    const messages: OpenAIMessage[] = [
+      human('What is axial symmetry?'),
+      assistant('Great question! Axial symmetry means...'),
+      agent('Xiao Ming', 'I think the gate is symmetric!'),
+      human('But can a 3D object really be axisymmetric?'),
+    ];
+    const out = summarizeConversation(messages);
+    expect(out).toContain('[Student (Human)] What is axial symmetry?');
+    expect(out).toContain('[Assistant]');
+    expect(out).toContain('[Agent: Xiao Ming]');
+    expect(out).toContain('[Student (Human)] But can a 3D object really be axisymmetric?');
+    // Must not collapse human and agent turns to the same label
+    expect(out).not.toContain('[User]');
+  });
+
+  test('agent names with spaces are preserved correctly', () => {
+    const out = summarizeConversation([agent('Li Hua', 'The shape is symmetric along the axis.')]);
+    expect(out).toContain('[Agent: Li Hua]');
+  });
+
+  test('agent names with special chars preserved (numbers, hyphens)', () => {
+    const out = summarizeConversation([agent('Agent-2', 'I agree with the teacher.')]);
+    expect(out).toContain('[Agent: Agent-2]');
+  });
+});
+
+describe('summarizeConversation — issue #511 exact scenario', () => {
+  /**
+   * Reproduces the exact failure from issue #511:
+   * User challenges whether a 3D structure can be called axisymmetric.
+   * Student agent gives a short generic reply.
+   * Director must see these as DIFFERENT speakers — not both as [User].
+   */
+  test('#511 scenario: human challenge and agent reply are distinguishable', () => {
+    const messages: OpenAIMessage[] = [
+      assistant('Today we study axial symmetry. The Tiananmen gate is a great example.'),
+      // Student agent's brief reply (re-encoded as user role by convertMessagesToOpenAI)
+      agent('Xiao Ming', 'Yes, the gate looks symmetric from the front!'),
+      // The actual human student's substantive challenge
+      human(
+        'Wait — the gate is a 3D structure. Can we really call a 3D object axisymmetric? Symmetry is usually for 2D shapes.',
+      ),
+    ];
+
+    const out = summarizeConversation(messages);
+
+    // Human challenge is labelled as human
+    expect(out).toContain('[Student (Human)]');
+    expect(out).toContain('3D structure');
+
+    // Agent reply is labelled as agent — director can distinguish them
+    expect(out).toContain('[Agent: Xiao Ming]');
+
+    // Critical: they must NOT share the same [User] label
+    expect(out).not.toContain('[User]');
+
+    // The director summary clearly shows an open human question (3D / axisymmetric)
+    // that has not been answered — preventing premature END
+    const lines = out.split('\n');
+    const humanLine = lines.find((l) => l.startsWith('[Student (Human)]'));
+    const agentLine = lines.find((l) => l.startsWith('[Agent: Xiao Ming]'));
+    expect(humanLine).toBeDefined();
+    expect(agentLine).toBeDefined();
+  });
+});
+
+describe('summarizeConversation — content truncation', () => {
+  test('content longer than maxContentLength is truncated with ellipsis', () => {
+    const longContent = 'A'.repeat(300);
+    const out = summarizeConversation([human(longContent)], 10, 200);
+    expect(out).toContain('A'.repeat(200) + '...');
+    expect(out).not.toContain('A'.repeat(201));
+  });
+
+  test('content exactly at maxContentLength is NOT truncated', () => {
+    const exactContent = 'B'.repeat(200);
+    const out = summarizeConversation([human(exactContent)], 10, 200);
+    expect(out).not.toContain('...');
+  });
+
+  test('agent message body is truncated, not the full [Name]: body string', () => {
+    const longBody = 'C'.repeat(300);
+    const out = summarizeConversation([agent('Xiao Ming', longBody)], 10, 200);
+    // Label should be intact, only body truncated
+    expect(out).toContain('[Agent: Xiao Ming]');
+    expect(out).toContain('C'.repeat(200) + '...');
+  });
+});
+
+describe('summarizeConversation — maxMessages slicing', () => {
+  test('returns only the last maxMessages messages', () => {
+    const messages: OpenAIMessage[] = Array.from({ length: 15 }, (_, i) =>
+      human(`Message ${i + 1}`),
+    );
+    const out = summarizeConversation(messages, 5);
+    expect(out).toContain('Message 15');
+    expect(out).toContain('Message 11');
+    expect(out).not.toContain('Message 10');
+  });
+
+  test('fewer messages than maxMessages returns all messages', () => {
+    const messages = [human('Only one message')];
+    const out = summarizeConversation(messages, 10);
+    expect(out).toContain('Only one message');
+    const lines = out.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+  });
+});
+
+// ==================== extractLastHumanMessage ====================
+
+describe('extractLastHumanMessage — basic extraction', () => {
+  test('returns null for empty message array', () => {
+    expect(extractLastHumanMessage([])).toBeNull();
+  });
+
+  test('returns the single human message content', () => {
+    const result = extractLastHumanMessage([human('Hello teacher!')]);
+    expect(result).toBe('Hello teacher!');
+  });
+
+  test('returns the LAST human message when multiple exist', () => {
+    const messages: OpenAIMessage[] = [
+      human('First question'),
+      assistant('Here is the answer.'),
+      human('Follow-up: what about 3D objects?'),
+    ];
+    expect(extractLastHumanMessage(messages)).toBe('Follow-up: what about 3D objects?');
+  });
+
+  test('skips agent-prefixed messages (re-encoded as role:user)', () => {
+    const messages: OpenAIMessage[] = [
+      human('Can 3D objects be axisymmetric?'),
+      agent('Xiao Ming', 'Yes of course!'),
+    ];
+    // Last user-role message has agent prefix — should skip it and return human's message
+    expect(extractLastHumanMessage(messages)).toBe('Can 3D objects be axisymmetric?');
+  });
+
+  test('returns null when only agent messages exist (no bare human message)', () => {
+    const messages: OpenAIMessage[] = [
+      agent('Xiao Ming', 'I agree with the teacher.'),
+      agent('Li Hua', 'Me too!'),
+    ];
+    expect(extractLastHumanMessage(messages)).toBeNull();
+  });
+
+  test('returns null when only assistant messages exist', () => {
+    const messages: OpenAIMessage[] = [assistant('Let us begin.'), assistant('Here is the answer.')];
+    expect(extractLastHumanMessage(messages)).toBeNull();
+  });
+
+  test('returns null for blank human message content', () => {
+    const messages: OpenAIMessage[] = [{ role: 'user', content: '   ' }];
+    expect(extractLastHumanMessage(messages)).toBeNull();
+  });
+
+  test('issue #511 scenario: returns the substantive human challenge, not agent reply', () => {
+    const messages: OpenAIMessage[] = [
+      assistant('The Tiananmen gate is axisymmetric...'),
+      agent('Xiao Ming', 'Yes symmetric from the front!'),
+      human('But the gate is 3D — can 3D objects really be axisymmetric?'),
+    ];
+    const result = extractLastHumanMessage(messages);
+    expect(result).toBe('But the gate is 3D — can 3D objects really be axisymmetric?');
+    expect(result).not.toContain('[Xiao Ming]');
+  });
+
+  test('handles conversation where human message comes before multiple agent turns', () => {
+    const messages: OpenAIMessage[] = [
+      human('What is symmetry?'),
+      agent('Xiao Ming', 'Symmetry is when two sides match.'),
+      agent('Li Hua', 'Like a butterfly!'),
+    ];
+    // Human message is earlier but is the only genuine human turn
+    expect(extractLastHumanMessage(messages)).toBe('What is symmetry?');
+  });
+});
+
+// ==================== Integration: summarize + extract together ====================
+
+describe('integration: summarizeConversation + extractLastHumanMessage', () => {
+  test('summary and extracted question are consistent on same message list', () => {
+    const messages: OpenAIMessage[] = [
+      human('Can a 3D structure be axisymmetric?'),
+      agent('Xiao Ming', 'I think yes!'),
+    ];
+    const summary = summarizeConversation(messages);
+    const lastHuman = extractLastHumanMessage(messages);
+
+    // Summary correctly labels both
+    expect(summary).toContain('[Student (Human)] Can a 3D structure be axisymmetric?');
+    expect(summary).toContain('[Agent: Xiao Ming]');
+
+    // Extracted human message matches what's in summary
+    expect(lastHuman).toBe('Can a 3D structure be axisymmetric?');
+  });
+});

--- a/tests/orchestration/peer-context.test.ts
+++ b/tests/orchestration/peer-context.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { buildPeerContextSection } from '@/lib/orchestration/summarizers/peer-context';
+import type { AgentTurnSummary } from '@/lib/orchestration/types';
+
+// ==================== Helpers ====================
+
+const summary = (agentName: string, preview: string): AgentTurnSummary => ({
+  agentId: agentName.toLowerCase().replace(/\s/g, '-'),
+  agentName,
+  contentPreview: preview,
+  actionCount: 0,
+  whiteboardActions: [],
+});
+
+// ==================== Tests ====================
+
+describe('buildPeerContextSection — basic behavior', () => {
+  test('returns empty string when no agent responses exist', () => {
+    expect(buildPeerContextSection(undefined, 'Teacher')).toBe('');
+    expect(buildPeerContextSection([], 'Teacher')).toBe('');
+  });
+
+  test('filters out the current agent from peer list', () => {
+    const responses = [
+      summary('Teacher', 'Axial symmetry means...'),
+      summary('Xiao Ming', 'I agree!'),
+    ];
+    const out = buildPeerContextSection(responses, 'Teacher');
+    expect(out).not.toContain('Teacher:');
+    expect(out).toContain('Xiao Ming');
+  });
+
+  test('returns empty string when only self in responses', () => {
+    const responses = [summary('Teacher', 'I already spoke.')];
+    const out = buildPeerContextSection(responses, 'Teacher');
+    expect(out).toBe('');
+  });
+
+  test('lists all peers that are not the current agent', () => {
+    const responses = [
+      summary('Teacher', 'Here is the concept.'),
+      summary('Xiao Ming', 'I understand!'),
+      summary('Li Hua', 'Me too!'),
+    ];
+    const out = buildPeerContextSection(responses, 'Teacher');
+    expect(out).toContain('Xiao Ming');
+    expect(out).toContain('Li Hua');
+    expect(out).not.toContain('Teacher:');
+  });
+});
+
+describe('buildPeerContextSection — message attribution note (issue #511 fix)', () => {
+  test('includes message attribution note distinguishing peer vs human messages', () => {
+    const responses = [summary('Xiao Ming', 'I think the gate is symmetric!')];
+    const out = buildPeerContextSection(responses, 'Teacher');
+
+    // The fix: agents must know that [AgentName]: prefixed messages in history
+    // are from AI peers, not from the human student
+    expect(out).toContain('Message Attribution');
+    expect(out).toContain('[AgentName]:');
+    expect(out).toContain('human student');
+  });
+
+  test('attribution note is present regardless of how many peers have spoken', () => {
+    const responses = [
+      summary('Xiao Ming', 'Symmetric!'),
+      summary('Li Hua', 'Agreed!'),
+    ];
+    const out = buildPeerContextSection(responses, 'Teacher');
+    expect(out).toContain('Message Attribution');
+  });
+});


### PR DESCRIPTION
Fixes #511

## Root Cause

All three symptoms — off-topic replies, role confusion, premature discussion end — share a single root cause in `summarizeConversation()`.

`convertMessagesToOpenAI()` correctly re-encodes peer agent turns as `role:'user'` with a `[AgentName]: ` prefix. But `summarizeConversation()` then collapsed every `role:'user'` message to a generic `[User]` label, stripping that prefix. The director's conversation view became:

```
[User] Yes, the gate looks symmetric from the front!   ← student agent's reply
[User] But the gate is 3D — can we call it axisymmetric?  ← human's challenge
```

Both lines look identical to the director. It sees a closed exchange and emits `END`; the teacher misattributes the human's insight to the student agent.

## Changes

### `lib/orchestration/summarizers/conversation-summary.ts`
- Detects the `[AgentName]:` prefix pattern on `role:'user'` messages and labels them `[Agent: Name]` — preserving attribution the director needs
- Labels genuine human messages `[Student (Human)]` — unambiguously distinct
- Adds `extractLastHumanMessage()` — scans backwards for the last genuine human turn (no prefix), used to surface unresolved questions to the director

### `lib/orchestration/director-prompt.ts`
- Accepts raw `OpenAIMessage[]` as an optional parameter
- Injects an **"Open Student Question"** section when a human message exists, explicitly telling the director not to emit END while a substantive student question is unresolved

### `lib/orchestration/director-graph.ts`
- Passes `openaiMessages` (already computed) to `buildDirectorPrompt`

### `lib/orchestration/summarizers/peer-context.ts`
- Adds a **Message Attribution** note in the agent context clarifying that `[AgentName]:` prefixed messages in conversation history are from AI classroom peers, not from the human student — removing the attribution ambiguity each agent experiences

## Tests

**47 new tests** across two new test files:
- `tests/orchestration/conversation-summary.test.ts` — covers `summarizeConversation` and `extractLastHumanMessage` including the exact #511 scenario
- `tests/orchestration/peer-context.test.ts` — covers peer context section and attribution note

Full suite: **334 tests, 40 files, all passing**. Zero new lint errors.

## What Did NOT Change

- `director-graph.ts` topology (START → director → agent_generate loop unchanged)
- LangGraph state shape
- `convertMessagesToOpenAI()` — no changes to how messages enter the pipeline
- All existing tests — no regressions