### PR TITLE
fix: hide unsupported MiniMax Hailuo Fast T2V model

### DIFF
--- a/lib/media/video-providers.ts
+++ b/lib/media/video-providers.ts
@@ -85,9 +85,10 @@ export const VIDEO_PROVIDERS: Record<VideoProviderId, VideoProviderConfig> = {
     name: 'MiniMax Video',
     requiresApiKey: true,
     defaultBaseUrl: 'https://api.minimaxi.com',
+    // Hailuo 2.3 Fast requires Image-to-Video with first_frame_image; this
+    // provider currently submits Text-to-Video requests only.
     models: [
       { id: 'MiniMax-Hailuo-2.3', name: 'Hailuo 2.3' },
-      { id: 'MiniMax-Hailuo-2.3-Fast', name: 'Hailuo 2.3 Fast' },
       { id: 'MiniMax-Hailuo-02', name: 'Hailuo 02' },
       { id: 'T2V-01-Director', name: 'T2V-01 Director' },
       { id: 'T2V-01', name: 'T2V-01' },

--- a/tests/media/minimax-video-provider.test.ts
+++ b/tests/media/minimax-video-provider.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { VIDEO_PROVIDERS } from '@/lib/media/video-providers';
+
+describe('MiniMax video provider', () => {
+  it('does not expose Hailuo 2.3 Fast in the current T2V-only model list', () => {
+    const modelIds = VIDEO_PROVIDERS['minimax-video'].models.map((model) => model.id);
+
+    expect(modelIds).toContain('MiniMax-Hailuo-2.3');
+    expect(modelIds).not.toContain('MiniMax-Hailuo-2.3-Fast');
+  });
+});


### PR DESCRIPTION
## Summary

- Remove `MiniMax-Hailuo-2.3-Fast` from the current MiniMax Text-to-Video model list.
- Add a regression test to keep the T2V-only selector from exposing the unsupported Fast model.

## Why

The current MiniMax video adapter submits Text-to-Video requests. MiniMax Hailuo 2.3 Fast requires Image-to-Video input with `first_frame_image`, so selecting the Fast model in the current flow causes the API to reject the request before a video task is created.

This keeps the UI aligned with the adapter's actual capabilities until OpenMAIC has a dedicated I2V / first-frame workflow.

Fixes #631.

## Test Plan

- `pnpm test tests/media/minimax-video-provider.test.ts`
- `pnpm test tests/media/minimax-video-provider.test.ts tests/store/settings-server-sync.test.ts`
- `git diff --check`
