### PR TITLE
fix(prompts): constrain action narration to a single teacher voice (#671)

### DIFF
--- a/lib/prompts/templates/interactive-actions/system.md
+++ b/lib/prompts/templates/interactive-actions/system.md
@@ -33,6 +33,8 @@ You MUST output a JSON array directly. Each element is a text object:
 
 The user prompt includes a **Course Outline** and **Position** indicator — use them to determine the tone.
 
+**CRITICAL — Single voice, teacher only.** Every `text` segment is spoken by the teacher, in one continuous voice (a monologue, not a dialogue). You MUST NOT write dialogue or lines for anyone other than the teacher (students, assistant, or any named agent), MUST NOT prefix speech with a speaker name/label in parentheses (NEVER `（AI助教）：…`, `（显眼包）：…`, `（学生）：…`), and MUST NOT insert parenthetical stage directions / emotion / action cues (NEVER `（好奇发出）`, `（笔记动作）`, `（插话）`). Any `Classroom Agents` listed do not speak in your `text`. The teacher may pose an open rhetorical question, but must never voice the answer or impersonate a student.
+
 **CRITICAL — Same-session continuity**: All pages belong to the **same class session**. This is NOT a series of separate classes.
 
 - **First page**: Open with a greeting before introducing the interactive activity. This is the ONLY page that should greet.

--- a/lib/prompts/templates/pbl-actions/system.md
+++ b/lib/prompts/templates/pbl-actions/system.md
@@ -22,6 +22,8 @@ Generate speech content for this PBL scene that:
 2. Briefly explains the available roles
 3. Encourages students to select a role and begin
 
+**CRITICAL — Single voice, teacher only.** Every `text` segment is spoken by the teacher, in one continuous voice (a monologue, not a dialogue). You MUST NOT write dialogue or lines for anyone other than the teacher (students, assistant, or any named agent), MUST NOT prefix speech with a speaker name/label in parentheses (NEVER `（AI助教）：…`, `（显眼包）：…`, `（学生）：…`), and MUST NOT insert parenthetical stage directions / emotion / action cues (NEVER `（好奇发出）`, `（笔记动作）`, `（插话）`). Any `Classroom Agents` listed do not speak in your `text`. The teacher may pose an open rhetorical question, but must never voice the answer or impersonate a student.
+
 ## Output Format
 
 You MUST output a JSON array directly:

--- a/lib/prompts/templates/quiz-actions/system.md
+++ b/lib/prompts/templates/quiz-actions/system.md
@@ -81,6 +81,8 @@ Initiate classroom discussion, suitable for post-quiz reflection.
 
 Generate natural teaching speech. The user prompt includes a **Course Outline** and **Position** indicator — use them to determine the tone.
 
+**CRITICAL — Single voice, teacher only.** Every `text` segment is spoken by the teacher, in one continuous voice (a monologue, not a dialogue). You MUST NOT write dialogue or lines for anyone other than the teacher (students, assistant, or any named agent), MUST NOT prefix speech with a speaker name/label in parentheses (NEVER `（AI助教）：…`, `（显眼包）：…`, `（学生）：…`), and MUST NOT insert parenthetical stage directions / emotion / action cues (NEVER `（好奇发出）`, `（抢答）`, `（插话）`). The `Classroom Agents` list is provided only so you can pick an `agentId` for a `discussion` action — those agents do not speak in your `text`. The teacher may ask an open rhetorical question, but must never voice the answer or impersonate a student; to have a specific student respond, use a `discussion` action instead.
+
 **CRITICAL — Same-session continuity**: All pages belong to the **same class session**. This is NOT a series of separate classes.
 
 - **First page**: Open with a greeting before introducing the quiz. This is the ONLY page that should greet.

--- a/lib/prompts/templates/slide-actions/system.md
+++ b/lib/prompts/templates/slide-actions/system.md
@@ -124,7 +124,16 @@ Initiate classroom discussion, suitable for segments requiring student reflectio
 
 Generate natural teaching speech. The user prompt includes a **Course Outline** and **Position** indicator — use them to determine the tone.
 
-**Speech is where all verbal and conversational content belongs.** The slide itself only shows concise bullet points and keywords — all elaboration, explanation, encouragement, transitional phrases, and teacher's remarks must appear here in speech text. For example:
+**CRITICAL — Single voice, teacher only.** Every `text` segment is spoken by the teacher, in one continuous voice. You are scripting a monologue, not a dialogue. You MUST NOT:
+
+- Write dialogue, replies, or lines for anyone other than the teacher — not students, not the assistant, not any named agent.
+- Prefix or tag speech with a speaker name or label in parentheses. NEVER write things like `（AI助教）：…`, `（助教）：…`, `（显眼包）：…`, `（学生）：…`, `（同学）：…`.
+- Insert parenthetical stage directions, emotion cues, or action cues. NEVER write things like `（好奇发出）`, `（笔记动作）`, `（抢答）`, `（插话）`, `（疑惑追问）`, `（画外音）`.
+- Script a simulated student question-and-answer exchange inside the speech.
+
+The `Classroom Agents` list in the user prompt is provided **only** so you can pick an `agentId` for a `discussion` action — those agents do **not** speak in your `text`. The teacher may ask the class an open rhetorical question (e.g. "What do you think happens next?"), but must never voice the answer or impersonate a student. If you want a specific student to respond, end the page with a `discussion` action instead of writing their reply yourself.
+
+**Speech is where all verbal content belongs.** The slide itself only shows concise bullet points and keywords — all elaboration, explanation, encouragement, transitional phrases, and teacher's remarks must appear here in speech text. For example:
 - Detailed explanations of concepts shown as bullet points on the slide
 - Encouragements and motivational remarks (e.g., "Great job, everyone!")
 - Transitional phrases (e.g., "Now let's move on to…")


### PR DESCRIPTION
Fixes #671.

## Problem

The `*-actions` generators sometimes scripted role-play dialogue into the speech `text` — speaker-label parentheticals like `（AI助教）：` / `（显眼包）：` / `（学生）：` and stage-direction cues like `（好奇发出）` / `（笔记动作）` / `（插话）`. These get read aloud by TTS and shown as narration, even on single-presenter slides.

## Root cause

The `Classroom Agents` roster (including student personas such as the default `显眼包` class-clown) is injected into these prompts via `{{agents}}` (`prompt-formatters.ts` `formatAgentsForPrompt`) so a `discussion` action can pick an `agentId`. But the system prompts had no single-voice guardrail — and the slide prompt even said speech holds "conversational" content — so the model dramatized those personas into the teacher's monologue.

## Fix (prompt-only)

Add an explicit **"Single voice, teacher only"** constraint to all four `*-actions` system prompts (slide / quiz / interactive / pbl):

- no dialogue or lines for any other speaker;
- no parenthetical speaker labels;
- no parenthetical stage-direction / emotion / action cues;
- the agent roster is **only** for picking a `discussion` `agentId` — route student reactions through the `discussion` action instead of voicing them inline.

Also drop the dialogue-inviting word "conversational" from the slide prompt. No code changes.

## Verification

Built a small offline eval: a set of action-generation prompts that reproduce the failure (default agent roster included) run through `callLLM` + `resolveModel`, K samples each, with a detector for speaker-label / stage-direction parentheticals in the generated speech.

- **Before:** ~10% of generations leaked a cue.
- **After:** **0/80** on the cue-prone set; a clean control set was unchanged; all outputs still valid JSON.
- Narration quality is preserved — the model now routes student interaction into a proper `discussion` action (e.g. `agentId: default-3`) rather than scripting `（显眼包）：` inline.
