### PR TITLE
fix: add defensive checks in ChartElement to prevent crash on malformed chart data

### DIFF
--- a/components/slide-renderer/components/element/ChartElement/chartOption.ts
+++ b/components/slide-renderer/components/element/ChartElement/chartOption.ts
@@ -59,6 +59,11 @@ export const getChartOption = ({
       }
     : {};
 
+  // Defensive check: ensure series is a non-empty array before processing
+  if (!Array.isArray(data?.series) || data.series.length === 0) {
+    return null;
+  }
+
   const legend =
     data.series.length > 1
       ? {
@@ -168,6 +173,8 @@ export const getChartOption = ({
     };
   }
   if (type === 'pie') {
+    const series0 = data.series[0];
+    if (!Array.isArray(series0)) return null;
     return {
       color: themeColors,
       textStyle,
@@ -177,7 +184,7 @@ export const getChartOption = ({
       },
       series: [
         {
-          data: data.series[0].map((item, index) => ({
+          data: series0.map((item, index) => ({
             value: item,
             name: data.labels[index],
           })),
@@ -205,6 +212,8 @@ export const getChartOption = ({
     };
   }
   if (type === 'ring') {
+    const series0 = data.series[0];
+    if (!Array.isArray(series0)) return null;
     return {
       color: themeColors,
       textStyle,
@@ -214,7 +223,7 @@ export const getChartOption = ({
       },
       series: [
         {
-          data: data.series[0].map((item, index) => ({
+          data: series0.map((item, index) => ({
             value: item,
             name: data.labels[index],
           })),
@@ -309,10 +318,12 @@ export const getChartOption = ({
     };
   }
   if (type === 'scatter') {
+    const series0 = data.series[0];
+    if (!Array.isArray(series0)) return null;
     const formatedData = [];
-    for (let i = 0; i < data.series[0].length; i++) {
-      const x = data.series[0][i];
-      const y = data.series[1] ? data.series[1][i] : x;
+    for (let i = 0; i < series0.length; i++) {
+      const x = series0[i];
+      const y = data.series[1]?.[i] ?? x;
       formatedData.push([x, y]);
     }
 


### PR DESCRIPTION
## Summary

Fixes #576

When LLM generates incomplete chart data (e.g. missing `series` array), `ChartElement` crashes with `Cannot read properties of undefined (reading 'length')` because `pie`, `ring`, and `scatter` chart types directly access `data.series[0]` without validation. This makes the entire classroom page unusable.

## Changes

- **Top-level guard**: return `null` if `data.series` is not a non-empty array (covers all chart types)
- **Per-type guards**: validate `data.series[0]` is an array before accessing it in `pie`, `ring`, and `scatter` branches
- **Optional chaining**: use `?.` for scatter's `data.series[1]` access

The caller (`Chart.tsx`) already handles `null` return gracefully (`if (option)` check at line 81), so invalid chart data now silently skips rendering instead of crashing the entire classroom.

## Test Plan

- [x] Verified all `data.series[0]` direct accesses in `chartOption.ts` are now guarded
- [ ] Reproduce with the steps from #576 (generate classroom with DeepSeek, trigger malformed chart)
- [ ] Verify classroom page remains functional when a chart has invalid data