### PR TITLE
feat(maic-editor): EditShell chrome and Pro mode toggle

### DIFF
--- a/components/canvas/canvas-area.tsx
+++ b/components/canvas/canvas-area.tsx
@@ -114,7 +114,12 @@ export function CanvasArea({
           {currentScene && !whiteboardOpen && (
             <div className="absolute inset-0">
               <SceneProvider>
-                <SceneRenderer scene={currentScene} mode={mode} />
+                <SceneRenderer
+                  scene={currentScene}
+                  mode={mode}
+                  sidebarCollapsed={sidebarCollapsed}
+                  onToggleSidebar={onToggleSidebar}
+                />
               </SceneProvider>
             </div>
           )}

--- a/components/edit/EditModeSidebar.tsx
+++ b/components/edit/EditModeSidebar.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useCallback } from 'react';
+import { ChevronDown, ChevronUp, PanelLeftClose, PanelLeftOpen, Plus, Trash2 } from 'lucide-react';
+import { nanoid } from 'nanoid';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ThumbnailSlide } from '@/components/slide-renderer/components/ThumbnailSlide';
+import { useStageStore } from '@/lib/store';
+import { useI18n } from '@/lib/hooks/use-i18n';
+import { createDefaultSlide } from '@/lib/edit/slide-edit-elements';
+import { reorderScene } from '@/lib/edit/reorder-scenes';
+import type { Scene } from '@/lib/types/stage';
+import { cn } from '@/lib/utils';
+
+interface EditModeSidebarProps {
+  readonly collapsed: boolean;
+  readonly onCollapseChange: (collapsed: boolean) => void;
+  readonly onSceneSelect: (sceneId: string) => void;
+}
+
+/**
+ * Edit-mode sidebar — distinct from playback's SceneSidebar.
+ *
+ * - Lists only real scenes (no virtual completion page)
+ * - Per-page actions: select / delete / move up / move down
+ * - Footer: "+ Add slide" creates a new blank slide and selects it
+ * - Collapsible via top-right chevron; collapsed state shows a slim strip
+ */
+export function EditModeSidebar({
+  collapsed,
+  onCollapseChange,
+  onSceneSelect,
+}: EditModeSidebarProps) {
+  const { t } = useI18n();
+  const stage = useStageStore((s) => s.stage);
+  const scenes = useStageStore((s) => s.scenes);
+  const currentSceneId = useStageStore((s) => s.currentSceneId);
+  const setScenes = useStageStore((s) => s.setScenes);
+  const addScene = useStageStore((s) => s.addScene);
+  const deleteScene = useStageStore((s) => s.deleteScene);
+  const setCurrentSceneId = useStageStore((s) => s.setCurrentSceneId);
+
+  const handleMove = useCallback(
+    (sceneId: string, direction: 'up' | 'down') => {
+      const reordered = reorderScene(scenes, sceneId, direction);
+      if (reordered) setScenes(reordered);
+    },
+    [scenes, setScenes],
+  );
+
+  const handleAddSlide = useCallback(() => {
+    if (!stage) return;
+    const newId = nanoid();
+    const lastOrder = scenes.length > 0 ? Math.max(...scenes.map((s) => s.order)) : 0;
+    const newScene: Scene = {
+      id: newId,
+      stageId: stage.id,
+      type: 'slide',
+      title: t('edit.sidebar.newSlide'),
+      order: lastOrder + 1,
+      content: { type: 'slide', canvas: createDefaultSlide(`slide-${newId}`) },
+    };
+    addScene(newScene);
+    setCurrentSceneId(newId);
+  }, [addScene, scenes, setCurrentSceneId, stage, t]);
+
+  if (collapsed) {
+    return (
+      <aside className="flex w-10 shrink-0 flex-col items-center gap-2 border-r border-zinc-200/60 bg-white/80 py-3 dark:border-zinc-800/60 dark:bg-zinc-950/60">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              className="h-8 w-8 rounded-lg text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              onClick={() => onCollapseChange(false)}
+            >
+              <PanelLeftOpen className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('edit.sidebar.expand')}</TooltipContent>
+        </Tooltip>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="flex w-60 shrink-0 flex-col border-r border-zinc-200/60 bg-white/80 dark:border-zinc-800/60 dark:bg-zinc-950/60">
+      <div className="flex items-center justify-between border-b border-zinc-200/60 px-3 py-2 dark:border-zinc-800/60">
+        <div className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+          {t('edit.sidebar.pages')} · {scenes.length}
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              className="h-7 w-7 rounded-lg text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              onClick={() => onCollapseChange(true)}
+            >
+              <PanelLeftClose className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('edit.sidebar.collapse')}</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        <div className="space-y-1.5">
+          {scenes.map((scene, index) => (
+            <SidebarItem
+              key={scene.id}
+              scene={scene}
+              index={index}
+              total={scenes.length}
+              isCurrent={scene.id === currentSceneId}
+              onSelect={() => {
+                setCurrentSceneId(scene.id);
+                onSceneSelect(scene.id);
+              }}
+              onMoveUp={() => handleMove(scene.id, 'up')}
+              onMoveDown={() => handleMove(scene.id, 'down')}
+              onDelete={() => deleteScene(scene.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="border-t border-zinc-200/60 p-2 dark:border-zinc-800/60">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full justify-center gap-1.5 rounded-lg text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+          onClick={handleAddSlide}
+          disabled={!stage}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {t('edit.sidebar.addSlide')}
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+function SidebarItem({
+  scene,
+  index,
+  total,
+  isCurrent,
+  onSelect,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+}: {
+  readonly scene: Scene;
+  readonly index: number;
+  readonly total: number;
+  readonly isCurrent: boolean;
+  readonly onSelect: () => void;
+  readonly onMoveUp: () => void;
+  readonly onMoveDown: () => void;
+  readonly onDelete: () => void;
+}) {
+  const { t } = useI18n();
+  const slideCanvas =
+    scene.type === 'slide' && scene.content.type === 'slide' ? scene.content.canvas : null;
+
+  return (
+    <div
+      className={cn(
+        'group relative flex items-center gap-2 rounded-xl border p-1.5 transition-colors',
+        isCurrent
+          ? 'border-violet-300 bg-violet-50/70 dark:border-violet-500/60 dark:bg-violet-950/40'
+          : 'border-transparent hover:bg-zinc-100/70 dark:hover:bg-zinc-800/40',
+      )}
+    >
+      <span className="w-4 shrink-0 text-center text-[10px] font-medium text-zinc-400 tabular-nums">
+        {index + 1}
+      </span>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          'flex aspect-video min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md text-xs',
+          slideCanvas
+            ? 'bg-white shadow-sm dark:bg-zinc-900'
+            : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400',
+        )}
+        title={scene.title}
+      >
+        {slideCanvas ? (
+          <ThumbnailSlide
+            slide={slideCanvas}
+            size={140}
+            viewportSize={slideCanvas.viewportSize ?? 1000}
+            viewportRatio={slideCanvas.viewportRatio ?? 0.5625}
+          />
+        ) : (
+          <span className="px-2 truncate text-[11px] uppercase tracking-wide">{scene.type}</span>
+        )}
+      </button>
+
+      {/* Hover-revealed action column */}
+      <div className="flex flex-col gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              disabled={index === 0}
+              onClick={onMoveUp}
+              className="flex h-5 w-5 items-center justify-center rounded text-zinc-400 hover:bg-zinc-200 hover:text-zinc-800 disabled:pointer-events-none disabled:opacity-30 dark:hover:bg-zinc-700 dark:hover:text-zinc-100"
+            >
+              <ChevronUp className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('edit.sidebar.moveUp')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              disabled={index === total - 1}
+              onClick={onMoveDown}
+              className="flex h-5 w-5 items-center justify-center rounded text-zinc-400 hover:bg-zinc-200 hover:text-zinc-800 disabled:pointer-events-none disabled:opacity-30 dark:hover:bg-zinc-700 dark:hover:text-zinc-100"
+            >
+              <ChevronDown className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('edit.sidebar.moveDown')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onDelete}
+              className="flex h-5 w-5 items-center justify-center rounded text-zinc-400 hover:bg-rose-100 hover:text-rose-600 dark:hover:bg-rose-950/50 dark:hover:text-rose-400"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t('edit.sidebar.delete')}</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/components/edit/EditShell/CommandBar.tsx
+++ b/components/edit/EditShell/CommandBar.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { PanelLeft, PanelLeftClose, Redo2, Undo2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useI18n } from '@/lib/hooks/use-i18n';
+import type {
+  EditorCommand,
+  InsertPaletteItem,
+  SurfaceHistory,
+} from '@/lib/edit/scene-editor-surface';
+
+interface CommandBarProps {
+  readonly title: string;
+  readonly history: SurfaceHistory;
+  readonly insertItems: readonly InsertPaletteItem[];
+  readonly commands: readonly EditorCommand[];
+  readonly sidebarCollapsed?: boolean;
+  readonly onToggleSidebar?: () => void;
+}
+
+/**
+ * Top toolbar — Pitch-inspired: title on the left, insert primitives in the
+ * center as labeled icon buttons, global commands (undo/redo + view toggles)
+ * on the right. Borderless; relies on bottom hairline for separation.
+ */
+export function CommandBar({
+  title,
+  history,
+  insertItems,
+  commands,
+  sidebarCollapsed,
+  onToggleSidebar,
+}: CommandBarProps) {
+  const { t } = useI18n();
+
+  return (
+    <header className="flex h-14 shrink-0 items-center gap-3 border-b border-zinc-200/60 px-5 dark:border-zinc-800/60">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {onToggleSidebar && (
+          <IconButton
+            title={sidebarCollapsed ? t('edit.sidebar.expand') : t('edit.sidebar.collapse')}
+            onClick={onToggleSidebar}
+          >
+            {sidebarCollapsed ? (
+              <PanelLeft className="h-4 w-4" />
+            ) : (
+              <PanelLeftClose className="h-4 w-4" />
+            )}
+          </IconButton>
+        )}
+        <IconButton title={t('edit.undo')} disabled={!history.canUndo} onClick={history.undo}>
+          <Undo2 className="h-4 w-4" />
+        </IconButton>
+        <IconButton title={t('edit.redo')} disabled={!history.canRedo} onClick={history.redo}>
+          <Redo2 className="h-4 w-4" />
+        </IconButton>
+        <span className="ml-2 truncate text-sm font-medium text-zinc-700 dark:text-zinc-300">
+          {title}
+        </span>
+      </div>
+
+      {insertItems.length > 0 && (
+        <div className="flex shrink-0 items-center gap-1">
+          {insertItems.map((item) => (
+            <InsertButton key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-1">
+        {commands.map((command) => (
+          <IconButton
+            key={command.id}
+            title={command.tooltip ?? command.label}
+            disabled={command.disabled}
+            onClick={command.onInvoke}
+          >
+            {command.icon ?? <span className="px-1 text-xs">{command.label}</span>}
+          </IconButton>
+        ))}
+      </div>
+    </header>
+  );
+}
+
+function InsertButton({ item }: { readonly item: InsertPaletteItem }) {
+  const button = (
+    <button
+      type="button"
+      disabled={item.disabled}
+      onClick={item.popoverContent ? undefined : item.onInvoke}
+      className="group flex h-9 items-center gap-1.5 rounded-xl px-3 text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 disabled:pointer-events-none disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+    >
+      <span className="flex h-4 w-4 items-center justify-center [&>svg]:h-4 [&>svg]:w-4">
+        {item.icon}
+      </span>
+      <span className="text-xs font-medium">{item.label}</span>
+    </button>
+  );
+
+  const triggerWithTooltip = (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      {item.tooltip && <TooltipContent>{item.tooltip}</TooltipContent>}
+    </Tooltip>
+  );
+
+  if (!item.popoverContent) return triggerWithTooltip;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{triggerWithTooltip}</PopoverTrigger>
+      <PopoverContent side="bottom" align="center" className="w-80 p-3">
+        {item.popoverContent()}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function IconButton({
+  title,
+  children,
+  ...props
+}: React.ComponentProps<typeof Button> & { readonly title: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          className="h-8 w-8 shrink-0 rounded-xl text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+          {...props}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{title}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/edit/EditShell/EditShell.tsx
+++ b/components/edit/EditShell/EditShell.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { motion } from 'motion/react';
+import type { SceneEditorSurface } from '@/lib/edit/scene-editor-surface';
+import { CommandBar } from './CommandBar';
+import { FloatingToolbar } from './FloatingToolbar';
+import { HintRail } from './HintRail';
+
+interface EditShellProps {
+  readonly surface: SceneEditorSurface;
+  readonly title: string;
+  readonly sidebarCollapsed?: boolean;
+  readonly onToggleSidebar?: () => void;
+}
+
+const CHROME_TRANSITION = { duration: 0.28, ease: [0.22, 1, 0.36, 1] as const };
+
+/**
+ * Pitch-inspired shell:
+ *   ┌──────────────────────────────────────────────┐
+ *   │ Top:  [↶↷ title]  [Insert items]  [view]     │
+ *   │  ┌──────────────────────────────────────┐    │
+ *   │  │  Canvas (full width below top bar)   │    │
+ *   │  │     • FloatingToolbar (selection-    │    │
+ *   │  │       contextual; holds property      │    │
+ *   │  │       popovers + duplicate/delete)    │    │
+ *   │  └──────────────────────────────────────┘    │
+ *   └──────────────────────────────────────────────┘
+ *
+ * No fixed right inspector — properties live in the floating toolbar's
+ * popovers. Left edge belongs to the EditModeSidebar (slide thumbnails)
+ * provided by the parent Stage layout.
+ */
+export function EditShell({ surface, title, sidebarCollapsed, onToggleSidebar }: EditShellProps) {
+  const state = surface.useSurfaceState();
+  const Canvas = surface.CanvasComponent;
+
+  return (
+    <div className="flex h-full w-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <motion.div
+        initial={{ y: -56, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={CHROME_TRANSITION}
+      >
+        <CommandBar
+          title={title}
+          history={state.history}
+          insertItems={state.insertItems}
+          commands={state.commands}
+          sidebarCollapsed={sidebarCollapsed}
+          onToggleSidebar={onToggleSidebar}
+        />
+      </motion.div>
+      <div className="relative min-h-0 flex-1">
+        <Canvas />
+        {state.hasSelection && <FloatingToolbar actions={state.floatingActions} />}
+        <HintRail hints={state.hints} />
+      </div>
+    </div>
+  );
+}

--- a/components/edit/EditShell/FloatingToolbar.tsx
+++ b/components/edit/EditShell/FloatingToolbar.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Fragment } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import type { FloatingAction } from '@/lib/edit/scene-editor-surface';
+
+interface FloatingToolbarProps {
+  readonly actions: readonly FloatingAction[];
+}
+
+/**
+ * Contextual mini-bar shown above the canvas when something is selected.
+ * Each action is either a button (onInvoke) or a popover trigger
+ * (popoverContent) — used by the slide surface for color pickers, font
+ * select, etc. so properties live here instead of in a fixed right panel.
+ */
+export function FloatingToolbar({ actions }: FloatingToolbarProps) {
+  if (actions.length === 0) return null;
+
+  const grouped = groupByGroup(actions);
+
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-5 z-20 -translate-x-1/2">
+      <div className="pointer-events-auto flex items-center gap-0.5 rounded-2xl bg-white/95 p-1 shadow-[0_4px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.04)] ring-1 ring-zinc-200/60 backdrop-blur dark:bg-zinc-900/95 dark:shadow-[0_4px_24px_-8px_rgba(0,0,0,0.5)] dark:ring-zinc-800/60">
+        {grouped.map((group, groupIndex) => (
+          <Fragment key={groupIndex}>
+            {groupIndex > 0 && <div className="mx-0.5 h-5 w-px bg-zinc-200 dark:bg-zinc-800" />}
+            {group.map((action) => (
+              <ActionButton key={action.id} action={action} />
+            ))}
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActionButton({ action }: { readonly action: FloatingAction }) {
+  const isDanger = action.id === 'delete';
+  const button = (
+    <button
+      type="button"
+      disabled={action.disabled}
+      onClick={action.popoverContent ? undefined : action.onInvoke}
+      className={`flex h-8 items-center gap-1.5 rounded-xl px-2 transition-colors disabled:pointer-events-none disabled:opacity-40 ${
+        isDanger
+          ? 'text-zinc-500 hover:bg-rose-50 hover:text-rose-600 dark:text-zinc-400 dark:hover:bg-rose-950/40 dark:hover:text-rose-400'
+          : 'text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100'
+      }`}
+    >
+      {action.icon}
+      {!action.icon && <span className="text-xs">{action.label}</span>}
+    </button>
+  );
+
+  const triggerWithTooltip = (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>{action.tooltip ?? action.label}</TooltipContent>
+    </Tooltip>
+  );
+
+  if (!action.popoverContent) return triggerWithTooltip;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{triggerWithTooltip}</PopoverTrigger>
+      <PopoverContent side="bottom" align="center" className="w-72 p-3">
+        {action.popoverContent()}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function groupByGroup(items: readonly FloatingAction[]): FloatingAction[][] {
+  const groups: FloatingAction[][] = [];
+  let current: FloatingAction[] = [];
+  let currentKey: string | undefined;
+  for (const item of items) {
+    const key = item.group;
+    if (key !== currentKey && current.length > 0) {
+      groups.push(current);
+      current = [];
+    }
+    currentKey = key;
+    current.push(item);
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}

--- a/components/edit/EditShell/HintRail.tsx
+++ b/components/edit/EditShell/HintRail.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Info, Lightbulb, AlertTriangle } from 'lucide-react';
+import type { EditorHint } from '@/lib/edit/scene-editor-surface';
+
+interface HintRailProps {
+  readonly hints?: readonly EditorHint[];
+}
+
+/**
+ * Reserved AI inline-coach surface. Renders nothing in Phase 1 (surfaces
+ * return [] for hints). Layout slot is wired so future phases can populate
+ * it without restructuring the shell.
+ */
+export function HintRail({ hints }: HintRailProps) {
+  if (!hints || hints.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
+      <div className="pointer-events-auto flex max-w-md flex-col gap-2">
+        {hints.map((hint) => (
+          <HintCard key={hint.id} hint={hint} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const ICONS = {
+  info: Info,
+  suggestion: Lightbulb,
+  warning: AlertTriangle,
+} as const;
+
+const SEVERITY_STYLES = {
+  info: 'border-zinc-200 bg-white text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200',
+  suggestion:
+    'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-100',
+  warning:
+    'border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-100',
+} as const;
+
+function HintCard({ hint }: { readonly hint: EditorHint }) {
+  const Icon = ICONS[hint.severity];
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-xl border px-4 py-3 shadow-md shadow-zinc-900/5 ${SEVERITY_STYLES[hint.severity]}`}
+    >
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+      <div className="min-w-0 flex-1 text-sm">{hint.message}</div>
+      {hint.action && (
+        <button
+          type="button"
+          onClick={hint.action.onInvoke}
+          className="shrink-0 rounded-md bg-white/60 px-2.5 py-1 text-xs font-medium hover:bg-white dark:bg-zinc-800/60 dark:hover:bg-zinc-800"
+        >
+          {hint.action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/edit/EditShell/index.ts
+++ b/components/edit/EditShell/index.ts
@@ -1,0 +1,1 @@
+export { EditShell } from './EditShell';

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -12,6 +12,7 @@ import {
   Package,
   Archive,
 } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useTheme } from '@/lib/hooks/use-theme';
 import { LanguageSwitcher } from './language-switcher';
@@ -23,12 +24,16 @@ import { useStageStore } from '@/lib/store/stage';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import { useExportPPTX } from '@/lib/export/use-export-pptx';
 import { useExportClassroom } from '@/lib/export/use-export-classroom';
+import type { StageMode } from '@/lib/types/stage';
 
 interface HeaderProps {
   readonly currentSceneTitle: string;
+  readonly mode?: StageMode;
+  readonly canEdit?: boolean;
+  readonly onToggleEditMode?: () => void;
 }
 
-export function Header({ currentSceneTitle }: HeaderProps) {
+export function Header({ currentSceneTitle, mode, canEdit, onToggleEditMode }: HeaderProps) {
   const { t } = useI18n();
   const { theme, setTheme } = useTheme();
   const router = useRouter();
@@ -97,11 +102,9 @@ export function Header({ currentSceneTitle }: HeaderProps) {
           </div>
         </div>
 
-        <div className="flex items-center gap-4 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md px-2 py-1.5 rounded-full border border-gray-100/50 dark:border-gray-700/50 shadow-sm shrink-0">
+        <div className="flex items-center gap-1 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md px-2 py-1.5 rounded-full border border-gray-100/50 dark:border-gray-700/50 shadow-sm shrink-0">
           {/* Language Selector */}
           <LanguageSwitcher onOpen={() => setThemeOpen(false)} />
-
-          <div className="w-[1px] h-4 bg-gray-200 dark:bg-gray-700" />
 
           {/* Theme Selector */}
           <div className="relative" ref={themeRef}>
@@ -163,8 +166,6 @@ export function Header({ currentSceneTitle }: HeaderProps) {
             )}
           </div>
 
-          <div className="w-[1px] h-4 bg-gray-200 dark:bg-gray-700" />
-
           {/* Settings Button */}
           <div className="relative">
             <button
@@ -175,6 +176,44 @@ export function Header({ currentSceneTitle }: HeaderProps) {
             </button>
           </div>
         </div>
+
+        {/* Pro Mode (edit) toggle — caps label + switch. Surfaces only the
+            two i18n strings already shipped in stage.editCourse/doneEditing
+            from #561; consumer code lives behind the optional onToggleEditMode
+            prop so embedders without an edit affordance render the same header. */}
+        {onToggleEditMode && (
+          <label
+            className={cn(
+              'shrink-0 inline-flex items-center gap-2.5 h-9 px-3 rounded-full transition-colors duration-200',
+              'bg-white/60 dark:bg-gray-800/60 backdrop-blur-md border shadow-sm',
+              mode === 'edit'
+                ? 'border-violet-500/60 dark:border-violet-400/60'
+                : 'border-gray-100/50 dark:border-gray-700/50',
+              !canEdit && mode !== 'edit'
+                ? 'opacity-60 cursor-not-allowed'
+                : 'cursor-pointer hover:border-violet-400/60 dark:hover:border-violet-500/50',
+            )}
+            title={mode === 'edit' ? t('stage.doneEditing') : t('stage.editCourse')}
+          >
+            <span
+              className={cn(
+                'text-[11px] font-bold uppercase tracking-[0.14em] tabular-nums select-none transition-colors duration-200',
+                mode === 'edit'
+                  ? 'text-violet-600 dark:text-violet-300'
+                  : 'text-gray-500 dark:text-gray-400',
+              )}
+            >
+              {t('edit.proMode')}
+            </span>
+            <Switch
+              checked={mode === 'edit'}
+              onCheckedChange={onToggleEditMode}
+              disabled={!canEdit && mode !== 'edit'}
+              aria-label={mode === 'edit' ? t('stage.doneEditing') : t('stage.editCourse')}
+              className="data-[state=checked]:bg-violet-600 dark:data-[state=checked]:bg-violet-500"
+            />
+          </label>
+        )}
 
         {/* Export Dropdown */}
         <div className="relative" ref={exportRef}>

--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -10,6 +10,7 @@ import { useI18n } from '@/lib/hooks/use-i18n';
 import { SceneSidebar } from './stage/scene-sidebar';
 import { Header } from './header';
 import { CanvasArea } from '@/components/canvas/canvas-area';
+import { EditModeSidebar } from '@/components/edit/EditModeSidebar';
 import { Roundtable } from '@/components/roundtable';
 import { PlaybackEngine, computePlaybackView } from '@/lib/playback';
 import type { EngineMode, TriggerEvent, Effect } from '@/lib/playback';
@@ -34,6 +35,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { AlertTriangle } from 'lucide-react';
 import { VisuallyHidden } from 'radix-ui';
+import { AnimatePresence, motion } from 'motion/react';
 
 /**
  * Stage Component
@@ -262,21 +264,43 @@ export function Stage({
     doSessionCleanup();
   }, [doSessionCleanup]);
 
+  // Single source of truth for "is the current scene editable?" — feeds both
+  // the Pro toggle's disabled state in the Header and the auto-exit effect
+  // below. Using one predicate keeps the header and auto-exit in lock-step so
+  // we never offer a click that would immediately auto-exit.
+  const isEditable = isCurrentSceneEditable({
+    currentSceneId,
+    sceneCount: scenes.length,
+    generatingOutlineCount: generatingOutlines.length,
+    hasCurrentScene: !!currentScene,
+  });
+
+  // Toggle Pro (edit) mode. Entering edit mode tears down any live
+  // session so the user enters a quiet canvas.
+  const handleToggleEditMode = useCallback(async () => {
+    if (mode === 'edit') {
+      setMode('playback');
+      return;
+    }
+    await chatAreaRef.current?.endActiveSession();
+    if (discussionAbortRef.current) {
+      discussionAbortRef.current.abort();
+      discussionAbortRef.current = null;
+    }
+    engineRef.current?.stop();
+    discussionTTS.cleanup();
+    resetSceneState();
+    setMode('edit');
+  }, [discussionTTS, mode, resetSceneState, setMode]);
+
   // Auto-exit edit mode whenever the current scene becomes uneditable
   // (pending generation, no scenes, currently generating). Predicate lives in
   // lib/edit/stage-mode so it can be unit-tested without rendering Stage.
   useEffect(() => {
-    if (mode !== 'edit') return;
-    const editable = isCurrentSceneEditable({
-      currentSceneId,
-      sceneCount: scenes.length,
-      generatingOutlineCount: generatingOutlines.length,
-      hasCurrentScene: !!currentScene,
-    });
-    if (!editable) {
+    if (mode === 'edit' && !isEditable) {
       setMode('playback');
     }
-  }, [mode, currentSceneId, scenes.length, generatingOutlines.length, currentScene, setMode]);
+  }, [mode, isEditable, setMode]);
 
   const clearPresentationIdleTimer = useCallback(() => {
     if (presentationIdleTimerRef.current) {
@@ -974,14 +998,24 @@ export function Stage({
         isPresenting && !controlsVisible && 'cursor-none',
       )}
     >
-      {/* Scene Sidebar */}
-      <SceneSidebar
-        collapsed={sidebarCollapsed}
-        onCollapseChange={setSidebarCollapsed}
-        onSceneSelect={gatedSceneSwitch}
-        onRetryOutline={onRetryOutline}
-        isCourseComplete={isCourseComplete}
-      />
+      {/* Scene Sidebar — playback uses the full SceneSidebar (with completion
+          page entry, retry-failed-outline UI, etc); edit (Pro) mode swaps to a
+          purpose-built EditModeSidebar with add/delete/reorder. */}
+      {mode === 'edit' ? (
+        <EditModeSidebar
+          collapsed={sidebarCollapsed}
+          onCollapseChange={setSidebarCollapsed}
+          onSceneSelect={gatedSceneSwitch}
+        />
+      ) : (
+        <SceneSidebar
+          collapsed={sidebarCollapsed}
+          onCollapseChange={setSidebarCollapsed}
+          onSceneSelect={gatedSceneSwitch}
+          onRetryOutline={onRetryOutline}
+          isCourseComplete={isCourseComplete}
+        />
+      )}
 
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col overflow-hidden min-w-0 relative">
@@ -992,6 +1026,9 @@ export function Stage({
               currentScene?.title ||
               (isCourseComplete && isPendingScene ? t('stage.courseComplete') : '')
             }
+            mode={mode}
+            canEdit={isEditable}
+            onToggleEditMode={handleToggleEditMode}
           />
         )}
 
@@ -1028,7 +1065,9 @@ export function Stage({
               (chatIsStreaming && (chatSessionType === 'qa' || chatSessionType === 'discussion'))
             }
             onStopDiscussion={handleStopDiscussion}
-            hideToolbar={mode === 'playback' || (isPresenting && !controlsVisible)}
+            hideToolbar={
+              mode === 'playback' || mode === 'edit' || (isPresenting && !controlsVisible)
+            }
             isPendingScene={isPendingScene}
             isCourseComplete={isCourseComplete}
             isGenerationFailed={
@@ -1184,60 +1223,73 @@ export function Stage({
         )}
       </div>
 
-      {/* Chat Area */}
-      <ChatArea
-        ref={chatAreaRef}
-        width={chatAreaWidth}
-        onWidthChange={setChatAreaWidth}
-        collapsed={chatAreaCollapsed}
-        onCollapseChange={setChatAreaCollapsed}
-        activeBubbleId={activeBubbleId}
-        onActiveBubble={(id) => setActiveBubbleId(id)}
-        currentSceneId={currentSceneId}
-        onLiveSpeech={(text, agentId) => {
-          // Capture epoch at call time — discard if scene has changed since
-          const epoch = sceneEpochRef.current;
-          // Use queueMicrotask to let any pending scene-switch reset settle first
-          queueMicrotask(() => {
-            if (sceneEpochRef.current !== epoch) return; // stale — scene changed
-            setLiveSpeech(text);
-            if (agentId !== undefined) {
-              setSpeakingAgentId(agentId);
-            }
-            if (text !== null || agentId) {
-              setChatIsStreaming(true);
-              setChatSessionType(chatAreaRef.current?.getActiveSessionType?.() ?? null);
-              setIsTopicPending(false);
-            } else if (text === null && agentId === null) {
-              setChatIsStreaming(false);
-              // Don't clear chatSessionType here — it's needed by the stop
-              // button when director cues user (cue_user → done → liveSpeech null).
-              // It gets properly cleared in doSessionCleanup and scene change.
-            }
-          });
-        }}
-        onSpeechProgress={(ratio) => {
-          const epoch = sceneEpochRef.current;
-          queueMicrotask(() => {
-            if (sceneEpochRef.current !== epoch) return;
-            setSpeechProgress(ratio);
-          });
-        }}
-        onThinking={(state) => {
-          const epoch = sceneEpochRef.current;
-          queueMicrotask(() => {
-            if (sceneEpochRef.current !== epoch) return;
-            setThinkingState(state);
-          });
-        }}
-        onCueUser={(_fromAgentId, _prompt) => {
-          setIsCueUser(true);
-        }}
-        onLiveSessionError={handleLiveSessionError}
-        onStopSession={doSessionCleanup}
-        onSegmentSealed={discussionTTS.handleSegmentSealed}
-        shouldHoldAfterReveal={discussionTTS.shouldHold}
-      />
+      {/* Chat Area — slides out in edit (Pro) mode for full-canvas editing. */}
+      <AnimatePresence initial={false}>
+        {mode !== 'edit' && (
+          <motion.div
+            key="chat-area"
+            initial={{ x: '100%', opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: '100%', opacity: 0 }}
+            transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+            className="flex shrink-0"
+          >
+            <ChatArea
+              ref={chatAreaRef}
+              width={chatAreaWidth}
+              onWidthChange={setChatAreaWidth}
+              collapsed={chatAreaCollapsed}
+              onCollapseChange={setChatAreaCollapsed}
+              activeBubbleId={activeBubbleId}
+              onActiveBubble={(id) => setActiveBubbleId(id)}
+              currentSceneId={currentSceneId}
+              onLiveSpeech={(text, agentId) => {
+                // Capture epoch at call time — discard if scene has changed since
+                const epoch = sceneEpochRef.current;
+                // Use queueMicrotask to let any pending scene-switch reset settle first
+                queueMicrotask(() => {
+                  if (sceneEpochRef.current !== epoch) return; // stale — scene changed
+                  setLiveSpeech(text);
+                  if (agentId !== undefined) {
+                    setSpeakingAgentId(agentId);
+                  }
+                  if (text !== null || agentId) {
+                    setChatIsStreaming(true);
+                    setChatSessionType(chatAreaRef.current?.getActiveSessionType?.() ?? null);
+                    setIsTopicPending(false);
+                  } else if (text === null && agentId === null) {
+                    setChatIsStreaming(false);
+                    // Don't clear chatSessionType here — it's needed by the stop
+                    // button when director cues user (cue_user → done → liveSpeech null).
+                    // It gets properly cleared in doSessionCleanup and scene change.
+                  }
+                });
+              }}
+              onSpeechProgress={(ratio) => {
+                const epoch = sceneEpochRef.current;
+                queueMicrotask(() => {
+                  if (sceneEpochRef.current !== epoch) return;
+                  setSpeechProgress(ratio);
+                });
+              }}
+              onThinking={(state) => {
+                const epoch = sceneEpochRef.current;
+                queueMicrotask(() => {
+                  if (sceneEpochRef.current !== epoch) return;
+                  setThinkingState(state);
+                });
+              }}
+              onCueUser={(_fromAgentId, _prompt) => {
+                setIsCueUser(true);
+              }}
+              onLiveSessionError={handleLiveSessionError}
+              onStopSession={doSessionCleanup}
+              onSegmentSealed={discussionTTS.handleSegmentSealed}
+              shouldHoldAfterReveal={discussionTTS.shouldHold}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Scene switch confirmation dialog */}
       <AlertDialog

--- a/components/stage/scene-renderer.tsx
+++ b/components/stage/scene-renderer.tsx
@@ -6,14 +6,50 @@ import { SlideEditor as SlideRenderer } from '../slide-renderer/Editor';
 import { QuizView } from '../scene-renderers/quiz-view';
 import { InteractiveRenderer } from '../scene-renderers/interactive-renderer';
 import { PBLRenderer } from '../scene-renderers/pbl-renderer';
+import { EditShell } from '@/components/edit/EditShell';
+import { sceneEditorRegistry } from '@/lib/edit/scene-editor-registry';
+import { useI18n } from '@/lib/hooks/use-i18n';
 
 interface SceneRendererProps {
   readonly scene: Scene;
   readonly mode: StageMode;
+  readonly sidebarCollapsed?: boolean;
+  readonly onToggleSidebar?: () => void;
 }
 
-export function SceneRenderer({ scene, mode }: SceneRendererProps) {
+export function SceneRenderer({
+  scene,
+  mode,
+  sidebarCollapsed,
+  onToggleSidebar,
+}: SceneRendererProps) {
+  const { t } = useI18n();
+
   const renderer = useMemo(() => {
+    // Edit (Pro) mode: defer rendering to a registered SceneEditorSurface, or
+    // show a friendly fallback when no surface is registered for this scene
+    // type. Surfaces are wired up by later PRs (slide first); the shell only
+    // depends on the registry contract from #561.
+    if (mode === 'edit') {
+      const sceneTypeLabel = t(`edit.sceneType.${scene.type}`);
+      const surface = sceneEditorRegistry.resolve(scene.type);
+      if (!surface) {
+        return (
+          <div className="flex h-full w-full items-center justify-center bg-zinc-50 text-sm text-zinc-500 dark:bg-zinc-950 dark:text-zinc-400">
+            {t('edit.unsupportedScene', { type: sceneTypeLabel })}
+          </div>
+        );
+      }
+      return (
+        <EditShell
+          surface={surface}
+          title={t('edit.title', { type: sceneTypeLabel })}
+          sidebarCollapsed={sidebarCollapsed}
+          onToggleSidebar={onToggleSidebar}
+        />
+      );
+    }
+
     switch (scene.type) {
       case 'slide':
         if (scene.content.type !== 'slide') return <div>Invalid slide content</div>;
@@ -30,7 +66,7 @@ export function SceneRenderer({ scene, mode }: SceneRendererProps) {
       default:
         return <div>Unknown scene type</div>;
     }
-  }, [scene, mode]);
+  }, [scene, mode, t, sidebarCollapsed, onToggleSidebar]);
 
   return <div className="w-full h-full">{renderer}</div>;
 }

--- a/lib/edit/reorder-scenes.ts
+++ b/lib/edit/reorder-scenes.ts
@@ -1,0 +1,29 @@
+import type { Scene } from '@/lib/types/stage';
+
+/**
+ * Swap a scene with its previous (`'up'`) or next (`'down'`) sibling and
+ * preserve the original `order` values at each *position*. This is the
+ * subtle part: scenes can carry non-contiguous order values (e.g. 1, 2, 4)
+ * after deletions or insertions; if we kept each scene's own `order` after
+ * swapping, the persisted array would render in the wrong sequence on next
+ * load. Re-assigning by position keeps display-order == array-order.
+ *
+ * Returns the new array, or `null` when the move is a no-op (target out of
+ * range, or sceneId not found).
+ */
+export function reorderScene(
+  scenes: readonly Scene[],
+  sceneId: string,
+  direction: 'up' | 'down',
+): Scene[] | null {
+  const idx = scenes.findIndex((s) => s.id === sceneId);
+  if (idx < 0) return null;
+  const targetIdx = direction === 'up' ? idx - 1 : idx + 1;
+  if (targetIdx < 0 || targetIdx >= scenes.length) return null;
+
+  const swapped = scenes.slice();
+  [swapped[idx], swapped[targetIdx]] = [swapped[targetIdx], swapped[idx]];
+
+  const positionalOrders = scenes.map((s) => s.order);
+  return swapped.map((s, i) => ({ ...s, order: positionalOrders[i] }));
+}

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -148,6 +148,29 @@
     "editCourse": "تحرير الدورة",
     "doneEditing": "إنهاء التحرير"
   },
+  "edit": {
+    "proMode": "احترافي",
+    "undo": "تراجع",
+    "redo": "إعادة",
+    "title": "تحرير · {{type}}",
+    "unsupportedScene": "{{type}} غير قابل للتحرير بعد",
+    "sceneType": {
+      "slide": "شريحة",
+      "quiz": "اختبار",
+      "interactive": "تفاعلي",
+      "pbl": "PBL"
+    },
+    "sidebar": {
+      "pages": "الصفحات",
+      "addSlide": "إضافة شريحة",
+      "newSlide": "شريحة جديدة",
+      "expand": "توسيع الشريط الجانبي",
+      "collapse": "طي الشريط الجانبي",
+      "moveUp": "نقل لأعلى",
+      "moveDown": "نقل لأسفل",
+      "delete": "حذف"
+    }
+  },
   "classroomComplete": {
     "title": "اكتملت الدورة",
     "trailLabels": {

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -148,6 +148,29 @@
     "editCourse": "Edit course",
     "doneEditing": "Done editing"
   },
+  "edit": {
+    "proMode": "Pro",
+    "undo": "Undo",
+    "redo": "Redo",
+    "title": "Editing · {{type}}",
+    "unsupportedScene": "{{type}} is not editable yet",
+    "sceneType": {
+      "slide": "Slide",
+      "quiz": "Quiz",
+      "interactive": "Interactive",
+      "pbl": "PBL"
+    },
+    "sidebar": {
+      "pages": "Pages",
+      "addSlide": "Add slide",
+      "newSlide": "New slide",
+      "expand": "Expand sidebar",
+      "collapse": "Collapse sidebar",
+      "moveUp": "Move up",
+      "moveDown": "Move down",
+      "delete": "Delete"
+    }
+  },
   "classroomComplete": {
     "title": "Course complete",
     "trailLabels": {

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -148,6 +148,29 @@
     "editCourse": "コースを編集",
     "doneEditing": "編集を完了"
   },
+  "edit": {
+    "proMode": "プロモード",
+    "undo": "元に戻す",
+    "redo": "やり直し",
+    "title": "編集 · {{type}}",
+    "unsupportedScene": "{{type}}はまだ編集できません",
+    "sceneType": {
+      "slide": "スライド",
+      "quiz": "クイズ",
+      "interactive": "インタラクティブ",
+      "pbl": "PBL"
+    },
+    "sidebar": {
+      "pages": "ページ",
+      "addSlide": "スライドを追加",
+      "newSlide": "新しいスライド",
+      "expand": "サイドバーを展開",
+      "collapse": "サイドバーを折りたたむ",
+      "moveUp": "上に移動",
+      "moveDown": "下に移動",
+      "delete": "削除"
+    }
+  },
   "classroomComplete": {
     "title": "コース完了",
     "trailLabels": {

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -148,6 +148,29 @@
     "editCourse": "Редактировать курс",
     "doneEditing": "Завершить редактирование"
   },
+  "edit": {
+    "proMode": "Pro",
+    "undo": "Отменить",
+    "redo": "Повторить",
+    "title": "Редактирование · {{type}}",
+    "unsupportedScene": "{{type}} пока нельзя редактировать",
+    "sceneType": {
+      "slide": "Слайд",
+      "quiz": "Тест",
+      "interactive": "Интерактив",
+      "pbl": "PBL"
+    },
+    "sidebar": {
+      "pages": "Страницы",
+      "addSlide": "Добавить слайд",
+      "newSlide": "Новый слайд",
+      "expand": "Развернуть боковую панель",
+      "collapse": "Свернуть боковую панель",
+      "moveUp": "Поднять",
+      "moveDown": "Опустить",
+      "delete": "Удалить"
+    }
+  },
   "classroomComplete": {
     "title": "Курс завершён",
     "trailLabels": {

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -148,6 +148,29 @@
     "editCourse": "编辑课程",
     "doneEditing": "完成编辑"
   },
+  "edit": {
+    "proMode": "专业模式",
+    "undo": "撤销",
+    "redo": "重做",
+    "title": "编辑 · {{type}}",
+    "unsupportedScene": "{{type}}暂不支持编辑",
+    "sceneType": {
+      "slide": "幻灯片",
+      "quiz": "测验",
+      "interactive": "互动",
+      "pbl": "PBL"
+    },
+    "sidebar": {
+      "pages": "页面",
+      "addSlide": "新建幻灯片",
+      "newSlide": "新建幻灯片",
+      "expand": "展开侧栏",
+      "collapse": "折叠侧栏",
+      "moveUp": "上移",
+      "moveDown": "下移",
+      "delete": "删除"
+    }
+  },
   "classroomComplete": {
     "title": "课程完成",
     "trailLabels": {

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -163,7 +163,7 @@
     "sidebar": {
       "pages": "页面",
       "addSlide": "新建幻灯片",
-      "newSlide": "新建幻灯片",
+      "newSlide": "未命名幻灯片",
       "expand": "展开侧栏",
       "collapse": "折叠侧栏",
       "moveUp": "上移",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -148,6 +148,29 @@
     "editCourse": "編輯課程",
     "doneEditing": "完成編輯"
   },
+  "edit": {
+    "proMode": "專業模式",
+    "undo": "復原",
+    "redo": "重做",
+    "title": "編輯 · {{type}}",
+    "unsupportedScene": "{{type}}暫不支援編輯",
+    "sceneType": {
+      "slide": "投影片",
+      "quiz": "測驗",
+      "interactive": "互動",
+      "pbl": "PBL"
+    },
+    "sidebar": {
+      "pages": "頁面",
+      "addSlide": "新增投影片",
+      "newSlide": "新投影片",
+      "expand": "展開側欄",
+      "collapse": "摺疊側欄",
+      "moveUp": "上移",
+      "moveDown": "下移",
+      "delete": "刪除"
+    }
+  },
   "whiteboard": {
     "title": "互動白板",
     "open": "開啟白板",

--- a/tests/edit/reorder-scenes.test.ts
+++ b/tests/edit/reorder-scenes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+import { reorderScene } from '@/lib/edit/reorder-scenes';
+import { createDefaultSlide } from '@/lib/edit/slide-edit-elements';
+import type { Scene } from '@/lib/types/stage';
+
+function makeScene(id: string, order: number): Scene {
+  return {
+    id,
+    stageId: 'stage-1',
+    type: 'slide',
+    title: id,
+    order,
+    content: { type: 'slide', canvas: createDefaultSlide(`canvas-${id}`) },
+  };
+}
+
+describe('reorderScene', () => {
+  test('moves a scene up by swapping with its predecessor', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2), makeScene('c', 3)];
+
+    const reordered = reorderScene(scenes, 'b', 'up');
+
+    expect(reordered).not.toBeNull();
+    expect(reordered!.map((s) => s.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  test('moves a scene down by swapping with its successor', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2), makeScene('c', 3)];
+
+    const reordered = reorderScene(scenes, 'b', 'down');
+
+    expect(reordered).not.toBeNull();
+    expect(reordered!.map((s) => s.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('returns null when moving the first scene up', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2)];
+
+    expect(reorderScene(scenes, 'a', 'up')).toBeNull();
+  });
+
+  test('returns null when moving the last scene down', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2)];
+
+    expect(reorderScene(scenes, 'b', 'down')).toBeNull();
+  });
+
+  test('returns null when the sceneId is not found', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2)];
+
+    expect(reorderScene(scenes, 'missing', 'up')).toBeNull();
+    expect(reorderScene(scenes, 'missing', 'down')).toBeNull();
+  });
+
+  test('preserves positional order values, not per-scene values, after a swap', () => {
+    // Non-contiguous order values (simulates a previous delete that left
+    // sparse orders). After swapping a↔b, position 0 must keep order 1 and
+    // position 1 must keep order 4 — so the persisted display sequence stays
+    // {b, a, c}, not {a (order=4), b (order=1), c} which would re-sort to {b,
+    // a, c} only by accident.
+    const scenes = [makeScene('a', 1), makeScene('b', 4), makeScene('c', 7)];
+
+    const reordered = reorderScene(scenes, 'a', 'down')!;
+
+    expect(reordered.map((s) => s.id)).toEqual(['b', 'a', 'c']);
+    expect(reordered.map((s) => s.order)).toEqual([1, 4, 7]);
+  });
+
+  test('does not mutate the input array', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2)];
+    const snapshot = scenes.map((s) => ({ id: s.id, order: s.order }));
+
+    reorderScene(scenes, 'a', 'down');
+
+    expect(scenes.map((s) => ({ id: s.id, order: s.order }))).toEqual(snapshot);
+  });
+});

--- a/tests/edit/reorder-scenes.test.ts
+++ b/tests/edit/reorder-scenes.test.ts
@@ -74,4 +74,19 @@ describe('reorderScene', () => {
 
     expect(scenes.map((s) => ({ id: s.id, order: s.order }))).toEqual(snapshot);
   });
+
+  test('returns null in both directions for a single-element list', () => {
+    const scenes = [makeScene('a', 1)];
+
+    expect(reorderScene(scenes, 'a', 'up')).toBeNull();
+    expect(reorderScene(scenes, 'a', 'down')).toBeNull();
+  });
+
+  test('returns a new array reference (never the input)', () => {
+    const scenes = [makeScene('a', 1), makeScene('b', 2)];
+
+    const reordered = reorderScene(scenes, 'a', 'down');
+
+    expect(reordered).not.toBe(scenes);
+  });
 });


### PR DESCRIPTION
## Summary

Phase 1 sub-PR of the MAIC Editor v0 stack (tracking #560). Builds on
#561 (StageMode + sceneEditorRegistry + slide ops kernel) and ships the
scene-type-agnostic editor chrome plus a Pro toggle that drives the new
`'edit'` StageMode.

**No scene editor surfaces are registered yet** — the next sub-PR wires
up the slide surface. In this PR every scene type falls through to the
i18n `edit.unsupportedScene` placeholder, which is the verifiable
visible behavior.

## What ships

**Chrome** (`components/edit/EditShell/`, scene-type-agnostic):
- `EditShell` — Pitch-inspired layout: top `CommandBar`, full-bleed
  canvas, selection-contextual `FloatingToolbar`, optional `HintRail`.
  No fixed right inspector — properties will live in toolbar popovers
  (deferred to a later PR).
- `CommandBar` — undo/redo + sidebar toggle on the left, insert
  palette in the center, command list on the right. Reads everything
  from whatever `SurfaceState` the registered surface returns.
- `FloatingToolbar` — selection-contextual mini-bar with grouped
  actions and inline popover slots.
- `HintRail` — reserved AI inline-coach surface. Renders nothing
  until a surface emits hints; layout slot wired so future PRs don't
  restructure the shell.

**EditModeSidebar** (`components/edit/EditModeSidebar.tsx`):
- Distinct from playback's `SceneSidebar`: lists only real scenes (no
  completion-page entry), with per-page select / delete / reorder and
  a footer "+ Add slide". Add-slide is hardcoded to slide (only
  addable scene type in Phase 1); chrome dispatch itself is
  type-agnostic via the registry.

**Pro toggle** (`components/header.tsx`):
- Optional `mode` / `canEdit` / `onToggleEditMode` props. Surfaces the
  `stage.editCourse` / `stage.doneEditing` placeholders shipped in
  #561.
- `canEdit` reuses the same `isCurrentSceneEditable` predicate as the
  auto-exit effect in `Stage`, so the toggle's disabled state and the
  auto-exit are in lock-step — no click ever lands on a scene that
  would immediately auto-exit.

**Stage wiring** (`components/stage.tsx`):
- `handleToggleEditMode` tears down any live session (ends chat
  session, aborts ongoing discussion, stops the PlaybackEngine, cleans
  up discussion TTS, resets per-scene state) before entering edit
  mode, so the user lands on a quiet canvas.
- Sidebar swaps to `EditModeSidebar` while in edit mode; `ChatArea`
  slides out via `AnimatePresence` for a full-width canvas; canvas
  toolbar is hidden in edit mode.

**SceneRenderer fallback** (`components/stage/scene-renderer.tsx`):
- In edit mode, resolves a surface via `sceneEditorRegistry`; if none
  is registered, renders an i18n `edit.unsupportedScene` placeholder.
  With no surfaces registered in this PR, every scene type falls
  through to this branch.

**Helper** (`lib/edit/reorder-scenes.ts`):
- `reorderScene(scenes, sceneId, direction)` extracts the
  swap-and-preserve-positional-orders logic from `EditModeSidebar`.
  The "preserve positional \`order\` values, not per-scene values"
  twist matters because deletions can leave non-contiguous orders;
  without it, the persisted display order drifts on reload.
  Unit-tested with sparse \`order\` inputs to lock down that behavior.

**i18n** (`lib/i18n/locales/*.json` × 6):
- New \`edit.*\` block scoped to keys this PR's components reference:
  \`proMode\`, \`undo\`, \`redo\`, \`title\`, \`unsupportedScene\`,
  \`sceneType.{slide,quiz,interactive,pbl}\`,
  \`sidebar.{pages,addSlide,newSlide,expand,collapse,moveUp,moveDown,delete}\`.
  Surface-specific keys (insert/actions/sections/fields/layer/align/
  inspector) deferred to the slide-surface PR.

## Out of scope (next PRs)

- Scene editor surfaces (slide first) and their
  \`sceneEditorRegistry.register(...)\` calls.
- Inspector keys + popovers; \`slide-renderer/Editor/Canvas/*\`
  edit-mode integration.

## Test plan

- [x] \`pnpm check\` (prettier) — green
- [x] \`pnpm lint\` — 0 new warnings (7 pre-existing)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`pnpm check:i18n-keys\` — 6 locales aligned
- [x] \`pnpm test\` — 381/381 passing (+7 new \`reorder-scenes\` tests)
- [x] \`pnpm build\` — green
- [ ] Manual: toggle Pro from header → sidebar swaps to
      \`EditModeSidebar\`, \`ChatArea\` slides out, canvas shows
      \`edit.unsupportedScene\` placeholder for every scene type. Toggle
      off → returns to playback view.