### PR TITLE
docs(document): describe multi-format course material upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ docker compose up --build
 
 ### Optional: MinerU (Advanced Document Parsing)
 
-[MinerU](https://github.com/opendatalab/MinerU) provides enhanced parsing for complex tables, formulas, and OCR. You can use the [MinerU official API](https://mineru.net/) or [self-host your own instance](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/).
+[MinerU](https://github.com/opendatalab/MinerU) provides enhanced parsing for complex tables, formulas, OCR, and Office-style course material. OpenMAIC can upload a single course material file and extract it through the document extractor boundary. PDF is supported by the built-in `unpdf` parser, plain text and Markdown are extracted locally, and DOCX/PPTX require a configured MinerU service.
 
-Set `PDF_MINERU_BASE_URL` (and `PDF_MINERU_API_KEY` if needed) in `.env.local`.
+You can use the [MinerU official API](https://mineru.net/) or [self-host your own instance](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/). Set `PDF_MINERU_BASE_URL` (and `PDF_MINERU_API_KEY` if needed) in `.env.local` or configure `pdf.mineru.baseUrl` in `server-providers.yml`.
 
 ### Optional: VoxCPM2 (Self-Hosted TTS with Voice Cloning)
 

--- a/lib/pdf/README.md
+++ b/lib/pdf/README.md
@@ -1,48 +1,68 @@
-# PDF 解析系统
+# Document Extraction and Course Material Upload
 
-提供统一接口支持多种 PDF 解析提供商。
+OpenMAIC routes uploaded course material through the document extraction boundary introduced by MAIC ETL:
 
-## 支持的提供商
-
-### 1. unpdf (内置)
-
-- **成本**: 免费，内置
-- **特性**: 基础文本提取、图片提取
-- **要求**: 无
-- **使用**: 直接上传 PDF 文件
-
-### 2. MinerU (本地部署)
-
-- **成本**: 免费（需要自己部署）
-- **特性**:
-  - 高级文本提取（保留 Markdown 布局）
-  - 表格识别
-  - 公式提取（LaTeX）
-  - 更好的 OCR 支持
-  - 多种输出格式（markdown, JSON, docx, html, latex）
-- **要求**:
-  - 部署 MinerU 服务（Docker 或源码）
-  - 配置服务器地址
-- **优势**: 数据隐私、无文件大小限制
-
-## 快速开始
-
-### 部署 MinerU（可选）
-
-```bash
-# Docker 部署（推荐）
-docker pull opendatalab/mineru:latest
-docker run -d --name mineru -p 8080:8080 opendatalab/mineru:latest
-
-# 验证
-curl http://localhost:8080/api/health
+```text
+file -> DocumentExtractorProvider -> DocumentArtifact -> generation compatibility shape
 ```
 
-### API 使用
+The generation flow still consumes the existing `pdfText` / `pdfImages` compatible fields internally, but the upload surface is document-oriented rather than PDF-only.
 
-#### 使用 unpdf（文件上传）
+## Supported File Types
 
-```typescript
+Initial single-file upload support:
+
+| Type | MIME type | Extractor |
+| --- | --- | --- |
+| PDF | `application/pdf` | `unpdf`, `mineru`, or `mineru-cloud` |
+| DOCX | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | `mineru` |
+| PPTX | `application/vnd.openxmlformats-officedocument.presentationml.presentation` | `mineru` |
+| TXT | `text/plain` | `plain-text` |
+| Markdown | `text/markdown`, `text/x-markdown` | `plain-text` |
+
+Only one course material file is accepted per generation session. Multi-document bundles are a later MAIC ETL milestone.
+
+## Provider Selection
+
+Provider selection follows two rules:
+
+1. If the user explicitly selects a PDF parser, that provider is used for PDF uploads.
+2. If no explicit provider is supplied, OpenMAIC selects a document extractor by MIME type and required capabilities.
+
+Unsupported combinations should fail clearly. For example, `unpdf` with a DOCX file is invalid because `unpdf` only supports PDF.
+
+## API Usage
+
+### Generic Document Extraction
+
+Use `/api/extract-document` for course material upload:
+
+```ts
+const formData = new FormData();
+formData.append('file', file);
+
+const response = await fetch('/api/extract-document', {
+  method: 'POST',
+  body: formData,
+});
+
+const result = await response.json();
+```
+
+For PDF uploads, callers may optionally pass a PDF provider:
+
+```ts
+formData.append('providerId', 'mineru');
+formData.append('baseUrl', 'http://localhost:7777');
+```
+
+For TXT and Markdown uploads, no MinerU service is needed. OpenMAIC extracts the text locally.
+
+### PDF Compatibility API
+
+`/api/parse-pdf` remains available for compatibility with the older PDF-only route:
+
+```ts
 const formData = new FormData();
 formData.append('pdf', pdfFile);
 formData.append('providerId', 'unpdf');
@@ -51,305 +71,94 @@ const response = await fetch('/api/parse-pdf', {
   method: 'POST',
   body: formData,
 });
-
-const result = await response.json();
-// result.data: ParsedPdfContent
 ```
 
-#### 使用 MinerU（本地服务）
+New upload UI code should prefer `/api/extract-document`.
 
-```typescript
-const formData = new FormData();
-formData.append('pdf', pdfFile);
-formData.append('providerId', 'mineru');
-formData.append('baseUrl', 'http://localhost:8080');
+## MinerU Setup
 
-const response = await fetch('/api/parse-pdf', {
-  method: 'POST',
-  body: formData,
-});
+MinerU is optional for PDF, but required for DOCX and PPTX in the initial multi-format upload scope.
 
-const result = await response.json();
-// result.data: ParsedPdfContent with imageMapping
+Set the self-hosted MinerU base URL in `.env.local`:
+
+```env
+PDF_MINERU_BASE_URL=http://localhost:7777
+PDF_MINERU_API_KEY=
 ```
 
-## 响应格式
+Or configure it as a server-managed provider:
 
-```typescript
-interface ParsedPdfContent {
-  text: string; // 提取的文本（MinerU 为 Markdown）
-  images: string[]; // Base64 图片数组
+```yaml
+pdf:
+  mineru:
+    baseUrl: http://localhost:7777
+```
 
-  // 扩展特性（MinerU）
-  tables?: Array<{
-    page: number;
-    data: string[][];
-    caption?: string;
-  }>;
+When configured server-side, OpenMAIC treats MinerU as admin-managed and ignores client-supplied base URLs for that provider.
 
-  formulas?: Array<{
-    page: number;
-    latex: string;
-    position?: { x: number; y: number; width: number; height: number };
-  }>;
+## Response Shape
 
-  layout?: Array<{
-    page: number;
-    type: 'title' | 'text' | 'image' | 'table' | 'formula';
-    content: string;
-    position?: { x: number; y: number; width: number; height: number };
-  }>;
+The document extractor output is normalized internally as `DocumentArtifact`:
 
-  metadata?: {
-    pageCount: number;
-    parser: 'unpdf' | 'mineru';
+```ts
+interface DocumentArtifact {
+  metadata: {
     fileName?: string;
     fileSize?: number;
+    mimeType?: string;
+    pageCount?: number;
+    providerId?: string;
     processingTime?: number;
+  };
+  blocks: DocumentBlock[];
+  assets: DocumentAsset[];
+  citations?: DocumentCitation[];
+  diagnostics?: DocumentDiagnostic[];
+  providerRaw?: unknown;
+}
+```
 
-    // 用于内容生成流程（MinerU）
-    imageMapping?: Record<string, string>; // img_1 -> base64 URL
+The upload/generation compatibility layer returns the existing `ParsedPdfContent` shape:
+
+```ts
+interface ParsedPdfContent {
+  text: string;
+  images: string[];
+  tables?: unknown[];
+  formulas?: unknown[];
+  layout?: unknown[];
+  metadata?: {
+    pageCount: number;
+    parser?: string;
+    fileName?: string;
+    fileSize?: number;
+    mimeType?: string;
+    processingTime?: number;
+    imageMapping?: Record<string, string>;
     pdfImages?: Array<{
-      id: string; // img_1, img_2, etc.
-      src: string; // base64 data URL
-      pageNumber: number; // PDF 页码
-      description?: string; // 图片描述
+      id: string;
+      src: string;
+      pageNumber: number;
+      description?: string;
     }>;
   };
 }
 ```
 
-## 与内容生成集成
+This keeps existing generation prompts and image assignment logic stable while allowing the upload boundary to evolve beyond PDF.
 
-MinerU 解析器与内容生成流程无缝集成：
+## Current Scope and Non-Goals
 
-```typescript
-// 1. 解析 PDF
-const parseResult = await parsePDF(
-  {
-    providerId: 'mineru',
-    baseUrl: 'http://localhost:8080',
-  },
-  buffer,
-);
+Included:
 
-// 2. 提取数据
-const pdfText = parseResult.text; // Markdown（含 img_1 引用）
-const pdfImages = parseResult.metadata.pdfImages; // 图片数组
-const imageMapping = parseResult.metadata.imageMapping; // 图片映射
+- Single-file course material upload.
+- PDF, DOCX, PPTX, TXT, and Markdown validation.
+- Provider selection by explicit user choice or capability match.
+- Clear errors for unsupported formats and unsupported provider/format combinations.
 
-// 3. 生成场景大纲
-await generateSceneOutlinesFromRequirements(
-  requirements,
-  pdfText, // Markdown 内容
-  pdfImages, // 带页码的图片
-  aiCall,
-);
+Not included:
 
-// 4. 生成场景（含图片）
-await buildSceneFromOutline(
-  outline,
-  aiCall,
-  stageId,
-  assignedImages, // 从 pdfImages 筛选
-  imageMapping, // 用于解析 img_1 到实际 URL
-);
-```
-
-## 图片处理流程
-
-MinerU 的图片处理：
-
-1. **提取**: PDF → MinerU → Markdown + 图片
-2. **转换**: `![alt](images/img_1.png)` → `![alt](img_1)`
-3. **映射**: 创建 `{ "img_1": "data:image/png;base64,..." }`
-4. **生成**: AI 使用 `img_1` 引用生成幻灯片
-5. **解析**: `resolveImageIds()` 替换为实际 URL
-6. **渲染**: 幻灯片显示图片
-
-## 配置
-
-### 全局设置
-
-```typescript
-import { useSettingsStore } from '@/lib/store/settings';
-
-useSettingsStore.setState({
-  pdfProviderId: 'mineru',
-  pdfProvidersConfig: {
-    mineru: {
-      baseUrl: 'http://localhost:8080',
-      apiKey: 'optional-if-needed',
-    },
-  },
-});
-```
-
-### 请求级配置
-
-```typescript
-// 在 API 调用时覆盖全局设置
-formData.append('providerId', 'mineru');
-formData.append('baseUrl', 'http://your-server:8080');
-formData.append('apiKey', 'optional');
-```
-
-## 添加新的提供商
-
-### 1. 定义提供商
-
-`lib/pdf/constants.ts`:
-
-```typescript
-export const PDF_PROVIDERS = {
-  myProvider: {
-    id: 'myProvider',
-    name: 'My Provider',
-    requiresApiKey: true,
-    features: ['text', 'images'],
-  },
-};
-```
-
-### 2. 实现解析器
-
-`lib/pdf/pdf-providers.ts`:
-
-```typescript
-async function parseWithMyProvider(
-  config: PDFParserConfig,
-  pdfBuffer: Buffer
-): Promise<ParsedPdfContent> {
-  // 实现解析逻辑
-  return {
-    text: '...',
-    images: [...],
-    metadata: {
-      pageCount: 0,
-      parser: 'myProvider',
-    },
-  };
-}
-```
-
-### 3. 添加到路由
-
-```typescript
-switch (config.providerId) {
-  case 'unpdf':
-    result = await parseWithUnpdf(pdfBuffer);
-    break;
-  case 'mineru':
-    result = await parseWithMinerU(config, pdfBuffer);
-    break;
-  case 'myProvider':
-    result = await parseWithMyProvider(config, pdfBuffer);
-    break;
-}
-```
-
-## 调试工具
-
-访问 http://localhost:3000/debug/pdf-parser 测试解析功能：
-
-- 切换提供商（unpdf/MinerU）
-- 上传 PDF 文件
-- 配置服务器地址
-- 查看解析结果
-- 检查图片映射
-
-## 常见问题
-
-### Q: MinerU 服务无法连接？
-
-**A**: 检查：
-
-```bash
-# 服务状态
-docker ps | grep mineru
-
-# 网络连通性
-curl http://localhost:8080/api/health
-
-# 日志
-docker logs mineru
-```
-
-### Q: 图片不显示？
-
-**A**: 确保：
-
-1. `imageMapping` 正确传递到 scene-stream API
-2. 图片 ID 格式正确（img_1, img_2）
-3. Base64 编码完整
-
-### Q: 解析速度慢？
-
-**A**: 优化：
-
-```bash
-# 增加 Docker 资源
-docker run -d \
-  --name mineru \
-  -p 8080:8080 \
-  --memory=4g \
-  --cpus=2 \
-  opendatalab/mineru:latest
-```
-
-### Q: unpdf vs MinerU 如何选择？
-
-**A**: 选择建议：
-
-| 场景               | 推荐   |
-| ------------------ | ------ |
-| 简单 PDF（纯文本） | unpdf  |
-| 包含表格、公式     | MinerU |
-| 需要保留布局       | MinerU |
-| 快速测试           | unpdf  |
-| 生产环境           | MinerU |
-| 无法部署服务       | unpdf  |
-
-## 性能建议
-
-### MinerU 并发处理
-
-```typescript
-const files = [file1, file2, file3];
-
-const results = await Promise.all(
-  files.map((file) => {
-    const formData = new FormData();
-    formData.append('pdf', file);
-    formData.append('providerId', 'mineru');
-    return fetch('/api/parse-pdf', {
-      method: 'POST',
-      body: formData,
-    }).then((r) => r.json());
-  }),
-);
-```
-
-### 结果缓存
-
-```typescript
-// 考虑缓存解析结果
-const cacheKey = `pdf_${fileHash}`;
-const cached = localStorage.getItem(cacheKey);
-if (cached) {
-  return JSON.parse(cached);
-}
-```
-
-## 参考资源
-
-- **MinerU GitHub**: https://github.com/opendatalab/MinerU
-- **快速开始**: `/MINERU_QUICKSTART.md`
-- **变更说明**: `/MINERU_LOCAL_DEPLOYMENT.md`
-- **调试工具**: http://localhost:3000/debug/pdf-parser
-
----
-
-**最后更新**: 2026-02-11
-**模式**: 本地自托管
-**状态**: 生产就绪
+- Multi-document bundles.
+- Long-document transforms or chapter slicing.
+- RAG, vector storage, or persistent knowledge workspaces.
+- A general knowledge-base UI.


### PR DESCRIPTION
## Summary

Document the MAIC ETL multi-format course material upload flow.

This PR updates the MinerU/document extraction documentation to describe `/api/extract-document`, supported file types, provider selection behavior, server-side MinerU configuration, the compatibility response shape, and the current Milestone 2 scope/non-goals.

## Related Issues

Related to #621, #611, #41, #140

## Changes

- Update the README MinerU section to describe course material upload and server-side configuration.
- Replace the old PDF-only parser README with document extraction and multi-format upload documentation.
- Document supported file types: PDF, DOCX, PPTX, TXT, and Markdown.
- Document provider selection by explicit PDF parser choice or capability match.
- Document unsupported provider/format diagnostics.
- Document MinerU setup via `.env.local` and `server-providers.yml`.
- Clarify the compatibility response shape used by the existing generation flow.
- Clarify current Milestone 2 scope and non-goals.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Read the updated README MinerU section.
2. Read `lib/pdf/README.md` and confirm it describes the current document extraction and multi-format upload behavior.
3. Confirm the docs-only branch contains only documentation changes.

### What you personally verified

- The docs PR changes only `README.md` and `lib/pdf/README.md`.
- The updated docs describe the split between local TXT/Markdown extraction and MinerU-backed DOCX/PPTX extraction.
- The updated docs preserve `/api/parse-pdf` as a compatibility route while recommending `/api/extract-document` for new upload UI code.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

Local verification:

```text
/tmp/openmaic-multiformat-upload/node_modules/.bin/prettier README.md lib/pdf/README.md --check
All matched files use Prettier code style!

git diff --name-only
README.md
lib/pdf/README.md
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
