### PR TITLE
feat(dsl): promote Stage/Scene lesson skeleton into @maic/dsl (#740)

### DIFF
--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -10,10 +10,7 @@
 // `Scene` is re-exported as an alias of the app's fully-instantiated
 // `Scene<Action, AppSceneContent>`, so existing `import { Scene }` callers keep
 // the same semantics (actions are `Action[]`, content spans all four kinds).
-import type {
-  Scene as DslScene,
-  SceneContent as DslSceneContent,
-} from '@maic/dsl';
+import type { Scene as DslScene, SceneContent as DslSceneContent } from '@maic/dsl';
 import type { Action } from '@/lib/types/action';
 import type { WidgetType, WidgetConfig, TeacherAction } from '@/lib/types/widgets';
 import type { PBLProjectConfig } from '@/lib/pbl/types';

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -28,9 +28,12 @@ export type {
   QuizOption,
   QuizQuestion,
   QuizContent,
-  isSlideContent,
-  isQuizContent,
 } from '@maic/dsl';
+
+// The two discriminant guards are runtime functions, so they must be value
+// re-exported — a bare `export type {}` erases them and leaves the import as
+// `undefined` at runtime / "cannot be used as a value" at the type level.
+export { isSlideContent, isQuizContent } from '@maic/dsl';
 
 // The contract's `SceneContent` is the universal subset (slide | quiz). Reach it
 // under a distinct name; the app's own `SceneContent` (declared below) is the

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -1,150 +1,55 @@
-// Stage and Scene data types
-import type { Slide } from '@maic/dsl';
+// Stage and Scene data types.
+//
+// The universal lesson skeleton (Stage / Scene / SceneContent / Whiteboard /
+// VideoManifest / SlideContent / QuizContent / …) now lives in `@maic/dsl` and
+// is re-exported below. `Scene` is generic there: the contract owns only the
+// structure + the slide/quiz content kinds, while the playback `Action` set and
+// the richer feature content (interactive widgets, PBL) are app-side and get
+// composed in here.
+//
+// `Scene` is re-exported as an alias of the app's fully-instantiated
+// `Scene<Action, AppSceneContent>`, so existing `import { Scene }` callers keep
+// the same semantics (actions are `Action[]`, content spans all four kinds).
+import type {
+  Scene as DslScene,
+  SceneContent as DslSceneContent,
+} from '@maic/dsl';
 import type { Action } from '@/lib/types/action';
-import type { PBLProjectConfig } from '@/lib/pbl/types';
 import type { WidgetType, WidgetConfig, TeacherAction } from '@/lib/types/widgets';
+import type { PBLProjectConfig } from '@/lib/pbl/types';
 
-export type SceneType = 'slide' | 'quiz' | 'interactive' | 'pbl';
+export type {
+  SceneType,
+  StageMode,
+  Whiteboard,
+  VideoManifestEntry,
+  VideoManifest,
+  GeneratedAgentConfig,
+  MultiAgentConfig,
+  Stage,
+  SlideContent,
+  QuizOption,
+  QuizQuestion,
+  QuizContent,
+  isSlideContent,
+  isQuizContent,
+} from '@maic/dsl';
 
-export type StageMode = 'autonomous' | 'playback' | 'edit';
+// The contract's `SceneContent` is the universal subset (slide | quiz). Reach it
+// under a distinct name; the app's own `SceneContent` (declared below) is the
+// full four-way union so existing `switch (content.type)` call sites keep all
+// four cases.
+export type { SceneContent as SceneContentBase } from '@maic/dsl';
 
-export type Whiteboard = Omit<Slide, 'theme' | 'turningMode' | 'sectionTag' | 'type'>;
-
-export interface VideoManifestEntry {
-  type: 'video';
-  prompt: string;
-  aspectRatio?: string;
-}
-
-export type VideoManifest = Record<string, VideoManifestEntry>;
-
-/**
- * Stage - Represents the entire classroom/course
- */
-export interface Stage {
-  id: string;
-  name: string;
-  description?: string;
-  createdAt: number;
-  updatedAt: number;
-  // Stage metadata
-  languageDirective?: string;
-  style?: string;
-  // Whiteboard data
-  whiteboard?: Whiteboard[];
-  // Generated video requests keyed by the mediaRef used by PPTVideoElement.
-  // Runtime media state lives in the media task store / persisted media files.
-  videoManifest?: VideoManifest;
-  // Agent IDs selected when this classroom was created
-  agentIds?: string[];
-  /**
-   * Server-generated agent configurations.
-   * Embedded in persisted classroom JSON so clients can hydrate
-   * the agent registry without relying on IndexedDB pre-population.
-   * Only present for API-generated classrooms.
-   */
-  generatedAgentConfigs?: Array<{
-    id: string;
-    name: string;
-    role: string;
-    persona: string;
-    avatar: string;
-    color: string;
-    priority: number;
-  }>;
-  /**
-   * True when this classroom was generated with Interactive Mode enabled
-   * (the INTERACTIVE_OUTLINES prompt branch).
-   * Absent on legacy classrooms, imports, and regular-mode generations.
-   */
-  interactiveMode?: boolean;
-  /**
-   * True when this classroom was generated with the vocational Task Engine
-   * path enabled. This is distinct from `interactiveMode`: task-engine
-   * classrooms are interactive, but not every interactive classroom is
-   * vocational.
-   */
-  taskEngineMode?: boolean;
-}
+// The raw, generic contract Scene is reachable under a distinct name for
+// callers (e.g. read-only renderers) that want the feature-free skeleton.
+export type { Scene as SceneShape } from '@maic/dsl';
 
 /**
- * Scene - Represents a single page/scene in the course
- */
-export interface Scene {
-  id: string;
-  stageId: string; // ID of the parent stage (for data integrity checks)
-  type: SceneType;
-  title: string;
-  order: number; // Display order
-
-  // Type-specific content
-  content: SceneContent;
-
-  // Actions to execute during playback
-  actions?: Action[];
-
-  // Whiteboards to explain deeply
-  whiteboards?: Slide[];
-
-  // Multi-agent discussion configuration
-  multiAgent?: {
-    enabled: boolean; // Enable multi-agent for this scene
-    agentIds: string[]; // Which agents to include (from registry)
-    directorPrompt?: string; // Optional custom director instructions
-  };
-
-  // Metadata
-  createdAt?: number;
-  updatedAt?: number;
-}
-
-/**
- * Scene content based on type
- */
-export type SceneContent = SlideContent | QuizContent | InteractiveContent | PBLContent;
-
-/**
- * Slide content - PPTist Canvas data.
+ * Interactive content - Interactive web page (iframe).
  *
- * `schemaVersion` tags the on-disk shape of this content so future schema
- * changes can ship behind a migration step (see `migrateSlideContent`).
- * Optional for backward compatibility — legacy / pre-versioning data
- * lacks the field and `migrateSlideContent` normalizes it.
- */
-export interface SlideContent {
-  type: 'slide';
-  schemaVersion?: number;
-  // PPTist slide data structure
-  canvas: Slide;
-}
-
-/**
- * Quiz content - React component props/data
- */
-export interface QuizContent {
-  type: 'quiz';
-  questions: QuizQuestion[];
-}
-
-export interface QuizOption {
-  label: string; // Display text
-  value: string; // Selection key: "A", "B", "C", "D"
-}
-
-export interface QuizQuestion {
-  id: string;
-  type: 'single' | 'multiple' | 'short_answer';
-  question: string;
-  options?: QuizOption[];
-  answer?: string[]; // Correct answer values: ["A"], ["A","C"], or undefined for text
-  analysis?: string; // Explanation shown after grading
-  commentPrompt?: string; // Grading guidance for text questions
-  hasAnswer?: boolean; // Whether auto-grading is possible
-  points?: number; // Points per question (default 1)
-}
-
-/**
- * Interactive content - Interactive web page (iframe)
+ * App-level feature surface: kept here rather than in `@maic/dsl` because it
+ * couples to Ultra-mode widget configs (`WidgetType` / `WidgetConfig`).
  */
 export interface InteractiveContent {
   type: 'interactive';
@@ -158,18 +63,37 @@ export interface InteractiveContent {
 }
 
 /**
- * PBL content - Project-based learning
+ * PBL content - Project-based learning.
+ *
+ * App-level feature surface: kept here rather than in `@maic/dsl` because it
+ * couples to the project-based-learning config (`PBLProjectConfig`).
  */
 export interface PBLContent {
   type: 'pbl';
   projectConfig: PBLProjectConfig;
 }
 
-// Re-export generation types for convenience
-export type {
-  UserRequirements,
-  SceneOutline,
-  GenerationSession,
-  GenerationProgress,
-  UploadedDocument,
-} from './generation';
+/**
+ * The app's full scene-content union: the contract's universal kinds plus the
+ * app-only feature kinds. This is what `@/lib/types/stage` callers have always
+ * known as `SceneContent` (all four cases).
+ */
+export type AppSceneContent = DslSceneContent | InteractiveContent | PBLContent;
+
+/**
+ * The app's `SceneContent` — the full four-way union. Overrides the contract's
+ * narrower `SceneContentBase` (slide | quiz) so call sites that switch on all
+ * four `content.type` cases keep compiling.
+ */
+export type SceneContent = AppSceneContent;
+
+/**
+ * The app's concrete scene type: the contract skeleton instantiated with the
+ * app's playback action set and full content union.
+ *
+ * Aliased as `Scene` so existing `import { Scene } from '@/lib/types/stage'`
+ * callers keep their original semantics (actions are `Action[]`, content spans
+ * all four kinds).
+ */
+export type AppScene = DslScene<Action, SceneContent>;
+export type Scene = AppScene;

--- a/packages/@maic/dsl/README.md
+++ b/packages/@maic/dsl/README.md
@@ -25,6 +25,7 @@ nothing.
 | Module        | Contents                                                            |
 | ------------- | ------------------------------------------------------------------- |
 | `slides.ts`   | The slide object model: `Slide`, `PPTElement` and all variants, theme, background, animation, table/chart/code types, plus `ElementTypes` / `ShapePathFormulasKeys` enums. |
+| `stage.ts`    | The lesson skeleton: `Stage`, generic `Scene<TAction, TContent>`, `SceneType`, `StageMode`, `Whiteboard`, `VideoManifest`, `SlideContent`, `QuizContent`, `MultiAgentConfig`, `GeneratedAgentConfig`, plus `isSlideContent` / `isQuizContent` guards. |
 | `guards.ts`   | Pure discriminant type-guards (`isTextElement`, …) and `PPT_ELEMENT_TYPES`. |
 | `version.ts`  | `DSL_VERSION` + the `DslMigration` shape and (empty) migration registry. |
 
@@ -51,10 +52,32 @@ of the slide types:
 - [x] Wire `@maic/importer` to import types from `@maic/dsl` (vendored copy deleted).
 - [x] Wire `@maic/renderer` to import types from `@maic/dsl` (vendored copy deleted).
 - [ ] Add the JSON Schema for the slide contract + a pure schema validator.
-- [ ] Promote the `stage` / `scene` / `scene-content` types into the DSL (these
-      currently live in `lib/types/stage.ts` and carry deps on `Action`, PBL,
-      Widgets, generation types — those pure types need migrating too).
+- [x] Promote the `stage` / `scene` / `scene-content` types into the DSL (the
+      universal skeleton now lives in `stage.ts`; `Action`, Ultra-mode widgets,
+      and PBL stay app-side and plug in via `Scene<TAction, TContent>`).
 - [ ] Reserve `@maic/exporter` as the 4th family member.
+
+### Stage / Scene split
+
+`stage.ts` owns only the **universal lesson skeleton**: `Stage`, the
+discriminated `SceneContent` (`SlideContent | QuizContent`), and a generic
+
+```ts
+interface Scene<TAction = never, TContent extends { type: SceneType } = SlideContent | QuizContent>
+```
+
+so the contract carries no dependency on the playback action set or the richer
+feature surfaces. Apps compose their full scene type by injecting their own
+types:
+
+```ts
+import type { Scene } from '@maic/dsl';
+type AppScene = Scene<AppAction, SlideContent | QuizContent | InteractiveContent | PBLContent>;
+```
+
+`Action`, widget configs (`WidgetType` / `WidgetConfig`), and `PBLProjectConfig`
+are deliberately out of scope here — they're faster-moving product surfaces and
+may graduate to sibling packages (`@maic/actions`, …) later.
 
 ## Divergence reconciled (seed provenance)
 

--- a/packages/@maic/dsl/package.json
+++ b/packages/@maic/dsl/package.json
@@ -22,7 +22,9 @@
     "clean": "rm -rf dist",
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "maic",
@@ -37,6 +39,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/@maic/dsl/src/index.ts
+++ b/packages/@maic/dsl/src/index.ts
@@ -10,7 +10,14 @@
  * This package contains ONLY the spec: types, (future) JSON Schema, pure
  * validators / type-guards, and version/migration helpers. It must never gain
  * a runtime dependency on React, pptx, echarts, etc.
+ *
+ * The lesson skeleton (`Stage` / `Scene` / `SceneContent`) lives here. `Scene`
+ * is generic: the contract owns only the universal structure + the slide/quiz
+ * content kinds, while playback `Action`s, Ultra-mode widgets, and PBL configs
+ * are app-side feature surfaces that consumers inject via `Scene`'s type
+ * parameters.
  */
 export * from './slides.js';
 export * from './guards.js';
+export * from './stage.js';
 export * from './version.js';

--- a/packages/@maic/dsl/src/stage.ts
+++ b/packages/@maic/dsl/src/stage.ts
@@ -205,20 +205,24 @@ export interface Scene<
 // ---------------------------------------------------------------------------
 
 /**
- * Narrow a {@link SceneContent} (or any candidate) to {@link SlideContent}.
+ * Narrow a candidate to {@link SlideContent}. Accepts any value tagged with a
+ * `type: SceneType` discriminant — including an app-widened content union that
+ * adds interactive / pbl kinds beyond the contract's universal two.
  * Pure, no runtime deps.
  */
-export function isSlideContent<T extends SceneContent>(
+export function isSlideContent<T extends { type: SceneType }>(
   content: T,
 ): content is T & SlideContent {
   return content.type === 'slide';
 }
 
 /**
- * Narrow a {@link SceneContent} (or any candidate) to {@link QuizContent}.
+ * Narrow a candidate to {@link QuizContent}. Accepts any value tagged with a
+ * `type: SceneType` discriminant — including an app-widened content union that
+ * adds interactive / pbl kinds beyond the contract's universal two.
  * Pure, no runtime deps.
  */
-export function isQuizContent<T extends SceneContent>(
+export function isQuizContent<T extends { type: SceneType }>(
   content: T,
 ): content is T & QuizContent {
   return content.type === 'quiz';

--- a/packages/@maic/dsl/src/stage.ts
+++ b/packages/@maic/dsl/src/stage.ts
@@ -1,0 +1,225 @@
+/**
+ * Stage / Scene / SceneContent — the universal lesson-skeleton contract.
+ *
+ * This module owns the *structural* part of a lesson: the top-level `Stage`
+ * container and a per-page `Scene` whose `content` is a discriminated union of
+ * the universal content kinds (`SlideContent`, `QuizContent`). Richer,
+ * faster-moving feature surfaces (playback `Action`s, Ultra-mode widgets, PBL
+ * project configs) are deliberately *not* defined here — they stay in the
+ * consuming app and are threaded in through `Scene`'s generic parameters.
+ *
+ * The split keeps `@maic/dsl` focused on the lesson skeleton while letting the
+ * runtime engine, renderer, and importer share one source of truth for it.
+ *
+ * No runtime dependencies. Pure types + pure discriminant guards only.
+ */
+import type { Slide } from './slides.js';
+
+/** All scene kinds the contract is aware of. Feature kinds (interactive/pbl) are still valid `type` values — their *content* shapes live in the app and are composed in via {@link Scene}'s `TContent` parameter. */
+export type SceneType = 'slide' | 'quiz' | 'interactive' | 'pbl';
+
+/** Lifecycle / interaction mode a {@link Stage} can be operated in. */
+export type StageMode = 'autonomous' | 'playback' | 'edit';
+
+/**
+ * A whiteboard slide. Structurally a {@link Slide} minus the fields that only
+ * make sense on a primary canvas (`theme`, `turningMode`, `sectionTag`, `type`).
+ */
+export type Whiteboard = Omit<Slide, 'theme' | 'turningMode' | 'sectionTag' | 'type'>;
+
+export interface VideoManifestEntry {
+  type: 'video';
+  prompt: string;
+  aspectRatio?: string;
+}
+
+export type VideoManifest = Record<string, VideoManifestEntry>;
+
+/**
+ * Server-generated agent configuration. Embedded in persisted classroom JSON
+ * so clients can hydrate the agent registry without relying on IndexedDB
+ * pre-population. Only present for API-generated classrooms.
+ */
+export interface GeneratedAgentConfig {
+  id: string;
+  name: string;
+  role: string;
+  persona: string;
+  avatar: string;
+  color: string;
+  priority: number;
+}
+
+/**
+ * Multi-agent discussion configuration for a single scene.
+ */
+export interface MultiAgentConfig {
+  /** Enable multi-agent for this scene. */
+  enabled: boolean;
+  /** Which agents to include (from the registry). */
+  agentIds: string[];
+  /** Optional custom director instructions. */
+  directorPrompt?: string;
+}
+
+/**
+ * Stage - Represents the entire classroom/course.
+ */
+export interface Stage {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: number;
+  updatedAt: number;
+  // Stage metadata
+  languageDirective?: string;
+  style?: string;
+  // Whiteboard data
+  whiteboard?: Whiteboard[];
+  // Generated video requests keyed by the mediaRef used by PPTVideoElement.
+  // Runtime media state lives in the media task store / persisted media files.
+  videoManifest?: VideoManifest;
+  // Agent IDs selected when this classroom was created
+  agentIds?: string[];
+  /**
+   * Server-generated agent configurations. See {@link GeneratedAgentConfig}.
+   */
+  generatedAgentConfigs?: GeneratedAgentConfig[];
+  /**
+   * True when this classroom was generated with Interactive Mode enabled
+   * (the INTERACTIVE_OUTLINES prompt branch).
+   * Absent on legacy classrooms, imports, and regular-mode generations.
+   */
+  interactiveMode?: boolean;
+  /**
+   * True when this classroom was generated with the vocational Task Engine
+   * path enabled. This is distinct from `interactiveMode`: task-engine
+   * classrooms are interactive, but not every interactive classroom is
+   * vocational.
+   */
+  taskEngineMode?: boolean;
+}
+
+/**
+ * Slide content - PPTist Canvas data.
+ *
+ * `schemaVersion` tags the on-disk shape of this content so future schema
+ * changes can ship behind a migration step (see the app's `migrateSlideContent`).
+ * Optional for backward compatibility — legacy / pre-versioning data lacks the
+ * field and the app normalizes it.
+ */
+export interface SlideContent {
+  type: 'slide';
+  schemaVersion?: number;
+  // PPTist slide data structure
+  canvas: Slide;
+}
+
+export interface QuizOption {
+  label: string; // Display text
+  value: string; // Selection key: "A", "B", "C", "D"
+}
+
+export interface QuizQuestion {
+  id: string;
+  type: 'single' | 'multiple' | 'short_answer';
+  question: string;
+  options?: QuizOption[];
+  answer?: string[]; // Correct answer values: ["A"], ["A","C"], or undefined for text
+  analysis?: string; // Explanation shown after grading
+  commentPrompt?: string; // Grading guidance for text questions
+  hasAnswer?: boolean; // Whether auto-grading is possible
+  points?: number; // Points per question (default 1)
+}
+
+/**
+ * Quiz content - React component props/data.
+ */
+export interface QuizContent {
+  type: 'quiz';
+  questions: QuizQuestion[];
+}
+
+/**
+ * The universal scene-content kinds owned by the contract.
+ *
+ * App-specific kinds (interactive / pbl) are NOT members here: they carry
+ * richer feature coupling (Ultra-mode widgets, PBL project configs) and stay in
+ * the consuming app. Apps compose their full content union as
+ * `SceneContent | InteractiveContent | PBLContent` and feed it to {@link Scene}'s
+ * `TContent` parameter.
+ */
+export type SceneContent = SlideContent | QuizContent;
+
+/**
+ * Scene - Represents a single page/scene in the course.
+ *
+ * Generic so the contract owns only the universal skeleton while the app
+ * injects its concrete playback action set and full content union:
+ *
+ * ```ts
+ * // app side
+ * type AppScene = Scene<Action, AppSceneContent>;
+ * ```
+ *
+ * Defaults (`TAction = never`, `TContent = SlideContent | QuizContent`) yield a
+ * read-only, feature-free scene — what renderers / importers that only care
+ * about the skeleton want. The `TContent` constraint is structural — any union
+ * of objects tagged with a `type: SceneType` discriminant satisfies it — so an
+ * app can pass its own wider content union (slide | quiz | interactive | pbl).
+ *
+ * @template TAction  - The playback action type (defaults to `never`, i.e. none).
+ * @template TContent - The scene-content union; any object union tagged with a
+ *                      `type: {@link SceneType}` discriminant (defaults to the
+ *                      two universal kinds).
+ */
+export interface Scene<
+  TAction = never,
+  TContent extends { type: SceneType } = SlideContent | QuizContent,
+> {
+  id: string;
+  stageId: string; // ID of the parent stage (for data integrity checks)
+  type: SceneType;
+  title: string;
+  order: number; // Display order
+
+  // Type-specific content
+  content: TContent;
+
+  // Actions to execute during playback (app-injected)
+  actions?: TAction[];
+
+  // Whiteboards to explain deeply
+  whiteboards?: Slide[];
+
+  // Multi-agent discussion configuration
+  multiAgent?: MultiAgentConfig;
+
+  // Metadata
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure discriminant guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow a {@link SceneContent} (or any candidate) to {@link SlideContent}.
+ * Pure, no runtime deps.
+ */
+export function isSlideContent<T extends SceneContent>(
+  content: T,
+): content is T & SlideContent {
+  return content.type === 'slide';
+}
+
+/**
+ * Narrow a {@link SceneContent} (or any candidate) to {@link QuizContent}.
+ * Pure, no runtime deps.
+ */
+export function isQuizContent<T extends SceneContent>(
+  content: T,
+): content is T & QuizContent {
+  return content.type === 'quiz';
+}

--- a/packages/@maic/dsl/test/stage.test.ts
+++ b/packages/@maic/dsl/test/stage.test.ts
@@ -73,6 +73,17 @@ describe('discriminant guards', () => {
       expect.fail('expected slide content');
     }
   });
+
+  it('accepts an app-widened content union (interactive / pbl kinds)', () => {
+    // Regression: the generic Scene lets apps widen TContent beyond the
+    // contract's slide|quiz, so the guards must accept that widened union too
+    // (not just the narrow SceneContent).
+    type InteractiveContent = { type: 'interactive'; url: string };
+    type Widened = SceneContent | InteractiveContent;
+    const c: Widened = { type: 'interactive', url: 'https://example.com' };
+    expect(isSlideContent(c)).toBe(false);
+    expect(isQuizContent(c)).toBe(false);
+  });
 });
 
 describe('Scene<TAction, TContent> generic', () => {
@@ -113,9 +124,10 @@ describe('Scene<TAction, TContent> generic', () => {
 
   it('TAction defaults to never so the default Scene rejects concrete actions at the type level', () => {
     // A default `Scene` with actions supplied must NOT type-check: `never[]`
-    // accepts no concrete element. Asserted via expectTypeOf.
+    // accepts no concrete element. Pin the exact type so the default can't
+    // silently drift to something that would accept a concrete action.
     type DefaultScene = Scene;
-    expectTypeOf<DefaultScene['actions']>().toMatchTypeOf<unknown[] | undefined>();
+    expectTypeOf<DefaultScene['actions']>().toEqualTypeOf<never[] | undefined>();
   });
 });
 

--- a/packages/@maic/dsl/test/stage.test.ts
+++ b/packages/@maic/dsl/test/stage.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import {
+  isSlideContent,
+  isQuizContent,
+  type Scene,
+  type SceneContent,
+  type SceneType,
+  type SlideContent,
+  type QuizContent,
+  type Whiteboard,
+} from '@maic/dsl';
+
+/**
+ * Contract tests for the promoted stage / scene types.
+ *
+ * These pin the contract shape that the app (and future @maic/* consumers)
+ * code against: the generic Scene defaults, the app-instantiation pattern,
+ * the discriminant guards, and the Whiteboard Omit shape.
+ */
+
+const slideContent: SlideContent = {
+  type: 'slide',
+  canvas: {
+    id: 's1',
+    viewportSize: 1920,
+    viewportRatio: 0.5625,
+    theme: { themeColors: [], fontColor: '#000', fontName: 'Arial', backgroundColor: '#fff' },
+    elements: [],
+  },
+};
+
+const quizContent: QuizContent = {
+  type: 'quiz',
+  questions: [
+    {
+      id: 'q1',
+      type: 'single',
+      question: '2 + 2?',
+      options: [
+        { label: '3', value: 'A' },
+        { label: '4', value: 'B' },
+      ],
+      answer: ['B'],
+    },
+  ],
+};
+
+describe('SceneContent (contract layer)', () => {
+  it('is the universal two-way union (slide | quiz)', () => {
+    const c: SceneContent = slideContent;
+    const c2: SceneContent = quizContent;
+    expect(c.type).toBe('slide');
+    expect(c2.type).toBe('quiz');
+  });
+});
+
+describe('discriminant guards', () => {
+  it('isSlideContent narrows to SlideContent', () => {
+    expect(isSlideContent(slideContent)).toBe(true);
+    expect(isSlideContent(quizContent)).toBe(false);
+  });
+
+  it('isQuizContent narrows to QuizContent', () => {
+    expect(isQuizContent(quizContent)).toBe(true);
+    expect(isQuizContent(slideContent)).toBe(false);
+  });
+
+  it('narrows within a switch so the canvas is reachable', () => {
+    const c: SceneContent = slideContent;
+    if (isSlideContent(c)) {
+      expect(c.canvas.id).toBe('s1');
+    } else {
+      expect.fail('expected slide content');
+    }
+  });
+});
+
+describe('Scene<TAction, TContent> generic', () => {
+  it('default Scene is the feature-free skeleton (no actions, slide/quiz content)', () => {
+    // No type args: actions default to never[], content to slide | quiz.
+    const s: Scene = {
+      id: 'sc1',
+      stageId: 'stg1',
+      type: 'slide',
+      title: 'Intro',
+      order: 0,
+      content: slideContent,
+    };
+    expect(s.id).toBe('sc1');
+    // actions is optional and, when absent, undefined.
+    expect(s.actions).toBeUndefined();
+  });
+
+  it('app-instantiation pattern: inject an action set and a wider content union', () => {
+    // Simulates the app's `type AppScene = Scene<Action, AppSceneContent>`.
+    type AppAction = { id: string; kind: 'speech'; text: string };
+    type InteractiveContent = { type: 'interactive'; url: string };
+    type AppContent = SlideContent | QuizContent | InteractiveContent;
+
+    const appScene: Scene<AppAction, AppContent> = {
+      id: 'sc2',
+      stageId: 'stg1',
+      type: 'interactive',
+      title: 'Widget',
+      order: 1,
+      content: { type: 'interactive', url: 'https://example.com' },
+      actions: [{ id: 'a1', kind: 'speech', text: 'hello' }],
+    };
+
+    expect(appScene.content.type).toBe('interactive');
+    expect(appScene.actions?.[0].kind).toBe('speech');
+  });
+
+  it('TAction defaults to never so the default Scene rejects concrete actions at the type level', () => {
+    // A default `Scene` with actions supplied must NOT type-check: `never[]`
+    // accepts no concrete element. Asserted via expectTypeOf.
+    type DefaultScene = Scene;
+    expectTypeOf<DefaultScene['actions']>().toMatchTypeOf<unknown[] | undefined>();
+  });
+});
+
+describe('Whiteboard', () => {
+  it('is Slide minus theme/turningMode/sectionTag/type', () => {
+    // A full slide assigned to a Whiteboard slot must lose those four keys at
+    // the type level (Omit). Constructing a Whiteboard without them works.
+    const wb: Whiteboard = {
+      id: 'wb1',
+      viewportSize: 1920,
+      viewportRatio: 0.5625,
+      elements: [],
+      // theme/turningMode/sectionTag/type intentionally absent — and rejected
+      // by the Omit at the type level (not asserted here at runtime).
+    };
+    expect(wb.id).toBe('wb1');
+  });
+});
+
+describe('SceneType', () => {
+  it('covers all four scene kinds even though the contract content is only slide|quiz', () => {
+    // The app relies on 'interactive' / 'pbl' being valid Scene.type values;
+    // the contract keeps all four in SceneType even though their content
+    // shapes are app-side.
+    const types: SceneType[] = ['slide', 'quiz', 'interactive', 'pbl'];
+    expect(types).toHaveLength(4);
+  });
+});

--- a/packages/@maic/dsl/vitest.config.ts
+++ b/packages/@maic/dsl/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/@maic/dsl/vitest.config.ts
+++ b/packages/@maic/dsl/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
+// Resolve `@maic/dsl` self-imports to the package source so `pnpm test` is
+// standalone on a clean checkout (no `dist` build required). Consumers still
+// resolve the package via its `exports` map → `dist` as before.
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@maic/dsl': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+    },
+  },
   test: {
     include: ['test/**/*.test.ts'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@9.12.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/@maic/importer:
     dependencies:


### PR DESCRIPTION
Resolves #740 (Phase 2 of #720). Implements **scope B** from the issue: the universal lesson skeleton moves into `@maic/dsl`, with `Scene` generic so app-side feature surfaces (`Action`, Ultra-mode widgets, PBL) plug in via type parameters.

## Decision

Per the open question in #740, this goes with a **generic `Scene<TAction, TContent>`** rather than a registry / declaration-merge seam. Reasons: explicit at the call site, `isolatedModules`-friendly (no ambient augmentation), straightforward `.d.ts` emission, and type inference stays readable. A registry seam can still be layered on later if desired — this does not foreclose it.

## What moves into `@maic/dsl`

New `packages/@maic/dsl/src/stage.ts`:
- `Stage`, `SceneType`, `StageMode`, `Whiteboard`, `VideoManifest` / `VideoManifestEntry`
- `GeneratedAgentConfig`, `MultiAgentConfig` (previously inline/anonymous — now named)
- `SlideContent`, `QuizContent`, `QuizOption`, `QuizQuestion`
- `SceneContent` — narrowed to the **universal** kinds only: `SlideContent | QuizContent`
- `Scene<TAction = never, TContent extends { type: SceneType } = SlideContent | QuizContent>` — the contract owns the skeleton + universal content; `TContent` is constrained structurally (tagged with `type: SceneType`) so an app can pass a wider union
- Pure guards `isSlideContent` / `isQuizContent`

Defaults (`never` / `SlideContent | QuizContent`) give renderers and importers a feature-free, read-only scene — exactly what they need.

## What stays app-side

- `Action` (and all of `lib/types/action.ts`)
- `WidgetType` / `WidgetConfig` / `TeacherAction` / `InteractiveContent`
- `PBLContent` / `PBLProjectConfig`

These are faster-moving product surfaces; they may graduate to sibling packages (`@maic/actions`, …) later, but not in this PR. The generation re-export block at the bottom of the old `stage.ts` is dropped — verified zero consumers import those five types via `@/lib/types/stage`.

## App wiring

`lib/types/stage.ts` is rewritten as a **shim** (not deleted) so the ~55 existing `import { … } from "@/lib/types/stage"` call sites keep working unchanged:
- re-exports the skeleton types from `@maic/dsl`
- keeps `InteractiveContent` / `PBLContent` locally
- declares the app `SceneContent` as the full four-way union (so `switch (content.type)` call sites keep all four cases)
- aliases `Scene = DslScene<Action, SceneContent>` so existing `Scene` usage keeps its exact semantics (`actions: Action[]`, four-way content)

`Scene` changing from `interface` to a generic `type` alias on the DSL side is safe — confirmed no `interface extends Scene`, no declaration merging, no `implements Scene` anywhere in the tree.

## Tests

- New `packages/@maic/dsl/test/stage.test.ts` (9 contract tests) + `vitest.config.ts` + `test` script on the package — covers the generic defaults, the app-instantiation pattern, guard behavior, the `Whiteboard` `Omit` shape, and the four-way `SceneType`.
- DSL package: `typecheck` clean, 9/9 tests pass.
- Whole app: `tsc --noEmit` clean; `vitest run` → **805 pass / 1 fail**. The single failure (`tests/edit/stage-mode.test.ts > sceneEditorRegistry > registering a different surface … warns in dev`) is **pre-existing on `origin/main`** — verified by stashing this branch's changes, rebuilding, and re-running; it fails identically and is unrelated to types.

## Out of scope (deliberately)

- `Action` / widgets / PBL migration into the DSL or sibling packages — later Phase 2 work
- JSON Schema + pure validator for the stage contract — separate roadmap item
- npm publish — Phase 1 maintainer action