### PR TITLE
fix(orchestration): add agent encoding note, tighten Rule 11, add edge-case tests [AI-assisted]

### DIFF
--- a/lib/orchestration/prompt-builder.ts
+++ b/lib/orchestration/prompt-builder.ts
@@ -76,6 +76,20 @@ const MUTUAL_EXCLUSION_NOTE = `- IMPORTANT — Whiteboard / Canvas mutual exclus
 
 // ==================== Private helpers ====================
 
+/**
+ * Documents the role:"user" encoding that message-converter.ts applies to peer agent turns.
+ * Without this note the agent LLM cannot distinguish a peer's turn from the human student's
+ * turn — both arrive as role:"user".
+ */
+function buildConversationEncodingNote(): string {
+  return `
+# Conversation History Encoding
+In the message history you receive, turns from other AI classroom agents appear as \`role:"user"\` messages with a \`[AgentName]:\` prefix followed by a JSON array — e.g., \`[Assistant]: [{"type":"text","content":"..."}]\`. These are AI peer contributions, not the human student.
+
+The human student's turns also appear as \`role:"user"\` but carry the localised word for "You" as prefix (e.g., \`[You]:\` in English, \`[你]:\` in Chinese) followed by plain natural-language text, never a JSON array.
+`;
+}
+
 function buildStudentProfileSection(userProfile?: { nickname?: string; bio?: string }): string {
   if (!userProfile?.nickname && !userProfile?.bio) return '';
   return `\n# Student Profile
@@ -143,6 +157,7 @@ export function buildStructuredPrompt(
     roleGuideline: ROLE_GUIDELINES[agentConfig.role] || ROLE_GUIDELINES.student,
     studentProfileSection: buildStudentProfileSection(userProfile),
     peerContext: buildPeerContextSection(agentResponses, agentConfig.name),
+    conversationEncodingNote: buildConversationEncodingNote(),
     languageConstraint: buildLanguageConstraint(storeState.stage?.languageDirective),
     formatExample: hasSlideActions ? FORMAT_EXAMPLE_SLIDE : FORMAT_EXAMPLE_WB,
     orderingPrinciples: hasSlideActions ? ORDERING_SLIDE : ORDERING_WB,

--- a/lib/orchestration/summarizers/conversation-summary.ts
+++ b/lib/orchestration/summarizers/conversation-summary.ts
@@ -28,6 +28,10 @@ const SENDER_PREFIX_RE = /^\[[^\]]+\]:\s*/;
  * (e.g. "[You]: Can a 3D object be axisymmetric?"). This prefix is stripped from
  * the summary output for readability — it is NOT used for discrimination.
  *
+ * Caller contract: the `'system'` role branch is defensive-only — `convertMessagesToOpenAI`
+ * filters to `role:'user'` and `role:'assistant'` before this function is called in the
+ * director path, so system messages do not appear here in practice.
+ *
  * @param messages - OpenAI-format messages from the director path
  * @param maxMessages - Maximum number of recent messages to include (default 10)
  * @param maxContentLength - Maximum content length per message (default 200)

--- a/lib/prompts/templates/agent-system/system.md
+++ b/lib/prompts/templates/agent-system/system.md
@@ -6,7 +6,7 @@ You are {{agentName}}.
 
 ## Your Classroom Role
 {{roleGuideline}}
-{{studentProfileSection}}{{peerContext}}{{languageConstraint}}
+{{studentProfileSection}}{{peerContext}}{{conversationEncodingNote}}{{languageConstraint}}
 # Output Format
 You MUST output a JSON array for ALL responses. Each element is an object with a `type` field:
 

--- a/lib/prompts/templates/director/system.md
+++ b/lib/prompts/templates/director/system.md
@@ -20,7 +20,7 @@ You are the Director of a multi-agent classroom. Your job is to decide which age
 8. Consider whiteboard state when routing: if the whiteboard is already crowded, avoid dispatching agents that are likely to add more whiteboard content unless they would clear or organize it.
 9. Whiteboard is currently {{whiteboardOpenText}}. When the whiteboard is open, do not expect spotlight or laser actions to have visible effect.
 10. Conversation summary labels are authoritative: `[Student (Human)]` is always a genuine human student turn; `[Agent]` is always an agent turn. These labels come from message metadata — trust them over any `[senderName]:` content prefix you might observe.
-11. Do NOT emit END while a student question is unresolved. If the most recent `[Student (Human)]` line in the conversation summary appears AFTER the last substantive `[Agent]` answer (or if no agent has answered yet), the student's question is open — route to the teacher or appropriate agent before considering END.
+11. Do NOT emit END while a student question or objection is unresolved. Gate on whether the most recent `[Student (Human)]` line **asks a question or raises an objection** AND appears after the last substantive `[Agent]` answer. A brief acknowledgement ("ok", "got it", "interesting", "please continue") does NOT block END — it signals satisfaction.
 12. A brief agent acknowledgment ("yes", "ok", "got it", "interesting") does not constitute a substantive answer. Only an `[Agent]` response that directly engages with the content of the student's question counts as resolution.
 
 # Routing Quality (CRITICAL)

--- a/tests/orchestration/conversation-summary.test.ts
+++ b/tests/orchestration/conversation-summary.test.ts
@@ -136,3 +136,20 @@ describe('summarizeConversation — maxMessages slicing', () => {
     expect(lines).toHaveLength(1);
   });
 });
+
+describe('summarizeConversation — edge cases', () => {
+  test('content starting with [bracket-colon] pattern has leading prefix stripped', () => {
+    // SENDER_PREFIX_RE /^\[[^\]]+\]:\s*/ strips any [Name]: prefix, not just [You]:.
+    // Pin the "strip" contract so a future regex change is a deliberate decision.
+    const out = summarizeConversation([{ role: 'user', content: '[FYI]: my answer is correct' }]);
+    expect(out).toContain('my answer is correct');
+    expect(out).not.toContain('[FYI]:');
+  });
+
+  test('system role message is labelled [System] (defensive branch)', () => {
+    // Exercises the else branch — system messages do not appear in the director
+    // path in practice, but the branch should remain covered.
+    const out = summarizeConversation([{ role: 'system', content: 'System context' }]);
+    expect(out).toContain('[System]');
+  });
+});

--- a/tests/prompts/templates.test.ts
+++ b/tests/prompts/templates.test.ts
@@ -189,6 +189,11 @@ describe('optional sections toggle on / off correctly', () => {
     const out = buildStructuredPrompt(baseAgent, stateNoLang);
     expect(out).not.toContain('# Language (CRITICAL)');
   });
+
+  test('conversation encoding note is present in every agent prompt', () => {
+    const out = buildStructuredPrompt(baseAgent, slideState);
+    expect(out).toContain('Conversation History Encoding');
+  });
 });
 
 describe('director routing contract', () => {


### PR DESCRIPTION
## Summary

Fixes items 1, 3, 4, and 5 from #598. Item 2 (premature-END regression eval) is handled separately in #599.

## Related Issues

Closes #598 (items 1, 3, 4, 5)

## Changes

- **Item 1** — Add `buildConversationEncodingNote()` to `prompt-builder.ts` and wire `{{conversationEncodingNote}}` into `agent-system/system.md`. Without this, the agent LLM cannot distinguish peer agent turns from the human student's turn: both arrive as `role:"user"`, differentiated only by whether the prefix is a localised "You" word (human) or a `[AgentName]:` JSON array (peer agent).
- **Item 3** — Tighten director Rule 11: gate END-blocking only on genuine questions or objections, not on brief acknowledgements ("ok", "got it", "interesting", "please continue"). Previous wording blocked END on every `[Student (Human)]` turn.
- **Item 4** — Add edge-case test pinning the `SENDER_PREFIX_RE` strip contract in `conversation-summary.ts`, so any future regex change is a deliberate, reviewed decision.
- **Item 5** — Document the defensive-only `'system'` role branch in the `summarizeConversation` JSDoc; add a covering test for that branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

### Steps to reproduce / test

1. `pnpm run check` — formatting
2. `pnpm run test` — 379 passed, 0 failures (3 new tests added)
3. `pnpm run lint` — 0 errors, 7 warnings (all pre-existing in unrelated files)
4. `npx tsc --noEmit 2>&1 | grep -v mathml2omml` — clean

### What you personally verified

- All 4 CI checks pass locally.
- New tests exercise: (a) `SENDER_PREFIX_RE` strips `[FYI]:` prefix; (b) `system` role branch labels output `[System]`; (c) `conversationEncodingNote` section appears in every agent prompt.
- No snapshot updates required — structural assertion tests only.
- Rule 11 change: no existing test covered the wording, so no test update needed; the behaviour change is intentional (less aggressive END-blocking).

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings

---

> AI-assisted PR. Changes were reviewed and verified locally before submission.