### PR TITLE
Fix generated video thumbnails

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,6 +46,7 @@ import {
   deleteStageData,
   renameStage,
   getFirstSlideByStages,
+  revokeThumbnailSlideMediaUrls,
 } from '@/lib/utils/stage-storage';
 import { ThumbnailSlide } from '@/components/slide-renderer/components/ThumbnailSlide';
 import type { Slide } from '@/lib/types/slides';
@@ -146,6 +147,14 @@ function HomePage() {
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const thumbnailsRef = useRef<Record<string, Slide>>({});
+
+  const replaceThumbnails = (slides: Record<string, Slide>) => {
+    const previous = thumbnailsRef.current;
+    thumbnailsRef.current = slides;
+    setThumbnails(slides);
+    window.setTimeout(() => revokeThumbnailSlideMediaUrls(previous), 0);
+  };
 
   // Close dropdowns when clicking outside
   useEffect(() => {
@@ -166,7 +175,9 @@ function HomePage() {
       // Load first slide thumbnails
       if (list.length > 0) {
         const slides = await getFirstSlideByStages(list.map((c) => c.id));
-        setThumbnails(slides);
+        replaceThumbnails(slides);
+      } else {
+        replaceThumbnails({});
       }
     } catch (err) {
       log.error('Failed to load classrooms:', err);
@@ -188,6 +199,11 @@ function HomePage() {
 
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Store hydration on mount
     loadClassrooms();
+
+    return () => {
+      revokeThumbnailSlideMediaUrls(thumbnailsRef.current);
+      thumbnailsRef.current = {};
+    };
   }, []);
 
   const handleDelete = (id: string, e: React.MouseEvent) => {

--- a/components/slide-renderer/components/ThumbnailSlide/ThumbnailElement.tsx
+++ b/components/slide-renderer/components/ThumbnailSlide/ThumbnailElement.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { ElementTypes, type PPTElement } from '@/lib/types/slides';
+import { ElementTypes, type PPTElement, type PPTVideoElement } from '@/lib/types/slides';
+import { isMediaPlaceholder } from '@/lib/store/media-generation';
 
 import { BaseImageElement } from '../element/ImageElement/BaseImageElement';
 import { BaseTextElement } from '../element/TextElement/BaseTextElement';
@@ -8,11 +9,55 @@ import { BaseLineElement } from '../element/LineElement/BaseLineElement';
 import { BaseChartElement } from '../element/ChartElement/BaseChartElement';
 import { BaseLatexElement } from '../element/LatexElement/BaseLatexElement';
 import { BaseTableElement } from '../element/TableElement/BaseTableElement';
-import { BaseVideoElement } from '../element/VideoElement/BaseVideoElement';
 
 interface ThumbnailElementProps {
   readonly elementInfo: PPTElement;
   readonly elementIndex: number;
+}
+
+function ThumbnailVideoElement({ elementInfo }: { readonly elementInfo: PPTVideoElement }) {
+  const src = elementInfo.src && !isMediaPlaceholder(elementInfo.src) ? elementInfo.src : undefined;
+
+  return (
+    <div
+      className="element-content absolute"
+      data-video-element
+      style={{
+        top: `${elementInfo.top}px`,
+        left: `${elementInfo.left}px`,
+        width: `${elementInfo.width}px`,
+        height: `${elementInfo.height}px`,
+      }}
+    >
+      <div className="w-full h-full" style={{ transform: `rotate(${elementInfo.rotate}deg)` }}>
+        {src ? (
+          <video
+            className="w-full h-full"
+            style={{ objectFit: 'contain' }}
+            src={src}
+            poster={elementInfo.poster}
+            preload="metadata"
+            muted
+            playsInline
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-black/10 rounded">
+            <svg
+              className="w-12 h-12 text-gray-400"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -32,7 +77,7 @@ export function ThumbnailElement({ elementInfo, elementIndex }: ThumbnailElement
       [ElementTypes.LATEX]: BaseLatexElement,
       [ElementTypes.TABLE]: BaseTableElement,
       // TODO: Add other element types
-      [ElementTypes.VIDEO]: BaseVideoElement,
+      [ElementTypes.VIDEO]: ThumbnailVideoElement,
       // [ElementTypes.AUDIO]: BaseAudioElement,
     };
     return elementTypeMap[elementInfo.type] || null;

--- a/components/slide-renderer/components/ThumbnailSlide/ThumbnailElement.tsx
+++ b/components/slide-renderer/components/ThumbnailSlide/ThumbnailElement.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { ElementTypes, type PPTElement, type PPTVideoElement } from '@/lib/types/slides';
 import { isMediaPlaceholder } from '@/lib/store/media-generation';
+import { Play } from 'lucide-react';
 
 import { BaseImageElement } from '../element/ImageElement/BaseImageElement';
 import { BaseTextElement } from '../element/TextElement/BaseTextElement';
@@ -13,6 +14,19 @@ import { BaseTableElement } from '../element/TableElement/BaseTableElement';
 interface ThumbnailElementProps {
   readonly elementInfo: PPTElement;
   readonly elementIndex: number;
+}
+
+function ThumbnailVideoIndicator() {
+  return (
+    <div
+      className="absolute inset-0 flex items-center justify-center pointer-events-none"
+      data-testid="thumbnail-video-indicator"
+    >
+      <div className="flex size-28 items-center justify-center rounded-full bg-black/45 shadow-lg ring-2 ring-white/85">
+        <Play className="ml-1 size-14 fill-white text-white" />
+      </div>
+    </div>
+  );
 }
 
 function ThumbnailVideoElement({ elementInfo }: { readonly elementInfo: PPTVideoElement }) {
@@ -30,7 +44,7 @@ function ThumbnailVideoElement({ elementInfo }: { readonly elementInfo: PPTVideo
       }}
     >
       <div className="w-full h-full" style={{ transform: `rotate(${elementInfo.rotate}deg)` }}>
-        {src ? (
+        {src && (
           <video
             className="w-full h-full"
             style={{ objectFit: 'contain' }}
@@ -40,21 +54,9 @@ function ThumbnailVideoElement({ elementInfo }: { readonly elementInfo: PPTVideo
             muted
             playsInline
           />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center bg-black/10 rounded">
-            <svg
-              className="w-12 h-12 text-gray-400"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polygon points="5 3 19 12 5 21 5 3" />
-            </svg>
-          </div>
         )}
+        {!src && <div className="w-full h-full bg-black/10 rounded" />}
+        <ThumbnailVideoIndicator />
       </div>
     </div>
   );

--- a/components/slide-renderer/components/ThumbnailSlide/index.tsx
+++ b/components/slide-renderer/components/ThumbnailSlide/index.tsx
@@ -38,7 +38,7 @@ export function ThumbnailSlide({
   if (!visible) {
     return (
       <div
-        className="thumbnail-slide bg-white overflow-hidden select-none"
+        className="thumbnail-slide bg-white overflow-hidden select-none pointer-events-none"
         style={{
           width: `${size}px`,
           height: `${size * viewportRatio}px`,
@@ -53,7 +53,7 @@ export function ThumbnailSlide({
 
   return (
     <div
-      className="thumbnail-slide bg-white overflow-hidden select-none"
+      className="thumbnail-slide bg-white overflow-hidden select-none pointer-events-none"
       style={{
         width: `${size}px`,
         height: `${size * viewportRatio}px`,

--- a/components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx
+++ b/components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx
@@ -19,6 +19,10 @@ export interface BaseVideoElementProps {
   elementInfo: PPTVideoElement;
 }
 
+function isLegacySequentialVideoRef(value: string | undefined): boolean {
+  return !!value && /^gen_vid_\d+$/i.test(value);
+}
+
 /**
  * Base video element component for read-only/presentation display.
  * Controlled exclusively by the canvas store via the play_video action.
@@ -41,7 +45,17 @@ export function BaseVideoElement({ elementInfo }: BaseVideoElementProps) {
     if (!mediaRef) return undefined;
     const t = s.tasks[mediaRef];
     if (t && t.stageId !== stageId) return undefined;
-    return t;
+    if (t) return t;
+
+    const sameStageVideoTasks = Object.values(s.tasks).filter(
+      (candidate) =>
+        candidate.type === 'video' && candidate.stageId === stageId && candidate.status === 'done',
+    );
+    if (isLegacySequentialVideoRef(mediaRef) && sameStageVideoTasks.length === 1) {
+      return sameStageVideoTasks[0];
+    }
+
+    return undefined;
   });
   const videoGenerationEnabled = useSettingsStore((s) => s.videoGenerationEnabled);
   const resolvedSrc = task?.status === 'done' && task.objectUrl ? task.objectUrl : concreteSrc;

--- a/e2e/tests/recent-video-thumbnail.spec.ts
+++ b/e2e/tests/recent-video-thumbnail.spec.ts
@@ -1,0 +1,187 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/base';
+import { defaultTheme } from '../fixtures/test-data/scene-content';
+
+const TEST_STAGE_ID = 'e2e-video-thumbnail-stage';
+const VIDEO_MEDIA_REF = 'gen_vid_thumbnail';
+const LEGACY_STAGE_ID = 'e2e-legacy-video-ref-stage';
+const LEGACY_VIDEO_REF = 'gen_vid_1';
+const UNIQUE_VIDEO_REF = 'gen_vid_unique_legacy';
+const POSTER_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+async function seedVideoThumbnailStage({
+  page,
+  stageId = TEST_STAGE_ID,
+  courseName = 'Video Thumbnail Course',
+  slideMediaRef = VIDEO_MEDIA_REF,
+  storedMediaRef = slideMediaRef,
+}: {
+  page: Page;
+  stageId?: string;
+  courseName?: string;
+  slideMediaRef?: string;
+  storedMediaRef?: string;
+}) {
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  await page.evaluate(
+    ({ stageId, courseName, slideMediaRef, storedMediaRef, posterBase64, theme }) => {
+      return new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction(
+            ['stages', 'scenes', 'stageOutlines', 'mediaFiles'],
+            'readwrite',
+          );
+          const now = Date.now();
+          const videoBytes = new Uint8Array([
+            0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50, 0, 0, 0, 0, 109, 112, 52, 50, 105,
+            115, 111, 109,
+          ]);
+          const posterBytes = Uint8Array.from(atob(posterBase64), (char) => char.charCodeAt(0));
+          const videoBlob = new Blob([videoBytes], { type: 'video/mp4' });
+          const posterBlob = new Blob([posterBytes], { type: 'image/png' });
+
+          tx.objectStore('stages').put({
+            id: stageId,
+            name: courseName,
+            description: '',
+            language: 'en-US',
+            style: 'professional',
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('scenes').put({
+            id: 'scene-video-thumbnail',
+            stageId,
+            type: 'slide',
+            title: 'Video preview',
+            order: 0,
+            content: {
+              type: 'slide',
+              canvas: {
+                id: 'slide-video-thumbnail',
+                viewportSize: 1000,
+                viewportRatio: 0.5625,
+                theme,
+                background: { type: 'solid', color: '#111827' },
+                elements: [
+                  {
+                    id: 'video-el',
+                    type: 'video',
+                    src: slideMediaRef,
+                    mediaRef: slideMediaRef,
+                    left: 0,
+                    top: 0,
+                    width: 1000,
+                    height: 562.5,
+                    rotate: 0,
+                    autoplay: false,
+                  },
+                ],
+              },
+            },
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('stageOutlines').put({
+            stageId,
+            outlines: [],
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('mediaFiles').put({
+            id: `${stageId}:${storedMediaRef}`,
+            stageId,
+            type: 'video',
+            blob: videoBlob,
+            mimeType: 'video/mp4',
+            size: videoBlob.size,
+            poster: posterBlob,
+            prompt: 'A generated classroom video preview',
+            params: '{}',
+            createdAt: now,
+          });
+
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+
+        request.onerror = () => reject(request.error);
+      });
+    },
+    {
+      stageId,
+      courseName,
+      slideMediaRef,
+      storedMediaRef,
+      posterBase64: POSTER_BASE64,
+      theme: defaultTheme,
+    },
+  );
+
+  await page.goto('/', { waitUntil: 'networkidle' });
+}
+
+test.describe('Home recent video thumbnails', () => {
+  test('renders generated video thumbnails and opens the card from the preview area', async ({
+    page,
+  }) => {
+    await seedVideoThumbnailStage({ page });
+
+    const card = page.locator('.group.cursor-pointer').filter({
+      hasText: 'Video Thumbnail Course',
+    });
+    const video = card.locator('[data-video-element] video');
+
+    await expect(video).toBeVisible({ timeout: 10_000 });
+    await expect(video).toHaveAttribute('src', /^blob:/);
+    await expect(video).toHaveAttribute('poster', /^blob:/);
+    await expect(video).not.toHaveAttribute('controls', '');
+
+    await card.click({ position: { x: 24, y: 24 } });
+    await page.waitForURL(`**/classroom/${TEST_STAGE_ID}`);
+
+    const classroomVideo = page.locator('[data-video-element] video[controls]');
+    await expect(classroomVideo).toHaveCount(1);
+    await expect(classroomVideo).toBeVisible({ timeout: 10_000 });
+    await expect(classroomVideo).toHaveAttribute('src', /^blob:/);
+  });
+
+  test('falls back from legacy gen_vid_1 refs to the single stored video media file', async ({
+    page,
+  }) => {
+    await seedVideoThumbnailStage({
+      page,
+      stageId: LEGACY_STAGE_ID,
+      courseName: 'Legacy Video Ref Course',
+      slideMediaRef: LEGACY_VIDEO_REF,
+      storedMediaRef: UNIQUE_VIDEO_REF,
+    });
+
+    const card = page.locator('.group.cursor-pointer').filter({
+      hasText: 'Legacy Video Ref Course',
+    });
+    const thumbnailVideo = card.locator('[data-video-element] video');
+
+    await expect(thumbnailVideo).toBeVisible({ timeout: 10_000 });
+    await expect(thumbnailVideo).toHaveAttribute('src', /^blob:/);
+
+    await card.click({ position: { x: 24, y: 24 } });
+    await page.waitForURL(`**/classroom/${LEGACY_STAGE_ID}`);
+
+    const classroomVideo = page.locator('[data-video-element] video[controls]');
+    await expect(classroomVideo).toHaveCount(1);
+    await expect(classroomVideo).toBeVisible({ timeout: 10_000 });
+    await expect(classroomVideo).toHaveAttribute('src', /^blob:/);
+  });
+});

--- a/e2e/tests/recent-video-thumbnail.spec.ts
+++ b/e2e/tests/recent-video-thumbnail.spec.ts
@@ -7,6 +7,8 @@ const VIDEO_MEDIA_REF = 'gen_vid_thumbnail';
 const LEGACY_STAGE_ID = 'e2e-legacy-video-ref-stage';
 const LEGACY_VIDEO_REF = 'gen_vid_1';
 const UNIQUE_VIDEO_REF = 'gen_vid_unique_legacy';
+const FAILED_EXACT_STAGE_ID = 'e2e-failed-exact-video-ref-stage';
+const OTHER_VIDEO_REF = 'gen_vid_other_success';
 const POSTER_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
 
@@ -16,17 +18,30 @@ async function seedVideoThumbnailStage({
   courseName = 'Video Thumbnail Course',
   slideMediaRef = VIDEO_MEDIA_REF,
   storedMediaRef = slideMediaRef,
+  storedError,
+  extraStoredMediaRefs = [],
 }: {
   page: Page;
   stageId?: string;
   courseName?: string;
   slideMediaRef?: string;
   storedMediaRef?: string;
+  storedError?: string;
+  extraStoredMediaRefs?: string[];
 }) {
   await page.goto('/', { waitUntil: 'networkidle' });
 
   await page.evaluate(
-    ({ stageId, courseName, slideMediaRef, storedMediaRef, posterBase64, theme }) => {
+    ({
+      stageId,
+      courseName,
+      slideMediaRef,
+      storedMediaRef,
+      storedError,
+      extraStoredMediaRefs,
+      posterBase64,
+      theme,
+    }) => {
       return new Promise<void>((resolve, reject) => {
         const request = indexedDB.open('MAIC-Database');
 
@@ -44,6 +59,24 @@ async function seedVideoThumbnailStage({
           const posterBytes = Uint8Array.from(atob(posterBase64), (char) => char.charCodeAt(0));
           const videoBlob = new Blob([videoBytes], { type: 'video/mp4' });
           const posterBlob = new Blob([posterBytes], { type: 'image/png' });
+          const failedVideoBlob = new Blob([], { type: 'video/mp4' });
+
+          const putVideoRecord = (mediaRef: string, error?: string) => {
+            const blob = error ? failedVideoBlob : videoBlob;
+            tx.objectStore('mediaFiles').put({
+              id: `${stageId}:${mediaRef}`,
+              stageId,
+              type: 'video',
+              blob,
+              mimeType: 'video/mp4',
+              size: blob.size,
+              poster: error ? undefined : posterBlob,
+              prompt: 'A generated classroom video preview',
+              params: '{}',
+              error,
+              createdAt: now,
+            });
+          };
 
           tx.objectStore('stages').put({
             id: stageId,
@@ -96,18 +129,10 @@ async function seedVideoThumbnailStage({
             updatedAt: now,
           });
 
-          tx.objectStore('mediaFiles').put({
-            id: `${stageId}:${storedMediaRef}`,
-            stageId,
-            type: 'video',
-            blob: videoBlob,
-            mimeType: 'video/mp4',
-            size: videoBlob.size,
-            poster: posterBlob,
-            prompt: 'A generated classroom video preview',
-            params: '{}',
-            createdAt: now,
-          });
+          putVideoRecord(storedMediaRef, storedError);
+          for (const mediaRef of extraStoredMediaRefs) {
+            putVideoRecord(mediaRef);
+          }
 
           tx.oncomplete = () => {
             db.close();
@@ -124,6 +149,8 @@ async function seedVideoThumbnailStage({
       courseName,
       slideMediaRef,
       storedMediaRef,
+      storedError,
+      extraStoredMediaRefs,
       posterBase64: POSTER_BASE64,
       theme: defaultTheme,
     },
@@ -185,5 +212,24 @@ test.describe('Home recent video thumbnails', () => {
     await expect(classroomVideo).toHaveCount(1);
     await expect(classroomVideo).toBeVisible({ timeout: 10_000 });
     await expect(classroomVideo).toHaveAttribute('src', /^blob:/);
+  });
+
+  test('does not fall back to another video when the exact legacy ref failed', async ({ page }) => {
+    await seedVideoThumbnailStage({
+      page,
+      stageId: FAILED_EXACT_STAGE_ID,
+      courseName: 'Failed Exact Video Ref Course',
+      slideMediaRef: LEGACY_VIDEO_REF,
+      storedMediaRef: LEGACY_VIDEO_REF,
+      storedError: 'Generation failed',
+      extraStoredMediaRefs: [OTHER_VIDEO_REF],
+    });
+
+    const card = page.locator('.group.cursor-pointer').filter({
+      hasText: 'Failed Exact Video Ref Course',
+    });
+
+    await expect(card.locator('[data-testid="thumbnail-video-indicator"]')).toBeVisible();
+    await expect(card.locator('[data-video-element] video')).toHaveCount(0);
   });
 });

--- a/e2e/tests/recent-video-thumbnail.spec.ts
+++ b/e2e/tests/recent-video-thumbnail.spec.ts
@@ -147,6 +147,7 @@ test.describe('Home recent video thumbnails', () => {
     await expect(video).toHaveAttribute('src', /^blob:/);
     await expect(video).toHaveAttribute('poster', /^blob:/);
     await expect(video).not.toHaveAttribute('controls', '');
+    await expect(card.locator('[data-testid="thumbnail-video-indicator"]')).toBeVisible();
 
     await card.click({ position: { x: 24, y: 24 } });
     await page.waitForURL(`**/classroom/${TEST_STAGE_ID}`);
@@ -175,6 +176,7 @@ test.describe('Home recent video thumbnails', () => {
 
     await expect(thumbnailVideo).toBeVisible({ timeout: 10_000 });
     await expect(thumbnailVideo).toHaveAttribute('src', /^blob:/);
+    await expect(card.locator('[data-testid="thumbnail-video-indicator"]')).toBeVisible();
 
     await card.click({ position: { x: 24, y: 24 } });
     await page.waitForURL(`**/classroom/${LEGACY_STAGE_ID}`);

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -182,6 +182,8 @@ type ThumbnailMediaElement = {
   poster?: string;
 };
 
+type ThumbnailSlide = import('../types/slides').Slide;
+
 function isGeneratedMediaRef(value: unknown): value is string {
   return typeof value === 'string' && /^gen_(img|vid)_[\w-]+$/i.test(value);
 }
@@ -209,6 +211,25 @@ function blobWithType(blob: Blob, mimeType: string): Blob {
   return blob.type ? blob : new Blob([blob], { type: mimeType });
 }
 
+function revokeObjectUrl(url: string | undefined) {
+  if (url?.startsWith('blob:')) {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export function revokeThumbnailSlideMediaUrls(slides: Record<string, ThumbnailSlide>) {
+  for (const slide of Object.values(slides)) {
+    for (const element of slide.elements as ThumbnailMediaElement[]) {
+      if (element.type === 'image' || element.type === 'video') {
+        revokeObjectUrl(element.src);
+      }
+      if (element.type === 'video') {
+        revokeObjectUrl(element.poster);
+      }
+    }
+  }
+}
+
 /**
  * Get first slide scene's canvas data for each stage (for thumbnail preview).
  * Also resolves generated image/video refs from mediaFiles so thumbnails show real media.
@@ -216,8 +237,8 @@ function blobWithType(blob: Blob, mimeType: string): Blob {
  */
 export async function getFirstSlideByStages(
   stageIds: string[],
-): Promise<Record<string, import('../types/slides').Slide>> {
-  const result: Record<string, import('../types/slides').Slide> = {};
+): Promise<Record<string, ThumbnailSlide>> {
+  const result: Record<string, ThumbnailSlide> = {};
   try {
     await Promise.all(
       stageIds.map(async (stageId) => {
@@ -235,21 +256,21 @@ export async function getFirstSlideByStages(
               (record) => !record.error && record.type === 'video',
             );
             const mediaMap = new Map(
-              mediaRecords
-                .filter((record) => !record.error)
-                .map((record) => [getMediaRecordElementId(record.id), record] as const),
+              mediaRecords.map((record) => [getMediaRecordElementId(record.id), record] as const),
             );
 
             for (const el of mediaElements as ThumbnailMediaElement[]) {
               const mediaRef = getThumbnailMediaRef(el);
               const exactRecord = mediaRef ? mediaMap.get(mediaRef) : undefined;
+              const usableExactRecord = exactRecord && !exactRecord.error ? exactRecord : undefined;
               const legacyRecord =
+                !exactRecord &&
                 el.type === 'video' &&
                 isLegacySequentialVideoRef(mediaRef) &&
                 videoRecords.length === 1
                   ? videoRecords[0]
                   : undefined;
-              const record = exactRecord ?? legacyRecord;
+              const record = usableExactRecord ?? legacyRecord;
 
               if (!mediaRef || !record) {
                 if (el.type === 'image') {

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -175,10 +175,44 @@ export async function listStages(): Promise<StageListItem[]> {
   }
 }
 
+type ThumbnailMediaElement = {
+  type: string;
+  src?: string;
+  mediaRef?: string;
+  poster?: string;
+};
+
+function isGeneratedMediaRef(value: unknown): value is string {
+  return typeof value === 'string' && /^gen_(img|vid)_[\w-]+$/i.test(value);
+}
+
+function isLegacySequentialVideoRef(value: unknown): value is string {
+  return typeof value === 'string' && /^gen_vid_\d+$/i.test(value);
+}
+
+function getThumbnailMediaRef(element: ThumbnailMediaElement): string | undefined {
+  if (element.type === 'image' && isGeneratedMediaRef(element.src)) {
+    return element.src;
+  }
+  if (element.type === 'video') {
+    if (isGeneratedMediaRef(element.mediaRef)) return element.mediaRef;
+    if (isGeneratedMediaRef(element.src)) return element.src;
+  }
+  return undefined;
+}
+
+function getMediaRecordElementId(recordId: string): string {
+  return recordId.includes(':') ? recordId.split(':').slice(1).join(':') : recordId;
+}
+
+function blobWithType(blob: Blob, mimeType: string): Blob {
+  return blob.type ? blob : new Blob([blob], { type: mimeType });
+}
+
 /**
  * Get first slide scene's canvas data for each stage (for thumbnail preview).
- * Also resolves gen_img_* placeholders from mediaFiles so thumbnails show real images.
- * Returns a map of stageId -> Slide (canvas data with resolved images)
+ * Also resolves generated image/video refs from mediaFiles so thumbnails show real media.
+ * Returns a map of stageId -> Slide (canvas data with resolved media)
  */
 export async function getFirstSlideByStages(
   stageIds: string[],
@@ -192,27 +226,48 @@ export async function getFirstSlideByStages(
         if (firstSlide && firstSlide.content.type === 'slide') {
           const slide = structuredClone(firstSlide.content.canvas);
 
-          // Resolve gen_img_* placeholders from mediaFiles
-          const placeholderEls = slide.elements.filter(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (el: any) => el.type === 'image' && /^gen_(img|vid)_[\w-]+$/i.test(el.src as string),
+          const mediaElements = slide.elements.filter((el) =>
+            getThumbnailMediaRef(el as ThumbnailMediaElement),
           );
-          if (placeholderEls.length > 0) {
+          if (mediaElements.length > 0) {
             const mediaRecords = await db.mediaFiles.where('stageId').equals(stageId).toArray();
-            const mediaMap = new Map(
-              mediaRecords.map((r) => {
-                // Key format: stageId:elementId → extract elementId
-                const elementId = r.id.includes(':') ? r.id.split(':').slice(1).join(':') : r.id;
-                return [elementId, r.blob] as const;
-              }),
+            const videoRecords = mediaRecords.filter(
+              (record) => !record.error && record.type === 'video',
             );
-            for (const el of placeholderEls as Array<{ src: string }>) {
-              const blob = mediaMap.get(el.src);
-              if (blob) {
-                el.src = URL.createObjectURL(blob);
-              } else {
-                // Clear unresolved placeholder so BaseImageElement won't subscribe
-                // to the global media store (which may have stale data from another course)
+            const mediaMap = new Map(
+              mediaRecords
+                .filter((record) => !record.error)
+                .map((record) => [getMediaRecordElementId(record.id), record] as const),
+            );
+
+            for (const el of mediaElements as ThumbnailMediaElement[]) {
+              const mediaRef = getThumbnailMediaRef(el);
+              const exactRecord = mediaRef ? mediaMap.get(mediaRef) : undefined;
+              const legacyRecord =
+                el.type === 'video' &&
+                isLegacySequentialVideoRef(mediaRef) &&
+                videoRecords.length === 1
+                  ? videoRecords[0]
+                  : undefined;
+              const record = exactRecord ?? legacyRecord;
+
+              if (!mediaRef || !record) {
+                if (el.type === 'image') {
+                  // Clear unresolved placeholder so BaseImageElement won't subscribe
+                  // to the global media store (which may have stale data from another course)
+                  el.src = '';
+                }
+                continue;
+              }
+
+              if (el.type === 'image' && record.type === 'image') {
+                el.src = URL.createObjectURL(blobWithType(record.blob, record.mimeType));
+              } else if (el.type === 'video' && record.type === 'video') {
+                el.src = URL.createObjectURL(blobWithType(record.blob, record.mimeType));
+                if (record.poster) {
+                  el.poster = URL.createObjectURL(blobWithType(record.poster, 'image/jpeg'));
+                }
+              } else if (el.type === 'image') {
                 el.src = '';
               }
             }


### PR DESCRIPTION
## Summary
- Resolve generated image/video media refs from IndexedDB when building recent-learning thumbnails.
- Render thumbnail videos with a lightweight thumbnail-only video element so controls and click handlers do not block the card.
- Add fallback handling for legacy `gen_vid_1` refs when a stage has a single completed generated video.
- Add e2e coverage for video thumbnail rendering, click-through, and legacy video refs.

## Root Cause
Generated video slides can persist placeholder-style refs such as `gen_vid_1` while the generated media file is stored under the actual media record id. Recent-learning thumbnails previously reused the normal classroom video component and did not consistently resolve those stored media records, so thumbnails could show placeholders or intercept card clicks.

## Validation
- `pnpm exec prettier --check components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx lib/utils/stage-storage.ts e2e/tests/recent-video-thumbnail.spec.ts components/slide-renderer/components/ThumbnailSlide/ThumbnailElement.tsx components/slide-renderer/components/ThumbnailSlide/index.tsx`
- `pnpm exec eslint components/slide-renderer/components/element/VideoElement/BaseVideoElement.tsx lib/utils/stage-storage.ts components/slide-renderer/components/ThumbnailSlide/ThumbnailElement.tsx components/slide-renderer/components/ThumbnailSlide/index.tsx`
- `pnpm exec vitest run tests/media/video-manifest.test.ts tests/generation/video-manifest-wiring.test.ts`
- `pnpm build`
- `pnpm exec playwright test e2e/tests/recent-video-thumbnail.spec.ts --project=chromium`
- Chrome e2e smoke: generated a course with a real local mp4 from `/api/generate/video`, verified classroom video blob metadata and recent-learning thumbnail click-through.

Fixes #545