### PR TITLE
Add MiniMax web search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,9 @@ BOCHA_BASE_URL=https://api.bocha.cn
 BRAVE_API_KEY=
 BAIDU_API_KEY=
 BAIDU_BASE_URL=https://qianfan.baidubce.com
+# Dedicated MiniMax web-search vars avoid conflicting with the LLM MINIMAX_* endpoint.
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com
 
 # --- Proxy (optional) --------------------------------------------------------
 

--- a/app/api/web-search/route.ts
+++ b/app/api/web-search/route.ts
@@ -139,6 +139,8 @@ function getWebSearchEnvKey(providerId: WebSearchProviderId): string {
       return 'BOCHA_API_KEY';
     case 'brave':
       return 'BRAVE_API_KEY';
+    case 'minimax':
+      return 'WEB_SEARCH_MINIMAX_API_KEY';
     case 'tavily':
     default:
       return 'TAVILY_API_KEY';

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -108,6 +108,7 @@ const WEB_SEARCH_ENV_MAP: Record<string, string> = {
   BOCHA: 'bocha',
   BRAVE: 'brave',
   BAIDU: 'baidu',
+  WEB_SEARCH_MINIMAX: 'minimax',
 };
 
 // ---------------------------------------------------------------------------
@@ -500,5 +501,6 @@ export function resolveServerWebSearchProviderId(preferredProviderId?: string): 
   if (webSearch.tavily?.apiKey) return 'tavily';
   if (webSearch.bocha?.apiKey) return 'bocha';
   if (webSearch.baidu?.apiKey) return 'baidu';
+  if (webSearch.minimax?.apiKey) return 'minimax';
   return Object.keys(webSearch)[0];
 }

--- a/lib/server/web-search-config.ts
+++ b/lib/server/web-search-config.ts
@@ -22,6 +22,16 @@ const OFFICIAL_CLIENT_BASE_URLS: Record<WebSearchProviderId, string[]> = {
     'https://api.search.brave.com',
   ],
   baidu: ['https://qianfan.baidubce.com'],
+  minimax: [
+    'https://api.minimaxi.com',
+    'https://api.minimaxi.com/v1',
+    'https://api.minimaxi.com/v1/coding_plan',
+    'https://api.minimaxi.com/v1/coding_plan/search',
+    'https://api.minimax.io',
+    'https://api.minimax.io/v1',
+    'https://api.minimax.io/v1/coding_plan',
+    'https://api.minimax.io/v1/coding_plan/search',
+  ],
 };
 
 function normalizeBaseUrl(value: string): string {

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -466,6 +466,12 @@ const getDefaultWebSearchConfig = () => ({
       requiresApiKey: false,
     },
     baidu: { apiKey: '', baseUrl: '', enabled: true, requiresApiKey: true },
+    minimax: {
+      apiKey: '',
+      baseUrl: WEB_SEARCH_PROVIDERS.minimax.defaultBaseUrl || '',
+      enabled: true,
+      requiresApiKey: true,
+    },
   } as Record<
     WebSearchProviderId,
     { apiKey: string; baseUrl: string; enabled: boolean; requiresApiKey?: boolean }
@@ -1772,6 +1778,12 @@ export const useSettingsStore = create<SettingsState>()(
             baidu: {
               apiKey: '',
               baseUrl: '',
+              enabled: true,
+              requiresApiKey: true,
+            },
+            minimax: {
+              apiKey: '',
+              baseUrl: WEB_SEARCH_PROVIDERS.minimax.defaultBaseUrl || '',
               enabled: true,
               requiresApiKey: true,
             },

--- a/lib/web-search/constants.ts
+++ b/lib/web-search/constants.ts
@@ -40,6 +40,14 @@ export const WEB_SEARCH_PROVIDERS: Record<WebSearchProviderId, WebSearchProvider
     endpointPath: '/v2/ai_search/web_search',
     icon: '/logos/baidu.png',
   },
+  minimax: {
+    id: 'minimax',
+    name: 'MiniMax',
+    requiresApiKey: true,
+    defaultBaseUrl: 'https://api.minimaxi.com',
+    endpointPath: '/v1/coding_plan/search',
+    icon: '/logos/minimax.svg',
+  },
 };
 
 export const BAIDU_SUB_SOURCES: Record<

--- a/lib/web-search/index.ts
+++ b/lib/web-search/index.ts
@@ -1,6 +1,7 @@
 import { searchWithBaidu } from './baidu';
 import { searchWithBocha } from './bocha';
 import { searchWithBrave } from './brave';
+import { searchWithMiniMax } from './minimax';
 import { searchWithTavily } from './tavily';
 import type { WebSearchResult } from '@/lib/types/web-search';
 import type { BaiduSubSources, WebSearchProviderId } from './types';
@@ -24,6 +25,8 @@ export async function searchWeb(params: {
       return searchWithBocha({ query, apiKey, maxResults, baseUrl });
     case 'brave':
       return searchWithBrave({ query, apiKey: apiKey || undefined, maxResults, baseUrl });
+    case 'minimax':
+      return searchWithMiniMax({ query, apiKey, maxResults, baseUrl });
     case 'tavily':
       return searchWithTavily({ query, apiKey, maxResults, baseUrl });
     default: {

--- a/lib/web-search/minimax.ts
+++ b/lib/web-search/minimax.ts
@@ -1,0 +1,141 @@
+/**
+ * MiniMax Web Search integration.
+ *
+ * Uses the Token Plan HTTP endpoint behind the MiniMax MCP web_search tool:
+ * POST https://api.minimaxi.com/v1/coding_plan/search
+ */
+
+import { proxyFetch } from '@/lib/server/proxy-fetch';
+import type { WebSearchResult, WebSearchSource } from '@/lib/types/web-search';
+
+const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimaxi.com';
+
+function buildMiniMaxWebSearchUrl(baseUrl?: string): string {
+  const trimmed = (baseUrl || MINIMAX_DEFAULT_BASE_URL).replace(/\/$/, '');
+  if (trimmed.endsWith('/v1/coding_plan/search')) return trimmed;
+  if (trimmed.endsWith('/v1/coding_plan')) return `${trimmed}/search`;
+  if (trimmed.endsWith('/v1')) return `${trimmed}/coding_plan/search`;
+  return `${trimmed}/v1/coding_plan/search`;
+}
+
+function getMiniMaxBaseResp(raw: unknown):
+  | {
+      status_code?: string | number;
+      status_msg?: string;
+    }
+  | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const value =
+    (raw as { base_resp?: unknown; baseResp?: unknown }).base_resp ||
+    (raw as { base_resp?: unknown; baseResp?: unknown }).baseResp;
+  if (!value || typeof value !== 'object') return undefined;
+  return value as { status_code?: string | number; status_msg?: string };
+}
+
+function formatMiniMaxError(status: number, statusText: string, errorText: string): string {
+  if (!errorText) return `MiniMax Web Search API error (${status}): ${statusText}`;
+
+  try {
+    const parsed = JSON.parse(errorText) as {
+      code?: string | number;
+      message?: string;
+      error?: { message?: string };
+      base_resp?: { status_code?: string | number; status_msg?: string };
+    };
+    const baseResp = getMiniMaxBaseResp(parsed);
+    const code = baseResp?.status_code ?? parsed.code ?? status;
+    const message = baseResp?.status_msg || parsed.message || parsed.error?.message || statusText;
+    return `MiniMax Web Search API error (${code}): ${message}`;
+  } catch {
+    return `MiniMax Web Search API error (${status}): ${errorText}`;
+  }
+}
+
+function getOrganicResults(raw: MiniMaxSearchResponse): MiniMaxOrganicResult[] {
+  return raw.organic || raw.data?.organic || raw.results || [];
+}
+
+/**
+ * Search the web using MiniMax Web Search API and return structured results.
+ */
+export async function searchWithMiniMax(params: {
+  query: string;
+  apiKey: string;
+  maxResults?: number;
+  baseUrl?: string;
+}): Promise<WebSearchResult> {
+  const { query, apiKey, maxResults = 10, baseUrl } = params;
+  const startedAt = Date.now();
+
+  const res = await proxyFetch(buildMiniMaxWebSearchUrl(baseUrl), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'MM-API-Source': 'OpenMAIC',
+    },
+    body: JSON.stringify({ q: query }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '');
+    throw new Error(formatMiniMaxError(res.status, res.statusText, errorText));
+  }
+
+  const raw = (await res.json()) as MiniMaxSearchResponse;
+  const baseResp = getMiniMaxBaseResp(raw);
+  if (baseResp?.status_code !== undefined && String(baseResp.status_code) !== '0') {
+    throw new Error(
+      `MiniMax Web Search API error (${baseResp.status_code}): ${
+        baseResp.status_msg || 'Request failed'
+      }`,
+    );
+  }
+
+  const limit = Math.max(Math.floor(maxResults), 1);
+  const sources: WebSearchSource[] = getOrganicResults(raw)
+    .map((item) => {
+      const url = item.link || item.url || '';
+      return {
+        title: item.title || url,
+        url,
+        content: item.snippet || item.summary || item.content || item.date || '',
+        score: 0,
+      };
+    })
+    .filter((source) => source.url)
+    .slice(0, limit);
+
+  return {
+    answer: '',
+    sources,
+    query,
+    responseTime: (Date.now() - startedAt) / 1000,
+  };
+}
+
+interface MiniMaxSearchResponse {
+  organic?: MiniMaxOrganicResult[];
+  results?: MiniMaxOrganicResult[];
+  data?: {
+    organic?: MiniMaxOrganicResult[];
+  };
+  base_resp?: {
+    status_code?: string | number;
+    status_msg?: string;
+  };
+  baseResp?: {
+    status_code?: string | number;
+    status_msg?: string;
+  };
+}
+
+interface MiniMaxOrganicResult {
+  title?: string;
+  link?: string;
+  url?: string;
+  snippet?: string;
+  summary?: string;
+  content?: string;
+  date?: string;
+}

--- a/lib/web-search/types.ts
+++ b/lib/web-search/types.ts
@@ -5,7 +5,7 @@
 /**
  * Web Search Provider IDs
  */
-export type WebSearchProviderId = 'tavily' | 'bocha' | 'brave' | 'baidu';
+export type WebSearchProviderId = 'tavily' | 'bocha' | 'brave' | 'baidu' | 'minimax';
 
 /**
  * Baidu sub-source toggles

--- a/packages/docs/content/docs/configuration.ar.mdx
+++ b/packages/docs/content/docs/configuration.ar.mdx
@@ -108,7 +108,7 @@ ACCESS_CODE=your-secret-code
 
 ## بحث الويب
 
-اضبط Tavily أو Bocha:
+اضبط Tavily أو Bocha أو MiniMax:
 
 ```bash
 TAVILY_API_KEY=
@@ -116,6 +116,9 @@ TAVILY_BASE_URL=           # تجاوز اختياري
 
 BOCHA_API_KEY=
 BOCHA_BASE_URL=            # تجاوز اختياري
+
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com  # تجاوز اختياري
 ```
 
 تعرض الواجهة الأمامية مفتاح تبديل لتفعيل البحث لكل عملية generation.
@@ -165,7 +168,9 @@ pdf:
 web-search:
   tavily:
     apiKey: tvly-...
+  minimax:
+    apiKey: sk-...
+    baseUrl: https://api.minimaxi.com
 ```
 
-تتجاوز متغيرات البيئة حقول YAML المطابقة حقلا بحقل. ترتبط المفاتيح بمعرّفات provider مثل `openai` أو `doubao-tts` أو `openai-whisper` أو `mineru` أو `tavily`.
-
+تتجاوز متغيرات البيئة حقول YAML المطابقة حقلا بحقل. ترتبط المفاتيح بمعرّفات provider مثل `openai` أو `doubao-tts` أو `openai-whisper` أو `mineru` أو `tavily` أو `minimax`.

--- a/packages/docs/content/docs/configuration.ja.mdx
+++ b/packages/docs/content/docs/configuration.ja.mdx
@@ -108,7 +108,7 @@ ACCESS_CODE=your-secret-code
 
 ## Web 検索
 
-Tavily または Bocha を設定します。
+Tavily、Bocha、または MiniMax を設定します。
 
 ```bash
 TAVILY_API_KEY=
@@ -116,6 +116,9 @@ TAVILY_BASE_URL=           # 任意の上書き
 
 BOCHA_API_KEY=
 BOCHA_BASE_URL=            # 任意の上書き
+
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com  # 任意の上書き
 ```
 
 フロントエンドには、生成ごとに検索を有効化するためのトグルが表示されます。
@@ -165,7 +168,9 @@ pdf:
 web-search:
   tavily:
     apiKey: tvly-...
+  minimax:
+    apiKey: sk-...
+    baseUrl: https://api.minimaxi.com
 ```
 
-環境変数は対応する YAML フィールドをフィールド単位で上書きします。キーは `openai`、`doubao-tts`、`openai-whisper`、`mineru`、`tavily` のような provider ID に対応します。
-
+環境変数は対応する YAML フィールドをフィールド単位で上書きします。キーは `openai`、`doubao-tts`、`openai-whisper`、`mineru`、`tavily`、`minimax` のような provider ID に対応します。

--- a/packages/docs/content/docs/configuration.mdx
+++ b/packages/docs/content/docs/configuration.mdx
@@ -109,7 +109,7 @@ Visitors are prompted once and the code is stored in an HTTP-only cookie. Leave 
 
 ## Web search
 
-Configure Tavily or Bocha:
+Configure Tavily, Bocha, or MiniMax:
 
 ```bash
 TAVILY_API_KEY=
@@ -117,6 +117,9 @@ TAVILY_BASE_URL=           # optional override
 
 BOCHA_API_KEY=
 BOCHA_BASE_URL=            # optional override
+
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com  # optional override
 ```
 
 The front-end exposes a toggle to enable search per generation.
@@ -166,7 +169,9 @@ pdf:
 web-search:
   tavily:
     apiKey: tvly-...
+  minimax:
+    apiKey: sk-...
+    baseUrl: https://api.minimaxi.com
 ```
 
-Environment variables override matching YAML fields field-by-field. Keys map to provider IDs such as `openai`, `doubao-tts`, `openai-whisper`, `mineru`, or `tavily`.
-
+Environment variables override matching YAML fields field-by-field. Keys map to provider IDs such as `openai`, `doubao-tts`, `openai-whisper`, `mineru`, `tavily`, or `minimax`.

--- a/packages/docs/content/docs/configuration.ru.mdx
+++ b/packages/docs/content/docs/configuration.ru.mdx
@@ -108,7 +108,7 @@ ACCESS_CODE=your-secret-code
 
 ## Web search
 
-Настройте Tavily или Bocha:
+Настройте Tavily, Bocha или MiniMax:
 
 ```bash
 TAVILY_API_KEY=
@@ -116,6 +116,9 @@ TAVILY_BASE_URL=           # необязательное переопредел
 
 BOCHA_API_KEY=
 BOCHA_BASE_URL=            # необязательное переопределение
+
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com  # необязательное переопределение
 ```
 
 На фронтенде есть toggle для включения поиска в каждом запуске generation.
@@ -165,7 +168,9 @@ pdf:
 web-search:
   tavily:
     apiKey: tvly-...
+  minimax:
+    apiKey: sk-...
+    baseUrl: https://api.minimaxi.com
 ```
 
-Переменные окружения переопределяют совпадающие YAML fields по отдельным полям. Ключи соответствуют provider ID, например `openai`, `doubao-tts`, `openai-whisper`, `mineru` или `tavily`.
-
+Переменные окружения переопределяют совпадающие YAML fields по отдельным полям. Ключи соответствуют provider ID, например `openai`, `doubao-tts`, `openai-whisper`, `mineru`, `tavily` или `minimax`.

--- a/packages/docs/content/docs/configuration.zh-cn.mdx
+++ b/packages/docs/content/docs/configuration.zh-cn.mdx
@@ -108,7 +108,7 @@ ACCESS_CODE=your-secret-code
 
 ## 联网搜索
 
-配置 Tavily 或 Bocha：
+配置 Tavily、Bocha 或 MiniMax：
 
 ```bash
 TAVILY_API_KEY=
@@ -116,6 +116,9 @@ TAVILY_BASE_URL=           # 可选覆盖
 
 BOCHA_API_KEY=
 BOCHA_BASE_URL=            # 可选覆盖
+
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com  # 可选覆盖
 ```
 
 前端会暴露一个 toggle，每次生成时可以选是否开启搜索。
@@ -165,7 +168,9 @@ pdf:
 web-search:
   tavily:
     apiKey: tvly-...
+  minimax:
+    apiKey: sk-...
+    baseUrl: https://api.minimaxi.com
 ```
 
-环境变量会逐字段覆盖 YAML 中的同名 provider 配置。键名使用 provider ID，例如 `openai`、`doubao-tts`、`openai-whisper`、`mineru` 或 `tavily`。
-
+环境变量会逐字段覆盖 YAML 中的同名 provider 配置。键名使用 provider ID，例如 `openai`、`doubao-tts`、`openai-whisper`、`mineru`、`tavily` 或 `minimax`。

--- a/packages/docs/content/docs/configuration.zh-tw.mdx
+++ b/packages/docs/content/docs/configuration.zh-tw.mdx
@@ -108,7 +108,7 @@ ACCESS_CODE=your-secret-code
 
 ## 聯網搜尋
 
-設定 Tavily 或 Bocha：
+設定 Tavily、Bocha 或 MiniMax：
 
 ```bash
 TAVILY_API_KEY=
@@ -116,6 +116,9 @@ TAVILY_BASE_URL=           # 選填覆蓋
 
 BOCHA_API_KEY=
 BOCHA_BASE_URL=            # 選填覆蓋
+
+WEB_SEARCH_MINIMAX_API_KEY=
+WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com  # 選填覆蓋
 ```
 
 前端會提供一個開關，讓每次生成時選擇是否啟用搜尋。
@@ -165,7 +168,9 @@ pdf:
 web-search:
   tavily:
     apiKey: tvly-...
+  minimax:
+    apiKey: sk-...
+    baseUrl: https://api.minimaxi.com
 ```
 
-環境變數會逐欄位覆蓋 YAML 中對應的 provider 設定。鍵名使用 provider ID，例如 `openai`、`doubao-tts`、`openai-whisper`、`mineru` 或 `tavily`。
-
+環境變數會逐欄位覆蓋 YAML 中對應的 provider 設定。鍵名使用 provider ID，例如 `openai`、`doubao-tts`、`openai-whisper`、`mineru`、`tavily` 或 `minimax`。

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -49,6 +49,7 @@ const ENV_PREFIXES_TO_CLEAR = [
   'VIDEO_MINIMAX',
   'VIDEO_GROK',
   'BOCHA',
+  'WEB_SEARCH_MINIMAX',
 ];
 
 function clearProviderEnv() {
@@ -300,6 +301,17 @@ providers:
       expect(resolveWebSearchBaseUrl('bocha', 'https://client.example.com')).toBe(
         'https://proxy.example.com/bocha',
       );
+    });
+
+    it('resolves MiniMax web search API key and base URL from dedicated env vars', async () => {
+      vi.stubEnv('WEB_SEARCH_MINIMAX_API_KEY', 'minimax-env-key');
+      vi.stubEnv('WEB_SEARCH_MINIMAX_BASE_URL', 'https://proxy.example.com/minimax');
+      const { getServerWebSearchProviders, resolveWebSearchApiKey, resolveWebSearchBaseUrl } =
+        await import('@/lib/server/provider-config');
+
+      expect(resolveWebSearchApiKey('minimax', undefined)).toBe('minimax-env-key');
+      expect(resolveWebSearchBaseUrl('minimax')).toBe('https://proxy.example.com/minimax');
+      expect(getServerWebSearchProviders().minimax).toEqual({});
     });
   });
 

--- a/tests/server/web-search-config.test.ts
+++ b/tests/server/web-search-config.test.ts
@@ -12,6 +12,8 @@ describe('server web search config', () => {
     delete process.env.BRAVE_BASE_URL;
     delete process.env.BAIDU_API_KEY;
     delete process.env.BAIDU_BASE_URL;
+    delete process.env.WEB_SEARCH_MINIMAX_API_KEY;
+    delete process.env.WEB_SEARCH_MINIMAX_BASE_URL;
   });
 
   it('rejects client-controlled base URLs outside the provider allowlist', async () => {
@@ -28,6 +30,17 @@ describe('server web search config', () => {
     expect(resolveSafeClientWebSearchBaseUrl('bocha', 'https://api.bochaai.com/v1')).toBe(
       'https://api.bochaai.com/v1',
     );
+  });
+
+  it('allows official MiniMax client base URLs', async () => {
+    const { resolveSafeClientWebSearchBaseUrl } = await import('@/lib/server/web-search-config');
+
+    expect(
+      resolveSafeClientWebSearchBaseUrl(
+        'minimax',
+        'https://api.minimaxi.com/v1/coding_plan/search',
+      ),
+    ).toBe('https://api.minimaxi.com/v1/coding_plan/search');
   });
 
   it('resolves classroom web search config from selected provider and client key', async () => {
@@ -65,6 +78,19 @@ describe('server web search config', () => {
       providerId: 'brave',
       apiKey: '',
       baseUrl: undefined,
+    });
+  });
+
+  it('resolves MiniMax classroom web search config from dedicated server env vars', async () => {
+    vi.stubEnv('WEB_SEARCH_MINIMAX_API_KEY', 'minimax-server-key');
+    vi.stubEnv('WEB_SEARCH_MINIMAX_BASE_URL', 'https://api.minimaxi.com');
+
+    const { resolveClassroomWebSearchConfig } = await import('@/lib/server/web-search-config');
+
+    expect(resolveClassroomWebSearchConfig({ webSearchProviderId: 'minimax' })).toEqual({
+      providerId: 'minimax',
+      apiKey: 'minimax-server-key',
+      baseUrl: 'https://api.minimaxi.com',
     });
   });
 

--- a/tests/web-search/constants.test.ts
+++ b/tests/web-search/constants.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getWebSearchProviderDisplayName } from '@/lib/web-search/constants';
+import {
+  getAllWebSearchProviders,
+  getWebSearchProviderDisplayName,
+  WEB_SEARCH_PROVIDERS,
+} from '@/lib/web-search/constants';
 
 describe('web search provider constants', () => {
   it('uses translated provider names when available', () => {
@@ -12,5 +16,16 @@ describe('web search provider constants', () => {
     const t = (key: string) => key;
 
     expect(getWebSearchProviderDisplayName('tavily', t)).toBe('Tavily');
+  });
+
+  it('registers MiniMax as an API-key web search provider', () => {
+    expect(WEB_SEARCH_PROVIDERS.minimax).toMatchObject({
+      id: 'minimax',
+      name: 'MiniMax',
+      requiresApiKey: true,
+      defaultBaseUrl: 'https://api.minimaxi.com',
+      endpointPath: '/v1/coding_plan/search',
+    });
+    expect(getAllWebSearchProviders().map((provider) => provider.id)).toContain('minimax');
   });
 });

--- a/tests/web-search/index.test.ts
+++ b/tests/web-search/index.test.ts
@@ -4,6 +4,7 @@ const searchWithBochaMock = vi.hoisted(() => vi.fn());
 const searchWithBraveMock = vi.hoisted(() => vi.fn());
 const searchWithBaiduMock = vi.hoisted(() => vi.fn());
 const searchWithTavilyMock = vi.hoisted(() => vi.fn());
+const searchWithMiniMaxMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/web-search/bocha', () => ({
   searchWithBocha: searchWithBochaMock,
@@ -21,6 +22,10 @@ vi.mock('@/lib/web-search/tavily', () => ({
   searchWithTavily: searchWithTavilyMock,
 }));
 
+vi.mock('@/lib/web-search/minimax', () => ({
+  searchWithMiniMax: searchWithMiniMaxMock,
+}));
+
 import { searchWeb } from '@/lib/web-search';
 
 describe('searchWeb', () => {
@@ -29,6 +34,7 @@ describe('searchWeb', () => {
     searchWithBraveMock.mockReset();
     searchWithBaiduMock.mockReset();
     searchWithTavilyMock.mockReset();
+    searchWithMiniMaxMock.mockReset();
   });
 
   it('dispatches Tavily provider requests', async () => {
@@ -133,6 +139,36 @@ describe('searchWeb', () => {
       maxResults: undefined,
       baseUrl: undefined,
       subSources: { webSearch: false, baike: true, scholar: false },
+    });
+  });
+
+  it('dispatches MiniMax provider requests', async () => {
+    searchWithMiniMaxMock.mockResolvedValueOnce({
+      answer: '',
+      sources: [],
+      query: 'q',
+      responseTime: 0.5,
+    });
+
+    await expect(
+      searchWeb({
+        providerId: 'minimax',
+        query: 'q',
+        apiKey: 'minimax-key',
+        maxResults: 5,
+        baseUrl: 'https://api.minimaxi.com',
+      }),
+    ).resolves.toEqual({
+      answer: '',
+      sources: [],
+      query: 'q',
+      responseTime: 0.5,
+    });
+    expect(searchWithMiniMaxMock).toHaveBeenCalledWith({
+      query: 'q',
+      apiKey: 'minimax-key',
+      maxResults: 5,
+      baseUrl: 'https://api.minimaxi.com',
     });
   });
 });

--- a/tests/web-search/minimax.test.ts
+++ b/tests/web-search/minimax.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const proxyFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/server/proxy-fetch', () => ({
+  proxyFetch: proxyFetchMock,
+}));
+
+import { searchWithMiniMax } from '@/lib/web-search/minimax';
+
+describe('searchWithMiniMax', () => {
+  beforeEach(() => {
+    proxyFetchMock.mockReset();
+  });
+
+  it('calls MiniMax Web Search API and maps organic results', async () => {
+    proxyFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          organic: [
+            {
+              title: 'OpenMAIC',
+              link: 'https://github.com/THU-MAIC/OpenMAIC',
+              snippet: 'OpenMAIC project repository.',
+              date: '2026-05-31',
+            },
+            {
+              title: '',
+              link: 'https://example.com/fallback',
+              snippet: '',
+              date: '2026-05-30',
+            },
+            {
+              title: 'No link',
+              snippet: 'Skipped because MiniMax did not return a URL.',
+            },
+          ],
+          base_resp: { status_code: 0, status_msg: 'success' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const result = await searchWithMiniMax({
+      query: 'MiniMax Token Plan',
+      apiKey: 'minimax-key',
+      maxResults: 10,
+    });
+
+    expect(proxyFetchMock).toHaveBeenCalledWith(
+      'https://api.minimaxi.com/v1/coding_plan/search',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer minimax-key',
+          'MM-API-Source': 'OpenMAIC',
+        },
+        body: JSON.stringify({ q: 'MiniMax Token Plan' }),
+      }),
+    );
+    expect(result.query).toBe('MiniMax Token Plan');
+    expect(result.answer).toBe('');
+    expect(result.sources).toEqual([
+      {
+        title: 'OpenMAIC',
+        url: 'https://github.com/THU-MAIC/OpenMAIC',
+        content: 'OpenMAIC project repository.',
+        score: 0,
+      },
+      {
+        title: 'https://example.com/fallback',
+        url: 'https://example.com/fallback',
+        content: '2026-05-30',
+        score: 0,
+      },
+    ]);
+  });
+
+  it('supports custom base URLs ending at host, /v1, /v1/coding_plan, or full endpoint', async () => {
+    proxyFetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ organic: [], base_resp: { status_code: 0 } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+
+    await searchWithMiniMax({ query: 'q1', apiKey: 'key', baseUrl: 'https://proxy.example.com' });
+    await searchWithMiniMax({
+      query: 'q2',
+      apiKey: 'key',
+      baseUrl: 'https://proxy.example.com/v1',
+    });
+    await searchWithMiniMax({
+      query: 'q3',
+      apiKey: 'key',
+      baseUrl: 'https://proxy.example.com/v1/coding_plan',
+    });
+    await searchWithMiniMax({
+      query: 'q4',
+      apiKey: 'key',
+      baseUrl: 'https://proxy.example.com/v1/coding_plan/search',
+    });
+
+    expect(proxyFetchMock.mock.calls.map((call) => call[0])).toEqual([
+      'https://proxy.example.com/v1/coding_plan/search',
+      'https://proxy.example.com/v1/coding_plan/search',
+      'https://proxy.example.com/v1/coding_plan/search',
+      'https://proxy.example.com/v1/coding_plan/search',
+    ]);
+  });
+
+  it('includes MiniMax error details when requests fail', async () => {
+    proxyFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          base_resp: {
+            status_code: 1001,
+            status_msg: 'invalid api key',
+          },
+        }),
+        {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    await expect(searchWithMiniMax({ query: 'q', apiKey: 'key' })).rejects.toThrow(
+      'MiniMax Web Search API error (1001): invalid api key',
+    );
+  });
+});

--- a/tests/web-search/route.test.ts
+++ b/tests/web-search/route.test.ts
@@ -55,6 +55,8 @@ describe('POST /api/web-search', () => {
     delete process.env.BRAVE_BASE_URL;
     delete process.env.BAIDU_API_KEY;
     delete process.env.BAIDU_BASE_URL;
+    delete process.env.WEB_SEARCH_MINIMAX_API_KEY;
+    delete process.env.WEB_SEARCH_MINIMAX_BASE_URL;
     mocks.searchWeb.mockReset();
     mocks.formatSearchResultsAsContext.mockClear();
     mocks.resolveModelFromRequest.mockReset();
@@ -164,6 +166,25 @@ describe('POST /api/web-search', () => {
           baike: true,
           scholar: false,
         },
+      }),
+    );
+  });
+
+  it('routes MiniMax web search through the dispatcher with server config', async () => {
+    vi.stubEnv('WEB_SEARCH_MINIMAX_API_KEY', 'minimax-server-key');
+    vi.stubEnv('WEB_SEARCH_MINIMAX_BASE_URL', 'https://api.minimaxi.com');
+
+    const res = await postWebSearch({
+      query: 'test query',
+      providerId: 'minimax',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.searchWeb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'minimax',
+        apiKey: 'minimax-server-key',
+        baseUrl: 'https://api.minimaxi.com',
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add MiniMax as a Web Search provider using the Token Plan HTTP endpoint (/v1/coding_plan/search)
- support WEB_SEARCH_MINIMAX_API_KEY / WEB_SEARCH_MINIMAX_BASE_URL server config and safe client base URL allowlisting
- update settings defaults, docs, .env.example, dispatcher, API route, and focused tests

## Verification
- pnpm test tests/web-search tests/server/provider-config.test.ts tests/server/web-search-config.test.ts
- pnpm run check:i18n-keys
- pnpm check
- pnpm exec eslint <changed files>
- pnpm exec vitest run
- pnpm exec tsc --noEmit --tsBuildInfoFile /tmp/openmaic-605-tsconfig.tsbuildinfo
- Real MiniMax endpoint E2E: POST https://api.minimaxi.com/v1/coding_plan/search returned HTTP 200, base_resp.status_code=0, and 10 results
- Local route E2E: Next dev server + POST /api/web-search with providerId=minimax returned HTTP 200, success=true, 10 sources, and formatted context
- UI E2E: Settings -> Web Search shows MiniMax in both server-managed and client-configurable states

## Notes
- MiniMax currently documents this capability as the Token Plan MCP web_search tool. This PR uses the same HTTP contract implemented by the official MiniMax MCP server, and keeps the real endpoint E2E as the release gate for that accepted coupling.
- Use a base URL matching the key region: https://api.minimaxi.com for Mainland China keys or https://api.minimax.io for Global keys.

Fixes #605