### PR TITLE
fix(audio): track string context when splitting Doubao TTS stream (#676)

### DIFF
--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -845,6 +845,51 @@ export async function getCurrentTTSConfig(): Promise<TTSModelConfig> {
 export { getAllTTSProviders, getTTSProvider, getTTSVoices } from './constants';
 
 /**
+ * Split a run of concatenated JSON objects (no delimiter between them) into
+ * individual object strings. Tracks string context and escapes so that a `{`
+ * or `}` inside a string value does not mis-align object boundaries.
+ */
+export function splitConcatenatedJsonObjects(text: string): string[] {
+  const objects: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escapeNext = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+    if (char === '\\' && inString) {
+      escapeNext = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (char === '{') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (char === '}') {
+      if (depth === 0) continue; // stray closer outside any object
+      depth--;
+      if (depth === 0 && start >= 0) {
+        objects.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+
+  return objects;
+}
+
+/**
  * Doubao TTS 2.0 implementation (Volcengine Seed-TTS 2.0)
  */
 async function generateDoubaoTTS(
@@ -890,38 +935,23 @@ async function generateDoubaoTTS(
   const responseText = await response.text();
   const audioChunks: Uint8Array[] = [];
 
-  let depth = 0;
-  let start = -1;
-  for (let i = 0; i < responseText.length; i++) {
-    if (responseText[i] === '{') {
-      if (depth === 0) start = i;
-      depth++;
-    } else if (responseText[i] === '}') {
-      depth--;
-      if (depth === 0 && start >= 0) {
-        let chunk: { code: number; message?: string; data?: string };
-        try {
-          chunk = JSON.parse(responseText.slice(start, i + 1));
-        } catch {
-          start = -1;
-          continue;
-        }
-        start = -1;
+  for (const objText of splitConcatenatedJsonObjects(responseText)) {
+    let chunk: { code: number; message?: string; data?: string };
+    try {
+      chunk = JSON.parse(objText);
+    } catch {
+      continue;
+    }
 
-        if (chunk.code === 0 && chunk.data) {
-          audioChunks.push(new Uint8Array(Buffer.from(chunk.data, 'base64')));
-        } else if (chunk.code === 20000000) {
-          break;
-        } else if (chunk.code && chunk.code !== 0) {
-          if (chunk.code === 45000000 || chunk.code === 45000292) {
-            throw new TTSRateLimitError(
-              'doubao-tts',
-              chunk.message || 'concurrency quota exceeded',
-            );
-          }
-          throw new Error(`Doubao TTS error: ${chunk.message || 'unknown'} (code: ${chunk.code})`);
-        }
+    if (chunk.code === 0 && chunk.data) {
+      audioChunks.push(new Uint8Array(Buffer.from(chunk.data, 'base64')));
+    } else if (chunk.code === 20000000) {
+      break;
+    } else if (chunk.code && chunk.code !== 0) {
+      if (chunk.code === 45000000 || chunk.code === 45000292) {
+        throw new TTSRateLimitError('doubao-tts', chunk.message || 'concurrency quota exceeded');
       }
+      throw new Error(`Doubao TTS error: ${chunk.message || 'unknown'} (code: ${chunk.code})`);
     }
   }
 

--- a/tests/audio/tts-providers-split.test.ts
+++ b/tests/audio/tts-providers-split.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { splitConcatenatedJsonObjects } from '@/lib/audio/tts-providers';
+
+describe('splitConcatenatedJsonObjects', () => {
+  it('returns an empty array for empty or object-free input', () => {
+    expect(splitConcatenatedJsonObjects('')).toEqual([]);
+    expect(splitConcatenatedJsonObjects('no json here')).toEqual([]);
+  });
+
+  it('extracts a single object', () => {
+    expect(splitConcatenatedJsonObjects('{"code":0}')).toEqual(['{"code":0}']);
+  });
+
+  it('splits two concatenated objects with no delimiter', () => {
+    const out = splitConcatenatedJsonObjects('{"code":0,"data":"a"}{"code":20000000}');
+    expect(out).toEqual(['{"code":0,"data":"a"}', '{"code":20000000}']);
+    expect(out.map((o) => JSON.parse(o))).toEqual([{ code: 0, data: 'a' }, { code: 20000000 }]);
+  });
+
+  it('does not split on a brace inside a string value (regression #676)', () => {
+    const out = splitConcatenatedJsonObjects('{"code":1,"message":"bad {input}"}');
+    expect(out).toEqual(['{"code":1,"message":"bad {input}"}']);
+    expect(JSON.parse(out[0])).toEqual({ code: 1, message: 'bad {input}' });
+  });
+
+  it('keeps following objects aligned after a brace-in-string object', () => {
+    const text = '{"code":1,"message":"oops }{"}{"code":0,"data":"xyz"}';
+    const out = splitConcatenatedJsonObjects(text);
+    expect(out).toHaveLength(2);
+    expect(JSON.parse(out[0])).toEqual({ code: 1, message: 'oops }{' });
+    expect(JSON.parse(out[1])).toEqual({ code: 0, data: 'xyz' });
+  });
+
+  it('handles escaped quotes inside string values', () => {
+    const text = '{"message":"he said \\"{hi}\\""}{"code":0}';
+    const out = splitConcatenatedJsonObjects(text);
+    expect(out).toHaveLength(2);
+    expect(JSON.parse(out[0])).toEqual({ message: 'he said "{hi}"' });
+    expect(JSON.parse(out[1])).toEqual({ code: 0 });
+  });
+
+  it('treats nested objects as a single top-level object', () => {
+    const text = '{"a":{"b":{"c":1}}}{"d":2}';
+    const out = splitConcatenatedJsonObjects(text);
+    expect(out).toEqual(['{"a":{"b":{"c":1}}}', '{"d":2}']);
+  });
+
+  it('ignores leading/trailing noise and stray closers', () => {
+    expect(splitConcatenatedJsonObjects('}}{"code":0}xx')).toEqual(['{"code":0}']);
+  });
+});


### PR DESCRIPTION
### Bug

The Doubao TTS provider (`lib/audio/tts-providers.ts`) splits its streamed response — a run of concatenated JSON objects with no delimiter — by counting `{`/`}` braces, but the counter does not track string context. A `{` or `}` inside a JSON string value mis-aligns the object boundaries. Closes #676.

For example, an error chunk `{"code":1,"message":"bad {input}"}` — the `}` inside `message` decrements `depth` early, so the object is split mid-string. `JSON.parse` of the fragment throws and the chunk is dropped (audio lost, or the real error swallowed). Worse, every following object in the stream stays mis-aligned.

### Fix

Extract a pure, unit-testable `splitConcatenatedJsonObjects(text)` helper that tracks string context and escapes while scanning — the same approach the depth-scanner in `lib/generation/json-repair.ts` already uses — and refactor the Doubao loop to iterate over its output. Behavior is unchanged for well-formed streams; only brace-in-string (and escaped-quote) cases are now handled correctly.

### Tests

Adds `tests/audio/tts-providers-split.test.ts`:

- single object; two concatenated objects with no delimiter
- **brace inside a string value is not split (regression)**
- following objects stay aligned after a brace-in-string object
- escaped quotes inside string values
- nested objects treated as one top-level object
- empty / noise / stray-closer inputs

### Verification

```
$ npx vitest run tests/audio/tts-providers-split.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

`prettier --check`, `eslint`, and `tsc --noEmit` all clean.
