### PR TITLE
fix(importer): include all color attributes in style cache key

### DIFF
--- a/packages/@maic/importer/src/serializer/StyleResolver.ts
+++ b/packages/@maic/importer/src/serializer/StyleResolver.ts
@@ -19,19 +19,32 @@ import { pctToDecimal, angleToDeg, emuToPx } from '../parser/units';
 // ---------------------------------------------------------------------------
 
 /**
- * Build a cache key for a color node based on its tag, value, and modifiers.
+ * Attributes that carry a color's identity across the OOXML color types:
+ *   srgbClr/schemeClr/prstClr@val, sysClr@lastClr (falls back to @val),
+ *   hslClr@hue/@sat/@lum, scrgbClr@r/@g/@b, and modifiers (lumMod, tint, …)@val.
+ * Keying on @val alone makes every scrgbClr and hslClr (and any sysClr differing
+ * only by @lastClr) collide in the cache, so the first such color resolved is
+ * wrongly reused for all later ones. Including these attributes keeps the key
+ * faithful to what resolveColorUncached actually reads.
+ */
+const COLOR_KEY_ATTRS = ['val', 'lastClr', 'r', 'g', 'b', 'hue', 'sat', 'lum'] as const;
+
+function colorNodeSignature(node: SafeXmlNode): string {
+  const attrs = COLOR_KEY_ATTRS.map((name) => node.attr(name) ?? '').join(',');
+  return `${node.localName}:${attrs}`;
+}
+
+/**
+ * Build a cache key for a color node based on its tag, identifying attributes,
+ * and nested modifier children.
  */
 function buildColorCacheKey(colorNode: SafeXmlNode): string {
-  const parts: string[] = [colorNode.localName, colorNode.attr('val') ?? ''];
+  const parts: string[] = [colorNodeSignature(colorNode)];
   for (const child of colorNode.allChildren()) {
-    const tag = child.localName;
-    const val = child.attr('val');
-    if (tag) parts.push(`${tag}:${val ?? ''}`);
+    if (child.localName) parts.push(colorNodeSignature(child));
     // Include nested color children for wrapper nodes
     for (const grandchild of child.allChildren()) {
-      const gtag = grandchild.localName;
-      const gval = grandchild.attr('val');
-      if (gtag) parts.push(`${gtag}:${gval ?? ''}`);
+      if (grandchild.localName) parts.push(colorNodeSignature(grandchild));
     }
   }
   return parts.join('|');


### PR DESCRIPTION
## Problem

In the newly-added `@maic/importer`, `StyleResolver.buildColorCacheKey` builds the color cache key from each node's `localName` + `@val` only. But `resolveColorUncached` reads several OOXML color types from **other** attributes:

| color type | identity attributes read | in cache key? |
|---|---|---|
| `scrgbClr` | `@r` `@g` `@b` | ❌ |
| `hslClr` | `@hue` `@sat` `@lum` | ❌ |
| `sysClr` | `@lastClr` | ❌ |

So every `scrgbClr` fill yields the **same** key regardless of its RGB (likewise every `hslClr`). The first such color resolved in a `RenderContext` is cached and then wrongly returned for every later one.

### Collision trace
Two shapes on one slide:
- A: `<a:solidFill><a:scrgbClr r="100000" g="0" b="0"/></a:solidFill>` → red
- B: `<a:solidFill><a:scrgbClr r="0" g="0" b="100000"/></a:solidFill>` → blue

`buildColorCacheKey` returns `solidFill||scrgbClr:` for **both** → B reuses A's cached **red**. Live on the import path (`lib/import/use-import-pptx.ts` → `@maic/importer` → `resolveFill` → `resolveColor`).

## Fix

Key each node by the full set of value-bearing attributes the resolver actually reads — `val, lastClr, r, g, b, hue, sat, lum` — applied to the top-level node **and** its children/grandchildren (the top-level node can itself be a bare `scrgbClr`/`hslClr`/`sysClr`, e.g. lines 167-190). Behavior-preserving for all previously-distinct keys; only previously-colliding keys become distinct.

With the fix the two fills above key to `…|scrgbClr:,,100000,0,0,,,` vs `…|scrgbClr:,,0,0,100000,,,` — distinct, correct colors.

## Notes
- No test added: `@maic/importer` currently ships no test setup, the root vitest config globs only `tests/**` with no DOM env, and `parseXml` needs `DOMParser` — a regression test would require standing up jsdom + a package test harness, out of scope for this fix. The collision trace above is the verification.
- Verified locally: `prettier` clean, `eslint` clean, `tsc --noEmit` error count unchanged (the only errors are pre-existing unresolved-workspace-module noise; `StyleResolver.ts` type-checks clean).

Closes #702
