### PR TITLE
fix(pptxgenjs): use ESM import for typescript in rollup config

### DIFF
--- a/packages/pptxgenjs/rollup.config.mjs
+++ b/packages/pptxgenjs/rollup.config.mjs
@@ -2,6 +2,7 @@ import pkg from "./package.json" with { type: "json" };
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "rollup-plugin-typescript2";
+import ts from "typescript";
 
 const nodeBuiltinsRE = /^node:.*/; /* Regex that matches all Node built-in specifiers */
 
@@ -24,7 +25,10 @@ export default {
 	],
 	plugins: [
 		resolve({ preferBuiltins: true }),
+		typescript({
+			typescript: ts,
+			include: [/\.tsx?$/],
+		}),
 		commonjs(),
-		typescript({ typescript: require("typescript") }),
 	]
 };


### PR DESCRIPTION
## Summary
`packages/pptxgenjs/rollup.config.mjs` is ESM but handed the compiler to `rollup-plugin-typescript2` via `require("typescript")`. When rollup loads the config as native ESM (e.g. workspace postinstall, without `--bundleConfigAsCjs`) this throws `require is not defined in ES module scope`. Switched to a top-level `import ts from "typescript"` and added an explicit `.ts/.tsx` include.

## Why a new PR
This supersedes #397, which had the right rollup fix but also deleted `.env.example` (still used as the `.env.local` template) and rewrote the entire `pnpm-lock.yaml`. This keeps only the 3-line config change. Credit to @abrahamU for the original fix.

## Test plan
- `pnpm --filter pptxgenjs build` → succeeds.
- `rollup -c rollup.config.mjs` (native ESM load, no `--bundleConfigAsCjs`) → succeeds with the fix; reproduces `require is not defined in ES module scope` without it.