### PR TITLE
fix: point SSRF private-network rejection at the ALLOW_LOCAL_NETWORKS escape hatch

### DIFF
--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -162,6 +162,9 @@ export function isPrivateIP(ip: string): boolean {
   return false;
 }
 
+const LOCAL_NETWORK_BLOCK_MESSAGE =
+  'Local/private network URLs are not allowed. If this is a self-hosted deployment or internal gateway (including split-horizon DNS), set ALLOW_LOCAL_NETWORKS=true to allow local network targets.';
+
 /**
  * Validate a URL against SSRF attacks.
  * Returns null if the URL is safe, or an error message string if blocked.
@@ -192,7 +195,7 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
     hostname === '::1' ||
     isPrivateIP(hostname)
   ) {
-    return 'Local/private network URLs are not allowed';
+    return LOCAL_NETWORK_BLOCK_MESSAGE;
   }
 
   if (isIP(hostname)) {
@@ -211,7 +214,7 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
   }
 
   if (resolvedAddresses.some(({ address }) => isPrivateIP(address))) {
-    return 'Local/private network URLs are not allowed';
+    return LOCAL_NETWORK_BLOCK_MESSAGE;
   }
 
   return null;

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { lookupMock } = vi.hoisted(() => ({
   lookupMock: vi.fn(),
@@ -10,10 +10,24 @@ vi.mock('node:dns', () => ({
   },
 }));
 
+const PRIVATE_NETWORK_BLOCK_MESSAGE =
+  'Local/private network URLs are not allowed. If this is a self-hosted deployment or internal gateway (including split-horizon DNS), set ALLOW_LOCAL_NETWORKS=true to allow local network targets.';
+const ALLOW_LOCAL_NETWORKS_GUIDANCE = 'ALLOW_LOCAL_NETWORKS=true';
+const originalAllowLocalNetworks = process.env.ALLOW_LOCAL_NETWORKS;
+
 describe('validateUrlForSSRF', () => {
   beforeEach(() => {
     vi.resetModules();
     lookupMock.mockReset();
+    delete process.env.ALLOW_LOCAL_NETWORKS;
+  });
+
+  afterEach(() => {
+    if (originalAllowLocalNetworks === undefined) {
+      delete process.env.ALLOW_LOCAL_NETWORKS;
+    } else {
+      process.env.ALLOW_LOCAL_NETWORKS = originalAllowLocalNetworks;
+    }
   });
 
   it('allows a public hostname when DNS resolves to a public IP', async () => {
@@ -57,11 +71,11 @@ describe('validateUrlForSSRF', () => {
   it('rejects blocked hostnames immediately', async () => {
     const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
 
-    await expect(validateUrlForSSRF('http://localhost')).resolves.toBe(
-      'Local/private network URLs are not allowed',
-    );
+    const localhostResult = await validateUrlForSSRF('http://localhost');
+    expect(localhostResult).toBe(PRIVATE_NETWORK_BLOCK_MESSAGE);
+    expect(localhostResult).toContain(ALLOW_LOCAL_NETWORKS_GUIDANCE);
     await expect(validateUrlForSSRF('http://printer.local')).resolves.toBe(
-      'Local/private network URLs are not allowed',
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
     );
     expect(lookupMock).not.toHaveBeenCalled();
   });
@@ -80,9 +94,7 @@ describe('validateUrlForSSRF', () => {
     ];
 
     for (const url of urls) {
-      await expect(validateUrlForSSRF(url)).resolves.toBe(
-        'Local/private network URLs are not allowed',
-      );
+      await expect(validateUrlForSSRF(url)).resolves.toBe(PRIVATE_NETWORK_BLOCK_MESSAGE);
     }
 
     expect(lookupMock).not.toHaveBeenCalled();
@@ -100,9 +112,7 @@ describe('validateUrlForSSRF', () => {
     ];
 
     for (const url of urls) {
-      await expect(validateUrlForSSRF(url)).resolves.toBe(
-        'Local/private network URLs are not allowed',
-      );
+      await expect(validateUrlForSSRF(url)).resolves.toBe(PRIVATE_NETWORK_BLOCK_MESSAGE);
     }
 
     expect(lookupMock).not.toHaveBeenCalled();
@@ -113,11 +123,11 @@ describe('validateUrlForSSRF', () => {
 
     // 2002:7f00:0001:: embeds 127.0.0.1
     await expect(validateUrlForSSRF('http://[2002:7f00:0001::]')).resolves.toBe(
-      'Local/private network URLs are not allowed',
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
     );
     // 2002:0a00:0001:: embeds 10.0.0.1
     await expect(validateUrlForSSRF('http://[2002:0a00:0001::]')).resolves.toBe(
-      'Local/private network URLs are not allowed',
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
     );
     expect(lookupMock).not.toHaveBeenCalled();
   });
@@ -136,7 +146,7 @@ describe('validateUrlForSSRF', () => {
     // Client IPv4 127.0.0.1 XOR 0xFFFFFFFF = 0x80FFFFFE → hextets 80ff:fffe
     await expect(
       validateUrlForSSRF('http://[2001:0000:4136:e378:8000:63bf:80ff:fffe]'),
-    ).resolves.toBe('Local/private network URLs are not allowed');
+    ).resolves.toBe(PRIVATE_NETWORK_BLOCK_MESSAGE);
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
@@ -155,9 +165,9 @@ describe('validateUrlForSSRF', () => {
 
     const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
 
-    await expect(validateUrlForSSRF('https://attacker.com')).resolves.toBe(
-      'Local/private network URLs are not allowed',
-    );
+    const result = await validateUrlForSSRF('https://attacker.com');
+    expect(result).toBe(PRIVATE_NETWORK_BLOCK_MESSAGE);
+    expect(result).toContain(ALLOW_LOCAL_NETWORKS_GUIDANCE);
   });
 
   it('rejects hostnames when any DNS answer is private', async () => {
@@ -169,8 +179,19 @@ describe('validateUrlForSSRF', () => {
     const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
 
     await expect(validateUrlForSSRF('https://mixed.example')).resolves.toBe(
-      'Local/private network URLs are not allowed',
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
     );
+  });
+
+  it('allows local network targets when ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+    lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('http://192.168.1.10')).resolves.toBeNull();
+    await expect(validateUrlForSSRF('https://internal.example')).resolves.toBeNull();
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 
   it('fails closed when DNS lookup errors', async () => {


### PR DESCRIPTION
## Summary

The SSRF guard's `Local/private network URLs are not allowed` rejection now names the `ALLOW_LOCAL_NETWORKS=true` escape hatch and the self-hosted/internal-gateway (split-horizon DNS) case that triggers it. Validation behavior is unchanged; only the message text is extended, in both rejection branches (direct hostname match and post-DNS resolution).

## Related Issues

Fixes #606

## Changes

- Extracted the rejection string into `LOCAL_NETWORK_BLOCK_MESSAGE` in `lib/server/ssrf-guard.ts` so both rejection branches stay in sync, and appended guidance pointing at `ALLOW_LOCAL_NETWORKS=true` (the existing env check at `ssrf-guard.ts:185`)
- Kept the original leading phrase so anything matching the message prefix still works
- Updated the vitest suite to assert the guidance appears in both rejection paths, with `process.env.ALLOW_LOCAL_NETWORKS` saved/restored per test

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Configure a custom base URL whose hostname resolves to a private IP (or use a private-IP literal like `http://192.168.1.10`)
2. Before this change: the rejection reads `Local/private network URLs are not allowed` with no pointer to the fix
3. After: the same rejection names `ALLOW_LOCAL_NETWORKS=true` and the split-horizon gateway case from #606

### What you personally verified

- `npx vitest run tests/server/ssrf-guard.test.ts` - 15/15 pass
- Both rejection branches (direct private-IP literal and public-hostname-resolving-private) carry the guidance
- Confirmed `ALLOW_LOCAL_NETWORKS=true`/`1` short-circuits before either check (`ssrf-guard.ts:185-188`), so the message's claim is accurate
- `npx tsc --noEmit` passes; `prettier --check` passes on both changed files
- Not verified: a live split-horizon corporate gateway (no access to one); the repro relies on the DNS-mock tests

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings

AI was used for assistance.
