### PR TITLE
[codex] Add Claude Opus 4.8 and MiniMax M3

### DIFF
--- a/lib/ai/llm.ts
+++ b/lib/ai/llm.ts
@@ -118,6 +118,8 @@ function getModelProviderId(params: GenerateTextParams | StreamTextParams): stri
   if (!m || typeof m !== 'object' || !('provider' in m)) return undefined;
   const provider = (m as { provider?: string }).provider;
   if (!provider) return undefined;
+  const modelId = 'modelId' in m ? (m as { modelId?: string }).modelId : undefined;
+  if (provider === 'anthropic.messages' && modelId?.startsWith('MiniMax-')) return 'minimax';
   if (provider in PROVIDERS) return provider;
   const prefix = provider.split('.')[0];
   return prefix in PROVIDERS ? prefix : undefined;
@@ -147,36 +149,36 @@ function buildThinkingProviderOptions(
     }
 
     case 'anthropic': {
-      if (mode === 'disabled') return { anthropic: { thinking: { type: 'disabled' } } };
+      const buildAnthropicOptions = (options: Record<string, unknown>): ProviderOptions => ({
+        anthropic: options,
+      });
+
+      if (mode === 'disabled') return buildAnthropicOptions({ thinking: { type: 'disabled' } });
 
       if (thinking.control === 'toggle-budget' || thinking.control === 'budget-only') {
         const budget = pickThinkingBudget(thinking, config);
         return budget === undefined
           ? undefined
-          : { anthropic: { thinking: { type: 'enabled', budgetTokens: budget } } };
+          : buildAnthropicOptions({ thinking: { type: 'enabled', budgetTokens: budget } });
       }
 
       const effort = getAnthropicEffort(thinking, config);
       if (!effort) return undefined;
 
       if (thinking.anthropicThinking?.type === 'adaptive') {
-        return {
-          anthropic: {
-            thinking: { type: 'adaptive' },
-            effort,
-          },
-        };
+        return buildAnthropicOptions({
+          thinking: { type: 'adaptive' },
+          effort,
+        });
       }
 
       const manualEffort = effort === 'xhigh' ? 'max' : effort;
       const budget = thinking.anthropicThinking?.budgetByEffort?.[manualEffort];
       if (!budget) return undefined;
-      return {
-        anthropic: {
-          thinking: { type: 'enabled', budgetTokens: budget },
-          effort: manualEffort,
-        },
-      };
+      return buildAnthropicOptions({
+        thinking: { type: 'enabled', budgetTokens: budget },
+        effort: manualEffort,
+      });
     }
 
     case 'google': {

--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -214,6 +214,8 @@ const doubaoSeed20Effort: ThinkingCapability = {
   defaultEnabled: true,
 };
 
+const minimaxM3Thinking = toggleCapability('anthropic', false);
+
 const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('openai', 'gpt-5.5')]: effortCapability(
     'openai',
@@ -241,6 +243,7 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
     'none',
   ),
 
+  [getModelMetadataKey('anthropic', 'claude-opus-4-8')]: anthropicOpus47Effort,
   [getModelMetadataKey('anthropic', 'claude-opus-4-7')]: anthropicOpus47Effort,
   [getModelMetadataKey('anthropic', 'claude-opus-4-6')]: anthropicAdaptiveEffort,
   [getModelMetadataKey('anthropic', 'claude-sonnet-4-6')]: anthropicAdaptiveEffort,
@@ -332,6 +335,7 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('grok', 'grok-4.20-multi-agent')]: fixedThinkingCapability,
   [getModelMetadataKey('grok', 'grok-4-1-fast-reasoning')]: fixedThinkingCapability,
 
+  [getModelMetadataKey('minimax', 'MiniMax-M3')]: minimaxM3Thinking,
   [getModelMetadataKey('minimax', 'MiniMax-M2.7')]: fixedThinkingCapability,
 
   [getModelMetadataKey('tencent-hunyuan', 'hy3-preview')]: hunyuanHy3Effort,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -156,6 +156,22 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     icon: '/logos/claude.svg',
     models: [
       {
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8',
+        contextWindow: 1000000,
+        outputWindow: 128000,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: true,
+          thinking: {
+            toggleable: true,
+            budgetAdjustable: true,
+            defaultEnabled: false,
+          },
+        },
+      },
+      {
         id: 'claude-opus-4-7',
         name: 'Claude Opus 4.7',
         contextWindow: 1000000,
@@ -681,6 +697,13 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     requiresApiKey: true,
     icon: '/logos/minimax.svg',
     models: [
+      {
+        id: 'MiniMax-M3',
+        name: 'MiniMax M3',
+        contextWindow: 1000000,
+        outputWindow: 32768,
+        capabilities: { streaming: true, tools: true, vision: true },
+      },
       {
         id: 'MiniMax-M2.7',
         name: 'MiniMax M2.7',
@@ -1399,10 +1422,43 @@ export function getModel(config: ModelConfig): ModelWithInfo {
     }
 
     case 'anthropic': {
-      const anthropic = createAnthropic({
-        apiKey: effectiveApiKey,
+      const anthropicOptions: Parameters<typeof createAnthropic>[0] = {
         baseURL: effectiveBaseUrl,
-      });
+      };
+      if (config.providerId === 'minimax' && effectiveApiKey.startsWith('sk-cp-')) {
+        anthropicOptions.authToken = effectiveApiKey;
+      } else {
+        anthropicOptions.apiKey = effectiveApiKey;
+      }
+      if (config.providerId === 'minimax') {
+        anthropicOptions.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+          const capability = getCatalogThinkingCapability(config.providerId, config.modelId);
+          const thinkingCtx = (globalThis as Record<string, unknown>).__thinkingContext as
+            | { getStore?: () => unknown }
+            | undefined;
+          const thinking = thinkingCtx?.getStore?.() as ThinkingConfig | undefined;
+
+          if (
+            capability?.requestAdapter === 'anthropic' &&
+            capability.control !== 'none' &&
+            getThinkingMode(thinking) === 'disabled' &&
+            init?.body &&
+            typeof init.body === 'string'
+          ) {
+            try {
+              const body = JSON.parse(init.body);
+              body.thinking = { type: 'disabled' };
+              init = { ...init, body: JSON.stringify(body) };
+            } catch {
+              /* leave body as-is */
+            }
+          }
+
+          return globalThis.fetch(url, init);
+        }) as typeof globalThis.fetch;
+      }
+
+      const anthropic = createAnthropic(anthropicOptions);
       model = anthropic.chat(config.modelId);
       break;
     }

--- a/tests/ai/anthropic-provider.test.ts
+++ b/tests/ai/anthropic-provider.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProvider } from '@/lib/ai/providers';
+
+describe('Anthropic provider defaults', () => {
+  it('lists Claude Opus 4.8 first with current token windows', () => {
+    const models = getProvider('anthropic')?.models ?? [];
+    const [latest] = models;
+
+    expect(latest).toMatchObject({
+      id: 'claude-opus-4-8',
+      name: 'Claude Opus 4.8',
+      contextWindow: 1000000,
+      outputWindow: 128000,
+      capabilities: {
+        streaming: true,
+        tools: true,
+        vision: true,
+      },
+    });
+  });
+});

--- a/tests/ai/llm-thinking-options.test.ts
+++ b/tests/ai/llm-thinking-options.test.ts
@@ -41,4 +41,29 @@ describe('LLM thinking provider options', () => {
     };
     expect(params.providerOptions?.anthropic).not.toHaveProperty('effort');
   });
+
+  it('sends MiniMax M3 thinking disablement through Anthropic provider options', async () => {
+    await callLLM(
+      {
+        model: {
+          provider: 'anthropic.messages',
+          modelId: 'MiniMax-M3',
+        },
+        prompt: 'hi',
+      } as Parameters<typeof callLLM>[0],
+      'test',
+      undefined,
+      { mode: 'disabled' },
+    );
+
+    expect(aiMock.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          anthropic: {
+            thinking: { type: 'disabled' },
+          },
+        },
+      }),
+    );
+  });
 });

--- a/tests/ai/minimax-provider.test.ts
+++ b/tests/ai/minimax-provider.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getProvider } from '@/lib/ai/providers';
+import { callLLM } from '@/lib/ai/llm';
+import { getModel, getProvider } from '@/lib/ai/providers';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('MiniMax provider defaults', () => {
   it('uses the Anthropic-compatible v1 endpoint by default', () => {
@@ -9,6 +14,140 @@ describe('MiniMax provider defaults', () => {
 
   it('matches the official Anthropic-compatible MiniMax model list', () => {
     const modelIds = getProvider('minimax')?.models.map((model) => model.id) ?? [];
-    expect(modelIds).toEqual(['MiniMax-M2.7']);
+    expect(modelIds).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+  });
+
+  it('sends Token Plan keys with Bearer auth for the Anthropic-compatible endpoint', async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('authorization')).toBe('Bearer sk-cp-test');
+      expect(headers.get('x-api-key')).toBeNull();
+
+      return new Response(
+        JSON.stringify({
+          type: 'message',
+          id: 'msg_test',
+          model: 'MiniMax-M3',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { model } = getModel({
+      providerId: 'minimax',
+      modelId: 'MiniMax-M3',
+      apiKey: 'sk-cp-test',
+      baseUrl: 'https://api.minimax.io/anthropic/v1',
+    });
+
+    await callLLM(
+      {
+        model,
+        prompt: 'hi',
+        maxOutputTokens: 10,
+      } as Parameters<typeof callLLM>[0],
+      'minimax-auth-test',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends MiniMax M3 thinking disablement through the Anthropic-compatible endpoint', async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+
+      expect(body.thinking).toEqual({ type: 'disabled' });
+
+      return new Response(
+        JSON.stringify({
+          type: 'message',
+          id: 'msg_test',
+          model: 'MiniMax-M3',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { model } = getModel({
+      providerId: 'minimax',
+      modelId: 'MiniMax-M3',
+      apiKey: 'sk-cp-test',
+      baseUrl: 'https://api.minimaxi.com/anthropic/v1',
+    });
+
+    await callLLM(
+      {
+        model,
+        prompt: 'hi',
+        maxOutputTokens: 10,
+      } as Parameters<typeof callLLM>[0],
+      'minimax-thinking-test',
+      undefined,
+      { mode: 'disabled' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send thinking disablement for fixed-thinking MiniMax models', async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+
+      expect(body.thinking).toBeUndefined();
+
+      return new Response(
+        JSON.stringify({
+          type: 'message',
+          id: 'msg_test',
+          model: 'MiniMax-M2.7',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { model } = getModel({
+      providerId: 'minimax',
+      modelId: 'MiniMax-M2.7',
+      apiKey: 'sk-cp-test',
+      baseUrl: 'https://api.minimaxi.com/anthropic/v1',
+    });
+
+    await callLLM(
+      {
+        model,
+        prompt: 'hi',
+        maxOutputTokens: 10,
+      } as Parameters<typeof callLLM>[0],
+      'minimax-fixed-thinking-test',
+      undefined,
+      { mode: 'disabled' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/ai/thinking-config.test.ts
+++ b/tests/ai/thinking-config.test.ts
@@ -25,12 +25,21 @@ describe('thinking config metadata', () => {
 
   it('does not expose fixed thinking models as configurable', () => {
     const thinking = getThinking('grok', 'grok-4.20-reasoning');
-    const minimaxThinking = getThinking('minimax', 'MiniMax-M2.7');
+    const minimaxM27Thinking = getThinking('minimax', 'MiniMax-M2.7');
 
     expect(thinking?.control).toBe('none');
     expect(supportsConfigurableThinking(thinking)).toBe(false);
-    expect(minimaxThinking?.control).toBe('none');
-    expect(supportsConfigurableThinking(minimaxThinking)).toBe(false);
+    expect(minimaxM27Thinking?.control).toBe('none');
+    expect(supportsConfigurableThinking(minimaxM27Thinking)).toBe(false);
+  });
+
+  it('exposes MiniMax M3 thinking as a toggle through the Anthropic adapter', () => {
+    const thinking = getThinking('minimax', 'MiniMax-M3');
+
+    expect(supportsConfigurableThinking(thinking)).toBe(true);
+    expect(thinking?.control).toBe('toggle');
+    expect(thinking?.requestAdapter).toBe('anthropic');
+    expect(getDefaultThinkingConfig(thinking)).toEqual({ mode: 'disabled' });
   });
 
   it('exposes Claude Haiku 4.5 thinking as budget-only, not effort', () => {
@@ -73,7 +82,7 @@ describe('thinking config metadata', () => {
     expect(googleModels).not.toContain('gemini-3-pro-preview');
     expect(deepseekModels).toEqual(['deepseek-v4-pro', 'deepseek-v4-flash']);
     expect(hunyuanModels).toEqual(['hy3-preview']);
-    expect(minimaxModels).toEqual(['MiniMax-M2.7']);
+    expect(minimaxModels).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
     expect(siliconflowModels).not.toContain('MiniMaxAI/MiniMax-M2');
   });
 });
@@ -108,6 +117,7 @@ describe('thinking config normalization', () => {
 
   it('normalizes Claude 4.5+ thinking as effort levels', () => {
     const thinking = getThinking('anthropic', 'claude-sonnet-4-6');
+    const opus48Thinking = getThinking('anthropic', 'claude-opus-4-8');
     const opus47Thinking = getThinking('anthropic', 'claude-opus-4-7');
 
     expect(getDefaultThinkingConfig(thinking)).toEqual({
@@ -122,6 +132,7 @@ describe('thinking config normalization', () => {
       mode: 'disabled',
       effort: 'none',
     });
+    expect(opus48Thinking?.effortValues).toEqual(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
     expect(opus47Thinking?.effortValues).toEqual(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
   });
 


### PR DESCRIPTION
Closes #633.

## Summary
- Add Claude Opus 4.8 to the Anthropic model catalog with thinking metadata.
- Add MiniMax M3 to the MiniMax model catalog and thinking configuration metadata.
- Support MiniMax Token Plan keys for the Anthropic-compatible endpoint by using bearer auth for `sk-cp-*` keys and forwarding disabled thinking state for MiniMax M3 requests without affecting fixed-thinking MiniMax models.
- Extend AI tests for catalog ordering, thinking options, Token Plan auth, and provider option routing.

## CR Loop
- Checked PR comments, reviews, and commit status; no external review feedback or statuses were pending at the time of the loop.
- Self-review tightened MiniMax thinking injection to only configurable Anthropic-adapter MiniMax models and added regression coverage for fixed-thinking MiniMax M2.7.

## Validation
- `pnpm exec vitest run tests/ai` — 7 files, 41 tests passed.
- `pnpm exec prettier --check lib/ai/providers.ts lib/ai/model-metadata.ts lib/ai/llm.ts tests/ai/anthropic-provider.test.ts tests/ai/minimax-provider.test.ts tests/ai/thinking-config.test.ts tests/ai/llm-thinking-options.test.ts` — passed.
- `pnpm exec eslint lib/ai/providers.ts lib/ai/model-metadata.ts lib/ai/llm.ts tests/ai/anthropic-provider.test.ts tests/ai/minimax-provider.test.ts tests/ai/thinking-config.test.ts tests/ai/llm-thinking-options.test.ts` — passed.
- `pnpm exec tsc --noEmit --pretty false --incremental false` — passed.
- E2E generation smoke: `anthropic:claude-opus-4-8` generated classroom `0wmbMcHOkl` with 1 scene.
- E2E generation smoke: `minimax:MiniMax-M3` generated classroom `qRGX4p5i4S` with 1 scene using Token Plan auth and disabled thinking.