### PR TITLE
fix: select newly added model after saving in settings

### DIFF
--- a/components/settings/index.tsx
+++ b/components/settings/index.tsx
@@ -235,6 +235,7 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
   // Store actions
   const setProviderConfig = useSettingsStore((state) => state.setProviderConfig);
   const setProvidersConfig = useSettingsStore((state) => state.setProvidersConfig);
+  const setModel = useSettingsStore((state) => state.setModel);
   const setTTSProvider = useSettingsStore((state) => state.setTTSProvider);
   const setASRProvider = useSettingsStore((state) => state.setASRProvider);
 
@@ -452,6 +453,12 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
       newModels[modelIndex] = model;
     }
     setProviderConfig(pid, { models: newModels });
+    // #542: Explicitly select the model so the global (providerId, modelId)
+    // pair stays consistent even when the provider has no API key yet.
+    // setProviderConfig's resolveLLMSelection handles provider switching,
+    // but a fresh provider with models but no credentials is State A;
+    // explicitly selecting the model here keeps the intent unambiguous.
+    setModel(pid, model.id);
     setShowModelDialog(false);
     setEditingModel(null);
   };


### PR DESCRIPTION
## Summary

Fixes #542 — After configuring a new provider (e.g. DeepSeek) and adding a model, the landing page still shows "Set up model" and prevents entering the classroom.

## Root Cause

When a user adds a custom model in settings via `handleSaveModel`, the `setProviderConfig` action calls `resolveLLMSelection`. If the provider has models but no API key yet, it's classified as State A (not usable), leaving both `providerId` and `modelId` empty. Subsequent API key configuration correctly resolves the provider but selects the first built-in model instead of the user's custom model. This can cause confusion and a perceived broken state.

## Changes

1 file: `components/settings/index.tsx` (+2 lines of logic, +5 lines of comment)

- Added `setModel` hook import in SettingsDialog
- In `handleSaveModel`, after writing models to the store, explicitly call `setModel(providerId, modelId)` to select the newly added/edited model
- This preserves the user's explicit model choice regardless of credential state

## Test Plan

1. Fresh install, open settings, select DeepSeek provider
2. Add a custom model (e.g. `deepseek-chat`) WITHOUT entering API key first
3. Enter API key, close settings
4. Landing page should show model selector with the custom model selected
5. Enter a requirement and click Enter Classroom — should navigate to generation preview
6. Also verify editing an existing model works correctly