### PR TITLE
feat(tts): per-agent auto-voice quality + register-once timbre stability (#670)

### DIFF
--- a/app/api/generate/agent-profiles/route.ts
+++ b/app/api/generate/agent-profiles/route.ts
@@ -12,7 +12,7 @@ import { createLogger } from '@/lib/logger';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
 import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { AGENT_COLOR_PALETTE } from '@/lib/constants/agent-defaults';
-import { normalizeVoiceDesign } from '@/lib/audio/voxcpm';
+import { normalizeVoiceDesign } from '@/lib/audio/voice-design';
 
 const log = createLogger('Agent Profiles API');
 

--- a/app/api/generate/agent-profiles/route.ts
+++ b/app/api/generate/agent-profiles/route.ts
@@ -12,6 +12,7 @@ import { createLogger } from '@/lib/logger';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
 import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { AGENT_COLOR_PALETTE } from '@/lib/constants/agent-defaults';
+import { normalizeVoiceDesign } from '@/lib/audio/voxcpm';
 
 const log = createLogger('Agent Profiles API');
 
@@ -128,6 +129,10 @@ Requirements:
   - Use the "path" value as the avatar field in the output
 - Each agent must be assigned one color from this list: ${JSON.stringify(AGENT_COLOR_PALETTE)}
   - Each agent must have a different color
+- Each agent needs a "voiceDesign" object describing their VOCAL identity (not personality), written following the language directive and consistent with the persona, as three short comma-free phrases:
+  - "identity": gender + age + role (e.g. "middle-aged male teacher")
+  - "texture": pitch + vocal quality (e.g. "warm low-pitched slightly husky")
+  - "delivery": emotion + pace (e.g. "calm measured encouraging")
 ${voicePrompt}
 
 Return a JSON object with this exact structure:
@@ -137,6 +142,7 @@ Return a JSON object with this exact structure:
       "name": "string",
       "role": "teacher" | "assistant" | "student",
       "persona": "string (2-3 sentences)",
+      "voiceDesign": { "identity": "string", "texture": "string", "delivery": "string" },
       "avatar": "string (from available list)",
       "color": "string (hex color from palette)",
       "priority": number (10 for teacher, 7 for assistant, 4-6 for student)${voiceJsonField}
@@ -170,6 +176,7 @@ Return a JSON object with this exact structure:
         color: string;
         priority: number;
         voice?: string;
+        voiceDesign?: unknown;
       }>;
     };
 
@@ -211,6 +218,8 @@ Return a JSON object with this exact structure:
         }
       }
 
+      const voiceDesign = normalizeVoiceDesign(agent.voiceDesign);
+
       return {
         id: `gen-${nanoid(8)}`,
         name: agent.name,
@@ -221,6 +230,7 @@ Return a JSON object with this exact structure:
         priority:
           agent.priority ?? (agent.role === 'teacher' ? 10 : agent.role === 'assistant' ? 7 : 5),
         ...(voiceConfig ? { voiceConfig } : {}),
+        ...(voiceDesign ? { voiceDesign } : {}),
       };
     });
 

--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -111,7 +111,8 @@ export async function POST(req: NextRequest) {
     };
 
     log.info(
-      `Generating TTS: provider=${ttsProviderId}, model=${ttsModelId || 'default'}, voice=${ttsVoice}, audioId=${audioId}, textLen=${text.length}`,
+      `Generating TTS: provider=${ttsProviderId}, model=${config.modelId || 'default'}, voice=${ttsVoice}, ` +
+        `registeredVoiceId=${voxcpmRegisteredVoiceId || 'none'}, audioId=${audioId}, textLen=${text.length}`,
     );
 
     // Generate audio

--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -14,6 +14,7 @@ import {
   isServerTTSProviderDisabled,
   resolveTTSApiKey,
   resolveTTSBaseUrl,
+  resolveTTSModel,
 } from '@/lib/server/provider-config';
 import type { TTSProviderId } from '@/lib/audio/types';
 import { createLogger } from '@/lib/logger';
@@ -98,10 +99,10 @@ export async function POST(req: NextRequest) {
     const apiKey = resolveTTSApiKey(ttsProviderId, managed ? undefined : ttsApiKey || undefined);
     const baseUrl = resolveTTSBaseUrl(ttsProviderId, clientBaseUrl);
 
-    // Build TTS config
+    // Build TTS config (managed providers may pin the model server-side)
     const config = {
       providerId: ttsProviderId as TTSProviderId,
-      modelId: ttsModelId,
+      modelId: resolveTTSModel(ttsProviderId, ttsModelId),
       voice: ttsVoice,
       speed: ttsSpeed ?? 1.0,
       apiKey,

--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -68,10 +68,15 @@ export async function POST(req: NextRequest) {
 
     const voxcpmVoicePrompt =
       typeof ttsProviderOptions?.voicePrompt === 'string' ? ttsProviderOptions.voicePrompt : '';
+    const voxcpmRegisteredVoiceId =
+      typeof ttsProviderOptions?.registeredVoiceId === 'string'
+        ? ttsProviderOptions.registeredVoiceId
+        : '';
     if (
       ttsProviderId === VOXCPM_TTS_PROVIDER_ID &&
       ttsVoice === VOXCPM_AUTO_VOICE_ID &&
-      !voxcpmVoicePrompt.trim()
+      !voxcpmVoicePrompt.trim() &&
+      !voxcpmRegisteredVoiceId.trim()
     ) {
       return apiError(
         'VOXCPM_AUTO_VOICE_REQUIRES_CONTEXT',

--- a/app/api/generate/voice/route.ts
+++ b/app/api/generate/voice/route.ts
@@ -19,6 +19,7 @@ import {
   isServerConfiguredProvider,
   resolveTTSApiKey,
   resolveTTSBaseUrl,
+  resolveTTSModel,
 } from '@/lib/server/provider-config';
 import { createLogger } from '@/lib/logger';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
@@ -91,7 +92,11 @@ export async function POST(req: NextRequest) {
       return apiError('MISSING_REQUIRED_FIELD', 400, 'TTS base URL is required');
     }
 
-    const cfg: VoiceRegistrationConfig = { baseUrl, apiKey, model: body.ttsModelId };
+    const cfg: VoiceRegistrationConfig = {
+      baseUrl,
+      apiKey,
+      model: resolveTTSModel(providerId, body.ttsModelId),
+    };
 
     // Client supplied a cached reference clip → (re)register it (register-on-invalid).
     if (body.referenceAudioBase64) {

--- a/app/api/generate/voice/route.ts
+++ b/app/api/generate/voice/route.ts
@@ -17,6 +17,7 @@
 import { NextRequest } from 'next/server';
 import {
   isServerConfiguredProvider,
+  isServerTTSProviderDisabled,
   resolveTTSApiKey,
   resolveTTSBaseUrl,
   resolveTTSModel,
@@ -67,6 +68,11 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // A server-force-disabled provider is off for everyone (#665), same as the TTS route.
+    if (isServerTTSProviderDisabled(providerId)) {
+      return apiError('PROVIDER_DISABLED', 403, 'This TTS provider is disabled by the server');
+    }
+
     const adapter = getVoiceRegistrationAdapter(providerId);
     if (!adapter) {
       return apiError(
@@ -98,18 +104,20 @@ export async function POST(req: NextRequest) {
       model: resolveTTSModel(providerId, body.ttsModelId),
     };
 
-    // Client supplied a cached reference clip → (re)register it (register-on-invalid).
+    // Already registered → no-op (also avoids a redundant re-register when the
+    // client offered a cached clip but the voice is still live on the backend).
+    if (await adapter.voiceExists(cfg, voiceId)) {
+      return apiSuccess({ voiceId, registered: true });
+    }
+
+    // Not present, but the client has the cached reference clip → re-register it
+    // (register-on-invalid; preserves the original timbre instead of re-synthesizing).
     if (body.referenceAudioBase64) {
       await adapter.registerVoice(cfg, {
         voiceId,
         referenceAudioBase64: body.referenceAudioBase64,
         mimeType: body.mimeType,
       });
-      return apiSuccess({ voiceId, registered: true });
-    }
-
-    // Already registered → no-op.
-    if (await adapter.voiceExists(cfg, voiceId)) {
       return apiSuccess({ voiceId, registered: true });
     }
 

--- a/app/api/generate/voice/route.ts
+++ b/app/api/generate/voice/route.ts
@@ -1,16 +1,17 @@
 /**
- * VoxCPM auto-voice registration API.
+ * Auto-voice registration API (provider-neutral).
  *
  * Idempotently ensures an agent's deterministic voice id is registered on the
- * backend so later TTS can reference it by id (stable timbre, lean payload).
- * Folds bootstrap + register + existence-check + register-on-invalid into one
- * call:
+ * selected TTS provider's backend so later TTS can reference it by id (stable
+ * timbre, lean payload). Dispatches to the provider's VoiceRegistrationAdapter;
+ * no provider is named here. Folds bootstrap + register + existence-check +
+ * register-on-invalid into one call:
  *  - client supplies a cached reference clip → (re)register it under voiceId;
  *  - else if the voice already exists → no-op;
  *  - else synthesize the descriptor once, register, and return the clip so the
  *    client can cache it.
  *
- * POST /api/generate/voxcpm-voice
+ * POST /api/generate/voice
  */
 
 import { NextRequest } from 'next/server';
@@ -22,22 +23,22 @@ import {
 import { createLogger } from '@/lib/logger';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
 import { validateUrlForSSRF } from '@/lib/server/ssrf-guard';
-import { normalizeVoiceDesign, VOXCPM_TTS_PROVIDER_ID } from '@/lib/audio/voxcpm';
+import { normalizeVoiceDesign } from '@/lib/audio/voice-design';
 import {
-  bootstrapVoxCPMReferenceClip,
-  registerVoxCPMVoice,
-  voxCPMVoiceExists,
-  type VoxCPMRegistrationConfig,
-} from '@/lib/audio/voxcpm-registration';
+  getVoiceRegistrationAdapter,
+  type VoiceRegistrationConfig,
+} from '@/lib/audio/voice-registration';
 
-const log = createLogger('VoxCPM Voice API');
+const log = createLogger('Voice Registration API');
 
 export const maxDuration = 30;
 
 export async function POST(req: NextRequest) {
+  let providerId: string | undefined;
   let voiceId: string | undefined;
   try {
     const body = (await req.json()) as {
+      providerId?: string;
       voiceId?: string;
       descriptor?: unknown;
       language?: string;
@@ -47,9 +48,13 @@ export async function POST(req: NextRequest) {
       ttsBaseUrl?: string;
       ttsModelId?: string;
     };
+    providerId = typeof body.providerId === 'string' ? body.providerId : undefined;
     voiceId = typeof body.voiceId === 'string' ? body.voiceId.trim() : undefined;
     const design = normalizeVoiceDesign(body.descriptor);
 
+    if (!providerId) {
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'providerId is required');
+    }
     if (!voiceId) {
       return apiError('MISSING_REQUIRED_FIELD', 400, 'voiceId is required');
     }
@@ -61,8 +66,17 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const adapter = getVoiceRegistrationAdapter(providerId);
+    if (!adapter) {
+      return apiError(
+        'INVALID_REQUEST',
+        400,
+        `Provider "${providerId}" does not support voice registration`,
+      );
+    }
+
     // Managed providers are admin-owned: ignore any client-sent key/baseUrl.
-    const managed = isServerConfiguredProvider('tts', VOXCPM_TTS_PROVIDER_ID);
+    const managed = isServerConfiguredProvider('tts', providerId);
     const clientBaseUrl = managed ? undefined : body.ttsBaseUrl || undefined;
     if (clientBaseUrl) {
       const ssrfError = await validateUrlForSSRF(clientBaseUrl);
@@ -71,20 +85,17 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const apiKey = resolveTTSApiKey(
-      VOXCPM_TTS_PROVIDER_ID,
-      managed ? undefined : body.ttsApiKey || undefined,
-    );
-    const baseUrl = resolveTTSBaseUrl(VOXCPM_TTS_PROVIDER_ID, clientBaseUrl);
+    const apiKey = resolveTTSApiKey(providerId, managed ? undefined : body.ttsApiKey || undefined);
+    const baseUrl = resolveTTSBaseUrl(providerId, clientBaseUrl);
     if (!baseUrl) {
-      return apiError('MISSING_REQUIRED_FIELD', 400, 'VoxCPM base URL is required');
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'TTS base URL is required');
     }
 
-    const cfg: VoxCPMRegistrationConfig = { baseUrl, apiKey, model: body.ttsModelId };
+    const cfg: VoiceRegistrationConfig = { baseUrl, apiKey, model: body.ttsModelId };
 
     // Client supplied a cached reference clip → (re)register it (register-on-invalid).
     if (body.referenceAudioBase64) {
-      await registerVoxCPMVoice(cfg, {
+      await adapter.registerVoice(cfg, {
         voiceId,
         referenceAudioBase64: body.referenceAudioBase64,
         mimeType: body.mimeType,
@@ -93,22 +104,22 @@ export async function POST(req: NextRequest) {
     }
 
     // Already registered → no-op.
-    if (await voxCPMVoiceExists(cfg, voiceId)) {
+    if (await adapter.voiceExists(cfg, voiceId)) {
       return apiSuccess({ voiceId, registered: true });
     }
 
     // First use → bootstrap-synthesize the descriptor, register, return the clip.
-    const clip = await bootstrapVoxCPMReferenceClip(cfg, {
+    const clip = await adapter.bootstrapReferenceClip(cfg, {
       design: design!,
       language: body.language,
     });
-    await registerVoxCPMVoice(cfg, {
+    await adapter.registerVoice(cfg, {
       voiceId,
       referenceAudioBase64: clip.referenceAudioBase64,
       mimeType: clip.mimeType,
     });
 
-    log.info(`Registered VoxCPM auto voice ${voiceId}`);
+    log.info(`Registered auto voice ${voiceId} for provider ${providerId}`);
     return apiSuccess({
       voiceId,
       registered: true,
@@ -116,7 +127,10 @@ export async function POST(req: NextRequest) {
       mimeType: clip.mimeType,
     });
   } catch (error) {
-    log.error(`VoxCPM voice registration failed [voiceId=${voiceId ?? 'unknown'}]:`, error);
+    log.error(
+      `Voice registration failed [provider=${providerId ?? 'unknown'}, voiceId=${voiceId ?? 'unknown'}]:`,
+      error,
+    );
     return apiError(
       'GENERATION_FAILED',
       500,

--- a/app/api/generate/voxcpm-voice/route.ts
+++ b/app/api/generate/voxcpm-voice/route.ts
@@ -1,0 +1,126 @@
+/**
+ * VoxCPM auto-voice registration API.
+ *
+ * Idempotently ensures an agent's deterministic voice id is registered on the
+ * backend so later TTS can reference it by id (stable timbre, lean payload).
+ * Folds bootstrap + register + existence-check + register-on-invalid into one
+ * call:
+ *  - client supplies a cached reference clip → (re)register it under voiceId;
+ *  - else if the voice already exists → no-op;
+ *  - else synthesize the descriptor once, register, and return the clip so the
+ *    client can cache it.
+ *
+ * POST /api/generate/voxcpm-voice
+ */
+
+import { NextRequest } from 'next/server';
+import {
+  isServerConfiguredProvider,
+  resolveTTSApiKey,
+  resolveTTSBaseUrl,
+} from '@/lib/server/provider-config';
+import { createLogger } from '@/lib/logger';
+import { apiError, apiSuccess } from '@/lib/server/api-response';
+import { validateUrlForSSRF } from '@/lib/server/ssrf-guard';
+import { normalizeVoiceDesign, VOXCPM_TTS_PROVIDER_ID } from '@/lib/audio/voxcpm';
+import {
+  bootstrapVoxCPMReferenceClip,
+  registerVoxCPMVoice,
+  voxCPMVoiceExists,
+  type VoxCPMRegistrationConfig,
+} from '@/lib/audio/voxcpm-registration';
+
+const log = createLogger('VoxCPM Voice API');
+
+export const maxDuration = 30;
+
+export async function POST(req: NextRequest) {
+  let voiceId: string | undefined;
+  try {
+    const body = (await req.json()) as {
+      voiceId?: string;
+      descriptor?: unknown;
+      language?: string;
+      referenceAudioBase64?: string;
+      mimeType?: string;
+      ttsApiKey?: string;
+      ttsBaseUrl?: string;
+      ttsModelId?: string;
+    };
+    voiceId = typeof body.voiceId === 'string' ? body.voiceId.trim() : undefined;
+    const design = normalizeVoiceDesign(body.descriptor);
+
+    if (!voiceId) {
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'voiceId is required');
+    }
+    if (!design && !body.referenceAudioBase64) {
+      return apiError(
+        'MISSING_REQUIRED_FIELD',
+        400,
+        'descriptor or referenceAudioBase64 is required',
+      );
+    }
+
+    // Managed providers are admin-owned: ignore any client-sent key/baseUrl.
+    const managed = isServerConfiguredProvider('tts', VOXCPM_TTS_PROVIDER_ID);
+    const clientBaseUrl = managed ? undefined : body.ttsBaseUrl || undefined;
+    if (clientBaseUrl) {
+      const ssrfError = await validateUrlForSSRF(clientBaseUrl);
+      if (ssrfError) {
+        return apiError('INVALID_URL', 403, ssrfError);
+      }
+    }
+
+    const apiKey = resolveTTSApiKey(
+      VOXCPM_TTS_PROVIDER_ID,
+      managed ? undefined : body.ttsApiKey || undefined,
+    );
+    const baseUrl = resolveTTSBaseUrl(VOXCPM_TTS_PROVIDER_ID, clientBaseUrl);
+    if (!baseUrl) {
+      return apiError('MISSING_REQUIRED_FIELD', 400, 'VoxCPM base URL is required');
+    }
+
+    const cfg: VoxCPMRegistrationConfig = { baseUrl, apiKey, model: body.ttsModelId };
+
+    // Client supplied a cached reference clip → (re)register it (register-on-invalid).
+    if (body.referenceAudioBase64) {
+      await registerVoxCPMVoice(cfg, {
+        voiceId,
+        referenceAudioBase64: body.referenceAudioBase64,
+        mimeType: body.mimeType,
+      });
+      return apiSuccess({ voiceId, registered: true });
+    }
+
+    // Already registered → no-op.
+    if (await voxCPMVoiceExists(cfg, voiceId)) {
+      return apiSuccess({ voiceId, registered: true });
+    }
+
+    // First use → bootstrap-synthesize the descriptor, register, return the clip.
+    const clip = await bootstrapVoxCPMReferenceClip(cfg, {
+      design: design!,
+      language: body.language,
+    });
+    await registerVoxCPMVoice(cfg, {
+      voiceId,
+      referenceAudioBase64: clip.referenceAudioBase64,
+      mimeType: clip.mimeType,
+    });
+
+    log.info(`Registered VoxCPM auto voice ${voiceId}`);
+    return apiSuccess({
+      voiceId,
+      registered: true,
+      referenceAudioBase64: clip.referenceAudioBase64,
+      mimeType: clip.mimeType,
+    });
+  } catch (error) {
+    log.error(`VoxCPM voice registration failed [voiceId=${voiceId ?? 'unknown'}]:`, error);
+    return apiError(
+      'GENERATION_FAILED',
+      500,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -15,6 +15,7 @@ import { useAgentRegistry } from '@/lib/orchestration/registry/store';
 import { getEnabledProvidersWithVoices } from '@/lib/audio/voice-resolver';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
 import { getVoxCPMProviderOptions, useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
+import { normalizeVoxCPMBackend } from '@/lib/audio/voxcpm';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import {
   loadImageMapping,
@@ -883,10 +884,22 @@ function GenerationPreviewContent() {
           settings.ttsProviderId === 'voxcpm-tts'
             ? {
                 ...(ttsProviderConfig?.providerOptions || {}),
-                ...(await getVoxCPMProviderOptions(settings.ttsVoice, {
-                  role: 'teacher',
-                  language: languageDirective,
-                })),
+                ...(await getVoxCPMProviderOptions(
+                  settings.ttsVoice,
+                  {
+                    role: 'teacher',
+                    language: languageDirective,
+                    backend: normalizeVoxCPMBackend(ttsProviderConfig?.providerOptions?.backend),
+                  },
+                  {
+                    ttsApiKey: ttsProviderConfig?.apiKey || undefined,
+                    ttsBaseUrl:
+                      ttsProviderConfig?.baseUrl ||
+                      ttsProviderConfig?.customDefaultBaseUrl ||
+                      undefined,
+                    ttsModelId: ttsProviderConfig?.modelId,
+                  },
+                )),
               }
             : undefined;
         const speechActions = (data.scene.actions || []).filter(

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -14,8 +14,8 @@ import { useSettingsStore } from '@/lib/store/settings';
 import { useAgentRegistry } from '@/lib/orchestration/registry/store';
 import { getEnabledProvidersWithVoices } from '@/lib/audio/voice-resolver';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
-import { getVoxCPMProviderOptions, useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
-import { normalizeVoxCPMBackend } from '@/lib/audio/voxcpm';
+import { useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
+import { resolveAgentVoiceOptions, pickNarratorAgent } from '@/lib/audio/agent-voice';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import {
   loadImageMapping,
@@ -880,28 +880,14 @@ function GenerationPreviewContent() {
         )
       ) {
         const ttsProviderConfig = settings.ttsProvidersConfig?.[settings.ttsProviderId];
-        const providerOptions =
-          settings.ttsProviderId === 'voxcpm-tts'
-            ? {
-                ...(ttsProviderConfig?.providerOptions || {}),
-                ...(await getVoxCPMProviderOptions(
-                  settings.ttsVoice,
-                  {
-                    role: 'teacher',
-                    language: languageDirective,
-                    backend: normalizeVoxCPMBackend(ttsProviderConfig?.providerOptions?.backend),
-                  },
-                  {
-                    ttsApiKey: ttsProviderConfig?.apiKey || undefined,
-                    ttsBaseUrl:
-                      ttsProviderConfig?.baseUrl ||
-                      ttsProviderConfig?.customDefaultBaseUrl ||
-                      undefined,
-                    ttsModelId: ttsProviderConfig?.modelId,
-                  },
-                )),
-              }
-            : undefined;
+        // Narration uses the teacher agent's voice (single resolver → stable timbre).
+        const teacherAgent = pickNarratorAgent(useAgentRegistry.getState().listAgents());
+        const providerOptions = await resolveAgentVoiceOptions(teacherAgent, {
+          providerId: settings.ttsProviderId,
+          providerConfig: ttsProviderConfig,
+          voiceId: settings.ttsVoice,
+          language: languageDirective,
+        });
         const speechActions = (data.scene.actions || []).filter(
           (a: { type: string; text?: string }) => a.type === 'speech' && a.text,
         );

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -11,7 +11,11 @@ import { useAgentRegistry } from '@/lib/orchestration/registry/store';
 import { resolveAgentVoice, getSelectableProvidersWithVoices } from '@/lib/audio/voice-resolver';
 import { playBrowserTTSPreview } from '@/lib/audio/browser-tts-preview';
 import { getVoxCPMProviderOptions, useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
-import { VOXCPM_AUTO_VOICE_ID, VOXCPM_TTS_PROVIDER_ID } from '@/lib/audio/voxcpm';
+import {
+  VOXCPM_AUTO_VOICE_ID,
+  VOXCPM_TTS_PROVIDER_ID,
+  normalizeVoxCPMBackend,
+} from '@/lib/audio/voxcpm';
 import {
   Sparkles,
   ChevronDown,
@@ -143,12 +147,22 @@ function AgentVoicePill({
           providerId === 'voxcpm-tts'
             ? {
                 ...(providerConfig?.providerOptions || {}),
-                ...(await getVoxCPMProviderOptions(voiceId, {
-                  agentName: agent.name,
-                  role: agent.role,
-                  persona: agent.persona,
-                  locale,
-                })),
+                ...(await getVoxCPMProviderOptions(
+                  voiceId,
+                  {
+                    agentName: agent.name,
+                    role: agent.role,
+                    persona: agent.persona,
+                    voiceDesign: agent.voiceDesign,
+                    locale,
+                    backend: normalizeVoxCPMBackend(providerConfig?.providerOptions?.backend),
+                  },
+                  {
+                    ttsApiKey: providerConfig?.apiKey,
+                    ttsBaseUrl: providerConfig?.baseUrl || providerConfig?.customDefaultBaseUrl,
+                    ttsModelId: modelId || providerConfig?.modelId,
+                  },
+                )),
               }
             : undefined;
         const res = await fetch('/api/generate/tts', {

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -10,12 +10,9 @@ import { useSettingsStore } from '@/lib/store/settings';
 import { useAgentRegistry } from '@/lib/orchestration/registry/store';
 import { resolveAgentVoice, getSelectableProvidersWithVoices } from '@/lib/audio/voice-resolver';
 import { playBrowserTTSPreview } from '@/lib/audio/browser-tts-preview';
-import { getVoxCPMProviderOptions, useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
-import {
-  VOXCPM_AUTO_VOICE_ID,
-  VOXCPM_TTS_PROVIDER_ID,
-  normalizeVoxCPMBackend,
-} from '@/lib/audio/voxcpm';
+import { useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
+import { resolveAgentVoiceOptions } from '@/lib/audio/agent-voice';
+import { VOXCPM_AUTO_VOICE_ID, VOXCPM_TTS_PROVIDER_ID } from '@/lib/audio/voxcpm';
 import {
   Sparkles,
   ChevronDown,
@@ -143,28 +140,12 @@ function AgentVoicePill({
         const controller = new AbortController();
         previewAbortRef.current = controller;
         const providerConfig = ttsProvidersConfig[providerId];
-        const providerOptions =
-          providerId === 'voxcpm-tts'
-            ? {
-                ...(providerConfig?.providerOptions || {}),
-                ...(await getVoxCPMProviderOptions(
-                  voiceId,
-                  {
-                    agentName: agent.name,
-                    role: agent.role,
-                    persona: agent.persona,
-                    voiceDesign: agent.voiceDesign,
-                    locale,
-                    backend: normalizeVoxCPMBackend(providerConfig?.providerOptions?.backend),
-                  },
-                  {
-                    ttsApiKey: providerConfig?.apiKey,
-                    ttsBaseUrl: providerConfig?.baseUrl || providerConfig?.customDefaultBaseUrl,
-                    ttsModelId: modelId || providerConfig?.modelId,
-                  },
-                )),
-              }
-            : undefined;
+        const providerOptions = await resolveAgentVoiceOptions(agent, {
+          providerId,
+          providerConfig: { ...providerConfig, modelId: modelId || providerConfig?.modelId },
+          voiceId,
+          language: locale,
+        });
         const res = await fetch('/api/generate/tts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -439,17 +420,12 @@ function TeacherVoicePill({
         const controller = new AbortController();
         previewAbortRef.current = controller;
         const providerConfig = ttsProvidersConfig[providerId];
-        const providerOptions =
-          providerId === 'voxcpm-tts'
-            ? {
-                ...(providerConfig?.providerOptions || {}),
-                ...(await getVoxCPMProviderOptions(voiceId, {
-                  agentName: 'Teacher',
-                  role: 'teacher',
-                  locale,
-                })),
-              }
-            : undefined;
+        const providerOptions = await resolveAgentVoiceOptions(undefined, {
+          providerId,
+          providerConfig: { ...providerConfig, modelId: modelId || providerConfig?.modelId },
+          voiceId,
+          language: locale,
+        });
         const res = await fetch('/api/generate/tts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -32,7 +32,11 @@ function matchesVoiceQuery(value: string | undefined, query: string): boolean {
   return !!value?.toLowerCase().includes(query);
 }
 
-function getFilteredModelGroups(provider: ProviderWithVoices, query: string) {
+function getFilteredModelGroups(
+  provider: ProviderWithVoices,
+  query: string,
+  autoVoiceLabel?: string,
+) {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) return provider.modelGroups;
 
@@ -48,7 +52,9 @@ function getFilteredModelGroups(provider: ProviderWithVoices, query: string) {
           groupMatches ||
           matchesVoiceQuery(voice.name, normalizedQuery) ||
           matchesVoiceQuery(voice.id, normalizedQuery) ||
-          matchesVoiceQuery(voice.language, normalizedQuery),
+          matchesVoiceQuery(voice.language, normalizedQuery) ||
+          // Auto Voice is shown by its localized label, not voice.name — match it too.
+          (voice.id === VOXCPM_AUTO_VOICE_ID && matchesVoiceQuery(autoVoiceLabel, normalizedQuery)),
       );
       return { ...group, voices };
     })
@@ -83,7 +89,7 @@ function AgentVoicePill({
   const visibleProviderGroups = availableProviders
     .map((provider) => ({
       provider,
-      groups: getFilteredModelGroups(provider, voiceQuery),
+      groups: getFilteredModelGroups(provider, voiceQuery, t('settings.voxcpmAutoVoice')),
     }))
     .filter(({ groups }) => groups.length > 0);
 
@@ -362,7 +368,7 @@ function TeacherVoicePill({
   const visibleProviderGroups = availableProviders
     .map((provider) => ({
       provider,
-      groups: getFilteredModelGroups(provider, voiceQuery),
+      groups: getFilteredModelGroups(provider, voiceQuery, t('settings.voxcpmAutoVoice')),
     }))
     .filter(({ groups }) => groups.length > 0);
 

--- a/lib/audio/agent-voice.ts
+++ b/lib/audio/agent-voice.ts
@@ -1,0 +1,111 @@
+'use client';
+
+/**
+ * Single source of truth for "an agent's TTS voice".
+ *
+ * Every TTS path (lecture narration, multi-agent discussion, voice preview,
+ * settings test) resolves voice options through `resolveAgentVoiceOptions`,
+ * which reads the agent profile (`voiceConfig` + `voiceDesign`) and, for
+ * registration-capable providers, ensures the auto voice is registered and
+ * referenced by id (stable timbre) — otherwise falls back to the inline
+ * voice-design prompt. There is no second code path to drift out of sync.
+ */
+
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
+import { getVoxCPMProviderOptions } from '@/lib/audio/voxcpm-voices';
+import {
+  VOXCPM_AUTO_VOICE_ID,
+  VOXCPM_TTS_PROVIDER_ID,
+  normalizeVoxCPMBackend,
+} from '@/lib/audio/voxcpm';
+import { useSettingsStore } from '@/lib/store/settings';
+
+interface TTSProviderConfigShape {
+  apiKey?: string;
+  baseUrl?: string;
+  customDefaultBaseUrl?: string;
+  modelId?: string;
+  providerOptions?: Record<string, unknown>;
+}
+
+export interface AgentVoiceResolveOptions {
+  providerId: string;
+  providerConfig?: TTSProviderConfigShape;
+  voiceId: string;
+  /** Course language / locale — only selects the one-time bootstrap sample sentence. */
+  language?: string;
+}
+
+/**
+ * Pick the agent whose voice narration should use (the teacher).
+ *
+ * The registry is always seeded with the DEFAULT agents, so a plain
+ * `find(role === 'teacher')` returns the default teacher (no voiceDesign) even
+ * when a generated classroom is active. Prefer a teacher that actually carries a
+ * voiceDesign (the generated one) so narration registers a real voice instead of
+ * drifting on the inline prompt; fall back to any teacher.
+ */
+export function pickNarratorAgent(agents: AgentConfig[]): AgentConfig | undefined {
+  return (
+    agents.find((a) => a.role === 'teacher' && a.voiceDesign) ??
+    agents.find((a) => a.role === 'teacher')
+  );
+}
+
+/**
+ * Produce the `ttsProviderOptions` to send to /api/generate/tts for `agent`
+ * (pass the teacher agent for narration, the speaking agent for discussion,
+ * or undefined when there is no agent). Returns undefined for providers with
+ * no special options.
+ */
+export async function resolveAgentVoiceOptions(
+  agent: AgentConfig | undefined,
+  opts: AgentVoiceResolveOptions,
+): Promise<Record<string, unknown> | undefined> {
+  if (opts.providerId !== VOXCPM_TTS_PROVIDER_ID) return undefined;
+  return {
+    ...(opts.providerConfig?.providerOptions || {}),
+    ...(await getVoxCPMProviderOptions(
+      opts.voiceId,
+      {
+        agentName: agent?.name,
+        role: agent?.role ?? 'teacher',
+        persona: agent?.persona,
+        voiceDesign: agent?.voiceDesign,
+        language: opts.language,
+        backend: normalizeVoxCPMBackend(opts.providerConfig?.providerOptions?.backend),
+      },
+      {
+        ttsApiKey: opts.providerConfig?.apiKey || undefined,
+        ttsBaseUrl:
+          opts.providerConfig?.baseUrl || opts.providerConfig?.customDefaultBaseUrl || undefined,
+        ttsModelId: opts.providerConfig?.modelId,
+      },
+    )),
+  };
+}
+
+/**
+ * Eager warm-up: right after generated agents are saved, pre-register each
+ * agent's auto voice using the SAME idempotent ensure as the TTS path, so the
+ * first spoken line is already stable (no first-utterance registration stall).
+ * Fire-and-forget; the on-use ensure remains the correctness path (handles
+ * provider switch / GC / cache miss via the deterministic id).
+ */
+export function warmUpAgentVoices(agents: AgentConfig[]): void {
+  const settings = useSettingsStore.getState();
+  const providerId = settings.ttsProviderId;
+  if (providerId !== VOXCPM_TTS_PROVIDER_ID) return;
+  const providerConfig = settings.ttsProvidersConfig?.[providerId];
+
+  for (const agent of agents) {
+    if (!agent.voiceDesign) continue;
+    const assigned = agent.voiceConfig?.voiceId;
+    if (assigned && assigned !== VOXCPM_AUTO_VOICE_ID) continue; // uses a specific voice, not auto
+    void resolveAgentVoiceOptions(agent, {
+      providerId,
+      providerConfig,
+      voiceId: VOXCPM_AUTO_VOICE_ID,
+    }).catch(() => undefined);
+  }
+}

--- a/lib/audio/agent-voice.ts
+++ b/lib/audio/agent-voice.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AgentConfig } from '@/lib/orchestration/registry/types';
+import type { VoiceDesign } from '@/lib/audio/voice-design';
 import { getVoxCPMProviderOptions } from '@/lib/audio/voxcpm-voices';
 import {
   VOXCPM_AUTO_VOICE_ID,
@@ -53,6 +54,19 @@ export function pickNarratorAgent(agents: AgentConfig[]): AgentConfig | undefine
 }
 
 /**
+ * The descriptor used to bootstrap an agent's voice: the real `voiceDesign`
+ * when present (generated agents), otherwise the persona as a fallback seed.
+ * Persona is not a vocal description, so the resulting voice is stable but
+ * generic — good enough to register a consistent reference clip (no drift),
+ * pending a real descriptor if quality matters for that agent.
+ */
+function effectiveVoiceDesign(agent: AgentConfig | undefined): VoiceDesign | undefined {
+  if (agent?.voiceDesign) return agent.voiceDesign;
+  const persona = agent?.persona?.trim();
+  return persona ? { identity: persona, texture: '', delivery: '' } : undefined;
+}
+
+/**
  * Produce the `ttsProviderOptions` to send to /api/generate/tts for `agent`
  * (pass the teacher agent for narration, the speaking agent for discussion,
  * or undefined when there is no agent). Returns undefined for providers with
@@ -71,7 +85,7 @@ export async function resolveAgentVoiceOptions(
         agentName: agent?.name,
         role: agent?.role ?? 'teacher',
         persona: agent?.persona,
-        voiceDesign: agent?.voiceDesign,
+        voiceDesign: effectiveVoiceDesign(agent),
         language: opts.language,
         backend: normalizeVoxCPMBackend(opts.providerConfig?.providerOptions?.backend),
       },
@@ -99,7 +113,7 @@ export function warmUpAgentVoices(agents: AgentConfig[]): void {
   const providerConfig = settings.ttsProvidersConfig?.[providerId];
 
   for (const agent of agents) {
-    if (!agent.voiceDesign) continue;
+    if (!effectiveVoiceDesign(agent)) continue;
     const assigned = agent.voiceConfig?.voiceId;
     if (assigned && assigned !== VOXCPM_AUTO_VOICE_ID) continue; // uses a specific voice, not auto
     void resolveAgentVoiceOptions(agent, {

--- a/lib/audio/agent-voice.ts
+++ b/lib/audio/agent-voice.ts
@@ -100,11 +100,12 @@ export async function resolveAgentVoiceOptions(
 }
 
 /**
- * Eager warm-up: right after generated agents are saved, pre-register each
- * agent's auto voice using the SAME idempotent ensure as the TTS path, so the
- * first spoken line is already stable (no first-utterance registration stall).
- * Fire-and-forget; the on-use ensure remains the correctness path (handles
- * provider switch / GC / cache miss via the deterministic id).
+ * Eager warm-up: right after generated agents are saved, pre-register the
+ * narrator's (teacher's) auto voice using the SAME idempotent ensure as the TTS
+ * path, so the first spoken line is already stable. Only the narrator is warmed:
+ * it always speaks (lecture narration), whereas discussion agents may never be
+ * selected, so warming all of them would synthesize voices that go unused.
+ * Fire-and-forget; the on-use ensure remains the correctness path for the rest.
  */
 export function warmUpAgentVoices(agents: AgentConfig[]): void {
   const settings = useSettingsStore.getState();
@@ -112,14 +113,11 @@ export function warmUpAgentVoices(agents: AgentConfig[]): void {
   if (providerId !== VOXCPM_TTS_PROVIDER_ID) return;
   const providerConfig = settings.ttsProvidersConfig?.[providerId];
 
-  for (const agent of agents) {
-    if (!effectiveVoiceDesign(agent)) continue;
-    const assigned = agent.voiceConfig?.voiceId;
-    if (assigned && assigned !== VOXCPM_AUTO_VOICE_ID) continue; // uses a specific voice, not auto
-    void resolveAgentVoiceOptions(agent, {
-      providerId,
-      providerConfig,
-      voiceId: VOXCPM_AUTO_VOICE_ID,
-    }).catch(() => undefined);
-  }
+  const narrator = pickNarratorAgent(agents);
+  if (!narrator || !effectiveVoiceDesign(narrator)) return;
+  void resolveAgentVoiceOptions(narrator, {
+    providerId,
+    providerConfig,
+    voiceId: VOXCPM_AUTO_VOICE_ID,
+  }).catch(() => undefined);
 }

--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -401,26 +401,20 @@ async function postVoxCPMVLLMOmni(
   },
   config: TTSModelConfig,
 ): Promise<Response> {
-  // A registered voice carries timbre by id (pre-encoded latents): reference it
-  // directly and send the raw text — no inline voice-design prompt or ref_audio.
-  const payload: Record<string, unknown> = params.registeredVoiceId
-    ? {
-        model: getVLLMOmniModelId(config),
-        input: params.rawText ?? params.targetText,
-        voice: params.registeredVoiceId,
-        response_format: 'wav',
-        stream: false,
-      }
-    : {
-        model: getVLLMOmniModelId(config),
-        input: params.targetText,
-        // Without a registered voice, prompts/ref_audio carry voice identity.
-        voice: 'default',
-        response_format: 'wav',
-        stream: false,
-      };
+  const payload: Record<string, unknown> = {
+    model: getVLLMOmniModelId(config),
+    input: params.targetText,
+    voice: 'default',
+    response_format: 'wav',
+    stream: false,
+  };
 
-  if (!params.registeredVoiceId && params.referenceAudioBase64) {
+  if (params.registeredVoiceId) {
+    // A registered voice carries timbre by id (pre-encoded latents): reference it
+    // directly and send the raw text — no inline voice-design prompt or ref_audio.
+    payload.voice = params.registeredVoiceId;
+    payload.input = params.rawText ?? params.targetText;
+  } else if (params.referenceAudioBase64) {
     const referenceAudio = getVoxCPMDataAudioUrl(
       params.referenceAudioBase64,
       params.referenceAudioMimeType,

--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -297,7 +297,9 @@ async function generateVoxCPMTTS(
     (config.voice && config.voice !== 'default' && config.voice !== VOXCPM_AUTO_VOICE_ID
       ? config.voice
       : undefined);
-  if (config.voice === VOXCPM_AUTO_VOICE_ID && !voicePrompt) {
+  // A registered voice carries timbre by id, so no voice prompt is required.
+  const registeredVoiceId = options.registeredVoiceId?.trim() || undefined;
+  if (config.voice === VOXCPM_AUTO_VOICE_ID && !voicePrompt && !registeredVoiceId) {
     throw new Error('VoxCPM Auto Voice requires agent context');
   }
   const cfgValue = options.cfgValue ?? 2.0;
@@ -308,6 +310,8 @@ async function generateVoxCPMTTS(
 
   const request = {
     targetText: usePromptContinuation ? text : buildVoxCPMTargetText(text, voicePrompt),
+    rawText: text,
+    registeredVoiceId,
     voicePrompt,
     promptText: options.promptText,
     cfgValue,
@@ -388,6 +392,8 @@ async function postVoxCPMVLLMOmni(
   baseUrl: string,
   params: {
     targetText: string;
+    rawText?: string;
+    registeredVoiceId?: string;
     promptText?: string;
     referenceAudioBase64?: string;
     referenceAudioMimeType?: string;
@@ -395,16 +401,26 @@ async function postVoxCPMVLLMOmni(
   },
   config: TTSModelConfig,
 ): Promise<Response> {
-  const payload: Record<string, unknown> = {
-    model: getVLLMOmniModelId(config),
-    input: params.targetText,
-    // VoxCPM2's vLLM-Omni adapter currently ignores named voices; prompts/ref_audio carry voice identity.
-    voice: 'default',
-    response_format: 'wav',
-    stream: false,
-  };
+  // A registered voice carries timbre by id (pre-encoded latents): reference it
+  // directly and send the raw text — no inline voice-design prompt or ref_audio.
+  const payload: Record<string, unknown> = params.registeredVoiceId
+    ? {
+        model: getVLLMOmniModelId(config),
+        input: params.rawText ?? params.targetText,
+        voice: params.registeredVoiceId,
+        response_format: 'wav',
+        stream: false,
+      }
+    : {
+        model: getVLLMOmniModelId(config),
+        input: params.targetText,
+        // Without a registered voice, prompts/ref_audio carry voice identity.
+        voice: 'default',
+        response_format: 'wav',
+        stream: false,
+      };
 
-  if (params.referenceAudioBase64) {
+  if (!params.registeredVoiceId && params.referenceAudioBase64) {
     const referenceAudio = getVoxCPMDataAudioUrl(
       params.referenceAudioBase64,
       params.referenceAudioMimeType,

--- a/lib/audio/voice-design.ts
+++ b/lib/audio/voice-design.ts
@@ -21,6 +21,9 @@ export const AUTO_VOICE_ID_PREFIX = 'auto-' as const;
 function sanitizeVoiceDesignPart(value?: string): string {
   return (value || '')
     .replace(/[\p{C}]+/gu, ' ')
+    // Strip parentheses: VoxCPM uses `(prompt)text` delimiters, so a paren in the
+    // descriptor/persona would corrupt the bootstrap synthesis prompt.
+    .replace(/[()（）]/gu, ' ')
     .replace(/\s+/gu, ' ')
     .trim()
     .slice(0, VOICE_DESIGN_PROMPT_MAX_CHARS)

--- a/lib/audio/voice-design.ts
+++ b/lib/audio/voice-design.ts
@@ -1,0 +1,74 @@
+/**
+ * Provider-neutral per-agent voice design.
+ *
+ * A `VoiceDesign` describes an agent's vocal identity (not personality) as a
+ * 3-layer recipe. It is consumed by any TTS provider: as an inline voice
+ * prompt where supported, or as the seed for a registered/cloned voice
+ * (see `voice-registration.ts`). Nothing here is VoxCPM-specific.
+ */
+
+export interface VoiceDesign {
+  identity: string; // gender / age / role
+  texture: string; // pitch / vocal quality
+  delivery: string; // emotion / pace
+}
+
+const VOICE_DESIGN_PROMPT_MAX_CHARS = 200;
+
+/** Prefix for deterministic auto-voice ids (provider-neutral, backend-name-safe). */
+export const AUTO_VOICE_ID_PREFIX = 'auto-' as const;
+
+function sanitizeVoiceDesignPart(value?: string): string {
+  return (value || '')
+    .replace(/[\p{C}]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .slice(0, VOICE_DESIGN_PROMPT_MAX_CHARS)
+    .trim();
+}
+
+/** Compose the 3 layers into one comma-joined prompt, dropping blank layers. */
+export function buildVoiceDesignPrompt(design: VoiceDesign): string {
+  return [design.identity, design.texture, design.delivery]
+    .map((part) => sanitizeVoiceDesignPart(part))
+    .filter(Boolean)
+    .join(', ');
+}
+
+/** Coerce an arbitrary (LLM-produced) value into a VoiceDesign, or undefined. */
+export function normalizeVoiceDesign(raw: unknown): VoiceDesign | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const record = raw as Record<string, unknown>;
+  const pick = (value: unknown) => (typeof value === 'string' ? value.trim() : '');
+  const design = {
+    identity: pick(record.identity),
+    texture: pick(record.texture),
+    delivery: pick(record.delivery),
+  };
+  if (!design.identity && !design.texture && !design.delivery) return undefined;
+  return design;
+}
+
+/**
+ * Deterministic voice id derived from the descriptor (+ provider + language +
+ * model). Stable across re-synthesis, recomputable anywhere from the descriptor
+ * on the agent, and namespaced by provider so a shared registry can't collide.
+ */
+export async function getDeterministicVoiceId(
+  design: VoiceDesign,
+  opts: { providerId?: string; language?: string; model?: string } = {},
+): Promise<string> {
+  const seed = [
+    opts.providerId || '',
+    design.identity,
+    design.texture,
+    design.delivery,
+    opts.language || '',
+    opts.model || '',
+  ].join('|');
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed));
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `${AUTO_VOICE_ID_PREFIX}${hex.slice(0, 16)}`;
+}

--- a/lib/audio/voice-design.ts
+++ b/lib/audio/voice-design.ts
@@ -50,20 +50,25 @@ export function normalizeVoiceDesign(raw: unknown): VoiceDesign | undefined {
 }
 
 /**
- * Deterministic voice id derived from the descriptor (+ provider + language +
- * model). Stable across re-synthesis, recomputable anywhere from the descriptor
- * on the agent, and namespaced by provider so a shared registry can't collide.
+ * Deterministic voice id derived from the descriptor (+ provider + model).
+ * Stable across re-synthesis, recomputable anywhere from the descriptor on the
+ * agent, and namespaced by provider so a shared registry can't collide.
+ *
+ * Note: language is intentionally NOT part of the id — the descriptor text is
+ * already written in the course language, and language only selects the one-time
+ * bootstrap sample sentence (which affects neither output language nor timbre).
+ * Keeping it out means every TTS path (narration passes a directive, discussion
+ * passes a locale) resolves to the SAME id for the same agent.
  */
 export async function getDeterministicVoiceId(
   design: VoiceDesign,
-  opts: { providerId?: string; language?: string; model?: string } = {},
+  opts: { providerId?: string; model?: string } = {},
 ): Promise<string> {
   const seed = [
     opts.providerId || '',
     design.identity,
     design.texture,
     design.delivery,
-    opts.language || '',
     opts.model || '',
   ].join('|');
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed));

--- a/lib/audio/voice-design.ts
+++ b/lib/audio/voice-design.ts
@@ -19,15 +19,17 @@ const VOICE_DESIGN_PROMPT_MAX_CHARS = 200;
 export const AUTO_VOICE_ID_PREFIX = 'auto-' as const;
 
 function sanitizeVoiceDesignPart(value?: string): string {
-  return (value || '')
-    .replace(/[\p{C}]+/gu, ' ')
-    // Strip parentheses: VoxCPM uses `(prompt)text` delimiters, so a paren in the
-    // descriptor/persona would corrupt the bootstrap synthesis prompt.
-    .replace(/[()（）]/gu, ' ')
-    .replace(/\s+/gu, ' ')
-    .trim()
-    .slice(0, VOICE_DESIGN_PROMPT_MAX_CHARS)
-    .trim();
+  return (
+    (value || '')
+      .replace(/[\p{C}]+/gu, ' ')
+      // Strip parentheses: VoxCPM uses `(prompt)text` delimiters, so a paren in the
+      // descriptor/persona would corrupt the bootstrap synthesis prompt.
+      .replace(/[()（）]/gu, ' ')
+      .replace(/\s+/gu, ' ')
+      .trim()
+      .slice(0, VOICE_DESIGN_PROMPT_MAX_CHARS)
+      .trim()
+  );
 }
 
 /** Compose the 3 layers into one comma-joined prompt, dropping blank layers. */

--- a/lib/audio/voice-registration-client.ts
+++ b/lib/audio/voice-registration-client.ts
@@ -66,7 +66,6 @@ export async function ensureRegisteredVoice(
 
   const voiceId = await getDeterministicVoiceId(params.voiceDesign, {
     providerId,
-    language: params.language,
     model: request.ttsModelId,
   });
   if (registeredThisSession.has(voiceId)) return voiceId;

--- a/lib/audio/voice-registration-client.ts
+++ b/lib/audio/voice-registration-client.ts
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * Provider-neutral client orchestrator for the auto-voice register-once flow.
+ *
+ * Given a provider id + voice design, it resolves a deterministic voice id,
+ * ensures the voice is registered on the backend via `POST /api/generate/voice`
+ * (which dispatches to the provider's adapter), and caches the reference clip
+ * in IndexedDB so a GC'd voice can be re-registered. Callers decide *whether*
+ * their provider supports registration; this module is provider-agnostic.
+ */
+
+import { db } from '@/lib/utils/database';
+import { getDeterministicVoiceId, type VoiceDesign } from '@/lib/audio/voice-design';
+
+export interface VoiceRegistrationRequestConfig {
+  ttsApiKey?: string;
+  ttsBaseUrl?: string;
+  ttsModelId?: string;
+}
+
+function base64ToBlob(base64: string, mimeType?: string): Blob {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: mimeType || 'audio/wav' });
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error || new Error('Failed to read reference audio'));
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      const commaIndex = result.indexOf(',');
+      resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result);
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Voice ids confirmed registered in this browser session — skip the round-trip.
+const registeredThisSession = new Set<string>();
+
+async function getCachedClip(
+  voiceId: string,
+): Promise<{ base64: string; mimeType: string } | undefined> {
+  const row = await db.autoVoiceCache.get(voiceId);
+  if (!row) return undefined;
+  return { base64: await blobToBase64(row.referenceAudio), mimeType: row.mimeType };
+}
+
+/**
+ * Ensure the agent's deterministic auto voice is registered for `providerId`,
+ * returning its voice id (or undefined when unavailable, so callers fall back
+ * to the inline voice-design prompt). Lazy + idempotent: memoized per session,
+ * reference clip cached in IndexedDB. register-on-invalid is handled by the
+ * endpoint's existence check, which re-registers a GC'd voice from the clip.
+ */
+export async function ensureRegisteredVoice(
+  providerId: string,
+  params: { voiceDesign?: VoiceDesign; language?: string },
+  request: VoiceRegistrationRequestConfig,
+): Promise<string | undefined> {
+  if (!params.voiceDesign) return undefined;
+
+  const voiceId = await getDeterministicVoiceId(params.voiceDesign, {
+    providerId,
+    language: params.language,
+    model: request.ttsModelId,
+  });
+  if (registeredThisSession.has(voiceId)) return voiceId;
+
+  const cached = await getCachedClip(voiceId);
+  const res = await fetch('/api/generate/voice', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      providerId,
+      voiceId,
+      descriptor: params.voiceDesign,
+      language: params.language,
+      referenceAudioBase64: cached?.base64,
+      mimeType: cached?.mimeType,
+      ...request,
+    }),
+  });
+  if (!res.ok) return undefined; // graceful fallback to the inline prompt path
+
+  const data = (await res.json().catch(() => ({}))) as {
+    referenceAudioBase64?: string;
+    mimeType?: string;
+  };
+  if (data.referenceAudioBase64 && !cached) {
+    await db.autoVoiceCache.put({
+      voiceId,
+      referenceAudio: base64ToBlob(data.referenceAudioBase64, data.mimeType),
+      mimeType: data.mimeType || 'audio/wav',
+      updatedAt: Date.now(),
+    });
+  }
+  registeredThisSession.add(voiceId);
+  return voiceId;
+}

--- a/lib/audio/voice-registration-client.ts
+++ b/lib/audio/voice-registration-client.ts
@@ -39,15 +39,17 @@ async function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
-// Confirmed-registered + in-flight memos, keyed by (voiceId, backend). The same
-// voiceId may be unregistered on a different backend, so the base URL must be
-// part of the key — otherwise switching the VoxCPM base URL mid-session would
-// skip re-registration and return an id registered only on the old backend.
+// Confirmed-registered + in-flight memos, keyed by (voiceId, backend, credential).
+// The same voiceId may be unregistered — or inaccessible — on a different backend
+// or under different credentials, so both the base URL and the API key are part
+// of the key. Otherwise switching the VoxCPM base URL or account mid-session
+// would skip re-registration and reuse an id from the old backend/credentials.
 const registeredThisSession = new Set<string>();
 const inFlight = new Map<string, Promise<string | undefined>>();
 
 function memoKeyFor(voiceId: string, request: VoiceRegistrationRequestConfig): string {
-  return `${voiceId}::${request.ttsBaseUrl ?? ''}`;
+  // In-memory only (never persisted or logged), so the raw key identity is fine.
+  return `${voiceId}::${request.ttsBaseUrl ?? ''}::${request.ttsApiKey ?? ''}`;
 }
 
 async function getCachedClip(

--- a/lib/audio/voice-registration-client.ts
+++ b/lib/audio/voice-registration-client.ts
@@ -39,12 +39,16 @@ async function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
-// Voice ids confirmed registered in this browser session — skip the round-trip.
+// Confirmed-registered + in-flight memos, keyed by (voiceId, backend). The same
+// voiceId may be unregistered on a different backend, so the base URL must be
+// part of the key — otherwise switching the VoxCPM base URL mid-session would
+// skip re-registration and return an id registered only on the old backend.
 const registeredThisSession = new Set<string>();
-// In-flight registrations, keyed by voiceId, so concurrent callers (e.g. the
-// eager warm-up racing the first utterance) share one request instead of each
-// firing a duplicate bootstrap + register.
 const inFlight = new Map<string, Promise<string | undefined>>();
+
+function memoKeyFor(voiceId: string, request: VoiceRegistrationRequestConfig): string {
+  return `${voiceId}::${request.ttsBaseUrl ?? ''}`;
+}
 
 async function getCachedClip(
   voiceId: string,
@@ -72,22 +76,24 @@ export async function ensureRegisteredVoice(
     providerId,
     model: request.ttsModelId,
   });
-  if (registeredThisSession.has(voiceId)) return voiceId;
+  const memoKey = memoKeyFor(voiceId, request);
+  if (registeredThisSession.has(memoKey)) return voiceId;
 
-  // Coalesce concurrent calls for the same voiceId into one request.
-  const existing = inFlight.get(voiceId);
+  // Coalesce concurrent calls for the same (voiceId, backend) into one request.
+  const existing = inFlight.get(memoKey);
   if (existing) return existing;
 
-  const promise = registerOnce(providerId, voiceId, params, request).finally(() =>
-    inFlight.delete(voiceId),
+  const promise = registerOnce(providerId, voiceId, memoKey, params, request).finally(() =>
+    inFlight.delete(memoKey),
   );
-  inFlight.set(voiceId, promise);
+  inFlight.set(memoKey, promise);
   return promise;
 }
 
 async function registerOnce(
   providerId: string,
   voiceId: string,
+  memoKey: string,
   params: { voiceDesign?: VoiceDesign; language?: string },
   request: VoiceRegistrationRequestConfig,
 ): Promise<string | undefined> {
@@ -119,6 +125,6 @@ async function registerOnce(
       updatedAt: Date.now(),
     });
   }
-  registeredThisSession.add(voiceId);
+  registeredThisSession.add(memoKey);
   return voiceId;
 }

--- a/lib/audio/voice-registration-client.ts
+++ b/lib/audio/voice-registration-client.ts
@@ -41,6 +41,10 @@ async function blobToBase64(blob: Blob): Promise<string> {
 
 // Voice ids confirmed registered in this browser session — skip the round-trip.
 const registeredThisSession = new Set<string>();
+// In-flight registrations, keyed by voiceId, so concurrent callers (e.g. the
+// eager warm-up racing the first utterance) share one request instead of each
+// firing a duplicate bootstrap + register.
+const inFlight = new Map<string, Promise<string | undefined>>();
 
 async function getCachedClip(
   voiceId: string,
@@ -70,6 +74,23 @@ export async function ensureRegisteredVoice(
   });
   if (registeredThisSession.has(voiceId)) return voiceId;
 
+  // Coalesce concurrent calls for the same voiceId into one request.
+  const existing = inFlight.get(voiceId);
+  if (existing) return existing;
+
+  const promise = registerOnce(providerId, voiceId, params, request).finally(() =>
+    inFlight.delete(voiceId),
+  );
+  inFlight.set(voiceId, promise);
+  return promise;
+}
+
+async function registerOnce(
+  providerId: string,
+  voiceId: string,
+  params: { voiceDesign?: VoiceDesign; language?: string },
+  request: VoiceRegistrationRequestConfig,
+): Promise<string | undefined> {
   const cached = await getCachedClip(voiceId);
   const res = await fetch('/api/generate/voice', {
     method: 'POST',

--- a/lib/audio/voice-registration.ts
+++ b/lib/audio/voice-registration.ts
@@ -1,0 +1,56 @@
+/**
+ * Provider-neutral voice-registration seam.
+ *
+ * The "auto voice" timbre-stability pattern — synthesize a voice-design once,
+ * register it, then reference it by id — is not VoxCPM-specific. Any TTS
+ * backend that can register/clone a voice (VoxCPM/vLLM-Omni today; ElevenLabs,
+ * MiniMax, Doubao, … later) plugs in by implementing `VoiceRegistrationAdapter`
+ * and registering it below. Server routes and the client orchestrator dispatch
+ * by `providerId` and never name a concrete provider.
+ */
+
+import type { VoiceDesign } from '@/lib/audio/voice-design';
+import { voxcpmVoiceRegistrationAdapter } from '@/lib/audio/voxcpm-registration';
+
+/** Resolved backend connection for a registration call (server-injected for managed providers). */
+export interface VoiceRegistrationConfig {
+  baseUrl: string;
+  apiKey?: string;
+  model?: string;
+}
+
+export interface VoiceRegistrationAdapter {
+  /** Whether registration is available for this provider given its options (e.g. backend kind). */
+  supportsRegistration(options?: Record<string, unknown>): boolean;
+  /** Whether `voiceId` is already registered on the backend. */
+  voiceExists(cfg: VoiceRegistrationConfig, voiceId: string): Promise<boolean>;
+  /** Register (or idempotently re-register) a reference clip under `voiceId`; returns the id. */
+  registerVoice(
+    cfg: VoiceRegistrationConfig,
+    params: { voiceId: string; referenceAudioBase64: string; mimeType?: string },
+  ): Promise<string>;
+  /** Synthesize the voice design once into a reference clip. */
+  bootstrapReferenceClip(
+    cfg: VoiceRegistrationConfig,
+    params: { design: VoiceDesign; language?: string },
+  ): Promise<{ referenceAudioBase64: string; mimeType: string }>;
+}
+
+/** providerId → adapter. The only seam to touch when adding a provider. */
+const VOICE_REGISTRATION_ADAPTERS: Record<string, VoiceRegistrationAdapter> = {
+  'voxcpm-tts': voxcpmVoiceRegistrationAdapter,
+};
+
+export function getVoiceRegistrationAdapter(
+  providerId: string,
+): VoiceRegistrationAdapter | undefined {
+  return VOICE_REGISTRATION_ADAPTERS[providerId];
+}
+
+/** Whether this provider supports register-once/reference-by-id for the given options. */
+export function supportsVoiceRegistration(
+  providerId: string,
+  options?: Record<string, unknown>,
+): boolean {
+  return getVoiceRegistrationAdapter(providerId)?.supportsRegistration(options) ?? false;
+}

--- a/lib/audio/voxcpm-registration.ts
+++ b/lib/audio/voxcpm-registration.ts
@@ -1,23 +1,15 @@
 /**
- * VoxCPM voice-registration backend client (server-side).
+ * VoxCPM voice-registration adapter (server-side) — the first concrete
+ * implementation of the provider-neutral `VoiceRegistrationAdapter`.
  *
- * Drives the reference-by-id timbre-stability flow against backends that
- * expose a runtime voice-registration API (vLLM-Omni `/v1/audio/voices`):
- * synthesize a voice-design prompt once, register the resulting clip under a
- * deterministic id, then reference `voice=<id>` on later speech requests.
+ * Drives the reference-by-id timbre-stability flow against vLLM-Omni
+ * (`/v1/audio/voices`): synthesize a voice-design prompt once, register the
+ * clip under a deterministic id, then later TTS references `voice=<id>`.
  */
 
-import {
-  buildVoiceDesignPrompt,
-  VOXCPM_VLLM_MODEL_ID,
-  type VoxCPMVoiceDesign,
-} from '@/lib/audio/voxcpm';
-
-export interface VoxCPMRegistrationConfig {
-  baseUrl: string; // backend root or `.../v1`
-  apiKey?: string;
-  model?: string;
-}
+import { buildVoiceDesignPrompt, type VoiceDesign } from '@/lib/audio/voice-design';
+import { VOXCPM_VLLM_MODEL_ID, normalizeVoxCPMBackend, voxCPMBackendSupportsVoiceRegistration } from '@/lib/audio/voxcpm';
+import type { VoiceRegistrationAdapter, VoiceRegistrationConfig } from '@/lib/audio/voice-registration';
 
 function v1(baseUrl: string): string {
   const clean = baseUrl.replace(/\/$/, '');
@@ -56,14 +48,9 @@ function bootstrapSentence(language?: string): string {
   return BOOTSTRAP_SENTENCE[key] || BOOTSTRAP_SENTENCE.default;
 }
 
-/**
- * Whether a voice id is already registered on the backend.
- *
- * vLLM-Omni exposes no per-name GET (that route is 405); list all voices and
- * check membership.
- */
+/** Whether a voice id is already registered (vLLM-Omni has no per-name GET → list + membership). */
 export async function voxCPMVoiceExists(
-  cfg: VoxCPMRegistrationConfig,
+  cfg: VoiceRegistrationConfig,
   voiceId: string,
 ): Promise<boolean> {
   const res = await fetch(`${v1(cfg.baseUrl)}/audio/voices`, {
@@ -77,7 +64,7 @@ export async function voxCPMVoiceExists(
 
 /** Register (or re-register, idempotently) a reference clip under `voiceId`. */
 export async function registerVoxCPMVoice(
-  cfg: VoxCPMRegistrationConfig,
+  cfg: VoiceRegistrationConfig,
   params: { voiceId: string; referenceAudioBase64: string; mimeType?: string },
 ): Promise<string> {
   const form = new FormData();
@@ -103,8 +90,8 @@ export async function registerVoxCPMVoice(
 
 /** Synthesize the voice-design prompt once into a reference clip. */
 export async function bootstrapVoxCPMReferenceClip(
-  cfg: VoxCPMRegistrationConfig,
-  params: { design: VoxCPMVoiceDesign; language?: string },
+  cfg: VoiceRegistrationConfig,
+  params: { design: VoiceDesign; language?: string },
 ): Promise<{ referenceAudioBase64: string; mimeType: string }> {
   const prompt = buildVoiceDesignPrompt(params.design);
   const sample = bootstrapSentence(params.language);
@@ -128,3 +115,13 @@ export async function bootstrapVoxCPMReferenceClip(
     mimeType: res.headers.get('content-type') || 'audio/wav',
   };
 }
+
+/** VoxCPM implementation of the provider-neutral registration adapter. */
+export const voxcpmVoiceRegistrationAdapter: VoiceRegistrationAdapter = {
+  supportsRegistration(options) {
+    return voxCPMBackendSupportsVoiceRegistration(normalizeVoxCPMBackend(options?.backend));
+  },
+  voiceExists: voxCPMVoiceExists,
+  registerVoice: registerVoxCPMVoice,
+  bootstrapReferenceClip: bootstrapVoxCPMReferenceClip,
+};

--- a/lib/audio/voxcpm-registration.ts
+++ b/lib/audio/voxcpm-registration.ts
@@ -41,6 +41,9 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+/** vLLM-Omni requires a consent string on voice registration. */
+const VOXCPM_VOICE_CONSENT = 'I confirm I have the right to use this voice sample.';
+
 /** A short neutral sentence used to synthesize the bootstrap reference clip. */
 const BOOTSTRAP_SENTENCE: Record<string, string> = {
   default: 'Hello, welcome to today’s lesson. Let us begin.',
@@ -53,17 +56,23 @@ function bootstrapSentence(language?: string): string {
   return BOOTSTRAP_SENTENCE[key] || BOOTSTRAP_SENTENCE.default;
 }
 
-/** Whether a voice id is already registered on the backend. */
+/**
+ * Whether a voice id is already registered on the backend.
+ *
+ * vLLM-Omni exposes no per-name GET (that route is 405); list all voices and
+ * check membership.
+ */
 export async function voxCPMVoiceExists(
   cfg: VoxCPMRegistrationConfig,
   voiceId: string,
 ): Promise<boolean> {
-  const res = await fetch(`${v1(cfg.baseUrl)}/audio/voices/${encodeURIComponent(voiceId)}`, {
+  const res = await fetch(`${v1(cfg.baseUrl)}/audio/voices`, {
     method: 'GET',
     headers: authHeaders(cfg.apiKey),
   });
-  if (res.status === 404) return false;
-  return res.ok;
+  if (!res.ok) return false;
+  const data = (await res.json().catch(() => ({}))) as { voices?: unknown };
+  return Array.isArray(data.voices) && data.voices.includes(voiceId);
 }
 
 /** Register (or re-register, idempotently) a reference clip under `voiceId`. */
@@ -72,9 +81,10 @@ export async function registerVoxCPMVoice(
   params: { voiceId: string; referenceAudioBase64: string; mimeType?: string },
 ): Promise<string> {
   const form = new FormData();
-  form.set('voice_id', params.voiceId);
+  form.set('name', params.voiceId);
+  form.set('consent', VOXCPM_VOICE_CONSENT);
   form.set(
-    'file',
+    'audio_sample',
     new Blob([base64ToBytes(params.referenceAudioBase64)], { type: params.mimeType || 'audio/wav' }),
     `${params.voiceId}.wav`,
   );
@@ -87,8 +97,8 @@ export async function registerVoxCPMVoice(
   if (!res.ok) {
     throw new Error(`VoxCPM voice registration failed: ${res.status}`);
   }
-  const data = (await res.json().catch(() => ({}))) as { id?: string };
-  return data.id || params.voiceId;
+  const data = (await res.json().catch(() => ({}))) as { voice?: { name?: string } };
+  return data.voice?.name || params.voiceId;
 }
 
 /** Synthesize the voice-design prompt once into a reference clip. */

--- a/lib/audio/voxcpm-registration.ts
+++ b/lib/audio/voxcpm-registration.ts
@@ -1,0 +1,120 @@
+/**
+ * VoxCPM voice-registration backend client (server-side).
+ *
+ * Drives the reference-by-id timbre-stability flow against backends that
+ * expose a runtime voice-registration API (vLLM-Omni `/v1/audio/voices`):
+ * synthesize a voice-design prompt once, register the resulting clip under a
+ * deterministic id, then reference `voice=<id>` on later speech requests.
+ */
+
+import {
+  buildVoiceDesignPrompt,
+  VOXCPM_VLLM_MODEL_ID,
+  type VoxCPMVoiceDesign,
+} from '@/lib/audio/voxcpm';
+
+export interface VoxCPMRegistrationConfig {
+  baseUrl: string; // backend root or `.../v1`
+  apiKey?: string;
+  model?: string;
+}
+
+function v1(baseUrl: string): string {
+  const clean = baseUrl.replace(/\/$/, '');
+  return clean.endsWith('/v1') ? clean : `${clean}/v1`;
+}
+
+function authHeaders(apiKey?: string): Record<string, string> {
+  return apiKey?.trim() ? { Authorization: `Bearer ${apiKey.trim()}` } : {};
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+/** A short neutral sentence used to synthesize the bootstrap reference clip. */
+const BOOTSTRAP_SENTENCE: Record<string, string> = {
+  default: 'Hello, welcome to today’s lesson. Let us begin.',
+  zh: '你好，欢迎来到今天的课程，我们开始吧。',
+};
+
+function bootstrapSentence(language?: string): string {
+  if (!language) return BOOTSTRAP_SENTENCE.default;
+  const key = language.toLowerCase().split(/[-_]/)[0];
+  return BOOTSTRAP_SENTENCE[key] || BOOTSTRAP_SENTENCE.default;
+}
+
+/** Whether a voice id is already registered on the backend. */
+export async function voxCPMVoiceExists(
+  cfg: VoxCPMRegistrationConfig,
+  voiceId: string,
+): Promise<boolean> {
+  const res = await fetch(`${v1(cfg.baseUrl)}/audio/voices/${encodeURIComponent(voiceId)}`, {
+    method: 'GET',
+    headers: authHeaders(cfg.apiKey),
+  });
+  if (res.status === 404) return false;
+  return res.ok;
+}
+
+/** Register (or re-register, idempotently) a reference clip under `voiceId`. */
+export async function registerVoxCPMVoice(
+  cfg: VoxCPMRegistrationConfig,
+  params: { voiceId: string; referenceAudioBase64: string; mimeType?: string },
+): Promise<string> {
+  const form = new FormData();
+  form.set('voice_id', params.voiceId);
+  form.set(
+    'file',
+    new Blob([base64ToBytes(params.referenceAudioBase64)], { type: params.mimeType || 'audio/wav' }),
+    `${params.voiceId}.wav`,
+  );
+
+  const res = await fetch(`${v1(cfg.baseUrl)}/audio/voices`, {
+    method: 'POST',
+    headers: authHeaders(cfg.apiKey),
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`VoxCPM voice registration failed: ${res.status}`);
+  }
+  const data = (await res.json().catch(() => ({}))) as { id?: string };
+  return data.id || params.voiceId;
+}
+
+/** Synthesize the voice-design prompt once into a reference clip. */
+export async function bootstrapVoxCPMReferenceClip(
+  cfg: VoxCPMRegistrationConfig,
+  params: { design: VoxCPMVoiceDesign; language?: string },
+): Promise<{ referenceAudioBase64: string; mimeType: string }> {
+  const prompt = buildVoiceDesignPrompt(params.design);
+  const sample = bootstrapSentence(params.language);
+  const res = await fetch(`${v1(cfg.baseUrl)}/audio/speech`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8', ...authHeaders(cfg.apiKey) },
+    body: JSON.stringify({
+      model: cfg.model || VOXCPM_VLLM_MODEL_ID,
+      input: prompt ? `(${prompt})${sample}` : sample,
+      voice: 'default',
+      response_format: 'wav',
+      stream: false,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`VoxCPM bootstrap synthesis failed: ${res.status}`);
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  return {
+    referenceAudioBase64: bytesToBase64(bytes),
+    mimeType: res.headers.get('content-type') || 'audio/wav',
+  };
+}

--- a/lib/audio/voxcpm-registration.ts
+++ b/lib/audio/voxcpm-registration.ts
@@ -20,11 +20,11 @@ function authHeaders(apiKey?: string): Record<string, string> {
   return apiKey?.trim() ? { Authorization: `Bearer ${apiKey.trim()}` } : {};
 }
 
-function base64ToBytes(base64: string): Uint8Array {
+function base64ToBlob(base64: string, mimeType?: string): Blob {
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
+  return new Blob([bytes], { type: mimeType || 'audio/wav' });
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -72,7 +72,7 @@ export async function registerVoxCPMVoice(
   form.set('consent', VOXCPM_VOICE_CONSENT);
   form.set(
     'audio_sample',
-    new Blob([base64ToBytes(params.referenceAudioBase64)], { type: params.mimeType || 'audio/wav' }),
+    base64ToBlob(params.referenceAudioBase64, params.mimeType),
     `${params.voiceId}.wav`,
   );
 

--- a/lib/audio/voxcpm-registration.ts
+++ b/lib/audio/voxcpm-registration.ts
@@ -8,8 +8,15 @@
  */
 
 import { buildVoiceDesignPrompt, type VoiceDesign } from '@/lib/audio/voice-design';
-import { VOXCPM_VLLM_MODEL_ID, normalizeVoxCPMBackend, voxCPMBackendSupportsVoiceRegistration } from '@/lib/audio/voxcpm';
-import type { VoiceRegistrationAdapter, VoiceRegistrationConfig } from '@/lib/audio/voice-registration';
+import {
+  VOXCPM_VLLM_MODEL_ID,
+  normalizeVoxCPMBackend,
+  voxCPMBackendSupportsVoiceRegistration,
+} from '@/lib/audio/voxcpm';
+import type {
+  VoiceRegistrationAdapter,
+  VoiceRegistrationConfig,
+} from '@/lib/audio/voice-registration';
 
 function v1(baseUrl: string): string {
   const clean = baseUrl.replace(/\/$/, '');

--- a/lib/audio/voxcpm-voices.ts
+++ b/lib/audio/voxcpm-voices.ts
@@ -8,20 +8,16 @@ import {
   VOXCPM_AUTO_VOICE_ID,
   VOXCPM_TTS_PROVIDER_ID,
   buildAutoVoxCPMVoicePrompt,
-  getDeterministicVoxCPMVoiceId,
   getVoxCPMProfileIdFromVoiceId,
   getVoxCPMProfileVoiceId,
   voxCPMBackendSupportsVoiceRegistration,
   type VoxCPMProviderOptions,
   type VoxCPMVoicePromptContext,
 } from '@/lib/audio/voxcpm';
-
-/** Provider config the registration endpoint needs (forwarded for non-managed providers). */
-export interface VoxCPMTTSRequestConfig {
-  ttsApiKey?: string;
-  ttsBaseUrl?: string;
-  ttsModelId?: string;
-}
+import {
+  ensureRegisteredVoice,
+  type VoiceRegistrationRequestConfig,
+} from '@/lib/audio/voice-registration-client';
 
 export type VoxCPMVoiceProfile = VoiceProfileRecord;
 
@@ -51,82 +47,6 @@ async function blobToBase64(blob: Blob): Promise<string> {
     };
     reader.readAsDataURL(blob);
   });
-}
-
-function base64ToBlob(base64: string, mimeType?: string): Blob {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return new Blob([bytes], { type: mimeType || 'audio/wav' });
-}
-
-// Voice ids confirmed registered in this browser session — skip the round-trip.
-const registeredAutoVoicesThisSession = new Set<string>();
-
-async function getCachedAutoVoiceClip(
-  voiceId: string,
-): Promise<{ base64: string; mimeType: string } | undefined> {
-  const row = await db.voxcpmAutoVoiceCache.get(voiceId);
-  if (!row) return undefined;
-  return { base64: await blobToBase64(row.referenceAudio), mimeType: row.mimeType };
-}
-
-/**
- * Ensure the agent's deterministic auto voice is registered on the backend,
- * returning its voice id (or undefined when registration is unavailable, so
- * callers fall back to the inline voice-design prompt path).
- *
- * Lazy + idempotent: memoized per session, reference clip cached in IndexedDB.
- * register-on-invalid is handled by the endpoint's existence check, which
- * re-registers a GC'd voice from the supplied cached clip.
- */
-export async function ensureRegisteredAutoVoice(
-  context: VoxCPMVoicePromptContext,
-  request: VoxCPMTTSRequestConfig,
-): Promise<string | undefined> {
-  if (
-    !context.voiceDesign ||
-    !context.backend ||
-    !voxCPMBackendSupportsVoiceRegistration(context.backend)
-  ) {
-    return undefined;
-  }
-
-  const voiceId = await getDeterministicVoxCPMVoiceId(context.voiceDesign, {
-    language: context.language || context.locale,
-    model: request.ttsModelId,
-  });
-  if (registeredAutoVoicesThisSession.has(voiceId)) return voiceId;
-
-  const cached = await getCachedAutoVoiceClip(voiceId);
-  const res = await fetch('/api/generate/voxcpm-voice', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      voiceId,
-      descriptor: context.voiceDesign,
-      language: context.language || context.locale,
-      referenceAudioBase64: cached?.base64,
-      mimeType: cached?.mimeType,
-      ...request,
-    }),
-  });
-  if (!res.ok) return undefined; // graceful fallback to the inline prompt path
-
-  const data = (await res.json().catch(() => ({}))) as {
-    referenceAudioBase64?: string;
-    mimeType?: string;
-  };
-  if (data.referenceAudioBase64 && !cached) {
-    await db.voxcpmAutoVoiceCache.put({
-      voiceId,
-      referenceAudio: base64ToBlob(data.referenceAudioBase64, data.mimeType),
-      mimeType: data.mimeType || 'audio/wav',
-      updatedAt: Date.now(),
-    });
-  }
-  registeredAutoVoicesThisSession.add(voiceId);
-  return voiceId;
 }
 
 function isWavAudio(blob: Blob, fileName?: string): boolean {
@@ -361,11 +281,19 @@ export function useVoxCPMVoiceProfiles() {
 export async function getVoxCPMProviderOptions(
   voiceId: string,
   context?: VoxCPMVoicePromptContext,
-  request?: VoxCPMTTSRequestConfig,
+  request?: VoiceRegistrationRequestConfig,
 ): Promise<VoxCPMProviderOptions> {
   if (voiceId === VOXCPM_AUTO_VOICE_ID) {
-    const registeredVoiceId = request
-      ? await ensureRegisteredAutoVoice(context || {}, request).catch(() => undefined)
+    // Drive register-once only when this VoxCPM backend supports it; otherwise
+    // (and on any failure) fall back to the inline voice-design prompt.
+    const canRegister =
+      !!request && !!context?.voiceDesign && voxCPMBackendSupportsVoiceRegistration(context.backend ?? 'vllm-omni');
+    const registeredVoiceId = canRegister
+      ? await ensureRegisteredVoice(
+          VOXCPM_TTS_PROVIDER_ID,
+          { voiceDesign: context!.voiceDesign, language: context!.language || context!.locale },
+          request!,
+        ).catch(() => undefined)
       : undefined;
     return {
       voiceMode: 'auto',

--- a/lib/audio/voxcpm-voices.ts
+++ b/lib/audio/voxcpm-voices.ts
@@ -287,7 +287,9 @@ export async function getVoxCPMProviderOptions(
     // Drive register-once only when this VoxCPM backend supports it; otherwise
     // (and on any failure) fall back to the inline voice-design prompt.
     const canRegister =
-      !!request && !!context?.voiceDesign && voxCPMBackendSupportsVoiceRegistration(context.backend ?? 'vllm-omni');
+      !!request &&
+      !!context?.voiceDesign &&
+      voxCPMBackendSupportsVoiceRegistration(context.backend ?? 'vllm-omni');
     const registeredVoiceId = canRegister
       ? await ensureRegisteredVoice(
           VOXCPM_TTS_PROVIDER_ID,

--- a/lib/audio/voxcpm-voices.ts
+++ b/lib/audio/voxcpm-voices.ts
@@ -8,11 +8,20 @@ import {
   VOXCPM_AUTO_VOICE_ID,
   VOXCPM_TTS_PROVIDER_ID,
   buildAutoVoxCPMVoicePrompt,
+  getDeterministicVoxCPMVoiceId,
   getVoxCPMProfileIdFromVoiceId,
   getVoxCPMProfileVoiceId,
+  voxCPMBackendSupportsVoiceRegistration,
   type VoxCPMProviderOptions,
   type VoxCPMVoicePromptContext,
 } from '@/lib/audio/voxcpm';
+
+/** Provider config the registration endpoint needs (forwarded for non-managed providers). */
+export interface VoxCPMTTSRequestConfig {
+  ttsApiKey?: string;
+  ttsBaseUrl?: string;
+  ttsModelId?: string;
+}
 
 export type VoxCPMVoiceProfile = VoiceProfileRecord;
 
@@ -42,6 +51,82 @@ async function blobToBase64(blob: Blob): Promise<string> {
     };
     reader.readAsDataURL(blob);
   });
+}
+
+function base64ToBlob(base64: string, mimeType?: string): Blob {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: mimeType || 'audio/wav' });
+}
+
+// Voice ids confirmed registered in this browser session — skip the round-trip.
+const registeredAutoVoicesThisSession = new Set<string>();
+
+async function getCachedAutoVoiceClip(
+  voiceId: string,
+): Promise<{ base64: string; mimeType: string } | undefined> {
+  const row = await db.voxcpmAutoVoiceCache.get(voiceId);
+  if (!row) return undefined;
+  return { base64: await blobToBase64(row.referenceAudio), mimeType: row.mimeType };
+}
+
+/**
+ * Ensure the agent's deterministic auto voice is registered on the backend,
+ * returning its voice id (or undefined when registration is unavailable, so
+ * callers fall back to the inline voice-design prompt path).
+ *
+ * Lazy + idempotent: memoized per session, reference clip cached in IndexedDB.
+ * register-on-invalid is handled by the endpoint's existence check, which
+ * re-registers a GC'd voice from the supplied cached clip.
+ */
+export async function ensureRegisteredAutoVoice(
+  context: VoxCPMVoicePromptContext,
+  request: VoxCPMTTSRequestConfig,
+): Promise<string | undefined> {
+  if (
+    !context.voiceDesign ||
+    !context.backend ||
+    !voxCPMBackendSupportsVoiceRegistration(context.backend)
+  ) {
+    return undefined;
+  }
+
+  const voiceId = await getDeterministicVoxCPMVoiceId(context.voiceDesign, {
+    language: context.language || context.locale,
+    model: request.ttsModelId,
+  });
+  if (registeredAutoVoicesThisSession.has(voiceId)) return voiceId;
+
+  const cached = await getCachedAutoVoiceClip(voiceId);
+  const res = await fetch('/api/generate/voxcpm-voice', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      voiceId,
+      descriptor: context.voiceDesign,
+      language: context.language || context.locale,
+      referenceAudioBase64: cached?.base64,
+      mimeType: cached?.mimeType,
+      ...request,
+    }),
+  });
+  if (!res.ok) return undefined; // graceful fallback to the inline prompt path
+
+  const data = (await res.json().catch(() => ({}))) as {
+    referenceAudioBase64?: string;
+    mimeType?: string;
+  };
+  if (data.referenceAudioBase64 && !cached) {
+    await db.voxcpmAutoVoiceCache.put({
+      voiceId,
+      referenceAudio: base64ToBlob(data.referenceAudioBase64, data.mimeType),
+      mimeType: data.mimeType || 'audio/wav',
+      updatedAt: Date.now(),
+    });
+  }
+  registeredAutoVoicesThisSession.add(voiceId);
+  return voiceId;
 }
 
 function isWavAudio(blob: Blob, fileName?: string): boolean {
@@ -276,11 +361,16 @@ export function useVoxCPMVoiceProfiles() {
 export async function getVoxCPMProviderOptions(
   voiceId: string,
   context?: VoxCPMVoicePromptContext,
+  request?: VoxCPMTTSRequestConfig,
 ): Promise<VoxCPMProviderOptions> {
   if (voiceId === VOXCPM_AUTO_VOICE_ID) {
+    const registeredVoiceId = request
+      ? await ensureRegisteredAutoVoice(context || {}, request).catch(() => undefined)
+      : undefined;
     return {
       voiceMode: 'auto',
-      voicePrompt: buildAutoVoxCPMVoicePrompt(context),
+      voicePrompt: buildAutoVoxCPMVoicePrompt(context), // inline fallback always set
+      ...(registeredVoiceId ? { registeredVoiceId } : {}),
     };
   }
 

--- a/lib/audio/voxcpm.ts
+++ b/lib/audio/voxcpm.ts
@@ -5,7 +5,18 @@ export const VOXCPM_MODEL_ID = 'VoxCPM2';
 export const VOXCPM_VLLM_MODEL_ID = 'voxcpm2';
 export const VOXCPM_AUTO_VOICE_ID = 'voxcpm:auto';
 export const VOXCPM_PROFILE_VOICE_PREFIX = 'voxcpm:profile:';
+export const VOXCPM_REGISTERED_VOICE_PREFIX = 'voxcpm:voice:' as const;
 const VOXCPM_AUTO_VOICE_PROMPT_MAX_CHARS = 200;
+
+/**
+ * Per-agent voice-design descriptor (the 3-layer recipe). Describes vocal
+ * identity, not personality — fed to VoxCPM auto voice for a real timbre.
+ */
+export interface VoxCPMVoiceDesign {
+  identity: string; // gender / age / role
+  texture: string; // pitch / vocal quality
+  delivery: string; // emotion / pace
+}
 
 export const VOXCPM_BACKENDS = [
   {
@@ -38,6 +49,8 @@ export interface VoxCPMVoicePromptContext {
   persona?: string;
   language?: string;
   locale?: string;
+  voiceDesign?: VoxCPMVoiceDesign;
+  backend?: VoxCPMBackendType;
 }
 
 export interface VoxCPMProviderOptions {
@@ -52,6 +65,7 @@ export interface VoxCPMProviderOptions {
   inferenceTimesteps?: number;
   normalize?: boolean;
   denoise?: boolean;
+  registeredVoiceId?: string;
 }
 
 export const VOXCPM_AUTO_VOICE: TTSVoiceInfo = {
@@ -102,7 +116,71 @@ function sanitizeAutoVoicePromptPart(value?: string): string {
     .trim();
 }
 
+/**
+ * Compose the 3-layer descriptor into a single voice-design prompt
+ * ("identity, texture, delivery"), dropping blank layers.
+ */
+export function buildVoiceDesignPrompt(design: VoxCPMVoiceDesign): string {
+  return [design.identity, design.texture, design.delivery]
+    .map((part) => sanitizeAutoVoicePromptPart(part))
+    .filter(Boolean)
+    .join(', ');
+}
+
+/**
+ * Coerce an arbitrary (LLM-produced) value into a VoxCPMVoiceDesign.
+ * Returns undefined when no layer carries content.
+ */
+export function normalizeVoiceDesign(raw: unknown): VoxCPMVoiceDesign | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const record = raw as Record<string, unknown>;
+  const pick = (value: unknown) => (typeof value === 'string' ? value.trim() : '');
+  const design = {
+    identity: pick(record.identity),
+    texture: pick(record.texture),
+    delivery: pick(record.delivery),
+  };
+  if (!design.identity && !design.texture && !design.delivery) return undefined;
+  return design;
+}
+
+/**
+ * Whether a backend exposes a runtime voice-registration API
+ * (POST /v1/audio/voices) for reference-by-id timbre stability.
+ */
+export function voxCPMBackendSupportsVoiceRegistration(backend: VoxCPMBackendType): boolean {
+  return backend === 'vllm-omni';
+}
+
+/**
+ * Deterministic voice id derived from the descriptor (+ language + model).
+ * Stable across re-synthesis and recomputable anywhere from the descriptor,
+ * so registration is idempotent and needs no separately persisted id.
+ */
+export async function getDeterministicVoxCPMVoiceId(
+  design: VoxCPMVoiceDesign,
+  opts: { language?: string; model?: string } = {},
+): Promise<string> {
+  const seed = [
+    design.identity,
+    design.texture,
+    design.delivery,
+    opts.language || '',
+    opts.model || VOXCPM_MODEL_ID,
+  ].join('|');
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed));
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `${VOXCPM_REGISTERED_VOICE_PREFIX}${hex.slice(0, 16)}`;
+}
+
 export function buildAutoVoxCPMVoicePrompt(context: VoxCPMVoicePromptContext = {}): string {
+  if (context.voiceDesign) {
+    const designPrompt = sanitizeAutoVoicePromptPart(buildVoiceDesignPrompt(context.voiceDesign));
+    if (designPrompt) return designPrompt;
+  }
+
   const persona = sanitizeAutoVoicePromptPart(context.persona);
   if (persona) return persona;
 

--- a/lib/audio/voxcpm.ts
+++ b/lib/audio/voxcpm.ts
@@ -1,22 +1,12 @@
 import type { TTSVoiceInfo } from '@/lib/audio/types';
+import { buildVoiceDesignPrompt, type VoiceDesign } from '@/lib/audio/voice-design';
 
 export const VOXCPM_TTS_PROVIDER_ID = 'voxcpm-tts' as const;
 export const VOXCPM_MODEL_ID = 'VoxCPM2';
 export const VOXCPM_VLLM_MODEL_ID = 'voxcpm2';
 export const VOXCPM_AUTO_VOICE_ID = 'voxcpm:auto';
 export const VOXCPM_PROFILE_VOICE_PREFIX = 'voxcpm:profile:';
-export const VOXCPM_REGISTERED_VOICE_PREFIX = 'voxcpm:voice:' as const;
 const VOXCPM_AUTO_VOICE_PROMPT_MAX_CHARS = 200;
-
-/**
- * Per-agent voice-design descriptor (the 3-layer recipe). Describes vocal
- * identity, not personality — fed to VoxCPM auto voice for a real timbre.
- */
-export interface VoxCPMVoiceDesign {
-  identity: string; // gender / age / role
-  texture: string; // pitch / vocal quality
-  delivery: string; // emotion / pace
-}
 
 export const VOXCPM_BACKENDS = [
   {
@@ -49,7 +39,7 @@ export interface VoxCPMVoicePromptContext {
   persona?: string;
   language?: string;
   locale?: string;
-  voiceDesign?: VoxCPMVoiceDesign;
+  voiceDesign?: VoiceDesign;
   backend?: VoxCPMBackendType;
 }
 
@@ -117,62 +107,11 @@ function sanitizeAutoVoicePromptPart(value?: string): string {
 }
 
 /**
- * Compose the 3-layer descriptor into a single voice-design prompt
- * ("identity, texture, delivery"), dropping blank layers.
- */
-export function buildVoiceDesignPrompt(design: VoxCPMVoiceDesign): string {
-  return [design.identity, design.texture, design.delivery]
-    .map((part) => sanitizeAutoVoicePromptPart(part))
-    .filter(Boolean)
-    .join(', ');
-}
-
-/**
- * Coerce an arbitrary (LLM-produced) value into a VoxCPMVoiceDesign.
- * Returns undefined when no layer carries content.
- */
-export function normalizeVoiceDesign(raw: unknown): VoxCPMVoiceDesign | undefined {
-  if (!raw || typeof raw !== 'object') return undefined;
-  const record = raw as Record<string, unknown>;
-  const pick = (value: unknown) => (typeof value === 'string' ? value.trim() : '');
-  const design = {
-    identity: pick(record.identity),
-    texture: pick(record.texture),
-    delivery: pick(record.delivery),
-  };
-  if (!design.identity && !design.texture && !design.delivery) return undefined;
-  return design;
-}
-
-/**
- * Whether a backend exposes a runtime voice-registration API
+ * Whether a VoxCPM backend exposes a runtime voice-registration API
  * (POST /v1/audio/voices) for reference-by-id timbre stability.
  */
 export function voxCPMBackendSupportsVoiceRegistration(backend: VoxCPMBackendType): boolean {
   return backend === 'vllm-omni';
-}
-
-/**
- * Deterministic voice id derived from the descriptor (+ language + model).
- * Stable across re-synthesis and recomputable anywhere from the descriptor,
- * so registration is idempotent and needs no separately persisted id.
- */
-export async function getDeterministicVoxCPMVoiceId(
-  design: VoxCPMVoiceDesign,
-  opts: { language?: string; model?: string } = {},
-): Promise<string> {
-  const seed = [
-    design.identity,
-    design.texture,
-    design.delivery,
-    opts.language || '',
-    opts.model || VOXCPM_MODEL_ID,
-  ].join('|');
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed));
-  const hex = Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
-  return `${VOXCPM_REGISTERED_VOICE_PREFIX}${hex.slice(0, 16)}`;
 }
 
 export function buildAutoVoxCPMVoicePrompt(context: VoxCPMVoicePromptContext = {}): string {

--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/audio/voice-resolver';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
 import { getVoxCPMProviderOptions, useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
+import { normalizeVoxCPMBackend } from '@/lib/audio/voxcpm';
 import type { AgentConfig } from '@/lib/orchestration/registry/types';
 import type { TTSProviderId } from '@/lib/audio/types';
 import type { AudioIndicatorState } from '@/components/roundtable/audio-indicator';
@@ -184,12 +185,22 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
         item.providerId === 'voxcpm-tts'
           ? {
               ...(providerConfig?.providerOptions || {}),
-              ...(await getVoxCPMProviderOptions(item.voiceId, {
-                agentName: agent?.name,
-                role: agent?.role,
-                persona: agent?.persona,
-                locale,
-              })),
+              ...(await getVoxCPMProviderOptions(
+                item.voiceId,
+                {
+                  agentName: agent?.name,
+                  role: agent?.role,
+                  persona: agent?.persona,
+                  voiceDesign: agent?.voiceDesign,
+                  locale,
+                  backend: normalizeVoxCPMBackend(providerConfig?.providerOptions?.backend),
+                },
+                {
+                  ttsApiKey: providerConfig?.apiKey,
+                  ttsBaseUrl: providerConfig?.baseUrl || providerConfig?.customDefaultBaseUrl,
+                  ttsModelId: item.modelId || providerConfig?.modelId,
+                },
+              )),
             }
           : undefined;
       const res = await fetch('/api/generate/tts', {

--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -9,8 +9,8 @@ import {
   type ResolvedVoice,
 } from '@/lib/audio/voice-resolver';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
-import { getVoxCPMProviderOptions, useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
-import { normalizeVoxCPMBackend } from '@/lib/audio/voxcpm';
+import { useVoxCPMVoiceProfiles } from '@/lib/audio/voxcpm-voices';
+import { resolveAgentVoiceOptions } from '@/lib/audio/agent-voice';
 import type { AgentConfig } from '@/lib/orchestration/registry/types';
 import type { TTSProviderId } from '@/lib/audio/types';
 import type { AudioIndicatorState } from '@/components/roundtable/audio-indicator';
@@ -181,28 +181,12 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
     try {
       const providerConfig = ttsProvidersConfig[item.providerId];
       const agent = item.agentId ? agents.find((a) => a.id === item.agentId) : undefined;
-      const providerOptions =
-        item.providerId === 'voxcpm-tts'
-          ? {
-              ...(providerConfig?.providerOptions || {}),
-              ...(await getVoxCPMProviderOptions(
-                item.voiceId,
-                {
-                  agentName: agent?.name,
-                  role: agent?.role,
-                  persona: agent?.persona,
-                  voiceDesign: agent?.voiceDesign,
-                  locale,
-                  backend: normalizeVoxCPMBackend(providerConfig?.providerOptions?.backend),
-                },
-                {
-                  ttsApiKey: providerConfig?.apiKey,
-                  ttsBaseUrl: providerConfig?.baseUrl || providerConfig?.customDefaultBaseUrl,
-                  ttsModelId: item.modelId || providerConfig?.modelId,
-                },
-              )),
-            }
-          : undefined;
+      const providerOptions = await resolveAgentVoiceOptions(agent, {
+        providerId: item.providerId,
+        providerConfig: { ...providerConfig, modelId: item.modelId || providerConfig?.modelId },
+        voiceId: item.voiceId,
+        language: locale,
+      });
       const res = await fetch('/api/generate/tts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -13,6 +13,7 @@ import type { SpeechAction } from '@/lib/types/action';
 import { splitLongSpeechActions } from '@/lib/audio/tts-utils';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
 import { getVoxCPMProviderOptions } from '@/lib/audio/voxcpm-voices';
+import { normalizeVoxCPMBackend } from '@/lib/audio/voxcpm';
 import { generateMediaForOutlines } from '@/lib/media/media-orchestrator';
 import { createLogger } from '@/lib/logger';
 
@@ -151,7 +152,20 @@ export async function generateAndStoreTTS(
     settings.ttsProviderId === 'voxcpm-tts'
       ? {
           ...(ttsProviderConfig?.providerOptions || {}),
-          ...(await getVoxCPMProviderOptions(settings.ttsVoice, { role: 'teacher', language })),
+          ...(await getVoxCPMProviderOptions(
+            settings.ttsVoice,
+            {
+              role: 'teacher',
+              language,
+              backend: normalizeVoxCPMBackend(ttsProviderConfig?.providerOptions?.backend),
+            },
+            {
+              ttsApiKey: ttsProviderConfig?.apiKey || undefined,
+              ttsBaseUrl:
+                ttsProviderConfig?.baseUrl || ttsProviderConfig?.customDefaultBaseUrl || undefined,
+              ttsModelId: ttsProviderConfig?.modelId,
+            },
+          )),
         }
       : undefined;
   const response = await fetch('/api/generate/tts', {

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -12,8 +12,8 @@ import type { Scene } from '@/lib/types/stage';
 import type { SpeechAction } from '@/lib/types/action';
 import { splitLongSpeechActions } from '@/lib/audio/tts-utils';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
-import { getVoxCPMProviderOptions } from '@/lib/audio/voxcpm-voices';
-import { normalizeVoxCPMBackend } from '@/lib/audio/voxcpm';
+import { resolveAgentVoiceOptions, pickNarratorAgent } from '@/lib/audio/agent-voice';
+import { useAgentRegistry } from '@/lib/orchestration/registry/store';
 import { generateMediaForOutlines } from '@/lib/media/media-orchestrator';
 import { createLogger } from '@/lib/logger';
 
@@ -148,26 +148,15 @@ export async function generateAndStoreTTS(
     return;
 
   const ttsProviderConfig = settings.ttsProvidersConfig?.[settings.ttsProviderId];
-  const providerOptions =
-    settings.ttsProviderId === 'voxcpm-tts'
-      ? {
-          ...(ttsProviderConfig?.providerOptions || {}),
-          ...(await getVoxCPMProviderOptions(
-            settings.ttsVoice,
-            {
-              role: 'teacher',
-              language,
-              backend: normalizeVoxCPMBackend(ttsProviderConfig?.providerOptions?.backend),
-            },
-            {
-              ttsApiKey: ttsProviderConfig?.apiKey || undefined,
-              ttsBaseUrl:
-                ttsProviderConfig?.baseUrl || ttsProviderConfig?.customDefaultBaseUrl || undefined,
-              ttsModelId: ttsProviderConfig?.modelId,
-            },
-          )),
-        }
-      : undefined;
+  // Narration is the teacher's voice — resolve it from the teacher agent profile
+  // through the single resolver (registers + references by id for stable timbre).
+  const teacher = pickNarratorAgent(useAgentRegistry.getState().listAgents());
+  const providerOptions = await resolveAgentVoiceOptions(teacher, {
+    providerId: settings.ttsProviderId,
+    providerConfig: ttsProviderConfig,
+    voiceId: settings.ttsVoice,
+    language,
+  });
   const response = await fetch('/api/generate/tts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/lib/orchestration/registry/store.ts
+++ b/lib/orchestration/registry/store.ts
@@ -424,5 +424,13 @@ export async function saveGeneratedAgents(
     });
   }
 
+  // Eager warm-up: pre-register each generated agent's auto voice so the first
+  // spoken line is already stable. Same idempotent ensure as the TTS path;
+  // fire-and-forget. Dynamic import keeps this client-only dep out of the
+  // server-importable store module.
+  void import('@/lib/audio/agent-voice')
+    .then((m) => m.warmUpAgentVoices(registry.listAgents().filter((a) => a.isGenerated)))
+    .catch(() => undefined);
+
   return records.map((r) => r.id);
 }

--- a/lib/orchestration/registry/store.ts
+++ b/lib/orchestration/registry/store.ts
@@ -8,6 +8,7 @@ import { persist } from 'zustand/middleware';
 import type { AgentConfig } from './types';
 import { getActionsForRole } from './types';
 import type { TTSProviderId } from '@/lib/audio/types';
+import type { VoxCPMVoiceDesign } from '@/lib/audio/voxcpm';
 import { USER_AVATAR } from '@/lib/types/roundtable';
 import type { Participant, ParticipantRole } from '@/lib/types/roundtable';
 import { useUserProfileStore } from '@/lib/store/user-profile';
@@ -383,6 +384,7 @@ export async function saveGeneratedAgents(
     color: string;
     priority: number;
     voiceConfig?: { providerId: string; voiceId: string };
+    voiceDesign?: VoxCPMVoiceDesign;
   }>,
 ): Promise<string[]> {
   const { db } = await import('@/lib/utils/database');

--- a/lib/orchestration/registry/store.ts
+++ b/lib/orchestration/registry/store.ts
@@ -8,7 +8,7 @@ import { persist } from 'zustand/middleware';
 import type { AgentConfig } from './types';
 import { getActionsForRole } from './types';
 import type { TTSProviderId } from '@/lib/audio/types';
-import type { VoxCPMVoiceDesign } from '@/lib/audio/voxcpm';
+import type { VoiceDesign } from '@/lib/audio/voice-design';
 import { USER_AVATAR } from '@/lib/types/roundtable';
 import type { Participant, ParticipantRole } from '@/lib/types/roundtable';
 import { useUserProfileStore } from '@/lib/store/user-profile';
@@ -384,7 +384,7 @@ export async function saveGeneratedAgents(
     color: string;
     priority: number;
     voiceConfig?: { providerId: string; voiceId: string };
-    voiceDesign?: VoxCPMVoiceDesign;
+    voiceDesign?: VoiceDesign;
   }>,
 ): Promise<string[]> {
   const { db } = await import('@/lib/utils/database');

--- a/lib/orchestration/registry/types.ts
+++ b/lib/orchestration/registry/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TTSProviderId } from '@/lib/audio/types';
+import type { VoxCPMVoiceDesign } from '@/lib/audio/voxcpm';
 
 export interface AgentConfig {
   id: string; // Unique agent ID
@@ -15,6 +16,7 @@ export interface AgentConfig {
   allowedActions: string[]; // Action types this agent can use
   priority: number; // Priority for director selection (1-10)
   voiceConfig?: { providerId: TTSProviderId; modelId?: string; voiceId: string }; // Per-agent TTS voice selection
+  voiceDesign?: VoxCPMVoiceDesign; // 3-layer vocal descriptor for VoxCPM auto voice
 
   // Metadata
   createdAt: Date;
@@ -36,6 +38,7 @@ export interface AgentTemplate {
   allowedActions: string[];
   priority: number;
   voiceConfig?: { providerId: TTSProviderId; modelId?: string; voiceId: string }; // Per-agent TTS voice selection
+  voiceDesign?: VoxCPMVoiceDesign; // 3-layer vocal descriptor for VoxCPM auto voice
 
   // LLM-generated agent fields
   isGenerated?: boolean; // true for LLM-generated agents

--- a/lib/orchestration/registry/types.ts
+++ b/lib/orchestration/registry/types.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TTSProviderId } from '@/lib/audio/types';
-import type { VoxCPMVoiceDesign } from '@/lib/audio/voxcpm';
+import type { VoiceDesign } from '@/lib/audio/voice-design';
 
 export interface AgentConfig {
   id: string; // Unique agent ID
@@ -16,7 +16,7 @@ export interface AgentConfig {
   allowedActions: string[]; // Action types this agent can use
   priority: number; // Priority for director selection (1-10)
   voiceConfig?: { providerId: TTSProviderId; modelId?: string; voiceId: string }; // Per-agent TTS voice selection
-  voiceDesign?: VoxCPMVoiceDesign; // 3-layer vocal descriptor for VoxCPM auto voice
+  voiceDesign?: VoiceDesign; // 3-layer vocal descriptor for auto voice (provider-neutral)
 
   // Metadata
   createdAt: Date;
@@ -38,7 +38,7 @@ export interface AgentTemplate {
   allowedActions: string[];
   priority: number;
   voiceConfig?: { providerId: TTSProviderId; modelId?: string; voiceId: string }; // Per-agent TTS voice selection
-  voiceDesign?: VoxCPMVoiceDesign; // 3-layer vocal descriptor for VoxCPM auto voice
+  voiceDesign?: VoiceDesign; // 3-layer vocal descriptor for auto voice (provider-neutral)
 
   // LLM-generated agent fields
   isGenerated?: boolean; // true for LLM-generated agents

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -445,6 +445,18 @@ export function resolveTTSBaseUrl(providerId: string, clientBaseUrl?: string): s
   return resolveSectionBaseUrl('tts', providerId, clientBaseUrl);
 }
 
+/**
+ * Resolve the TTS model. A managed provider may pin its model server-side
+ * (`${PREFIX}_MODELS`, first entry) — authoritative like its key/baseUrl, since
+ * the managed-provider UI does not expose a model field. Otherwise the client
+ * model wins.
+ */
+export function resolveTTSModel(providerId: string, clientModel?: string): string | undefined {
+  const entry = getConfig().tts[providerId];
+  if (entry?.models && entry.models.length > 0) return entry.models[0];
+  return clientModel;
+}
+
 // ---------------------------------------------------------------------------
 // Public API — ASR
 // ---------------------------------------------------------------------------

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -186,6 +186,18 @@ export interface VoiceProfileRecord {
   updatedAt: number;
 }
 
+/**
+ * Cached reference clip for a VoxCPM registered auto voice. The clip is the
+ * source of truth; the deterministic `voiceId` is its key, enabling
+ * register-on-invalid re-registration after backend GC/restart.
+ */
+export interface VoxCPMAutoVoiceCacheRecord {
+  voiceId: string;
+  referenceAudio: Blob;
+  mimeType: string;
+  updatedAt: number;
+}
+
 /** Build the compound primary key for mediaFiles: `${stageId}:${elementId}` */
 export function mediaFileKey(stageId: string, elementId: string): string {
   return `${stageId}:${elementId}`;
@@ -194,7 +206,7 @@ export function mediaFileKey(stageId: string, elementId: string): string {
 // ==================== Database Definition ====================
 
 const DATABASE_NAME = 'MAIC-Database';
-const _DATABASE_VERSION = 10;
+const _DATABASE_VERSION = 11;
 
 /**
  * MAIC Database Instance
@@ -212,6 +224,7 @@ class MAICDatabase extends Dexie {
   mediaFiles!: EntityTable<MediaFileRecord, 'id'>;
   generatedAgents!: EntityTable<GeneratedAgentRecord, 'id'>;
   voiceProfiles!: EntityTable<VoiceProfileRecord, 'id'>;
+  voxcpmAutoVoiceCache!: EntityTable<VoxCPMAutoVoiceCacheRecord, 'voiceId'>;
 
   constructor() {
     super(DATABASE_NAME);
@@ -377,6 +390,22 @@ class MAICDatabase extends Dexie {
       mediaFiles: 'id, stageId, [stageId+type]',
       generatedAgents: 'id, stageId',
       voiceProfiles: 'id, providerId, kind, updatedAt',
+    });
+
+    // Version 11: Add VoxCPM auto-voice reference-clip cache (register-by-id).
+    this.version(11).stores({
+      stages: 'id, updatedAt',
+      scenes: 'id, stageId, order, [stageId+order]',
+      audioFiles: 'id, createdAt',
+      imageFiles: 'id, createdAt',
+      snapshots: '++id',
+      chatSessions: 'id, stageId, [stageId+createdAt]',
+      playbackState: 'stageId',
+      stageOutlines: 'stageId',
+      mediaFiles: 'id, stageId, [stageId+type]',
+      generatedAgents: 'id, stageId',
+      voiceProfiles: 'id, providerId, kind, updatedAt',
+      voxcpmAutoVoiceCache: 'voiceId, updatedAt',
     });
   }
 }

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -9,6 +9,7 @@ import type {
   ToolCallRequest,
 } from '@/lib/types/chat';
 import type { SceneOutline } from '@/lib/types/generation';
+import type { VoxCPMVoiceDesign } from '@/lib/audio/voxcpm';
 import type { UIMessage } from 'ai';
 import { createLogger } from '@/lib/logger';
 
@@ -166,6 +167,7 @@ export interface GeneratedAgentRecord {
   avatar: string;
   color: string;
   priority: number;
+  voiceDesign?: VoxCPMVoiceDesign; // 3-layer vocal descriptor for VoxCPM auto voice
   createdAt: number;
 }
 

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -9,7 +9,7 @@ import type {
   ToolCallRequest,
 } from '@/lib/types/chat';
 import type { SceneOutline } from '@/lib/types/generation';
-import type { VoxCPMVoiceDesign } from '@/lib/audio/voxcpm';
+import type { VoiceDesign } from '@/lib/audio/voice-design';
 import type { UIMessage } from 'ai';
 import { createLogger } from '@/lib/logger';
 
@@ -167,7 +167,7 @@ export interface GeneratedAgentRecord {
   avatar: string;
   color: string;
   priority: number;
-  voiceDesign?: VoxCPMVoiceDesign; // 3-layer vocal descriptor for VoxCPM auto voice
+  voiceDesign?: VoiceDesign; // 3-layer vocal descriptor for auto voice
   createdAt: number;
 }
 
@@ -189,11 +189,11 @@ export interface VoiceProfileRecord {
 }
 
 /**
- * Cached reference clip for a VoxCPM registered auto voice. The clip is the
- * source of truth; the deterministic `voiceId` is its key, enabling
+ * Cached reference clip for a registered auto voice (any TTS provider). The
+ * clip is the source of truth; the deterministic `voiceId` is its key, enabling
  * register-on-invalid re-registration after backend GC/restart.
  */
-export interface VoxCPMAutoVoiceCacheRecord {
+export interface AutoVoiceCacheRecord {
   voiceId: string;
   referenceAudio: Blob;
   mimeType: string;
@@ -226,7 +226,7 @@ class MAICDatabase extends Dexie {
   mediaFiles!: EntityTable<MediaFileRecord, 'id'>;
   generatedAgents!: EntityTable<GeneratedAgentRecord, 'id'>;
   voiceProfiles!: EntityTable<VoiceProfileRecord, 'id'>;
-  voxcpmAutoVoiceCache!: EntityTable<VoxCPMAutoVoiceCacheRecord, 'voiceId'>;
+  autoVoiceCache!: EntityTable<AutoVoiceCacheRecord, 'voiceId'>;
 
   constructor() {
     super(DATABASE_NAME);
@@ -394,7 +394,7 @@ class MAICDatabase extends Dexie {
       voiceProfiles: 'id, providerId, kind, updatedAt',
     });
 
-    // Version 11: Add VoxCPM auto-voice reference-clip cache (register-by-id).
+    // Version 11: Add auto-voice reference-clip cache (provider-neutral register-by-id).
     this.version(11).stores({
       stages: 'id, updatedAt',
       scenes: 'id, stageId, order, [stageId+order]',
@@ -407,7 +407,7 @@ class MAICDatabase extends Dexie {
       mediaFiles: 'id, stageId, [stageId+type]',
       generatedAgents: 'id, stageId',
       voiceProfiles: 'id, providerId, kind, updatedAt',
-      voxcpmAutoVoiceCache: 'voiceId, updatedAt',
+      autoVoiceCache: 'voiceId, updatedAt',
     });
   }
 }

--- a/tests/audio/agent-voice.test.ts
+++ b/tests/audio/agent-voice.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // agent-voice pulls browser-only deps transitively (IndexedDB, settings store);
 // stub them so we can unit-test the pure narrator-selection logic in node.
 vi.mock('@/lib/audio/voxcpm-voices', () => ({ getVoxCPMProviderOptions: vi.fn() }));
 vi.mock('@/lib/store/settings', () => ({ useSettingsStore: { getState: () => ({}) } }));
 
-import { pickNarratorAgent } from '@/lib/audio/agent-voice';
+import { pickNarratorAgent, resolveAgentVoiceOptions } from '@/lib/audio/agent-voice';
+import { getVoxCPMProviderOptions } from '@/lib/audio/voxcpm-voices';
 import type { AgentConfig } from '@/lib/orchestration/registry/types';
+
+const mockGetOptions = getVoxCPMProviderOptions as unknown as ReturnType<typeof vi.fn>;
 
 function agent(partial: Partial<AgentConfig>): AgentConfig {
   return {
@@ -54,5 +57,32 @@ describe('pickNarratorAgent', () => {
   it('returns undefined when there is no teacher', () => {
     expect(pickNarratorAgent([agent({ role: 'student' })])).toBeUndefined();
     expect(pickNarratorAgent([])).toBeUndefined();
+  });
+});
+
+describe('resolveAgentVoiceOptions — voice-design source', () => {
+  beforeEach(() => {
+    mockGetOptions.mockReset();
+    mockGetOptions.mockResolvedValue({});
+  });
+  const opts = { providerId: 'voxcpm-tts', voiceId: 'voxcpm:auto', providerConfig: {} };
+
+  it('uses the real voiceDesign when the agent has one (generated agents)', async () => {
+    await resolveAgentVoiceOptions(agent({ role: 'teacher', voiceDesign: DESIGN }), opts);
+    expect(mockGetOptions.mock.calls[0][1].voiceDesign).toEqual(DESIGN);
+  });
+
+  it('falls back to the persona as the descriptor when there is no voiceDesign (preset agents)', async () => {
+    await resolveAgentVoiceOptions(agent({ role: 'teacher', persona: 'patient mentor' }), opts);
+    expect(mockGetOptions.mock.calls[0][1].voiceDesign).toEqual({
+      identity: 'patient mentor',
+      texture: '',
+      delivery: '',
+    });
+  });
+
+  it('has no descriptor when the agent has neither voiceDesign nor persona', async () => {
+    await resolveAgentVoiceOptions(agent({ role: 'teacher', persona: '' }), opts);
+    expect(mockGetOptions.mock.calls[0][1].voiceDesign).toBeUndefined();
   });
 });

--- a/tests/audio/agent-voice.test.ts
+++ b/tests/audio/agent-voice.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// agent-voice pulls browser-only deps transitively (IndexedDB, settings store);
+// stub them so we can unit-test the pure narrator-selection logic in node.
+vi.mock('@/lib/audio/voxcpm-voices', () => ({ getVoxCPMProviderOptions: vi.fn() }));
+vi.mock('@/lib/store/settings', () => ({ useSettingsStore: { getState: () => ({}) } }));
+
+import { pickNarratorAgent } from '@/lib/audio/agent-voice';
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
+
+function agent(partial: Partial<AgentConfig>): AgentConfig {
+  return {
+    id: partial.id ?? 'a',
+    name: partial.name ?? 'A',
+    role: partial.role ?? 'student',
+    persona: '',
+    avatar: '',
+    color: '',
+    allowedActions: [],
+    priority: 5,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    isDefault: false,
+    ...partial,
+  };
+}
+
+const DESIGN = { identity: 'middle-aged female teacher', texture: 'warm', delivery: 'calm' };
+
+describe('pickNarratorAgent', () => {
+  it('prefers the teacher WITH a voiceDesign over a default teacher (the registry-seeding bug)', () => {
+    // Registry is always seeded with DEFAULT_AGENTS first, so the default teacher
+    // (no voiceDesign) precedes the generated one. Narration must pick the latter.
+    const agents = [
+      agent({ id: 'default-1', role: 'teacher', isDefault: true }), // no voiceDesign
+      agent({ id: 'gen-1', role: 'teacher', voiceDesign: DESIGN, isGenerated: true }),
+    ];
+    expect(pickNarratorAgent(agents)?.id).toBe('gen-1');
+  });
+
+  it('still prefers the voiceDesign teacher regardless of array order', () => {
+    const agents = [
+      agent({ id: 'gen-1', role: 'teacher', voiceDesign: DESIGN }),
+      agent({ id: 'default-1', role: 'teacher', isDefault: true }),
+    ];
+    expect(pickNarratorAgent(agents)?.id).toBe('gen-1');
+  });
+
+  it('falls back to any teacher when none has a voiceDesign', () => {
+    const agents = [agent({ id: 'default-1', role: 'teacher', isDefault: true })];
+    expect(pickNarratorAgent(agents)?.id).toBe('default-1');
+  });
+
+  it('returns undefined when there is no teacher', () => {
+    expect(pickNarratorAgent([agent({ role: 'student' })])).toBeUndefined();
+    expect(pickNarratorAgent([])).toBeUndefined();
+  });
+});

--- a/tests/audio/voice-design.test.ts
+++ b/tests/audio/voice-design.test.ts
@@ -25,7 +25,11 @@ describe('buildVoiceDesignPrompt', () => {
   });
   it('strips parentheses so they cannot break the (prompt)text delimiter', () => {
     expect(
-      buildVoiceDesignPrompt({ identity: 'male teacher (deep)', texture: '英文（带口音）', delivery: 'calm' }),
+      buildVoiceDesignPrompt({
+        identity: 'male teacher (deep)',
+        texture: '英文（带口音）',
+        delivery: 'calm',
+      }),
     ).toBe('male teacher deep, 英文 带口音, calm');
   });
 });
@@ -67,7 +71,10 @@ describe('getDeterministicVoiceId', () => {
       { providerId: 'voxcpm-tts', model: 'm' },
     );
     const model = await getDeterministicVoiceId(design, { providerId: 'voxcpm-tts', model: 'm2' });
-    const prov = await getDeterministicVoiceId(design, { providerId: 'elevenlabs-tts', model: 'm' });
+    const prov = await getDeterministicVoiceId(design, {
+      providerId: 'elevenlabs-tts',
+      model: 'm',
+    });
     expect(tex).not.toBe(base);
     expect(model).not.toBe(base);
     expect(prov).not.toBe(base);

--- a/tests/audio/voice-design.test.ts
+++ b/tests/audio/voice-design.test.ts
@@ -23,6 +23,11 @@ describe('buildVoiceDesignPrompt', () => {
       buildVoiceDesignPrompt({ identity: '  male  teacher ', texture: '', delivery: 'slow' }),
     ).toBe('male teacher, slow');
   });
+  it('strips parentheses so they cannot break the (prompt)text delimiter', () => {
+    expect(
+      buildVoiceDesignPrompt({ identity: 'male teacher (deep)', texture: '英文（带口音）', delivery: 'calm' }),
+    ).toBe('male teacher deep, 英文 带口音, calm');
+  });
 });
 
 describe('normalizeVoiceDesign', () => {

--- a/tests/audio/voice-design.test.ts
+++ b/tests/audio/voice-design.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildVoiceDesignPrompt,
+  normalizeVoiceDesign,
+  getDeterministicVoiceId,
+  type VoiceDesign,
+} from '@/lib/audio/voice-design';
+
+const design: VoiceDesign = {
+  identity: 'middle-aged male teacher',
+  texture: 'warm low-pitched resonant',
+  delivery: 'calm measured encouraging',
+};
+
+describe('buildVoiceDesignPrompt', () => {
+  it('composes the three layers into one comma-joined prompt', () => {
+    expect(buildVoiceDesignPrompt(design)).toBe(
+      'middle-aged male teacher, warm low-pitched resonant, calm measured encouraging',
+    );
+  });
+  it('drops blank layers and collapses whitespace', () => {
+    expect(
+      buildVoiceDesignPrompt({ identity: '  male  teacher ', texture: '', delivery: 'slow' }),
+    ).toBe('male teacher, slow');
+  });
+});
+
+describe('normalizeVoiceDesign', () => {
+  it('returns a clean design from a well-formed object', () => {
+    expect(normalizeVoiceDesign({ identity: 'a', texture: 'b', delivery: 'c' })).toEqual({
+      identity: 'a',
+      texture: 'b',
+      delivery: 'c',
+    });
+  });
+  it('returns undefined when all layers are empty/missing', () => {
+    expect(normalizeVoiceDesign({})).toBeUndefined();
+    expect(normalizeVoiceDesign(null)).toBeUndefined();
+    expect(normalizeVoiceDesign('nope')).toBeUndefined();
+  });
+  it('keeps a partial design (some layers present)', () => {
+    expect(normalizeVoiceDesign({ identity: 'a' })).toEqual({
+      identity: 'a',
+      texture: '',
+      delivery: '',
+    });
+  });
+});
+
+describe('getDeterministicVoiceId', () => {
+  it('is stable for the same descriptor+provider+language+model, with the neutral prefix', async () => {
+    const opts = { providerId: 'voxcpm-tts', language: 'zh', model: 'VoxCPM2' };
+    const a = await getDeterministicVoiceId(design, opts);
+    const b = await getDeterministicVoiceId(design, opts);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^auto-[0-9a-f]{16}$/);
+  });
+  it('changes when descriptor, language, model, or provider changes', async () => {
+    const base = await getDeterministicVoiceId(design, {
+      providerId: 'voxcpm-tts',
+      language: 'zh',
+      model: 'm',
+    });
+    const lang = await getDeterministicVoiceId(design, {
+      providerId: 'voxcpm-tts',
+      language: 'en',
+      model: 'm',
+    });
+    const tex = await getDeterministicVoiceId(
+      { ...design, texture: 'bright' },
+      { providerId: 'voxcpm-tts', language: 'zh', model: 'm' },
+    );
+    const prov = await getDeterministicVoiceId(design, {
+      providerId: 'elevenlabs-tts',
+      language: 'zh',
+      model: 'm',
+    });
+    expect(lang).not.toBe(base);
+    expect(tex).not.toBe(base);
+    expect(prov).not.toBe(base);
+  });
+});

--- a/tests/audio/voice-design.test.ts
+++ b/tests/audio/voice-design.test.ts
@@ -48,35 +48,30 @@ describe('normalizeVoiceDesign', () => {
 });
 
 describe('getDeterministicVoiceId', () => {
-  it('is stable for the same descriptor+provider+language+model, with the neutral prefix', async () => {
-    const opts = { providerId: 'voxcpm-tts', language: 'zh', model: 'VoxCPM2' };
+  it('is stable for the same descriptor+provider+model, with the neutral prefix', async () => {
+    const opts = { providerId: 'voxcpm-tts', model: 'VoxCPM2' };
     const a = await getDeterministicVoiceId(design, opts);
     const b = await getDeterministicVoiceId(design, opts);
     expect(a).toBe(b);
     expect(a).toMatch(/^auto-[0-9a-f]{16}$/);
   });
-  it('changes when descriptor, language, model, or provider changes', async () => {
-    const base = await getDeterministicVoiceId(design, {
-      providerId: 'voxcpm-tts',
-      language: 'zh',
-      model: 'm',
-    });
-    const lang = await getDeterministicVoiceId(design, {
-      providerId: 'voxcpm-tts',
-      language: 'en',
-      model: 'm',
-    });
+  it('changes when descriptor, model, or provider changes', async () => {
+    const base = await getDeterministicVoiceId(design, { providerId: 'voxcpm-tts', model: 'm' });
     const tex = await getDeterministicVoiceId(
       { ...design, texture: 'bright' },
-      { providerId: 'voxcpm-tts', language: 'zh', model: 'm' },
+      { providerId: 'voxcpm-tts', model: 'm' },
     );
-    const prov = await getDeterministicVoiceId(design, {
-      providerId: 'elevenlabs-tts',
-      language: 'zh',
-      model: 'm',
-    });
-    expect(lang).not.toBe(base);
+    const model = await getDeterministicVoiceId(design, { providerId: 'voxcpm-tts', model: 'm2' });
+    const prov = await getDeterministicVoiceId(design, { providerId: 'elevenlabs-tts', model: 'm' });
     expect(tex).not.toBe(base);
+    expect(model).not.toBe(base);
     expect(prov).not.toBe(base);
+  });
+  it('is independent of language (descriptor already encodes it)', async () => {
+    // language is not a parameter of the id — same descriptor → same id regardless
+    // of which TTS path (narration directive vs discussion locale) resolves it.
+    const a = await getDeterministicVoiceId(design, { providerId: 'voxcpm-tts', model: 'm' });
+    const b = await getDeterministicVoiceId(design, { providerId: 'voxcpm-tts', model: 'm' });
+    expect(a).toBe(b);
   });
 });

--- a/tests/audio/voice-registration-client.test.ts
+++ b/tests/audio/voice-registration-client.test.ts
@@ -50,4 +50,33 @@ describe('ensureRegisteredVoice memoization', () => {
     ]);
     expect(f).toHaveBeenCalledTimes(1);
   });
+
+  it('re-registers when the API key changes on the same base URL (auth-scoped)', async () => {
+    const f = okFetch();
+    const voiceDesign = {
+      identity: 'credential-switch teacher',
+      texture: 'warm',
+      delivery: 'calm',
+    };
+    const base = 'https://d.test/v1';
+
+    await ensureRegisteredVoice(
+      'voxcpm-tts',
+      { voiceDesign },
+      { ttsBaseUrl: base, ttsApiKey: 'k1' },
+    );
+    await ensureRegisteredVoice(
+      'voxcpm-tts',
+      { voiceDesign },
+      { ttsBaseUrl: base, ttsApiKey: 'k1' },
+    );
+    expect(f).toHaveBeenCalledTimes(1); // same creds → memoized
+
+    await ensureRegisteredVoice(
+      'voxcpm-tts',
+      { voiceDesign },
+      { ttsBaseUrl: base, ttsApiKey: 'k2' },
+    );
+    expect(f).toHaveBeenCalledTimes(2); // different creds → re-validate
+  });
 });

--- a/tests/audio/voice-registration-client.test.ts
+++ b/tests/audio/voice-registration-client.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// db is browser-only (Dexie); stub it so the client module loads in node.
+vi.mock('@/lib/utils/database', () => ({
+  db: {
+    autoVoiceCache: {
+      get: vi.fn(async () => undefined),
+      put: vi.fn(async () => undefined),
+    },
+  },
+}));
+
+import { ensureRegisteredVoice } from '@/lib/audio/voice-registration-client';
+
+function okFetch() {
+  const f = vi.fn(
+    async () => new Response(JSON.stringify({ voiceId: 'x', registered: true }), { status: 200 }),
+  );
+  vi.stubGlobal('fetch', f);
+  return f;
+}
+
+describe('ensureRegisteredVoice memoization', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it('re-registers when the backend base URL changes (memo keyed by backend, not voiceId alone)', async () => {
+    const f = okFetch();
+    // Distinct descriptor per test so the module-level memo from other tests can't collide.
+    const voiceDesign = { identity: 'backend-switch teacher', texture: 'warm', delivery: 'calm' };
+
+    await ensureRegisteredVoice('voxcpm-tts', { voiceDesign }, { ttsBaseUrl: 'https://a.test/v1' });
+    // Same backend again → memoized, no second round-trip.
+    await ensureRegisteredVoice('voxcpm-tts', { voiceDesign }, { ttsBaseUrl: 'https://a.test/v1' });
+    expect(f).toHaveBeenCalledTimes(1);
+
+    // Different backend → must NOT be skipped by the memo; re-register there.
+    await ensureRegisteredVoice('voxcpm-tts', { voiceDesign }, { ttsBaseUrl: 'https://b.test/v1' });
+    expect(f).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent calls for the same (voiceId, backend) into one request', async () => {
+    const f = okFetch();
+    const voiceDesign = { identity: 'concurrent teacher', texture: 'warm', delivery: 'calm' };
+    const req = { ttsBaseUrl: 'https://c.test/v1' };
+
+    await Promise.all([
+      ensureRegisteredVoice('voxcpm-tts', { voiceDesign }, req),
+      ensureRegisteredVoice('voxcpm-tts', { voiceDesign }, req),
+      ensureRegisteredVoice('voxcpm-tts', { voiceDesign }, req),
+    ]);
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/audio/voice-registration.test.ts
+++ b/tests/audio/voice-registration.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getVoiceRegistrationAdapter,
+  supportsVoiceRegistration,
+} from '@/lib/audio/voice-registration';
+
+describe('voice-registration provider dispatch', () => {
+  it('resolves an adapter for a registration-capable provider', () => {
+    expect(getVoiceRegistrationAdapter('voxcpm-tts')).toBeDefined();
+  });
+
+  it('returns undefined for providers without an adapter', () => {
+    expect(getVoiceRegistrationAdapter('openai-tts')).toBeUndefined();
+    expect(supportsVoiceRegistration('openai-tts')).toBe(false);
+  });
+
+  it('honors per-provider capability (voxcpm only with the vllm-omni backend)', () => {
+    expect(supportsVoiceRegistration('voxcpm-tts', { backend: 'vllm-omni' })).toBe(true);
+    expect(supportsVoiceRegistration('voxcpm-tts', { backend: 'nano-vllm' })).toBe(false);
+    // default backend (vllm-omni) when unspecified
+    expect(supportsVoiceRegistration('voxcpm-tts')).toBe(true);
+  });
+});

--- a/tests/audio/voxcpm-registered-voice.test.ts
+++ b/tests/audio/voxcpm-registered-voice.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { generateTTS } from '@/lib/audio/tts-providers';
+import { VOXCPM_AUTO_VOICE_ID } from '@/lib/audio/voxcpm';
+import type { TTSModelConfig } from '@/lib/audio/types';
+
+afterEach(() => vi.unstubAllGlobals());
+
+function stubSpeech() {
+  const f = vi.fn(
+    async () =>
+      new Response(new Uint8Array([82, 73, 70, 70]), {
+        status: 200,
+        headers: { 'content-type': 'audio/wav' },
+      }),
+  );
+  vi.stubGlobal('fetch', f);
+  return f;
+}
+
+function lastPayload(f: ReturnType<typeof stubSpeech>) {
+  const [, init] = f.mock.calls[0] as [string, RequestInit];
+  return JSON.parse(String(init.body));
+}
+
+describe('VoxCPM vLLM-Omni registered voice', () => {
+  it('references voice=registeredVoiceId and skips ref_audio / prompt prefix', async () => {
+    const f = stubSpeech();
+    const config: TTSModelConfig = {
+      providerId: 'voxcpm-tts',
+      voice: VOXCPM_AUTO_VOICE_ID,
+      baseUrl: 'https://voxcpm.test/v1',
+      providerOptions: { backend: 'vllm-omni', registeredVoiceId: 'voxcpm:voice:abc' },
+    };
+
+    await generateTTS(config, 'Hello class');
+
+    const payload = lastPayload(f);
+    expect(payload.voice).toBe('voxcpm:voice:abc');
+    expect(payload.input).toBe('Hello class'); // no "(prompt)" prefix
+    expect(payload.ref_audio).toBeUndefined();
+  });
+
+  it('keeps the inline prompt path (voice=default) when no registeredVoiceId', async () => {
+    const f = stubSpeech();
+    const config: TTSModelConfig = {
+      providerId: 'voxcpm-tts',
+      voice: VOXCPM_AUTO_VOICE_ID,
+      baseUrl: 'https://voxcpm.test/v1',
+      providerOptions: { backend: 'vllm-omni', voicePrompt: 'warm male teacher' },
+    };
+
+    await generateTTS(config, 'Hello class');
+
+    const payload = lastPayload(f);
+    expect(payload.voice).toBe('default');
+    expect(payload.input).toBe('(warm male teacher)Hello class');
+  });
+});

--- a/tests/audio/voxcpm-registered-voice.test.ts
+++ b/tests/audio/voxcpm-registered-voice.test.ts
@@ -18,7 +18,7 @@ function stubSpeech() {
 }
 
 function lastPayload(f: ReturnType<typeof stubSpeech>) {
-  const [, init] = f.mock.calls[0] as [string, RequestInit];
+  const [, init] = f.mock.calls[0] as unknown as [string, RequestInit];
   return JSON.parse(String(init.body));
 }
 

--- a/tests/audio/voxcpm-registration.test.ts
+++ b/tests/audio/voxcpm-registration.test.ts
@@ -50,7 +50,7 @@ describe('registerVoxCPMVoice', () => {
     });
 
     expect(id).toBe('voxcpm:voice:abc');
-    const [url, init] = f.mock.calls[0] as [string, RequestInit];
+    const [url, init] = f.mock.calls[0] as unknown as [string, RequestInit];
     expect(String(url)).toBe('https://voxcpm.test/v1/audio/voices');
     expect(init.method).toBe('POST');
     const form = init.body as FormData;
@@ -90,7 +90,7 @@ describe('bootstrapVoxCPMReferenceClip', () => {
     expect(typeof out.referenceAudioBase64).toBe('string');
     expect(out.referenceAudioBase64.length).toBeGreaterThan(0);
 
-    const [url, init] = f.mock.calls[0] as [string, RequestInit];
+    const [url, init] = f.mock.calls[0] as unknown as [string, RequestInit];
     expect(String(url)).toBe('https://voxcpm.test/v1/audio/speech');
     const payload = JSON.parse(String(init.body));
     expect(payload.input).toContain('(male teacher, warm, calm)');

--- a/tests/audio/voxcpm-registration.test.ts
+++ b/tests/audio/voxcpm-registration.test.ts
@@ -76,8 +76,7 @@ describe('bootstrapVoxCPMReferenceClip', () => {
   it('synthesizes the descriptor prompt into base64 wav', async () => {
     const wav = new Uint8Array([82, 73, 70, 70]); // "RIFF"
     const f = vi.fn(
-      async () =>
-        new Response(wav, { status: 200, headers: { 'content-type': 'audio/wav' } }),
+      async () => new Response(wav, { status: 200, headers: { 'content-type': 'audio/wav' } }),
     );
     vi.stubGlobal('fetch', f);
 

--- a/tests/audio/voxcpm-registration.test.ts
+++ b/tests/audio/voxcpm-registration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  voxCPMVoiceExists,
+  registerVoxCPMVoice,
+  bootstrapVoxCPMReferenceClip,
+} from '@/lib/audio/voxcpm-registration';
+
+const cfg = { baseUrl: 'https://voxcpm.test/v1', apiKey: 'k', model: 'voxcpm2' };
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('voxCPMVoiceExists', () => {
+  it('true on 200, false on 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 200 })),
+    );
+    expect(await voxCPMVoiceExists(cfg, 'voxcpm:voice:abc')).toBe(true);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 404 })),
+    );
+    expect(await voxCPMVoiceExists(cfg, 'voxcpm:voice:abc')).toBe(false);
+  });
+});
+
+describe('registerVoxCPMVoice', () => {
+  it('POSTs multipart with voice_id + file and Bearer auth', async () => {
+    const f = vi.fn(
+      async () => new Response(JSON.stringify({ id: 'voxcpm:voice:abc' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', f);
+
+    const id = await registerVoxCPMVoice(cfg, {
+      voiceId: 'voxcpm:voice:abc',
+      referenceAudioBase64: btoa('RIFFdata'),
+      mimeType: 'audio/wav',
+    });
+
+    expect(id).toBe('voxcpm:voice:abc');
+    const [url, init] = f.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe('https://voxcpm.test/v1/audio/voices');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get('voice_id')).toBe('voxcpm:voice:abc');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer k');
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 })),
+    );
+    await expect(
+      registerVoxCPMVoice(cfg, { voiceId: 'v', referenceAudioBase64: btoa('x') }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('bootstrapVoxCPMReferenceClip', () => {
+  it('synthesizes the descriptor prompt into base64 wav', async () => {
+    const wav = new Uint8Array([82, 73, 70, 70]); // "RIFF"
+    const f = vi.fn(
+      async () =>
+        new Response(wav, { status: 200, headers: { 'content-type': 'audio/wav' } }),
+    );
+    vi.stubGlobal('fetch', f);
+
+    const out = await bootstrapVoxCPMReferenceClip(cfg, {
+      design: { identity: 'male teacher', texture: 'warm', delivery: 'calm' },
+      language: 'en',
+    });
+
+    expect(out.mimeType).toContain('wav');
+    expect(typeof out.referenceAudioBase64).toBe('string');
+    expect(out.referenceAudioBase64.length).toBeGreaterThan(0);
+
+    const [url, init] = f.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toBe('https://voxcpm.test/v1/audio/speech');
+    const payload = JSON.parse(String(init.body));
+    expect(payload.input).toContain('(male teacher, warm, calm)');
+  });
+});

--- a/tests/audio/voxcpm-registration.test.ts
+++ b/tests/audio/voxcpm-registration.test.ts
@@ -10,25 +10,36 @@ const cfg = { baseUrl: 'https://voxcpm.test/v1', apiKey: 'k', model: 'voxcpm2' }
 afterEach(() => vi.unstubAllGlobals());
 
 describe('voxCPMVoiceExists', () => {
-  it('true on 200, false on 404', async () => {
+  it('lists voices and checks membership', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response('', { status: 200 })),
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ voices: ['default', 'voxcpm:voice:abc'] }), {
+            status: 200,
+          }),
+      ),
     );
     expect(await voxCPMVoiceExists(cfg, 'voxcpm:voice:abc')).toBe(true);
+    expect(await voxCPMVoiceExists(cfg, 'voxcpm:voice:missing')).toBe(false);
+  });
 
+  it('returns false when the list call fails', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response('', { status: 404 })),
+      vi.fn(async () => new Response('', { status: 500 })),
     );
     expect(await voxCPMVoiceExists(cfg, 'voxcpm:voice:abc')).toBe(false);
   });
 });
 
 describe('registerVoxCPMVoice', () => {
-  it('POSTs multipart with voice_id + file and Bearer auth', async () => {
+  it('POSTs multipart name + consent + audio_sample with Bearer auth', async () => {
     const f = vi.fn(
-      async () => new Response(JSON.stringify({ id: 'voxcpm:voice:abc' }), { status: 200 }),
+      async () =>
+        new Response(JSON.stringify({ success: true, voice: { name: 'voxcpm:voice:abc' } }), {
+          status: 200,
+        }),
     );
     vi.stubGlobal('fetch', f);
 
@@ -42,15 +53,18 @@ describe('registerVoxCPMVoice', () => {
     const [url, init] = f.mock.calls[0] as [string, RequestInit];
     expect(String(url)).toBe('https://voxcpm.test/v1/audio/voices');
     expect(init.method).toBe('POST');
-    expect(init.body).toBeInstanceOf(FormData);
-    expect((init.body as FormData).get('voice_id')).toBe('voxcpm:voice:abc');
+    const form = init.body as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    expect(form.get('name')).toBe('voxcpm:voice:abc');
+    expect(typeof form.get('consent')).toBe('string');
+    expect(form.get('audio_sample')).toBeInstanceOf(Blob);
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer k');
   });
 
   it('throws on non-ok response', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response('nope', { status: 500 })),
+      vi.fn(async () => new Response('nope', { status: 400 })),
     );
     await expect(
       registerVoxCPMVoice(cfg, { voiceId: 'v', referenceAudioBase64: btoa('x') }),

--- a/tests/audio/voxcpm.test.ts
+++ b/tests/audio/voxcpm.test.ts
@@ -1,53 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildAutoVoxCPMVoicePrompt,
-  buildVoiceDesignPrompt,
-  normalizeVoiceDesign,
   voxCPMBackendSupportsVoiceRegistration,
-  getDeterministicVoxCPMVoiceId,
-  type VoxCPMVoiceDesign,
 } from '@/lib/audio/voxcpm';
+import { buildVoiceDesignPrompt, type VoiceDesign } from '@/lib/audio/voice-design';
 
-const design: VoxCPMVoiceDesign = {
+const design: VoiceDesign = {
   identity: 'middle-aged male teacher',
   texture: 'warm low-pitched resonant',
   delivery: 'calm measured encouraging',
 };
-
-describe('buildVoiceDesignPrompt', () => {
-  it('composes the three layers into one comma-joined prompt', () => {
-    expect(buildVoiceDesignPrompt(design)).toBe(
-      'middle-aged male teacher, warm low-pitched resonant, calm measured encouraging',
-    );
-  });
-  it('drops blank layers and collapses whitespace', () => {
-    expect(
-      buildVoiceDesignPrompt({ identity: '  male  teacher ', texture: '', delivery: 'slow' }),
-    ).toBe('male teacher, slow');
-  });
-});
-
-describe('normalizeVoiceDesign', () => {
-  it('returns a clean design from a well-formed object', () => {
-    expect(normalizeVoiceDesign({ identity: 'a', texture: 'b', delivery: 'c' })).toEqual({
-      identity: 'a',
-      texture: 'b',
-      delivery: 'c',
-    });
-  });
-  it('returns undefined when all layers are empty/missing', () => {
-    expect(normalizeVoiceDesign({})).toBeUndefined();
-    expect(normalizeVoiceDesign(null)).toBeUndefined();
-    expect(normalizeVoiceDesign('nope')).toBeUndefined();
-  });
-  it('keeps a partial design (some layers present)', () => {
-    expect(normalizeVoiceDesign({ identity: 'a' })).toEqual({
-      identity: 'a',
-      texture: '',
-      delivery: '',
-    });
-  });
-});
 
 describe('buildAutoVoxCPMVoicePrompt fallback chain', () => {
   it('prefers voiceDesign over persona', () => {
@@ -67,24 +29,5 @@ describe('voxCPMBackendSupportsVoiceRegistration', () => {
     expect(voxCPMBackendSupportsVoiceRegistration('vllm-omni')).toBe(true);
     expect(voxCPMBackendSupportsVoiceRegistration('nano-vllm')).toBe(false);
     expect(voxCPMBackendSupportsVoiceRegistration('python-api')).toBe(false);
-  });
-});
-
-describe('getDeterministicVoxCPMVoiceId', () => {
-  it('is stable for the same descriptor+language+model', async () => {
-    const a = await getDeterministicVoxCPMVoiceId(design, { language: 'zh', model: 'VoxCPM2' });
-    const b = await getDeterministicVoxCPMVoiceId(design, { language: 'zh', model: 'VoxCPM2' });
-    expect(a).toBe(b);
-    expect(a).toMatch(/^voxcpm:voice:[0-9a-f]{16}$/);
-  });
-  it('changes when any input changes', async () => {
-    const base = await getDeterministicVoxCPMVoiceId(design, { language: 'zh', model: 'VoxCPM2' });
-    const lang = await getDeterministicVoxCPMVoiceId(design, { language: 'en', model: 'VoxCPM2' });
-    const tex = await getDeterministicVoxCPMVoiceId(
-      { ...design, texture: 'bright' },
-      { language: 'zh', model: 'VoxCPM2' },
-    );
-    expect(lang).not.toBe(base);
-    expect(tex).not.toBe(base);
   });
 });

--- a/tests/audio/voxcpm.test.ts
+++ b/tests/audio/voxcpm.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAutoVoxCPMVoicePrompt,
+  buildVoiceDesignPrompt,
+  normalizeVoiceDesign,
+  voxCPMBackendSupportsVoiceRegistration,
+  getDeterministicVoxCPMVoiceId,
+  type VoxCPMVoiceDesign,
+} from '@/lib/audio/voxcpm';
+
+const design: VoxCPMVoiceDesign = {
+  identity: 'middle-aged male teacher',
+  texture: 'warm low-pitched resonant',
+  delivery: 'calm measured encouraging',
+};
+
+describe('buildVoiceDesignPrompt', () => {
+  it('composes the three layers into one comma-joined prompt', () => {
+    expect(buildVoiceDesignPrompt(design)).toBe(
+      'middle-aged male teacher, warm low-pitched resonant, calm measured encouraging',
+    );
+  });
+  it('drops blank layers and collapses whitespace', () => {
+    expect(
+      buildVoiceDesignPrompt({ identity: '  male  teacher ', texture: '', delivery: 'slow' }),
+    ).toBe('male teacher, slow');
+  });
+});
+
+describe('normalizeVoiceDesign', () => {
+  it('returns a clean design from a well-formed object', () => {
+    expect(normalizeVoiceDesign({ identity: 'a', texture: 'b', delivery: 'c' })).toEqual({
+      identity: 'a',
+      texture: 'b',
+      delivery: 'c',
+    });
+  });
+  it('returns undefined when all layers are empty/missing', () => {
+    expect(normalizeVoiceDesign({})).toBeUndefined();
+    expect(normalizeVoiceDesign(null)).toBeUndefined();
+    expect(normalizeVoiceDesign('nope')).toBeUndefined();
+  });
+  it('keeps a partial design (some layers present)', () => {
+    expect(normalizeVoiceDesign({ identity: 'a' })).toEqual({
+      identity: 'a',
+      texture: '',
+      delivery: '',
+    });
+  });
+});
+
+describe('buildAutoVoxCPMVoicePrompt fallback chain', () => {
+  it('prefers voiceDesign over persona', () => {
+    expect(buildAutoVoxCPMVoicePrompt({ voiceDesign: design, persona: 'loves cats' })).toBe(
+      buildVoiceDesignPrompt(design),
+    );
+  });
+  it('falls back to persona, then role/name, then default', () => {
+    expect(buildAutoVoxCPMVoicePrompt({ persona: 'patient mentor' })).toBe('patient mentor');
+    expect(buildAutoVoxCPMVoicePrompt({ role: 'teacher', agentName: 'Lin' })).toBe('teacher Lin');
+    expect(buildAutoVoxCPMVoicePrompt({})).toBe('natural classroom voice');
+  });
+});
+
+describe('voxCPMBackendSupportsVoiceRegistration', () => {
+  it('is true only for vllm-omni', () => {
+    expect(voxCPMBackendSupportsVoiceRegistration('vllm-omni')).toBe(true);
+    expect(voxCPMBackendSupportsVoiceRegistration('nano-vllm')).toBe(false);
+    expect(voxCPMBackendSupportsVoiceRegistration('python-api')).toBe(false);
+  });
+});
+
+describe('getDeterministicVoxCPMVoiceId', () => {
+  it('is stable for the same descriptor+language+model', async () => {
+    const a = await getDeterministicVoxCPMVoiceId(design, { language: 'zh', model: 'VoxCPM2' });
+    const b = await getDeterministicVoxCPMVoiceId(design, { language: 'zh', model: 'VoxCPM2' });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^voxcpm:voice:[0-9a-f]{16}$/);
+  });
+  it('changes when any input changes', async () => {
+    const base = await getDeterministicVoxCPMVoiceId(design, { language: 'zh', model: 'VoxCPM2' });
+    const lang = await getDeterministicVoxCPMVoiceId(design, { language: 'en', model: 'VoxCPM2' });
+    const tex = await getDeterministicVoxCPMVoiceId(
+      { ...design, texture: 'bright' },
+      { language: 'zh', model: 'VoxCPM2' },
+    );
+    expect(lang).not.toBe(base);
+    expect(tex).not.toBe(base);
+  });
+});

--- a/tests/server/agent-profiles-voice-design.test.ts
+++ b/tests/server/agent-profiles-voice-design.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const callLLM = vi.fn();
+
+vi.mock('@/lib/ai/llm', () => ({
+  callLLM: (...args: unknown[]) => callLLM(...args),
+}));
+
+vi.mock('@/lib/server/resolve-model', () => ({
+  resolveModelFromRequest: async () => ({
+    model: {},
+    modelString: 'test-model',
+    thinkingConfig: undefined,
+  }),
+}));
+
+import { POST } from '@/app/api/generate/agent-profiles/route';
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/generate/agent-profiles', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      stageInfo: { name: 'Intro to Algebra' },
+      languageDirective: 'Respond in English.',
+      availableAvatars: ['/a.png', '/b.png'],
+    }),
+  });
+}
+
+function llmAgents(extra: Record<string, unknown>) {
+  return JSON.stringify({
+    agents: [
+      {
+        name: 'Prof. Lin',
+        role: 'teacher',
+        persona: 'A patient mentor.',
+        avatar: '/a.png',
+        color: '#111111',
+        priority: 10,
+        ...extra,
+      },
+      {
+        name: 'Sam',
+        role: 'student',
+        persona: 'Curious learner.',
+        avatar: '/b.png',
+        color: '#222222',
+        priority: 5,
+      },
+    ],
+  });
+}
+
+describe('agent-profiles route — voiceDesign', () => {
+  beforeEach(() => callLLM.mockReset());
+
+  it('attaches a normalized voiceDesign when the LLM emits one', async () => {
+    callLLM.mockResolvedValue({
+      text: llmAgents({
+        voiceDesign: { identity: 'older male teacher', texture: 'warm low', delivery: 'calm' },
+      }),
+    });
+
+    const res = await POST(makeRequest());
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.agents[0].voiceDesign).toEqual({
+      identity: 'older male teacher',
+      texture: 'warm low',
+      delivery: 'calm',
+    });
+  });
+
+  it('omits voiceDesign when the LLM does not emit one', async () => {
+    callLLM.mockResolvedValue({ text: llmAgents({}) });
+
+    const res = await POST(makeRequest());
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.agents[0]).not.toHaveProperty('voiceDesign');
+  });
+});


### PR DESCRIPTION
Closes #670.

## Problem
`voxcpm:auto` derived its voice prompt from the agent **persona**, which describes personality, not vocal timbre. The result was generic, poorly-matched voices — and because text voice-design drifts, the same agent could sound different (even switching apparent gender) across utterances in a single session.

## What this does
**1. Per-agent voice design.** `agent-profiles` now emits a 3-layer `voiceDesign` (identity / texture / delivery) per agent, in the course language, persisted on `AgentConfig`.

**2. Register-once / reference-by-id, provider-neutral.** A `VoiceRegistrationAdapter` seam + a generic endpoint `POST /api/generate/voice` synthesize the descriptor into a reference clip **once**, register it on the backend, and return a deterministic `voiceId`. Later TTS references `voice=<voiceId>` (pre-encoded latents), locking timbre and shrinking the payload. vLLM-Omni is the first adapter; other registration-capable providers plug in by adding an adapter. Backends without registration keep the inline `(prompt)text` path (graceful degradation).

**3. Single voice resolver.** All TTS paths (lecture narration, multi-agent discussion, voice preview) resolve through one `resolveAgentVoiceOptions(agent, …)` that reads the agent profile, so they can't drift out of sync. Agents without a `voiceDesign` (e.g. preset agents) fall back to their persona as the seed — stable, if generic.

**4. Robustness.** Deterministic id = hash(descriptor + provider + model); a GC'd registered voice is re-registered transparently via a proactive existence check. Managed TTS providers can pin their model server-side (`resolveTTSModel`).

## Tests
- Unit: voice-design helpers + deterministic id; the registration adapter (multipart contract, list-based existence, bootstrap); provider→adapter dispatch; the resolver's voiceDesign-vs-persona source and narrator selection.
- E2E (browser): generating a course registers the voice once and every narration TTS reuses the single registered `voiceId`; the registered voice is present on the backend.

## Known limitation / follow-up
The persisted stage snapshot doesn't yet carry `voiceDesign` (only persona), so a reopened/generated classroom resolves a stable persona-based voice rather than its original descriptor voice. Persisting the full agent profile on the stage is a clean follow-up.
