### PR TITLE
fix(export): include line control points in getElementRange

### DIFF
--- a/lib/utils/element.ts
+++ b/lib/utils/element.ts
@@ -253,8 +253,13 @@ export const getLineElementPath = (element: PPTLineElement) => {
     const mid = element.broken.join(',');
     return `M${start} L${mid} L${end}`;
   } else if (element.broken2) {
-    const { minX, maxX, minY, maxY } = getElementRange(element);
-    if (maxX - minX >= maxY - minY)
+    // Pick the elbow orientation from the endpoint extent, computed locally.
+    // getElementRange now folds in control points (#674); reusing it here would
+    // let the broken2 point itself flip the orientation. This preserves the
+    // exact pre-#674 heuristic (max of the endpoint offsets per axis).
+    const extentX = Math.max(startArr[0], endArr[0]);
+    const extentY = Math.max(startArr[1], endArr[1]);
+    if (extentX >= extentY)
       return `M${start} L${element.broken2[0]},${startArr[1]} L${element.broken2[0]},${endArr[1]} ${end}`;
     return `M${start} L${startArr[0]},${element.broken2[1]} L${endArr[0]},${element.broken2[1]} ${end}`;
   } else if (element.curve) {

--- a/lib/utils/element.ts
+++ b/lib/utils/element.ts
@@ -82,10 +82,34 @@ export const getElementRange = (element: PPTElement) => {
   let minX, maxX, minY, maxY;
 
   if (element.type === 'line') {
-    minX = element.left;
-    maxX = element.left + Math.max(element.start[0], element.end[0]);
-    minY = element.top;
-    maxY = element.top + Math.max(element.start[1], element.end[1]);
+    // Include every point the line can reach — endpoints AND the optional
+    // control points (broken/broken2 elbows, quadratic curve, cubic bezier) —
+    // and take min/max on both axes. The previous code used only
+    // `Math.max(start, end)` with `minX/minY = left`, which clipped curved or
+    // elbow lines (their control points extend past the endpoints) and assumed
+    // the nearer endpoint always sits at offset 0.
+    const xs = [element.start[0], element.end[0]];
+    const ys = [element.start[1], element.end[1]];
+    if (element.broken) {
+      xs.push(element.broken[0]);
+      ys.push(element.broken[1]);
+    }
+    if (element.broken2) {
+      xs.push(element.broken2[0]);
+      ys.push(element.broken2[1]);
+    }
+    if (element.curve) {
+      xs.push(element.curve[0]);
+      ys.push(element.curve[1]);
+    }
+    if (element.cubic) {
+      xs.push(element.cubic[0][0], element.cubic[1][0]);
+      ys.push(element.cubic[0][1], element.cubic[1][1]);
+    }
+    minX = element.left + Math.min(...xs);
+    maxX = element.left + Math.max(...xs);
+    minY = element.top + Math.min(...ys);
+    maxY = element.top + Math.max(...ys);
   } else if ('rotate' in element && element.rotate) {
     const { left, top, width, height, rotate } = element;
     const { xRange, yRange } = getRectRotatedRange({

--- a/tests/utils/element.test.ts
+++ b/tests/utils/element.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { getElementRange } from '@/lib/utils/element';
+import type { PPTLineElement } from '@/lib/types/slides';
+
+// Minimal line factory — getElementRange only reads
+// type/left/top/start/end/broken/broken2/curve/cubic.
+const line = (overrides: Partial<PPTLineElement>): PPTLineElement =>
+  ({
+    id: 'l1',
+    type: 'line',
+    left: 100,
+    top: 100,
+    width: 0,
+    start: [0, 0],
+    end: [50, 0],
+    style: 'solid',
+    color: '#000000',
+    points: ['', ''],
+    ...overrides,
+  }) as unknown as PPTLineElement;
+
+describe('getElementRange — line elements', () => {
+  it('is unchanged for a plain endpoint-only line', () => {
+    expect(getElementRange(line({ start: [0, 0], end: [50, 30] }))).toEqual({
+      minX: 100,
+      maxX: 150,
+      minY: 100,
+      maxY: 130,
+    });
+  });
+
+  it('uses the min of the endpoints, not just `left`', () => {
+    // Neither endpoint sits at offset 0, so the left/top edges are inset.
+    expect(getElementRange(line({ start: [10, 5], end: [40, 25] }))).toEqual({
+      minX: 110,
+      maxX: 140,
+      minY: 105,
+      maxY: 125,
+    });
+  });
+
+  it('expands the box to include a quadratic curve control point', () => {
+    const r = getElementRange(line({ start: [0, 0], end: [40, 0], curve: [20, 60] }));
+    expect(r.maxY).toBe(160); // 100 + 60 — was 100 (clipped) before the fix
+    expect(r.maxX).toBe(140);
+  });
+
+  it('includes broken / elbow control points', () => {
+    const r = getElementRange(line({ start: [0, 0], end: [40, 40], broken: [80, 10] }));
+    expect(r.maxX).toBe(180); // 100 + 80 — was 140 before the fix
+  });
+
+  it('includes both cubic bezier control points (incl. negative offsets)', () => {
+    const r = getElementRange(
+      line({
+        start: [0, 0],
+        end: [40, 0],
+        cubic: [
+          [-10, 20],
+          [50, -30],
+        ],
+      }),
+    );
+    expect(r).toEqual({ minX: 90, maxX: 150, minY: 70, maxY: 120 });
+  });
+});

--- a/tests/utils/element.test.ts
+++ b/tests/utils/element.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getElementRange } from '@/lib/utils/element';
+import { getElementRange, getLineElementPath } from '@/lib/utils/element';
 import type { PPTLineElement } from '@/lib/types/slides';
 
 // Minimal line factory — getElementRange only reads
@@ -63,5 +63,28 @@ describe('getElementRange — line elements', () => {
       }),
     );
     expect(r).toEqual({ minX: 90, maxX: 150, minY: 70, maxY: 120 });
+  });
+});
+
+describe('getLineElementPath — broken2 elbow orientation', () => {
+  it('routes horizontally when the line is wider than tall', () => {
+    expect(getLineElementPath(line({ start: [0, 0], end: [100, 30], broken2: [50, 15] }))).toBe(
+      'M0,0 L50,0 L50,30 100,30',
+    );
+  });
+
+  it('routes vertically when the line is taller than wide', () => {
+    expect(getLineElementPath(line({ start: [0, 0], end: [30, 100], broken2: [15, 50] }))).toBe(
+      'M0,0 L0,50 L30,50 30,100',
+    );
+  });
+
+  it('orientation ignores the broken2 control-point position (decoupled from bbox)', () => {
+    // A wide line stays horizontal even when broken2 is dragged far down — the
+    // orientation must come from the endpoint extent, not the (now control-point
+    // aware) element range.
+    expect(getLineElementPath(line({ start: [0, 0], end: [100, 20], broken2: [50, 500] }))).toBe(
+      'M0,0 L50,0 L50,20 100,20',
+    );
   });
 });


### PR DESCRIPTION
## What & why

`getElementRange` (`lib/utils/element.ts`) computed a `line` element’s bounding box as `Math.max(start, end)` with `minX/minY = left` — ignoring the optional `broken`/`broken2`/`curve`/`cubic` control points a line can bow out to, and assuming the nearer endpoint sits at offset 0.

`PPTLineElement` carries those control points (`lib/types/slides.ts`), so a curved or elbow line extends past its endpoints and its range came out too small — clipping it on PPTX export (`use-export-pptx.ts`) and under-sizing its selection box in the editor (`useMouseSelection.ts`). Same class of bug as the SVG bbox fix in #656.

Closes #674.

## Fix

Collect every reachable point (both endpoints + any present control points) and take `min`/`max` per axis. Backward-compatible for plain `[0,0] → [w,h]` lines (their min offset is already 0), so the common case is unchanged.

## Test plan

New `tests/utils/element.test.ts` (5 cases, all green):
- plain endpoint-only line is unchanged;
- box uses the min of the endpoints (not just `left`);
- box expands for a quadratic `curve` control point (the headline clip);
- includes `broken`/elbow points;
- includes both `cubic` bezier points, incl. negative offsets.

`npx tsc --noEmit`, `prettier --check`, `eslint` all clean; full suite unaffected.

No user-facing strings (no i18n impact).

---

*AI-assisted (Claude), self-reviewed: verified the control-point fields on `PPTLineElement` and that the fix is a no-op for normal `[0,0]→[w,h]` lines before committing.*