### PR TITLE
fix(mathml2omml): call includes() instead of indexing it, preserving trailing text (#680)

### DIFF
--- a/packages/mathml2omml/src/parse-stringify/parse.js
+++ b/packages/mathml2omml/src/parse-stringify/parse.js
@@ -79,7 +79,7 @@ export function parse(html, options = {}) {
       }
       if (
         level > -1 &&
-        textContainerNames.includes[arr[level].name] &&
+        textContainerNames.includes(arr[level].name) &&
         nextChar !== '<' &&
         nextChar
       ) {

--- a/tests/export/mathml2omml-trailing-text.test.ts
+++ b/tests/export/mathml2omml-trailing-text.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { mml2omml } from 'mathml2omml';
+
+/**
+ * Regression for #680: parse.js indexed `textContainerNames.includes[...]`
+ * instead of calling `.includes(...)`, so the "trailing text node" branch was
+ * always skipped and trailing text inside a text container was dropped.
+ */
+describe('mml2omml trailing text in text containers (#680)', () => {
+  it('preserves text that trails a child element inside <mtext>', () => {
+    const omml = mml2omml('<math><mtext>a<mspace/>b</mtext></math>');
+    // The trailing "b" used to be silently dropped.
+    expect(omml).toContain('b');
+    expect(omml).toContain('a');
+  });
+
+  it('preserves trailing text inside <mi>', () => {
+    const omml = mml2omml('<math><mi>f<mspace/>g</mi></math>');
+    expect(omml).toContain('g');
+  });
+
+  it('still emits valid OMML for a plain text container', () => {
+    const omml = mml2omml('<math><mtext>hello</mtext></math>');
+    expect(omml).toContain('hello');
+    expect(omml).toContain('m:oMath');
+  });
+});


### PR DESCRIPTION
### Bug

In the vendored `mathml2omml` package, `parse.js` indexes the `includes` **method** instead of calling it:

```js
textContainerNames.includes[arr[level].name] &&   // always undefined → falsy
```

`textContainerNames` is an array; `arr[level].name` is a string like `"mtext"`. `Array.prototype.includes` has no such index property, so the expression is always `undefined` (falsy). The whole "trailing text node" branch is therefore never taken, and trailing text inside a text container (`mtext`/`mi`/`mn`/`mo`/`ms`) is silently dropped. Closes #680.

### Fix

Call the method:

```js
textContainerNames.includes(arr[level].name) &&
```

(The sibling check on line 48 already uses the correct `includes(...)` call.)

### Verification

Before/after on the rebuilt package:

```
input:  <math><mtext>a<mspace/>b</mtext></math>
buggy:  OMML contains "b" → false   (trailing "b" dropped)
fixed:  OMML contains "b" → true
```

Adds `tests/export/mathml2omml-trailing-text.test.ts` (3 cases: trailing text in `<mtext>` and `<mi>`, plus a plain-text-container sanity check):

```
$ npx vitest run tests/export/mathml2omml-trailing-text.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`prettier --check` and `eslint` clean. Source change is a single character-level edit (`[ ]` → `( )`).
