### PR TITLE
fix(web-search): allow keyless Brave as a server-side default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,10 @@ TAVILY_API_KEY=
 BOCHA_API_KEY=
 BOCHA_BASE_URL=https://api.bocha.cn
 BRAVE_API_KEY=
+# Brave also works without a key by scraping its public results page. Set
+# BRAVE_BASE_URL (e.g. https://search.brave.com) to enable Brave as a keyless
+# server-side provider — no BRAVE_API_KEY required.
+BRAVE_BASE_URL=
 BAIDU_API_KEY=
 BAIDU_BASE_URL=https://qianfan.baidubce.com
 # Dedicated MiniMax web-search vars avoid conflicting with the LLM MINIMAX_* endpoint.

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -308,7 +308,9 @@ function buildConfig(yamlData: YamlData): ServerConfig {
     pdf: loadEnvSection(PDF_ENV_MAP, yamlData.pdf, { requiresBaseUrl: true }),
     image,
     video: loadEnvSection(VIDEO_ENV_MAP, yamlData.video),
-    webSearch: loadEnvSection(WEB_SEARCH_ENV_MAP, yamlData['web-search']),
+    webSearch: loadEnvSection(WEB_SEARCH_ENV_MAP, yamlData['web-search'], {
+      keylessProviders: new Set(['brave']),
+    }),
     ttsDisabled: collectDisabledTTS(yamlData.tts),
   };
 }
@@ -566,5 +568,8 @@ export function resolveServerWebSearchProviderId(preferredProviderId?: string): 
   if (webSearch.bocha?.apiKey) return 'bocha';
   if (webSearch.baidu?.apiKey) return 'baidu';
   if (webSearch.minimax?.apiKey) return 'minimax';
+  // Brave needs no API key (it scrapes the public results page), so a configured
+  // keyless Brave is a valid fallback even though it has no apiKey.
+  if (webSearch.brave) return 'brave';
   return Object.keys(webSearch)[0];
 }

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -315,6 +315,30 @@ providers:
     });
   });
 
+  describe('resolveServerWebSearchProviderId', () => {
+    it('selects keyless Brave when only BRAVE_BASE_URL is set (no API key)', async () => {
+      vi.stubEnv('BRAVE_BASE_URL', 'https://search.brave.com');
+      const {
+        resolveServerWebSearchProviderId,
+        getServerWebSearchProviders,
+        resolveWebSearchBaseUrl,
+      } = await import('@/lib/server/provider-config');
+      // Brave is activated as a keyless server provider via base URL alone. The
+      // exposed map shows only presence (managed flag), not the base URL (#624).
+      expect(getServerWebSearchProviders().brave).toEqual({});
+      expect(resolveWebSearchBaseUrl('brave')).toBe('https://search.brave.com');
+      // ...and Brave is then auto-selected as the server default.
+      expect(resolveServerWebSearchProviderId()).toBe('brave');
+    });
+
+    it('prefers a keyed provider over keyless Brave', async () => {
+      vi.stubEnv('BRAVE_BASE_URL', 'https://search.brave.com');
+      vi.stubEnv('TAVILY_API_KEY', 'tvly-key');
+      const { resolveServerWebSearchProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerWebSearchProviderId()).toBe('tavily');
+    });
+  });
+
   describe('baseUrl-only providers (e.g. mineru)', () => {
     it('includes PDF provider from YAML when only baseUrl is configured (no apiKey)', async () => {
       yamlOverride = `


### PR DESCRIPTION
## Summary

Brave Search is `requiresApiKey: false` and `searchWithBrave` already scrapes Brave's public results page when no key is set — but the server-side wiring never let keyless Brave **activate** or be **selected**, so in the autonomous classroom-generation flow `resolveClassroomWebSearchConfig` returned `undefined` and web search was silently disabled for operators who wanted free, keyless Brave.

This mirrors the existing keyless handling for Ollama/Lemonade: set `BRAVE_BASE_URL` (e.g. `https://search.brave.com`) to enable keyless Brave, which then becomes a valid server default (after any keyed providers).

## Related Issues

Closes #641

## Changes

- `lib/server/provider-config.ts`: pass `keylessProviders: new Set(['brave'])` to the web-search `loadEnvSection` (so `BRAVE_BASE_URL` alone activates Brave), and add Brave to the `resolveServerWebSearchProviderId` fallback chain (after keyed providers).
- `.env.example`: document `BRAVE_BASE_URL` for keyless Brave.
- `tests/server/provider-config.test.ts`: tests that keyless Brave is selected via `BRAVE_BASE_URL`, and that a keyed provider still takes priority.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

### Steps to reproduce / test

1. With no web-search keys but `BRAVE_BASE_URL=https://search.brave.com`, the server now resolves `brave` and web search works (previously: `undefined`, disabled).
2. `pnpm vitest run tests/server/provider-config.test.ts` → 31 passed (2 new).

### What you personally verified

- New tests cover keyless selection + keyed-provider priority.
- Behavior-preserving for existing setups: Brave only activates when `BRAVE_BASE_URL` is explicitly set; keyed-provider resolution is unchanged.

### Evidence

- [x] CI passes (`pnpm check` ✓, `pnpm lint` ✓, `npx tsc --noEmit` ✓, `vitest` 31/31 ✓)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (`.env.example`)
- [x] My changes do not introduce new warnings

---

🤖 **AI-assisted PR** (Claude). Self-reviewed before submission.
