### PR TITLE
fix(interactive): keep-alive iframe pool — interactive scenes no longer reload on remount (#619)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ eval/orchestration/results-answering/
 
 # e2e screenshot artifacts
 e2e/screenshots/
+
+# local e2e screenshots for #619 review
+e2e/__screenshots-619/

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -439,8 +439,15 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
         engineRef.current.stop();
       }
 
-      // Get widget iframe messaging callback for interactive scenes (keyed by sceneId)
-      const widgetSendMessage = useWidgetIframeStore.getState().getSendMessage(currentScene.id);
+      // Widget iframe messaging callback for interactive scenes, resolved lazily
+      // at send time (keyed by sceneId). The interactive iframe now lives in the
+      // keep-alive host (#619), which registers its postMessage callback a commit
+      // after this engine is built — so resolving eagerly here would capture null
+      // on a scene's first visit and silently drop every widget action. Looking it
+      // up per-send always sees the live registration.
+      const sceneIdForWidget = currentScene.id;
+      const widgetSendMessage = (type: string, payload: Record<string, unknown>) =>
+        useWidgetIframeStore.getState().getSendMessage(sceneIdForWidget)?.(type, payload);
 
       // Create ActionEngine for playback (with audioPlayer for TTS and widget messaging)
       const actionEngine = new ActionEngine(

--- a/components/scene-renderers/InteractiveIframeHost.tsx
+++ b/components/scene-renderers/InteractiveIframeHost.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { useStageStore } from '@/lib/store';
 import { useWidgetIframeStore } from '@/lib/store/widget-iframe';
@@ -16,19 +16,34 @@ import {
  * unmounts and remounts — so the iframe elements it renders survive Pro mode
  * toggles, scene switches, and any PlaybackChromeRoot remount. The in-tree
  * `InteractiveRenderer` is only a placeholder that registers content and reports
- * the on-screen rect; the actual iframes live here, portaled to `document.body`
- * and positioned over each scene's rect via `position: fixed`.
+ * the on-screen rect; the actual iframes live here, portaled into a stable host
+ * node and positioned over each scene's rect via `position: fixed`.
  *
- * Body-portaled with a low z-index so it sits under Radix dialogs (e.g. the
- * scene-switch confirm) while still covering the canvas box during plain
- * interactive playback. Hidden (never unmounted) in edit mode and whenever the
- * placeholder is gone, so the document is preserved for a zero-reload return.
+ * Portal target follows `document.fullscreenElement` so the iframe stays inside
+ * the fullscreen subtree during presentation mode (which calls requestFullscreen
+ * on the playback stage, not on body); otherwise it lives on `document.body`.
+ * A low z-index keeps it under Radix dialogs (e.g. the scene-switch confirm)
+ * while still covering the canvas box during plain interactive playback. Hidden
+ * (never unmounted) in edit mode and whenever the placeholder is gone, so the
+ * document is preserved for a zero-reload return.
  */
 export function InteractiveIframeHost() {
   const entries = useInteractiveIframePool((s) => s.entries);
   const activeSceneId = useInteractiveIframePool((s) => s.activeSceneId);
+  const reset = useInteractiveIframePool((s) => s.reset);
   const setActiveScene = useWidgetIframeStore((s) => s.setActiveScene);
   const mode = useStageStore((s) => s.mode);
+
+  // Portal into the fullscreen element when one is active (presentation mode
+  // fullscreens the stage, and a body-portaled iframe would not be part of that
+  // subtree, so it would vanish). Falls back to body otherwise.
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
+  useEffect(() => {
+    const sync = () => setPortalTarget(document.fullscreenElement ?? document.body);
+    sync();
+    document.addEventListener('fullscreenchange', sync);
+    return () => document.removeEventListener('fullscreenchange', sync);
+  }, []);
 
   // Keep the messaging store's active scene in lock-step (its legacy fallback
   // path resolves the current widget by active scene when no id is passed).
@@ -36,7 +51,12 @@ export function InteractiveIframeHost() {
     setActiveScene(activeSceneId);
   }, [activeSceneId, setActiveScene]);
 
-  if (typeof document === 'undefined') return null;
+  // The host is mounted once per classroom (inside Stage). When it unmounts —
+  // e.g. on classroom switch — drop the pool so a new classroom doesn't briefly
+  // render the previous one's stale iframes.
+  useEffect(() => reset, [reset]);
+
+  if (!portalTarget) return null;
 
   return createPortal(
     <>
@@ -49,7 +69,7 @@ export function InteractiveIframeHost() {
         />
       ))}
     </>,
-    document.body,
+    portalTarget,
   );
 }
 
@@ -63,7 +83,7 @@ interface PooledIframeProps {
  * One persisted iframe. Stays mounted as long as its pool entry exists (only
  * evicted by LRU), so its document is preserved across scene/mode changes.
  * `srcDoc` / `src` come straight from the entry and only change when the
- * content hash changes — that is the single intended reload path.
+ * content changes — that is the single intended reload path.
  */
 function PooledIframe({ sceneId, entry, visible }: PooledIframeProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -81,7 +101,10 @@ function PooledIframe({ sceneId, entry, visible }: PooledIframeProps) {
   }, [sceneId, registerIframe]);
 
   const rect = entry.rect;
-  const shown = visible && rect !== null;
+  // Require a real measured box before showing — a null or zero-size rect means
+  // the slot hasn't laid out yet; showing then would flash a 0x0 iframe pinned
+  // at the viewport origin.
+  const shown = visible && rect !== null && rect.width > 0 && rect.height > 0;
   const style: CSSProperties = {
     position: 'fixed',
     left: rect?.left ?? 0,

--- a/components/scene-renderers/InteractiveIframeHost.tsx
+++ b/components/scene-renderers/InteractiveIframeHost.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect, useRef, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+import { useStageStore } from '@/lib/store';
+import { useWidgetIframeStore } from '@/lib/store/widget-iframe';
+import {
+  useInteractiveIframePool,
+  type IframePoolEntry,
+} from '@/lib/store/interactive-iframe-pool';
+
+/**
+ * Stable host for interactive scene iframes (#619).
+ *
+ * Mounted once at the `Stage` root — outside the mode-swap / scene subtree that
+ * unmounts and remounts — so the iframe elements it renders survive Pro mode
+ * toggles, scene switches, and any PlaybackChromeRoot remount. The in-tree
+ * `InteractiveRenderer` is only a placeholder that registers content and reports
+ * the on-screen rect; the actual iframes live here, portaled to `document.body`
+ * and positioned over each scene's rect via `position: fixed`.
+ *
+ * Body-portaled with a low z-index so it sits under Radix dialogs (e.g. the
+ * scene-switch confirm) while still covering the canvas box during plain
+ * interactive playback. Hidden (never unmounted) in edit mode and whenever the
+ * placeholder is gone, so the document is preserved for a zero-reload return.
+ */
+export function InteractiveIframeHost() {
+  const entries = useInteractiveIframePool((s) => s.entries);
+  const activeSceneId = useInteractiveIframePool((s) => s.activeSceneId);
+  const setActiveScene = useWidgetIframeStore((s) => s.setActiveScene);
+  const mode = useStageStore((s) => s.mode);
+
+  // Keep the messaging store's active scene in lock-step (its legacy fallback
+  // path resolves the current widget by active scene when no id is passed).
+  useEffect(() => {
+    setActiveScene(activeSceneId);
+  }, [activeSceneId, setActiveScene]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <>
+      {Object.entries(entries).map(([sceneId, entry]) => (
+        <PooledIframe
+          key={sceneId}
+          sceneId={sceneId}
+          entry={entry}
+          visible={mode !== 'edit' && entry.visible && sceneId === activeSceneId}
+        />
+      ))}
+    </>,
+    document.body,
+  );
+}
+
+interface PooledIframeProps {
+  readonly sceneId: string;
+  readonly entry: IframePoolEntry;
+  readonly visible: boolean;
+}
+
+/**
+ * One persisted iframe. Stays mounted as long as its pool entry exists (only
+ * evicted by LRU), so its document is preserved across scene/mode changes.
+ * `srcDoc` / `src` come straight from the entry and only change when the
+ * content hash changes — that is the single intended reload path.
+ */
+function PooledIframe({ sceneId, entry, visible }: PooledIframeProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const registerIframe = useWidgetIframeStore((s) => s.registerIframe);
+
+  // Register the postMessage callback for this scene (moved here from the
+  // placeholder, since the iframe now lives in the host). Stable per scene:
+  // the callback reads contentWindow lazily at send time.
+  useEffect(() => {
+    const send = (type: string, payload: Record<string, unknown>) => {
+      iframeRef.current?.contentWindow?.postMessage({ type, ...payload }, '*');
+    };
+    registerIframe(sceneId, send);
+    return () => registerIframe(sceneId, null);
+  }, [sceneId, registerIframe]);
+
+  const rect = entry.rect;
+  const shown = visible && rect !== null;
+  const style: CSSProperties = {
+    position: 'fixed',
+    left: rect?.left ?? 0,
+    top: rect?.top ?? 0,
+    width: rect?.width ?? 0,
+    height: rect?.height ?? 0,
+    border: 0,
+    borderRadius: '0.5rem', // matches the canvas box's rounded-lg
+    overflow: 'hidden',
+    zIndex: 1,
+    // visibility (not display) — display:none can drop the document on re-show.
+    visibility: shown ? 'visible' : 'hidden',
+    pointerEvents: shown ? 'auto' : 'none',
+  };
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={entry.srcDoc}
+      src={entry.srcDoc ? undefined : entry.src}
+      style={style}
+      title={`Interactive Scene ${sceneId}`}
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+    />
+  );
+}

--- a/components/scene-renderers/InteractiveIframeHost.tsx
+++ b/components/scene-renderers/InteractiveIframeHost.tsx
@@ -65,7 +65,7 @@ export function InteractiveIframeHost() {
           key={sceneId}
           sceneId={sceneId}
           entry={entry}
-          visible={mode !== 'edit' && entry.visible && sceneId === activeSceneId}
+          visible={mode !== 'edit' && entry.owner !== null && sceneId === activeSceneId}
         />
       ))}
     </>,

--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useRef, useEffect, useCallback } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import type { InteractiveContent } from '@/lib/types/stage';
-import { useWidgetIframeStore } from '@/lib/store/widget-iframe';
+import { hashContent, useInteractiveIframePool } from '@/lib/store/interactive-iframe-pool';
 import { patchHtmlForIframe } from '@/lib/utils/iframe';
 
 interface InteractiveRendererProps {
@@ -10,43 +10,62 @@ interface InteractiveRendererProps {
   readonly sceneId: string;
 }
 
+/**
+ * Placeholder for an interactive scene. The actual iframe lives in the stable
+ * `InteractiveIframeHost` (keyed by sceneId) so it survives remounts (#619);
+ * this component only (1) registers the scene's content in the keep-alive pool,
+ * (2) marks it active/visible while mounted, and (3) reports its on-screen rect
+ * so the host can position the iframe over this slot. On unmount it hides the
+ * iframe but never evicts it — that preserves the document for a zero-reload
+ * return on the next mount.
+ */
 export function InteractiveRenderer({ content, sceneId }: InteractiveRendererProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const registerIframe = useWidgetIframeStore((state) => state.registerIframe);
-  const setActiveScene = useWidgetIframeStore((state) => state.setActiveScene);
+  const slotRef = useRef<HTMLDivElement>(null);
+  const mount = useInteractiveIframePool((s) => s.mount);
+  const setRect = useInteractiveIframePool((s) => s.setRect);
+  const show = useInteractiveIframePool((s) => s.show);
+  const hide = useInteractiveIframePool((s) => s.hide);
+  const setActive = useInteractiveIframePool((s) => s.setActive);
 
   const patchedHtml = useMemo(
     () => (content.html ? patchHtmlForIframe(content.html) : undefined),
     [content.html],
   );
-
-  // Create iframe messaging callback
-  const sendMessageToIframe = useCallback((type: string, payload: Record<string, unknown>) => {
-    if (iframeRef.current?.contentWindow) {
-      iframeRef.current.contentWindow.postMessage({ type, ...payload }, '*');
-    }
-  }, []);
-
-  // Register iframe messaging callback on mount, unregister on unmount
-  // Key by sceneId to prevent race conditions on scene switch
-  useEffect(() => {
-    registerIframe(sceneId, sendMessageToIframe);
-    setActiveScene(sceneId);
-    return () => {
-      registerIframe(sceneId, null);
-    };
-  }, [sceneId, registerIframe, sendMessageToIframe, setActiveScene]);
-
-  return (
-    <div className="w-full h-full relative">
-      <iframe
-        ref={iframeRef}
-        srcDoc={patchedHtml}
-        src={patchedHtml ? undefined : content.url}
-        className="absolute inset-0 w-full h-full border-0"
-        title={`Interactive Scene ${sceneId}`}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-      />
-    </div>
+  const hash = useMemo(
+    () => hashContent(patchedHtml ?? content.url ?? ''),
+    [patchedHtml, content.url],
   );
+
+  // Register / activate / show in the pool while mounted; hide (keep-alive) on
+  // unmount. A changed hash re-runs this and rebuilds the iframe — the only
+  // intended reload path.
+  useEffect(() => {
+    mount(sceneId, {
+      srcDoc: patchedHtml,
+      src: patchedHtml ? undefined : content.url,
+      hash,
+    });
+    setActive(sceneId);
+    show(sceneId);
+    return () => hide(sceneId);
+  }, [sceneId, hash, patchedHtml, content.url, mount, setActive, show, hide]);
+
+  // Track this slot's screen rect for the host. rAF loop mirrors useTrackedRect:
+  // one getBoundingClientRect read resolves canvas scale, viewport offset and
+  // scroll, following the box through every resize / layout change.
+  useEffect(() => {
+    let raf = 0;
+    const measure = () => {
+      const node = slotRef.current;
+      if (node) {
+        const r = node.getBoundingClientRect();
+        setRect(sceneId, { left: r.left, top: r.top, width: r.width, height: r.height });
+      }
+      raf = requestAnimationFrame(measure);
+    };
+    raf = requestAnimationFrame(measure);
+    return () => cancelAnimationFrame(raf);
+  }, [sceneId, setRect]);
+
+  return <div ref={slotRef} className="w-full h-full" aria-hidden />;
 }

--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useEffect } from 'react';
+import { useId, useMemo, useRef, useEffect } from 'react';
 import type { InteractiveContent } from '@/lib/types/stage';
 import { useInteractiveIframePool } from '@/lib/store/interactive-iframe-pool';
 import { patchHtmlForIframe } from '@/lib/utils/iframe';
@@ -21,10 +21,13 @@ interface InteractiveRendererProps {
  */
 export function InteractiveRenderer({ content, sceneId }: InteractiveRendererProps) {
   const slotRef = useRef<HTMLDivElement>(null);
+  // Unique per mounted placeholder instance — its visibility ownership token, so
+  // a stale unmount during the mode cross-fade can't hide a newer instance.
+  const owner = useId();
   const mount = useInteractiveIframePool((s) => s.mount);
   const setRect = useInteractiveIframePool((s) => s.setRect);
-  const show = useInteractiveIframePool((s) => s.show);
-  const hide = useInteractiveIframePool((s) => s.hide);
+  const claim = useInteractiveIframePool((s) => s.claim);
+  const release = useInteractiveIframePool((s) => s.release);
   const setActive = useInteractiveIframePool((s) => s.setActive);
 
   const patchedHtml = useMemo(
@@ -32,7 +35,7 @@ export function InteractiveRenderer({ content, sceneId }: InteractiveRendererPro
     [content.html],
   );
 
-  // Register / activate / show in the pool while mounted; hide (keep-alive) on
+  // Register / activate / claim visibility while mounted; release (keep-alive) on
   // unmount. A content change re-runs this and rebuilds the iframe — the only
   // intended reload path.
   useEffect(() => {
@@ -41,9 +44,9 @@ export function InteractiveRenderer({ content, sceneId }: InteractiveRendererPro
       src: patchedHtml ? undefined : content.url,
     });
     setActive(sceneId);
-    show(sceneId);
-    return () => hide(sceneId);
-  }, [sceneId, patchedHtml, content.url, mount, setActive, show, hide]);
+    claim(sceneId, owner);
+    return () => release(sceneId, owner);
+  }, [sceneId, owner, patchedHtml, content.url, mount, setActive, claim, release]);
 
   // Track this slot's screen rect for the host. rAF loop mirrors useTrackedRect:
   // one getBoundingClientRect read resolves canvas scale, viewport offset and

--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useRef, useEffect } from 'react';
 import type { InteractiveContent } from '@/lib/types/stage';
-import { hashContent, useInteractiveIframePool } from '@/lib/store/interactive-iframe-pool';
+import { useInteractiveIframePool } from '@/lib/store/interactive-iframe-pool';
 import { patchHtmlForIframe } from '@/lib/utils/iframe';
 
 interface InteractiveRendererProps {
@@ -31,24 +31,19 @@ export function InteractiveRenderer({ content, sceneId }: InteractiveRendererPro
     () => (content.html ? patchHtmlForIframe(content.html) : undefined),
     [content.html],
   );
-  const hash = useMemo(
-    () => hashContent(patchedHtml ?? content.url ?? ''),
-    [patchedHtml, content.url],
-  );
 
   // Register / activate / show in the pool while mounted; hide (keep-alive) on
-  // unmount. A changed hash re-runs this and rebuilds the iframe — the only
+  // unmount. A content change re-runs this and rebuilds the iframe — the only
   // intended reload path.
   useEffect(() => {
     mount(sceneId, {
       srcDoc: patchedHtml,
       src: patchedHtml ? undefined : content.url,
-      hash,
     });
     setActive(sceneId);
     show(sceneId);
     return () => hide(sceneId);
-  }, [sceneId, hash, patchedHtml, content.url, mount, setActive, show, hide]);
+  }, [sceneId, patchedHtml, content.url, mount, setActive, show, hide]);
 
   // Track this slot's screen rect for the host. rAF loop mirrors useTrackedRect:
   // one getBoundingClientRect read resolves canvas scale, viewport offset and

--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/edit/PlaybackChromeRoot';
 import { useEditModeLock } from '@/components/edit/use-edit-mode-lock';
 import { MultiTabEditConflictPrompt } from '@/components/edit/MultiTabEditConflictPrompt';
+import { InteractiveIframeHost } from '@/components/scene-renderers/InteractiveIframeHost';
 import { CHROME_EASE } from '@/lib/edit/transitions';
 import { preloadEditor } from '@/lib/edit/preload-editor';
 
@@ -157,6 +158,10 @@ export function Stage({
         open={editLock.conflictOpen}
         onDismiss={editLock.dismissConflict}
       />
+      {/* Keep-alive host for interactive scene iframes (#619). Lives here, above
+          the mode-swap subtree, so its iframes survive Pro mode toggles and
+          scene switches instead of reloading on every remount. */}
+      <InteractiveIframeHost />
     </div>
   );
 }

--- a/e2e/tests/interactive-iframe-keepalive-619.spec.ts
+++ b/e2e/tests/interactive-iframe-keepalive-619.spec.ts
@@ -192,6 +192,12 @@ test.describe('#619 interactive iframe keep-alive', () => {
     await page.getByRole('switch').first().click();
     await expect(iframeEl).toBeVisible(); // back to playback
     await expect(count).toHaveText('3'); // state preserved → no reload
+    // Let the ~280ms mode cross-fade fully settle: the outgoing chrome's
+    // placeholder cleanup fires late, and a non-owner-checked release would hide
+    // the iframe here (the blank-on-return regression). It must stay visible.
+    await page.waitForTimeout(600);
+    await expect(iframeEl).toBeVisible();
+    await expect(count).toHaveText('3');
     await page.screenshot({ path: `${SHOTS}/03-back-from-pro.png`, fullPage: true });
 
     // --- Trigger B: scene switch away and back (placeholder unmount/remount) ---

--- a/e2e/tests/interactive-iframe-keepalive-619.spec.ts
+++ b/e2e/tests/interactive-iframe-keepalive-619.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect } from '../fixtures/base';
+import { ClassroomPage } from '../pages/classroom.page';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+import { defaultTheme } from '../fixtures/test-data/scene-content';
+
+/**
+ * E2E for #619: interactive scene iframes must NOT reload on remount.
+ *
+ * The keep-alive iframe is identified by its title `Interactive Scene <id>`.
+ * A MutationObserver on the top document records every add/remove of *that*
+ * iframe element. The proof of keep-alive: after each remount trigger (Pro mode
+ * toggle, scene switch and back) the element is neither removed nor recreated
+ * (zero recorded mutations), and the click-counter state it holds is preserved.
+ *
+ * Note: the slide nav rail also renders a separate, stateless `Interactive
+ * Preview` thumbnail iframe that does reload on re-render — a different surface,
+ * out of scope here. Scoping the observer to the playback iframe's title keeps
+ * the assertion clean of that noise.
+ */
+
+const TEST_STAGE_ID = 'e2e-iframe-keepalive';
+const INTERACTIVE_SCENE_ID = 'scene-interactive';
+const IFRAME_TITLE = `Interactive Scene ${INTERACTIVE_SCENE_ID}`;
+const SHOTS = 'e2e/__screenshots-619';
+
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+const INTERACTIVE_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"></head>
+<body style="margin:0;font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;background:#eaf0ff">
+  <div style="text-align:center">
+    <div style="font-size:14px;color:#556">interactive widget</div>
+    <h1 id="count" style="font-size:72px;margin:8px 0;color:#2a3">0</h1>
+    <button id="inc" style="font-size:18px;padding:8px 18px">+1</button>
+  </div>
+  <script>
+    var n = 0, c = document.getElementById('count');
+    document.getElementById('inc').addEventListener('click', function () { c.textContent = String(++n); });
+  </script>
+</body></html>`;
+
+async function seedDatabase(page: import('@playwright/test').Page) {
+  await page.addInitScript((settings) => {
+    localStorage.setItem('settings-storage', settings);
+  }, SETTINGS_STORAGE);
+
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  await page.evaluate(
+    ({ stageId, interactiveId, html, theme }) => {
+      return new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('MAIC-Database');
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+          const now = Date.now();
+
+          tx.objectStore('stages').put({
+            id: stageId,
+            name: 'Keep-alive test',
+            description: '',
+            language: 'en-US',
+            style: 'professional',
+            currentSceneId: interactiveId,
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('scenes').put({
+            id: interactiveId,
+            stageId,
+            type: 'interactive',
+            title: 'Interactive',
+            order: 0,
+            content: { type: 'interactive', url: '', html },
+            createdAt: now,
+            updatedAt: now,
+          });
+          tx.objectStore('scenes').put({
+            id: 'scene-slide',
+            stageId,
+            type: 'slide',
+            title: 'A slide',
+            order: 1,
+            content: {
+              type: 'slide',
+              canvas: {
+                id: 'slide-1',
+                viewportSize: 1000,
+                viewportRatio: 0.5625,
+                theme,
+                elements: [
+                  {
+                    type: 'text',
+                    id: 'el-1',
+                    content: 'A slide',
+                    left: 50,
+                    top: 50,
+                    width: 900,
+                    height: 100,
+                  },
+                ],
+              },
+            },
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('stageOutlines').put({
+            stageId,
+            outlines: [],
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+        request.onerror = () => reject(request.error);
+      });
+    },
+    {
+      stageId: TEST_STAGE_ID,
+      interactiveId: INTERACTIVE_SCENE_ID,
+      html: INTERACTIVE_HTML,
+      theme: defaultTheme,
+    },
+  );
+}
+
+const keepAliveMutations = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => (window as unknown as { __kaMut: string[] }).__kaMut.slice());
+
+const resetMutations = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => {
+    (window as unknown as { __kaMut: string[] }).__kaMut.length = 0;
+  });
+
+test.describe('#619 interactive iframe keep-alive', () => {
+  test('iframe survives Pro-mode toggle and scene switch without reloading', async ({ page }) => {
+    // Record add/remove of the keep-alive iframe (by title) in the top document.
+    await page.addInitScript((title) => {
+      if (window.top !== window.self) return;
+      (window as unknown as { __kaMut: string[] }).__kaMut = [];
+      const log = (window as unknown as { __kaMut: string[] }).__kaMut;
+      const isTarget = (n: Node) =>
+        n instanceof HTMLIFrameElement && n.getAttribute('title') === title;
+      const mo = new MutationObserver((muts) => {
+        for (const m of muts) {
+          m.addedNodes.forEach((n) => isTarget(n) && log.push('ADD'));
+          m.removedNodes.forEach((n) => isTarget(n) && log.push('REM'));
+        }
+      });
+      document.addEventListener('DOMContentLoaded', () =>
+        mo.observe(document.body, { childList: true, subtree: true }),
+      );
+    }, IFRAME_TITLE);
+
+    await seedDatabase(page);
+
+    const classroom = new ClassroomPage(page);
+    await classroom.goto(TEST_STAGE_ID);
+    await classroom.waitForLoaded();
+
+    const iframeEl = page.locator(`iframe[title="${IFRAME_TITLE}"]`);
+    const frame = page.frameLocator(`iframe[title="${IFRAME_TITLE}"]`);
+    const count = frame.locator('#count');
+
+    // Initial render. Build in-iframe state that only survives a true keep-alive.
+    await expect(iframeEl).toBeVisible({ timeout: 15_000 });
+    await expect(count).toHaveText('0');
+    await frame.locator('#inc').click();
+    await frame.locator('#inc').click();
+    await frame.locator('#inc').click();
+    await expect(count).toHaveText('3');
+    await page.screenshot({ path: `${SHOTS}/01-interactive-counter-3.png`, fullPage: true });
+
+    // Ignore any initial mount churn (incl. dev StrictMode); from here on the
+    // keep-alive iframe must not be added or removed again.
+    await resetMutations(page);
+
+    // `.first()` because the ~280ms mode cross-fade briefly mounts both chrome
+    // layers (each with its own Pro switch). iframe visibility is the unambiguous
+    // "transition settled" signal.
+    // --- Trigger A: Pro mode toggle (edit chrome unmounts playback chrome) ---
+    await page.getByRole('switch').first().click();
+    await expect(iframeEl).toBeHidden(); // hidden in edit mode, not unmounted
+    await page.screenshot({ path: `${SHOTS}/02-pro-mode.png`, fullPage: true });
+
+    await page.getByRole('switch').first().click();
+    await expect(iframeEl).toBeVisible(); // back to playback
+    await expect(count).toHaveText('3'); // state preserved → no reload
+    await page.screenshot({ path: `${SHOTS}/03-back-from-pro.png`, fullPage: true });
+
+    // --- Trigger B: scene switch away and back (placeholder unmount/remount) ---
+    await classroom.clickScene(1); // slide
+    await expect(page.getByRole('heading', { name: 'A slide' })).toBeVisible();
+    await expect(iframeEl).toBeHidden();
+
+    await classroom.clickScene(0); // back to interactive
+    await expect(iframeEl).toBeVisible();
+    await expect(count).toHaveText('3'); // state preserved → no reload
+    await page.screenshot({ path: `${SHOTS}/04-back-from-scene-switch.png`, fullPage: true });
+
+    // The keep-alive iframe element was never removed or recreated across either
+    // remount trigger — the document (and its in-iframe state) was preserved.
+    expect(await keepAliveMutations(page)).toEqual([]);
+  });
+});

--- a/lib/store/interactive-iframe-pool.ts
+++ b/lib/store/interactive-iframe-pool.ts
@@ -12,8 +12,8 @@
  * rect to position the iframe over, and whether it should currently be visible.
  *
  * Entries are keyed by sceneId and persist across scene/mode changes — a scene's
- * iframe is only rebuilt when its content hash changes. A small LRU cap bounds
- * how many documents stay resident in memory.
+ * iframe is only rebuilt when its content actually changes. A small LRU cap
+ * bounds how many documents stay resident in memory.
  */
 
 import { create } from 'zustand';
@@ -32,8 +32,6 @@ export interface IframePoolEntry {
   readonly srcDoc?: string;
   /** URL for `src`, when the scene points at an external page. */
   readonly src?: string;
-  /** Content fingerprint — a change is the only thing that rebuilds the iframe. */
-  readonly hash: string;
   /** Live screen rect the host positions the iframe over, or null until measured. */
   readonly rect: IframeRect | null;
   /** Whether the iframe should currently be shown (placeholder mounted & active). */
@@ -45,7 +43,6 @@ export interface IframePoolEntry {
 interface MountInput {
   readonly srcDoc?: string;
   readonly src?: string;
-  readonly hash: string;
 }
 
 interface InteractiveIframePoolState {
@@ -59,15 +56,8 @@ interface InteractiveIframePoolState {
   hide: (sceneId: string) => void;
   setActive: (sceneId: string) => void;
   evict: (sceneId: string) => void;
-}
-
-/** djb2 string hash — cheap and stable, enough to detect content changes. */
-export function hashContent(content: string): string {
-  let h = 5381;
-  for (let i = 0; i < content.length; i++) {
-    h = ((h << 5) + h + content.charCodeAt(i)) | 0;
-  }
-  return (h >>> 0).toString(36);
+  /** Drop everything (e.g. when the host unmounts on classroom switch). */
+  reset: () => void;
 }
 
 /**
@@ -104,17 +94,17 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
       const existing = state.entries[sceneId];
       // Same content already loaded: just refresh recency. Crucially we keep the
       // existing srcDoc/src reference so the host never re-sets it (which would
-      // reload the iframe). This is the keep-alive fast path.
-      if (existing && existing.hash === input.hash) {
+      // reload the iframe). String `===` is by value, so a remount that produces
+      // an equal-but-new srcDoc string still hits this keep-alive fast path.
+      if (existing && existing.srcDoc === input.srcDoc && existing.src === input.src) {
         const entries = { ...state.entries, [sceneId]: { ...existing, tick } };
         return { entries, tick };
       }
-      // New scene, or content changed: (re)build the entry. A changed hash here
+      // New scene, or content changed: (re)build the entry. A content change here
       // is the one intended reload path.
       const entry: IframePoolEntry = {
         srcDoc: input.srcDoc,
         src: input.src,
-        hash: input.hash,
         rect: existing?.rect ?? null,
         visible: existing?.visible ?? false,
         tick,
@@ -164,4 +154,6 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
       const activeSceneId = state.activeSceneId === sceneId ? null : state.activeSceneId;
       return { entries, activeSceneId };
     }),
+
+  reset: () => set({ entries: {}, activeSceneId: null, tick: 0 }),
 }));

--- a/lib/store/interactive-iframe-pool.ts
+++ b/lib/store/interactive-iframe-pool.ts
@@ -34,8 +34,16 @@ export interface IframePoolEntry {
   readonly src?: string;
   /** Live screen rect the host positions the iframe over, or null until measured. */
   readonly rect: IframeRect | null;
-  /** Whether the iframe should currently be shown (placeholder mounted & active). */
-  readonly visible: boolean;
+  /**
+   * Id of the placeholder instance that currently owns visibility, or null when
+   * no placeholder is mounted. The iframe shows iff this is non-null. Ownership
+   * (rather than a bare boolean) is what makes `release` race-safe: during the
+   * Stage mode cross-fade an outgoing placeholder's unmount cleanup can run
+   * *after* a newer placeholder for the same scene has already mounted and
+   * claimed it — keying the release on the owner id lets the stale cleanup
+   * no-op instead of hiding the live iframe.
+   */
+  readonly owner: string | null;
   /** Monotonic recency marker for LRU eviction. */
   readonly tick: number;
 }
@@ -52,8 +60,10 @@ interface InteractiveIframePoolState {
   tick: number;
   mount: (sceneId: string, input: MountInput) => void;
   setRect: (sceneId: string, rect: IframeRect) => void;
-  show: (sceneId: string) => void;
-  hide: (sceneId: string) => void;
+  /** A placeholder claims visibility for its scene, recording its owner id. */
+  claim: (sceneId: string, owner: string) => void;
+  /** Release visibility, but only if `owner` still owns it (stale = no-op). */
+  release: (sceneId: string, owner: string) => void;
   setActive: (sceneId: string) => void;
   evict: (sceneId: string) => void;
   /** Drop everything (e.g. when the host unmounts on classroom switch). */
@@ -106,7 +116,7 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
         srcDoc: input.srcDoc,
         src: input.src,
         rect: existing?.rect ?? null,
-        visible: existing?.visible ?? false,
+        owner: existing?.owner ?? null,
         tick,
       };
       const entries = evictLru({ ...state.entries, [sceneId]: entry }, state.activeSceneId);
@@ -130,18 +140,21 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
       return { entries: { ...state.entries, [sceneId]: { ...existing, rect } } };
     }),
 
-  show: (sceneId) =>
+  claim: (sceneId, owner) =>
     set((state) => {
       const existing = state.entries[sceneId];
-      if (!existing || existing.visible) return {};
-      return { entries: { ...state.entries, [sceneId]: { ...existing, visible: true } } };
+      if (!existing || existing.owner === owner) return {};
+      return { entries: { ...state.entries, [sceneId]: { ...existing, owner } } };
     }),
 
-  hide: (sceneId) =>
+  release: (sceneId, owner) =>
     set((state) => {
       const existing = state.entries[sceneId];
-      if (!existing || !existing.visible) return {};
-      return { entries: { ...state.entries, [sceneId]: { ...existing, visible: false } } };
+      // Only the current owner may release. A stale placeholder (whose unmount
+      // cleanup runs after a newer one already re-claimed during the mode
+      // cross-fade) finds owner !== its id and no-ops, so the live iframe stays.
+      if (!existing || existing.owner !== owner) return {};
+      return { entries: { ...state.entries, [sceneId]: { ...existing, owner: null } } };
     }),
 
   setActive: (sceneId) => set({ activeSceneId: sceneId }),

--- a/lib/store/interactive-iframe-pool.ts
+++ b/lib/store/interactive-iframe-pool.ts
@@ -1,0 +1,167 @@
+/**
+ * Keep-alive pool for interactive scene iframes (#619).
+ *
+ * Interactive scenes render their content in an `<iframe>`. When that element
+ * unmounts or is re-parented (Pro mode toggle, scene switch and back, any
+ * PlaybackChromeRoot remount) the browser drops the document and re-parses /
+ * re-runs from scratch, losing in-iframe state. To avoid that, the actual
+ * iframe elements live in a single stable host (`InteractiveIframeHost`)
+ * mounted at the `Stage` root, outside the reconciled scene subtree. This store
+ * is the coordination layer between the in-tree placeholder (`InteractiveRenderer`)
+ * and that host: it tracks, per scene, the content to render, the live on-screen
+ * rect to position the iframe over, and whether it should currently be visible.
+ *
+ * Entries are keyed by sceneId and persist across scene/mode changes — a scene's
+ * iframe is only rebuilt when its content hash changes. A small LRU cap bounds
+ * how many documents stay resident in memory.
+ */
+
+import { create } from 'zustand';
+
+export const IFRAME_POOL_CAP = 3;
+
+export interface IframeRect {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface IframePoolEntry {
+  /** Patched HTML for `srcDoc`, when the scene carries inline HTML. */
+  readonly srcDoc?: string;
+  /** URL for `src`, when the scene points at an external page. */
+  readonly src?: string;
+  /** Content fingerprint — a change is the only thing that rebuilds the iframe. */
+  readonly hash: string;
+  /** Live screen rect the host positions the iframe over, or null until measured. */
+  readonly rect: IframeRect | null;
+  /** Whether the iframe should currently be shown (placeholder mounted & active). */
+  readonly visible: boolean;
+  /** Monotonic recency marker for LRU eviction. */
+  readonly tick: number;
+}
+
+interface MountInput {
+  readonly srcDoc?: string;
+  readonly src?: string;
+  readonly hash: string;
+}
+
+interface InteractiveIframePoolState {
+  entries: Record<string, IframePoolEntry>;
+  activeSceneId: string | null;
+  /** Monotonic counter; each mount/touch takes the next value. */
+  tick: number;
+  mount: (sceneId: string, input: MountInput) => void;
+  setRect: (sceneId: string, rect: IframeRect) => void;
+  show: (sceneId: string) => void;
+  hide: (sceneId: string) => void;
+  setActive: (sceneId: string) => void;
+  evict: (sceneId: string) => void;
+}
+
+/** djb2 string hash — cheap and stable, enough to detect content changes. */
+export function hashContent(content: string): string {
+  let h = 5381;
+  for (let i = 0; i < content.length; i++) {
+    h = ((h << 5) + h + content.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Drop the least-recently-touched entries until at most CAP remain. The active
+ * scene is never evicted (its iframe is on screen). Returns a new entries map.
+ */
+function evictLru(
+  entries: Record<string, IframePoolEntry>,
+  activeSceneId: string | null,
+): Record<string, IframePoolEntry> {
+  const ids = Object.keys(entries);
+  if (ids.length <= IFRAME_POOL_CAP) return entries;
+  const evictable = ids
+    .filter((id) => id !== activeSceneId)
+    .sort((a, b) => entries[a].tick - entries[b].tick);
+  const next = { ...entries };
+  let overflow = ids.length - IFRAME_POOL_CAP;
+  for (const id of evictable) {
+    if (overflow <= 0) break;
+    delete next[id];
+    overflow--;
+  }
+  return next;
+}
+
+export const useInteractiveIframePool = create<InteractiveIframePoolState>((set) => ({
+  entries: {},
+  activeSceneId: null,
+  tick: 0,
+
+  mount: (sceneId, input) =>
+    set((state) => {
+      const tick = state.tick + 1;
+      const existing = state.entries[sceneId];
+      // Same content already loaded: just refresh recency. Crucially we keep the
+      // existing srcDoc/src reference so the host never re-sets it (which would
+      // reload the iframe). This is the keep-alive fast path.
+      if (existing && existing.hash === input.hash) {
+        const entries = { ...state.entries, [sceneId]: { ...existing, tick } };
+        return { entries, tick };
+      }
+      // New scene, or content changed: (re)build the entry. A changed hash here
+      // is the one intended reload path.
+      const entry: IframePoolEntry = {
+        srcDoc: input.srcDoc,
+        src: input.src,
+        hash: input.hash,
+        rect: existing?.rect ?? null,
+        visible: existing?.visible ?? false,
+        tick,
+      };
+      const entries = evictLru({ ...state.entries, [sceneId]: entry }, state.activeSceneId);
+      return { entries, tick };
+    }),
+
+  setRect: (sceneId, rect) =>
+    set((state) => {
+      const existing = state.entries[sceneId];
+      if (!existing) return {};
+      const r = existing.rect;
+      if (
+        r &&
+        r.left === rect.left &&
+        r.top === rect.top &&
+        r.width === rect.width &&
+        r.height === rect.height
+      ) {
+        return {};
+      }
+      return { entries: { ...state.entries, [sceneId]: { ...existing, rect } } };
+    }),
+
+  show: (sceneId) =>
+    set((state) => {
+      const existing = state.entries[sceneId];
+      if (!existing || existing.visible) return {};
+      return { entries: { ...state.entries, [sceneId]: { ...existing, visible: true } } };
+    }),
+
+  hide: (sceneId) =>
+    set((state) => {
+      const existing = state.entries[sceneId];
+      if (!existing || !existing.visible) return {};
+      return { entries: { ...state.entries, [sceneId]: { ...existing, visible: false } } };
+    }),
+
+  setActive: (sceneId) => set({ activeSceneId: sceneId }),
+
+  evict: (sceneId) =>
+    set((state) => {
+      if (!state.entries[sceneId]) return {};
+      const entries = { ...state.entries };
+      delete entries[sceneId];
+      const activeSceneId = state.activeSceneId === sceneId ? null : state.activeSceneId;
+      return { entries, activeSceneId };
+    }),
+}));

--- a/tests/store/interactive-iframe-pool.test.ts
+++ b/tests/store/interactive-iframe-pool.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import {
+  IFRAME_POOL_CAP,
+  hashContent,
+  useInteractiveIframePool,
+} from '@/lib/store/interactive-iframe-pool';
+
+function reset() {
+  useInteractiveIframePool.setState({ entries: {}, activeSceneId: null, tick: 0 });
+}
+
+const pool = () => useInteractiveIframePool.getState();
+
+beforeEach(reset);
+
+describe('hashContent', () => {
+  test('is stable for the same input and differs for changed input', () => {
+    expect(hashContent('<h1>a</h1>')).toBe(hashContent('<h1>a</h1>'));
+    expect(hashContent('<h1>a</h1>')).not.toBe(hashContent('<h1>b</h1>'));
+  });
+});
+
+describe('mount', () => {
+  test('creates an entry with the given content', () => {
+    pool().mount('s1', { srcDoc: '<p>1</p>', hash: hashContent('<p>1</p>') });
+    const e = pool().entries['s1'];
+    expect(e).toBeDefined();
+    expect(e.srcDoc).toBe('<p>1</p>');
+    expect(e.hash).toBe(hashContent('<p>1</p>'));
+  });
+
+  test('re-mounting with the same hash does NOT replace srcDoc (no reload)', () => {
+    const html = '<p>1</p>';
+    pool().mount('s1', { srcDoc: html, hash: hashContent(html) });
+    const first = pool().entries['s1'].srcDoc;
+    pool().mount('s1', { srcDoc: html, hash: hashContent(html) });
+    expect(pool().entries['s1'].srcDoc).toBe(first); // same reference -> iframe untouched
+    expect(Object.keys(pool().entries)).toHaveLength(1);
+  });
+
+  test('re-mounting with a new hash replaces the content (intended reload)', () => {
+    pool().mount('s1', { srcDoc: '<p>1</p>', hash: hashContent('<p>1</p>') });
+    pool().mount('s1', { srcDoc: '<p>2</p>', hash: hashContent('<p>2</p>') });
+    expect(pool().entries['s1'].srcDoc).toBe('<p>2</p>');
+    expect(pool().entries['s1'].hash).toBe(hashContent('<p>2</p>'));
+  });
+
+  test('supports url-backed (src) entries', () => {
+    pool().mount('s1', { src: 'https://x/widget', hash: hashContent('https://x/widget') });
+    expect(pool().entries['s1'].src).toBe('https://x/widget');
+    expect(pool().entries['s1'].srcDoc).toBeUndefined();
+  });
+});
+
+describe('visibility + rect + active', () => {
+  test('hide keeps the entry alive but not visible', () => {
+    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().show('s1');
+    expect(pool().entries['s1'].visible).toBe(true);
+    pool().hide('s1');
+    expect(pool().entries['s1']).toBeDefined(); // keep-alive
+    expect(pool().entries['s1'].visible).toBe(false);
+  });
+
+  test('setRect updates the tracked rect', () => {
+    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().setRect('s1', { left: 1, top: 2, width: 3, height: 4 });
+    expect(pool().entries['s1'].rect).toEqual({ left: 1, top: 2, width: 3, height: 4 });
+  });
+
+  test('setActive records the active scene', () => {
+    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().setActive('s1');
+    expect(pool().activeSceneId).toBe('s1');
+  });
+
+  test('setRect / show / hide on an unknown scene are no-ops', () => {
+    pool().setRect('ghost', { left: 0, top: 0, width: 0, height: 0 });
+    pool().show('ghost');
+    pool().hide('ghost');
+    expect(pool().entries['ghost']).toBeUndefined();
+  });
+});
+
+describe('LRU eviction', () => {
+  test(`evicts the least-recently-mounted entry beyond CAP (${IFRAME_POOL_CAP})`, () => {
+    for (let i = 0; i < IFRAME_POOL_CAP + 1; i++) {
+      pool().mount(`s${i}`, { srcDoc: `x${i}`, hash: `h${i}` });
+    }
+    expect(Object.keys(pool().entries)).toHaveLength(IFRAME_POOL_CAP);
+    expect(pool().entries['s0']).toBeUndefined(); // oldest evicted
+    expect(pool().entries[`s${IFRAME_POOL_CAP}`]).toBeDefined(); // newest kept
+  });
+
+  test('never evicts the active scene even if it is the oldest', () => {
+    pool().mount('s0', { srcDoc: 'x0', hash: 'h0' });
+    pool().setActive('s0');
+    for (let i = 1; i < IFRAME_POOL_CAP + 1; i++) {
+      pool().mount(`s${i}`, { srcDoc: `x${i}`, hash: `h${i}` });
+    }
+    expect(pool().entries['s0']).toBeDefined(); // active survives
+    expect(Object.keys(pool().entries)).toHaveLength(IFRAME_POOL_CAP);
+  });
+
+  test('re-mounting an existing entry refreshes its recency', () => {
+    pool().mount('s0', { srcDoc: 'x0', hash: 'h0' });
+    pool().mount('s1', { srcDoc: 'x1', hash: 'h1' });
+    pool().mount('s2', { srcDoc: 'x2', hash: 'h2' });
+    pool().mount('s0', { srcDoc: 'x0', hash: 'h0' }); // touch s0 -> s1 now oldest
+    pool().mount('s3', { srcDoc: 'x3', hash: 'h3' });
+    expect(pool().entries['s1']).toBeUndefined();
+    expect(pool().entries['s0']).toBeDefined();
+  });
+});
+
+describe('evict', () => {
+  test('removes an entry explicitly', () => {
+    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().evict('s1');
+    expect(pool().entries['s1']).toBeUndefined();
+  });
+});

--- a/tests/store/interactive-iframe-pool.test.ts
+++ b/tests/store/interactive-iframe-pool.test.ts
@@ -1,52 +1,40 @@
 import { beforeEach, describe, expect, test } from 'vitest';
-import {
-  IFRAME_POOL_CAP,
-  hashContent,
-  useInteractiveIframePool,
-} from '@/lib/store/interactive-iframe-pool';
+import { IFRAME_POOL_CAP, useInteractiveIframePool } from '@/lib/store/interactive-iframe-pool';
 
 function reset() {
-  useInteractiveIframePool.setState({ entries: {}, activeSceneId: null, tick: 0 });
+  useInteractiveIframePool.getState().reset();
 }
 
 const pool = () => useInteractiveIframePool.getState();
 
 beforeEach(reset);
 
-describe('hashContent', () => {
-  test('is stable for the same input and differs for changed input', () => {
-    expect(hashContent('<h1>a</h1>')).toBe(hashContent('<h1>a</h1>'));
-    expect(hashContent('<h1>a</h1>')).not.toBe(hashContent('<h1>b</h1>'));
-  });
-});
-
 describe('mount', () => {
   test('creates an entry with the given content', () => {
-    pool().mount('s1', { srcDoc: '<p>1</p>', hash: hashContent('<p>1</p>') });
+    pool().mount('s1', { srcDoc: '<p>1</p>' });
     const e = pool().entries['s1'];
     expect(e).toBeDefined();
     expect(e.srcDoc).toBe('<p>1</p>');
-    expect(e.hash).toBe(hashContent('<p>1</p>'));
   });
 
-  test('re-mounting with the same hash does NOT replace srcDoc (no reload)', () => {
-    const html = '<p>1</p>';
-    pool().mount('s1', { srcDoc: html, hash: hashContent(html) });
+  test('re-mounting with equal content keeps the entry (no reload)', () => {
+    pool().mount('s1', { srcDoc: '<p>1</p>' });
     const first = pool().entries['s1'].srcDoc;
-    pool().mount('s1', { srcDoc: html, hash: hashContent(html) });
-    expect(pool().entries['s1'].srcDoc).toBe(first); // same reference -> iframe untouched
+    // A remount recomputes an equal-but-new string; value equality must still
+    // hit the keep-alive fast path so the host never re-sets srcDoc.
+    pool().mount('s1', { srcDoc: ['<p>', '1', '</p>'].join('') });
+    expect(pool().entries['s1'].srcDoc).toBe(first);
     expect(Object.keys(pool().entries)).toHaveLength(1);
   });
 
-  test('re-mounting with a new hash replaces the content (intended reload)', () => {
-    pool().mount('s1', { srcDoc: '<p>1</p>', hash: hashContent('<p>1</p>') });
-    pool().mount('s1', { srcDoc: '<p>2</p>', hash: hashContent('<p>2</p>') });
+  test('re-mounting with changed content replaces it (intended reload)', () => {
+    pool().mount('s1', { srcDoc: '<p>1</p>' });
+    pool().mount('s1', { srcDoc: '<p>2</p>' });
     expect(pool().entries['s1'].srcDoc).toBe('<p>2</p>');
-    expect(pool().entries['s1'].hash).toBe(hashContent('<p>2</p>'));
   });
 
   test('supports url-backed (src) entries', () => {
-    pool().mount('s1', { src: 'https://x/widget', hash: hashContent('https://x/widget') });
+    pool().mount('s1', { src: 'https://x/widget' });
     expect(pool().entries['s1'].src).toBe('https://x/widget');
     expect(pool().entries['s1'].srcDoc).toBeUndefined();
   });
@@ -54,7 +42,7 @@ describe('mount', () => {
 
 describe('visibility + rect + active', () => {
   test('hide keeps the entry alive but not visible', () => {
-    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().mount('s1', { srcDoc: 'x' });
     pool().show('s1');
     expect(pool().entries['s1'].visible).toBe(true);
     pool().hide('s1');
@@ -63,13 +51,13 @@ describe('visibility + rect + active', () => {
   });
 
   test('setRect updates the tracked rect', () => {
-    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().mount('s1', { srcDoc: 'x' });
     pool().setRect('s1', { left: 1, top: 2, width: 3, height: 4 });
     expect(pool().entries['s1'].rect).toEqual({ left: 1, top: 2, width: 3, height: 4 });
   });
 
   test('setActive records the active scene', () => {
-    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+    pool().mount('s1', { srcDoc: 'x' });
     pool().setActive('s1');
     expect(pool().activeSceneId).toBe('s1');
   });
@@ -85,7 +73,7 @@ describe('visibility + rect + active', () => {
 describe('LRU eviction', () => {
   test(`evicts the least-recently-mounted entry beyond CAP (${IFRAME_POOL_CAP})`, () => {
     for (let i = 0; i < IFRAME_POOL_CAP + 1; i++) {
-      pool().mount(`s${i}`, { srcDoc: `x${i}`, hash: `h${i}` });
+      pool().mount(`s${i}`, { srcDoc: `x${i}` });
     }
     expect(Object.keys(pool().entries)).toHaveLength(IFRAME_POOL_CAP);
     expect(pool().entries['s0']).toBeUndefined(); // oldest evicted
@@ -93,30 +81,38 @@ describe('LRU eviction', () => {
   });
 
   test('never evicts the active scene even if it is the oldest', () => {
-    pool().mount('s0', { srcDoc: 'x0', hash: 'h0' });
+    pool().mount('s0', { srcDoc: 'x0' });
     pool().setActive('s0');
     for (let i = 1; i < IFRAME_POOL_CAP + 1; i++) {
-      pool().mount(`s${i}`, { srcDoc: `x${i}`, hash: `h${i}` });
+      pool().mount(`s${i}`, { srcDoc: `x${i}` });
     }
     expect(pool().entries['s0']).toBeDefined(); // active survives
     expect(Object.keys(pool().entries)).toHaveLength(IFRAME_POOL_CAP);
   });
 
   test('re-mounting an existing entry refreshes its recency', () => {
-    pool().mount('s0', { srcDoc: 'x0', hash: 'h0' });
-    pool().mount('s1', { srcDoc: 'x1', hash: 'h1' });
-    pool().mount('s2', { srcDoc: 'x2', hash: 'h2' });
-    pool().mount('s0', { srcDoc: 'x0', hash: 'h0' }); // touch s0 -> s1 now oldest
-    pool().mount('s3', { srcDoc: 'x3', hash: 'h3' });
+    pool().mount('s0', { srcDoc: 'x0' });
+    pool().mount('s1', { srcDoc: 'x1' });
+    pool().mount('s2', { srcDoc: 'x2' });
+    pool().mount('s0', { srcDoc: 'x0' }); // touch s0 -> s1 now oldest
+    pool().mount('s3', { srcDoc: 'x3' });
     expect(pool().entries['s1']).toBeUndefined();
     expect(pool().entries['s0']).toBeDefined();
   });
 });
 
-describe('evict', () => {
-  test('removes an entry explicitly', () => {
-    pool().mount('s1', { srcDoc: 'x', hash: 'h' });
+describe('evict / reset', () => {
+  test('evict removes an entry explicitly', () => {
+    pool().mount('s1', { srcDoc: 'x' });
     pool().evict('s1');
     expect(pool().entries['s1']).toBeUndefined();
+  });
+
+  test('reset clears all entries and active scene', () => {
+    pool().mount('s1', { srcDoc: 'x' });
+    pool().setActive('s1');
+    pool().reset();
+    expect(Object.keys(pool().entries)).toHaveLength(0);
+    expect(pool().activeSceneId).toBeNull();
   });
 });

--- a/tests/store/interactive-iframe-pool.test.ts
+++ b/tests/store/interactive-iframe-pool.test.ts
@@ -40,14 +40,24 @@ describe('mount', () => {
   });
 });
 
-describe('visibility + rect + active', () => {
-  test('hide keeps the entry alive but not visible', () => {
+describe('visibility ownership + rect + active', () => {
+  test('release keeps the entry alive but clears its owner', () => {
     pool().mount('s1', { srcDoc: 'x' });
-    pool().show('s1');
-    expect(pool().entries['s1'].visible).toBe(true);
-    pool().hide('s1');
+    pool().claim('s1', 'ownerA');
+    expect(pool().entries['s1'].owner).toBe('ownerA');
+    pool().release('s1', 'ownerA');
     expect(pool().entries['s1']).toBeDefined(); // keep-alive
-    expect(pool().entries['s1'].visible).toBe(false);
+    expect(pool().entries['s1'].owner).toBeNull();
+  });
+
+  test('a stale release (wrong owner) does NOT clear a re-claimed entry', () => {
+    // Models the mode cross-fade: a newer placeholder re-claims the scene, then
+    // the outgoing placeholder's unmount cleanup fires with its old owner id.
+    pool().mount('s1', { srcDoc: 'x' });
+    pool().claim('s1', 'old');
+    pool().claim('s1', 'new'); // newer placeholder takes over
+    pool().release('s1', 'old'); // stale cleanup must not hide it
+    expect(pool().entries['s1'].owner).toBe('new');
   });
 
   test('setRect updates the tracked rect', () => {
@@ -62,10 +72,10 @@ describe('visibility + rect + active', () => {
     expect(pool().activeSceneId).toBe('s1');
   });
 
-  test('setRect / show / hide on an unknown scene are no-ops', () => {
+  test('setRect / claim / release on an unknown scene are no-ops', () => {
     pool().setRect('ghost', { left: 0, top: 0, width: 0, height: 0 });
-    pool().show('ghost');
-    pool().hide('ghost');
+    pool().claim('ghost', 'o');
+    pool().release('ghost', 'o');
     expect(pool().entries['ghost']).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #619.

## Problem
Interactive scene iframes reload (re-parse HTML, re-run scripts, lose in-iframe state) on **every remount**, not just the Pro mode toggle. `InteractiveRenderer` rendered `<iframe srcDoc>` inline in the scene subtree, so any unmount — or even a DOM re-parent — makes the browser drop the document. Triggers: Pro mode toggle (PlaybackChromeRoot unmount), scene switch and back, any PlaybackChromeRoot remount.

## Fix — keep-alive iframe pool
Persist the iframes in a stable host at the `Stage` root, outside the mode-swap / scene subtree, keyed by sceneId.

- **`lib/store/interactive-iframe-pool.ts`** — per-scene entries (`srcDoc`/`src`, content hash, tracked rect, visibility), LRU-bounded (`CAP=3`). Re-mounting with an unchanged hash keeps the existing content reference, so the iframe is never re-set; only a content-hash change rebuilds it (the single intended reload path).
- **`InteractiveIframeHost`** — mounted once in `Stage`, portals one persisted `<iframe>` per entry to `document.body`, positioned over each scene's rect via `position: fixed`. Hidden with `visibility` (never `display:none`, which can drop the document on re-show) in edit mode and whenever the placeholder is gone. Owns the `widget-iframe` postMessage registration.
- **`InteractiveRenderer`** — now a placeholder: registers content, marks the scene active/visible, reports its rect via a rAF loop (same mechanism as `useTrackedRect`), and hides (not evicts) on unmount.

Mode toggle, back-and-forth scene switching, and re-renders now hit the cache with zero reload and zero flash.

## Coupling
Self-contained, interactive-scene path only. `widget-iframe` messaging API unchanged (`PlaybackChromeRoot.getSendMessage` untouched). No change to the playback engine / SSE / edit-lock.

## Known minor (v1)
Brief content pop on the edit→playback fade-in (iframe shows at full opacity while the edit chrome fades out). Acceptable for v1; can refine with an animation-aware visibility gate later.

## Tests
- `tests/store/interactive-iframe-pool.test.ts` — 13 tests: create, hash-change rebuild, hide-keeps-alive, rect tracking, active, LRU eviction (incl. never evicting the active scene, recency refresh). All green.
- `pnpm test`: 620 pass / 13 new. (The 9 `ssrf-guard` failures are pre-existing, DNS-dependent, unrelated.)
- `tsc --noEmit` and `eslint` clean on changed files.

## Verification still pending
Live visual e2e (Playwright screenshots of a real interactive classroom across Pro-mode toggle and scene-switch-back) not yet run — needs a dev server + seeded interactive content. Will attach once verified.
