### PR TITLE
feat(maic-editor): framework primitives + edit StageMode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, feat/maic-editor-v0]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/components/scene-renderers/pbl-renderer.tsx
+++ b/components/scene-renderers/pbl-renderer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import type { PBLContent } from '@/lib/types/stage';
+import type { PBLContent, StageMode } from '@/lib/types/stage';
 import type { PBLProjectConfig } from '@/lib/pbl/types';
 import { useStageStore } from '@/lib/store/stage';
 import { PBLRoleSelection } from './pbl/role-selection';
@@ -10,7 +10,7 @@ import { useI18n } from '@/lib/hooks/use-i18n';
 
 interface PBLRendererProps {
   readonly content: PBLContent;
-  readonly mode: 'autonomous' | 'playback';
+  readonly mode: StageMode;
   readonly sceneId: string;
 }
 

--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -49,6 +49,7 @@ export function Stage({
   const { t } = useI18n();
   const {
     mode,
+    setMode,
     getCurrentScene,
     scenes,
     currentSceneId,
@@ -259,6 +260,19 @@ export function Stage({
     await chatAreaRef.current?.endActiveSession();
     doSessionCleanup();
   }, [doSessionCleanup]);
+
+  // Auto-exit edit mode whenever the current scene becomes uneditable
+  // (pending generation, no scenes, currently generating). Without this guard,
+  // a follow-up sub-PR's Pro toggle could strand the user in an empty edit shell.
+  useEffect(() => {
+    if (mode !== 'edit') return;
+    const isPending = currentSceneId === PENDING_SCENE_ID;
+    const stillEditable =
+      !isPending && scenes.length > 0 && generatingOutlines.length === 0 && !!currentScene;
+    if (!stillEditable) {
+      setMode('playback');
+    }
+  }, [mode, currentSceneId, scenes.length, generatingOutlines.length, currentScene, setMode]);
 
   const clearPresentationIdleTimer = useCallback(() => {
     if (presentationIdleTimerRef.current) {

--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useStageStore } from '@/lib/store';
 import { PENDING_SCENE_ID } from '@/lib/store/stage';
+import { isCurrentSceneEditable } from '@/lib/edit/stage-mode';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useSettingsStore } from '@/lib/store/settings';
 import { useI18n } from '@/lib/hooks/use-i18n';
@@ -262,14 +263,17 @@ export function Stage({
   }, [doSessionCleanup]);
 
   // Auto-exit edit mode whenever the current scene becomes uneditable
-  // (pending generation, no scenes, currently generating). Without this guard,
-  // a follow-up sub-PR's Pro toggle could strand the user in an empty edit shell.
+  // (pending generation, no scenes, currently generating). Predicate lives in
+  // lib/edit/stage-mode so it can be unit-tested without rendering Stage.
   useEffect(() => {
     if (mode !== 'edit') return;
-    const isPending = currentSceneId === PENDING_SCENE_ID;
-    const stillEditable =
-      !isPending && scenes.length > 0 && generatingOutlines.length === 0 && !!currentScene;
-    if (!stillEditable) {
+    const editable = isCurrentSceneEditable({
+      currentSceneId,
+      sceneCount: scenes.length,
+      generatingOutlineCount: generatingOutlines.length,
+      hasCurrentScene: !!currentScene,
+    });
+    if (!editable) {
       setMode('playback');
     }
   }, [mode, currentSceneId, scenes.length, generatingOutlines.length, currentScene, setMode]);

--- a/lib/edit/scene-editor-registry.ts
+++ b/lib/edit/scene-editor-registry.ts
@@ -5,7 +5,21 @@ const surfaces = new Map<SceneType, SceneEditorSurface>();
 
 export const sceneEditorRegistry: SceneEditorRegistry = {
   register: (surface) => {
+    // Re-registering the same instance is benign (HMR re-executes module init
+    // and the second pass passes the identical surface object). Only warn when
+    // a different surface tries to take the slot, since that silently masks
+    // bugs like accidental double-imports from divergent paths.
+    const existing = surfaces.get(surface.sceneType);
+    if (existing && existing !== surface && process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[sceneEditorRegistry] overwriting existing surface for "${surface.sceneType}". ` +
+          `If this is HMR, call unregister first.`,
+      );
+    }
     surfaces.set(surface.sceneType, surface as SceneEditorSurface);
+  },
+  unregister: (sceneType) => {
+    surfaces.delete(sceneType);
   },
   resolve: (sceneType) => surfaces.get(sceneType),
 };

--- a/lib/edit/scene-editor-registry.ts
+++ b/lib/edit/scene-editor-registry.ts
@@ -1,0 +1,11 @@
+import type { SceneType } from '@/lib/types/stage';
+import type { SceneEditorRegistry, SceneEditorSurface } from './scene-editor-surface';
+
+const surfaces = new Map<SceneType, SceneEditorSurface>();
+
+export const sceneEditorRegistry: SceneEditorRegistry = {
+  register: (surface) => {
+    surfaces.set(surface.sceneType, surface as SceneEditorSurface);
+  },
+  resolve: (sceneType) => surfaces.get(sceneType),
+};

--- a/lib/edit/scene-editor-surface.ts
+++ b/lib/edit/scene-editor-surface.ts
@@ -1,0 +1,136 @@
+/**
+ * SceneEditorSurface — interface contract for scene-type editors.
+ *
+ * The edit-mode shell (workbench + command bar + insert strip + inspector +
+ * floating contextual bar) is scene-type-agnostic. Each SceneType registers a
+ * SceneEditorSurface; the shell calls `useSurfaceState()` and renders the
+ * returned slots. Phase 1 ships the slide surface; quiz / interactive / pbl
+ * surfaces can plug in later without touching the shell.
+ */
+
+import type { ComponentType, ReactNode } from 'react';
+import type { SceneContent, SceneType } from '@/lib/types/stage';
+
+// ---------------------------------------------------------------------------
+// Contribution primitives — shell renders these; surface only declares them.
+// All carry user-facing label/icon/tooltip so the same item can render in
+// novice-friendly big-label form (left strip) or compact form (floating bar).
+// ---------------------------------------------------------------------------
+
+export interface UiAffordance {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  tooltip?: string;
+  disabled?: boolean;
+  /** Optional grouping hint — shell may insert dividers between groups. */
+  group?: string;
+}
+
+/** Items in the left "insert" strip (kept always-visible for discoverability). */
+export interface InsertPaletteItem extends UiAffordance {
+  onInvoke: () => void;
+  /**
+   * Optional popover content. When provided, the button opens a popover with
+   * this content instead of firing onInvoke. Useful for sub-pickers like
+   * "choose a shape" or "choose an image source".
+   */
+  popoverContent?: () => ReactNode;
+}
+
+/**
+ * Floating contextual actions — shown as an inline bar above the canvas when
+ * selection is non-empty. Each action is either a one-shot button (onInvoke)
+ * or a popover trigger (popoverContent) for property panels.
+ */
+export interface FloatingAction extends UiAffordance {
+  onInvoke?: () => void;
+  /**
+   * Optional popover content. When provided, the button opens a popover
+   * instead of (or in addition to, if onInvoke is also set) firing onInvoke.
+   * Used for property surfaces like color picker, font select, etc.
+   */
+  popoverContent?: () => ReactNode;
+}
+
+/**
+ * Editor commands — global actions surfaced in the top command bar.
+ * Element-scoped actions (align, delete, layer) belong in `floatingActions`,
+ * not here. `commands` is for things like Save / Export / Zoom / Exit-edit.
+ */
+export interface EditorCommand extends UiAffordance {
+  onInvoke: () => void;
+}
+
+/**
+ * AI inline coach hint — reserved slot, not used in Phase 1.
+ * The shell renders a hint rail when this slot has any items.
+ */
+export interface EditorHint {
+  id: string;
+  severity: 'info' | 'suggestion' | 'warning';
+  message: string;
+  action?: { label: string; onInvoke: () => void };
+}
+
+// ---------------------------------------------------------------------------
+// SurfaceState — what the surface's hook returns to the shell each render.
+// ---------------------------------------------------------------------------
+
+export interface SurfaceHistory {
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+}
+
+export interface SurfaceState<
+  TContent extends SceneContent = SceneContent,
+  TSelection = unknown,
+> {
+  content: TContent;
+  selection: TSelection;
+  /** True when the surface considers selection non-empty (drives floating bar). */
+  hasSelection: boolean;
+
+  history: SurfaceHistory;
+
+  insertItems: InsertPaletteItem[];
+  floatingActions: FloatingAction[];
+  commands: EditorCommand[];
+
+  /** Reserved for AI phase. Surface returns [] in Phase 1. */
+  hints?: EditorHint[];
+}
+
+// ---------------------------------------------------------------------------
+// SceneEditorSurface — the contract a scene type registers.
+// ---------------------------------------------------------------------------
+
+export interface SceneEditorSurface<
+  TContent extends SceneContent = SceneContent,
+  TSelection = unknown,
+> {
+  sceneType: SceneType;
+
+  /** Center canvas — surface fully owns rendering. */
+  CanvasComponent: ComponentType;
+
+  /**
+   * React hook called by the shell once per render. Owns selection, history,
+   * and op dispatch internally; returns the slot contributions.
+   */
+  useSurfaceState: () => SurfaceState<TContent, TSelection>;
+}
+
+// ---------------------------------------------------------------------------
+// Registry — shell resolves a surface by SceneType. Surfaces register once
+// at module init time; the shell never imports surfaces directly.
+// ---------------------------------------------------------------------------
+
+export interface SceneEditorRegistry {
+  register: <TContent extends SceneContent, TSelection>(
+    surface: SceneEditorSurface<TContent, TSelection>,
+  ) => void;
+  resolve: (sceneType: SceneType) => SceneEditorSurface | undefined;
+}

--- a/lib/edit/scene-editor-surface.ts
+++ b/lib/edit/scene-editor-surface.ts
@@ -129,5 +129,7 @@ export interface SceneEditorRegistry {
   register: <TContent extends SceneContent, TSelection>(
     surface: SceneEditorSurface<TContent, TSelection>,
   ) => void;
+  /** Remove a registration. Mainly for HMR cleanup and tests. */
+  unregister: (sceneType: SceneType) => void;
   resolve: (sceneType: SceneType) => SceneEditorSurface | undefined;
 }

--- a/lib/edit/scene-editor-surface.ts
+++ b/lib/edit/scene-editor-surface.ts
@@ -84,10 +84,7 @@ export interface SurfaceHistory {
   redo: () => void;
 }
 
-export interface SurfaceState<
-  TContent extends SceneContent = SceneContent,
-  TSelection = unknown,
-> {
+export interface SurfaceState<TContent extends SceneContent = SceneContent, TSelection = unknown> {
   content: TContent;
   selection: TSelection;
   /** True when the surface considers selection non-empty (drives floating bar). */

--- a/lib/edit/slide-edit-elements.ts
+++ b/lib/edit/slide-edit-elements.ts
@@ -1,10 +1,5 @@
 import type { ShapePathFormulasKeys } from '@/lib/types/slides';
-import type {
-  PPTImageElement,
-  PPTShapeElement,
-  PPTTextElement,
-  Slide,
-} from '@/lib/types/slides';
+import type { PPTImageElement, PPTShapeElement, PPTTextElement, Slide } from '@/lib/types/slides';
 
 export interface ShapeSpec {
   viewBox: [number, number];

--- a/lib/edit/slide-edit-elements.ts
+++ b/lib/edit/slide-edit-elements.ts
@@ -1,0 +1,104 @@
+import type { ShapePathFormulasKeys } from '@/lib/types/slides';
+import type {
+  PPTImageElement,
+  PPTShapeElement,
+  PPTTextElement,
+  Slide,
+} from '@/lib/types/slides';
+
+export interface ShapeSpec {
+  viewBox: [number, number];
+  path: string;
+  pathFormula?: ShapePathFormulasKeys;
+  pptxShapeType?: string;
+}
+
+export function plainTextToParagraphHtml(value: string) {
+  return `<p>${escapeHtml(value)}</p>`;
+}
+
+export function htmlToPlainText(value: string) {
+  return value.replace(/<[^>]+>/g, '').trim();
+}
+
+export function createDefaultTextElement(id: string): PPTTextElement {
+  return {
+    id,
+    type: 'text',
+    left: 120,
+    top: 120,
+    width: 360,
+    height: 72,
+    rotate: 0,
+    content: '<p>New text</p>',
+    defaultFontName: 'Inter',
+    defaultColor: '#111827',
+    lineHeight: 1.4,
+  };
+}
+
+export function createDefaultShapeElement(id: string, spec?: ShapeSpec): PPTShapeElement {
+  const viewBox = spec?.viewBox ?? ([260, 140] as [number, number]);
+  // Picked shapes tend to be square (200x200) in the shape pool — scale to
+  // a reasonable canvas width while preserving aspect ratio.
+  const width = spec ? 200 : viewBox[0];
+  const height = spec ? 200 * (viewBox[1] / viewBox[0]) : viewBox[1];
+  return {
+    id,
+    type: 'shape',
+    left: 160,
+    top: 160,
+    width,
+    height,
+    rotate: 0,
+    viewBox,
+    path: spec?.path ?? 'M 0 0 L 260 0 L 260 140 L 0 140 Z',
+    pathFormula: spec?.pathFormula,
+    fixedRatio: false,
+    fill: '#dbeafe',
+    outline: {
+      width: 2,
+      color: '#2563eb',
+      style: 'solid',
+    },
+  };
+}
+
+export function createDefaultSlide(id: string): Slide {
+  return {
+    id,
+    viewportSize: 1000,
+    viewportRatio: 0.5625, // 16:9
+    theme: {
+      backgroundColor: '#ffffff',
+      themeColors: ['#5b8def', '#8b5cf6', '#10b981', '#f59e0b'],
+      fontColor: '#111827',
+      fontName: 'Inter',
+    },
+    elements: [],
+    background: { type: 'solid', color: '#ffffff' },
+  };
+}
+
+export function createDefaultImageElement(id: string, src: string): PPTImageElement {
+  return {
+    id,
+    type: 'image',
+    left: 180,
+    top: 140,
+    width: 360,
+    height: 220,
+    rotate: 0,
+    fixedRatio: true,
+    src,
+  };
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/lib/edit/slide-ops.ts
+++ b/lib/edit/slide-ops.ts
@@ -174,7 +174,9 @@ function applyOperationToContent(
         return;
       case 'element.deleteMany': {
         const elementIds = new Set(operation.elementIds);
-        draft.canvas.elements = draft.canvas.elements.filter((element) => !elementIds.has(element.id));
+        draft.canvas.elements = draft.canvas.elements.filter(
+          (element) => !elementIds.has(element.id),
+        );
         if (draft.canvas.animations) {
           draft.canvas.animations = draft.canvas.animations.filter(
             (animation) => !elementIds.has(animation.elId),

--- a/lib/edit/slide-ops.ts
+++ b/lib/edit/slide-ops.ts
@@ -1,9 +1,13 @@
-import { produce } from 'immer';
+import { current, produce } from 'immer';
 import type { SlideContent } from '@/lib/types/stage';
 import type { PPTElement, Slide } from '@/lib/types/slides';
+import { getElementListRange } from '@/lib/utils/element';
 
 type ElementPatch = Partial<PPTElement>;
 type ElementPropName = string;
+
+// Cap undo history so long editing sessions don't grow memory unbounded.
+const MAX_HISTORY = 50;
 
 export type SlideElementAlignCommand =
   | 'top'
@@ -14,10 +18,15 @@ export type SlideElementAlignCommand =
   | 'horizontal'
   | 'center';
 
+// slide.update is for slide metadata only (theme, background, viewport, etc).
+// Element and animation collections must be mutated through their dedicated
+// ops so undo/redo, serialization, and (future) PPTX round-trip stay coherent.
+export type SlideMetaPatch = Partial<Omit<Slide, 'elements' | 'animations'>>;
+
 export type SlideEditOperation =
   | {
       type: 'slide.update';
-      patch: Partial<Slide>;
+      patch: SlideMetaPatch;
     }
   | {
       type: 'element.add';
@@ -81,6 +90,9 @@ export interface SlideEditHistory {
 export function createSlideEditHistory(initial: SlideContent): SlideEditHistory {
   return {
     past: [],
+    // Defensive clone: initial comes from outside immer, so the caller could
+    // still mutate it after construction. Internal history snapshots are
+    // immer-produced and already frozen, so we never re-clone them.
     present: cloneSlideContent(initial),
     future: [],
   };
@@ -100,8 +112,12 @@ export function applySlideEditOperation(
 ): SlideContent | SlideEditHistory {
   if (isSlideEditHistory(target)) {
     const next = applyOperationToContent(target.present, operation);
+    // immer's produce returns the same reference when the recipe didn't
+    // mutate the draft (e.g. element.update against a missing id). Skip the
+    // history push so undo doesn't replay empty steps.
+    if (next === target.present) return target;
     return {
-      past: [...target.past, cloneSlideContent(target.present)],
+      past: capHistory([...target.past, target.present]),
       present: next,
       future: [],
     };
@@ -116,8 +132,8 @@ export function undoSlideEditOperation(history: SlideEditHistory): SlideEditHist
   const previous = history.past[history.past.length - 1];
   return {
     past: history.past.slice(0, -1),
-    present: cloneSlideContent(previous),
-    future: [cloneSlideContent(history.present), ...history.future],
+    present: previous,
+    future: [history.present, ...history.future],
   };
 }
 
@@ -126,8 +142,8 @@ export function redoSlideEditOperation(history: SlideEditHistory): SlideEditHist
 
   const next = history.future[0];
   return {
-    past: [...history.past, cloneSlideContent(history.present)],
-    present: cloneSlideContent(next),
+    past: capHistory([...history.past, history.present]),
+    present: next,
     future: history.future.slice(1),
   };
 }
@@ -142,6 +158,9 @@ function applyOperationToContent(
         Object.assign(draft.canvas, operation.patch);
         return;
       case 'element.add': {
+        if (draft.canvas.elements.some((el) => el.id === operation.element.id)) {
+          throw new Error(`element.add: id "${operation.element.id}" already exists`);
+        }
         const index =
           typeof operation.index === 'number'
             ? Math.max(0, Math.min(operation.index, draft.canvas.elements.length))
@@ -162,7 +181,11 @@ function applyOperationToContent(
         });
         return;
       }
-      case 'element.delete':
+      case 'element.delete': {
+        // Pre-check so deleting a missing id is a real no-op (same content ref)
+        // — without this, the unconditional .filter assignment would always
+        // count as a mutation and bloat undo history with empty steps.
+        if (!draft.canvas.elements.some((el) => el.id === operation.elementId)) return;
         draft.canvas.elements = draft.canvas.elements.filter(
           (element) => element.id !== operation.elementId,
         );
@@ -172,8 +195,10 @@ function applyOperationToContent(
           );
         }
         return;
+      }
       case 'element.deleteMany': {
         const elementIds = new Set(operation.elementIds);
+        if (!draft.canvas.elements.some((el) => elementIds.has(el.id))) return;
         draft.canvas.elements = draft.canvas.elements.filter(
           (element) => !elementIds.has(element.id),
         );
@@ -196,16 +221,37 @@ function applyOperationToContent(
         return;
       }
       case 'element.duplicate': {
+        const missing = operation.elementIds.filter((id) => !operation.idMap[id]);
+        if (missing.length > 0) {
+          throw new Error(`element.duplicate: idMap missing entries for [${missing.join(', ')}]`);
+        }
+        const existing = new Set(draft.canvas.elements.map((el) => el.id));
+        const collisions = operation.elementIds
+          .map((id) => operation.idMap[id])
+          .filter((newId) => existing.has(newId));
+        if (collisions.length > 0) {
+          throw new Error(
+            `element.duplicate: new ids collide with existing elements: [${collisions.join(', ')}]`,
+          );
+        }
+
         const offset = operation.offset ?? { x: 20, y: 20 };
         const elementIds = new Set(operation.elementIds);
         const duplicatedElements = draft.canvas.elements
-          .filter((element) => elementIds.has(element.id) && operation.idMap[element.id])
-          .map((element) => ({
-            ...cloneElement(element),
-            id: operation.idMap[element.id],
-            left: element.left + offset.x,
-            top: element.top + offset.y,
-          }));
+          .filter((element) => elementIds.has(element.id))
+          .map((element) => {
+            // Un-proxy via current() — structuredClone can't clone immer
+            // drafts. immer will freeze the resulting object as part of
+            // produce, so a shallow spread is enough; nested refs are
+            // shared with the source until something rewrites them.
+            const source = current(element) as PPTElement;
+            return {
+              ...source,
+              id: operation.idMap[source.id],
+              left: source.left + offset.x,
+              top: source.top + offset.y,
+            };
+          });
 
         draft.canvas.elements.push(...duplicatedElements);
         return;
@@ -241,7 +287,11 @@ function cloneSlideContent(content: SlideContent): SlideContent {
 }
 
 function cloneElement(element: PPTElement): PPTElement {
-  return JSON.parse(JSON.stringify(element)) as PPTElement;
+  return structuredClone(element);
+}
+
+function capHistory(past: SlideContent[]): SlideContent[] {
+  return past.length > MAX_HISTORY ? past.slice(past.length - MAX_HISTORY) : past;
 }
 
 function alignElementsToCanvas(
@@ -253,6 +303,9 @@ function alignElementsToCanvas(
   const selectedElements = slide.elements.filter((element) => selectedIds.has(element.id));
   if (selectedElements.length === 0) return;
 
+  // Reuse the canonical geometry helper so line/rotated elements compute the
+  // right bounding box. The local fork that lived here treated lines as
+  // height 0 and ignored rotation.
   const range = getElementListRange(selectedElements);
   const viewportWidth = slide.viewportSize;
   const viewportHeight = slide.viewportSize * slide.viewportRatio;
@@ -290,21 +343,4 @@ function alignElementsToCanvas(
     element.left -= offsetX;
     element.top -= offsetY;
   });
-}
-
-function getElementListRange(elements: PPTElement[]) {
-  return elements.reduce(
-    (range, element) => ({
-      minX: Math.min(range.minX, element.left),
-      maxX: Math.max(range.maxX, element.left + element.width),
-      minY: Math.min(range.minY, element.top),
-      maxY: Math.max(range.maxY, element.top + ('height' in element ? element.height : 0)),
-    }),
-    {
-      minX: Infinity,
-      maxX: -Infinity,
-      minY: Infinity,
-      maxY: -Infinity,
-    },
-  );
 }

--- a/lib/edit/slide-ops.ts
+++ b/lib/edit/slide-ops.ts
@@ -154,9 +154,19 @@ function applyOperationToContent(
 ): SlideContent {
   return produce(content, (draft) => {
     switch (operation.type) {
-      case 'slide.update':
+      case 'slide.update': {
+        // Type-level narrowing via SlideMetaPatch already forbids elements /
+        // animations, but a runtime guard closes the `as any` escape hatch
+        // at call sites. Those collections must go through their dedicated
+        // ops so undo/redo / serialization stays single-source.
+        if ('elements' in operation.patch || 'animations' in operation.patch) {
+          throw new Error(
+            'slide.update: use dedicated element / animation ops to mutate those collections',
+          );
+        }
         Object.assign(draft.canvas, operation.patch);
         return;
+      }
       case 'element.add': {
         if (draft.canvas.elements.some((el) => el.id === operation.element.id)) {
           throw new Error(`element.add: id "${operation.element.id}" already exists`);
@@ -240,11 +250,14 @@ function applyOperationToContent(
         const duplicatedElements = draft.canvas.elements
           .filter((element) => elementIds.has(element.id))
           .map((element) => {
-            // Un-proxy via current() — structuredClone can't clone immer
-            // drafts. immer will freeze the resulting object as part of
-            // produce, so a shallow spread is enough; nested refs are
-            // shared with the source until something rewrites them.
-            const source = current(element) as PPTElement;
+            // Deep clone via current() + structuredClone so the duplicate
+            // doesn't share nested references (start/end tuples, outline,
+            // points, etc) with the source. immer's COW would handle most
+            // mutations safely, but future ops that operate on nested
+            // arrays in-place (sort/reverse/splice) would silently leak —
+            // keep the kernel's invariants independent of which mutation
+            // shape future op consumers pick.
+            const source = structuredClone(current(element)) as PPTElement;
             return {
               ...source,
               id: operation.idMap[source.id],

--- a/lib/edit/slide-ops.ts
+++ b/lib/edit/slide-ops.ts
@@ -1,0 +1,308 @@
+import { produce } from 'immer';
+import type { SlideContent } from '@/lib/types/stage';
+import type { PPTElement, Slide } from '@/lib/types/slides';
+
+type ElementPatch = Partial<PPTElement>;
+type ElementPropName = string;
+
+export type SlideElementAlignCommand =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'vertical'
+  | 'horizontal'
+  | 'center';
+
+export type SlideEditOperation =
+  | {
+      type: 'slide.update';
+      patch: Partial<Slide>;
+    }
+  | {
+      type: 'element.add';
+      element: PPTElement;
+      index?: number;
+    }
+  | {
+      type: 'element.update';
+      elementId: string;
+      patch: ElementPatch;
+    }
+  | {
+      type: 'element.updateMany';
+      elementIds: string[];
+      patch: ElementPatch;
+    }
+  | {
+      type: 'element.delete';
+      elementId: string;
+    }
+  | {
+      type: 'element.deleteMany';
+      elementIds: string[];
+    }
+  | {
+      type: 'element.reorder';
+      elementId: string;
+      index: number;
+    }
+  | {
+      type: 'element.duplicate';
+      elementIds: string[];
+      idMap: Record<string, string>;
+      offset?: {
+        x: number;
+        y: number;
+      };
+    }
+  | {
+      type: 'element.align';
+      elementIds: string[];
+      command: SlideElementAlignCommand;
+    }
+  | {
+      type: 'element.removeProps';
+      elementId: string;
+      propNames: ElementPropName[];
+    }
+  | {
+      type: 'text.updateContent';
+      elementId: string;
+      content: string;
+    };
+
+export interface SlideEditHistory {
+  past: SlideContent[];
+  present: SlideContent;
+  future: SlideContent[];
+}
+
+export function createSlideEditHistory(initial: SlideContent): SlideEditHistory {
+  return {
+    past: [],
+    present: cloneSlideContent(initial),
+    future: [],
+  };
+}
+
+export function applySlideEditOperation(
+  content: SlideContent,
+  operation: SlideEditOperation,
+): SlideContent;
+export function applySlideEditOperation(
+  history: SlideEditHistory,
+  operation: SlideEditOperation,
+): SlideEditHistory;
+export function applySlideEditOperation(
+  target: SlideContent | SlideEditHistory,
+  operation: SlideEditOperation,
+): SlideContent | SlideEditHistory {
+  if (isSlideEditHistory(target)) {
+    const next = applyOperationToContent(target.present, operation);
+    return {
+      past: [...target.past, cloneSlideContent(target.present)],
+      present: next,
+      future: [],
+    };
+  }
+
+  return applyOperationToContent(target, operation);
+}
+
+export function undoSlideEditOperation(history: SlideEditHistory): SlideEditHistory {
+  if (history.past.length === 0) return history;
+
+  const previous = history.past[history.past.length - 1];
+  return {
+    past: history.past.slice(0, -1),
+    present: cloneSlideContent(previous),
+    future: [cloneSlideContent(history.present), ...history.future],
+  };
+}
+
+export function redoSlideEditOperation(history: SlideEditHistory): SlideEditHistory {
+  if (history.future.length === 0) return history;
+
+  const next = history.future[0];
+  return {
+    past: [...history.past, cloneSlideContent(history.present)],
+    present: cloneSlideContent(next),
+    future: history.future.slice(1),
+  };
+}
+
+function applyOperationToContent(
+  content: SlideContent,
+  operation: SlideEditOperation,
+): SlideContent {
+  return produce(content, (draft) => {
+    switch (operation.type) {
+      case 'slide.update':
+        Object.assign(draft.canvas, operation.patch);
+        return;
+      case 'element.add': {
+        const index =
+          typeof operation.index === 'number'
+            ? Math.max(0, Math.min(operation.index, draft.canvas.elements.length))
+            : draft.canvas.elements.length;
+        draft.canvas.elements.splice(index, 0, cloneElement(operation.element));
+        return;
+      }
+      case 'element.update': {
+        const element = draft.canvas.elements.find((item) => item.id === operation.elementId);
+        if (!element) return;
+        Object.assign(element, operation.patch);
+        return;
+      }
+      case 'element.updateMany': {
+        const elementIds = new Set(operation.elementIds);
+        draft.canvas.elements.forEach((element) => {
+          if (elementIds.has(element.id)) Object.assign(element, operation.patch);
+        });
+        return;
+      }
+      case 'element.delete':
+        draft.canvas.elements = draft.canvas.elements.filter(
+          (element) => element.id !== operation.elementId,
+        );
+        if (draft.canvas.animations) {
+          draft.canvas.animations = draft.canvas.animations.filter(
+            (animation) => animation.elId !== operation.elementId,
+          );
+        }
+        return;
+      case 'element.deleteMany': {
+        const elementIds = new Set(operation.elementIds);
+        draft.canvas.elements = draft.canvas.elements.filter((element) => !elementIds.has(element.id));
+        if (draft.canvas.animations) {
+          draft.canvas.animations = draft.canvas.animations.filter(
+            (animation) => !elementIds.has(animation.elId),
+          );
+        }
+        return;
+      }
+      case 'element.reorder': {
+        const currentIndex = draft.canvas.elements.findIndex(
+          (element) => element.id === operation.elementId,
+        );
+        if (currentIndex === -1) return;
+
+        const [element] = draft.canvas.elements.splice(currentIndex, 1);
+        const nextIndex = Math.max(0, Math.min(operation.index, draft.canvas.elements.length));
+        draft.canvas.elements.splice(nextIndex, 0, element);
+        return;
+      }
+      case 'element.duplicate': {
+        const offset = operation.offset ?? { x: 20, y: 20 };
+        const elementIds = new Set(operation.elementIds);
+        const duplicatedElements = draft.canvas.elements
+          .filter((element) => elementIds.has(element.id) && operation.idMap[element.id])
+          .map((element) => ({
+            ...cloneElement(element),
+            id: operation.idMap[element.id],
+            left: element.left + offset.x,
+            top: element.top + offset.y,
+          }));
+
+        draft.canvas.elements.push(...duplicatedElements);
+        return;
+      }
+      case 'element.align': {
+        alignElementsToCanvas(draft.canvas, operation.elementIds, operation.command);
+        return;
+      }
+      case 'element.removeProps': {
+        const element = draft.canvas.elements.find((item) => item.id === operation.elementId);
+        if (!element) return;
+        operation.propNames.forEach((propName) => {
+          delete (element as Record<string, unknown>)[propName];
+        });
+        return;
+      }
+      case 'text.updateContent': {
+        const element = draft.canvas.elements.find((item) => item.id === operation.elementId);
+        if (!element || element.type !== 'text') return;
+        element.content = operation.content;
+        return;
+      }
+    }
+  });
+}
+
+function isSlideEditHistory(target: SlideContent | SlideEditHistory): target is SlideEditHistory {
+  return 'present' in target && 'past' in target && 'future' in target;
+}
+
+function cloneSlideContent(content: SlideContent): SlideContent {
+  return structuredClone(content);
+}
+
+function cloneElement(element: PPTElement): PPTElement {
+  return JSON.parse(JSON.stringify(element)) as PPTElement;
+}
+
+function alignElementsToCanvas(
+  slide: Slide,
+  elementIds: string[],
+  command: SlideElementAlignCommand,
+) {
+  const selectedIds = new Set(elementIds);
+  const selectedElements = slide.elements.filter((element) => selectedIds.has(element.id));
+  if (selectedElements.length === 0) return;
+
+  const range = getElementListRange(selectedElements);
+  const viewportWidth = slide.viewportSize;
+  const viewportHeight = slide.viewportSize * slide.viewportRatio;
+
+  let offsetX = 0;
+  let offsetY = 0;
+
+  switch (command) {
+    case 'center':
+      offsetX = range.minX + (range.maxX - range.minX) / 2 - viewportWidth / 2;
+      offsetY = range.minY + (range.maxY - range.minY) / 2 - viewportHeight / 2;
+      break;
+    case 'top':
+      offsetY = range.minY;
+      break;
+    case 'vertical':
+      offsetY = range.minY + (range.maxY - range.minY) / 2 - viewportHeight / 2;
+      break;
+    case 'bottom':
+      offsetY = range.maxY - viewportHeight;
+      break;
+    case 'left':
+      offsetX = range.minX;
+      break;
+    case 'horizontal':
+      offsetX = range.minX + (range.maxX - range.minX) / 2 - viewportWidth / 2;
+      break;
+    case 'right':
+      offsetX = range.maxX - viewportWidth;
+      break;
+  }
+
+  slide.elements.forEach((element) => {
+    if (!selectedIds.has(element.id)) return;
+    element.left -= offsetX;
+    element.top -= offsetY;
+  });
+}
+
+function getElementListRange(elements: PPTElement[]) {
+  return elements.reduce(
+    (range, element) => ({
+      minX: Math.min(range.minX, element.left),
+      maxX: Math.max(range.maxX, element.left + element.width),
+      minY: Math.min(range.minY, element.top),
+      maxY: Math.max(range.maxY, element.top + ('height' in element ? element.height : 0)),
+    }),
+    {
+      minX: Infinity,
+      maxX: -Infinity,
+      minY: Infinity,
+      maxY: -Infinity,
+    },
+  );
+}

--- a/lib/edit/stage-mode.ts
+++ b/lib/edit/stage-mode.ts
@@ -1,0 +1,27 @@
+import { PENDING_SCENE_ID } from '@/lib/store/stage';
+
+/**
+ * Inputs the edit-mode auto-exit guard reads. Kept as primitives so callers
+ * can derive the values cheaply without holding full Scene / SceneOutline
+ * objects, and so the predicate is trivially testable without rendering Stage.
+ */
+export interface StageEditModeContext {
+  currentSceneId: string | null;
+  sceneCount: number;
+  generatingOutlineCount: number;
+  hasCurrentScene: boolean;
+}
+
+/**
+ * Whether edit mode should remain active for the given stage state.
+ * Returns false in cases that would otherwise strand the user in an empty
+ * edit shell — pending scene, no scenes, generation in flight, or no current
+ * scene resolved yet.
+ */
+export function isCurrentSceneEditable(ctx: StageEditModeContext): boolean {
+  if (ctx.currentSceneId === PENDING_SCENE_ID) return false;
+  if (ctx.sceneCount === 0) return false;
+  if (ctx.generatingOutlineCount > 0) return false;
+  if (!ctx.hasCurrentScene) return false;
+  return true;
+}

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -144,7 +144,9 @@
     "generatingNextPage": "جارٍ توليد المشهد، يرجى الانتظار...",
     "courseComplete": "اكتملت الدورة",
     "fullscreen": "ملء الشاشة",
-    "exitFullscreen": "الخروج من ملء الشاشة"
+    "exitFullscreen": "الخروج من ملء الشاشة",
+    "editCourse": "تحرير الدورة",
+    "doneEditing": "إنهاء التحرير"
   },
   "classroomComplete": {
     "title": "اكتملت الدورة",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -144,7 +144,9 @@
     "generatingNextPage": "Scene is being generated, please wait...",
     "courseComplete": "Course complete",
     "fullscreen": "Fullscreen",
-    "exitFullscreen": "Exit Fullscreen"
+    "exitFullscreen": "Exit Fullscreen",
+    "editCourse": "Edit course",
+    "doneEditing": "Done editing"
   },
   "classroomComplete": {
     "title": "Course complete",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -144,7 +144,9 @@
     "generatingNextPage": "シーンを生成中です。お待ちください...",
     "courseComplete": "コース完了",
     "fullscreen": "全画面表示",
-    "exitFullscreen": "全画面表示を終了"
+    "exitFullscreen": "全画面表示を終了",
+    "editCourse": "コースを編集",
+    "doneEditing": "編集を完了"
   },
   "classroomComplete": {
     "title": "コース完了",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -144,7 +144,9 @@
     "generatingNextPage": "Сцена генерируется, пожалуйста подождите...",
     "courseComplete": "Курс завершён",
     "fullscreen": "Полный экран",
-    "exitFullscreen": "Свернуть"
+    "exitFullscreen": "Свернуть",
+    "editCourse": "Редактировать курс",
+    "doneEditing": "Завершить редактирование"
   },
   "classroomComplete": {
     "title": "Курс завершён",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -144,7 +144,9 @@
     "generatingNextPage": "场景正在生成，请稍候...",
     "courseComplete": "课程完成",
     "fullscreen": "全屏",
-    "exitFullscreen": "退出全屏"
+    "exitFullscreen": "退出全屏",
+    "editCourse": "编辑课程",
+    "doneEditing": "完成编辑"
   },
   "classroomComplete": {
     "title": "课程完成",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -144,7 +144,9 @@
     "generatingNextPage": "場景正在生成，請稍候...",
     "fullscreen": "全螢幕",
     "exitFullscreen": "離開全螢幕",
-    "courseComplete": "課程完成"
+    "courseComplete": "課程完成",
+    "editCourse": "編輯課程",
+    "doneEditing": "完成編輯"
   },
   "whiteboard": {
     "title": "互動白板",

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -4,6 +4,7 @@ import { createSelectors } from '@/lib/utils/create-selectors';
 import type { ChatSession } from '@/lib/types/chat';
 import type { SceneOutline } from '@/lib/types/generation';
 import { createLogger } from '@/lib/logger';
+import { useCanvasStore } from '@/lib/store/canvas';
 
 const log = createLogger('StageStore');
 
@@ -189,7 +190,14 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     debouncedSave();
   },
 
-  setMode: (mode) => set({ mode }),
+  setMode: (mode) => {
+    const previousMode = get().mode;
+    set({ mode });
+
+    if (previousMode === 'edit' && mode !== 'edit') {
+      useCanvasStore.getState().resetCanvasState();
+    }
+  },
 
   setToolbarState: (toolbarState) => set({ toolbarState }),
 

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -6,7 +6,7 @@ import type { WidgetType, WidgetConfig, TeacherAction } from '@/lib/types/widget
 
 export type SceneType = 'slide' | 'quiz' | 'interactive' | 'pbl';
 
-export type StageMode = 'autonomous' | 'playback';
+export type StageMode = 'autonomous' | 'playback' | 'edit';
 
 export type Whiteboard = Omit<Slide, 'theme' | 'turningMode' | 'sectionTag' | 'type'>;
 

--- a/tests/edit/slide-edit-elements.test.ts
+++ b/tests/edit/slide-edit-elements.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+import {
+  createDefaultImageElement,
+  createDefaultShapeElement,
+  createDefaultTextElement,
+  htmlToPlainText,
+  plainTextToParagraphHtml,
+} from '@/lib/edit/slide-edit-elements';
+
+describe('slide edit element factories', () => {
+  test('creates default text elements compatible with the slide schema', () => {
+    const element = createDefaultTextElement('text-1');
+
+    expect(element).toMatchObject({
+      id: 'text-1',
+      type: 'text',
+      content: '<p>New text</p>',
+      defaultFontName: 'Inter',
+      defaultColor: '#111827',
+      lineHeight: 1.4,
+    });
+  });
+
+  test('creates default shape elements with editable fill and outline', () => {
+    const element = createDefaultShapeElement('shape-1');
+
+    expect(element).toMatchObject({
+      id: 'shape-1',
+      type: 'shape',
+      fill: '#dbeafe',
+      outline: {
+        width: 2,
+        color: '#2563eb',
+        style: 'solid',
+      },
+    });
+    expect(element.viewBox).toEqual([260, 140]);
+  });
+
+  test('creates shape elements from a picked spec, preserving viewBox + path', () => {
+    const element = createDefaultShapeElement('shape-2', {
+      viewBox: [200, 200],
+      path: 'M 100 0 L 200 200 L 0 200 Z',
+    });
+
+    expect(element).toMatchObject({
+      id: 'shape-2',
+      type: 'shape',
+      viewBox: [200, 200],
+      path: 'M 100 0 L 200 200 L 0 200 Z',
+    });
+    expect(element.width).toBe(200);
+    expect(element.height).toBe(200);
+  });
+
+  test('creates default image elements from a source URL', () => {
+    const element = createDefaultImageElement('image-1', 'https://example.com/image.png');
+
+    expect(element).toMatchObject({
+      id: 'image-1',
+      type: 'image',
+      src: 'https://example.com/image.png',
+      fixedRatio: true,
+      width: 360,
+      height: 220,
+    });
+  });
+
+  test('converts plain text to escaped paragraph html', () => {
+    expect(plainTextToParagraphHtml('A < B & C')).toBe('<p>A &lt; B &amp; C</p>');
+  });
+
+  test('converts stored html content into editable plain text', () => {
+    expect(htmlToPlainText('<p>Hello</p><p>World</p>')).toBe('HelloWorld');
+  });
+});

--- a/tests/edit/slide-ops.test.ts
+++ b/tests/edit/slide-ops.test.ts
@@ -74,7 +74,14 @@ describe('applySlideEditOperation', () => {
       textElement({ id: 'subtitle', content: '<p>Subtitle</p>' }),
     ]);
     original.canvas.animations = [
-      { id: 'anim-1', elId: 'subtitle', effect: 'fade', type: 'in', duration: 600, trigger: 'click' },
+      {
+        id: 'anim-1',
+        elId: 'subtitle',
+        effect: 'fade',
+        type: 'in',
+        duration: 600,
+        trigger: 'click',
+      },
     ];
 
     const updated = applySlideEditOperation(original, {

--- a/tests/edit/slide-ops.test.ts
+++ b/tests/edit/slide-ops.test.ts
@@ -271,6 +271,30 @@ describe('element.add', () => {
   });
 });
 
+describe('slide.update contract', () => {
+  test('rejects element / animation collections at runtime even via type cast', () => {
+    const original = slideContent();
+    expect(() =>
+      applySlideEditOperation(original, {
+        type: 'slide.update',
+        // `as never` defeats the SlideMetaPatch type narrowing — the runtime
+        // guard is the second line of defense for misuse from JS callers or
+        // anywhere a cast slips through.
+        patch: { elements: [] } as never,
+      }),
+    ).toThrow(/dedicated/);
+  });
+
+  test('applies meta-only patches (theme/background) successfully', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'slide.update',
+      patch: { background: { type: 'solid', color: '#000000' } },
+    });
+    expect(updated.canvas.background).toEqual({ type: 'solid', color: '#000000' });
+  });
+});
+
 describe('element.duplicate contract', () => {
   test('uses the default offset {x:20, y:20} when no offset is given', () => {
     const original = slideContent([textElement({ id: 'a', left: 100, top: 50 })]);
@@ -306,6 +330,24 @@ describe('element.duplicate contract', () => {
         idMap: { a: 'b' },
       }),
     ).toThrow(/collide/);
+  });
+
+  test('deep-clones nested fields so the duplicate cannot leak mutations to the source', () => {
+    // A line element carries a mutable tuple (start). A shallow spread would
+    // share the same array between source and duplicate; a subsequent op
+    // that mutates the duplicate's start in place would silently mutate the
+    // source too. After the deep clone the two are independent.
+    const original = slideContent([lineElement({ id: 'l1', start: [0, 0], end: [10, 10] })]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.duplicate',
+      elementIds: ['l1'],
+      idMap: { l1: 'l1-copy' },
+    });
+    const source = updated.canvas.elements[0] as PPTLineElement;
+    const dup = updated.canvas.elements[1] as PPTLineElement;
+    expect(source.start).not.toBe(dup.start);
+    expect(source.end).not.toBe(dup.end);
+    expect(source.points).not.toBe(dup.points);
   });
 });
 

--- a/tests/edit/slide-ops.test.ts
+++ b/tests/edit/slide-ops.test.ts
@@ -6,7 +6,7 @@ import {
   undoSlideEditOperation,
 } from '@/lib/edit/slide-ops';
 import type { SlideContent } from '@/lib/types/stage';
-import type { PPTElement, PPTTextElement } from '@/lib/types/slides';
+import type { PPTElement, PPTLineElement, PPTTextElement } from '@/lib/types/slides';
 
 function textElement(overrides: Partial<PPTTextElement> = {}): PPTTextElement {
   return {
@@ -20,6 +20,22 @@ function textElement(overrides: Partial<PPTTextElement> = {}): PPTTextElement {
     content: '<p>Original title</p>',
     defaultFontName: 'Inter',
     defaultColor: '#111827',
+    ...overrides,
+  };
+}
+
+function lineElement(overrides: Partial<PPTLineElement> = {}): PPTLineElement {
+  return {
+    id: 'line-1',
+    type: 'line',
+    left: 100,
+    top: 100,
+    width: 200,
+    start: [0, 0],
+    end: [200, 100],
+    style: 'solid',
+    color: '#000000',
+    points: ['', ''],
     ...overrides,
   };
 }
@@ -166,7 +182,7 @@ describe('applySlideEditOperation', () => {
     expect(updated.canvas.animations?.map((animation) => animation.elId)).toEqual(['footer']);
   });
 
-  test('aligns selected elements to the slide canvas', () => {
+  test('aligns selected elements horizontally to the slide canvas', () => {
     const original = slideContent([
       textElement({ id: 'title', left: 100, top: 80, width: 200, height: 90 }),
       textElement({ id: 'caption', left: 360, top: 180, width: 100, height: 60 }),
@@ -200,6 +216,289 @@ describe('applySlideEditOperation', () => {
   });
 });
 
+describe('element.add', () => {
+  test('appends to the end when no index is given', () => {
+    const original = slideContent([textElement({ id: 'a' })]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.add',
+      element: textElement({ id: 'b' }),
+    });
+
+    expect(updated.canvas.elements.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  test('inserts at the requested index', () => {
+    const original = slideContent([textElement({ id: 'a' }), textElement({ id: 'c' })]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.add',
+      element: textElement({ id: 'b' }),
+      index: 1,
+    });
+
+    expect(updated.canvas.elements.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('clamps out-of-range index to the end of the list', () => {
+    const original = slideContent([textElement({ id: 'a' })]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.add',
+      element: textElement({ id: 'b' }),
+      index: 999,
+    });
+
+    expect(updated.canvas.elements.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  test('clamps negative index to 0', () => {
+    const original = slideContent([textElement({ id: 'a' })]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.add',
+      element: textElement({ id: 'b' }),
+      index: -5,
+    });
+
+    expect(updated.canvas.elements.map((e) => e.id)).toEqual(['b', 'a']);
+  });
+
+  test('throws when the new id collides with an existing element', () => {
+    const original = slideContent([textElement({ id: 'title' })]);
+    expect(() =>
+      applySlideEditOperation(original, {
+        type: 'element.add',
+        element: textElement({ id: 'title', content: '<p>Dup</p>' }),
+      }),
+    ).toThrow(/already exists/);
+  });
+});
+
+describe('element.duplicate contract', () => {
+  test('uses the default offset {x:20, y:20} when no offset is given', () => {
+    const original = slideContent([textElement({ id: 'a', left: 100, top: 50 })]);
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.duplicate',
+      elementIds: ['a'],
+      idMap: { a: 'a-copy' },
+    });
+
+    expect(updated.canvas.elements[1]).toMatchObject({ id: 'a-copy', left: 120, top: 70 });
+  });
+
+  test('throws when idMap is missing an entry for a selected id', () => {
+    const original = slideContent([textElement({ id: 'a' }), textElement({ id: 'b' })]);
+
+    expect(() =>
+      applySlideEditOperation(original, {
+        type: 'element.duplicate',
+        elementIds: ['a', 'b'],
+        idMap: { a: 'a-copy' },
+      }),
+    ).toThrow(/missing entries/);
+  });
+
+  test('throws when a new id would collide with an existing element', () => {
+    const original = slideContent([textElement({ id: 'a' }), textElement({ id: 'b' })]);
+
+    expect(() =>
+      applySlideEditOperation(original, {
+        type: 'element.duplicate',
+        elementIds: ['a'],
+        idMap: { a: 'b' },
+      }),
+    ).toThrow(/collide/);
+  });
+});
+
+describe('element.align all directions', () => {
+  function twoBoxes(): SlideContent {
+    return slideContent([
+      textElement({ id: 'a', left: 100, top: 80, width: 200, height: 90 }),
+      textElement({ id: 'b', left: 360, top: 180, width: 100, height: 60 }),
+    ]);
+  }
+
+  test('top aligns the group to the top edge of the canvas', () => {
+    const updated = applySlideEditOperation(twoBoxes(), {
+      type: 'element.align',
+      elementIds: ['a', 'b'],
+      command: 'top',
+    });
+    // group's minY is 80, so subtract 80 from each top
+    expect(updated.canvas.elements.map((e) => e.top)).toEqual([0, 100]);
+  });
+
+  test('bottom aligns the group to the bottom edge of the canvas', () => {
+    const updated = applySlideEditOperation(twoBoxes(), {
+      type: 'element.align',
+      elementIds: ['a', 'b'],
+      command: 'bottom',
+    });
+    // viewportHeight = 1000 * 0.5625 = 562.5; group's maxY = max(80+90, 180+60) = 240
+    // offsetY = 240 - 562.5 = -322.5; new tops = 80 - (-322.5) = 402.5, 180 - (-322.5) = 502.5
+    expect(updated.canvas.elements.map((e) => e.top)).toEqual([402.5, 502.5]);
+  });
+
+  test('left aligns the group to the left edge of the canvas', () => {
+    const updated = applySlideEditOperation(twoBoxes(), {
+      type: 'element.align',
+      elementIds: ['a', 'b'],
+      command: 'left',
+    });
+    // group's minX = 100, so subtract 100 from each left
+    expect(updated.canvas.elements.map((e) => e.left)).toEqual([0, 260]);
+  });
+
+  test('right aligns the group to the right edge of the canvas', () => {
+    const updated = applySlideEditOperation(twoBoxes(), {
+      type: 'element.align',
+      elementIds: ['a', 'b'],
+      command: 'right',
+    });
+    // viewportWidth = 1000; group's maxX = max(100+200, 360+100) = 460
+    // offsetX = 460 - 1000 = -540; new lefts = 100 - (-540) = 640, 360 - (-540) = 900
+    expect(updated.canvas.elements.map((e) => e.left)).toEqual([640, 900]);
+  });
+
+  test('vertical centers the group on the vertical axis', () => {
+    const updated = applySlideEditOperation(twoBoxes(), {
+      type: 'element.align',
+      elementIds: ['a', 'b'],
+      command: 'vertical',
+    });
+    // group's midY = 80 + (240 - 80) / 2 = 160; canvasMidY = 562.5 / 2 = 281.25
+    // offsetY = 160 - 281.25 = -121.25
+    expect(updated.canvas.elements.map((e) => e.top)).toEqual([201.25, 301.25]);
+  });
+
+  test('center centers the group on both axes', () => {
+    const updated = applySlideEditOperation(twoBoxes(), {
+      type: 'element.align',
+      elementIds: ['a', 'b'],
+      command: 'center',
+    });
+    expect(updated.canvas.elements.map((e) => e.left)).toEqual([320, 580]);
+    expect(updated.canvas.elements.map((e) => e.top)).toEqual([201.25, 301.25]);
+  });
+
+  test('uses canonical geometry for line elements (start/end, not width/height=0)', () => {
+    // A line visually spanning (left+0, top+0) to (left+200, top+100).
+    // The old local fork ignored start/end and treated the line as height 0,
+    // so 'bottom' would have aligned by line.top alone. The canonical helper
+    // uses start/end so the real extent (top..top+end[1]) drives the offset.
+    const original = slideContent([
+      lineElement({ id: 'line-1', left: 100, top: 50, start: [0, 0], end: [200, 100] }),
+    ]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.align',
+      elementIds: ['line-1'],
+      command: 'bottom',
+    });
+    // viewportHeight = 562.5; line maxY = top + end[1] = 50 + 100 = 150
+    // offsetY = 150 - 562.5 = -412.5; new top = 50 - (-412.5) = 462.5
+    expect(updated.canvas.elements[0].top).toBe(462.5);
+  });
+
+  test('uses rotated bounding box for rotated elements', () => {
+    // A 100×100 square rotated 45° fills an axis-aligned box wider than 100,
+    // anchored at its center. The canonical helper accounts for rotation;
+    // the old local fork used the unrotated rect and would put left at 0.
+    const original = slideContent([
+      textElement({ id: 'r', left: 100, top: 100, width: 100, height: 100, rotate: 45 }),
+    ]);
+    const updated = applySlideEditOperation(original, {
+      type: 'element.align',
+      elementIds: ['r'],
+      command: 'left',
+    });
+    // Pre-fix: unrotated minX = 100 → after align left, left ends at 0.
+    // Post-fix: rotated OOBB minX < 100 → after align, left ends > 0.
+    expect(updated.canvas.elements[0].left).toBeGreaterThan(0);
+    expect(updated.canvas.elements[0].left).toBeLessThan(100);
+  });
+});
+
+describe('no-op operations skip history push', () => {
+  test('element.update against a missing id returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'element.update',
+      elementId: 'nope',
+      patch: { left: 999 },
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('element.delete against a missing id returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'element.delete',
+      elementId: 'nope',
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('element.deleteMany against unmatched ids returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'element.deleteMany',
+      elementIds: ['nope-1', 'nope-2'],
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('element.reorder against a missing id returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'element.reorder',
+      elementId: 'nope',
+      index: 0,
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('element.removeProps against a missing id returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'element.removeProps',
+      elementId: 'nope',
+      propNames: ['outline'],
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('text.updateContent against a missing id returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'text.updateContent',
+      elementId: 'nope',
+      content: '<p>X</p>',
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('element.align with empty selection returns the same content reference', () => {
+    const original = slideContent();
+    const updated = applySlideEditOperation(original, {
+      type: 'element.align',
+      elementIds: [],
+      command: 'center',
+    });
+    expect(updated).toBe(original);
+  });
+
+  test('history is unchanged when the underlying op is a no-op', () => {
+    const original = slideContent();
+    const history = createSlideEditHistory(original);
+    const next = applySlideEditOperation(history, {
+      type: 'element.update',
+      elementId: 'nope',
+      patch: { left: 1 },
+    });
+    expect(next).toBe(history);
+    expect(next.past).toHaveLength(0);
+  });
+});
+
 describe('slide edit history', () => {
   test('undoes and redoes operations using immutable snapshots', () => {
     const original = slideContent();
@@ -217,5 +516,40 @@ describe('slide edit history', () => {
 
     history = redoSlideEditOperation(history);
     expect(history.present.canvas.elements[0].left).toBe(200);
+  });
+
+  test('clears the redo stack after a new op following undo', () => {
+    let history = createSlideEditHistory(slideContent());
+
+    history = applySlideEditOperation(history, {
+      type: 'element.update',
+      elementId: 'title',
+      patch: { left: 200 },
+    });
+    history = undoSlideEditOperation(history);
+    expect(history.future).toHaveLength(1);
+
+    // A new op branches the timeline and should drop the redo stack.
+    history = applySlideEditOperation(history, {
+      type: 'element.update',
+      elementId: 'title',
+      patch: { left: 300 },
+    });
+    expect(history.future).toEqual([]);
+    expect(history.present.canvas.elements[0].left).toBe(300);
+  });
+
+  test('caps past length so long edit sessions do not grow unbounded', () => {
+    let history = createSlideEditHistory(slideContent());
+    // More ops than MAX_HISTORY (50) — past should be clamped, present is current.
+    for (let i = 0; i < 70; i++) {
+      history = applySlideEditOperation(history, {
+        type: 'element.update',
+        elementId: 'title',
+        patch: { left: 100 + i },
+      });
+    }
+    expect(history.past.length).toBeLessThanOrEqual(50);
+    expect(history.present.canvas.elements[0].left).toBe(169);
   });
 });

--- a/tests/edit/slide-ops.test.ts
+++ b/tests/edit/slide-ops.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'vitest';
+import {
+  applySlideEditOperation,
+  createSlideEditHistory,
+  redoSlideEditOperation,
+  undoSlideEditOperation,
+} from '@/lib/edit/slide-ops';
+import type { SlideContent } from '@/lib/types/stage';
+import type { PPTElement, PPTTextElement } from '@/lib/types/slides';
+
+function textElement(overrides: Partial<PPTTextElement> = {}): PPTTextElement {
+  return {
+    id: 'title',
+    type: 'text',
+    left: 100,
+    top: 80,
+    width: 420,
+    height: 90,
+    rotate: 0,
+    content: '<p>Original title</p>',
+    defaultFontName: 'Inter',
+    defaultColor: '#111827',
+    ...overrides,
+  };
+}
+
+function slideContent(elements: PPTElement[] = [textElement()]): SlideContent {
+  return {
+    type: 'slide',
+    canvas: {
+      id: 'slide-1',
+      viewportSize: 1000,
+      viewportRatio: 0.5625,
+      theme: {
+        backgroundColor: '#ffffff',
+        themeColors: ['#2563eb'],
+        fontColor: '#111827',
+        fontName: 'Inter',
+      },
+      elements,
+    },
+  };
+}
+
+describe('applySlideEditOperation', () => {
+  test('updates an element without mutating the original slide content', () => {
+    const original = slideContent();
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.update',
+      elementId: 'title',
+      patch: { left: 160, top: 120, rotate: 12 },
+    });
+
+    expect(updated.canvas.elements[0]).toMatchObject({ left: 160, top: 120, rotate: 12 });
+    expect(original.canvas.elements[0]).toMatchObject({ left: 100, top: 80, rotate: 0 });
+  });
+
+  test('updates text content only for text elements', () => {
+    const original = slideContent();
+
+    const updated = applySlideEditOperation(original, {
+      type: 'text.updateContent',
+      elementId: 'title',
+      content: '<p>Edited title</p>',
+    });
+
+    expect(updated.canvas.elements[0]).toMatchObject({ content: '<p>Edited title</p>' });
+  });
+
+  test('deletes an element and clears its animations', () => {
+    const original = slideContent([
+      textElement({ id: 'title' }),
+      textElement({ id: 'subtitle', content: '<p>Subtitle</p>' }),
+    ]);
+    original.canvas.animations = [
+      { id: 'anim-1', elId: 'subtitle', effect: 'fade', type: 'in', duration: 600, trigger: 'click' },
+    ];
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.delete',
+      elementId: 'subtitle',
+    });
+
+    expect(updated.canvas.elements.map((element) => element.id)).toEqual(['title']);
+    expect(updated.canvas.animations).toEqual([]);
+  });
+
+  test('reorders an element by moving it to the requested index', () => {
+    const original = slideContent([
+      textElement({ id: 'background' }),
+      textElement({ id: 'title' }),
+      textElement({ id: 'caption' }),
+    ]);
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.reorder',
+      elementId: 'background',
+      index: 2,
+    });
+
+    expect(updated.canvas.elements.map((element) => element.id)).toEqual([
+      'title',
+      'caption',
+      'background',
+    ]);
+    expect(original.canvas.elements.map((element) => element.id)).toEqual([
+      'background',
+      'title',
+      'caption',
+    ]);
+  });
+
+  test('updates multiple selected elements with the same patch', () => {
+    const original = slideContent([textElement({ id: 'title' }), textElement({ id: 'caption' })]);
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.updateMany',
+      elementIds: ['title', 'caption'],
+      patch: { lock: true },
+    });
+
+    expect(updated.canvas.elements.map((element) => element.lock)).toEqual([true, true]);
+    expect(original.canvas.elements.map((element) => element.lock)).toEqual([undefined, undefined]);
+  });
+
+  test('duplicates selected elements with caller-provided ids and offsets', () => {
+    const original = slideContent([textElement({ id: 'title' })]);
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.duplicate',
+      elementIds: ['title'],
+      idMap: { title: 'title-copy' },
+      offset: { x: 24, y: 16 },
+    });
+
+    expect(updated.canvas.elements.map((element) => element.id)).toEqual(['title', 'title-copy']);
+    expect(updated.canvas.elements[1]).toMatchObject({ left: 124, top: 96 });
+    expect(original.canvas.elements).toHaveLength(1);
+  });
+
+  test('deletes multiple selected elements and clears their animations', () => {
+    const original = slideContent([
+      textElement({ id: 'title' }),
+      textElement({ id: 'caption' }),
+      textElement({ id: 'footer' }),
+    ]);
+    original.canvas.animations = [
+      { id: 'anim-1', elId: 'title', effect: 'fade', type: 'in', duration: 600, trigger: 'click' },
+      { id: 'anim-2', elId: 'footer', effect: 'fade', type: 'in', duration: 600, trigger: 'click' },
+    ];
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.deleteMany',
+      elementIds: ['title', 'caption'],
+    });
+
+    expect(updated.canvas.elements.map((element) => element.id)).toEqual(['footer']);
+    expect(updated.canvas.animations?.map((animation) => animation.elId)).toEqual(['footer']);
+  });
+
+  test('aligns selected elements to the slide canvas', () => {
+    const original = slideContent([
+      textElement({ id: 'title', left: 100, top: 80, width: 200, height: 90 }),
+      textElement({ id: 'caption', left: 360, top: 180, width: 100, height: 60 }),
+    ]);
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.align',
+      elementIds: ['title', 'caption'],
+      command: 'horizontal',
+    });
+
+    expect(updated.canvas.elements.map((element) => element.left)).toEqual([320, 580]);
+  });
+
+  test('removes element properties from selected elements', () => {
+    const original = slideContent([
+      textElement({
+        id: 'title',
+        outline: { width: 2, color: '#111111', style: 'solid' },
+      }),
+    ]);
+
+    const updated = applySlideEditOperation(original, {
+      type: 'element.removeProps',
+      elementId: 'title',
+      propNames: ['outline'],
+    });
+
+    expect('outline' in updated.canvas.elements[0]).toBe(false);
+    expect('outline' in original.canvas.elements[0]).toBe(true);
+  });
+});
+
+describe('slide edit history', () => {
+  test('undoes and redoes operations using immutable snapshots', () => {
+    const original = slideContent();
+    let history = createSlideEditHistory(original);
+
+    history = applySlideEditOperation(history, {
+      type: 'element.update',
+      elementId: 'title',
+      patch: { left: 200 },
+    });
+    expect(history.present.canvas.elements[0].left).toBe(200);
+
+    history = undoSlideEditOperation(history);
+    expect(history.present.canvas.elements[0].left).toBe(100);
+
+    history = redoSlideEditOperation(history);
+    expect(history.present.canvas.elements[0].left).toBe(200);
+  });
+});

--- a/tests/edit/stage-mode.test.ts
+++ b/tests/edit/stage-mode.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { useCanvasStore, useStageStore } from '@/lib/store';
+
+describe('stage edit mode', () => {
+  beforeEach(() => {
+    useStageStore.getState().clearStore();
+    useCanvasStore.getState().resetCanvasState();
+  });
+
+  test('supports a global edit mode', () => {
+    useStageStore.getState().setMode('edit');
+
+    expect(useStageStore.getState().mode).toBe('edit');
+  });
+
+  test('clears canvas selection when leaving edit mode', () => {
+    useStageStore.getState().setMode('edit');
+    useCanvasStore.getState().setActiveElementIdList(['title']);
+    useCanvasStore.getState().setEditingElementId('title');
+
+    useStageStore.getState().setMode('playback');
+
+    expect(useCanvasStore.getState().activeElementIdList).toEqual([]);
+    expect(useCanvasStore.getState().handleElementId).toBe('');
+    expect(useCanvasStore.getState().editingElementId).toBe('');
+  });
+});

--- a/tests/edit/stage-mode.test.ts
+++ b/tests/edit/stage-mode.test.ts
@@ -1,7 +1,12 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { useCanvasStore, useStageStore } from '@/lib/store';
+import { PENDING_SCENE_ID } from '@/lib/store/stage';
+import { isCurrentSceneEditable } from '@/lib/edit/stage-mode';
+import { sceneEditorRegistry } from '@/lib/edit/scene-editor-registry';
+import type { SceneEditorSurface } from '@/lib/edit/scene-editor-surface';
+import type { SceneType } from '@/lib/types/stage';
 
-describe('stage edit mode', () => {
+describe('stage edit mode store', () => {
   beforeEach(() => {
     useStageStore.getState().clearStore();
     useCanvasStore.getState().resetCanvasState();
@@ -23,5 +28,130 @@ describe('stage edit mode', () => {
     expect(useCanvasStore.getState().activeElementIdList).toEqual([]);
     expect(useCanvasStore.getState().handleElementId).toBe('');
     expect(useCanvasStore.getState().editingElementId).toBe('');
+  });
+});
+
+describe('isCurrentSceneEditable', () => {
+  test('returns true when a real scene is resolved and nothing is generating', () => {
+    expect(
+      isCurrentSceneEditable({
+        currentSceneId: 'scene-1',
+        sceneCount: 3,
+        generatingOutlineCount: 0,
+        hasCurrentScene: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('returns false on the pending placeholder scene', () => {
+    expect(
+      isCurrentSceneEditable({
+        currentSceneId: PENDING_SCENE_ID,
+        sceneCount: 3,
+        generatingOutlineCount: 0,
+        hasCurrentScene: true,
+      }),
+    ).toBe(false);
+  });
+
+  test('returns false when no scenes have materialised yet', () => {
+    expect(
+      isCurrentSceneEditable({
+        currentSceneId: null,
+        sceneCount: 0,
+        generatingOutlineCount: 0,
+        hasCurrentScene: false,
+      }),
+    ).toBe(false);
+  });
+
+  test('returns false while outline generation is still in flight', () => {
+    expect(
+      isCurrentSceneEditable({
+        currentSceneId: 'scene-1',
+        sceneCount: 1,
+        generatingOutlineCount: 2,
+        hasCurrentScene: true,
+      }),
+    ).toBe(false);
+  });
+
+  test('returns false when current scene id does not resolve to a scene', () => {
+    expect(
+      isCurrentSceneEditable({
+        currentSceneId: 'scene-x',
+        sceneCount: 3,
+        generatingOutlineCount: 0,
+        hasCurrentScene: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('sceneEditorRegistry', () => {
+  function makeSurface(sceneType: SceneType, label = 'A'): SceneEditorSurface {
+    return {
+      sceneType,
+      CanvasComponent: () => null,
+      useSurfaceState: () => ({
+        // Cast through unknown because tests don't need a real surface state;
+        // we only exercise the registry contract here.
+        content: { type: sceneType, label } as unknown as never,
+        selection: null,
+        hasSelection: false,
+        history: { canUndo: false, canRedo: false, undo: () => {}, redo: () => {} },
+        insertItems: [],
+        floatingActions: [],
+        commands: [],
+      }),
+    };
+  }
+
+  afterEach(() => {
+    sceneEditorRegistry.unregister('slide');
+    sceneEditorRegistry.unregister('quiz');
+  });
+
+  test('register and resolve round-trip by sceneType', () => {
+    const surface = makeSurface('slide');
+    sceneEditorRegistry.register(surface);
+    expect(sceneEditorRegistry.resolve('slide')).toBe(surface);
+  });
+
+  test('resolve returns undefined for unregistered sceneType', () => {
+    expect(sceneEditorRegistry.resolve('pbl')).toBeUndefined();
+  });
+
+  test('re-registering the identical surface instance does not warn (HMR-safe)', () => {
+    const surface = makeSurface('slide');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    sceneEditorRegistry.register(surface);
+    sceneEditorRegistry.register(surface);
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test('registering a different surface for the same sceneType warns in dev', () => {
+    const first = makeSurface('slide', 'A');
+    const second = makeSurface('slide', 'B');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    sceneEditorRegistry.register(first);
+    sceneEditorRegistry.register(second);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(sceneEditorRegistry.resolve('slide')).toBe(second);
+    warn.mockRestore();
+  });
+
+  test('unregister removes the surface', () => {
+    const surface = makeSurface('quiz');
+    sceneEditorRegistry.register(surface);
+    expect(sceneEditorRegistry.resolve('quiz')).toBe(surface);
+
+    sceneEditorRegistry.unregister('quiz');
+    expect(sceneEditorRegistry.resolve('quiz')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

First sub-PR of the MAIC Editor Phase 1 (RFC #547, tracking #560). Adds the framework primitives — types, store transitions, and the `SceneEditorSurface` contract — without shipping any UI consumers. The EditShell chrome and the slide surface registration come in follow-up sub-PRs.

**About positioning.** MAIC Editor is the editing framework for *static display components* in MAIC classrooms — the parts that present non-interactive content to learners. Slide is the first surface; other static-display media (e.g. HTML-based) will plug into the same contract in later phases.

## What ships

- **`StageMode`** gains `'edit'` alongside `'autonomous' | 'playback'`. `setMode` resets canvas selection when leaving `'edit'` so stale selection never bleeds into playback.
- **Auto-exit guard** in `<Stage>`: leaves `'edit'` whenever the current scene becomes uneditable (no scenes, pending generation, no current scene). Pre-wires the follow-up Pro toggle so it can never strand the user in an empty edit shell.
- **`SceneEditorSurface` contract** + a tiny in-memory registry under `lib/edit/`. The shell will resolve surfaces by `SceneType`; surfaces register themselves at module init. Surfaces declare `CanvasComponent`, `useSurfaceState()`, and contribute insert palette items, floating actions, commands, and (reserved for AI) inline coach hints.
- **Slide kernel** (`lib/edit/slide-ops.ts`): immutable, history-aware operations — `slide.update`, element `add` / `update` / `updateMany` / `delete` / `deleteMany` / `reorder` / `duplicate` / `align` / `removeProps`, plus `text.updateContent`. Single entry point so undo/redo and (future) PPTX-export round-tripping stay coherent.
- **Slide element factories** (`lib/edit/slide-edit-elements.ts`) for default text / shape / image elements and HTML ↔ plain-text helpers.
- **i18n**: `stage.editCourse` + `stage.doneEditing` across all 6 locales (en-US, zh-CN, zh-TW, ja-JP, ru-RU, ar-SA). Consumed by the header toggle in the next sub-PR.
- **Tests**: vitest coverage for the slide kernel (operations + history) and the edit-mode store transition (entry + canvas reset on exit).

## Explicitly out of scope

- **No UI entry into edit mode** — no Pro toggle in the header yet. The new `'edit'` mode is reachable only programmatically until the follow-up chrome PR lands.
- **No EditShell / EditModeSidebar** — chrome ships in a follow-up.
- **No slide surface registration** — the kernel is there but the slide surface that calls `register()` ships in a follow-up.

## Type widening

`PBLRenderer`'s `mode` prop was `'autonomous' | 'playback'`; widened to `StageMode` so `<SceneRenderer>` (which already passes `StageMode`) type-checks. The prop is unused inside the renderer, so behavior is unchanged.

## CI

`ci.yml` now also runs on PRs targeting `feat/maic-editor-v0`. The MAIC Editor lands as a series of stacked sub-PRs against that long-lived branch, and without this entry none of them get a style/lint/type/test gate — regressions would only surface when `feat/maic-editor-v0` finally merges back to `main`, which is a much worse place to catch them. Push trigger stays `main`-only since nobody pushes directly to the long-lived branch.

Note: GitHub Actions reads workflow config from the PR's **base** branch, so this change only starts gating once #564 merges into `feat/maic-editor-v0` — the next sub-PR (#562) will be the first to actually run CI.

## Test plan

- [x] `pnpm test` → 335 passed (was 317, +18 from new files)
- [x] `pnpm exec tsc --noEmit` → clean
- [x] `pnpm lint` → 0 errors (7 pre-existing warnings, none introduced)
- [x] `pnpm check:i18n-keys` → 6 locales aligned
- [x] `pnpm build` → compiled successfully

Tracking issue: #560.
Closes #561.
