### PR TITLE
feat(ai): add Xiaomi MiMo Token Plan support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,9 +68,13 @@ TENCENT_BASE_URL=https://tokenhub.tencentmaas.com/v1
 TENCENT_MODELS=
 
 XIAOMI_API_KEY=
-# MIMO_* is also accepted as an alias.
+# MIMO_* is also accepted as an alias. Use tp-... keys only with Token Plan URLs.
 XIAOMI_BASE_URL=https://api.xiaomimimo.com/v1
-# Example: mimo-v2.5-pro,mimo-v2.5
+# Token Plan regional examples:
+# XIAOMI_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
+# XIAOMI_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1
+# XIAOMI_BASE_URL=https://token-plan-ams.xiaomimimo.com/v1
+# Example: mimo-v2.5-pro,mimo-v2-pro,mimo-v2.5,mimo-v2-omni,mimo-v2-flash
 XIAOMI_MODELS=
 
 # --- Ollama (Local Models) ---------------------------------------------------

--- a/README-zh.md
+++ b/README-zh.md
@@ -165,6 +165,16 @@ VIDEO_MINIMAX_API_KEY=...
 VIDEO_MINIMAX_BASE_URL=https://api.minimaxi.com
 ```
 
+小米 MiMo Token Plan 快速示例：
+
+```env
+MIMO_API_KEY=tp-...
+MIMO_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
+DEFAULT_MODEL=xiaomi:mimo-v2.5-pro
+```
+
+新加坡或欧洲 Token Plan 集群可分别使用 `https://token-plan-sgp.xiaomimimo.com/v1`、`https://token-plan-ams.xiaomimimo.com/v1`。
+
 智谱 GLM 快速示例：
 
 ```env

--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ VIDEO_MINIMAX_API_KEY=...
 VIDEO_MINIMAX_BASE_URL=https://api.minimaxi.com
 ```
 
+Xiaomi MiMo Token Plan quick example:
+
+```env
+MIMO_API_KEY=tp-...
+MIMO_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
+DEFAULT_MODEL=xiaomi:mimo-v2.5-pro
+```
+
+Use `https://token-plan-sgp.xiaomimimo.com/v1` or `https://token-plan-ams.xiaomimimo.com/v1` for the Singapore or Europe Token Plan clusters.
+
 GLM (Zhipu) quick examples:
 
 ```env

--- a/app/api/verify-model/route.ts
+++ b/app/api/verify-model/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from 'next/server';
-import { generateText } from 'ai';
 import { createLogger } from '@/lib/logger';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
 import { resolveModel } from '@/lib/server/resolve-model';
+import { callLLM } from '@/lib/ai/llm';
 const log = createLogger('Verify Model');
 
 export async function POST(req: NextRequest) {
@@ -34,11 +34,18 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Send a minimal test message
-    const { text } = await generateText({
-      model: languageModel,
-      prompt: 'Say "OK" if you can hear me.',
-    });
+    // Send a minimal test message. Use the unified wrapper so compatible
+    // providers can receive provider-specific request options.
+    const { text } = await callLLM(
+      {
+        model: languageModel,
+        prompt: 'Say "OK" if you can hear me.',
+        maxOutputTokens: 64,
+      },
+      'verify-model',
+      undefined,
+      { mode: 'disabled', enabled: false },
+    );
 
     return apiSuccess({
       message: 'Connection successful',

--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -333,7 +333,10 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('tencent-hunyuan', 'hy3-preview')]: hunyuanHy3Effort,
 
   [getModelMetadataKey('xiaomi', 'mimo-v2.5-pro')]: toggleCapability('xiaomi'),
+  [getModelMetadataKey('xiaomi', 'mimo-v2-pro')]: toggleCapability('xiaomi'),
   [getModelMetadataKey('xiaomi', 'mimo-v2.5')]: toggleCapability('xiaomi'),
+  [getModelMetadataKey('xiaomi', 'mimo-v2-omni')]: toggleCapability('xiaomi'),
+  [getModelMetadataKey('xiaomi', 'mimo-v2-flash')]: toggleCapability('xiaomi'),
 
   [getModelMetadataKey('lemonade', 'Qwen3-4B-GGUF')]: lemonadeToggleBudget,
   [getModelMetadataKey('lemonade', 'Qwen3.5-4B-GGUF')]: lemonadeToggleBudget,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -21,6 +21,8 @@
  * - https://siliconflow.cn/models
  * - https://siliconflow.cn/pricing
  * - https://www.volcengine.com/docs/82379/1330310
+ * - https://platform.xiaomimimo.com/static/docs/pricing.md
+ * - https://platform.xiaomimimo.com/static/docs/tokenplan/quick-access.md
  */
 
 import { createOpenAI } from '@ai-sdk/openai';
@@ -911,12 +913,44 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     name: 'Xiaomi MiMo',
     type: 'openai',
     defaultBaseUrl: 'https://api.xiaomimimo.com/v1',
+    // Token Plan endpoints use the same OpenAI-compatible path with regional hosts.
+    alternateBaseUrls: [
+      { label: 'settings.baseUrlRegion.xiaomiPayg', url: 'https://api.xiaomimimo.com/v1' },
+      {
+        label: 'settings.baseUrlRegion.xiaomiTokenPlanCN',
+        url: 'https://token-plan-cn.xiaomimimo.com/v1',
+      },
+      {
+        label: 'settings.baseUrlRegion.xiaomiTokenPlanSGP',
+        url: 'https://token-plan-sgp.xiaomimimo.com/v1',
+      },
+      {
+        label: 'settings.baseUrlRegion.xiaomiTokenPlanEU',
+        url: 'https://token-plan-ams.xiaomimimo.com/v1',
+      },
+    ],
     requiresApiKey: true,
     icon: '/logos/xiaomi.svg',
     models: [
       {
         id: 'mimo-v2.5-pro',
         name: 'MiMo V2.5 Pro',
+        contextWindow: 1048576,
+        outputWindow: 131072,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: false,
+          thinking: {
+            toggleable: true,
+            budgetAdjustable: false,
+            defaultEnabled: true,
+          },
+        },
+      },
+      {
+        id: 'mimo-v2-pro',
+        name: 'MiMo V2 Pro',
         contextWindow: 1048576,
         outputWindow: 131072,
         capabilities: {
@@ -939,6 +973,38 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
           streaming: true,
           tools: true,
           vision: true,
+          thinking: {
+            toggleable: true,
+            budgetAdjustable: false,
+            defaultEnabled: true,
+          },
+        },
+      },
+      {
+        id: 'mimo-v2-omni',
+        name: 'MiMo V2 Omni',
+        contextWindow: 262144,
+        outputWindow: 131072,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: true,
+          thinking: {
+            toggleable: true,
+            budgetAdjustable: false,
+            defaultEnabled: true,
+          },
+        },
+      },
+      {
+        id: 'mimo-v2-flash',
+        name: 'MiMo V2 Flash',
+        contextWindow: 262144,
+        outputWindow: 65536,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: false,
           thinking: {
             toggleable: true,
             budgetAdjustable: false,
@@ -1241,7 +1307,7 @@ export function getModel(config: ModelConfig): ModelWithInfo {
       // callLLM / streamLLM at call time.
       if (config.providerId !== 'openai') {
         const providerId = config.providerId;
-        openaiOptions.fetch = async (url: RequestInfo | URL, init?: RequestInit) => {
+        const compatFetch = async (url: RequestInfo | URL, init?: RequestInit) => {
           // Read thinking config from globalThis (set by thinking-context.ts)
           const thinkingCtx = (globalThis as Record<string, unknown>).__thinkingContext as
             | { getStore?: () => unknown }
@@ -1306,6 +1372,7 @@ export function getModel(config: ModelConfig): ModelWithInfo {
 
           return response;
         };
+        openaiOptions.fetch = compatFetch as typeof globalThis.fetch;
       }
 
       const openai = createOpenAI(openaiOptions);

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -526,7 +526,11 @@
     "apiHost": "العنوان الأساسي",
     "baseUrlRegion": {
       "china": "الصين",
-      "international": "دولي"
+      "international": "دولي",
+      "xiaomiPayg": "الدفع حسب الاستخدام",
+      "xiaomiTokenPlanCN": "Token Plan الصين",
+      "xiaomiTokenPlanSGP": "Token Plan سنغافورة",
+      "xiaomiTokenPlanEU": "Token Plan أوروبا"
     },
     "requestUrl": "عنوان الطلب",
     "models": "النماذج",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -526,7 +526,11 @@
     "apiHost": "Base URL",
     "baseUrlRegion": {
       "china": "China",
-      "international": "International"
+      "international": "International",
+      "xiaomiPayg": "Pay-as-you-go",
+      "xiaomiTokenPlanCN": "Token Plan CN",
+      "xiaomiTokenPlanSGP": "Token Plan SG",
+      "xiaomiTokenPlanEU": "Token Plan EU"
     },
     "requestUrl": "Request URL",
     "models": "Models",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -526,7 +526,11 @@
     "apiHost": "ベースURL",
     "baseUrlRegion": {
       "china": "中国",
-      "international": "国際"
+      "international": "国際",
+      "xiaomiPayg": "従量課金",
+      "xiaomiTokenPlanCN": "Token Plan 中国",
+      "xiaomiTokenPlanSGP": "Token Plan シンガポール",
+      "xiaomiTokenPlanEU": "Token Plan 欧州"
     },
     "requestUrl": "リクエストURL",
     "models": "モデル",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -526,7 +526,11 @@
     "apiHost": "Base URL",
     "baseUrlRegion": {
       "china": "Китай",
-      "international": "Международный"
+      "international": "Международный",
+      "xiaomiPayg": "Оплата по факту",
+      "xiaomiTokenPlanCN": "Token Plan Китай",
+      "xiaomiTokenPlanSGP": "Token Plan Сингапур",
+      "xiaomiTokenPlanEU": "Token Plan Европа"
     },
     "requestUrl": "URL запроса",
     "models": "Модели",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -526,7 +526,11 @@
     "apiHost": "Base URL",
     "baseUrlRegion": {
       "china": "国内站",
-      "international": "国际站"
+      "international": "国际站",
+      "xiaomiPayg": "按量付费",
+      "xiaomiTokenPlanCN": "Token Plan 中国",
+      "xiaomiTokenPlanSGP": "Token Plan 新加坡",
+      "xiaomiTokenPlanEU": "Token Plan 欧洲"
     },
     "requestUrl": "请求地址",
     "models": "模型",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -942,7 +942,11 @@
     "asrResultPlaceholder": "錄音完成後將顯示辨識結果",
     "baseUrlRegion": {
       "china": "中國",
-      "international": "國際"
+      "international": "國際",
+      "xiaomiPayg": "按量付費",
+      "xiaomiTokenPlanCN": "Token Plan 中國",
+      "xiaomiTokenPlanSGP": "Token Plan 新加坡",
+      "xiaomiTokenPlanEU": "Token Plan 歐洲"
     },
     "browserTTSNoVoices": "目前瀏覽器沒有可用的 TTS 聲音",
     "browserTTSNotSupported": "瀏覽器不支援語音合成 API",

--- a/tests/ai/xiaomi-provider.test.ts
+++ b/tests/ai/xiaomi-provider.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProvider } from '@/lib/ai/providers';
+import { supportsConfigurableThinking } from '@/lib/ai/thinking-config';
+
+describe('Xiaomi MiMo provider defaults', () => {
+  it('exposes pay-as-you-go and Token Plan OpenAI-compatible endpoints', () => {
+    const provider = getProvider('xiaomi');
+
+    expect(provider?.defaultBaseUrl).toBe('https://api.xiaomimimo.com/v1');
+    expect(provider?.alternateBaseUrls).toEqual([
+      { label: 'settings.baseUrlRegion.xiaomiPayg', url: 'https://api.xiaomimimo.com/v1' },
+      {
+        label: 'settings.baseUrlRegion.xiaomiTokenPlanCN',
+        url: 'https://token-plan-cn.xiaomimimo.com/v1',
+      },
+      {
+        label: 'settings.baseUrlRegion.xiaomiTokenPlanSGP',
+        url: 'https://token-plan-sgp.xiaomimimo.com/v1',
+      },
+      {
+        label: 'settings.baseUrlRegion.xiaomiTokenPlanEU',
+        url: 'https://token-plan-ams.xiaomimimo.com/v1',
+      },
+    ]);
+  });
+
+  it('matches the supported MiMo text and multimodal model catalog', () => {
+    const modelIds = getProvider('xiaomi')?.models.map((model) => model.id) ?? [];
+
+    expect(modelIds).toEqual([
+      'mimo-v2.5-pro',
+      'mimo-v2-pro',
+      'mimo-v2.5',
+      'mimo-v2-omni',
+      'mimo-v2-flash',
+    ]);
+  });
+
+  it('marks MiMo reasoning models as configurable thinking models', () => {
+    const models = getProvider('xiaomi')?.models ?? [];
+
+    for (const model of models) {
+      expect(model.capabilities?.thinking?.requestAdapter).toBe('xiaomi');
+      expect(supportsConfigurableThinking(model.capabilities?.thinking)).toBe(true);
+    }
+  });
+});

--- a/tests/api/verify-model.test.ts
+++ b/tests/api/verify-model.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  resolveModel: vi.fn(),
+  callLLM: vi.fn(),
+}));
+
+vi.mock('@/lib/server/resolve-model', () => ({
+  resolveModel: mocks.resolveModel,
+}));
+
+vi.mock('@/lib/ai/llm', () => ({
+  callLLM: mocks.callLLM,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+async function postVerifyModel(body: Record<string, unknown>) {
+  const { POST } = await import('@/app/api/verify-model/route');
+  const request = new Request('http://localhost/api/verify-model', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return POST(request as unknown as NextRequest);
+}
+
+describe('POST /api/verify-model', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.resolveModel.mockReset();
+    mocks.callLLM.mockReset();
+    mocks.resolveModel.mockResolvedValue({ model: { id: 'language-model' } });
+    mocks.callLLM.mockResolvedValue({ text: 'OK' });
+  });
+
+  it('rejects requests without a model name', async () => {
+    const res = await postVerifyModel({});
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json).toMatchObject({
+      success: false,
+      errorCode: 'MISSING_REQUIRED_FIELD',
+    });
+    expect(mocks.resolveModel).not.toHaveBeenCalled();
+    expect(mocks.callLLM).not.toHaveBeenCalled();
+  });
+
+  it('uses the unified LLM wrapper with thinking disabled for connection checks', async () => {
+    const res = await postVerifyModel({
+      model: 'xiaomi:mimo-v2.5-pro',
+      apiKey: 'tp-test',
+      baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+      providerType: 'openai',
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({
+      success: true,
+      message: 'Connection successful',
+      response: 'OK',
+    });
+    expect(mocks.resolveModel).toHaveBeenCalledWith({
+      modelString: 'xiaomi:mimo-v2.5-pro',
+      apiKey: 'tp-test',
+      baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+      providerType: 'openai',
+    });
+    expect(mocks.callLLM).toHaveBeenCalledWith(
+      {
+        model: { id: 'language-model' },
+        prompt: 'Say "OK" if you can hear me.',
+        maxOutputTokens: 64,
+      },
+      'verify-model',
+      undefined,
+      { mode: 'disabled', enabled: false },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Add Xiaomi MiMo Token Plan support to the built-in Xiaomi provider and make the model connection check use the same unified LLM wrapper as normal generation.

## Related Issues

N/A

## Changes

- Added Xiaomi MiMo Token Plan OpenAI-compatible Base URL presets for China, Singapore, and Europe.
- Expanded the built-in Xiaomi MiMo model catalog to include `mimo-v2-pro`, `mimo-v2-omni`, and `mimo-v2-flash` alongside the existing V2.5 models.
- Added thinking metadata for the added MiMo models.
- Updated `/api/verify-model` to call through `callLLM` with thinking disabled, so OpenAI-compatible provider request adapters are applied during connection tests.
- Added Xiaomi provider and verify-model route tests.
- Documented MiMo Token Plan setup in `.env.example`, `README.md`, and `README-zh.md`, with locale labels for the new Base URL chips.
- Fixed the OpenAI-compatible fetch wrapper assignment for Next/TypeScript build compatibility.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Configure Xiaomi Token Plan credentials with `MIMO_API_KEY=tp-...`, `MIMO_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1`, and `DEFAULT_MODEL=xiaomi:mimo-v2.5-pro`.
2. Use the settings model connection test or any server-side LLM call path using `xiaomi:mimo-v2.5-pro`.
3. Confirm the model returns text successfully and the Token Plan endpoint is used.

### What I personally verified

- `pnpm vitest run tests/ai/xiaomi-provider.test.ts tests/api/verify-model.test.ts tests/ai/openai-provider.test.ts tests/server/provider-config.test.ts tests/ai/thinking-config.test.ts`
  - Result: 5 test files passed, 62 tests passed.
- `pnpm test`
  - Result: 47 test files passed, 338 tests passed.
- `pnpm check:i18n-keys`
  - Result: passed for 6 locale files.
- `pnpm check`
  - Result: all matched files use Prettier style.
- `pnpm lint`
  - Result: 0 errors, 7 existing warnings in unrelated files.
- `pnpm build`
  - Result: compiled successfully; Next emitted existing workspace-root and middleware convention warnings.
- Real Xiaomi MiMo Token Plan smoke via `getModel` + `callLLM` against `https://token-plan-cn.xiaomimimo.com/v1`, using `mimo-v2.5-pro` and thinking disabled.
  - Sanitized result: `text=MIMO_OK`, `inputTokens=263`, `outputTokens=4`, `reasoningTokens=0`.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
