### PR TITLE
fix(web-search): accept <div> result titles in Brave keyless scraper

### DIFF
--- a/lib/web-search/brave.ts
+++ b/lib/web-search/brave.ts
@@ -71,10 +71,11 @@ export function parseBraveSearchHtml(html: string, maxResults: number): WebSearc
     const url = decodeHtml(linkMatch[1].trim());
     if (!url || isBraveOwnedUrl(url)) continue;
 
+    // Brave has used both <span> and <div> for the result title over time
     const titleMatch = block.match(
-      /<span[^>]*class="[^"]*search-snippet-title[^"]*"[^>]*>([\s\S]*?)<\/span>/i,
+      /<(span|div)[^>]*class="[^"]*search-snippet-title[^"]*"[^>]*>([\s\S]*?)<\/\1>/i,
     );
-    const title = titleMatch ? stripHtml(titleMatch[1]) : '';
+    const title = titleMatch ? stripHtml(titleMatch[2]) : '';
     if (!title) continue;
 
     const genericMatch = block.match(

--- a/tests/web-search/brave.test.ts
+++ b/tests/web-search/brave.test.ts
@@ -10,20 +10,21 @@ import { parseBraveSearchHtml, searchWithBrave } from '@/lib/web-search/brave';
 
 describe('parseBraveSearchHtml', () => {
   it('extracts web results, decodes entities, strips date prefixes, and skips Brave links', () => {
+    // Brave's current markup: the result title is a <div>, not a <span>
     const html = `
       <div class="snippet svelte-abc" data-pos="0" data-type="web">
         <a href="https://example.com/a?x=1&amp;y=2">
-          <span class="search-snippet-title">Example &amp; Title</span>
+          <div class="title search-snippet-title line-clamp-1 svelte-abc" title="Example &amp; Title">Example &amp; Title</div>
         </a>
         <div class="generic-snippet">Jan 1, 2026 - Result <strong>content</strong> &amp; more</div>
       </div>
       <div class="snippet svelte-def" data-pos="1" data-type="web">
-        <a href="https://search.brave.com/help"><span class="search-snippet-title">Brave Help</span></a>
+        <a href="https://search.brave.com/help"><div class="title search-snippet-title line-clamp-1">Brave Help</div></a>
         <div class="generic-snippet">Internal Brave result</div>
       </div>
       <div class="snippet svelte-ghi" data-pos="2" data-type="web">
         <a href="https://second.example.com">
-          <span class="search-snippet-title">Second result</span>
+          <div class="title search-snippet-title line-clamp-1">Second result</div>
         </a>
         <p class="snippet-description">2 days ago - Secondary description</p>
       </div>
@@ -45,6 +46,26 @@ describe('parseBraveSearchHtml', () => {
       },
     ]);
   });
+
+  it('still parses the legacy <span> title markup', () => {
+    const html = `
+      <div class="snippet" data-type="web">
+        <a href="https://legacy.example.com">
+          <span class="search-snippet-title">Legacy title</span>
+        </a>
+        <div class="generic-snippet">Legacy content</div>
+      </div>
+    `;
+
+    expect(parseBraveSearchHtml(html, 5)).toEqual([
+      {
+        title: 'Legacy title',
+        url: 'https://legacy.example.com',
+        content: 'Legacy content',
+        score: 1,
+      },
+    ]);
+  });
 });
 
 describe('searchWithBrave', () => {
@@ -57,7 +78,7 @@ describe('searchWithBrave', () => {
       new Response(
         `
           <div class="snippet" data-type="web">
-            <a href="https://example.com"><span class="search-snippet-title">Example</span></a>
+            <a href="https://example.com"><div class="title search-snippet-title line-clamp-1">Example</div></a>
             <div class="generic-snippet">Content</div>
           </div>
         `,


### PR DESCRIPTION
## Summary
Fixes #687 — the keyless Brave web-search path returns 0 results because Brave moved the result title from a `<span>` to a `<div>`.

## Problem
`parseBraveSearchHtml` matched the title with a `<span class="search-snippet-title">`-only regex. Brave's current markup is:

```html
<div class="title search-snippet-title line-clamp-1 …" title="Title">Title</div>
```

So `titleMatch` was always null, `if (!title) continue;` skipped every snippet, and the scraper returned an empty list even though the page contained 20 `data-type="web"` blocks (see the live evidence in #687).

## Fix
Accept either tag for the title element, using a backreference so the open/close tags stay consistent:

```ts
/<(span|div)[^>]*class="[^"]*search-snippet-title[^"]*"[^>]*>([\s\S]*?)<\/\1>/i
```

## Tests
- Updated the `parseBraveSearchHtml` and `searchWithBrave` fixtures to Brave's current `<div>` markup (the old fixtures had drifted from the live page, which is why the suite stayed green through the breakage).
- Added a dedicated legacy `<span>` case so back-compat stays covered.
- `tests/web-search`: 25 tests green; `prettier --check` clean.

Note on live verification: repeat scrapes from my IP are currently answered with HTTP 429 (Brave rate-limits rapid keyless requests — consistent with the best-effort caveat in #687), so the fixtures mirror the live markup captured in the issue's evidence rather than a fresh scrape.
