### PR TITLE
fix(web-search): accept div result titles in Brave keyless scraper

### DIFF
--- a/lib/web-search/brave.ts
+++ b/lib/web-search/brave.ts
@@ -71,10 +71,12 @@ export function parseBraveSearchHtml(html: string, maxResults: number): WebSearc
     const url = decodeHtml(linkMatch[1].trim());
     if (!url || isBraveOwnedUrl(url)) continue;
 
+    // Brave has shipped the result title as both <span> and <div> over time;
+    // accept either so a markup change doesn't silently drop every result.
     const titleMatch = block.match(
-      /<span[^>]*class="[^"]*search-snippet-title[^"]*"[^>]*>([\s\S]*?)<\/span>/i,
+      /<(span|div)[^>]*class="[^"]*search-snippet-title[^"]*"[^>]*>([\s\S]*?)<\/\1>/i,
     );
-    const title = titleMatch ? stripHtml(titleMatch[1]) : '';
+    const title = titleMatch ? stripHtml(titleMatch[2]) : '';
     if (!title) continue;
 
     const genericMatch = block.match(

--- a/tests/web-search/brave.test.ts
+++ b/tests/web-search/brave.test.ts
@@ -9,21 +9,21 @@ vi.mock('@/lib/server/proxy-fetch', () => ({
 import { parseBraveSearchHtml, searchWithBrave } from '@/lib/web-search/brave';
 
 describe('parseBraveSearchHtml', () => {
-  it('extracts web results, decodes entities, strips date prefixes, and skips Brave links', () => {
+  it('extracts web results from current markup (div titles), decodes entities, strips date prefixes, and skips Brave links', () => {
     const html = `
       <div class="snippet svelte-abc" data-pos="0" data-type="web">
         <a href="https://example.com/a?x=1&amp;y=2">
-          <span class="search-snippet-title">Example &amp; Title</span>
+          <div class="title search-snippet-title line-clamp-1 svelte-xyz" title="Example &amp; Title">Example &amp; Title</div>
         </a>
         <div class="generic-snippet">Jan 1, 2026 - Result <strong>content</strong> &amp; more</div>
       </div>
       <div class="snippet svelte-def" data-pos="1" data-type="web">
-        <a href="https://search.brave.com/help"><span class="search-snippet-title">Brave Help</span></a>
+        <a href="https://search.brave.com/help"><div class="title search-snippet-title line-clamp-1">Brave Help</div></a>
         <div class="generic-snippet">Internal Brave result</div>
       </div>
       <div class="snippet svelte-ghi" data-pos="2" data-type="web">
         <a href="https://second.example.com">
-          <span class="search-snippet-title">Second result</span>
+          <div class="title search-snippet-title line-clamp-1">Second result</div>
         </a>
         <p class="snippet-description">2 days ago - Secondary description</p>
       </div>
@@ -42,6 +42,26 @@ describe('parseBraveSearchHtml', () => {
         url: 'https://second.example.com',
         content: 'Secondary description',
         score: 0.9,
+      },
+    ]);
+  });
+
+  it('still extracts titles from the legacy <span> markup', () => {
+    const html = `
+      <div class="snippet svelte-abc" data-pos="0" data-type="web">
+        <a href="https://example.com/legacy">
+          <span class="search-snippet-title">Legacy result</span>
+        </a>
+        <div class="generic-snippet">Legacy content</div>
+      </div>
+    `;
+
+    expect(parseBraveSearchHtml(html, 5)).toEqual([
+      {
+        title: 'Legacy result',
+        url: 'https://example.com/legacy',
+        content: 'Legacy content',
+        score: 1,
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Fixes #687. The keyless Brave web-search path returned **0 results** because Brave moved the result title element:

- old: `<span class="search-snippet-title">Title</span>`
- now: `<div class="title search-snippet-title line-clamp-1 ..." title="Title">Title</div>`

The title regex matched `<span>` only, so `if (!title) continue;` skipped every snippet.

## Changes

- `parseBraveSearchHtml` accepts `<span>` **or** `<div>` for the title via a backreferenced `(span|div)` group, so the closing tag must match the opening one.
- Test fixtures updated to Brave's current `<div>` markup; one legacy `<span>` case kept for back-compat (per the issue's suggestion).

## Verification

- Live check just now: `https://search.brave.com/search?q=photosynthesis` returns HTTP 200 with **20** `data-type="web"` snippets — **0** span titles, **20** div titles. The old parser extracts 0 of them; the fixed one extracts them all.
- `vitest run tests/web-search/brave.test.ts` — 3/3 pass; `prettier --check` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
