### PR TITLE
fix(llm): increase maxOutputTokens for search query rewrite to suppor…

### DIFF
--- a/app/api/web-search/route.ts
+++ b/app/api/web-search/route.ts
@@ -87,7 +87,7 @@ export async function POST(req: NextRequest) {
               { role: 'system', content: systemPrompt },
               { role: 'user', content: userPrompt },
             ],
-            maxOutputTokens: 256,
+            maxOutputTokens: 2048,
           },
           'web-search-query-rewrite',
           undefined,

--- a/lib/ai/llm.ts
+++ b/lib/ai/llm.ts
@@ -282,6 +282,21 @@ export async function callLLM<T extends GenerateTextParams>(
         continue;
       }
 
+      // Diagnostic: warn when the model returns empty text so we can identify root cause
+      if (!result.text || result.text.trim().length === 0) {
+        const resultAsUnknown = result as unknown as Record<string, unknown>;
+        log.warn(`[${source}] LLM returned empty text`, {
+          finishReason: result.finishReason,
+          usage: result.usage,
+          hasReasoning: !!resultAsUnknown.reasoning,
+          reasoningLength:
+            typeof resultAsUnknown.reasoning === 'string'
+              ? resultAsUnknown.reasoning.length
+              : undefined,
+          model: getModelId(params),
+        });
+      }
+
       return result;
     } catch (error) {
       lastError = error;

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -217,7 +217,7 @@ export async function generateClassroom(
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt },
         ],
-        maxOutputTokens: 256,
+        maxOutputTokens: 2048,
       },
       'web-search-query-rewrite',
     );


### PR DESCRIPTION
When using reasoning models (e.g. DeepSeek V4 Pro), the `web-search-query-rewrite`
call consistently produces empty output and causes JSON parse failures:

```text
WARN] [LLM] [web-search-query-rewrite] LLM returned empty text
{"finishReason":"length","outputTokens":256,"textTokens":0,"reasoningTokens":256}
[WARN] [Generation] Attempt 1 parse error: Unexpected end of JSON input
[ERROR] [Generation] Failed to parse JSON from response
[WARN] [SearchQueryBuilder] Query rewrite returned empty output, falling back to raw requirement
```

**Root cause:** Reasoning models share `max_tokens` between internal thinking tokens
and visible output tokens. With `maxOutputTokens=256`, all 256 tokens are consumed
by the model's internal reasoning, leaving zero tokens for visible output.

Verified via direct API call:
- `max_tokens=256` → `finish_reason: length`, `text_tokens: 0`, `reasoning_tokens: 256`
- `max_tokens=2048` → `finish_reason: stop`, output: `{"query": "..."}`

## Changes

- **`app/api/web-search/route.ts`**: `maxOutputTokens: 256 → 2048`
- **`lib/server/classroom-generation.ts`**: `maxOutputTokens: 256 → 2048`
- **`lib/ai/llm.ts`**: add diagnostic warning when LLM returns empty text, logging
  `finishReason`, full usage breakdown (including `reasoningTokens`), and model name
  to make future debugging easier

## Impact

Only affects the web search query rewrite call. No impact on non-reasoning models
(256 tokens is already sufficient for a short JSON query on those models).