### PR TITLE
fix: remove defaultBaseUrl fallback in TTS availability check

### DIFF
--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -134,8 +134,7 @@ export function getAvailableProvidersWithVoices(
       !config.requiresApiKey &&
       !!(
         providerConfig?.serverBaseUrl?.trim() ||
-        providerConfig?.baseUrl?.trim() ||
-        config.defaultBaseUrl
+        providerConfig?.baseUrl?.trim()
       );
     const isLocalVoxCPM =
       providerId === VOXCPM_TTS_PROVIDER_ID &&

--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -132,10 +132,7 @@ export function getAvailableProvidersWithVoices(
     const isServerConfigured = providerConfig?.isServerConfigured === true;
     const isKeylessLocalProvider =
       !config.requiresApiKey &&
-      !!(
-        providerConfig?.serverBaseUrl?.trim() ||
-        providerConfig?.baseUrl?.trim()
-      );
+      !!(providerConfig?.serverBaseUrl?.trim() || providerConfig?.baseUrl?.trim());
     const isLocalVoxCPM =
       providerId === VOXCPM_TTS_PROVIDER_ID &&
       !!(providerConfig?.serverBaseUrl?.trim() || providerConfig?.baseUrl?.trim());

--- a/tests/audio/voice-resolver.test.ts
+++ b/tests/audio/voice-resolver.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getAvailableProvidersWithVoices } from '@/lib/audio/voice-resolver';
+
+describe('getAvailableProvidersWithVoices keyless availability (#574)', () => {
+  it('excludes a keyless provider when only defaultBaseUrl exists (no user-configured URL)', () => {
+    // lemonade-tts is keyless and ships defaultBaseUrl; with no user config it must not be listed
+    const providers = getAvailableProvidersWithVoices({});
+    expect(providers.map((p) => p.providerId)).not.toContain('lemonade-tts');
+  });
+
+  it('excludes a keyless provider whose config has neither serverBaseUrl nor baseUrl', () => {
+    const providers = getAvailableProvidersWithVoices({
+      'lemonade-tts': { enabled: true },
+    });
+    expect(providers.map((p) => p.providerId)).not.toContain('lemonade-tts');
+  });
+
+  it('includes a keyless provider when the user sets serverBaseUrl', () => {
+    const providers = getAvailableProvidersWithVoices({
+      'lemonade-tts': { serverBaseUrl: 'http://localhost:13305/v1' },
+    });
+    expect(providers.map((p) => p.providerId)).toContain('lemonade-tts');
+  });
+
+  it('includes a keyless provider when the user sets baseUrl', () => {
+    const providers = getAvailableProvidersWithVoices({
+      'lemonade-tts': { baseUrl: 'http://localhost:13305/v1' },
+    });
+    expect(providers.map((p) => p.providerId)).toContain('lemonade-tts');
+  });
+
+  it('ignores whitespace-only URLs for keyless providers', () => {
+    const providers = getAvailableProvidersWithVoices({
+      'lemonade-tts': { serverBaseUrl: '   ', baseUrl: '' },
+    });
+    expect(providers.map((p) => p.providerId)).not.toContain('lemonade-tts');
+  });
+
+  it('still includes key-based providers via apiKey', () => {
+    const providers = getAvailableProvidersWithVoices({
+      'openai-tts': { apiKey: 'sk-test' },
+    });
+    expect(providers.map((p) => p.providerId)).toContain('openai-tts');
+  });
+});


### PR DESCRIPTION
﻿## Summary
Fixes #574 — TTS provider availability check produces false positives for local keyless providers.

## Problem
The `isKeylessLocalProvider` condition in `lib/audio/voice-resolver.ts` included `config.defaultBaseUrl` as a fallback. This caused local keyless TTS providers (VoxCPM, Lemonade) to be marked as "available" even when the user had not deployed the corresponding server. Agents were then assigned to unreachable providers, resulting in silent TTS failures (connection refused) for some agents while others worked fine.

## Root Cause
`lib/audio/voice-resolver.ts` lines 133-139 — the `isKeylessLocalProvider` check unconditionally accepted `config.defaultBaseUrl` as a valid URL, ignoring whether the user had actually deployed and configured the server.

## Changes
- **1 file changed**: `lib/audio/voice-resolver.ts`
- Removed `config.defaultBaseUrl` from the `isKeylessLocalProvider` availability check
- Local keyless providers are now only available when the user explicitly sets `serverBaseUrl` or `baseUrl` in their configuration

## Test Plan
1. Deploy only Lemonade TTS server (do not deploy VoxCPM)
2. Do not configure VoxCPM base URL in settings
3. Generate a classroom
4. ✅ All agent voices should use providers with actual configured URLs (no VoxCPM)
5. ✅ Previously broken agents should no longer be assigned to unreachable providers

Related to #587 — its logs show `lemonade-tts: fetch failed`, consistent with this fix's symptom. Worth asking the reporter to verify whether Lemonade was explicitly configured after this merges.
