### PR TITLE
fix: remove weak Lemonade recommended models

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -990,21 +990,6 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     icon: '/logos/lemonade.svg',
     models: [
       {
-        id: 'Qwen3.5-4B-GGUF',
-        name: 'Qwen3.5 4B GGUF',
-        capabilities: { streaming: true, tools: true, vision: true },
-      },
-      {
-        id: 'Qwen3-4B-GGUF',
-        name: 'Qwen3 4B GGUF',
-        capabilities: { streaming: true, tools: true, vision: false },
-      },
-      {
-        id: 'gpt-oss-20b',
-        name: 'GPT-OSS 20B',
-        capabilities: { streaming: true, tools: true, vision: false },
-      },
-      {
         id: 'Gemma-4-26B-A4B-it-GGUF',
         name: 'Gemma 4 26B A4B IT GGUF',
         capabilities: { streaming: true, tools: true, vision: false },

--- a/tests/ai/openai-provider.test.ts
+++ b/tests/ai/openai-provider.test.ts
@@ -147,7 +147,7 @@ describe('OpenAI provider defaults', () => {
     ],
     [
       'lemonade',
-      'Qwen3.5-4B-GGUF',
+      'Gemma-4-26B-A4B-it-GGUF',
       { mode: 'enabled', budgetTokens: 4096 },
       { chat_template_kwargs: { enable_thinking: true, thinking_budget: 4096 } },
     ],
@@ -160,7 +160,7 @@ describe('OpenAI provider defaults', () => {
   );
 
   it('disables Lemonade thinking by default for recognized local reasoning models', async () => {
-    const body = await captureInjectedRequestBody('lemonade', 'Qwen3.5-4B-GGUF');
+    const body = await captureInjectedRequestBody('lemonade', 'Gemma-4-26B-A4B-it-GGUF');
 
     expect(body).toMatchObject({
       chat_template_kwargs: { enable_thinking: false },

--- a/tests/ai/thinking-config.test.ts
+++ b/tests/ai/thinking-config.test.ts
@@ -153,7 +153,7 @@ describe('thinking config normalization', () => {
   });
 
   it('normalizes Lemonade reasoning models as disabled-by-default token budgets', () => {
-    const thinking = getThinking('lemonade', 'Qwen3.5-4B-GGUF');
+    const thinking = getThinking('lemonade', 'Gemma-4-26B-A4B-it-GGUF');
 
     expect(supportsConfigurableThinking(thinking)).toBe(true);
     expect(thinking?.requestAdapter).toBe('lemonade');


### PR DESCRIPTION
## Summary
Remove low-quality and redundant recommended models from the Lemonade provider list, and align Lemonade reasoning tests with the remaining supported recommended model.

## Related Issues
Closes #566

## Changes
- Remove `Qwen3.5 4B GGUF` from Lemonade recommended models
- Remove `Qwen3 4B GGUF` from Lemonade recommended models
- Remove `GPT-OSS 20B` from Lemonade recommended models
- Update Lemonade reasoning-related tests to use `Gemma-4-26B-A4B-it-GGUF`, which remains in the current recommended list

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification
### Steps to reproduce / test

1. Open provider settings for Lemonade in the frontend.
2. Inspect the recommended model list.
3. Confirm `Qwen3.5 4B GGUF`, `Qwen3 4B GGUF`, and `GPT-OSS 20B` are no longer shown.
4. Run `pnpm vitest run tests/ai/thinking-config.test.ts tests/ai/openai-provider.test.ts`.

### What you personally verified

- Frontend behavior was manually verified locally.
- Confirmed the code change updates the Lemonade recommended model list in `lib/ai/providers.ts`.
- Confirmed the Lemonade reasoning tests were updated to reference a remaining supported model.
- Verified `tests/ai/thinking-config.test.ts` passes.
- Verified `tests/ai/openai-provider.test.ts` passes.
- Did not run the full project validation suite in this environment.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings