### PR TITLE
feat(maic-editor): gate slide scene creation until inserted scenes are playable

### DIFF
--- a/components/edit/SlideNavRail/InsertionZone.tsx
+++ b/components/edit/SlideNavRail/InsertionZone.tsx
@@ -30,6 +30,7 @@ export function InsertionZone({ label, onInsert }: InsertionZoneProps) {
         onClick={onInsert}
         aria-label={label}
         title={label}
+        data-testid="slide-nav-insert"
         className="absolute inset-0 z-10 outline-none focus-visible:opacity-100"
       >
         <span className="sr-only">{label}</span>

--- a/components/edit/SlideNavRail/SlideNavRail.tsx
+++ b/components/edit/SlideNavRail/SlideNavRail.tsx
@@ -11,6 +11,7 @@ import { useSettingsStore } from '@/lib/store/settings';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useDeletedSceneRecycle } from '@/lib/edit/deleted-scene-recycle';
 import { createBlankSlideScene, duplicateSlideScene } from '@/lib/edit/slide-defaults';
+import { SCENE_CREATION_ENABLED } from '@/lib/edit/scene-creation-enabled';
 import { CHROME_DURATION_MS, CHROME_EASE, CHROME_EASE_CSS } from '@/lib/edit/transitions';
 import type { Scene } from '@/lib/types/stage';
 import { ThumbItem } from './ThumbItem';
@@ -441,7 +442,7 @@ export function SlideNavRail() {
                 {/* Leading zone — hover the top padding to insert
                     before the first thumb. Hits the `+ at top` use
                     case the user called out. */}
-                {scenes[0] ? (
+                {SCENE_CREATION_ENABLED && scenes[0] ? (
                   <InsertionZone
                     label={t('edit.nav.addSlide')}
                     onInsert={() => handleInsertBefore(scenes[0].id)}
@@ -458,10 +459,12 @@ export function SlideNavRail() {
                       onDuplicate={() => handleDuplicate(scene.id)}
                       onDelete={() => handleDelete(scene.id)}
                     />
-                    <InsertionZone
-                      label={t('edit.nav.addSlide')}
-                      onInsert={() => handleInsertAt(scene.id)}
-                    />
+                    {SCENE_CREATION_ENABLED && (
+                      <InsertionZone
+                        label={t('edit.nav.addSlide')}
+                        onInsert={() => handleInsertAt(scene.id)}
+                      />
+                    )}
                   </Fragment>
                 ))}
               </Reorder.Group>

--- a/components/edit/SlideNavRail/ThumbItem.tsx
+++ b/components/edit/SlideNavRail/ThumbItem.tsx
@@ -195,6 +195,7 @@ function ThumbItemComponent({
                   onClick={(e) => e.stopPropagation()}
                   onPointerDown={(e) => e.stopPropagation()}
                   aria-label={t('edit.nav.moreActions')}
+                  data-testid="slide-nav-more"
                   className={cn(
                     'shrink-0 rounded p-0.5 text-zinc-400 transition-opacity',
                     'opacity-0 group-hover/thumb:opacity-100 data-[state=open]:opacity-100',

--- a/components/edit/SlideNavRail/ThumbItem.tsx
+++ b/components/edit/SlideNavRail/ThumbItem.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { SceneThumbnailContent } from '@/components/stage/scene-thumbnail-content';
+import { SCENE_CREATION_ENABLED } from '@/lib/edit/scene-creation-enabled';
 import type { Scene } from '@/lib/types/stage';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useStageStore } from '@/lib/store/stage';
@@ -211,9 +212,11 @@ function ThumbItemComponent({
                 onClick={(e) => e.stopPropagation()}
               >
                 <DropdownMenuItem onSelect={startRename}>{t('edit.nav.rename')}</DropdownMenuItem>
-                <DropdownMenuItem onSelect={onDuplicate}>
-                  {t('edit.nav.duplicate')}
-                </DropdownMenuItem>
+                {SCENE_CREATION_ENABLED && (
+                  <DropdownMenuItem onSelect={onDuplicate}>
+                    {t('edit.nav.duplicate')}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem disabled={!canDelete} onSelect={onDelete} variant="destructive">
                   {t('edit.nav.delete')}
                 </DropdownMenuItem>

--- a/e2e/tests/slide-scene-creation-gate.spec.ts
+++ b/e2e/tests/slide-scene-creation-gate.spec.ts
@@ -20,7 +20,9 @@ test.describe('Slide editor — scene-creation gate (MVP)', () => {
     await mockApi.setupGenerationMocks();
   });
 
-  test('Pro mode rail hides insert + duplicate, keeps rename/delete', async ({ page }) => {
+  test('Pro mode rail hides insert + duplicate, keeps rename/delete', async ({
+    page,
+  }, testInfo) => {
     // Generate a classroom through the mocked pipeline.
     const home = new HomePage(page);
     await home.goto();
@@ -52,7 +54,10 @@ test.describe('Slide editor — scene-creation gate (MVP)', () => {
     await page.getByTestId('slide-nav-more').first().click();
     await expect(page.getByRole('menuitem')).toHaveCount(2);
 
-    // Visual evidence of the gated rail.
-    await rail.screenshot({ path: 'e2e-artifacts/pro-rail-gated.png' });
+    // Visual evidence of the gated rail, attached to the Playwright report.
+    await testInfo.attach('pro-rail-gated', {
+      body: await rail.screenshot(),
+      contentType: 'image/png',
+    });
   });
 });

--- a/e2e/tests/slide-scene-creation-gate.spec.ts
+++ b/e2e/tests/slide-scene-creation-gate.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../fixtures/base';
+import { HomePage } from '../pages/home.page';
+import { GenerationPreviewPage } from '../pages/generation-preview.page';
+import { ClassroomPage } from '../pages/classroom.page';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+/**
+ * MVP gate: the slide editor must not expose scene-creation (blank insert +
+ * duplicate) because editor-created scenes have no playback actions and get
+ * skipped during playback. Reorder / delete / rename stay. This test fails if
+ * SCENE_CREATION_ENABLED is flipped back on without removing the gate.
+ */
+test.describe('Slide editor — scene-creation gate (MVP)', () => {
+  test.beforeEach(async ({ page, mockApi }) => {
+    await page.addInitScript((settings) => {
+      localStorage.setItem('settings-storage', settings);
+    }, SETTINGS_STORAGE);
+    await mockApi.setupGenerationMocks();
+  });
+
+  test('Pro mode rail hides insert + duplicate, keeps rename/delete', async ({ page }) => {
+    // Generate a classroom through the mocked pipeline.
+    const home = new HomePage(page);
+    await home.goto();
+    await home.fillRequirement('讲解光合作用');
+    await home.submit();
+    await page.waitForURL(/\/generation-preview/);
+
+    const preview = new GenerationPreviewPage(page);
+    await preview.waitForRedirectToClassroom();
+    expect(page.url()).toMatch(/\/classroom\//);
+
+    const classroom = new ClassroomPage(page);
+    await classroom.waitForLoaded();
+    await expect(classroom.sidebarScenes.first()).toBeVisible({ timeout: 10_000 });
+
+    // Enter Pro mode via the header Pro Switch.
+    await page.getByRole('switch').click();
+
+    // The slide nav rail replaces the playback sidebar in Pro mode.
+    const rail = page.getByTestId('slide-nav-rail');
+    await expect(rail).toBeVisible({ timeout: 10_000 });
+
+    // Gate 1: no inter-thumb "+" insertion zones.
+    await expect(page.getByTestId('slide-nav-insert')).toHaveCount(0);
+
+    // Gate 2: the per-slide overflow menu has exactly Rename + Delete
+    // (Duplicate removed). Counting menuitems keeps the assertion
+    // locale-independent.
+    await page.getByTestId('slide-nav-more').first().click();
+    await expect(page.getByRole('menuitem')).toHaveCount(2);
+
+    // Visual evidence of the gated rail.
+    await rail.screenshot({ path: 'e2e-artifacts/pro-rail-gated.png' });
+  });
+});

--- a/lib/edit/scene-creation-enabled.ts
+++ b/lib/edit/scene-creation-enabled.ts
@@ -1,0 +1,11 @@
+/**
+ * Editor-created slide scenes (blank insert + duplicate) ship without
+ * playback `actions`, so the playback engine gives them zero dwell and
+ * skips straight past them. Until inserted scenes are seeded with default
+ * actions, the editor hides its two scene-creation entry points — the
+ * inter-thumb "+" insertion zones and the per-slide Duplicate menu item —
+ * while keeping reorder / delete / rename, which are playback-safe.
+ *
+ * Flip to `true` once newly-created scenes are made playable.
+ */
+export const SCENE_CREATION_ENABLED = false;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
     url: 'http://localhost:3002',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
-    env: { PORT: '3002' },
+    // Enable the MAIC Editor (Pro mode) so editor e2e can reach it. This is a
+    // build-time NEXT_PUBLIC_* flag, so it must be set when the webServer runs
+    // `pnpm build` (CI) or `pnpm dev` (local).
+    env: { PORT: '3002', NEXT_PUBLIC_MAIC_EDITOR_ENABLED: 'true' },
   },
 });


### PR DESCRIPTION
## Why

Editor-created slide scenes (blank insert + duplicate) ship without playback `actions`. The playback engine treats an action-less scene as zero-dwell and skips straight past it, so a freshly inserted slide is effectively unplayable. Seeding default actions on new scenes is a separate change; until that lands, this gates the two scene-creation entry points so the editor stays coherent as an in-place "fine-tune the AI-generated deck" tool for the MVP release.

## What

- Add `lib/edit/scene-creation-enabled.ts` exporting `SCENE_CREATION_ENABLED = false`.
- Hide the inter-thumb `+` insertion zones in `SlideNavRail`.
- Hide the per-slide Duplicate menu item in `ThumbItem`.
- Keep reorder / delete / rename. These are playback-safe: scene `actions` are per-scene and id-bound, so reordering or removing scenes never produces an unplayable scene.

The insert/duplicate handlers and `createBlankSlideScene` / `duplicateSlideScene` helpers are untouched and still referenced behind the flag, so re-enabling is a one-line flip once new scenes are seeded with default actions.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `prettier --check` clean
- [x] `vitest run` edit suite green (480 passed; the only local failures are environment-dependent `ssrf-guard` DNS tests, unrelated to this diff)
- [x] e2e (`e2e/tests/slide-scene-creation-gate.spec.ts`): generates a classroom via the mocked pipeline, enters Pro mode, asserts no `+` insertion zones and that the per-slide overflow menu has only Rename + Delete (no Duplicate). Verified as a real guard by flipping `SCENE_CREATION_ENABLED` on → the e2e fails (4 insert zones, 3 menu items), then flipping back.

Target branch: `feat/maic-editor-v0`