### PR TITLE
fix(audio): gate SpeechButton on ASR availability

### DIFF
--- a/components/audio/speech-button.tsx
+++ b/components/audio/speech-button.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { Mic, Loader2 } from 'lucide-react';
 import { useAudioRecorder } from '@/lib/hooks/use-audio-recorder';
+import { useASRAvailable } from '@/lib/hooks/use-asr-available';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -44,6 +45,13 @@ export function SpeechButton({
 
   const active = isRecording || isProcessing;
 
+  // Gate on ASR availability (toggle + provider configured + browser support)
+  // so every call site is disabled uniformly when ASR is off/unusable — but
+  // never while actively recording/processing, so the user can always click to
+  // stop (the recorder has no auto-stop and would otherwise leave the mic open).
+  const asrAvailable = useASRAvailable();
+  const isDisabled = (disabled || !asrAvailable) && !active;
+
   const handleClick = () => {
     if (isRecording) {
       stopRecording();
@@ -62,7 +70,7 @@ export function SpeechButton({
       <TooltipTrigger asChild>
         <button
           type="button"
-          disabled={disabled || isProcessing}
+          disabled={isDisabled || isProcessing}
           onClick={handleClick}
           className={cn(
             'relative flex items-center justify-center rounded-lg transition-all duration-200 shrink-0 cursor-pointer',
@@ -70,7 +78,7 @@ export function SpeechButton({
             active
               ? 'bg-violet-500/90 dark:bg-violet-600/80 text-white shadow-[0_0_12px_rgba(139,92,246,0.45)] dark:shadow-[0_0_12px_rgba(139,92,246,0.3)]'
               : 'text-muted-foreground/60 hover:text-muted-foreground hover:bg-muted/80',
-            disabled && 'opacity-40 pointer-events-none',
+            isDisabled && 'opacity-40 pointer-events-none',
             className,
           )}
         >

--- a/lib/hooks/use-asr-available.ts
+++ b/lib/hooks/use-asr-available.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { useSettingsStore } from '@/lib/store/settings';
+import { ASR_PROVIDERS } from '@/lib/audio/constants';
+import type { BuiltInASRProviderId } from '@/lib/audio/types';
+
+// Web Speech API support is constant per environment, so subscribing is a no-op.
+const subscribe = () => () => {};
+const getBrowserSpeechSupported = () =>
+  !!(window.SpeechRecognition || window.webkitSpeechRecognition);
+
+/**
+ * Single source of truth for "can the user use ASR right now".
+ *
+ * Combines the three things that gate speech input:
+ * - the global on/off toggle (`asrEnabled`),
+ * - whether the selected provider is actually usable (keyless, has a client
+ *   key, or is server-managed — mirrors the `cfgOk` check in media-popover),
+ * - and, for `browser-native`, whether the browser supports the Web Speech API.
+ *
+ * Consumed by `SpeechButton` so every call site is gated uniformly instead of
+ * each one having to remember to wire the toggle through a `disabled` prop.
+ */
+export function useASRAvailable(): boolean {
+  const asrEnabled = useSettingsStore((s) => s.asrEnabled);
+  const asrProviderId = useSettingsStore((s) => s.asrProviderId);
+  const providerConfig = useSettingsStore((s) => s.asrProvidersConfig[s.asrProviderId]);
+
+  // SSR-safe Web Speech support check: the server snapshot assumes supported so
+  // the button is never falsely disabled before hydration.
+  const browserSpeechSupported = useSyncExternalStore(
+    subscribe,
+    getBrowserSpeechSupported,
+    () => true,
+  );
+
+  const builtIn = ASR_PROVIDERS[asrProviderId as BuiltInASRProviderId];
+  const requiresKey = builtIn ? builtIn.requiresApiKey : (providerConfig?.requiresApiKey ?? true);
+  const configured =
+    !requiresKey || !!providerConfig?.apiKey || !!providerConfig?.isServerConfigured;
+  const browserOk = asrProviderId !== 'browser-native' || browserSpeechSupported;
+
+  return asrEnabled && configured && browserOk;
+}

--- a/lib/hooks/use-asr-available.ts
+++ b/lib/hooks/use-asr-available.ts
@@ -37,9 +37,14 @@ export function useASRAvailable(): boolean {
 
   const builtIn = ASR_PROVIDERS[asrProviderId as BuiltInASRProviderId];
   const requiresKey = builtIn ? builtIn.requiresApiKey : (providerConfig?.requiresApiKey ?? true);
-  const configured =
-    !requiresKey || !!providerConfig?.apiKey || !!providerConfig?.isServerConfigured;
+  // Trim to match what the recorder actually sends — a whitespace-only key is
+  // dropped at request time, so it must not count as configured here.
+  const keyOk =
+    !requiresKey || !!providerConfig?.apiKey?.trim() || !!providerConfig?.isServerConfigured;
+  // Custom providers are unusable until at least one model is configured
+  // (mirrors the media-popover listing rule that hides model-less customs).
+  const modelOk = !!builtIn || (providerConfig?.customModels?.length ?? 0) > 0;
   const browserOk = asrProviderId !== 'browser-native' || browserSpeechSupported;
 
-  return asrEnabled && configured && browserOk;
+  return asrEnabled && keyOk && modelOk && browserOk;
 }


### PR DESCRIPTION
Closes #710

### Problem

`SpeechButton` only honors the `disabled` prop and never reads ASR state, so call sites must each remember to wire it. The home page passes nothing, leaving the mic button clickable even when ASR is turned off.

### Fix

- Add `lib/hooks/use-asr-available.ts` — a single source of truth combining the three things that gate speech input: the `asrEnabled` toggle, whether the selected provider is usable (keyless / has a key / server-managed, mirroring the `cfgOk` check in the media popover), and Web Speech API support for `browser-native` (via `useSyncExternalStore`, SSR-safe).
- Have `SpeechButton` consume `useASRAvailable()` internally. The external `disabled` prop still composes on top, so existing call-site conditions (e.g. `isLoading`) keep working. Every call site — home, PBL chat, quiz — is now gated uniformly; new call sites are protected by default.

No call-site changes required.

### Test

- `tsc --noEmit` clean (no new errors); `eslint` clean.
- Toggling ASR off greys out and disables the button across all call sites; switching to an unconfigured key-required provider, or a browser without Web Speech support, does the same.