### PR TITLE
fix(action): keep wb_edit_code replace_lines in document order

### DIFF
--- a/lib/action/code-line-edit.ts
+++ b/lib/action/code-line-edit.ts
@@ -1,0 +1,66 @@
+import type { CodeLine } from '@/lib/types/slides';
+import type { WbEditCodeAction } from '@/lib/types/action';
+
+/**
+ * Apply a line-level edit (insert / delete / replace) to a code block's lines.
+ *
+ * Pure and side-effect free: returns the new lines array, or `null` when the
+ * operation is a no-op (target line not found, or no line IDs supplied) so the
+ * caller can skip the re-render — mirroring the original early-return behaviour.
+ *
+ * `newLineIds` supplies IDs for inserted lines (the caller pre-generates them).
+ */
+export function applyCodeLineEdit(
+  inputLines: CodeLine[],
+  action: WbEditCodeAction,
+  newLineIds: string[],
+): CodeLine[] | null {
+  let lines: CodeLine[] = [...inputLines];
+  const newContentLines = action.content ? action.content.split('\n') : [];
+
+  switch (action.operation) {
+    case 'insert_after': {
+      const idx = lines.findIndex((l) => l.id === action.lineId);
+      if (idx === -1) return null;
+      const newLines = newContentLines.map((content, i) => ({ id: newLineIds[i], content }));
+      lines.splice(idx + 1, 0, ...newLines);
+      return lines;
+    }
+    case 'insert_before': {
+      const idx = lines.findIndex((l) => l.id === action.lineId);
+      if (idx === -1) return null;
+      const newLines = newContentLines.map((content, i) => ({ id: newLineIds[i], content }));
+      lines.splice(idx, 0, ...newLines);
+      return lines;
+    }
+    case 'delete_lines': {
+      if (!action.lineIds?.length) return null;
+      const deleteSet = new Set(action.lineIds);
+      return lines.filter((l) => !deleteSet.has(l.id));
+    }
+    case 'replace_lines': {
+      if (!action.lineIds?.length) return null;
+      const replaceIds = action.lineIds;
+      // Anchor the insertion at the *topmost* (lowest original index) replaced
+      // line, not at `replaceIds[0]`. `lineIds` can arrive out of document order,
+      // and the filter below removes every replaced line, so an index taken from
+      // `replaceIds[0]` may be left stale and place the replacement at the wrong
+      // spot (e.g. lineIds ["L5","L2"] inserted at L5's now-shifted index).
+      const replaceIndexes = replaceIds
+        .map((id) => lines.findIndex((l) => l.id === id))
+        .filter((i) => i !== -1);
+      if (replaceIndexes.length === 0) return null;
+      const firstIdx = Math.min(...replaceIndexes);
+      const deleteSet = new Set(replaceIds);
+      lines = lines.filter((l) => !deleteSet.has(l.id));
+      const newLines = newContentLines.map((content, i) => ({
+        id: i < replaceIds.length ? replaceIds[i] : newLineIds[i],
+        content,
+      }));
+      lines.splice(firstIdx, 0, ...newLines);
+      return lines;
+    }
+    default:
+      return lines;
+  }
+}

--- a/lib/action/engine.ts
+++ b/lib/action/engine.ts
@@ -37,6 +37,7 @@ import type {
   WidgetRevealAction,
 } from '@/lib/types/action';
 import type { CodeLine } from '@maic/dsl';
+import { applyCodeLineEdit } from '@/lib/action/code-line-edit';
 import katex from 'katex';
 import { createLogger } from '@/lib/logger';
 
@@ -589,46 +590,9 @@ export class ActionEngine {
     const element = elementResult.data as any;
     if (element.type !== 'code') return;
 
-    let lines: CodeLine[] = [...element.lines];
     const newContentLines = action.content ? action.content.split('\n') : [];
-    const newLineIds = generateLineIds(newContentLines.length);
-
-    switch (action.operation) {
-      case 'insert_after': {
-        const idx = lines.findIndex((l) => l.id === action.lineId);
-        if (idx === -1) return;
-        const newLines = newContentLines.map((content, i) => ({ id: newLineIds[i], content }));
-        lines.splice(idx + 1, 0, ...newLines);
-        break;
-      }
-      case 'insert_before': {
-        const idx = lines.findIndex((l) => l.id === action.lineId);
-        if (idx === -1) return;
-        const newLines = newContentLines.map((content, i) => ({ id: newLineIds[i], content }));
-        lines.splice(idx, 0, ...newLines);
-        break;
-      }
-      case 'delete_lines': {
-        if (!action.lineIds?.length) return;
-        const deleteSet = new Set(action.lineIds);
-        lines = lines.filter((l) => !deleteSet.has(l.id));
-        break;
-      }
-      case 'replace_lines': {
-        if (!action.lineIds?.length) return;
-        const replaceIds = action.lineIds;
-        const firstIdx = lines.findIndex((l) => l.id === replaceIds[0]);
-        if (firstIdx === -1) return;
-        const deleteSet = new Set(replaceIds);
-        lines = lines.filter((l) => !deleteSet.has(l.id));
-        const newLines = newContentLines.map((content, i) => ({
-          id: i < replaceIds.length ? replaceIds[i] : newLineIds[i],
-          content,
-        }));
-        lines.splice(firstIdx, 0, ...newLines);
-        break;
-      }
-    }
+    const lines = applyCodeLineEdit(element.lines, action, generateLineIds(newContentLines.length));
+    if (lines === null) return;
 
     this.stageAPI.whiteboard.updateElement(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/action/code-line-edit.test.ts
+++ b/tests/action/code-line-edit.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { applyCodeLineEdit } from '@/lib/action/code-line-edit';
+import type { WbEditCodeAction } from '@/lib/types/action';
+import type { CodeLine } from '@/lib/types/slides';
+
+const linesOf = (ids: string[]): CodeLine[] => ids.map((id) => ({ id, content: id }));
+const edit = (a: Partial<WbEditCodeAction>): WbEditCodeAction =>
+  ({ id: 'a1', type: 'wb_edit_code', elementId: 'el', ...a }) as WbEditCodeAction;
+
+describe('applyCodeLineEdit', () => {
+  it('replace_lines anchors at the topmost replaced line even when lineIds are out of order', () => {
+    // Replace B and D, but supply the IDs OUT of document order (D before B).
+    const result = applyCodeLineEdit(
+      linesOf(['A', 'B', 'C', 'D', 'E']),
+      edit({ operation: 'replace_lines', lineIds: ['D', 'B'], content: 'X' }),
+      ['N1'],
+    );
+    // The replacement lands where B was (topmost), not at D's now-stale index.
+    // (Before the fix this produced ['A', 'C', 'E', 'X'].)
+    expect(result?.map((l) => l.content)).toEqual(['A', 'X', 'C', 'E']);
+  });
+
+  it('replace_lines reuses the replaced IDs for the first new lines', () => {
+    const result = applyCodeLineEdit(
+      linesOf(['A', 'B', 'C']),
+      edit({ operation: 'replace_lines', lineIds: ['B'], content: 'X' }),
+      ['N1'],
+    );
+    expect(result).toEqual([
+      { id: 'A', content: 'A' },
+      { id: 'B', content: 'X' },
+      { id: 'C', content: 'C' },
+    ]);
+  });
+
+  it('insert_after / insert_before / delete_lines behave as before', () => {
+    expect(
+      applyCodeLineEdit(
+        linesOf(['A', 'B']),
+        edit({ operation: 'insert_after', lineId: 'A', content: 'X' }),
+        ['N1'],
+      )?.map((l) => l.content),
+    ).toEqual(['A', 'X', 'B']);
+    expect(
+      applyCodeLineEdit(
+        linesOf(['A', 'B']),
+        edit({ operation: 'insert_before', lineId: 'B', content: 'X' }),
+        ['N1'],
+      )?.map((l) => l.content),
+    ).toEqual(['A', 'X', 'B']);
+    expect(
+      applyCodeLineEdit(
+        linesOf(['A', 'B', 'C']),
+        edit({ operation: 'delete_lines', lineIds: ['B'] }),
+        [],
+      )?.map((l) => l.content),
+    ).toEqual(['A', 'C']);
+  });
+
+  it('returns null for a no-op (target not found / no line IDs)', () => {
+    expect(
+      applyCodeLineEdit(
+        linesOf(['A']),
+        edit({ operation: 'insert_after', lineId: 'NOPE', content: 'X' }),
+        ['N1'],
+      ),
+    ).toBeNull();
+    expect(
+      applyCodeLineEdit(
+        linesOf(['A']),
+        edit({ operation: 'replace_lines', lineIds: ['NOPE'], content: 'X' }),
+        ['N1'],
+      ),
+    ).toBeNull();
+    expect(
+      applyCodeLineEdit(linesOf(['A']), edit({ operation: 'delete_lines', lineIds: [] }), []),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`executeWbEditCode`'s `replace_lines` took the splice anchor from `lines.findIndex(replaceIds[0])`, computed **before** filtering out the replaced lines. `WbEditCodeAction.lineIds` has no ordering contract, so when the model emits IDs out of document order (e.g. `["L5","L2"]`) the filter removes a line above the anchor and the index goes stale — the replacement lands at the wrong position, corrupting the code block.

This anchors the insertion at the topmost (minimum original index) replaced line. In-order `lineIds` are unaffected.

## Related Issues

Closes #653

## Changes

- `lib/action/code-line-edit.ts` (new): pure `applyCodeLineEdit(lines, action, newLineIds)` helper containing the insert/delete/replace logic, with the ordering fix. Returns `null` for no-ops so the caller preserves the original early-return (skip re-render) behavior.
- `lib/action/engine.ts`: `executeWbEditCode` now delegates to the helper (drops ~46 lines of inline logic).
- `tests/action/code-line-edit.test.ts` (new): unit tests, incl. the out-of-order `replace_lines` regression.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

### What you personally verified

- The out-of-order regression test fails on `main` (`['A','C','E','X']`) and passes with the fix (`['A','X','C','E']`).
- Extraction is behavior-preserving: `null` return reproduces the original early-returns; in-order `lineIds` and the other operations are unchanged.

### Evidence

- [x] CI passes (`pnpm check` ✓, `pnpm lint` ✓ — no new warnings, `npx tsc --noEmit` ✓, `vitest` 4/4 ✓)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes do not introduce new warnings

---

🤖 **AI-assisted PR** (Claude). Self-reviewed before submission.
