### PR TITLE
fix(export): preserve attributes before an empty style attribute (#682)

### DIFF
--- a/lib/export/html-parser/stringify.ts
+++ b/lib/export/html-parser/stringify.ts
@@ -5,7 +5,7 @@ export const formatAttributes = (attributes: ElementAttribute[]) => {
   return attributes.reduce((attrs, attribute) => {
     const { key, value } = attribute;
     if (value === null) return `${attrs} ${key}`;
-    if (key === 'style' && !value) return '';
+    if (key === 'style' && !value) return attrs;
 
     const quoteEscape = value.indexOf("'") !== -1;
     const quote = quoteEscape ? '"' : "'";

--- a/tests/export/stringify.test.ts
+++ b/tests/export/stringify.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { formatAttributes, toHTML } from '@/lib/export/html-parser/stringify';
+import type { AST, ElementAttribute } from '@/lib/export/html-parser/types';
+
+describe('formatAttributes', () => {
+  it('formats a value attribute with single quotes', () => {
+    const attrs: ElementAttribute[] = [{ key: 'id', value: 'main' }];
+    expect(formatAttributes(attrs)).toBe(" id='main'");
+  });
+
+  it('renders a null value as a boolean attribute', () => {
+    const attrs: ElementAttribute[] = [{ key: 'disabled', value: null }];
+    expect(formatAttributes(attrs)).toBe(' disabled');
+  });
+
+  it('switches to double quotes when the value contains a single quote', () => {
+    const attrs: ElementAttribute[] = [{ key: 'data-x', value: "it's" }];
+    expect(formatAttributes(attrs)).toBe(' data-x="it\'s"');
+  });
+
+  it('omits an empty style attribute', () => {
+    const attrs: ElementAttribute[] = [{ key: 'style', value: '' }];
+    expect(formatAttributes(attrs)).toBe('');
+  });
+
+  it('keeps attributes accumulated before an empty style attribute (regression #682)', () => {
+    const attrs: ElementAttribute[] = [
+      { key: 'id', value: 'a' },
+      { key: 'style', value: '' },
+      { key: 'class', value: 'b' },
+    ];
+    // Previously the empty-style branch returned '' and wiped `id`.
+    expect(formatAttributes(attrs)).toBe(" id='a' class='b'");
+  });
+
+  it('preserves a non-empty style attribute', () => {
+    const attrs: ElementAttribute[] = [
+      { key: 'id', value: 'a' },
+      { key: 'style', value: 'color:red' },
+    ];
+    expect(formatAttributes(attrs)).toBe(" id='a' style='color:red'");
+  });
+});
+
+describe('toHTML', () => {
+  it('serializes an element whose first attribute precedes an empty style (regression #682)', () => {
+    const tree: AST[] = [
+      {
+        type: 'element',
+        tagName: 'div',
+        attributes: [
+          { key: 'id', value: 'box' },
+          { key: 'style', value: '' },
+        ],
+        children: [{ type: 'text', content: 'hi' }],
+      },
+    ];
+    expect(toHTML(tree)).toBe("<div id='box'>hi</div>");
+  });
+
+  it('serializes void tags without a closing tag', () => {
+    const tree: AST[] = [
+      {
+        type: 'element',
+        tagName: 'br',
+        attributes: [],
+        children: [],
+      },
+    ];
+    expect(toHTML(tree)).toBe('<br>');
+  });
+
+  it('passes through text and comment nodes', () => {
+    const tree: AST[] = [
+      { type: 'text', content: 'a' },
+      { type: 'comment', content: ' note ' },
+    ];
+    expect(toHTML(tree)).toBe('a<!-- note -->');
+  });
+});


### PR DESCRIPTION
### Bug

`formatAttributes` in `lib/export/html-parser/stringify.ts` drops every attribute accumulated **before** an empty `style` attribute, because the empty-style branch returns `''` — which becomes the new `reduce` accumulator — instead of the accumulated string. Closes #682.

```ts
if (key === 'style' && !value) return '';   // resets the accumulator
```

For an element like `{ id: 'box', style: '' }`, serialization produced `<div>` instead of `<div id='box'>` — the `id` (and any other earlier attribute) silently disappears from exported HTML.

### Fix

Return the accumulator unchanged so the empty `style` is skipped without discarding prior attributes:

```ts
if (key === 'style' && !value) return attrs;
```

### Tests

Adds `tests/export/stringify.test.ts` (none existed for this module):

- `formatAttributes`: value attribute quoting, `null` → boolean attribute, single→double quote switch when the value contains `'`, empty `style` omitted, **regression: attributes before an empty `style` are kept**, non-empty `style` preserved
- `toHTML`: element whose first attribute precedes an empty `style` (regression), void-tag serialization, text/comment passthrough

### Verification

```
$ npx vitest run tests/export/stringify.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

`prettier --check`, `eslint`, and `tsc --noEmit` all clean.
