### PR TITLE
fix(pbl): explain the tool-calling requirement when generation is rejected before the first step

### DIFF
--- a/lib/pbl/generate-pbl.ts
+++ b/lib/pbl/generate-pbl.ts
@@ -285,28 +285,46 @@ export async function generatePBLContent(
   // Run the agentic loop
   const systemPrompt = buildPBLSystemPrompt(config);
 
-  const _result = await callLLM(
-    {
-      model,
-      system: systemPrompt,
-      prompt: `Design a PBL project. Start in project_info mode by setting the project title and description.`,
-      tools: pblTools,
-      stopWhen: stepCountIs(30),
-      onStepFinish: ({ toolCalls, text }) => {
-        if (text) {
-          callbacks?.onProgress?.(`Thinking: ${text.slice(0, 100)}...`);
-        }
-        if (toolCalls) {
-          for (const tc of toolCalls) {
-            callbacks?.onProgress?.(`Tool: ${tc.toolName}`);
+  // PBL is the only generation path that requires native tool calling, and
+  // providers whose chat template lacks tools support reject such requests
+  // outright (e.g. LM Studio templates without a tools section, see #664).
+  // Track loop progress so a rejection before the first step — the signature
+  // of missing tool support — gets an actionable message instead of a raw
+  // provider error, while mid-loop failures keep their original error.
+  let completedSteps = 0;
+  try {
+    await callLLM(
+      {
+        model,
+        system: systemPrompt,
+        prompt: `Design a PBL project. Start in project_info mode by setting the project title and description.`,
+        tools: pblTools,
+        stopWhen: stepCountIs(30),
+        onStepFinish: ({ toolCalls, text }) => {
+          completedSteps += 1;
+          if (text) {
+            callbacks?.onProgress?.(`Thinking: ${text.slice(0, 100)}...`);
           }
-        }
+          if (toolCalls) {
+            for (const tc of toolCalls) {
+              callbacks?.onProgress?.(`Tool: ${tc.toolName}`);
+            }
+          }
+        },
       },
-    },
-    'pbl-generate',
-    undefined,
-    thinkingConfig,
-  );
+      'pbl-generate',
+      undefined,
+      thinkingConfig,
+    );
+  } catch (error) {
+    if (completedSteps === 0) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `PBL generation was rejected before the first step. PBL scenes drive the model through tool/function calls, so the selected model must support tool calling; models without it reject the request immediately. Pick a tool-capable model for PBL scenes, or change this scene's type. Original error: ${message}`,
+      );
+    }
+    throw error;
+  }
 
   // Check if mode reached idle; if not, the LLM may have stopped early
   if (modeMCP.getCurrentMode() !== 'idle') {

--- a/tests/pbl/generate-pbl-tool-rejection.test.ts
+++ b/tests/pbl/generate-pbl-tool-rejection.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for issue #664: PBL generation is the only path that
+ * requires native tool calling, and models without tool support reject the
+ * request outright with a raw provider error (e.g. an immediate 500 from
+ * LM Studio when the chat template has no tools section).
+ *
+ * A rejection before the first agentic step must be wrapped with an
+ * actionable message naming the tool-calling requirement; a failure after
+ * steps have completed must keep its original error (no misdiagnosis).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/ai/llm', () => ({
+  callLLM: vi.fn(),
+}));
+
+import { callLLM } from '@/lib/ai/llm';
+import { generatePBLContent, type GeneratePBLConfig } from '@/lib/pbl/generate-pbl';
+import type { LanguageModel } from 'ai';
+
+type StepCallback = (step: { toolCalls: unknown[]; text: string }) => void;
+
+const config: GeneratePBLConfig = {
+  projectTopic: 'Bridge building',
+  projectDescription: 'Design and stress-test a model bridge',
+  targetSkills: ['statics'],
+  languageDirective: 'Respond in English.',
+};
+
+const model = {} as unknown as LanguageModel;
+
+describe('generatePBLContent tool-rejection context (issue #664)', () => {
+  beforeEach(() => {
+    vi.mocked(callLLM).mockReset();
+  });
+
+  it('wraps a rejection before the first step with the tool-calling requirement', async () => {
+    vi.mocked(callLLM).mockRejectedValue(
+      new Error('500 status: this model template does not support tools'),
+    );
+
+    await expect(generatePBLContent(config, model)).rejects.toThrow(
+      /must support tool calling[\s\S]*Original error: 500 status: this model template does not support tools/,
+    );
+  });
+
+  it('keeps the original error when the loop fails after completing a step', async () => {
+    vi.mocked(callLLM).mockImplementation(async (params) => {
+      // Simulate one completed agentic step, then a mid-loop failure.
+      (params as { onStepFinish?: StepCallback }).onStepFinish?.({ toolCalls: [], text: 'plan' });
+      throw new Error('network reset mid-loop');
+    });
+
+    const failure = generatePBLContent(config, model);
+    await expect(failure).rejects.toThrow('network reset mid-loop');
+    await expect(failure).rejects.not.toThrow(/must support tool calling/);
+  });
+});


### PR DESCRIPTION
Refs #664 (first, diagnostic half — see "Scope" below for why it doesn't close it).

## Problem

PBL is the **only** generation path that requires native tool calling (`generateText` + Zod `tools` + `stopWhen`, the agentic MCP loop in `lib/pbl/generate-pbl.ts`). Models whose chat template lacks tools support reject such a request **outright** — #664 reports LM Studio + Gemma 4 returning an instant 500 (while Gemma 3, whose LM Studio template has tools support, works). The raw provider error propagates to the failed-scene UI with no hint that the *model capability*, not the course or the app, is the problem — and retrying can never succeed.

## Fix

Track how many agentic steps completed. When the call fails **before the first step** — the signature of a tools-incapable model rejecting the request — wrap the error with an actionable message:

> PBL generation was rejected before the first step. PBL scenes drive the model through tool/function calls, so the selected model must support tool calling; models without it reject the request immediately. Pick a tool-capable model for PBL scenes, or change this scene's type. Original error: …

Failures **after** steps have completed rethrow unchanged, so mid-loop network/provider errors are not misdiagnosed.

Same shape as the merged #644 (surface TTS provider rate-limits as 429s): convert a cryptic provider failure into an actionable one at the layer that knows the cause.

## Scope (why `Refs` and not `Closes`)

This makes the failure clear and actionable; it does not make tools-incapable models able to generate PBL scenes. That needs a design decision on #664 — e.g. a single-shot JSON text-mode fallback (reusing the existing json-repair machinery) or a `tools` capability flag that gates `pbl` outlines per model. Happy to implement either if maintainers pick a direction; the agentic MCP loop is clearly a deliberate design so I didn't want to parallel it unilaterally.

## Verification
- New regression tests (`tests/pbl/generate-pbl-tool-rejection.test.ts`, 2 cases): zero-step rejection gets the wrapped message incl. the original error; post-step failure keeps its original error.
- `prettier` clean, `eslint` clean, `tsc --noEmit` error count unchanged, adjacent PBL/generation suites green (11/11).
