### PR TITLE
fix(generation): strip reasoning blocks before JSON parsing

### DIFF
--- a/lib/generation/json-repair.ts
+++ b/lib/generation/json-repair.ts
@@ -33,8 +33,51 @@ function logJsonParseError(stage: string, jsonStr: string, error: unknown): void
 }
 
 export function parseJsonResponse<T>(response: string): T | null {
+  const exactParsed = tryParseExactJson<T>(response);
+  if (exactParsed !== null) return exactParsed;
+
+  const cleanedResponse = stripReasoningPrefix(response);
+  if (cleanedResponse !== response.trim()) {
+    const parsedCleaned = parseJsonResponseCandidate<T>(cleanedResponse);
+    if (parsedCleaned !== null) return parsedCleaned;
+  }
+
+  const parsed = parseJsonResponseCandidate<T>(response);
+  if (parsed !== null) return parsed;
+
+  log.error('Failed to parse JSON from response');
+  log.error('Raw response (first 500 chars):', cleanedResponse.substring(0, 500));
+  log.error(
+    'Raw response (last 500 chars):',
+    cleanedResponse.substring(Math.max(0, cleanedResponse.length - 500)),
+  );
+
+  return null;
+}
+
+function tryParseExactJson<T>(response: string): T | null {
+  try {
+    return JSON.parse(response.trim()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function stripReasoningPrefix(response: string): string {
+  const trimmed = response.trim();
+  const matches = [...trimmed.matchAll(/<\/(?:think|thinking|reasoning)>\s*/gi)];
+  const lastMatch = matches.at(-1);
+
+  if (!lastMatch || lastMatch.index === undefined) return trimmed;
+
+  return trimmed.slice(lastMatch.index + lastMatch[0].length).trim();
+}
+
+function parseJsonResponseCandidate<T>(response: string): T | null {
+  const cleanedResponse = response.trim();
+
   // Strategy 1: Try to extract JSON from markdown code blocks (may have multiple)
-  const codeBlockMatches = response.matchAll(/```(?:json)?\s*([\s\S]*?)```/g);
+  const codeBlockMatches = cleanedResponse.matchAll(/```(?:json)?\s*([\s\S]*?)```/g);
   for (const match of codeBlockMatches) {
     const extracted = match[1].trim();
     // Only try if it looks like JSON (starts with { or [)
@@ -49,8 +92,8 @@ export function parseJsonResponse<T>(response: string): T | null {
 
   // Strategy 2: Try to find JSON structure directly in response (no code block)
   // Look for array or object start
-  const jsonStartArray = response.indexOf('[');
-  const jsonStartObject = response.indexOf('{');
+  const jsonStartArray = cleanedResponse.indexOf('[');
+  const jsonStartObject = cleanedResponse.indexOf('{');
 
   if (jsonStartArray !== -1 || jsonStartObject !== -1) {
     // Prefer the structure that appears first
@@ -67,8 +110,8 @@ export function parseJsonResponse<T>(response: string): T | null {
     let inString = false;
     let escapeNext = false;
 
-    for (let i = startIndex; i < response.length; i++) {
-      const char = response[i];
+    for (let i = startIndex; i < cleanedResponse.length; i++) {
+      const char = cleanedResponse[i];
 
       if (escapeNext) {
         escapeNext = false;
@@ -98,7 +141,7 @@ export function parseJsonResponse<T>(response: string): T | null {
     }
 
     if (endIndex !== -1) {
-      const jsonStr = response.substring(startIndex, endIndex + 1);
+      const jsonStr = cleanedResponse.substring(startIndex, endIndex + 1);
       const result = tryParseJson<T>(jsonStr);
       if (result !== null) {
         log.debug('Successfully parsed JSON from response body');
@@ -108,18 +151,11 @@ export function parseJsonResponse<T>(response: string): T | null {
   }
 
   // Strategy 3: Last resort - try the whole response
-  const result = tryParseJson<T>(response.trim());
+  const result = tryParseJson<T>(cleanedResponse.trim());
   if (result !== null) {
     log.debug('Successfully parsed raw response as JSON');
     return result;
   }
-
-  log.error('Failed to parse JSON from response');
-  log.error('Raw response (first 500 chars):', response.substring(0, 500));
-  log.error(
-    'Raw response (last 500 chars):',
-    response.substring(Math.max(0, response.length - 500)),
-  );
 
   return null;
 }

--- a/tests/generation/json-repair.test.ts
+++ b/tests/generation/json-repair.test.ts
@@ -54,4 +54,52 @@ describe('json-repair targeted fixes', () => {
     expect(parsed?.elements[0]?.height).toBe(58);
     expect(parsed?.elements[0]?.content).toBe('<p>literal text: height: 58</p>');
   });
+
+  it('strips reasoning prefix ending with an unpaired closing think tag before JSON', () => {
+    const raw = `reasoning prose with {not json} and [not json] </think>
+{"ok": true}`;
+
+    const parsed = parseJsonResponse<{ ok: boolean }>(raw);
+
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('prefers the final payload after an unpaired closing tag with parseable draft JSON', () => {
+    const raw = `reasoning draft {"draft": true} </think>
+{"ok": true}`;
+
+    const parsed = parseJsonResponse<{ ok: boolean }>(raw);
+
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('prefers the final payload after a reasoning block with parseable draft JSON', () => {
+    const raw = `<think>{"draft": true}</think>
+{"ok": true}`;
+
+    const parsed = parseJsonResponse<{ ok: boolean }>(raw);
+
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('prefers the final payload after a reasoning block with fenced draft JSON', () => {
+    const raw = `<think>
+\`\`\`json
+{"draft": true}
+\`\`\`
+</think>
+{"ok": true}`;
+
+    const parsed = parseJsonResponse<{ ok: boolean }>(raw);
+
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('preserves literal think tags inside valid JSON strings', () => {
+    const raw = '{"text":"literal <think>keep me</think>"}';
+
+    const parsed = parseJsonResponse<{ text: string }>(raw);
+
+    expect(parsed).toEqual({ text: 'literal <think>keep me</think>' });
+  });
 });


### PR DESCRIPTION
  ## Summary
  Strip model reasoning blocks before parsing JSON responses.

  Some reasoning models may wrap intermediate thoughts in `<think>...</think>` before emitting the final
  JSON. This can prevent otherwise valid JSON extraction and parsing.

  ## Changes

  - Remove `<think>...</think>` blocks before JSON extraction.
  - Apply all existing parsing strategies to the cleaned response.
  - Log parse failure snippets from the cleaned response so diagnostics match the parser input.

  ## Verification

  - `pnpm lint` passes locally with existing warnings.
  - `pnpm exec tsc --noEmit` was attempted locally, but the current working tree has stale `.next` generated type references and unresolved workspace package types unrelated to this one-file change.