### PR TITLE
feat(ai): add Qwen3.7 Plus and Qwen3.7 Max to the model registry

### DIFF
--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -290,6 +290,8 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('glm', 'glm-4.6v')]: toggleCapability('glm'),
   [getModelMetadataKey('glm', 'glm-4.6v-flash')]: toggleCapability('glm'),
 
+  [getModelMetadataKey('qwen', 'qwen3.7-plus')]: qwenBudgetEnabled,
+  [getModelMetadataKey('qwen', 'qwen3.7-max')]: qwenBudgetEnabled,
   [getModelMetadataKey('qwen', 'qwen3.6-max-preview')]: qwenBudgetDisabled,
   [getModelMetadataKey('qwen', 'qwen3.6-plus')]: qwenBudgetEnabled,
   [getModelMetadataKey('qwen', 'qwen3.6-plus-2026-04-02')]: qwenBudgetEnabled,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -452,6 +452,38 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     icon: '/logos/qwen.svg',
     models: [
       {
+        id: 'qwen3.7-plus',
+        name: 'Qwen3.7 Plus',
+        contextWindow: 1000000,
+        outputWindow: 64000,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: true,
+          thinking: {
+            toggleable: true,
+            budgetAdjustable: true,
+            defaultEnabled: true,
+          },
+        },
+      },
+      {
+        id: 'qwen3.7-max',
+        name: 'Qwen3.7 Max',
+        contextWindow: 1000000,
+        outputWindow: 64000,
+        capabilities: {
+          streaming: true,
+          tools: true,
+          vision: false,
+          thinking: {
+            toggleable: true,
+            budgetAdjustable: true,
+            defaultEnabled: true,
+          },
+        },
+      },
+      {
         id: 'qwen3.6-max-preview',
         name: 'Qwen3.6 Max Preview',
         contextWindow: 256000,


### PR DESCRIPTION
Adds the Qwen3.7 series to the built-in `qwen` provider, mirroring the existing Qwen3.6 model-card shape.

- `qwen3.7-plus` — 1M context, 64K output, vision, tools, toggleable thinking + budget (default on)
- `qwen3.7-max` — 1M context, 64K output, text-only, tools, toggleable thinking + budget (default on)

Both run over the already-configured DashScope OpenAI-compatible endpoint; no transport changes. Thinking is wired through the existing `qwen` request adapter (`qwenBudgetEnabled`, 0–81920 budget).

Output ceiling and thinking-budget max reuse the Qwen3.6 conventions already in the registry, since the public docs don't spell these out per-model.

**Files**
- `lib/ai/providers.ts` — two model cards
- `lib/ai/model-metadata.ts` — thinking-capability mappings

Closes #752
