### PR TITLE
fix(agents): persist AgentBar voice picks and mode/selection across reloads

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -87,17 +87,19 @@ export default function ClassroomDetailPage() {
       const { useSettingsStore } = await import('@/lib/store/settings');
       const { restoreAgentSelection } =
         await import('@/lib/orchestration/registry/agent-selection');
-      // Keep the user's persisted mode/selection when still valid for this
-      // stage instead of unconditionally forcing auto mode (which clobbered
-      // AgentBar choices on every classroom visit); fall back to the
-      // stage-derived defaults when the persisted choice is stale. Stale
-      // generated IDs (from another stage / pre-bleed-fix) never validate, so
-      // they don't resolve against a leftover registry entry.
+      // Keep the user's explicit AgentBar mode/selection when still valid for
+      // this stage instead of unconditionally forcing auto mode (which
+      // clobbered it on every classroom visit); fall back to the stage-derived
+      // defaults otherwise, marking them as NOT user-set so the next classroom
+      // never mistakes them for a choice. Stale generated IDs (from another
+      // stage / pre-bleed-fix) never validate, so they don't resolve against a
+      // leftover registry entry.
       const settings = useSettingsStore.getState();
       const registry = useAgentRegistry.getState();
       const stage = useStageStore.getState().stage;
-      const next = restoreAgentSelection({
+      const { selection: next, isUserSet } = restoreAgentSelection({
         persisted: { mode: settings.agentMode, selectedAgentIds: settings.selectedAgentIds },
+        persistedIsUserSet: settings.agentSelectionIsUserSet,
         generatedAgentIds,
         stageAgentIds: stage?.agentIds,
         isPresetAgent: (id) => {
@@ -110,6 +112,9 @@ export default function ClassroomDetailPage() {
       if (next.mode !== settings.agentMode) settings.setAgentMode(next.mode);
       if (next.selectedAgentIds !== settings.selectedAgentIds) {
         settings.setSelectedAgentIds(next.selectedAgentIds);
+      }
+      if (isUserSet !== settings.agentSelectionIsUserSet) {
+        settings.setAgentSelectionIsUserSet(isUserSet);
       }
     } catch (error) {
       log.error('Failed to load classroom:', error);

--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -85,27 +85,31 @@ export default function ClassroomDetailPage() {
         await import('@/lib/orchestration/registry/store');
       const generatedAgentIds = await loadGeneratedAgentsForStage(classroomId);
       const { useSettingsStore } = await import('@/lib/store/settings');
-      if (generatedAgentIds.length > 0) {
-        // Auto mode — use generated agents from IndexedDB
-        useSettingsStore.getState().setAgentMode('auto');
-        useSettingsStore.getState().setSelectedAgentIds(generatedAgentIds);
-      } else {
-        // Preset mode — restore agent IDs saved in the stage at creation time.
-        // Filter out any stale generated IDs that may have been persisted before
-        // the bleed-fix, so they don't resolve against a leftover registry entry.
-        const stage = useStageStore.getState().stage;
-        const stageAgentIds = stage?.agentIds;
-        const registry = useAgentRegistry.getState();
-        const cleanIds = stageAgentIds?.filter((id) => {
+      const { restoreAgentSelection } =
+        await import('@/lib/orchestration/registry/agent-selection');
+      // Keep the user's persisted mode/selection when still valid for this
+      // stage instead of unconditionally forcing auto mode (which clobbered
+      // AgentBar choices on every classroom visit); fall back to the
+      // stage-derived defaults when the persisted choice is stale. Stale
+      // generated IDs (from another stage / pre-bleed-fix) never validate, so
+      // they don't resolve against a leftover registry entry.
+      const settings = useSettingsStore.getState();
+      const registry = useAgentRegistry.getState();
+      const stage = useStageStore.getState().stage;
+      const next = restoreAgentSelection({
+        persisted: { mode: settings.agentMode, selectedAgentIds: settings.selectedAgentIds },
+        generatedAgentIds,
+        stageAgentIds: stage?.agentIds,
+        isPresetAgent: (id) => {
           const a = registry.getAgent(id);
-          return a && !a.isGenerated;
-        });
-        useSettingsStore.getState().setAgentMode('preset');
-        useSettingsStore
-          .getState()
-          .setSelectedAgentIds(
-            cleanIds && cleanIds.length > 0 ? cleanIds : ['default-1', 'default-2', 'default-3'],
-          );
+          return !!a && !a.isGenerated;
+        },
+      });
+      // restoreAgentSelection returns the persisted object as-is when keeping
+      // it, so reference checks skip redundant store writes.
+      if (next.mode !== settings.agentMode) settings.setAgentMode(next.mode);
+      if (next.selectedAgentIds !== settings.selectedAgentIds) {
+        settings.setSelectedAgentIds(next.selectedAgentIds);
       }
     } catch (error) {
       log.error('Failed to load classroom:', error);

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -730,6 +730,8 @@ function GenerationPreviewContent() {
           const { saveGeneratedAgents } = await import('@/lib/orchestration/registry/store');
           const savedIds = await saveGeneratedAgents(stage.id, agentData.agents);
           settings.setSelectedAgentIds(savedIds);
+          // Stage-derived, not a user choice — must not carry across classrooms.
+          settings.setAgentSelectionIsUserSet(false);
           stage.agentIds = savedIds;
 
           // Show card-reveal modal, continue generation once all cards are revealed

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -664,6 +664,9 @@ export function AgentBar() {
   }, [open]);
 
   const handleModeChange = (mode: 'preset' | 'auto') => {
+    // Clicking the already-active tab is a visual no-op; it must not convert
+    // stage-derived defaults into a "user choice".
+    if (mode === agentMode) return;
     // An explicit choice — restoreAgentSelection keeps it across classrooms.
     setAgentSelectionIsUserSet(true);
     setAgentMode(mode);

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -683,6 +683,14 @@ export function AgentBar() {
       setSelectedAgentIds(
         presetIds.length > 0 ? presetIds : ['default-1', 'default-2', 'default-3'],
       );
+    } else {
+      // Auto mode plays the current classroom's generated agents — leaving the
+      // preset ids selected would desync playback from the toggle (UI says
+      // Auto, discussion still uses preset agents) and persist an auto
+      // selection that can never validate on restore. When no classroom's
+      // agents are loaded (fresh home), an empty selection falls back to the
+      // stage-derived defaults on the next classroom load.
+      setSelectedAgentIds(allAgents.filter((a) => a.isGenerated).map((a) => a.id));
     }
   };
 

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -77,9 +77,10 @@ function AgentVoicePill({
   disabled?: boolean;
 }) {
   const { t, locale } = useI18n();
-  const updateAgent = useAgentRegistry((s) => s.updateAgent);
   const ttsProvidersConfig = useSettingsStore((s) => s.ttsProvidersConfig);
-  const resolved = resolveAgentVoice(agent, agentIndex, availableProviders);
+  const agentVoiceOverrides = useSettingsStore((s) => s.agentVoiceOverrides);
+  const setAgentVoiceOverride = useSettingsStore((s) => s.setAgentVoiceOverride);
+  const resolved = resolveAgentVoice(agent, agentIndex, availableProviders, agentVoiceOverrides);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [voiceQuery, setVoiceQuery] = useState('');
   const [previewingId, setPreviewingId] = useState<string | null>(null);
@@ -290,12 +291,13 @@ function AgentVoicePill({
                       <button
                         type="button"
                         onClick={() => {
-                          updateAgent(agent.id, {
-                            voiceConfig: {
-                              providerId: provider.providerId,
-                              modelId: group.modelId || undefined,
-                              voiceId: voice.id,
-                            },
+                          // Persisted in settings, not on the registry record:
+                          // default/generated agent records are rebuilt from
+                          // code/IndexedDB on every load and would drop the pick.
+                          setAgentVoiceOverride(agent.id, {
+                            providerId: provider.providerId,
+                            modelId: group.modelId || undefined,
+                            voiceId: voice.id,
                           });
                           setPopoverOpen(false);
                         }}

--- a/components/agent/agent-bar.tsx
+++ b/components/agent/agent-bar.tsx
@@ -292,8 +292,8 @@ function AgentVoicePill({
                         type="button"
                         onClick={() => {
                           // Persisted in settings, not on the registry record:
-                          // default/generated agent records are rebuilt from
-                          // code/IndexedDB on every load and would drop the pick.
+                          // default agent records are reset from code on every
+                          // load and would drop the pick.
                           setAgentVoiceOverride(agent.id, {
                             providerId: provider.providerId,
                             modelId: group.modelId || undefined,
@@ -618,6 +618,7 @@ export function AgentBar() {
   const setSelectedAgentIds = useSettingsStore((s) => s.setSelectedAgentIds);
   const agentMode = useSettingsStore((s) => s.agentMode);
   const setAgentMode = useSettingsStore((s) => s.setAgentMode);
+  const setAgentSelectionIsUserSet = useSettingsStore((s) => s.setAgentSelectionIsUserSet);
   const ttsProvidersConfig = useSettingsStore((s) => s.ttsProvidersConfig);
   const ttsEnabled = useSettingsStore((s) => s.ttsEnabled);
 
@@ -663,6 +664,8 @@ export function AgentBar() {
   }, [open]);
 
   const handleModeChange = (mode: 'preset' | 'auto') => {
+    // An explicit choice — restoreAgentSelection keeps it across classrooms.
+    setAgentSelectionIsUserSet(true);
     setAgentMode(mode);
     if (mode === 'preset') {
       // Remove stale auto-generated agent IDs that may linger from a previous auto classroom
@@ -683,6 +686,7 @@ export function AgentBar() {
   const toggleAgent = (agentId: string) => {
     const agent = agents.find((a) => a.id === agentId);
     if (agent?.role === 'teacher') return;
+    setAgentSelectionIsUserSet(true);
     if (selectedAgentIds.includes(agentId)) {
       setSelectedAgentIds(selectedAgentIds.filter((id) => id !== agentId));
     } else {

--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -20,13 +20,20 @@ export interface ResolvedVoice {
   voiceId: string;
 }
 
+/** Persisted per-agent voice picks, keyed by agent id (settings store). */
+export type AgentVoiceOverrides = Record<
+  string,
+  { providerId: TTSProviderId; modelId?: string; voiceId: string }
+>;
+
 /**
  * Resolve the TTS provider + voice for an agent, choosing only among ENABLED
  * providers (`enabledProviders` is the output of getEnabledProvidersWithVoices,
  * which already excludes disabled/unconfigured providers and browser-native).
  *
- * 1. If the agent has a voiceConfig whose provider is in `enabledProviders`
- *    (and the voiceId is known), use it.
+ * 1. If the user picked a voice for this agent (persisted `overrides`, keyed by
+ *    agent id) whose provider is in `enabledProviders` (and the voiceId is
+ *    known), use it; the agent's own voiceConfig is validated the same way next.
  * 2. Otherwise, deterministically pick the first provider in the given list by
  *    index. Whether browser-native can be picked depends on the caller's list:
  *    getEnabledProvidersWithVoices excludes it, getSelectableProvidersWithVoices
@@ -39,34 +46,29 @@ export function resolveAgentVoice(
   agent: AgentConfig,
   agentIndex: number,
   enabledProviders: ProviderWithVoices[],
+  overrides?: AgentVoiceOverrides,
 ): ResolvedVoice | null {
-  // Agent-specific config — honored only when its provider is still enabled.
-  if (agent.voiceConfig) {
+  // Candidates in priority order: the user's persisted per-agent override
+  // (settings store — survives reloads; registry records for default/generated
+  // agents do not), then the agent's own voiceConfig. Each is honored only
+  // when its provider is still enabled and the voice is known.
+  const candidates = [overrides?.[agent.id], agent.voiceConfig];
+  for (const choice of candidates) {
+    if (!choice) continue;
     // Browser-native voices are dynamic (not in static registry); it is a
     // first-class provider only when present in the enabled list.
-    if (agent.voiceConfig.providerId === 'browser-native-tts') {
+    if (choice.providerId === 'browser-native-tts') {
       if (enabledProviders.some((p) => p.providerId === 'browser-native-tts')) {
-        return {
-          providerId: agent.voiceConfig.providerId,
-          modelId: agent.voiceConfig.modelId,
-          voiceId: agent.voiceConfig.voiceId,
-        };
+        return { providerId: choice.providerId, modelId: choice.modelId, voiceId: choice.voiceId };
       }
-    } else {
-      const fromEnabled = enabledProviders.find(
-        (p) => p.providerId === agent.voiceConfig!.providerId,
-      );
-      if (fromEnabled) {
-        const list = getServerVoiceList(agent.voiceConfig.providerId);
-        const allVoiceIds = new Set([...list, ...fromEnabled.voices.map((v) => v.id)]);
-        if (allVoiceIds.has(agent.voiceConfig.voiceId)) {
-          return {
-            providerId: agent.voiceConfig.providerId,
-            modelId: agent.voiceConfig.modelId,
-            voiceId: agent.voiceConfig.voiceId,
-          };
-        }
-      }
+      continue;
+    }
+    const fromEnabled = enabledProviders.find((p) => p.providerId === choice.providerId);
+    if (!fromEnabled) continue;
+    const list = getServerVoiceList(choice.providerId);
+    const allVoiceIds = new Set([...list, ...fromEnabled.voices.map((v) => v.id)]);
+    if (allVoiceIds.has(choice.voiceId)) {
+      return { providerId: choice.providerId, modelId: choice.modelId, voiceId: choice.voiceId };
     }
   }
 

--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -20,11 +20,15 @@ export interface ResolvedVoice {
   voiceId: string;
 }
 
+/** A user-picked voice for one agent (same shape as AgentConfig.voiceConfig). */
+export interface AgentVoiceOverride {
+  providerId: TTSProviderId;
+  modelId?: string;
+  voiceId: string;
+}
+
 /** Persisted per-agent voice picks, keyed by agent id (settings store). */
-export type AgentVoiceOverrides = Record<
-  string,
-  { providerId: TTSProviderId; modelId?: string; voiceId: string }
->;
+export type AgentVoiceOverrides = Record<string, AgentVoiceOverride>;
 
 /**
  * Resolve the TTS provider + voice for an agent, choosing only among ENABLED

--- a/lib/hooks/use-discussion-tts.ts
+++ b/lib/hooks/use-discussion-tts.ts
@@ -42,6 +42,7 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
   // Global lecture voice — used as fallback for teacher agent
   const globalTtsProviderId = useSettingsStore((s) => s.ttsProviderId);
   const globalTtsVoice = useSettingsStore((s) => s.ttsVoice);
+  const agentVoiceOverrides = useSettingsStore((s) => s.agentVoiceOverrides);
   const { profiles: voxcpmProfiles } = useVoxCPMVoiceProfiles();
 
   const queueRef = useRef<QueueItem[]>([]);
@@ -141,7 +142,7 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
       }
 
       const index = agentIndexMap.current.get(agentId!) ?? 0;
-      return resolveAgentVoice(agent, index, providers);
+      return resolveAgentVoice(agent, index, providers, agentVoiceOverrides);
     },
     [
       agents,
@@ -150,6 +151,7 @@ export function useDiscussionTTS({ enabled, agents, onAudioStateChange }: Discus
       browserVoices,
       globalTtsProviderId,
       globalTtsVoice,
+      agentVoiceOverrides,
     ],
   );
 

--- a/lib/orchestration/registry/agent-selection.ts
+++ b/lib/orchestration/registry/agent-selection.ts
@@ -3,41 +3,56 @@ export interface AgentSelection {
   selectedAgentIds: string[];
 }
 
+export interface RestoredAgentSelection {
+  selection: AgentSelection;
+  /** Whether `selection` is the user's explicit choice (vs stage-derived defaults). */
+  isUserSet: boolean;
+}
+
 /**
  * Decide the agent mode/selection to apply when a classroom loads.
  *
- * Honors the user's persisted choice when it is still valid for this stage —
- * a preset selection of known non-generated agents, or an auto selection
- * drawn from this stage's generated agents. Otherwise falls back to the
- * stage-derived defaults (the previous unconditional behavior): auto with all
+ * Only an explicit user choice (made in the AgentBar, `persistedIsUserSet`)
+ * may carry across classrooms — and only while it is still valid for the
+ * loaded stage: a preset selection of known non-generated agents, or an auto
+ * selection drawn from this stage's generated agents. Stage-derived defaults
+ * written by previous classroom loads are NOT user choices and must never be
+ * re-read as one, or visiting a preset classroom would permanently downgrade
+ * every auto classroom to preset agents.
+ *
+ * The fallback reproduces the previous unconditional behavior: auto with all
  * generated agents when the stage has them, else the stage's preset agents,
  * else the default trio.
  */
 export function restoreAgentSelection(params: {
   persisted: AgentSelection;
+  persistedIsUserSet: boolean;
   generatedAgentIds: string[];
   stageAgentIds?: string[];
   isPresetAgent: (id: string) => boolean;
-}): AgentSelection {
-  const { persisted, generatedAgentIds, stageAgentIds, isPresetAgent } = params;
+}): RestoredAgentSelection {
+  const { persisted, persistedIsUserSet, generatedAgentIds, stageAgentIds, isPresetAgent } = params;
 
-  if (persisted.selectedAgentIds.length > 0) {
+  if (persistedIsUserSet && persisted.selectedAgentIds.length > 0) {
     if (persisted.mode === 'auto') {
       const generated = new Set(generatedAgentIds);
       if (persisted.selectedAgentIds.every((id) => generated.has(id))) {
-        return persisted;
+        return { selection: persisted, isUserSet: true };
       }
     } else if (persisted.selectedAgentIds.every(isPresetAgent)) {
-      return persisted;
+      return { selection: persisted, isUserSet: true };
     }
   }
 
   if (generatedAgentIds.length > 0) {
-    return { mode: 'auto', selectedAgentIds: generatedAgentIds };
+    return { selection: { mode: 'auto', selectedAgentIds: generatedAgentIds }, isUserSet: false };
   }
   const cleanIds = stageAgentIds?.filter(isPresetAgent) ?? [];
   return {
-    mode: 'preset',
-    selectedAgentIds: cleanIds.length > 0 ? cleanIds : ['default-1', 'default-2', 'default-3'],
+    selection: {
+      mode: 'preset',
+      selectedAgentIds: cleanIds.length > 0 ? cleanIds : ['default-1', 'default-2', 'default-3'],
+    },
+    isUserSet: false,
   };
 }

--- a/lib/orchestration/registry/agent-selection.ts
+++ b/lib/orchestration/registry/agent-selection.ts
@@ -1,0 +1,43 @@
+export interface AgentSelection {
+  mode: 'preset' | 'auto';
+  selectedAgentIds: string[];
+}
+
+/**
+ * Decide the agent mode/selection to apply when a classroom loads.
+ *
+ * Honors the user's persisted choice when it is still valid for this stage —
+ * a preset selection of known non-generated agents, or an auto selection
+ * drawn from this stage's generated agents. Otherwise falls back to the
+ * stage-derived defaults (the previous unconditional behavior): auto with all
+ * generated agents when the stage has them, else the stage's preset agents,
+ * else the default trio.
+ */
+export function restoreAgentSelection(params: {
+  persisted: AgentSelection;
+  generatedAgentIds: string[];
+  stageAgentIds?: string[];
+  isPresetAgent: (id: string) => boolean;
+}): AgentSelection {
+  const { persisted, generatedAgentIds, stageAgentIds, isPresetAgent } = params;
+
+  if (persisted.selectedAgentIds.length > 0) {
+    if (persisted.mode === 'auto') {
+      const generated = new Set(generatedAgentIds);
+      if (persisted.selectedAgentIds.every((id) => generated.has(id))) {
+        return persisted;
+      }
+    } else if (persisted.selectedAgentIds.every(isPresetAgent)) {
+      return persisted;
+    }
+  }
+
+  if (generatedAgentIds.length > 0) {
+    return { mode: 'auto', selectedAgentIds: generatedAgentIds };
+  }
+  const cleanIds = stageAgentIds?.filter(isPresetAgent) ?? [];
+  return {
+    mode: 'preset',
+    selectedAgentIds: cleanIds.length > 0 ? cleanIds : ['default-1', 'default-2', 'default-3'],
+  };
+}

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -54,6 +54,13 @@ function pruneThinkingConfigs(
 export const PLAYBACK_SPEEDS = [1, 1.25, 1.5, 2] as const;
 export type PlaybackSpeed = (typeof PLAYBACK_SPEEDS)[number];
 
+/** A user-picked voice for one agent (same shape as AgentConfig.voiceConfig). */
+export interface AgentVoiceOverride {
+  providerId: TTSProviderId;
+  modelId?: string;
+  voiceId: string;
+}
+
 export interface SettingsState {
   // Model selection
   providerId: ProviderId;
@@ -194,6 +201,13 @@ export interface SettingsState {
   selectedAgentIds: string[];
   agentMode: 'preset' | 'auto';
   autoAgentCount: number;
+  /**
+   * Per-agent voice picks made in the AgentBar, keyed by agent id. Lives here
+   * (persisted) rather than on registry AgentConfig records because default
+   * agents are reset from code and generated agents are rebuilt from IndexedDB
+   * on every load. Highest-priority input to resolveAgentVoice.
+   */
+  agentVoiceOverrides: Record<string, AgentVoiceOverride>;
 
   // Layout preferences (persisted via localStorage)
   sidebarCollapsed: boolean;
@@ -220,6 +234,7 @@ export interface SettingsState {
   setSelectedAgentIds: (ids: string[]) => void;
   setAgentMode: (mode: 'preset' | 'auto') => void;
   setAutoAgentCount: (count: number) => void;
+  setAgentVoiceOverride: (agentId: string, voice: AgentVoiceOverride) => void;
 
   // Layout actions
   setSidebarCollapsed: (collapsed: boolean) => void;
@@ -814,6 +829,7 @@ export const useSettingsStore = create<SettingsState>()(
         selectedAgentIds: migratedData?.selectedAgentIds || ['default-1', 'default-2', 'default-3'],
         agentMode: 'auto' as const,
         autoAgentCount: 3,
+        agentVoiceOverrides: {},
 
         // Playback controls
         ttsMuted: false,
@@ -935,6 +951,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         setAgentMode: (mode) => set({ agentMode: mode }),
         setAutoAgentCount: (count) => set({ autoAgentCount: count }),
+        setAgentVoiceOverride: (agentId, voice) =>
+          set((state) => ({
+            agentVoiceOverrides: { ...state.agentVoiceOverrides, [agentId]: voice },
+          })),
 
         // Layout actions
         setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -11,6 +11,7 @@ import { PROVIDERS } from '@/lib/ai/providers';
 import type { ThinkingConfig } from '@/lib/types/provider';
 import { getThinkingConfigKey, supportsConfigurableThinking } from '@/lib/ai/thinking-config';
 import type { TTSProviderId, ASRProviderId, BuiltInTTSProviderId } from '@/lib/audio/types';
+import type { AgentVoiceOverride } from '@/lib/audio/voice-resolver';
 import { isCustomTTSProvider, isCustomASRProvider } from '@/lib/audio/types';
 import { ASR_PROVIDERS, DEFAULT_TTS_VOICES, TTS_PROVIDERS } from '@/lib/audio/constants';
 import { DEFAULT_VOXCPM_BACKEND, VOXCPM_MODEL_ID, VOXCPM_VLLM_MODEL_ID } from '@/lib/audio/voxcpm';
@@ -53,13 +54,6 @@ function pruneThinkingConfigs(
 /** Available playback speed tiers */
 export const PLAYBACK_SPEEDS = [1, 1.25, 1.5, 2] as const;
 export type PlaybackSpeed = (typeof PLAYBACK_SPEEDS)[number];
-
-/** A user-picked voice for one agent (same shape as AgentConfig.voiceConfig). */
-export interface AgentVoiceOverride {
-  providerId: TTSProviderId;
-  modelId?: string;
-  voiceId: string;
-}
 
 export interface SettingsState {
   // Model selection
@@ -208,6 +202,12 @@ export interface SettingsState {
    * on every load. Highest-priority input to resolveAgentVoice.
    */
   agentVoiceOverrides: Record<string, AgentVoiceOverride>;
+  /**
+   * Whether agentMode/selectedAgentIds were explicitly set by the user (in the
+   * AgentBar), as opposed to stage-derived defaults written by a classroom
+   * load. Only a user-set selection carries across classrooms on restore.
+   */
+  agentSelectionIsUserSet: boolean;
 
   // Layout preferences (persisted via localStorage)
   sidebarCollapsed: boolean;
@@ -234,7 +234,9 @@ export interface SettingsState {
   setSelectedAgentIds: (ids: string[]) => void;
   setAgentMode: (mode: 'preset' | 'auto') => void;
   setAutoAgentCount: (count: number) => void;
-  setAgentVoiceOverride: (agentId: string, voice: AgentVoiceOverride) => void;
+  /** Set (or clear, with `undefined`) the persisted voice pick for one agent. */
+  setAgentVoiceOverride: (agentId: string, voice: AgentVoiceOverride | undefined) => void;
+  setAgentSelectionIsUserSet: (isUserSet: boolean) => void;
 
   // Layout actions
   setSidebarCollapsed: (collapsed: boolean) => void;
@@ -830,6 +832,7 @@ export const useSettingsStore = create<SettingsState>()(
         agentMode: 'auto' as const,
         autoAgentCount: 3,
         agentVoiceOverrides: {},
+        agentSelectionIsUserSet: false,
 
         // Playback controls
         ttsMuted: false,
@@ -952,9 +955,16 @@ export const useSettingsStore = create<SettingsState>()(
         setAgentMode: (mode) => set({ agentMode: mode }),
         setAutoAgentCount: (count) => set({ autoAgentCount: count }),
         setAgentVoiceOverride: (agentId, voice) =>
-          set((state) => ({
-            agentVoiceOverrides: { ...state.agentVoiceOverrides, [agentId]: voice },
-          })),
+          set((state) => {
+            const next = { ...state.agentVoiceOverrides };
+            if (voice) {
+              next[agentId] = voice;
+            } else {
+              delete next[agentId];
+            }
+            return { agentVoiceOverrides: next };
+          }),
+        setAgentSelectionIsUserSet: (isUserSet) => set({ agentSelectionIsUserSet: isUserSet }),
 
         // Layout actions
         setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),

--- a/tests/audio/voice-resolver-overrides.test.ts
+++ b/tests/audio/voice-resolver-overrides.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-agent voice overrides (persisted in settings) take precedence over the
+ * agent's registry voiceConfig and the deterministic fallback, with the same
+ * enablement validation as voiceConfig.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
+import { resolveAgentVoice, type ProviderWithVoices } from '@/lib/audio/voice-resolver';
+
+const agent = (id: string, voiceConfig?: AgentConfig['voiceConfig']) =>
+  ({ id, voiceConfig }) as AgentConfig;
+
+const qwen: ProviderWithVoices = {
+  providerId: 'qwen-tts',
+  providerName: 'Qwen TTS',
+  voices: [
+    { id: 'Cherry', name: 'Cherry' },
+    { id: 'Dylan', name: 'Dylan' },
+  ],
+  modelGroups: [],
+};
+
+describe('resolveAgentVoice with overrides', () => {
+  it('prefers the override over voiceConfig and fallback', () => {
+    const resolved = resolveAgentVoice(
+      agent('default-2', { providerId: 'qwen-tts', voiceId: 'Cherry' }),
+      0,
+      [qwen],
+      { 'default-2': { providerId: 'qwen-tts', voiceId: 'Dylan' } },
+    );
+    expect(resolved).toEqual({ providerId: 'qwen-tts', modelId: undefined, voiceId: 'Dylan' });
+  });
+
+  it('ignores an override whose provider is not enabled, falling back to voiceConfig', () => {
+    const resolved = resolveAgentVoice(
+      agent('default-2', { providerId: 'qwen-tts', voiceId: 'Cherry' }),
+      0,
+      [qwen],
+      { 'default-2': { providerId: 'openai-tts', voiceId: 'alloy' } },
+    );
+    expect(resolved).toEqual({ providerId: 'qwen-tts', modelId: undefined, voiceId: 'Cherry' });
+  });
+
+  it('ignores an override whose voice is unknown to the provider', () => {
+    const resolved = resolveAgentVoice(agent('default-2'), 1, [qwen], {
+      'default-2': { providerId: 'qwen-tts', voiceId: 'NotAVoice' },
+    });
+    // falls through to deterministic fallback: voices[1 % 2] = Dylan
+    expect(resolved).toEqual({ providerId: 'qwen-tts', voiceId: 'Dylan' });
+  });
+
+  it('only applies the override of the matching agent id', () => {
+    const resolved = resolveAgentVoice(agent('default-3'), 0, [qwen], {
+      'default-2': { providerId: 'qwen-tts', voiceId: 'Dylan' },
+    });
+    expect(resolved).toEqual({ providerId: 'qwen-tts', voiceId: 'Cherry' });
+  });
+
+  it('honors a browser-native override only when browser-native is selectable', () => {
+    const browserNative: ProviderWithVoices = {
+      providerId: 'browser-native-tts',
+      providerName: 'Browser',
+      voices: [{ id: 'Anna', name: 'Anna' }],
+      modelGroups: [],
+    };
+    const override = {
+      'default-2': { providerId: 'browser-native-tts' as const, voiceId: 'Anna' },
+    };
+    expect(resolveAgentVoice(agent('default-2'), 0, [qwen], override)).toEqual({
+      providerId: 'qwen-tts',
+      voiceId: 'Cherry',
+    });
+    expect(resolveAgentVoice(agent('default-2'), 0, [qwen, browserNative], override)).toEqual({
+      providerId: 'browser-native-tts',
+      modelId: undefined,
+      voiceId: 'Anna',
+    });
+  });
+});

--- a/tests/classroom/agent-selection-restore.test.ts
+++ b/tests/classroom/agent-selection-restore.test.ts
@@ -1,77 +1,171 @@
 /**
- * restoreAgentSelection: classroom load must honor the user's persisted
- * agent mode/selection when still valid for the loaded stage, and only fall
- * back to stage-derived defaults when the persisted choice is stale
- * (e.g. ids from another stage) — the previous behavior unconditionally
- * forced auto mode whenever generated agents existed.
+ * restoreAgentSelection: classroom load must honor the user's explicit
+ * agent mode/selection (set in the AgentBar) when still valid for the loaded
+ * stage, and fall back to stage-derived defaults otherwise. Stage-derived
+ * defaults written by previous classroom loads are NOT user choices and must
+ * never carry across stages — otherwise visiting a preset classroom would
+ * permanently downgrade every auto classroom to preset agents.
  */
 import { describe, it, expect } from 'vitest';
-import { restoreAgentSelection } from '@/lib/orchestration/registry/agent-selection';
+import {
+  restoreAgentSelection,
+  type AgentSelection,
+} from '@/lib/orchestration/registry/agent-selection';
 
 const PRESETS = new Set(['default-1', 'default-2', 'default-3', 'default-4']);
 const isPresetAgent = (id: string) => PRESETS.has(id);
 
 describe('restoreAgentSelection', () => {
-  it('keeps a persisted preset selection even when the stage has generated agents', () => {
-    const persisted = { mode: 'preset' as const, selectedAgentIds: ['default-2', 'default-3'] };
+  it('keeps a user-set preset selection even when the stage has generated agents', () => {
+    const persisted: AgentSelection = {
+      mode: 'preset',
+      selectedAgentIds: ['default-2', 'default-3'],
+    };
     expect(
       restoreAgentSelection({
         persisted,
+        persistedIsUserSet: true,
         generatedAgentIds: ['gen-a', 'gen-b'],
         isPresetAgent,
       }),
-    ).toEqual(persisted);
+    ).toEqual({ selection: persisted, isUserSet: true });
   });
 
-  it("keeps a persisted auto selection that is a subset of this stage's generated agents", () => {
-    const persisted = { mode: 'auto' as const, selectedAgentIds: ['gen-b'] };
+  it("keeps a user-set auto selection that is a subset of this stage's generated agents", () => {
+    const persisted: AgentSelection = { mode: 'auto', selectedAgentIds: ['gen-b'] };
     expect(
       restoreAgentSelection({
         persisted,
+        persistedIsUserSet: true,
         generatedAgentIds: ['gen-a', 'gen-b'],
         isPresetAgent,
       }),
-    ).toEqual(persisted);
+    ).toEqual({ selection: persisted, isUserSet: true });
   });
 
-  it("resets a stale auto selection (ids from another stage) to this stage's generated agents", () => {
+  it('ignores a stage-derived persisted selection and applies this stage defaults', () => {
+    // A previous classroom load wrote {preset, trio} as its fallback; that is
+    // not a user choice, so an auto stage must still get its generated agents.
+    expect(
+      restoreAgentSelection({
+        persisted: { mode: 'preset', selectedAgentIds: ['default-1', 'default-2', 'default-3'] },
+        persistedIsUserSet: false,
+        generatedAgentIds: ['gen-a', 'gen-b'],
+        isPresetAgent,
+      }),
+    ).toEqual({
+      selection: { mode: 'auto', selectedAgentIds: ['gen-a', 'gen-b'] },
+      isUserSet: false,
+    });
+  });
+
+  it("resets a stale user-set auto selection (ids from another stage) to this stage's defaults", () => {
     expect(
       restoreAgentSelection({
         persisted: { mode: 'auto', selectedAgentIds: ['other-stage-gen'] },
+        persistedIsUserSet: true,
         generatedAgentIds: ['gen-a', 'gen-b'],
         isPresetAgent,
       }),
-    ).toEqual({ mode: 'auto', selectedAgentIds: ['gen-a', 'gen-b'] });
+    ).toEqual({
+      selection: { mode: 'auto', selectedAgentIds: ['gen-a', 'gen-b'] },
+      isUserSet: false,
+    });
   });
 
-  it('falls back to auto defaults when a persisted preset selection contains unknown ids', () => {
+  it('falls back to auto defaults when a user-set preset selection contains unknown ids', () => {
     expect(
       restoreAgentSelection({
         persisted: { mode: 'preset', selectedAgentIds: ['gen-stale', 'default-2'] },
+        persistedIsUserSet: true,
         generatedAgentIds: ['gen-a'],
         isPresetAgent,
       }),
-    ).toEqual({ mode: 'auto', selectedAgentIds: ['gen-a'] });
+    ).toEqual({ selection: { mode: 'auto', selectedAgentIds: ['gen-a'] }, isUserSet: false });
   });
 
-  it('falls back to stage preset agents when nothing is generated and persisted auto is stale', () => {
+  it('falls back to stage preset agents when nothing is generated and nothing was user-set', () => {
     expect(
       restoreAgentSelection({
         persisted: { mode: 'auto', selectedAgentIds: ['other-stage-gen'] },
+        persistedIsUserSet: false,
         generatedAgentIds: [],
         stageAgentIds: ['default-4', 'gen-stale'],
         isPresetAgent,
       }),
-    ).toEqual({ mode: 'preset', selectedAgentIds: ['default-4'] });
+    ).toEqual({
+      selection: { mode: 'preset', selectedAgentIds: ['default-4'] },
+      isUserSet: false,
+    });
   });
 
   it('falls back to the default preset trio when nothing else is valid', () => {
     expect(
       restoreAgentSelection({
         persisted: { mode: 'preset', selectedAgentIds: [] },
+        persistedIsUserSet: true,
         generatedAgentIds: [],
         isPresetAgent,
       }),
-    ).toEqual({ mode: 'preset', selectedAgentIds: ['default-1', 'default-2', 'default-3'] });
+    ).toEqual({
+      selection: { mode: 'preset', selectedAgentIds: ['default-1', 'default-2', 'default-3'] },
+      isUserSet: false,
+    });
+  });
+
+  it('round-trips A(auto) → B(preset) → A without degrading A to preset agents', () => {
+    // Simulates sequential classroom loads with no user interaction: each
+    // load persists its result and feeds it into the next load.
+    const loadA = () => ({ generatedAgentIds: ['gen-a1', 'gen-a2'], stageAgentIds: undefined });
+    const loadB = () => ({ generatedAgentIds: [], stageAgentIds: ['default-1', 'default-2'] });
+
+    let state = {
+      selection: { mode: 'auto', selectedAgentIds: [] } as AgentSelection,
+      isUserSet: false,
+    };
+    state = restoreAgentSelection({
+      persisted: state.selection,
+      persistedIsUserSet: state.isUserSet,
+      ...loadA(),
+      isPresetAgent,
+    });
+    expect(state.selection).toEqual({ mode: 'auto', selectedAgentIds: ['gen-a1', 'gen-a2'] });
+
+    state = restoreAgentSelection({
+      persisted: state.selection,
+      persistedIsUserSet: state.isUserSet,
+      ...loadB(),
+      isPresetAgent,
+    });
+    expect(state.selection).toEqual({
+      mode: 'preset',
+      selectedAgentIds: ['default-1', 'default-2'],
+    });
+
+    state = restoreAgentSelection({
+      persisted: state.selection,
+      persistedIsUserSet: state.isUserSet,
+      ...loadA(),
+      isPresetAgent,
+    });
+    expect(state.selection).toEqual({ mode: 'auto', selectedAgentIds: ['gen-a1', 'gen-a2'] });
+  });
+
+  it('carries a user-set preset choice through the same A → B → A round-trip', () => {
+    const persisted: AgentSelection = { mode: 'preset', selectedAgentIds: ['default-2'] };
+    let state = { selection: persisted, isUserSet: true };
+    for (const stage of [
+      { generatedAgentIds: ['gen-a1'], stageAgentIds: undefined },
+      { generatedAgentIds: [], stageAgentIds: ['default-1'] },
+      { generatedAgentIds: ['gen-a1'], stageAgentIds: undefined },
+    ]) {
+      state = restoreAgentSelection({
+        persisted: state.selection,
+        persistedIsUserSet: state.isUserSet,
+        ...stage,
+        isPresetAgent,
+      });
+      expect(state).toEqual({ selection: persisted, isUserSet: true });
+    }
   });
 });

--- a/tests/classroom/agent-selection-restore.test.ts
+++ b/tests/classroom/agent-selection-restore.test.ts
@@ -1,0 +1,77 @@
+/**
+ * restoreAgentSelection: classroom load must honor the user's persisted
+ * agent mode/selection when still valid for the loaded stage, and only fall
+ * back to stage-derived defaults when the persisted choice is stale
+ * (e.g. ids from another stage) — the previous behavior unconditionally
+ * forced auto mode whenever generated agents existed.
+ */
+import { describe, it, expect } from 'vitest';
+import { restoreAgentSelection } from '@/lib/orchestration/registry/agent-selection';
+
+const PRESETS = new Set(['default-1', 'default-2', 'default-3', 'default-4']);
+const isPresetAgent = (id: string) => PRESETS.has(id);
+
+describe('restoreAgentSelection', () => {
+  it('keeps a persisted preset selection even when the stage has generated agents', () => {
+    const persisted = { mode: 'preset' as const, selectedAgentIds: ['default-2', 'default-3'] };
+    expect(
+      restoreAgentSelection({
+        persisted,
+        generatedAgentIds: ['gen-a', 'gen-b'],
+        isPresetAgent,
+      }),
+    ).toEqual(persisted);
+  });
+
+  it("keeps a persisted auto selection that is a subset of this stage's generated agents", () => {
+    const persisted = { mode: 'auto' as const, selectedAgentIds: ['gen-b'] };
+    expect(
+      restoreAgentSelection({
+        persisted,
+        generatedAgentIds: ['gen-a', 'gen-b'],
+        isPresetAgent,
+      }),
+    ).toEqual(persisted);
+  });
+
+  it("resets a stale auto selection (ids from another stage) to this stage's generated agents", () => {
+    expect(
+      restoreAgentSelection({
+        persisted: { mode: 'auto', selectedAgentIds: ['other-stage-gen'] },
+        generatedAgentIds: ['gen-a', 'gen-b'],
+        isPresetAgent,
+      }),
+    ).toEqual({ mode: 'auto', selectedAgentIds: ['gen-a', 'gen-b'] });
+  });
+
+  it('falls back to auto defaults when a persisted preset selection contains unknown ids', () => {
+    expect(
+      restoreAgentSelection({
+        persisted: { mode: 'preset', selectedAgentIds: ['gen-stale', 'default-2'] },
+        generatedAgentIds: ['gen-a'],
+        isPresetAgent,
+      }),
+    ).toEqual({ mode: 'auto', selectedAgentIds: ['gen-a'] });
+  });
+
+  it('falls back to stage preset agents when nothing is generated and persisted auto is stale', () => {
+    expect(
+      restoreAgentSelection({
+        persisted: { mode: 'auto', selectedAgentIds: ['other-stage-gen'] },
+        generatedAgentIds: [],
+        stageAgentIds: ['default-4', 'gen-stale'],
+        isPresetAgent,
+      }),
+    ).toEqual({ mode: 'preset', selectedAgentIds: ['default-4'] });
+  });
+
+  it('falls back to the default preset trio when nothing else is valid', () => {
+    expect(
+      restoreAgentSelection({
+        persisted: { mode: 'preset', selectedAgentIds: [] },
+        generatedAgentIds: [],
+        isPresetAgent,
+      }),
+    ).toEqual({ mode: 'preset', selectedAgentIds: ['default-1', 'default-2', 'default-3'] });
+  });
+});

--- a/tests/config/settings-agent-voice-overrides.test.ts
+++ b/tests/config/settings-agent-voice-overrides.test.ts
@@ -1,0 +1,28 @@
+/**
+ * agentVoiceOverrides: persisted per-agent voice picks (the UI-preference home
+ * for AgentBar voice selection — registry agent records are reset from
+ * code/IndexedDB on every load and must not own user picks).
+ */
+import { describe, it, expect } from 'vitest';
+import { useSettingsStore } from '@/lib/store/settings';
+
+describe('agentVoiceOverrides', () => {
+  it('defaults to an empty map', () => {
+    expect(useSettingsStore.getState().agentVoiceOverrides).toEqual({});
+  });
+
+  it('setAgentVoiceOverride adds and replaces entries per agent id', () => {
+    const { setAgentVoiceOverride } = useSettingsStore.getState();
+    setAgentVoiceOverride('default-2', { providerId: 'qwen-tts', voiceId: 'Dylan' });
+    setAgentVoiceOverride('default-3', {
+      providerId: 'qwen-tts',
+      modelId: 'qwen3-tts-flash',
+      voiceId: 'Cherry',
+    });
+    setAgentVoiceOverride('default-2', { providerId: 'qwen-tts', voiceId: 'Serena' });
+    expect(useSettingsStore.getState().agentVoiceOverrides).toEqual({
+      'default-2': { providerId: 'qwen-tts', voiceId: 'Serena' },
+      'default-3': { providerId: 'qwen-tts', modelId: 'qwen3-tts-flash', voiceId: 'Cherry' },
+    });
+  });
+});

--- a/tests/config/settings-agent-voice-overrides.test.ts
+++ b/tests/config/settings-agent-voice-overrides.test.ts
@@ -1,18 +1,47 @@
 /**
- * agentVoiceOverrides: persisted per-agent voice picks (the UI-preference home
- * for AgentBar voice selection — registry agent records are reset from
+ * agentVoiceOverrides + agentSelectionIsUserSet: persisted UI preferences (the
+ * home for AgentBar choices — registry agent records are reset from
  * code/IndexedDB on every load and must not own user picks).
+ *
+ * localStorage is stubbed and the store imported per-test so the persist
+ * rehydration path (merge of an existing blob) is exercised for real.
  */
-import { describe, it, expect } from 'vitest';
-import { useSettingsStore } from '@/lib/store/settings';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const storage = new Map<string, string>();
+const localStorageStub = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => void storage.set(k, v),
+  removeItem: (k: string) => void storage.delete(k),
+  clear: () => void storage.clear(),
+  key: () => null,
+  length: 0,
+};
+vi.stubGlobal('localStorage', localStorageStub);
+// Several init paths guard on `typeof window` before touching storage.
+vi.stubGlobal('window', { localStorage: localStorageStub });
+
+async function freshStore(persistedState?: Record<string, unknown>) {
+  vi.resetModules();
+  storage.clear();
+  if (persistedState) {
+    storage.set('settings-storage', JSON.stringify({ state: persistedState, version: 4 }));
+  }
+  const { useSettingsStore } = await import('@/lib/store/settings');
+  return useSettingsStore;
+}
 
 describe('agentVoiceOverrides', () => {
-  it('defaults to an empty map', () => {
-    expect(useSettingsStore.getState().agentVoiceOverrides).toEqual({});
+  beforeEach(() => storage.clear());
+
+  it('defaults to an empty map', async () => {
+    const store = await freshStore();
+    expect(store.getState().agentVoiceOverrides).toEqual({});
   });
 
-  it('setAgentVoiceOverride adds and replaces entries per agent id', () => {
-    const { setAgentVoiceOverride } = useSettingsStore.getState();
+  it('setAgentVoiceOverride adds, replaces, and deletes entries per agent id', async () => {
+    const store = await freshStore();
+    const { setAgentVoiceOverride } = store.getState();
     setAgentVoiceOverride('default-2', { providerId: 'qwen-tts', voiceId: 'Dylan' });
     setAgentVoiceOverride('default-3', {
       providerId: 'qwen-tts',
@@ -20,9 +49,44 @@ describe('agentVoiceOverrides', () => {
       voiceId: 'Cherry',
     });
     setAgentVoiceOverride('default-2', { providerId: 'qwen-tts', voiceId: 'Serena' });
-    expect(useSettingsStore.getState().agentVoiceOverrides).toEqual({
+    expect(store.getState().agentVoiceOverrides).toEqual({
       'default-2': { providerId: 'qwen-tts', voiceId: 'Serena' },
       'default-3': { providerId: 'qwen-tts', modelId: 'qwen3-tts-flash', voiceId: 'Cherry' },
     });
+
+    // undefined deletes — the symmetric way back to deterministic auto-assignment
+    setAgentVoiceOverride('default-2', undefined);
+    expect(store.getState().agentVoiceOverrides).toEqual({
+      'default-3': { providerId: 'qwen-tts', modelId: 'qwen3-tts-flash', voiceId: 'Cherry' },
+    });
+  });
+
+  it('survives persist rehydration of an existing blob', async () => {
+    const store = await freshStore({
+      agentVoiceOverrides: { 'default-2': { providerId: 'qwen-tts', voiceId: 'Dylan' } },
+      agentSelectionIsUserSet: true,
+    });
+    expect(store.getState().agentVoiceOverrides).toEqual({
+      'default-2': { providerId: 'qwen-tts', voiceId: 'Dylan' },
+    });
+    expect(store.getState().agentSelectionIsUserSet).toBe(true);
+  });
+
+  it('defaults to {} when rehydrating a pre-existing blob without the field', async () => {
+    const store = await freshStore({ ttsSpeed: 1.25 });
+    expect(store.getState().agentVoiceOverrides).toEqual({});
+    expect(store.getState().agentSelectionIsUserSet).toBe(false);
+    expect(store.getState().ttsSpeed).toBe(1.25);
+  });
+});
+
+describe('agentSelectionIsUserSet', () => {
+  it('defaults to false and is settable', async () => {
+    const store = await freshStore();
+    expect(store.getState().agentSelectionIsUserSet).toBe(false);
+    store.getState().setAgentSelectionIsUserSet(true);
+    expect(store.getState().agentSelectionIsUserSet).toBe(true);
+    store.getState().setAgentSelectionIsUserSet(false);
+    expect(store.getState().agentSelectionIsUserSet).toBe(false);
   });
 });

--- a/tests/config/settings-agent-voice-overrides.test.ts
+++ b/tests/config/settings-agent-voice-overrides.test.ts
@@ -59,6 +59,13 @@ describe('agentVoiceOverrides', () => {
     expect(store.getState().agentVoiceOverrides).toEqual({
       'default-3': { providerId: 'qwen-tts', modelId: 'qwen3-tts-flash', voiceId: 'Cherry' },
     });
+
+    // The write must actually reach storage (would break if a future
+    // partialize omits the field) — sync storage writes synchronously.
+    const blob = JSON.parse(storage.get('settings-storage')!);
+    expect(blob.state.agentVoiceOverrides).toEqual({
+      'default-3': { providerId: 'qwen-tts', modelId: 'qwen3-tts-flash', voiceId: 'Cherry' },
+    });
   });
 
   it('survives persist rehydration of an existing blob', async () => {
@@ -86,6 +93,7 @@ describe('agentSelectionIsUserSet', () => {
     expect(store.getState().agentSelectionIsUserSet).toBe(false);
     store.getState().setAgentSelectionIsUserSet(true);
     expect(store.getState().agentSelectionIsUserSet).toBe(true);
+    expect(JSON.parse(storage.get('settings-storage')!).state.agentSelectionIsUserSet).toBe(true);
     store.getState().setAgentSelectionIsUserSet(false);
     expect(store.getState().agentSelectionIsUserSet).toBe(false);
   });


### PR DESCRIPTION
## Problem

User choices made in the AgentBar did not survive page loads:

1. **Per-agent voice picks were lost on refresh.** Picks were stored via `updateAgent(id, { voiceConfig })` on registry records, but the registry persist merge deliberately resets default agents from code (and generated agents are rebuilt from IndexedDB), so the pick silently rolled back to the default voice. Confusingly, the teacher's voice *did* survive, because the teacher pill writes the global `ttsVoice` setting instead.
2. **Visiting a classroom clobbered the AgentBar.** `app/classroom/[id]/page.tsx` unconditionally forced `setAgentMode('auto')` + reset `selectedAgentIds` whenever the stage had generated agents, so merely opening an old course wiped the user's preset/auto choice and agent selection.

Both reproduced end-to-end in a real browser before the fix.

## Approach

User UI preferences get one persistent home, the already-persisted settings store; the agent registry stays a derived runtime view (code + IndexedDB).

- **`agentVoiceOverrides`** (persisted map, keyed by agent id): written by the AgentBar voice picker, consulted at read time by `resolveAgentVoice` with priority *override → agent voiceConfig → deterministic fallback*, validated against enabled providers exactly like `voiceConfig`. `setAgentVoiceOverride(id, undefined)` clears an entry.
- **`agentSelectionIsUserSet`** (persisted flag): set only by real AgentBar interactions (switching to a *different* mode, toggling an agent); cleared whenever a classroom load or generation-preview writes a stage-derived selection. The new pure `restoreAgentSelection` honors the persisted mode/selection on classroom load only when it is user-set **and** still valid for the loaded stage (a preset selection of known non-generated agents, or an auto selection drawn from this stage's generated agents); otherwise it applies the previous stage-derived defaults and marks them not-user-set. This keeps the old behavior for fresh users, imported and server-hydrated classrooms, while a user's explicit choice survives refreshes and classroom visits.

## Known limitations (intentional)

- A user-set preset selection wins over an auto classroom's generated personas — user intent takes precedence. Switching back to Auto-generate in the AgentBar restores the generated roster.
- The picker has no "Auto" reset row yet; the settings API supports clearing an override (`undefined` deletes), UI affordance is a follow-up.

## Testing

- New unit tests: override precedence/validation in `resolveAgentVoice`, persisted override CRUD + real persist-rehydration round-trip (stubbed localStorage, fresh module import), `restoreAgentSelection` including sequential classroom round-trips (auto → preset → auto must not degrade the auto classroom).
- Full suite: 105 files / 796 tests green; `tsc --noEmit`, eslint (one pre-existing warning untouched), prettier clean.
- Browser e2e on a production build: voice pick survives a home refresh; preset mode + selection survive visiting a classroom and returning; a fresh profile visiting an auto classroom still gets its generated agents (no regression).
