### PR TITLE
feat: support custom MiniMax voice_id

### DIFF
--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -878,7 +878,9 @@ function GenerationPreviewContent() {
                   language: languageDirective,
                 })),
               }
-            : undefined;
+            : settings.ttsProviderId === 'minimax-tts'
+              ? (ttsProviderConfig?.providerOptions || undefined)
+              : undefined;
         const speechActions = (data.scene.actions || []).filter(
           (a: { type: string; text?: string }) => a.type === 'speech' && a.text,
         );

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -879,7 +879,7 @@ function GenerationPreviewContent() {
                 })),
               }
             : settings.ttsProviderId === 'minimax-tts'
-              ? (ttsProviderConfig?.providerOptions || undefined)
+              ? ttsProviderConfig?.providerOptions || undefined
               : undefined;
         const speechActions = (data.scene.actions || []).filter(
           (a: { type: string; text?: string }) => a.type === 'speech' && a.text,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -915,7 +915,10 @@ function GreetingBar() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="leading-none select-none flex items-center gap-1">
-                  <span className="text-[13px] font-semibold text-foreground/85 group-hover:text-foreground transition-colors">
+                  <span
+                    className="text-[13px] font-semibold text-foreground/85 group-hover:text-foreground transition-colors"
+                    suppressHydrationWarning
+                  >
                     {t('home.greetingWithName', { name: displayName })}
                   </span>
                   <ChevronDown className="size-3 text-muted-foreground/30 group-hover:text-muted-foreground/60 transition-colors shrink-0" />

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -149,7 +149,9 @@ function AgentVoicePill({
                   locale,
                 })),
               }
-            : undefined;
+            : providerId === 'minimax-tts'
+              ? (providerConfig?.providerOptions || undefined)
+              : undefined;
         const res = await fetch('/api/generate/tts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -430,7 +432,9 @@ function TeacherVoicePill({
                   locale,
                 })),
               }
-            : undefined;
+            : providerId === 'minimax-tts'
+              ? (providerConfig?.providerOptions || undefined)
+              : undefined;
         const res = await fetch('/api/generate/tts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -150,7 +150,7 @@ function AgentVoicePill({
                 })),
               }
             : providerId === 'minimax-tts'
-              ? (providerConfig?.providerOptions || undefined)
+              ? providerConfig?.providerOptions || undefined
               : undefined;
         const res = await fetch('/api/generate/tts', {
           method: 'POST',
@@ -433,7 +433,7 @@ function TeacherVoicePill({
                 })),
               }
             : providerId === 'minimax-tts'
-              ? (providerConfig?.providerOptions || undefined)
+              ? providerConfig?.providerOptions || undefined
               : undefined;
         const res = await fetch('/api/generate/tts', {
           method: 'POST',

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -155,7 +155,9 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
               ...(ttsProvidersConfig[selectedProviderId]?.providerOptions || {}),
               ...(await getVoxCPMProviderOptions(effectiveVoice, { role: 'teacher', locale })),
             }
-          : undefined;
+          : selectedProviderId === 'minimax-tts'
+            ? (ttsProvidersConfig[selectedProviderId]?.providerOptions || undefined)
+            : undefined;
       await startPreview({
         text: testText,
         providerId: selectedProviderId,
@@ -450,6 +452,33 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
             )}
           </>
         ))}
+
+      {/* MiniMax TTS: Custom Voice ID */}
+      {selectedProviderId === 'minimax-tts' && (
+        <div className="space-y-2">
+          <Label className="text-sm">{t('settings.minimaxVoiceId')}</Label>
+          <Input
+            name="minimax-voice-id"
+            autoComplete="off"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            placeholder={t('settings.minimaxVoiceIdPlaceholder')}
+            value={
+              (ttsProvidersConfig[selectedProviderId]?.providerOptions?.voiceId as string) || ''
+            }
+            onChange={(e) =>
+              setTTSProviderConfig(selectedProviderId, {
+                providerOptions: {
+                  ...(ttsProvidersConfig[selectedProviderId]?.providerOptions || {}),
+                  voiceId: e.target.value,
+                },
+              })
+            }
+            className="text-sm font-mono"
+          />
+        </div>
+      )}
 
       {/* Test TTS */}
       <div className="space-y-2">

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -156,7 +156,7 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
               ...(await getVoxCPMProviderOptions(effectiveVoice, { role: 'teacher', locale })),
             }
           : selectedProviderId === 'minimax-tts'
-            ? (ttsProvidersConfig[selectedProviderId]?.providerOptions || undefined)
+            ? ttsProvidersConfig[selectedProviderId]?.providerOptions || undefined
             : undefined;
       await startPreview({
         text: testText,

--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -692,7 +692,7 @@ async function generateMiniMaxTTS(
       stream: false,
       output_format: 'hex',
       voice_setting: {
-        voice_id: config.voice,
+        voice_id: (config.providerOptions?.voiceId as string) || config.voice,
         speed: config.speed || 1.0,
         vol: 1,
         pitch: 0,

--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -165,7 +165,7 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
               })),
             }
           : item.providerId === 'minimax-tts'
-            ? (providerConfig?.providerOptions || undefined)
+            ? providerConfig?.providerOptions || undefined
             : undefined;
       const res = await fetch('/api/generate/tts', {
         method: 'POST',

--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -164,7 +164,9 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
                 locale,
               })),
             }
-          : undefined;
+          : item.providerId === 'minimax-tts'
+            ? (providerConfig?.providerOptions || undefined)
+            : undefined;
       const res = await fetch('/api/generate/tts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -143,7 +143,9 @@ export async function generateAndStoreTTS(
           ...(ttsProviderConfig?.providerOptions || {}),
           ...(await getVoxCPMProviderOptions(settings.ttsVoice, { role: 'teacher', language })),
         }
-      : undefined;
+      : settings.ttsProviderId === 'minimax-tts'
+        ? (ttsProviderConfig?.providerOptions || undefined)
+        : undefined;
   const response = await fetch('/api/generate/tts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -144,7 +144,7 @@ export async function generateAndStoreTTS(
           ...(await getVoxCPMProviderOptions(settings.ttsVoice, { role: 'teacher', language })),
         }
       : settings.ttsProviderId === 'minimax-tts'
-        ? (ttsProviderConfig?.providerOptions || undefined)
+        ? ttsProviderConfig?.providerOptions || undefined
         : undefined;
   const response = await fetch('/api/generate/tts', {
     method: 'POST',

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -733,6 +733,8 @@
     "voiceBaseUrlRequired": "العنوان الأساسي مطلوب",
     "ttsTestTextPlaceholder": "أدخل نصًا للتحويل",
     "ttsTestTextDefault": "مرحبًا، هذا كلام تجريبي.",
+    "minimaxVoiceId": "Voice ID / معرّف الصوت المخصص",
+    "minimaxVoiceIdPlaceholder": "مثال ttv-voice-2026053021002326-CYyvUlBU",
     "startRecording": "بدء التسجيل",
     "stopRecording": "إيقاف التسجيل",
     "recording": "جارٍ التسجيل...",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -733,6 +733,8 @@
     "voiceBaseUrlRequired": "Base URL required",
     "ttsTestTextPlaceholder": "Enter text to convert",
     "ttsTestTextDefault": "Hello, this is a test speech.",
+    "minimaxVoiceId": "Voice ID / Custom Voice ID",
+    "minimaxVoiceIdPlaceholder": "e.g. ttv-voice-2026053021002326-CYyvUlBU",
     "startRecording": "Start Recording",
     "stopRecording": "Stop Recording",
     "recording": "Recording...",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -733,6 +733,8 @@
     "voiceBaseUrlRequired": "ベースURLが必要です",
     "ttsTestTextPlaceholder": "変換するテキストを入力",
     "ttsTestTextDefault": "こんにちは、これはテスト音声です。",
+    "minimaxVoiceId": "Voice ID / カスタム音声 ID",
+    "minimaxVoiceIdPlaceholder": "例: ttv-voice-2026053021002326-CYyvUlBU",
     "startRecording": "録音を開始",
     "stopRecording": "録音を停止",
     "recording": "録音中...",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -733,6 +733,8 @@
     "voiceBaseUrlRequired": "URL base obrigatória",
     "ttsTestTextPlaceholder": "Digite o texto a ser convertido",
     "ttsTestTextDefault": "Olá, este é um teste de fala.",
+    "minimaxVoiceId": "Voice ID / ID de voz personalizado",
+    "minimaxVoiceIdPlaceholder": "ex. ttv-voice-2026053021002326-CYyvUlBU",
     "startRecording": "Iniciar Gravação",
     "stopRecording": "Parar Gravação",
     "recording": "Gravando...",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -733,6 +733,8 @@
     "voiceBaseUrlRequired": "Требуется Base URL",
     "ttsTestTextPlaceholder": "Введите текст для озвучивания",
     "ttsTestTextDefault": "Привет, это тестовая речь.",
+    "minimaxVoiceId": "Voice ID / Пользовательский ID голоса",
+    "minimaxVoiceIdPlaceholder": "например ttv-voice-2026053021002326-CYyvUlBU",
     "startRecording": "Начать запись",
     "stopRecording": "Остановить запись",
     "recording": "Запись...",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -733,6 +733,8 @@
     "voiceBaseUrlRequired": "需要 Base URL",
     "ttsTestTextPlaceholder": "输入要转换的文本",
     "ttsTestTextDefault": "你好，这是一段测试语音。",
+    "minimaxVoiceId": "Voice ID / 自定义音色 ID",
+    "minimaxVoiceIdPlaceholder": "例如 ttv-voice-2026053021002326-CYyvUlBU",
     "startRecording": "开始录音",
     "stopRecording": "停止录音",
     "recording": "录音中...",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -967,6 +967,8 @@
     "transcribing": "轉錄中...",
     "transcriptionResult": "轉錄結果",
     "ttsTestTextDefault": "你好，這是測試語音。",
+    "minimaxVoiceId": "Voice ID / 自訂音色 ID",
+    "minimaxVoiceIdPlaceholder": "例如 ttv-voice-2026053021002326-CYyvUlBU",
     "ttsTestTextPlaceholder": "輸入要轉換的文字",
     "useThisProvider": "使用此供應商",
     "voiceApiKeyRequired": "需要 API 金鑰",


### PR DESCRIPTION
## Feature

Add support for custom MiniMax voice_id in MiniMax TTS settings.

## Changes

- Added custom Voice ID input field
- Persist voice_id configuration
- Inject voice_setting.voice_id into MiniMax TTS request body
- Support custom voice during TTS testing and Agent playback

## Example

ttv-voice-2026053021002326-CYyvUlBU