### PR TITLE
[codex] fix server LLM model auto-selection

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1241,7 +1241,7 @@ export function getModel(config: ModelConfig): ModelWithInfo {
       // callLLM / streamLLM at call time.
       if (config.providerId !== 'openai') {
         const providerId = config.providerId;
-        openaiOptions.fetch = async (url: RequestInfo | URL, init?: RequestInit) => {
+        const compatFetch = async (url: RequestInfo | URL, init?: RequestInit) => {
           // Read thinking config from globalThis (set by thinking-context.ts)
           const thinkingCtx = (globalThis as Record<string, unknown>).__thinkingContext as
             | { getStore?: () => unknown }
@@ -1306,6 +1306,7 @@ export function getModel(config: ModelConfig): ModelWithInfo {
 
           return response;
         };
+        openaiOptions.fetch = compatFetch as typeof globalThis.fetch;
       }
 
       const openai = createOpenAI(openaiOptions);

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -1325,11 +1325,15 @@ export const useSettingsStore = create<SettingsState>()(
                 if (models?.length) recoveredVideoModel = models[0].id;
               }
 
+              const llmModels = validLLMProvider
+                ? (newProvidersConfig[validLLMProvider as ProviderId]?.models ?? [])
+                : [];
               const validLLMModel = validLLMProvider
-                ? validateModel(
-                    state.modelId,
-                    newProvidersConfig[validLLMProvider as ProviderId]?.models ?? [],
-                  )
+                ? validateModel(state.modelId, llmModels) ||
+                  (newProvidersConfig[validLLMProvider as ProviderId]?.isServerConfigured
+                    ? llmModels[0]?.id
+                    : '') ||
+                  ''
                 : '';
               const imageModels =
                 IMAGE_PROVIDERS[validImageProvider as ImageProviderId]?.models ?? [];

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -41,6 +41,18 @@ vi.mock('@/lib/ai/providers', () => ({
         { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },
       ],
     },
+    deepseek: {
+      id: 'deepseek',
+      name: 'DeepSeek',
+      type: 'openai',
+      defaultBaseUrl: 'https://api.deepseek.com/v1',
+      requiresApiKey: true,
+      icon: '/logos/deepseek.svg',
+      models: [
+        { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+        { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+      ],
+    },
   },
 }));
 
@@ -504,6 +516,23 @@ describe('fetchServerProviders — provider availability sync', () => {
     // gpt-4o is still available — selection should be preserved
     expect(store.getState().providerId).toBe('openai');
     expect(store.getState().modelId).toBe('gpt-4o');
+  });
+
+  it('selects the server LLM model when provider fallback replaces the default provider', async () => {
+    const store = await getStore();
+
+    expect(store.getState().providerId).toBe('openai');
+    expect(store.getState().modelId).toBe('');
+
+    mockServerResponse({
+      providers: {
+        deepseek: { models: ['deepseek-chat'] },
+      },
+    });
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().providerId).toBe('deepseek');
+    expect(store.getState().modelId).toBe('deepseek-chat');
   });
 
   // ---- Error handling ----


### PR DESCRIPTION
## Summary

Fix server-configured LLM startup so a provider selected by server sync also gets a usable default model when the current `modelId` is empty.

## Related Issues

Fixes #498

## Changes

- Auto-fill the first available model for a server-configured LLM provider when server sync falls back from an unusable default provider, matching the existing image/video recovery behavior.
- Add a regression test that mirrors the reported DeepSeek server-only setup: default `openai` provider, empty `modelId`, server response containing `deepseek` with `deepseek-chat`.
- Add a narrow TypeScript compatibility fix for the OpenAI-compatible `fetch` wrapper so `next build` passes with the current Next/TypeScript fetch type.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Start from a store state with `providerId: openai` and an empty `modelId`.
2. Mock `/api/server-providers` to return only `deepseek` with `models: ['deepseek-chat']`.
3. Run `fetchServerProviders()` and verify the store selects `providerId: deepseek` and `modelId: deepseek-chat`.
4. Run the full local validation commands listed below.

### What you personally verified

- RED: `pnpm vitest run tests/store/settings-server-sync.test.ts -t "selects the server LLM model"` failed before the fix with `expected '' to be 'deepseek-chat'`.
- GREEN: the same targeted test passed after the store sync change.
- `pnpm vitest run tests/store/settings-server-sync.test.ts` passed: 47 tests.
- `pnpm test` passed: 45 test files, 334 tests.
- `pnpm lint && pnpm check && pnpm build` passed. Lint reports 7 existing warnings and 0 errors.
- `pnpm exec playwright install chromium` was run because the local Playwright browser cache was missing.
- `CI=1 pnpm test:e2e` passed: 11 Playwright tests. I used CI mode because a pre-existing `next dev` process held `.next/dev/lock` on port 3000; CI mode starts the production server on 3002 without touching that process.

### Evidence

- [x] CI-style local checks passed (`pnpm lint && pnpm check && pnpm build`)
- [x] Unit/integration tests passed (`pnpm test`)
- [x] E2E tests passed (`CI=1 pnpm test:e2e`)
- [x] Manually verified the regression through a dedicated store sync test

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
