### PR TITLE
feat: add Gemini 3.5 Flash

### DIFF
--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -247,6 +247,10 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('anthropic', 'claude-sonnet-4-5')]: anthropicManualEffort,
   [getModelMetadataKey('anthropic', 'claude-haiku-4-5')]: anthropicBudget,
 
+  [getModelMetadataKey('google', 'gemini-3.5-flash')]: levelCapability(
+    ['minimal', 'low', 'medium', 'high'],
+    'high',
+  ),
   [getModelMetadataKey('google', 'gemini-3.1-pro-preview')]: levelCapability(
     ['minimal', 'low', 'medium', 'high'],
     'high',

--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -249,7 +249,7 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
 
   [getModelMetadataKey('google', 'gemini-3.5-flash')]: levelCapability(
     ['minimal', 'low', 'medium', 'high'],
-    'high',
+    'medium',
   ),
   [getModelMetadataKey('google', 'gemini-3.1-pro-preview')]: levelCapability(
     ['minimal', 'low', 'medium', 'high'],

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -247,6 +247,22 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     icon: '/logos/gemini.svg',
     models: [
       {
+        id: 'gemini-3.5-flash',
+        name: 'Gemini 3.5 Flash',
+        contextWindow: 1048576,
+        outputWindow: 65536,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: true,
+          thinking: {
+            toggleable: false,
+            budgetAdjustable: true,
+            defaultEnabled: true,
+          },
+        },
+      },
+      {
         id: 'gemini-3.1-pro-preview',
         name: 'Gemini 3.1 Pro Preview',
         contextWindow: 1048576,


### PR DESCRIPTION
Adds `gemini-3.5-flash` to the Google provider (placed at the top of the model list) and registers matching `levelCapability` metadata, mirroring `gemini-3-flash-preview`.

Closes #583