### PR TITLE
fix(generation): make stop/abort actually stop the generation end-to-end

### DIFF
--- a/app/api/generate/agent-profiles/route.ts
+++ b/app/api/generate/agent-profiles/route.ts
@@ -156,6 +156,7 @@ Return a JSON object with this exact structure:
         'agent-profiles',
         undefined,
         thinkingConfig,
+        req.signal,
       )
     ).text;
 

--- a/app/api/generate/scene-actions/route.ts
+++ b/app/api/generate/scene-actions/route.ts
@@ -113,6 +113,7 @@ export async function POST(req: NextRequest) {
           'scene-actions',
           undefined,
           thinkingConfig,
+          req.signal,
         );
         return result.text;
       }
@@ -126,6 +127,7 @@ export async function POST(req: NextRequest) {
         'scene-actions',
         undefined,
         thinkingConfig,
+        req.signal,
       );
       return result.text;
     };

--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -104,6 +104,7 @@ export async function POST(req: NextRequest) {
           'scene-content',
           undefined,
           thinkingConfig,
+          req.signal,
         );
         return result.text;
       }
@@ -117,6 +118,7 @@ export async function POST(req: NextRequest) {
         'scene-content',
         undefined,
         thinkingConfig,
+        req.signal,
       );
       return result.text;
     };

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -291,6 +291,7 @@ export async function POST(req: NextRequest) {
                 streamParams,
                 'scene-outlines-stream',
                 thinkingConfig,
+                req.signal,
               ).textStream;
 
               for await (const chunk of textStream) {

--- a/app/api/web-search/route.ts
+++ b/app/api/web-search/route.ts
@@ -84,6 +84,7 @@ export async function POST(req: NextRequest) {
           'web-search-query-rewrite',
           undefined,
           thinkingConfig,
+          req.signal,
         );
         return result.text;
       };

--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -204,7 +204,7 @@ export default function ClassroomDetailPage() {
               </div>
             </div>
           ) : (
-            <Stage onRetryOutline={retrySingleOutline} />
+            <Stage onRetryOutline={retrySingleOutline} onStopGeneration={stop} />
           )}
         </div>
       </MediaStageProvider>

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -3,7 +3,17 @@
 import { useEffect, useState, Suspense, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'motion/react';
-import { CheckCircle2, Sparkles, AlertCircle, AlertTriangle, ArrowLeft, Bot } from 'lucide-react';
+import {
+  CheckCircle2,
+  Sparkles,
+  AlertCircle,
+  AlertTriangle,
+  ArrowLeft,
+  Bot,
+  Square,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { runStopGeneration } from './stop-generation';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -879,6 +889,21 @@ function GenerationPreviewContent() {
     router.push('/');
   };
 
+  const handleStopGeneration = () => {
+    runStopGeneration({
+      abortControllerRef,
+      clearSession: () => sessionStorage.removeItem('generationSession'),
+      toast: (msg) => toast.success(msg),
+      pushHome: () => router.push('/'),
+      t,
+    });
+  };
+
+  // Show the stop pill while generation is actively running — not on the
+  // session-not-found / loading shells, and not after `error` is set
+  // (that view already offers explicit recovery).
+  const isGenerationActive = sessionLoaded && !!session && !error && !isComplete;
+
   // Still loading session from sessionStorage
   if (!sessionLoaded) {
     return (
@@ -939,6 +964,26 @@ function GenerationPreviewContent() {
           {t('generation.backToHome')}
         </Button>
       </motion.div>
+
+      {/* Stop generation pill — only while generation is running */}
+      {isGenerationActive && (
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="absolute top-4 right-4 z-20"
+        >
+          <button
+            type="button"
+            onClick={handleStopGeneration}
+            title={t('stage.stopGeneration')}
+            aria-label={t('stage.stopGeneration')}
+            className="flex items-center gap-1.5 px-3 h-8 rounded-full text-xs font-medium bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50 border border-red-100 dark:border-red-900/40 transition-colors"
+          >
+            <Square className="w-3 h-3 fill-current" />
+            <span>{t('stage.stopGeneration')}</span>
+          </button>
+        </motion.div>
+      )}
 
       <div className="z-10 w-full max-w-lg space-y-8 flex flex-col items-center">
         <motion.div

--- a/app/generation-preview/stop-generation.ts
+++ b/app/generation-preview/stop-generation.ts
@@ -1,0 +1,27 @@
+/**
+ * Stop-generation handler for the generation-preview page.
+ *
+ * Lives outside the page component so it can be unit-tested without
+ * mounting React. The page passes its `abortControllerRef`, the
+ * router, the i18n function, and a toast function; we wire the same
+ * three side effects every press requires:
+ *
+ *   1. Abort the in-flight requests so we stop burning provider tokens.
+ *   2. Tell the user we heard them (toast).
+ *   3. Drop the saved session and route home — staying on this page
+ *      with everything cancelled would be a confusing dead-end.
+ */
+export interface StopGenerationDeps {
+  readonly abortControllerRef: { current: AbortController | null };
+  readonly clearSession: () => void;
+  readonly toast: (message: string) => void;
+  readonly pushHome: () => void;
+  readonly t: (key: string) => string;
+}
+
+export function runStopGeneration(deps: StopGenerationDeps): void {
+  deps.abortControllerRef.current?.abort();
+  deps.clearSession();
+  deps.toast(deps.t('generation.stopGenerationToast'));
+  deps.pushHome();
+}

--- a/components/canvas/canvas-area.tsx
+++ b/components/canvas/canvas-area.tsx
@@ -21,6 +21,11 @@ interface CanvasAreaProps extends CanvasToolbarProps {
   readonly isCourseComplete?: boolean;
   readonly isGenerationFailed?: boolean;
   readonly onRetryGeneration?: () => void;
+  /**
+   * When true, the retry button is disabled to prevent double-click
+   * concurrency. Defense-in-depth on top of the hook-level guard.
+   */
+  readonly isRetryingGeneration?: boolean;
 }
 
 export function CanvasArea({
@@ -48,6 +53,7 @@ export function CanvasArea({
   isCourseComplete,
   isGenerationFailed,
   onRetryGeneration,
+  isRetryingGeneration,
 }: CanvasAreaProps) {
   const { t } = useI18n();
   const showControls = mode === 'playback' && !whiteboardOpen;
@@ -164,9 +170,12 @@ export function CanvasArea({
                     {onRetryGeneration && (
                       <button
                         onClick={onRetryGeneration}
-                        className="mt-1 px-4 py-1.5 text-xs font-medium rounded-full bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors active:scale-95"
+                        disabled={isRetryingGeneration}
+                        className="mt-1 px-4 py-1.5 text-xs font-medium rounded-full bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                       >
-                        {t('generation.retryScene')}
+                        {isRetryingGeneration
+                          ? t('generation.retryingScene')
+                          : t('generation.retryScene')}
                       </button>
                     )}
                   </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -11,6 +11,7 @@ import {
   FileDown,
   Package,
   Archive,
+  Square,
 } from 'lucide-react';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useTheme } from '@/lib/hooks/use-theme';
@@ -26,9 +27,15 @@ import { useExportClassroom } from '@/lib/export/use-export-classroom';
 
 interface HeaderProps {
   readonly currentSceneTitle: string;
+  /**
+   * If provided, a stop button is shown next to the title to abort the
+   * in-flight scene generation pipeline. Caller should pass `undefined`
+   * when there is no active generation so the button stays hidden.
+   */
+  readonly onStopGeneration?: () => void;
 }
 
-export function Header({ currentSceneTitle }: HeaderProps) {
+export function Header({ currentSceneTitle, onStopGeneration }: HeaderProps) {
   const { t } = useI18n();
   const { theme, setTheme } = useTheme();
   const router = useRouter();
@@ -95,6 +102,18 @@ export function Header({ currentSceneTitle }: HeaderProps) {
               {currentSceneTitle || t('common.loading')}
             </h1>
           </div>
+          {onStopGeneration && (
+            <button
+              type="button"
+              onClick={onStopGeneration}
+              title={t('stage.stopGeneration')}
+              aria-label={t('stage.stopGeneration')}
+              className="shrink-0 flex items-center gap-1.5 px-3 h-8 rounded-full text-xs font-medium bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50 border border-red-100 dark:border-red-900/40 transition-colors"
+            >
+              <Square className="w-3 h-3 fill-current" />
+              <span>{t('stage.stopGeneration')}</span>
+            </button>
+          )}
         </div>
 
         <div className="flex items-center gap-4 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md px-2 py-1.5 rounded-full border border-gray-100/50 dark:border-gray-700/50 shadow-sm shrink-0">

--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -43,8 +43,14 @@ import { VisuallyHidden } from 'radix-ui';
  */
 export function Stage({
   onRetryOutline,
+  onStopGeneration,
 }: {
   onRetryOutline?: (outlineId: string) => Promise<void>;
+  /**
+   * Aborts the active scene generation pipeline. Wired from
+   * `useSceneGenerator().stop` in the page-level component.
+   */
+  onStopGeneration?: () => void;
 }) {
   const { t } = useI18n();
   const {
@@ -57,6 +63,22 @@ export function Stage({
     outlines,
   } = useStageStore();
   const failedOutlines = useStageStore.use.failedOutlines();
+  const generationStatus = useStageStore.use.generationStatus();
+  const isGenerating = generationStatus === 'generating';
+
+  const handleStopGeneration = useCallback(() => {
+    if (!onStopGeneration) return;
+    onStopGeneration();
+    // Sonner is already used elsewhere in the codebase for transient feedback.
+    // Lazy-import keeps this side effect off the SSR / non-classroom paths.
+    import('sonner')
+      .then(({ toast }) => {
+        toast.success(t('generation.stopGenerationToast'));
+      })
+      .catch(() => {
+        // Ignore — toast is best-effort feedback. Stop already fired.
+      });
+  }, [onStopGeneration, t]);
 
   const currentScene = getCurrentScene();
 
@@ -962,6 +984,7 @@ export function Stage({
         onCollapseChange={setSidebarCollapsed}
         onSceneSelect={gatedSceneSwitch}
         onRetryOutline={onRetryOutline}
+        onStopGeneration={isGenerating && onStopGeneration ? handleStopGeneration : undefined}
         isCourseComplete={isCourseComplete}
       />
 
@@ -974,6 +997,7 @@ export function Stage({
               currentScene?.title ||
               (isCourseComplete && isPendingScene ? t('stage.courseComplete') : '')
             }
+            onStopGeneration={isGenerating && onStopGeneration ? handleStopGeneration : undefined}
           />
         )}
 

--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -120,6 +120,12 @@ export function Stage({
   const [chatIsStreaming, setChatIsStreaming] = useState(false);
   const [chatSessionType, setChatSessionType] = useState<string | null>(null);
 
+  // Bug #3 defense-in-depth: track which outline is currently being retried
+  // by the canvas-area "Retry" button. The hook itself guards against
+  // concurrent retries, but disabling the button prevents the
+  // user-visible flicker between click and the next render.
+  const [retryingPendingOutlineId, setRetryingPendingOutlineId] = useState<string | null>(null);
+
   // Topic pending state: session is soft-paused, bubble stays visible, waiting for user input
   const [isTopicPending, setIsTopicPending] = useState(false);
 
@@ -1042,8 +1048,20 @@ export function Stage({
             }
             onRetryGeneration={
               onRetryOutline && generatingOutlines[0]
-                ? () => onRetryOutline(generatingOutlines[0].id)
+                ? async () => {
+                    const target = generatingOutlines[0];
+                    if (!target || retryingPendingOutlineId === target.id) return;
+                    setRetryingPendingOutlineId(target.id);
+                    try {
+                      await onRetryOutline(target.id);
+                    } finally {
+                      setRetryingPendingOutlineId((prev) => (prev === target.id ? null : prev));
+                    }
+                  }
                 : undefined
+            }
+            isRetryingGeneration={
+              !!generatingOutlines[0] && retryingPendingOutlineId === generatingOutlines[0].id
             }
           />
         </div>

--- a/components/stage/scene-sidebar.tsx
+++ b/components/stage/scene-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   AlertCircle,
   RefreshCw,
   Trophy,
+  Square,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ThumbnailSlide } from '@/components/slide-renderer/components/ThumbnailSlide';
@@ -26,6 +27,12 @@ interface SceneSidebarProps {
   readonly onCollapseChange: (collapsed: boolean) => void;
   readonly onSceneSelect?: (sceneId: string) => void;
   readonly onRetryOutline?: (outlineId: string) => Promise<void>;
+  /**
+   * If provided, a stop button is rendered alongside the generating
+   * placeholder so the user can abort scene generation in progress.
+   * Caller passes `undefined` when generation is not active.
+   */
+  readonly onStopGeneration?: () => void;
   readonly isCourseComplete?: boolean;
 }
 
@@ -38,6 +45,7 @@ export function SceneSidebar({
   onCollapseChange,
   onSceneSelect,
   onRetryOutline,
+  onStopGeneration,
   isCourseComplete,
 }: SceneSidebarProps) {
   const { t } = useI18n();
@@ -446,6 +454,21 @@ export function SceneSidebar({
                           <span className="text-[9px] font-medium text-gray-400 dark:text-gray-500 mt-0.5">
                             {isPaused ? t('stage.paused') : t('stage.generating')}
                           </span>
+                          {!isPaused && onStopGeneration && (
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onStopGeneration();
+                              }}
+                              title={t('stage.stopGeneration')}
+                              aria-label={t('stage.stopGeneration')}
+                              className="mt-1 inline-flex items-center gap-1 px-2 h-5 rounded-full text-[9px] font-medium bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50 border border-red-100 dark:border-red-900/40 transition-colors"
+                            >
+                              <Square className="w-2 h-2 fill-current" />
+                              <span>{t('stage.stopGeneration')}</span>
+                            </button>
+                          )}
                         </>
                       )}
                     </div>

--- a/lib/ai/llm.ts
+++ b/lib/ai/llm.ts
@@ -237,18 +237,35 @@ export interface LLMRetryOptions {
 const DEFAULT_VALIDATE = (text: string) => text.trim().length > 0;
 
 /**
+ * Merge a caller-supplied AbortSignal into params.abortSignal.
+ *
+ * If the caller already populated `params.abortSignal`, we respect it and
+ * leave `params` untouched — overriding silently would be surprising and
+ * would break call sites that wire their own controller (e.g. tests).
+ */
+function withSignal<T extends Record<string, unknown>>(params: T, signal?: AbortSignal): T {
+  if (!signal) return params;
+  if ((params as { abortSignal?: AbortSignal }).abortSignal) return params;
+  return { ...params, abortSignal: signal };
+}
+
+/**
  * Unified wrapper around `generateText`.
  *
  * @param params - Same parameters as AI SDK's `generateText`
  * @param source - A short label for log grouping (e.g. 'scene-stream', 'pbl-chat')
  * @param retryOptions - Optional retry-on-validation-failure settings
  * @param thinking - Optional per-call thinking config (overrides global LLM_THINKING_DISABLED)
+ * @param signal - Optional AbortSignal forwarded to AI SDK as `abortSignal`.
+ *   Routes pass `request.signal` so client disconnects cancel the upstream
+ *   provider call. Ignored when `params.abortSignal` is already set.
  */
 export async function callLLM<T extends GenerateTextParams>(
   params: T,
   source: string,
   retryOptions?: LLMRetryOptions,
   thinking?: ThinkingConfig,
+  signal?: AbortSignal,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<GenerateTextResult<any, any>> {
   const maxAttempts = (retryOptions?.retries ?? 0) + 1;
@@ -262,7 +279,7 @@ export async function callLLM<T extends GenerateTextParams>(
     try {
       // Resolve effective thinking config: per-call > global env > undefined
       const effectiveThinking = thinking ?? getGlobalThinkingConfig();
-      const injectedParams = injectProviderOptions(params, effectiveThinking);
+      const injectedParams = withSignal(injectProviderOptions(params, effectiveThinking), signal);
 
       // Wrap in thinkingContext so the custom fetch wrapper in providers.ts
       // can read the config and inject vendor-specific body params for
@@ -304,16 +321,20 @@ export async function callLLM<T extends GenerateTextParams>(
  * @param params - Same parameters as AI SDK's `streamText`
  * @param source - A short label for log grouping
  * @param thinking - Optional per-call thinking config (overrides global LLM_THINKING_DISABLED)
+ * @param signal - Optional AbortSignal forwarded to AI SDK as `abortSignal`.
+ *   Routes pass `request.signal` so client disconnects cancel the upstream
+ *   provider call. Ignored when `params.abortSignal` is already set.
  */
 export function streamLLM<T extends StreamTextParams>(
   params: T,
   source: string,
   thinking?: ThinkingConfig,
+  signal?: AbortSignal,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): StreamTextResult<any, any> {
   // Resolve effective thinking config and wrap in thinkingContext
   const effectiveThinking = thinking ?? getGlobalThinkingConfig();
-  const injectedParams = injectProviderOptions(params, effectiveThinking);
+  const injectedParams = withSignal(injectProviderOptions(params, effectiveThinking), signal);
   const result = thinkingContext.run(effectiveThinking, () => streamText(injectedParams));
 
   return result;

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -258,6 +258,24 @@ export interface GenerationParams {
   languageDirective?: string;
 }
 
+/**
+ * Returns true when the given outline is already being (re)generated.
+ *
+ * Used by `retrySingleOutline` to short-circuit duplicate retry clicks:
+ * the UI watches the same `generatingOutlines` list to render the
+ * spinner, so any outline present here has an in-flight content/actions
+ * pipeline. Re-entering would spawn parallel LLM calls and race to
+ * write the scene.
+ *
+ * Exported for unit testing; not part of the public hook API.
+ */
+export function isOutlineRetryInFlight(
+  state: { generatingOutlines: { id: string }[] },
+  outlineId: string,
+): boolean {
+  return state.generatingOutlines.some((o) => o.id === outlineId);
+}
+
 export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
   const abortRef = useRef(false);
   const generatingRef = useRef(false);
@@ -475,6 +493,17 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
       const outline = state.failedOutlines.find((o) => o.id === outlineId);
       const params = lastParamsRef.current;
       if (!outline || !state.stage || !params) return;
+
+      // Bug #3: in-flight retry guard. Without this, rapid clicks on the
+      // retry button (or a stale UI that doesn't disable itself fast
+      // enough) launched parallel content+actions+TTS pipelines for the
+      // same outline, racing to write the scene and burning tokens.
+      // `generatingOutlines` is the same list the spinner watches, so
+      // its presence is the canonical "already retrying" signal.
+      if (isOutlineRetryInFlight(state, outlineId)) {
+        log.warn('Retry skipped: outline already in flight', { outlineId });
+        return;
+      }
 
       const removeGeneratingOutline = () => {
         const current = store.getState().generatingOutlines;

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -144,7 +144,8 @@
     "generatingNextPage": "جارٍ توليد المشهد، يرجى الانتظار...",
     "courseComplete": "اكتملت الدورة",
     "fullscreen": "ملء الشاشة",
-    "exitFullscreen": "الخروج من ملء الشاشة"
+    "exitFullscreen": "الخروج من ملء الشاشة",
+    "stopGeneration": "إيقاف التوليد"
   },
   "classroomComplete": {
     "title": "اكتملت الدورة",
@@ -340,6 +341,7 @@
     "speechFailed": "فشل توليد الكلام",
     "retryScene": "إعادة المحاولة",
     "retryingScene": "جارٍ إعادة التوليد...",
+    "stopGenerationToast": "تم إيقاف التوليد",
     "backToHome": "العودة للرئيسية",
     "sessionNotFound": "الجلسة غير موجودة",
     "sessionNotFoundDesc": "يرجى ملء متطلبات المقرر لبدء عملية التوليد.",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -144,7 +144,8 @@
     "generatingNextPage": "Scene is being generated, please wait...",
     "courseComplete": "Course complete",
     "fullscreen": "Fullscreen",
-    "exitFullscreen": "Exit Fullscreen"
+    "exitFullscreen": "Exit Fullscreen",
+    "stopGeneration": "Stop generation"
   },
   "classroomComplete": {
     "title": "Course complete",
@@ -340,6 +341,7 @@
     "speechFailed": "Speech generation failed",
     "retryScene": "Retry",
     "retryingScene": "Regenerating...",
+    "stopGenerationToast": "Generation stopped",
     "backToHome": "Back to Home",
     "sessionNotFound": "Session Not Found",
     "sessionNotFoundDesc": "Please fill in course requirements to start the generation process.",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -144,7 +144,8 @@
     "generatingNextPage": "シーンを生成中です。お待ちください...",
     "courseComplete": "コース完了",
     "fullscreen": "全画面表示",
-    "exitFullscreen": "全画面表示を終了"
+    "exitFullscreen": "全画面表示を終了",
+    "stopGeneration": "生成を停止"
   },
   "classroomComplete": {
     "title": "コース完了",
@@ -340,6 +341,7 @@
     "speechFailed": "音声の生成に失敗しました",
     "retryScene": "やり直す",
     "retryingScene": "再生成中...",
+    "stopGenerationToast": "生成を停止しました",
     "backToHome": "ホームに戻る",
     "sessionNotFound": "セッションが見つかりません",
     "sessionNotFoundDesc": "コースの要件を入力して生成プロセスを開始してください。",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -144,7 +144,8 @@
     "generatingNextPage": "Сцена генерируется, пожалуйста подождите...",
     "courseComplete": "Курс завершён",
     "fullscreen": "Полный экран",
-    "exitFullscreen": "Свернуть"
+    "exitFullscreen": "Свернуть",
+    "stopGeneration": "Остановить генерацию"
   },
   "classroomComplete": {
     "title": "Курс завершён",
@@ -340,6 +341,7 @@
     "speechFailed": "Ошибка генерации речи",
     "retryScene": "Повторить",
     "retryingScene": "Перегенерация...",
+    "stopGenerationToast": "Генерация остановлена",
     "backToHome": "На главную",
     "sessionNotFound": "Сессия не найдена",
     "sessionNotFoundDesc": "Пожалуйста, заполните требования к курсу, чтобы начать генерацию.",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -144,7 +144,8 @@
     "generatingNextPage": "场景正在生成，请稍候...",
     "courseComplete": "课程完成",
     "fullscreen": "全屏",
-    "exitFullscreen": "退出全屏"
+    "exitFullscreen": "退出全屏",
+    "stopGeneration": "停止生成"
   },
   "classroomComplete": {
     "title": "课程完成",
@@ -340,6 +341,7 @@
     "speechFailed": "语音合成失败",
     "retryScene": "重试生成",
     "retryingScene": "正在重新生成...",
+    "stopGenerationToast": "已停止生成",
     "backToHome": "返回首页",
     "sessionNotFound": "未找到生成会话",
     "sessionNotFoundDesc": "请先填写课程需求开始生成流程。",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -144,7 +144,8 @@
     "generatingNextPage": "場景正在生成，請稍候...",
     "fullscreen": "全螢幕",
     "exitFullscreen": "離開全螢幕",
-    "courseComplete": "課程完成"
+    "courseComplete": "課程完成",
+    "stopGeneration": "停止生成"
   },
   "whiteboard": {
     "title": "互動白板",
@@ -325,6 +326,7 @@
     "speechFailed": "語音合成失敗",
     "retryScene": "重試生成",
     "retryingScene": "正在重新生成...",
+    "stopGenerationToast": "已停止生成",
     "backToHome": "返回首頁",
     "sessionNotFound": "未找到生成會話",
     "sessionNotFoundDesc": "請先填寫課程需求開始生成流程。",

--- a/tests/ai/llm-abort-signal.test.ts
+++ b/tests/ai/llm-abort-signal.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const aiMock = vi.hoisted(() => ({
+  generateText: vi.fn(async (params: unknown) => ({ text: 'ok', params })),
+  streamText: vi.fn((params: unknown) => ({ params, textStream: (async function* () {})() })),
+}));
+
+vi.mock('ai', () => ({
+  generateText: aiMock.generateText,
+  streamText: aiMock.streamText,
+}));
+
+import { callLLM, streamLLM } from '@/lib/ai/llm';
+
+describe('LLM AbortSignal propagation', () => {
+  beforeEach(() => {
+    aiMock.generateText.mockClear();
+    aiMock.streamText.mockClear();
+  });
+
+  it('callLLM forwards the supplied signal to generateText as abortSignal', async () => {
+    const controller = new AbortController();
+    await callLLM(
+      {
+        model: { provider: 'openai.chat', modelId: 'gpt-4o-mini' },
+        prompt: 'hi',
+      } as Parameters<typeof callLLM>[0],
+      'test',
+      undefined,
+      undefined,
+      controller.signal,
+    );
+
+    expect(aiMock.generateText).toHaveBeenCalledTimes(1);
+    const params = aiMock.generateText.mock.calls[0]?.[0] as { abortSignal?: AbortSignal };
+    expect(params.abortSignal).toBe(controller.signal);
+  });
+
+  it('callLLM omits abortSignal when no signal is supplied', async () => {
+    await callLLM(
+      {
+        model: { provider: 'openai.chat', modelId: 'gpt-4o-mini' },
+        prompt: 'hi',
+      } as Parameters<typeof callLLM>[0],
+      'test',
+    );
+
+    const params = aiMock.generateText.mock.calls[0]?.[0] as { abortSignal?: AbortSignal };
+    expect(params.abortSignal).toBeUndefined();
+  });
+
+  it("respects an abortSignal that the caller already placed in params (caller's wins)", async () => {
+    const callerController = new AbortController();
+    const overrideController = new AbortController();
+    await callLLM(
+      {
+        model: { provider: 'openai.chat', modelId: 'gpt-4o-mini' },
+        prompt: 'hi',
+        abortSignal: callerController.signal,
+      } as Parameters<typeof callLLM>[0],
+      'test',
+      undefined,
+      undefined,
+      overrideController.signal,
+    );
+
+    const params = aiMock.generateText.mock.calls[0]?.[0] as { abortSignal?: AbortSignal };
+    // If the caller already wired their own signal, do not silently overwrite it.
+    expect(params.abortSignal).toBe(callerController.signal);
+  });
+
+  it('streamLLM forwards the supplied signal to streamText as abortSignal', () => {
+    const controller = new AbortController();
+    streamLLM(
+      {
+        model: { provider: 'openai.chat', modelId: 'gpt-4o-mini' },
+        prompt: 'hi',
+      } as Parameters<typeof streamLLM>[0],
+      'test',
+      undefined,
+      controller.signal,
+    );
+
+    expect(aiMock.streamText).toHaveBeenCalledTimes(1);
+    const params = aiMock.streamText.mock.calls[0]?.[0] as { abortSignal?: AbortSignal };
+    expect(params.abortSignal).toBe(controller.signal);
+  });
+});

--- a/tests/generation/preview-stop-generation.test.ts
+++ b/tests/generation/preview-stop-generation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the generation-preview stop handler.
+ *
+ * The generation-preview page does not use the `useSceneGenerator` hook
+ * because outline generation runs inline (the hook only owns scene
+ * content + actions + TTS, after redirect to /classroom). It manages
+ * its own AbortController, so it needs its own stop entry point.
+ *
+ * These tests pin the three required side effects of pressing
+ * "Stop generation" on this page: abort the controller, clear the
+ * session, fire a toast, push home.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { runStopGeneration } from '@/app/generation-preview/stop-generation';
+
+function makeDeps(overrides: Partial<Parameters<typeof runStopGeneration>[0]> = {}) {
+  const controller = new AbortController();
+  const abortSpy = vi.spyOn(controller, 'abort');
+  const clearSession = vi.fn();
+  const toast = vi.fn();
+  const pushHome = vi.fn();
+  const t = vi.fn((key: string) => key);
+  return {
+    deps: {
+      abortControllerRef: { current: controller },
+      clearSession,
+      toast,
+      pushHome,
+      t,
+      ...overrides,
+    },
+    controller,
+    abortSpy,
+    clearSession,
+    toast,
+    pushHome,
+    t,
+  };
+}
+
+describe('runStopGeneration (generation-preview)', () => {
+  it('aborts the in-flight controller, clears session, toasts, and pushes home', () => {
+    const { deps, abortSpy, clearSession, toast, pushHome, t } = makeDeps();
+
+    runStopGeneration(deps);
+
+    expect(abortSpy).toHaveBeenCalledTimes(1);
+    expect(clearSession).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(pushHome).toHaveBeenCalledTimes(1);
+    // toast text comes via t() so layouts stay i18n-compliant
+    expect(t).toHaveBeenCalledWith('generation.stopGenerationToast');
+    expect(toast).toHaveBeenCalledWith('generation.stopGenerationToast');
+  });
+
+  it('still toasts and pushes home when no controller is registered', () => {
+    const { deps, toast, pushHome, clearSession } = makeDeps();
+    deps.abortControllerRef.current = null;
+
+    runStopGeneration(deps);
+
+    expect(clearSession).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(pushHome).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs side effects in a deterministic order (abort → clear → toast → push)', () => {
+    const calls: string[] = [];
+    const controller = new AbortController();
+    vi.spyOn(controller, 'abort').mockImplementation(() => {
+      calls.push('abort');
+    });
+    const deps = {
+      abortControllerRef: { current: controller },
+      clearSession: () => calls.push('clearSession'),
+      toast: () => calls.push('toast'),
+      pushHome: () => calls.push('pushHome'),
+      t: (key: string) => key,
+    };
+
+    runStopGeneration(deps);
+
+    expect(calls).toEqual(['abort', 'clearSession', 'toast', 'pushHome']);
+  });
+});

--- a/tests/generation/retry-outline-guard.test.ts
+++ b/tests/generation/retry-outline-guard.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression test for the retrySingleOutline concurrency bug.
+ *
+ * Before this fix, clicking the per-outline retry button N times in
+ * quick succession spun up N parallel content + actions + TTS pipelines
+ * for the same outline. Each round burned tokens, raced to write the
+ * scene, and produced duplicate IDs in IndexedDB. The fix gates entry
+ * on `generatingOutlines` (the same list the UI watches to render the
+ * spinner): if the outline is already in flight, the second invocation
+ * early-returns without sending a request.
+ *
+ * The hook itself is a React closure and is exercised end-to-end in
+ * Playwright. This test pins the pure predicate that the guard relies
+ * on so a regression here is caught immediately at unit-test speed.
+ */
+import { describe, expect, it } from 'vitest';
+import { isOutlineRetryInFlight } from '@/lib/hooks/use-scene-generator';
+import type { SceneOutline } from '@/lib/types/generation';
+
+function outline(id: string, order = 0): SceneOutline {
+  return {
+    id,
+    type: 'slide',
+    title: `outline-${id}`,
+    description: '',
+    keyPoints: [],
+    order,
+  };
+}
+
+describe('isOutlineRetryInFlight (Bug #3 retry concurrency guard)', () => {
+  it('returns false when no outline is generating', () => {
+    expect(isOutlineRetryInFlight({ generatingOutlines: [] }, 'scene-1')).toBe(false);
+  });
+
+  it('returns true when the same outline is already in flight', () => {
+    expect(isOutlineRetryInFlight({ generatingOutlines: [outline('scene-1')] }, 'scene-1')).toBe(
+      true,
+    );
+  });
+
+  it('returns false when only an unrelated outline is in flight', () => {
+    expect(isOutlineRetryInFlight({ generatingOutlines: [outline('scene-2')] }, 'scene-1')).toBe(
+      false,
+    );
+  });
+
+  it('matches by id even when multiple outlines are in flight', () => {
+    expect(
+      isOutlineRetryInFlight(
+        { generatingOutlines: [outline('a'), outline('b'), outline('c')] },
+        'b',
+      ),
+    ).toBe(true);
+    expect(
+      isOutlineRetryInFlight(
+        { generatingOutlines: [outline('a'), outline('b'), outline('c')] },
+        'd',
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/i18n/stop-generation-keys.test.ts
+++ b/tests/i18n/stop-generation-keys.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Bug #1 (stop button): the classroom now exposes a "stop generation" UI affordance.
+ *
+ * The button label and the toast text shown after stopping must be translated in
+ * every supported locale. CI's `pnpm check:i18n-keys` already enforces parity
+ * against `en-US.json`, but this test gives us a tight TDD loop without depending
+ * on the script: it fails if any locale is missing one of the new keys.
+ */
+
+const LOCALES_DIR = path.join(__dirname, '..', '..', 'lib', 'i18n', 'locales');
+
+const REQUIRED_KEYS = [
+  ['stage', 'stopGeneration'],
+  ['generation', 'stopGenerationToast'],
+] as const;
+
+function getNested(obj: unknown, segments: readonly string[]): string | undefined {
+  let cursor: unknown = obj;
+  for (const seg of segments) {
+    if (!cursor || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[seg];
+  }
+  return typeof cursor === 'string' ? cursor : undefined;
+}
+
+const localeFiles = fs
+  .readdirSync(LOCALES_DIR)
+  .filter((name) => name.endsWith('.json'))
+  .sort();
+
+describe('stop-generation i18n keys', () => {
+  it('has at least the 6 known locales available to extend', () => {
+    expect(localeFiles.length).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const file of localeFiles) {
+    const fullPath = path.join(LOCALES_DIR, file);
+    const data = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+
+    for (const segments of REQUIRED_KEYS) {
+      const keyPath = segments.join('.');
+      it(`${file} provides "${keyPath}" with a non-empty translation`, () => {
+        const value = getNested(data, segments);
+        expect(value, `Missing or non-string ${keyPath} in ${file}`).toBeTruthy();
+        expect(typeof value).toBe('string');
+        expect((value as string).trim().length).toBeGreaterThan(0);
+      });
+    }
+  }
+});


### PR DESCRIPTION
> **AI-assisted PR** (Claude Code). See "AI-assisted review" section below for self-review details.

## Summary

Make the stop/abort path actually stop the generation end-to-end. Three failure modes in the same user story:

- **UI surface (gap)**: `useSceneGenerator.stop()` already existed but was never wired to a visible affordance on `/classroom/[id]`, and `/generation-preview` had no stop UI at all. Adds a destructive pill (header) + chip (sidebar generating placeholder card) + pill (preview top-right), each gated on the active generation phase.
- **Server-side leak (bug)**: `request.signal` was not forwarded into `callLLM` / `streamLLM`; client disconnect did not cancel the upstream provider call → tokens kept burning after the user gave up.
- **Concurrency (bug)**: `retrySingleOutline` had no in-flight guard; rapid retry clicks spawned N parallel content + actions + TTS pipelines for the same outline.

## Related Issues

<!--
Filed as umbrella issue alongside this PR (replace placeholder with real
issue number before requesting review):
-->

- Closes #550
- Related to #127 (Roundtable UI state cleanup after QA/Discussion failure — same family of cleanup gap, different surface)
- Related to #185 (Stale `generationSession` causes false Tavily error on retry — adjacent retry-flow cleanup)

## Changes

- `app/classroom/[id]/page.tsx` — pass `stop` to `<Stage onStopGeneration>`
- `components/header.tsx` — accept `onStopGeneration?`, render destructive pill next to the scene title when generation is active
- `components/stage.tsx` — accept `onStopGeneration?`, compute `isGenerating` from the store, drive the toast via `import('sonner')`, forward to `<Header>` and `<SceneSidebar>`. Also tracks per-outline retry state for canvas retry button
- `components/stage/scene-sidebar.tsx` — accept `onStopGeneration?`, render small destructive chip on the generating placeholder card
- `components/canvas/canvas-area.tsx` — accept `isRetryingGeneration?`; disable retry button + flip label to "Regenerating…" while a retry is in flight
- `lib/ai/llm.ts` — add optional `signal?: AbortSignal` to `callLLM` and `streamLLM`; merge into `params.abortSignal` via a private helper that respects an already-set caller signal
- `app/api/generate/{scene-content,scene-actions,scene-outlines-stream,agent-profiles}/route.ts` and `app/api/web-search/route.ts` — forward `req.signal`. The pre-outline routes (`web-search` ~12 s, `agent-profiles` ~18 s) are exactly when the user is most likely to give up, so signal coverage there is critical
- `lib/hooks/use-scene-generator.ts` — export predicate `isOutlineRetryInFlight(state, outlineId)` and short-circuit `retrySingleOutline` if the outline is already in `generatingOutlines`
- `app/generation-preview/page.tsx` + `app/generation-preview/stop-generation.ts` — extract a pure `runStopGeneration` helper (4 deterministic side effects), render the destructive pill while generation is active
- `lib/i18n/locales/{ar-SA,en-US,ja-JP,ru-RU,zh-CN,zh-TW}.json` — two new keys (`stage.stopGeneration`, `generation.stopGenerationToast`)
- `tests/i18n/stop-generation-keys.test.ts`, `tests/ai/llm-abort-signal.test.ts`, `tests/generation/retry-outline-guard.test.ts`, `tests/generation/preview-stop-generation.test.ts` — 24 new vitest tests

24 files changed, +537 / −14, across 5 commits.

## Type of Change

- [x] Bug fix (server-side abort propagation + retry concurrency)
- [x] New feature (UI affordances for the existing-but-unwired hook `stop()`)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

> The UI portion is "wiring an existing hook function to a visible affordance" — `useSceneGenerator.stop()` and `abortControllerRef` already existed in both surfaces; this PR adds the missing UI affordance plus i18n. The substantive correctness changes are server signal forwarding and the retry concurrency guard. Combined here because all three are the same user story — clicking Stop must actually stop.

## Verification

### Steps to reproduce / test

1. `pnpm install && pnpm dev` (uses your `.env.local` provider keys).
2. From `/`, generate a course with a small prompt (e.g. "Explain photosynthesis", 3 outlines).
3. While "Drafting Course Outline" is on screen, confirm the **Stop generation** pill is visible in the top-right corner. Click it — toast appears, you land on home, `generationSession` is cleared.
4. Generate again, let it pass outline + first scene → redirect to `/classroom/<id>`.
5. While additional scenes are still generating, confirm:
   - Header pill **Stop generation** is visible.
   - Sidebar generating placeholder shows the same red **Stop generation** chip.
   - Click stop → server log shows the in-flight LLM call cancelled (look for `AbortError` in `callLLM`).
6. Force a scene to fail (temporary invalid model id, or hand-rigged 500). Click the canvas retry button repeatedly; only one fetch should fire (the button disables itself between click and re-render; the hook predicate guards the concurrent path even if the click slips through).

### What you personally verified

- ✅ `pnpm check` clean
- ✅ `pnpm lint` 0 errors (7 pre-existing warnings, all in untouched files)
- ✅ `npx tsc --noEmit` clean
- ✅ `pnpm check:i18n-keys` 6 locales aligned
- ✅ `pnpm test` — 328 pass; 9 failures are **pre-existing** in `tests/server/ssrf-guard.test.ts` (DNS-dependent on `main`; reproduced on `main` via `git stash`)
- ✅ Headless Playwright: generation-preview pill renders + click navigates home (screenshots attached)
- ⚠ Headless Playwright did **not** drive the classroom into the in-flight state (auto-resume effect didn't fire reliably from a seeded IndexedDB on reload); coverage delegated to the 13 + 4 + 4 + 3 unit tests + manual repro per steps above. See `VERIFICATION.md` ("Classroom integration limit") for the diagnostic trail.
- ⚠ Bug #2 server-side abort confirmation via real provider log inspection: **not run** in this PR (would burn real tokens). The unit tests pin the contract that `callLLM`/`streamLLM` thread `abortSignal` through to the AI SDK; the SDK documents it as cancelling the upstream call.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots attached (UI changes)

**Stop pill visible** while "Drafting Course Outline" is on screen:

![Stop generation pill visible top-right while drafting course outline](https://raw.githubusercontent.com/hiveden/OpenMAIC/db99ca86cdad262975899b5f9f28e9cd1ffecccb/01.png)

**After click** → toast fires, navigated back to `/`:

![Back on home page after clicking stop generation](https://raw.githubusercontent.com/hiveden/OpenMAIC/db99ca86cdad262975899b5f9f28e9cd1ffecccb/02.png)

## AI-assisted review

Per `CONTRIBUTING.md` §"AI-Assisted PRs": ran a structured 4-dimension self-review on `a5a465f` (type safety / abort propagation / i18n completeness / test coverage). The review caught one concrete miss: two routes (`agent-profiles`, `web-search`) were calling `callLLM` without `req.signal`, leaving Bug #2 half-fixed for the pre-outline phases. Addressed in commit `bb36551` before this PR was opened.

Self-review transcript available on request (`~/projects/OpenMAIC-PR/SELF-REVIEW.md`).

**Follow-ups deliberately scoped out of this PR** (will be filed as separate issues after merge):

1. Forward `AbortSignal` for the remaining `callLLM` callers (`pbl/chat`, `quiz-grade`, plus several `lib/*` non-route sites). Same shape, mechanical fix.
2. Parameterised route-level "signal-wired" contract test — would have caught the agent-profiles + web-search miss before the self-review did.
3. Playwright e2e for "click Stop generation in classroom" once a viable IndexedDB-seed harness lands.

## Checklist

- [x] My code follows the project's coding style (Prettier + ESLint clean)
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (no user-facing docs changes; new behaviour documented in `BUG-ANALYSIS.md` posted as a top-level PR comment, plus inline JSDoc on the new helpers)
- [x] My changes do not introduce new warnings
- [x] AI-assisted PR — flagged here per `CONTRIBUTING.md` §"AI-Assisted PRs"; ran AI self-review (see above) and addressed the must-fix finding in `bb36551` before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)
