### PR TITLE
feat(generation): parallelize scene content on the server path

### DIFF
--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -15,6 +15,8 @@ import type { AICallFn } from '@/lib/generation/pipeline-types';
 import type { AgentInfo } from '@/lib/generation/pipeline-types';
 import { getDefaultAgents } from '@/lib/orchestration/registry/store';
 import { createLogger } from '@/lib/logger';
+import { lazyBoundedMap } from '@/lib/utils/concurrency';
+import { getParallelSceneConcurrency } from '@/lib/server/provider-config';
 import { isProviderKeyRequired } from '@/lib/ai/providers';
 import { resolveClassroomWebSearchConfig } from '@/lib/server/web-search-config';
 import { resolveModel } from '@/lib/server/resolve-model';
@@ -361,25 +363,52 @@ export async function generateClassroom(
   log.info('Stage 2: Generating scene content and actions...');
   let generatedScenes = 0;
 
-  for (const [index, outline] of outlines.entries()) {
-    const safeOutline = applyOutlineFallbacks(outline, true, {
-      allowProceduralSkill: vocationalActive,
-    });
-    const progressStart = 30 + Math.floor((index / Math.max(outlines.length, 1)) * 60);
+  const safeOutlines = outlines.map((outline) =>
+    applyOutlineFallbacks(outline, true, { allowProceduralSkill: vocationalActive }),
+  );
+
+  // #660 follow-up: pre-warm scene CONTENT with bounded concurrency when the
+  // server opts into parallel generation (PARALLEL_SCENE_CONCURRENCY > 1). Content
+  // has no cross-scene dependency, so it is safe to run ahead; actions + scene
+  // assembly stay serial in the loop below to keep scenes in outline order and
+  // report progress in order. Default (0 / unset) keeps the original
+  // strictly-serial pipeline. A content failure resolves to undefined and is
+  // skipped per-scene (same as the serial path) rather than aborting the batch.
+  const sceneConcurrency = getParallelSceneConcurrency();
+  const contentPromises =
+    sceneConcurrency > 1 && safeOutlines.length > 1
+      ? lazyBoundedMap(safeOutlines, sceneConcurrency, async (safeOutline) => {
+          try {
+            return await generateSceneContent(safeOutline, aiCall, {
+              agents,
+              languageDirective,
+              allowProceduralSkill: vocationalActive,
+            });
+          } catch (err) {
+            log.warn(`Scene content generation threw for "${safeOutline.title}":`, err);
+            return undefined;
+          }
+        })
+      : null;
+
+  for (const [index, safeOutline] of safeOutlines.entries()) {
+    const progressStart = 30 + Math.floor((index / Math.max(safeOutlines.length, 1)) * 60);
 
     await options.onProgress?.({
       step: 'generating_scenes',
       progress: Math.max(progressStart, 31),
-      message: `Generating scene ${index + 1}/${outlines.length}: ${safeOutline.title}`,
+      message: `Generating scene ${index + 1}/${safeOutlines.length}: ${safeOutline.title}`,
       scenesGenerated: generatedScenes,
-      totalScenes: outlines.length,
+      totalScenes: safeOutlines.length,
     });
 
-    const content = await generateSceneContent(safeOutline, aiCall, {
-      agents,
-      languageDirective,
-      allowProceduralSkill: vocationalActive,
-    });
+    const content = contentPromises
+      ? await contentPromises[index]
+      : await generateSceneContent(safeOutline, aiCall, {
+          agents,
+          languageDirective,
+          allowProceduralSkill: vocationalActive,
+        });
     if (!content) {
       log.warn(`Skipping scene "${safeOutline.title}" — content generation failed`);
       continue;


### PR DESCRIPTION
## What & why

Follow-up to #660 (merged), which added opt-in parallel scene-**content** generation to the **client** path. The **server** path — `lib/server/classroom-generation.ts`, used by `/api/generate-classroom` and the background job-runner — was still strictly serial (`for … of outlines` → `await generateSceneContent` → `await generateSceneActions`), so server-side / background generations got none of #660’s speedup. #572 listed this as the explicit "adopt the same pattern later" item.

Closes #697.

## Change

Mirror #660’s pipeline on the server:
- **Pre-warm scene content** with bounded concurrency via `lazyBoundedMap`, reusing the server-side `getParallelSceneConcurrency()` helper (both added in #660).
- Keep the existing **serial loop** for actions + scene assembly + `onProgress` reporting, so scenes stay in **outline order** and progress events fire in order.

Properties:
- Gated by the same `PARALLEL_SCENE_CONCURRENCY` env. **Default `0`/unset is byte-for-byte the original serial pipeline.**
- Content has no cross-scene dependency, so running it ahead is safe; a content failure resolves to `undefined` and is **skipped per-scene exactly as today** (the parallel callback also catches throws → `undefined`, so one bad scene never aborts the batch).

## Test plan

`npx vitest run` — **742 tests pass**; `tsc`/`prettier`/`eslint` clean. The concurrency mechanism is already unit-tested (`tests/utils/concurrency.test.ts`); the serial default path is unchanged. (`classroom-generation.ts` orchestrates LLM/IO and has no existing unit test — same as the rest of the server pipeline.)

No user-facing strings (no i18n impact).