### PR TITLE
Fix overlay layout shift in home and classroom

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -28,6 +28,13 @@ export default function ClassroomDetailPage() {
 
   const generationStartedRef = useRef(false);
 
+  useEffect(() => {
+    document.body.dataset.maicClassroom = 'true';
+    return () => {
+      delete document.body.dataset.maicClassroom;
+    };
+  }, []);
+
   const { generateRemaining, retrySingleOutline, stop } = useSceneGenerator({
     onComplete: () => {
       log.info('[Classroom] All scenes generated');

--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -28,13 +28,6 @@ export default function ClassroomDetailPage() {
 
   const generationStartedRef = useRef(false);
 
-  useEffect(() => {
-    document.body.dataset.maicClassroom = 'true';
-    return () => {
-      delete document.body.dataset.maicClassroom;
-    };
-  }, []);
-
   const { generateRemaining, retrySingleOutline, stop } = useSceneGenerator({
     onComplete: () => {
       log.info('[Classroom] All scenes generated');

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,15 +132,18 @@
   body {
     @apply bg-background text-foreground;
   }
-  /* Radix Select / Popover wrap with `react-remove-scroll`, which adds a
-     compensation `padding-right` to <body> when they open. Our <html>
+  /* Radix overlays wrap with `react-remove-scroll`, which compensates for
+     the removed page scrollbar by adding right-side body spacing. Classroom
+     playback/edit shells are fixed-height inner-scroll layouts and <html>
      already reserves the scrollbar gutter (above), so that compensation
-     creates a visible layout shift on every dropdown open. Scope the
-     override to editor mode — the SlideCanvas sets `data-maic-editor` on
-     the body while mounted — so Radix's compensation still works on the
-     rest of the app (modals, sheets, etc. on non-editor pages). */
-  body[data-maic-editor='true'] {
+     creates a visible horizontal layout shift. Keep Radix's modal focus and
+     interaction locking, but neutralize only the gap compensation in
+     classroom/editor chrome. */
+  body[data-maic-editor='true'],
+  body[data-maic-editor='true'][data-scroll-locked],
+  body[data-maic-classroom='true'][data-scroll-locked] {
     padding-right: 0 !important;
+    margin-right: 0 !important;
   }
 }
 /* ProseMirror Editor Styles */

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,16 +132,14 @@
   body {
     @apply bg-background text-foreground;
   }
-  /* Radix overlays wrap with `react-remove-scroll`, which compensates for
-     the removed page scrollbar by adding right-side body spacing. Classroom
-     playback/edit shells are fixed-height inner-scroll layouts and <html>
-     already reserves the scrollbar gutter (above), so that compensation
-     creates a visible horizontal layout shift. Keep Radix's modal focus and
-     interaction locking, but neutralize only the gap compensation in
-     classroom/editor chrome. */
+  /* Radix modal overlays wrap with `react-remove-scroll`, which compensates
+     for the removed page scrollbar by adding right-side body spacing. This
+     app already reserves the scrollbar gutter on <html> (above), so that
+     extra compensation creates a visible horizontal layout shift when opening
+     Settings on the homepage/classroom shells. Keep Radix's modal focus and
+     interaction locking, but neutralize only the redundant gap compensation. */
   body[data-maic-editor='true'],
-  body[data-maic-editor='true'][data-scroll-locked],
-  body[data-maic-classroom='true'][data-scroll-locked] {
+  body[data-scroll-locked] {
     padding-right: 0 !important;
     margin-right: 0 !important;
   }

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -26,6 +26,7 @@ export function LanguageSwitcher({ onOpen }: LanguageSwitcherProps) {
 
   return (
     <DropdownMenu
+      modal={false}
       onOpenChange={(open) => {
         if (open) onOpen?.();
       }}

--- a/components/stage/header-controls.tsx
+++ b/components/stage/header-controls.tsx
@@ -123,8 +123,9 @@ export function HeaderControls({
             and never gets clipped by an ancestor's overflow-hidden. */}
         <LanguageSwitcher />
 
-        {/* Theme — same Portal-backed DropdownMenu pattern. */}
-        <DropdownMenu>
+        {/* Theme — same Portal-backed DropdownMenu pattern. Non-modal keeps
+            Radix from body scroll-locking a fixed-height classroom layout. */}
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <button
               className="p-2 rounded-full text-gray-400 dark:text-gray-500 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200 hover:shadow-sm transition-all group"

--- a/e2e/tests/classroom-interaction.spec.ts
+++ b/e2e/tests/classroom-interaction.spec.ts
@@ -12,6 +12,7 @@ async function seedDatabase(page: import('@playwright/test').Page) {
   // Inject settings before navigating so it's available immediately on load
   await page.addInitScript((settings) => {
     localStorage.setItem('settings-storage', settings);
+    localStorage.setItem('locale', 'en-US');
   }, SETTINGS_STORAGE);
 
   // Navigate to home page first — this causes Dexie to open/create the DB at v8
@@ -21,106 +22,121 @@ async function seedDatabase(page: import('@playwright/test').Page) {
   // Now seed data by opening the DB at its current version (no upgrade).
   // Opening without a version number returns the current version without triggering
   // onupgradeneeded, so we can safely write to the already-initialized schema.
-  await page.evaluate(
-    ({ stageId, theme }) => {
-      return new Promise<void>((resolve, reject) => {
-        // Open without specifying version — uses current DB version, no upgrade event
-        const request = indexedDB.open('MAIC-Database');
+  const seedStageData = () =>
+    page.evaluate(
+      ({ stageId, theme }) => {
+        return new Promise<void>((resolve, reject) => {
+          // Open without specifying version — uses current DB version, no upgrade event
+          const request = indexedDB.open('MAIC-Database');
 
-        request.onsuccess = (event) => {
-          const db = (event.target as IDBOpenDBRequest).result;
-          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
-          const now = Date.now();
+          request.onsuccess = (event) => {
+            const db = (event.target as IDBOpenDBRequest).result;
+            const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+            const now = Date.now();
 
-          tx.objectStore('stages').put({
-            id: stageId,
-            name: '光合作用',
-            description: '',
-            language: 'zh-CN',
-            style: 'professional',
-            createdAt: now,
-            updatedAt: now,
-          });
-
-          // Scene content uses SlideContent shape: { type: 'slide', canvas: Slide }
-          const makeSlideContent = (title: string, elId: string) => ({
-            type: 'slide',
-            canvas: {
-              id: `slide-${elId}`,
-              viewportSize: 1000,
-              viewportRatio: 0.5625,
-              theme,
-              elements: [
-                {
-                  type: 'text',
-                  id: `el-${elId}`,
-                  content: title,
-                  left: 50,
-                  top: 50,
-                  width: 900,
-                  height: 100,
-                },
-              ],
-            },
-          });
-
-          const scenes = [
-            {
-              id: 'scene-0',
-              stageId,
-              type: 'slide',
-              title: '基本概念',
-              order: 0,
-              content: makeSlideContent('基本概念', '0'),
+            tx.objectStore('stages').put({
+              id: stageId,
+              name: '光合作用',
+              description: '',
+              language: 'zh-CN',
+              style: 'professional',
               createdAt: now,
               updatedAt: now,
-            },
-            {
-              id: 'scene-1',
-              stageId,
+            });
+
+            // Scene content uses SlideContent shape: { type: 'slide', canvas: Slide }
+            const makeSlideContent = (title: string, elId: string) => ({
               type: 'slide',
-              title: '光反应',
-              order: 1,
-              content: makeSlideContent('光反应', '1'),
+              canvas: {
+                id: `slide-${elId}`,
+                viewportSize: 1000,
+                viewportRatio: 0.5625,
+                theme,
+                elements: [
+                  {
+                    type: 'text',
+                    id: `el-${elId}`,
+                    content: title,
+                    left: 50,
+                    top: 50,
+                    width: 900,
+                    height: 100,
+                  },
+                ],
+              },
+            });
+
+            const scenes = [
+              {
+                id: 'scene-0',
+                stageId,
+                type: 'slide',
+                title: '基本概念',
+                order: 0,
+                content: makeSlideContent('基本概念', '0'),
+                createdAt: now,
+                updatedAt: now,
+              },
+              {
+                id: 'scene-1',
+                stageId,
+                type: 'slide',
+                title: '光反应',
+                order: 1,
+                content: makeSlideContent('光反应', '1'),
+                createdAt: now,
+                updatedAt: now,
+              },
+              {
+                id: 'scene-2',
+                stageId,
+                type: 'slide',
+                title: '暗反应',
+                order: 2,
+                content: makeSlideContent('暗反应', '2'),
+                createdAt: now,
+                updatedAt: now,
+              },
+            ];
+            for (const scene of scenes) {
+              tx.objectStore('scenes').put(scene);
+            }
+
+            // Empty outlines = all scenes generated, no pending work
+            // StageOutlinesRecord requires createdAt + updatedAt
+            tx.objectStore('stageOutlines').put({
+              stageId,
+              outlines: [],
               createdAt: now,
               updatedAt: now,
-            },
-            {
-              id: 'scene-2',
-              stageId,
-              type: 'slide',
-              title: '暗反应',
-              order: 2,
-              content: makeSlideContent('暗反应', '2'),
-              createdAt: now,
-              updatedAt: now,
-            },
-          ];
-          for (const scene of scenes) {
-            tx.objectStore('scenes').put(scene);
-          }
+            });
 
-          // Empty outlines = all scenes generated, no pending work
-          // StageOutlinesRecord requires createdAt + updatedAt
-          tx.objectStore('stageOutlines').put({
-            stageId,
-            outlines: [],
-            createdAt: now,
-            updatedAt: now,
-          });
-
-          tx.oncomplete = () => {
-            db.close();
-            resolve();
+            tx.oncomplete = () => {
+              db.close();
+              resolve();
+            };
+            tx.onerror = () => reject(tx.error);
           };
-          tx.onerror = () => reject(tx.error);
-        };
 
-        request.onerror = () => reject(request.error);
-      });
-    },
-    { stageId: TEST_STAGE_ID, theme: defaultTheme },
-  );
+          request.onerror = () => reject(request.error);
+        });
+      },
+      { stageId: TEST_STAGE_ID, theme: defaultTheme },
+    );
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await seedStageData();
+      break;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('Execution context was destroyed') || attempt === 2) {
+        throw error;
+      }
+      await page.waitForLoadState('domcontentloaded').catch(() => {});
+      await page.waitForTimeout(250);
+    }
+  }
 }
 
 test.describe('Classroom Interaction', () => {
@@ -144,5 +160,53 @@ test.describe('Classroom Interaction', () => {
 
     // Verify second scene is now active — heading in the top bar shows the current scene name
     await expect(page.getByRole('heading', { name: '光反应' })).toBeVisible();
+  });
+
+  test('keeps body spacing stable for header menus and settings modal', async ({ page }) => {
+    const classroom = new ClassroomPage(page);
+    await classroom.goto(TEST_STAGE_ID);
+    await classroom.waitForLoaded();
+
+    const initialBodySpacing = await page.evaluate(() => {
+      const styles = getComputedStyle(document.body);
+      return {
+        paddingRight: styles.paddingRight,
+        marginRight: styles.marginRight,
+      };
+    });
+
+    const expectBodyScrollState = async (locked: boolean) => {
+      await expect
+        .poll(() =>
+          page.evaluate(() => ({
+            locked: document.body.hasAttribute('data-scroll-locked'),
+            paddingRight: getComputedStyle(document.body).paddingRight,
+            marginRight: getComputedStyle(document.body).marginRight,
+          })),
+        )
+        .toEqual({
+          locked,
+          paddingRight: initialBodySpacing.paddingRight,
+          marginRight: initialBodySpacing.marginRight,
+        });
+    };
+
+    await page.getByRole('button', { name: 'EN', exact: true }).click();
+    await expect(page.getByRole('menuitem', { name: 'English' })).toBeVisible();
+    await expectBodyScrollState(false);
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('menuitem', { name: 'English' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Theme' }).click();
+    await expect(page.getByRole('menuitem', { name: 'Light' })).toBeVisible();
+    await expectBodyScrollState(false);
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('menuitem', { name: 'Light' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+    await expectBodyScrollState(true);
   });
 });

--- a/e2e/tests/home-to-generation.spec.ts
+++ b/e2e/tests/home-to-generation.spec.ts
@@ -1,14 +1,47 @@
 import { test, expect } from '../fixtures/base';
 import { HomePage } from '../pages/home.page';
 import { createSettingsStorage } from '../fixtures/test-data/settings';
+import type { Page } from '@playwright/test';
 
 // Inject settings with modelId so the "enter classroom" button works
 const SETTINGS_STORAGE = createSettingsStorage();
+
+interface BodySpacing {
+  paddingRight: string;
+  marginRight: string;
+}
+
+async function readBodySpacing(page: Page): Promise<BodySpacing> {
+  return page.evaluate(() => {
+    const styles = getComputedStyle(document.body);
+    return {
+      paddingRight: styles.paddingRight,
+      marginRight: styles.marginRight,
+    };
+  });
+}
+
+async function expectBodyScrollState(page: Page, initialSpacing: BodySpacing, locked: boolean) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        locked: document.body.hasAttribute('data-scroll-locked'),
+        paddingRight: getComputedStyle(document.body).paddingRight,
+        marginRight: getComputedStyle(document.body).marginRight,
+      })),
+    )
+    .toEqual({
+      locked,
+      paddingRight: initialSpacing.paddingRight,
+      marginRight: initialSpacing.marginRight,
+    });
+}
 
 test.describe('Home → Generation', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript((settings) => {
       localStorage.setItem('settings-storage', settings);
+      localStorage.setItem('locale', 'en-US');
     }, SETTINGS_STORAGE);
   });
 
@@ -29,5 +62,17 @@ test.describe('Home → Generation', () => {
     await home.submit();
     await page.waitForURL(/\/generation-preview/);
     expect(page.url()).toContain('/generation-preview');
+  });
+
+  test('keeps body spacing stable when the settings dialog opens', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.goto();
+    await expect(home.logo).toBeVisible();
+
+    const initialBodySpacing = await readBodySpacing(page);
+
+    await page.locator('button:has(svg.lucide-settings)').first().click();
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+    await expectBodyScrollState(page, initialBodySpacing, true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes overlay layout shift when opening the header language menu, theme menu, and Settings dialog from the homepage or classroom shells.

## Related Issues

Closes #689

## Changes

- Make the classroom language and theme dropdown menus non-modal so they do not lock body scrolling for lightweight menu interactions.
- Suppress redundant Radix scroll-lock gap compensation while preserving modal focus and interaction locking.
- Keep the Settings dialog modal behavior intact while preventing its body spacing compensation from shifting the fixed-height classroom layout.
- Add Playwright regression tests covering homepage Settings, classroom Settings, and classroom header dropdown body spacing behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open the homepage and click the Settings gear.
2. Open a classroom stage in playback or edit mode.
3. Open the language dropdown, theme dropdown, and Settings dialog from the classroom header.
4. Confirm the page/classroom content does not horizontally shift while overlays open or close.

### What you personally verified

- `pnpm exec playwright test e2e/tests/classroom-interaction.spec.ts --grep "keeps body spacing stable for header menus and settings modal" --workers=1`
- `pnpm exec playwright test e2e/tests/home-to-generation.spec.ts --grep "keeps body spacing stable when the settings dialog opens" --workers=1`
- `pnpm exec eslint app/classroom/[id]/page.tsx components/language-switcher.tsx components/stage/header-controls.tsx e2e/tests/classroom-interaction.spec.ts`
- `pnpm exec tsc --noEmit --pretty false`
- Pre-commit hook passed: `pnpm format`, `pnpm lint --fix`, and `npx tsc --noEmit`
- The targeted ESLint command reports that the e2e spec is ignored by project config; no related source lint errors were reported.
- Full-project lint still reports existing warnings in unrelated files; this PR does not add new warnings.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [x] Local automated checks and targeted Playwright regression test passed
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
