### PR TITLE
fix(vocational): send taskEngineMode on the on-demand scene generation path

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -175,6 +175,7 @@ export default function ClassroomDetailPage() {
           agents: params.agents,
           userProfile: params.userProfile,
           languageDirective: params.languageDirective || stage.languageDirective,
+          taskEngineMode: stage.taskEngineMode,
         });
       });
     } else if (outlines.length > 0 && stage) {

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -83,6 +83,7 @@ async function fetchSceneContent(
     };
     agents?: AgentInfo[];
     languageDirective?: string;
+    requirements?: { taskEngineMode?: boolean };
   },
   signal?: AbortSignal,
 ): Promise<SceneContentResult> {
@@ -269,6 +270,8 @@ export interface GenerationParams {
   agents?: AgentInfo[];
   userProfile?: string;
   languageDirective?: string;
+  /** Vocational task-engine flag; gates procedural-skill generation server-side (see resolveVocationalActive). */
+  taskEngineMode?: boolean;
 }
 
 export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
@@ -372,6 +375,7 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
               stageInfo: params.stageInfo,
               agents: params.agents,
               languageDirective: params.languageDirective,
+              requirements: { taskEngineMode: params.taskEngineMode === true },
             },
             signal,
           );
@@ -617,6 +621,7 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
             stageInfo: params.stageInfo,
             agents: params.agents,
             languageDirective: params.languageDirective,
+            requirements: { taskEngineMode: params.taskEngineMode === true },
           },
           signal,
         );


### PR DESCRIPTION
Fixes #715.

## Problem

The vocational task-engine gate is driven by `requirements.taskEngineMode` in the `/api/generate/scene-content` request body (`resolveVocationalActive` → `applyOutlineFallbacks({ allowProceduralSkill })`). Only the **first** scene sends it (`app/generation-preview/page.tsx`). Scenes 2..N and retries are generated by `useSceneGenerator.generateRemaining` / `fetchSceneContent`, which never included `requirements` — so `vocationalActive` was `false` for them and `applyOutlineFallbacks` rewrote every `procedural-skill` outline to `diagram`. The outline says `procedural-skill`, the content path strips it; most scenes of a vocational course silently lose the task-engine widget. (Full trace in #715.)

## Fix (minimal, client-side)

`taskEngineMode` is already persisted on the stage (`lib/types/stage.ts`, `lib/utils/database.ts`, written in `stage-storage.ts`), so this mirrors what scene 1 already does:

- add `taskEngineMode?: boolean` to `GenerationParams`
- populate it at the single `generateRemaining(...)` call site from `stage.taskEngineMode`
- include `requirements: { taskEngineMode: params.taskEngineMode === true }` in both `fetchSceneContent` bodies

The retry path (`retrySingleOutline`) inherits it automatically — it reuses `lastParamsRef.current`. **Server contract is unchanged**; the flag is still ANDed with the `OPENMAIC_ENABLE_VOCATIONAL` env gate, so this is not a security/routing change — it only stops the client from dropping a flag it already sends for scene 1.

## Note on approach

This is the smallest fix that restores parity with the first-scene path. If you'd prefer a **server-authoritative** shape instead — e.g. persisting `taskEngineMode` onto the outline so the content route doesn't depend on the client re-sending it — I'm happy to revise this PR that way; it's your feature and I'd rather match your intended design.

## Verification
- `prettier` clean, `eslint` clean, `tsc --noEmit` error count unchanged (only pre-existing unresolved `@maic/*` workspace-module errors; neither edited file appears).
- No test added: the server gate this feeds is already covered by `tests/generation/scene-content-route-vocational-gate.test.ts`; the gap is purely the client hook's request body, and the repo has no React-hook (renderHook + fetch-mock + Zustand) harness to assert it without adding disproportionate test infra. Happy to add one if you'd like to introduce that harness.
