### PR TITLE
docs: align provider key setup with default model

### DIFF
--- a/skills/openmaic/references/provider-keys.md
+++ b/skills/openmaic/references/provider-keys.md
@@ -39,13 +39,13 @@ Recommended when the user wants the smallest amount of configuration.
 Set:
 
 ```env
-ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
 ```
 
 Why:
 
-- OpenMAIC server fallback is currently `gpt-4o-mini` if `DEFAULT_MODEL` is unset.
-- If the user wants Anthropic or Google by default, they should set `DEFAULT_MODEL` explicitly.
+- OpenMAIC server fallback is currently OpenAI `gpt-5.4-mini` if `DEFAULT_MODEL` is unset.
+- If the user wants Anthropic, Google, or another provider by default, they should set `DEFAULT_MODEL` explicitly.
 
 ### 2. Better Speed / Cost Balance
 
@@ -72,7 +72,12 @@ Examples:
 
 ```env
 OPENAI_API_KEY=sk-...
-DEFAULT_MODEL=openai:gpt-4o-mini
+DEFAULT_MODEL=openai:gpt-5.4-mini
+```
+
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+DEFAULT_MODEL=anthropic:claude-3-5-haiku-20241022
 ```
 
 ```env
@@ -86,7 +91,7 @@ When recommending or showing `DEFAULT_MODEL`, always include the provider prefix
 
 - `google:gemini-3-flash-preview`
 - `anthropic:claude-3-5-haiku-20241022`
-- `openai:gpt-4o-mini`
+- `openai:gpt-5.4-mini`
 - `deepseek:deepseek-chat`
 
 Do not recommend bare model IDs such as `gemini-3-flash-preview` by themselves, because OpenMAIC will otherwise parse them as OpenAI models.
@@ -128,7 +133,7 @@ DEFAULT_MODEL=google:gemini-3-flash-preview
 Preferred:
 
 - "I recommend configuring OpenMAIC through `.env.local` first. Please edit that file locally and tell me when you're done."
-- "For the simplest setup, I recommend Anthropic. For better speed/cost balance, I recommend Google plus `DEFAULT_MODEL=google:gemini-3-flash-preview`. Which path do you want?"
+- "For the simplest setup, I recommend OpenAI because it matches the unset `DEFAULT_MODEL` fallback. For better speed/cost balance, I recommend Google plus `DEFAULT_MODEL=google:gemini-3-flash-preview`. Which path do you want?"
 
 Avoid as the first move:
 


### PR DESCRIPTION
## Summary

Fix the OpenMAIC skill provider setup guidance so the lowest-friction path matches the actual server default model resolution.

AI-assisted PR: prepared with Codex and self-reviewed before submission.

## Related Issues

Fixes #433

## Changes

- Change the lowest-friction setup from `ANTHROPIC_API_KEY` to `OPENAI_API_KEY`, because an unset `DEFAULT_MODEL` resolves to OpenAI.
- Update the documented unset fallback from stale `gpt-4o-mini` to current `gpt-5.4-mini`.
- Add an explicit Anthropic example that sets both `ANTHROPIC_API_KEY` and `DEFAULT_MODEL=anthropic:...`.
- Update the recommended setup prompt so it no longer suggests Anthropic without an Anthropic `DEFAULT_MODEL`.

## Type of Change

- [x] Documentation update

## Verification

### Steps to reproduce / test

1. Compare `skills/openmaic/references/provider-keys.md` with `lib/server/resolve-model.ts`.
2. Confirm `resolveModel()` uses `process.env.DEFAULT_MODEL || 'gpt-5.4-mini'`.
3. Confirm bare model strings default to the OpenAI provider in `parseModelString()`.
4. Run the local checks below.

### What you personally verified

- Verified the original issue still existed on current `main` before changing the docs.
- Verified the docs now recommend an OpenAI key for the unset fallback path.
- Verified Anthropic setup now includes an explicit Anthropic `DEFAULT_MODEL`.
- Removed stale local `.next` and generated `dist/` caches before checking, so lint/typecheck reflected the source branch rather than local generated artifacts.

### Evidence

- [x] `pnpm check` passed
- [x] `pnpm lint` exited 0 (current upstream main still reports existing warnings unrelated to this docs-only change)
- [x] `pnpm exec tsc --noEmit` passed after clearing stale `.next` generated types
- [x] `pnpm run check:i18n-keys` passed
- [x] `pnpm test` passed: 42 files, 313 tests
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
