### PR TITLE
docs: align lowest-friction provider key example

### DIFF
--- a/skills/openmaic/references/provider-keys.md
+++ b/skills/openmaic/references/provider-keys.md
@@ -39,13 +39,13 @@ Recommended when the user wants the smallest amount of configuration.
 Set:
 
 ```env
-ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
 ```
 
 Why:
 
-- OpenMAIC server fallback is currently `gpt-4o-mini` if `DEFAULT_MODEL` is unset.
-- If the user wants Anthropic or Google by default, they should set `DEFAULT_MODEL` explicitly.
+- OpenMAIC server fallback is currently `openai:gpt-4o-mini` if `DEFAULT_MODEL` is unset.
+- If the user wants Anthropic, Google, or another provider by default, they should set `DEFAULT_MODEL` explicitly with the provider prefix.
 
 ### 2. Better Speed / Cost Balance
 
@@ -128,7 +128,7 @@ DEFAULT_MODEL=google:gemini-3-flash-preview
 Preferred:
 
 - "I recommend configuring OpenMAIC through `.env.local` first. Please edit that file locally and tell me when you're done."
-- "For the simplest setup, I recommend Anthropic. For better speed/cost balance, I recommend Google plus `DEFAULT_MODEL=google:gemini-3-flash-preview`. Which path do you want?"
+- "For the simplest setup, I recommend OpenAI because it matches the default server fallback. For better speed/cost balance, I recommend Google plus `DEFAULT_MODEL=google:gemini-3-flash-preview`. Which path do you want?"
 
 Avoid as the first move:
 


### PR DESCRIPTION
## Summary
- Update the lowest-friction provider key example to use `OPENAI_API_KEY`, matching the default `openai:gpt-4o-mini` fallback.
- Clarify that Anthropic, Google, or other providers need an explicit provider-prefixed `DEFAULT_MODEL`.
- This PR was prepared with Codex assistance. I reviewed the diff and verified it is limited to documentation wording.

## Related Issues
Closes #433

## Changes
- Replace the Anthropic-only key example in `skills/openmaic/references/provider-keys.md` with an OpenAI key example.
- Align the fallback model wording with the provider-prefixed default model string.
- Update the preferred recommendation wording so the simplest setup points to OpenAI instead of Anthropic.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test
1. Review the lowest-friction setup in `skills/openmaic/references/provider-keys.md`.
2. Confirm the example key matches the default `openai:gpt-4o-mini` fallback.
3. Run the local checks listed below.

### What you personally verified
- `pnpm.cmd lint` completed with 0 errors. The remaining 19 warnings are pre-existing repository warnings.
- `git diff --check` completed successfully.
- The diff is limited to the provider key reference documentation.

### Evidence
- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings