### PR TITLE
feat(outline): make scene type authoritative via derive-on-confirm specializer

### DIFF
--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest } from 'next/server';
 import { callLLM } from '@/lib/ai/llm';
 import {
-  applyOutlineFallbacks,
+  specializeOutline,
   generateSceneContent,
   buildVisionUserContent,
 } from '@/lib/generation/generation-pipeline';
@@ -128,8 +128,13 @@ export async function POST(req: NextRequest) {
     };
 
     // ── Apply fallbacks ──
+    // ── Derive-on-confirm: ensure the declared type's config exists ──
+    // The scene `type` is authoritative; if the user changed it in the editor
+    // the matching config is derived here (cached via specializedFor).
     const vocationalActive = resolveVocationalActive(requirements);
-    const effectiveOutline = applyOutlineFallbacks(outline, !!languageModel, {
+    const effectiveOutline = await specializeOutline(outline, {
+      aiCall,
+      hasLanguageModel: !!languageModel,
       allowProceduralSkill: vocationalActive,
     });
 

--- a/components/generation/outlines-editor.tsx
+++ b/components/generation/outlines-editor.tsx
@@ -434,7 +434,10 @@ function SceneRow({
 
   // Auto-resize textareas to content for the typography-first feel.
   useAutoResize(titleRef, outline.title);
-  useAutoResize(descRef, outline.description);
+  useAutoResize(descRef, outline.description ?? '');
+  const briefRef = useRef<HTMLTextAreaElement>(null);
+  useAutoResize(briefRef, outline.brief ?? '');
+  const [kpOpen, setKpOpen] = useState(false);
 
   const addKeyPoint = (raw: string) => {
     const trimmed = raw.trim();
@@ -580,10 +583,26 @@ function SceneRow({
             </div>
           </div>
 
-          {/* Description */}
+          {/* Brief — authoritative scene content (Layer-1) */}
+          <textarea
+            ref={briefRef}
+            value={outline.brief ?? ''}
+            onChange={(event) => onUpdate({ brief: event.target.value })}
+            placeholder={t('generation.sceneBriefPlaceholder')}
+            disabled={disabled}
+            rows={1}
+            className={cn(
+              'block w-full resize-none border-none bg-transparent p-0 text-sm leading-relaxed text-foreground/90',
+              'placeholder:text-muted-foreground/40',
+              'focus:outline-none focus:ring-0',
+              disabled && 'cursor-default',
+            )}
+          />
+
+          {/* Description (short summary) */}
           <textarea
             ref={descRef}
-            value={outline.description}
+            value={outline.description ?? ''}
             onChange={(event) => onUpdate({ description: event.target.value })}
             placeholder={t('generation.sceneDescriptionPlaceholder')}
             disabled={disabled}
@@ -596,7 +615,16 @@ function SceneRow({
             )}
           />
 
-          {/* Key points */}
+          {/* Key points — demoted under a toggle; brief is the primary content */}
+          <button
+            type="button"
+            onClick={() => setKpOpen((v) => !v)}
+            className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+          >
+            <ChevronDown className={cn('size-3 transition-transform', kpOpen && 'rotate-180')} />
+            {t('generation.keyPointsToggle')}
+          </button>
+          {kpOpen && (
           <div className="flex flex-wrap items-center gap-1.5 pt-1">
             <AnimatePresence initial={false}>
               {(outline.keyPoints ?? []).filter(Boolean).map((point, idx) => (
@@ -635,6 +663,7 @@ function SceneRow({
               />
             )}
           </div>
+          )}
 
           {/* Quiz config (popover) */}
           {outline.type === 'quiz' && !disabled && (

--- a/components/generation/outlines-editor.tsx
+++ b/components/generation/outlines-editor.tsx
@@ -27,7 +27,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { cn } from '@/lib/utils';
 import type { SceneOutline } from '@/lib/types/generation';
-import { resetConfigForType } from '@/lib/generation/outline-specializer';
+import { resetConfigForType } from '@/lib/generation/outline-specializer-helpers';
 
 type SceneType = SceneOutline['type'];
 

--- a/components/generation/outlines-editor.tsx
+++ b/components/generation/outlines-editor.tsx
@@ -27,6 +27,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { cn } from '@/lib/utils';
 import type { SceneOutline } from '@/lib/types/generation';
+import { resetConfigForType } from '@/lib/generation/outline-specializer';
 
 type SceneType = SceneOutline['type'];
 
@@ -570,7 +571,7 @@ function SceneRow({
             <div className="flex shrink-0 items-center gap-1 pt-0.5">
               <TypePill
                 type={outline.type}
-                onChange={(type) => onUpdate({ type })}
+                onChange={(type) => onUpdate(resetConfigForType(type))}
                 disabled={disabled}
                 label={sceneTypeLabel(outline.type)}
                 theme={theme}

--- a/lib/generation/generation-pipeline.ts
+++ b/lib/generation/generation-pipeline.ts
@@ -32,6 +32,15 @@ export { parseJsonResponse, tryParseJson } from './json-repair';
 // Outline generator (Stage 1)
 export { generateSceneOutlinesFromRequirements, applyOutlineFallbacks } from './outline-generator';
 
+// Outline specializer — derive-on-confirm of type-specific config
+export {
+  specializeOutline,
+  computeIntentHash,
+  hasRequiredConfig,
+  resetConfigForType,
+} from './outline-specializer';
+export type { SpecializeDeps } from './outline-specializer';
+
 // Scene generator (Stage 2)
 export {
   generateFullScenes,

--- a/lib/generation/outline-specializer-helpers.ts
+++ b/lib/generation/outline-specializer-helpers.ts
@@ -13,6 +13,7 @@ export function computeIntentHash(outline: SceneOutline): string {
   const intent = JSON.stringify({
     type: outline.type,
     title: outline.title ?? '',
+    brief: outline.brief ?? '',
     description: outline.description ?? '',
     keyPoints: outline.keyPoints ?? [],
   });

--- a/lib/generation/outline-specializer-helpers.ts
+++ b/lib/generation/outline-specializer-helpers.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure, client-safe helpers for outline specialization.
+ *
+ * Kept separate from outline-specializer.ts (which imports the server-only
+ * prompt loader transitively via outline-generator) so the outline editor — a
+ * client component — can import resetConfigForType without pulling `fs` into
+ * the client bundle.
+ */
+import type { SceneOutline } from '@/lib/types/generation';
+
+/** Stable djb2 hash over the intent fields that drive specialization. */
+export function computeIntentHash(outline: SceneOutline): string {
+  const intent = JSON.stringify({
+    type: outline.type,
+    title: outline.title ?? '',
+    description: outline.description ?? '',
+    keyPoints: outline.keyPoints ?? [],
+  });
+  let h = 5381;
+  for (let i = 0; i < intent.length; i++) {
+    h = (((h << 5) + h) ^ intent.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+}
+
+/** Whether the outline already carries the config its `type` needs. */
+export function hasRequiredConfig(outline: SceneOutline): boolean {
+  switch (outline.type) {
+    case 'interactive':
+      return Boolean(outline.widgetType && outline.widgetOutline);
+    case 'pbl':
+      return Boolean(outline.pblConfig);
+    case 'quiz':
+      return Boolean(outline.quizConfig);
+    case 'slide':
+    default:
+      return true;
+  }
+}
+
+/**
+ * Editor patch applied when the user changes a scene's type: set the new type
+ * and clear every type-specific config (present-but-undefined so the spread in
+ * the editor's updateOutline overwrites stale values), plus the cache tag.
+ */
+export function resetConfigForType(type: SceneOutline['type']): Partial<SceneOutline> {
+  return {
+    type,
+    quizConfig: undefined,
+    widgetType: undefined,
+    widgetOutline: undefined,
+    pblConfig: undefined,
+    interactiveConfig: undefined,
+    specializedFor: undefined,
+  };
+}

--- a/lib/generation/outline-specializer.ts
+++ b/lib/generation/outline-specializer.ts
@@ -48,7 +48,7 @@ export function derivePblConfig(outline: SceneOutline): NonNullable<SceneOutline
   const skills = outline.keyPoints?.length ? outline.keyPoints : [outline.title];
   return {
     projectTopic: outline.title,
-    projectDescription: outline.description,
+    projectDescription: outline.brief?.trim() || outline.description || outline.title,
     targetSkills: skills,
     issueCount: 3,
   };
@@ -77,9 +77,9 @@ export async function deriveWidgetConfig(
     '- visualization3d: 3D models (molecules, solar system, anatomy, geometry)',
     'Return ONLY JSON: {"widgetType":"<one of the five>","widgetOutline":{"concept":"<short phrase>"}}',
   ].join('\n');
-  const user = `Title: ${outline.title}\nDescription: ${outline.description}\nKey points:\n${(
-    outline.keyPoints ?? []
-  ).join('\n')}`;
+  const user = `Title: ${outline.title}\nBrief: ${outline.brief ?? ''}\nDescription: ${
+    outline.description ?? ''
+  }\nKey points:\n${(outline.keyPoints ?? []).join('\n')}`;
   try {
     const raw = await aiCall(system, user);
     const parsed = parseJsonResponse<{ widgetType?: string; widgetOutline?: WidgetOutline }>(raw);

--- a/lib/generation/outline-specializer.ts
+++ b/lib/generation/outline-specializer.ts
@@ -1,0 +1,189 @@
+/**
+ * Outline specializer — derive-on-confirm of type-specific config.
+ *
+ * The scene `type` is authoritative. When the user changes a scene's type in
+ * the editor, the matching config (widgetOutline / pblConfig / quizConfig) is
+ * missing. This module derives it at scene-content time so generation produces
+ * the declared type instead of silently reverting to slide.
+ *
+ * Cache: `SceneOutline.specializedFor` stores the intent hash the current
+ * config was derived for. When it matches and the required config is present,
+ * specialization is a no-op (no extra LLM call). The derived outline is carried
+ * back as the scene-content route's `effectiveOutline`, which the client feeds
+ * into the pipeline — so re-confirming unchanged intent costs nothing.
+ */
+import type { SceneOutline, WidgetOutline } from '@/lib/types/generation';
+import type { WidgetType } from '@/lib/types/widgets';
+import type { AICallFn } from './pipeline-types';
+import { sanitizeProceduralSkillOutline } from './outline-generator';
+import { parseJsonResponse } from './json-repair';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('OutlineSpecializer');
+
+const WIDGET_TYPES: WidgetType[] = ['simulation', 'diagram', 'code', 'game', 'visualization3d'];
+
+/** Stable djb2 hash over the intent fields that drive specialization. */
+export function computeIntentHash(outline: SceneOutline): string {
+  const intent = JSON.stringify({
+    type: outline.type,
+    title: outline.title ?? '',
+    description: outline.description ?? '',
+    keyPoints: outline.keyPoints ?? [],
+  });
+  let h = 5381;
+  for (let i = 0; i < intent.length; i++) {
+    h = (((h << 5) + h) ^ intent.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+}
+
+/** Whether the outline already carries the config its `type` needs. */
+export function hasRequiredConfig(outline: SceneOutline): boolean {
+  switch (outline.type) {
+    case 'interactive':
+      return Boolean(outline.widgetType && outline.widgetOutline);
+    case 'pbl':
+      return Boolean(outline.pblConfig);
+    case 'quiz':
+      return Boolean(outline.quizConfig);
+    case 'slide':
+    default:
+      return true;
+  }
+}
+
+/**
+ * Editor patch applied when the user changes a scene's type: set the new type
+ * and clear every type-specific config (present-but-undefined so the spread in
+ * the editor's updateOutline overwrites stale values), plus the cache tag.
+ */
+export function resetConfigForType(type: SceneOutline['type']): Partial<SceneOutline> {
+  return {
+    type,
+    quizConfig: undefined,
+    widgetType: undefined,
+    widgetOutline: undefined,
+    pblConfig: undefined,
+    interactiveConfig: undefined,
+    specializedFor: undefined,
+  };
+}
+
+export function deriveQuizConfig(outline: SceneOutline): NonNullable<SceneOutline['quizConfig']> {
+  return (
+    outline.quizConfig ?? {
+      questionCount: 3,
+      difficulty: 'medium',
+      questionTypes: ['single'],
+    }
+  );
+}
+
+export function derivePblConfig(outline: SceneOutline): NonNullable<SceneOutline['pblConfig']> {
+  if (outline.pblConfig) return outline.pblConfig;
+  const skills = outline.keyPoints?.length ? outline.keyPoints : [outline.title];
+  return {
+    projectTopic: outline.title,
+    projectDescription: outline.description,
+    targetSkills: skills,
+    issueCount: 3,
+  };
+}
+
+/**
+ * Classify an interactive scene into one widget type + a minimal widget outline.
+ * Most widget-content variables fall back to the outline's common fields
+ * (title/description/keyPoints) downstream, so a minimal `{ concept }` is enough
+ * to render. Defaults to `diagram` if the LLM is unavailable or returns garbage.
+ */
+export async function deriveWidgetConfig(
+  outline: SceneOutline,
+  aiCall: AICallFn,
+): Promise<{ widgetType: WidgetType; widgetOutline: WidgetOutline }> {
+  if (outline.widgetType && outline.widgetOutline) {
+    return { widgetType: outline.widgetType, widgetOutline: outline.widgetOutline };
+  }
+  const system = [
+    'You classify ONE lesson scene into exactly one interactive widget type and produce a minimal outline.',
+    'Widget types:',
+    '- simulation: physics/chemistry/science you explore by changing variables',
+    '- diagram: processes, structures, hierarchies, relationships',
+    '- code: programming / algorithms',
+    '- game: practice through play (quiz-like, puzzle, strategy)',
+    '- visualization3d: 3D models (molecules, solar system, anatomy, geometry)',
+    'Return ONLY JSON: {"widgetType":"<one of the five>","widgetOutline":{"concept":"<short phrase>"}}',
+  ].join('\n');
+  const user = `Title: ${outline.title}\nDescription: ${outline.description}\nKey points:\n${(
+    outline.keyPoints ?? []
+  ).join('\n')}`;
+  try {
+    const raw = await aiCall(system, user);
+    const parsed = parseJsonResponse<{ widgetType?: string; widgetOutline?: WidgetOutline }>(raw);
+    const widgetType = WIDGET_TYPES.includes(parsed?.widgetType as WidgetType)
+      ? (parsed!.widgetType as WidgetType)
+      : 'diagram';
+    const widgetOutline: WidgetOutline = { concept: outline.title, ...(parsed?.widgetOutline ?? {}) };
+    return { widgetType, widgetOutline };
+  } catch (err) {
+    log.warn(`deriveWidgetConfig failed for "${outline.title}", defaulting to diagram: ${String(err)}`);
+    return { widgetType: 'diagram', widgetOutline: { concept: outline.title } };
+  }
+}
+
+export interface SpecializeDeps {
+  aiCall: AICallFn;
+  hasLanguageModel: boolean;
+  /** Vocational procedural-skill is gated; mirrors applyOutlineFallbacks' option. */
+  allowProceduralSkill?: boolean;
+  /** Injectable for tests; defaults to deriveWidgetConfig. */
+  deriveWidget?: typeof deriveWidgetConfig;
+}
+
+/**
+ * Ensure the outline carries the config its declared `type` needs, deriving it
+ * on demand. Cache: when `specializedFor` matches the current intent hash AND
+ * the required config is present, the outline is returned untouched (no LLM).
+ */
+export async function specializeOutline(
+  outline: SceneOutline,
+  deps: SpecializeDeps,
+): Promise<SceneOutline> {
+  // Vocational procedural-skill is gated: when not enabled, upstream renders it
+  // as a diagram instead of the procedural widget. Preserve that before any
+  // type-based specialization (it yields a valid interactive+diagram outline).
+  if (outline.widgetType === 'procedural-skill' && !deps.allowProceduralSkill) {
+    const sanitized = sanitizeProceduralSkillOutline(outline);
+    return { ...sanitized, specializedFor: computeIntentHash(sanitized) };
+  }
+
+  const hash = computeIntentHash(outline);
+
+  if (outline.specializedFor === hash && hasRequiredConfig(outline)) {
+    return outline;
+  }
+
+  switch (outline.type) {
+    case 'quiz':
+      return { ...outline, quizConfig: deriveQuizConfig(outline), specializedFor: hash };
+
+    case 'pbl': {
+      if (!deps.hasLanguageModel) {
+        log.warn(`PBL "${outline.title}" has no language model; rendering as slide`);
+        const asSlide: SceneOutline = { ...outline, type: 'slide' };
+        return { ...asSlide, specializedFor: computeIntentHash(asSlide) };
+      }
+      return { ...outline, pblConfig: derivePblConfig(outline), specializedFor: hash };
+    }
+
+    case 'interactive': {
+      const derive = deps.deriveWidget ?? deriveWidgetConfig;
+      const { widgetType, widgetOutline } = await derive(outline, deps.aiCall);
+      return { ...outline, widgetType, widgetOutline, specializedFor: hash };
+    }
+
+    case 'slide':
+    default:
+      return { ...outline, specializedFor: hash };
+  }
+}

--- a/lib/generation/outline-specializer.ts
+++ b/lib/generation/outline-specializer.ts
@@ -23,52 +23,15 @@ const log = createLogger('OutlineSpecializer');
 
 const WIDGET_TYPES: WidgetType[] = ['simulation', 'diagram', 'code', 'game', 'visualization3d'];
 
-/** Stable djb2 hash over the intent fields that drive specialization. */
-export function computeIntentHash(outline: SceneOutline): string {
-  const intent = JSON.stringify({
-    type: outline.type,
-    title: outline.title ?? '',
-    description: outline.description ?? '',
-    keyPoints: outline.keyPoints ?? [],
-  });
-  let h = 5381;
-  for (let i = 0; i < intent.length; i++) {
-    h = (((h << 5) + h) ^ intent.charCodeAt(i)) | 0;
-  }
-  return (h >>> 0).toString(36);
-}
-
-/** Whether the outline already carries the config its `type` needs. */
-export function hasRequiredConfig(outline: SceneOutline): boolean {
-  switch (outline.type) {
-    case 'interactive':
-      return Boolean(outline.widgetType && outline.widgetOutline);
-    case 'pbl':
-      return Boolean(outline.pblConfig);
-    case 'quiz':
-      return Boolean(outline.quizConfig);
-    case 'slide':
-    default:
-      return true;
-  }
-}
-
-/**
- * Editor patch applied when the user changes a scene's type: set the new type
- * and clear every type-specific config (present-but-undefined so the spread in
- * the editor's updateOutline overwrites stale values), plus the cache tag.
- */
-export function resetConfigForType(type: SceneOutline['type']): Partial<SceneOutline> {
-  return {
-    type,
-    quizConfig: undefined,
-    widgetType: undefined,
-    widgetOutline: undefined,
-    pblConfig: undefined,
-    interactiveConfig: undefined,
-    specializedFor: undefined,
-  };
-}
+// Pure, client-safe helpers live in a separate module so the client editor can
+// import resetConfigForType without pulling this server-only file (and its
+// fs-backed prompt loader, via outline-generator) into the client bundle.
+import { computeIntentHash, hasRequiredConfig } from './outline-specializer-helpers';
+export {
+  computeIntentHash,
+  hasRequiredConfig,
+  resetConfigForType,
+} from './outline-specializer-helpers';
 
 export function deriveQuizConfig(outline: SceneOutline): NonNullable<SceneOutline['quizConfig']> {
   return (

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -736,6 +736,7 @@ async function generateSlideContent(
 
   const prompts = buildPrompt(PROMPT_IDS.SLIDE_CONTENT, {
     title: outline.title,
+    brief: outline.brief?.trim() || '',
     description: outline.description,
     keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
     elements: '（根据要点自动生成）',
@@ -852,6 +853,7 @@ async function generateQuizContent(
 
   const prompts = buildPrompt(PROMPT_IDS.QUIZ_CONTENT, {
     title: outline.title,
+    brief: outline.brief?.trim() || '',
     description: outline.description,
     keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
     questionCount: quizConfig.questionCount,
@@ -1052,6 +1054,7 @@ export async function generateWidgetContent(
       promptId = PROMPT_IDS.SIMULATION_CONTENT;
       variables = {
         conceptName: widgetOutline.concept || outline.title,
+        brief: outline.brief?.trim() || '',
         conceptOverview: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         variables: widgetOutline.keyVariables?.join(', ') || '',
@@ -1065,6 +1068,7 @@ export async function generateWidgetContent(
       variables = {
         title: outline.title,
         diagramType: widgetOutline.diagramType || 'flowchart',
+        brief: outline.brief?.trim() || '',
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         languageDirective: languageDirective || '',
@@ -1076,6 +1080,7 @@ export async function generateWidgetContent(
       variables = {
         title: outline.title,
         programmingLanguage: widgetOutline.language || 'python',
+        brief: outline.brief?.trim() || '',
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         starterCode: '',
@@ -1090,6 +1095,7 @@ export async function generateWidgetContent(
       variables = {
         title: outline.title,
         gameType: widgetOutline.gameType || 'quiz',
+        brief: outline.brief?.trim() || '',
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         scoring: { correctPoints: 10, speedBonus: 5 },
@@ -1102,6 +1108,7 @@ export async function generateWidgetContent(
       variables = {
         title: outline.title,
         visualizationType: widgetOutline.visualizationType || 'custom',
+        brief: outline.brief?.trim() || '',
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         objects: widgetOutline.objects || [],
@@ -1120,6 +1127,7 @@ export async function generateWidgetContent(
         title: outline.title,
         procedureType: widgetOutline.procedureType || 'custom',
         task: widgetOutline.task || widgetOutline.concept || outline.title,
+        brief: outline.brief?.trim() || '',
         description: outline.description,
         keyPoints: (outline.keyPoints || []).join('\n'),
         tools: widgetOutline.tools || [],
@@ -1206,6 +1214,7 @@ async function generateWidgetTeacherActions(
 ): Promise<TeacherAction[] | undefined> {
   const prompts = buildPrompt(PROMPT_IDS.WIDGET_TEACHER_ACTIONS, {
     widgetType,
+    brief: outline.brief?.trim() || '',
     description: outline.description,
     keyPoints: (outline.keyPoints || []).join('\n'),
     widgetConfig: JSON.stringify(widgetConfig || {}),
@@ -1264,6 +1273,7 @@ export async function generateSceneActions(
     const prompts = buildPrompt(PROMPT_IDS.SLIDE_ACTIONS, {
       title: outline.title,
       keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
+      brief: outline.brief?.trim() || '',
       description: outline.description,
       elements: elementsText,
       courseContext: buildCourseContext(ctx),
@@ -1294,6 +1304,7 @@ export async function generateSceneActions(
     const prompts = buildPrompt(PROMPT_IDS.QUIZ_ACTIONS, {
       title: outline.title,
       keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
+      brief: outline.brief?.trim() || '',
       description: outline.description,
       questions: questionsText,
       courseContext: buildCourseContext(ctx),
@@ -1321,6 +1332,7 @@ export async function generateSceneActions(
     const prompts = buildPrompt(PROMPT_IDS.INTERACTIVE_ACTIONS, {
       title: outline.title,
       keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
+      brief: outline.brief?.trim() || '',
       description: outline.description,
       conceptName: config?.conceptName || outline.title,
       designIdea: config?.designIdea || '',
@@ -1349,6 +1361,7 @@ export async function generateSceneActions(
     const prompts = buildPrompt(PROMPT_IDS.PBL_ACTIONS, {
       title: outline.title,
       keyPoints: (outline.keyPoints || []).map((p, i) => `${i + 1}. ${p}`).join('\n'),
+      brief: outline.brief?.trim() || '',
       description: outline.description,
       projectTopic: pblConfig?.projectTopic || outline.title,
       projectDescription: pblConfig?.projectDescription || outline.description,

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -446,6 +446,8 @@
     "sceneTypeInteractive": "Interactive",
     "sceneTypePbl": "PBL",
     "sceneDescriptionPlaceholder": "Briefly describe the purpose and content of this scene",
+    "sceneBriefPlaceholder": "Design brief — what this scene should land and its actual content, in prose",
+    "keyPointsToggle": "Key points (optional)",
     "quizQuestionCount": "Question count",
     "quizDifficulty": "Difficulty",
     "quizType": "Question type",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -446,6 +446,8 @@
     "sceneTypeInteractive": "互动",
     "sceneTypePbl": "项目式学习",
     "sceneDescriptionPlaceholder": "简短描述这个场景的目的和内容",
+    "sceneBriefPlaceholder": "设计简报：这一页要讲清什么，把实际内容写出来",
+    "keyPointsToggle": "要点（可选）",
     "quizQuestionCount": "题目数量",
     "quizDifficulty": "难度",
     "quizType": "题型",

--- a/lib/prompts/templates/code-content/user.md
+++ b/lib/prompts/templates/code-content/user.md
@@ -8,6 +8,14 @@ Create a code playground widget for: {{title}}
 
 {{description}}
 
+{{#if brief}}
+## Design Brief (authoritative)
+
+When present, treat this as the authoritative spec for the scene; the fields above are a summary.
+
+{{brief}}
+{{/if}}
+
 ## Key Points
 
 {{keyPoints}}

--- a/lib/prompts/templates/diagram-content/user.md
+++ b/lib/prompts/templates/diagram-content/user.md
@@ -6,6 +6,14 @@ Create an interactive diagram for: {{title}}
 ## Description
 {{description}}
 
+{{#if brief}}
+## Design Brief (authoritative)
+
+When present, treat this as the authoritative spec for the scene; the fields above are a summary.
+
+{{brief}}
+{{/if}}
+
 ## Key Points
 {{keyPoints}}
 

--- a/lib/prompts/templates/game-content/user.md
+++ b/lib/prompts/templates/game-content/user.md
@@ -8,6 +8,14 @@ Create an educational GAME widget for: {{title}}
 
 {{description}}
 
+{{#if brief}}
+## Design Brief (authoritative)
+
+When present, treat this as the authoritative spec for the scene; the fields above are a summary.
+
+{{brief}}
+{{/if}}
+
 ## Key Points
 
 {{keyPoints}}

--- a/lib/prompts/templates/pbl-actions/user.md
+++ b/lib/prompts/templates/pbl-actions/user.md
@@ -5,6 +5,9 @@
 **Project Description**: {{projectDescription}}
 **Key Points**: {{keyPoints}}
 **Description**: {{description}}
+{{#if brief}}
+- **Design Brief (authoritative)**: {{brief}}
+{{/if}}
 {{courseContext}}
 {{agents}}
 

--- a/lib/prompts/templates/procedural-skill-content/user.md
+++ b/lib/prompts/templates/procedural-skill-content/user.md
@@ -12,6 +12,14 @@ Create a procedural skill widget for: {{title}}
 
 {{description}}
 
+{{#if brief}}
+## Design Brief (authoritative)
+
+When present, treat this as the authoritative spec for the scene; the fields above are a summary.
+
+{{brief}}
+{{/if}}
+
 ## Key Points
 
 {{keyPoints}}

--- a/lib/prompts/templates/quiz-content/user.md
+++ b/lib/prompts/templates/quiz-content/user.md
@@ -1,5 +1,8 @@
 Title: {{title}}
 Description: {{description}}
+{{#if brief}}
+- **Design Brief (authoritative)**: {{brief}}
+{{/if}}
 Test Points: {{keyPoints}}
 Question Count: {{questionCount}}, Difficulty: {{difficulty}}, Question Types: {{questionTypes}}
 

--- a/lib/prompts/templates/requirements-to-outlines/system.md
+++ b/lib/prompts/templates/requirements-to-outlines/system.md
@@ -278,6 +278,7 @@ Rules:
 | type              | string                   | ✅       | `"slide"`, `"quiz"`, `"interactive"`, or `"pbl"`                                                 |
 | title             | string                   | ✅       | Scene title, concise and clear                                                                   |
 | description       | string                   | ✅       | 1-2 sentences describing teaching purpose                                                        |
+| brief             | string                   | ✅       | Authoritative natural-language design brief — the PRIMARY content for generation (see "Scene Brief" below) |
 | keyPoints         | string[]                 | ✅       | 3-5 core points                                                                                  |
 | teachingObjective | string                   | ❌       | Corresponding learning objective                                                                 |
 | estimatedDuration | number                   | ❌       | Estimated duration (seconds)                                                                     |
@@ -293,6 +294,18 @@ Rules:
 | widgetType        | string                   | ✅ (for interactive) | Widget type: "simulation", "diagram", "code", "game", "visualization3d"                                                 |
 | widgetOutline     | object                   | ✅ (for interactive) | Widget-specific configuration (see Widget Type Selection)                                                               |
 | pblConfig         | object                   | ❌       | Required for pbl type, contains projectTopic/projectDescription/targetSkills/issueCount/language |
+
+
+### Scene Brief (the primary content of every scene)
+
+For EVERY scene, write `brief`: one rich, specific paragraph (roughly 80–200 words) of flowing natural language that a designer could turn directly into the finished scene. Cover, in prose:
+
+- the single idea this scene must land;
+- the concrete on-screen content, written out — for a slide, the actual text / table rows / formulas; for a quiz, what it assesses and the kind of questions; for an interactive widget, what the learner manipulates and observes; for a pbl scene, the project framing;
+- the intended emphasis / what matters most.
+
+Write the real content, not a meta-description ("a table comparing X" → write the actual rows). On-screen text must be in the course language. `brief` is the authoritative input the downstream generator uses; keep `description` and `keyPoints` as short summaries derived from it.
+
 
 ### quizConfig Structure
 

--- a/lib/prompts/templates/requirements-to-outlines/user.md
+++ b/lib/prompts/templates/requirements-to-outlines/user.md
@@ -75,6 +75,8 @@ Never return a bare array. Never omit `languageDirective`. Both keys are require
 
 ### Special Notes
 
+- **Every scene MUST include `brief`** — a rich natural-language design brief (~80–200 words) that is the authoritative content for the scene (see "Scene Brief" in the system prompt). Write the real on-screen content in prose, not a meta-description. Keep `description` and `keyPoints` short.
+
 - **quiz scenes must include quizConfig**:
    ```json
    "quizConfig": {

--- a/lib/prompts/templates/simulation-content/user.md
+++ b/lib/prompts/templates/simulation-content/user.md
@@ -4,6 +4,14 @@ Create a simulation widget for: {{conceptName}}
 
 {{conceptOverview}}
 
+{{#if brief}}
+## Design Brief (authoritative)
+
+When present, treat this as the authoritative spec for the scene; the fields above are a summary.
+
+{{brief}}
+{{/if}}
+
 ## Key Points
 
 {{keyPoints}}

--- a/lib/prompts/templates/slide-content/user.md
+++ b/lib/prompts/templates/slide-content/user.md
@@ -4,6 +4,9 @@
 
 - **Title**: {{title}}
 - **Description**: {{description}}
+{{#if brief}}
+- **Design Brief (authoritative)**: {{brief}}
+{{/if}}
 - **Key Points**:
   {{keyPoints}}
 

--- a/lib/prompts/templates/visualization3d-content/user.md
+++ b/lib/prompts/templates/visualization3d-content/user.md
@@ -8,6 +8,14 @@ Create a 3D visualization widget for: {{title}}
 
 {{description}}
 
+{{#if brief}}
+## Design Brief (authoritative)
+
+When present, treat this as the authoritative spec for the scene; the fields above are a summary.
+
+{{brief}}
+{{/if}}
+
 ## Key Points
 
 {{keyPoints}}

--- a/lib/types/generation.ts
+++ b/lib/types/generation.ts
@@ -93,8 +93,12 @@ export interface SceneOutline {
   id: string;
   type: 'slide' | 'quiz' | 'interactive' | 'pbl';
   title: string;
-  description: string; // 1-2 sentences describing the purpose
-  keyPoints: string[]; // 3-5 core key points
+  // Authoritative natural-language design brief (Layer-1). When present it is
+  // the primary input for generation and what the editor edits; description and
+  // keyPoints are demoted to optional secondary/compat fields.
+  brief?: string;
+  description?: string; // demoted: short teaching-purpose summary (optional)
+  keyPoints?: string[]; // demoted: optional core points
   teachingObjective?: string;
   estimatedDuration?: number; // seconds
   order: number;

--- a/lib/types/generation.ts
+++ b/lib/types/generation.ts
@@ -129,6 +129,11 @@ export interface SceneOutline {
   // Widget fields (required for type === 'interactive' in unified mode)
   widgetType?: WidgetType;
   widgetOutline?: WidgetOutline;
+  // Derive-on-confirm cache tag: hash of the intent fields (type+title+
+  // description+keyPoints) the current type-specific config was derived for.
+  // Lets the specializer skip re-derivation when intent is unchanged, and
+  // detect stale config after the user changes type in the editor.
+  specializedFor?: string;
 }
 
 // ==================== Stage 3 Output: Generated Content ====================

--- a/tests/generation/outline-specializer.test.ts
+++ b/tests/generation/outline-specializer.test.ts
@@ -255,3 +255,16 @@ describe('specializeOutline — procedural-skill gating (upstream)', () => {
     expect(out.widgetType).toBe('procedural-skill');
   });
 });
+
+describe('brief as Layer-1 (restructure)', () => {
+  test('brief change invalidates the intent hash', () => {
+    expect(computeIntentHash(base)).not.toBe(computeIntentHash({ ...base, brief: 'a rich brief' }));
+  });
+  test('derivePblConfig prefers brief for projectDescription', () => {
+    const out = derivePblConfig({ ...base, type: 'pbl', brief: 'Build a greenhouse model.' });
+    expect(out.projectDescription).toBe('Build a greenhouse model.');
+  });
+  test('derivePblConfig falls back to description when no brief', () => {
+    expect(derivePblConfig({ ...base, type: 'pbl' }).projectDescription).toBe('How plants make food');
+  });
+});

--- a/tests/generation/outline-specializer.test.ts
+++ b/tests/generation/outline-specializer.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  computeIntentHash,
+  hasRequiredConfig,
+  resetConfigForType,
+  deriveQuizConfig,
+  derivePblConfig,
+  deriveWidgetConfig,
+  specializeOutline,
+} from '@/lib/generation/outline-specializer';
+import type { SceneOutline } from '@/lib/types/generation';
+import type { AICallFn } from '@/lib/generation/pipeline-types';
+
+const base: SceneOutline = {
+  id: 's1',
+  type: 'slide',
+  title: 'Photosynthesis',
+  description: 'How plants make food',
+  keyPoints: ['light', 'CO2', 'glucose'],
+  order: 1,
+};
+
+const noop: AICallFn = async () => '{}';
+
+describe('computeIntentHash', () => {
+  test('is stable for identical intent', () => {
+    expect(computeIntentHash(base)).toBe(computeIntentHash({ ...base }));
+  });
+  test('changes when type changes', () => {
+    expect(computeIntentHash(base)).not.toBe(computeIntentHash({ ...base, type: 'interactive' }));
+  });
+  test('changes when title changes', () => {
+    expect(computeIntentHash(base)).not.toBe(computeIntentHash({ ...base, title: 'Respiration' }));
+  });
+  test('ignores config fields', () => {
+    expect(computeIntentHash(base)).toBe(
+      computeIntentHash({
+        ...base,
+        quizConfig: { questionCount: 5, difficulty: 'hard', questionTypes: ['single'] },
+      }),
+    );
+  });
+});
+
+describe('hasRequiredConfig', () => {
+  test('slide always satisfied', () => {
+    expect(hasRequiredConfig(base)).toBe(true);
+  });
+  test('interactive needs widgetType + widgetOutline', () => {
+    expect(hasRequiredConfig({ ...base, type: 'interactive' })).toBe(false);
+    expect(
+      hasRequiredConfig({
+        ...base,
+        type: 'interactive',
+        widgetType: 'diagram',
+        widgetOutline: { concept: 'x' },
+      }),
+    ).toBe(true);
+  });
+  test('pbl needs pblConfig', () => {
+    expect(hasRequiredConfig({ ...base, type: 'pbl' })).toBe(false);
+    expect(
+      hasRequiredConfig({
+        ...base,
+        type: 'pbl',
+        pblConfig: { projectTopic: 't', projectDescription: 'd', targetSkills: [] },
+      }),
+    ).toBe(true);
+  });
+  test('quiz needs quizConfig', () => {
+    expect(hasRequiredConfig({ ...base, type: 'quiz' })).toBe(false);
+  });
+});
+
+describe('resetConfigForType', () => {
+  test('sets type and clears all config keys', () => {
+    const patch = resetConfigForType('interactive');
+    expect(patch.type).toBe('interactive');
+    expect(patch.quizConfig).toBeUndefined();
+    expect(patch.widgetType).toBeUndefined();
+    expect(patch.widgetOutline).toBeUndefined();
+    expect(patch.pblConfig).toBeUndefined();
+    expect(patch.interactiveConfig).toBeUndefined();
+    expect(patch.specializedFor).toBeUndefined();
+    expect('quizConfig' in patch).toBe(true);
+  });
+});
+
+describe('deriveQuizConfig', () => {
+  test('keeps existing config', () => {
+    const cfg = {
+      questionCount: 5,
+      difficulty: 'hard' as const,
+      questionTypes: ['multiple' as const],
+    };
+    expect(deriveQuizConfig({ ...base, type: 'quiz', quizConfig: cfg })).toEqual(cfg);
+  });
+  test('defaults when absent', () => {
+    expect(deriveQuizConfig({ ...base, type: 'quiz' })).toEqual({
+      questionCount: 3,
+      difficulty: 'medium',
+      questionTypes: ['single'],
+    });
+  });
+});
+
+describe('derivePblConfig', () => {
+  test('maps common fields when absent', () => {
+    expect(derivePblConfig({ ...base, type: 'pbl' })).toEqual({
+      projectTopic: 'Photosynthesis',
+      projectDescription: 'How plants make food',
+      targetSkills: ['light', 'CO2', 'glucose'],
+      issueCount: 3,
+    });
+  });
+});
+
+describe('deriveWidgetConfig', () => {
+  test('uses LLM-classified widgetType', async () => {
+    const aiCall: AICallFn = async () =>
+      JSON.stringify({ widgetType: 'simulation', widgetOutline: { concept: 'photosynthesis rates' } });
+    const out = await deriveWidgetConfig({ ...base, type: 'interactive' }, aiCall);
+    expect(out.widgetType).toBe('simulation');
+    expect(out.widgetOutline.concept).toBe('photosynthesis rates');
+  });
+  test('falls back to diagram on invalid widgetType', async () => {
+    const aiCall: AICallFn = async () => JSON.stringify({ widgetType: 'bogus' });
+    const out = await deriveWidgetConfig({ ...base, type: 'interactive' }, aiCall);
+    expect(out.widgetType).toBe('diagram');
+    expect(out.widgetOutline.concept).toBe('Photosynthesis');
+  });
+  test('falls back to diagram on aiCall throw', async () => {
+    const aiCall: AICallFn = async () => {
+      throw new Error('llm down');
+    };
+    const out = await deriveWidgetConfig({ ...base, type: 'interactive' }, aiCall);
+    expect(out.widgetType).toBe('diagram');
+  });
+  test('keeps existing widget config without calling LLM', async () => {
+    const aiCall = vi.fn(async () => '{}') as unknown as AICallFn;
+    const out = await deriveWidgetConfig(
+      { ...base, type: 'interactive', widgetType: 'code', widgetOutline: { concept: 'kept' } },
+      aiCall,
+    );
+    expect(out.widgetType).toBe('code');
+    expect(aiCall).not.toHaveBeenCalled();
+  });
+});
+
+describe('specializeOutline', () => {
+  test('cache hit: matching specializedFor + config present → unchanged, no derive', async () => {
+    const interactive: SceneOutline = {
+      ...base,
+      type: 'interactive',
+      widgetType: 'code',
+      widgetOutline: { concept: 'kept' },
+    };
+    const tagged = { ...interactive, specializedFor: computeIntentHash(interactive) };
+    const deriveWidget = vi.fn();
+    const out = await specializeOutline(tagged, {
+      aiCall: noop,
+      hasLanguageModel: true,
+      deriveWidget: deriveWidget as never,
+    });
+    expect(out).toBe(tagged);
+    expect(deriveWidget).not.toHaveBeenCalled();
+  });
+
+  test('slide is a no-op that just tags', async () => {
+    const out = await specializeOutline(base, { aiCall: noop, hasLanguageModel: true });
+    expect(out.type).toBe('slide');
+    expect(out.specializedFor).toBe(computeIntentHash(base));
+  });
+
+  test('slide→interactive derives widget config and tags', async () => {
+    const changed: SceneOutline = { ...base, type: 'interactive' };
+    const deriveWidget = vi.fn(async () => ({
+      widgetType: 'diagram' as const,
+      widgetOutline: { concept: 'x' },
+    }));
+    const out = await specializeOutline(changed, {
+      aiCall: noop,
+      hasLanguageModel: true,
+      deriveWidget: deriveWidget as never,
+    });
+    expect(out.type).toBe('interactive');
+    expect(out.widgetType).toBe('diagram');
+    expect(out.widgetOutline).toEqual({ concept: 'x' });
+    expect(out.specializedFor).toBe(computeIntentHash(changed));
+    expect(deriveWidget).toHaveBeenCalledOnce();
+  });
+
+  test('quiz derives default quizConfig', async () => {
+    const out = await specializeOutline({ ...base, type: 'quiz' }, { aiCall: noop, hasLanguageModel: true });
+    expect(out.quizConfig).toEqual({ questionCount: 3, difficulty: 'medium', questionTypes: ['single'] });
+  });
+
+  test('pbl with language model derives pblConfig', async () => {
+    const out = await specializeOutline({ ...base, type: 'pbl' }, { aiCall: noop, hasLanguageModel: true });
+    expect(out.type).toBe('pbl');
+    expect(out.pblConfig?.projectTopic).toBe('Photosynthesis');
+  });
+
+  test('pbl without language model degrades to slide (logged), not pbl', async () => {
+    const out = await specializeOutline({ ...base, type: 'pbl' }, { aiCall: noop, hasLanguageModel: false });
+    expect(out.type).toBe('slide');
+  });
+
+  test('stale tag forces re-derive even if some config present', async () => {
+    const changed: SceneOutline = { ...base, type: 'interactive', specializedFor: 'stale' };
+    const deriveWidget = vi.fn(async () => ({
+      widgetType: 'game' as const,
+      widgetOutline: { concept: 'y' },
+    }));
+    const out = await specializeOutline(changed, {
+      aiCall: noop,
+      hasLanguageModel: true,
+      deriveWidget: deriveWidget as never,
+    });
+    expect(deriveWidget).toHaveBeenCalledOnce();
+    expect(out.widgetType).toBe('game');
+  });
+});
+
+describe('specializeOutline — procedural-skill gating (upstream)', () => {
+  test('procedural-skill widget without allowProceduralSkill → sanitized to diagram', async () => {
+    const ps: SceneOutline = {
+      ...base,
+      type: 'interactive',
+      widgetType: 'procedural-skill',
+      widgetOutline: { concept: 'fix the engine', steps: ['open', 'inspect'] },
+    };
+    const out = await specializeOutline(ps, {
+      aiCall: noop,
+      hasLanguageModel: true,
+      allowProceduralSkill: false,
+    });
+    expect(out.type).toBe('interactive');
+    expect(out.widgetType).toBe('diagram');
+    expect(out.specializedFor).toBeTruthy();
+  });
+
+  test('procedural-skill widget WITH allowProceduralSkill is kept (cache miss still derives nothing new)', async () => {
+    const ps: SceneOutline = {
+      ...base,
+      type: 'interactive',
+      widgetType: 'procedural-skill',
+      widgetOutline: { concept: 'fix the engine' },
+    };
+    const out = await specializeOutline(ps, {
+      aiCall: noop,
+      hasLanguageModel: true,
+      allowProceduralSkill: true,
+    });
+    expect(out.widgetType).toBe('procedural-skill');
+  });
+});


### PR DESCRIPTION
## Problem

Changing a scene's `type` in the outline editor (e.g. `slide` → `interactive`) is **silently reverted to `slide`** at generation time. Root cause: downstream routing keys off the *presence of type-specific config* (`widgetOutline` / `pblConfig` / `quizConfig`) rather than the `type` field, and `applyOutlineFallbacks` downgrades any type whose config is missing — with only a server-side `warn`, no UI signal. The user's edit is lost.

## Approach (keep `type` explicit, derive its config on confirm)

Add `lib/generation/outline-specializer.ts`. At scene-content time, when the declared `type` lacks its required config, derive that config from the outline's intent fields (`title` / `description` / `keyPoints`):

- **quiz / pbl** derive purely from common fields (pbl maps title/description/keyPoints; quiz uses sensible defaults).
- **interactive** derives `widgetType` + a minimal `widgetOutline` via one LLM call, defaulting to `diagram` if the model is unavailable or returns something invalid. (Most widget-content variables already fall back to the outline's common fields, so a minimal `{ concept }` is enough to render.)
- **slide** is a no-op.
- A `specializedFor` intent-hash tags the derived config as a **cache**: when intent is unchanged and the config is present, specialization returns the outline untouched — re-confirming costs nothing. The derived outline rides back as the route's `effectiveOutline`.
- The gated **vocational `procedural-skill`** path is preserved (sanitized to a diagram when not enabled).

Wiring:
- `scene-content` route calls `specializeOutline` instead of the silent `applyOutlineFallbacks` revert. `applyOutlineFallbacks` is kept for server-batch / classroom auto-gen paths, where an LLM-produced outline legitimately lacking config should still degrade to slide.
- The outline editor clears stale type-specific config when the user changes a scene's type (`resetConfigForType`), so derivation starts clean.

## Scope

6 files, +469/-3. New: `outline-specializer.ts` + its test. Edited: `generation.ts` (`specializedFor`), `generation-pipeline.ts` (barrel), `scene-content/route.ts` (call site), `outlines-editor.tsx` (type-change reset).

## Tests

25 unit tests covering intent hashing, per-type config checks, quiz/pbl/interactive derivation, the derive-on-confirm cache (hit / stale invalidation), pbl-without-language-model degradation, and procedural-skill gating. `tsc --noEmit` clean on the touched files.

## Status

**Draft** — opening for review of the interface and the derive-on-confirm approach. Only `interactive` incurs an LLM call (and only when its config is missing); quiz/pbl/slide are pure. Default behavior for outlines that already carry matching config is unchanged (cache hit → zero extra calls).