### PR TITLE
ci: add Claude Code GitHub Actions workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main, feat/maic-editor-v0]
+    branches: [main, feat/maic-editor-v0, develop]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/claude-discussions.yml
+++ b/.github/workflows/claude-discussions.yml
@@ -1,0 +1,72 @@
+name: Claude Code (Discussions)
+
+# EXPERIMENTAL — needs a live test.
+#
+# anthropics/claude-code-action does NOT support GitHub Discussions
+# (discussion / discussion_comment are not in its event list), which is why
+# "@claude" in a Discussion goes unanswered. This workflow bridges that gap
+# WITHOUT the action: it runs the Claude Code CLI headlessly to draft an answer,
+# then posts that answer back into the Discussion via the GitHub GraphQL API.
+#
+# Like other discussion events, these always run from the DEFAULT branch (main),
+# so this covers Discussions in every category with no per-branch copy.
+on:
+  discussion:
+    types: [created]
+  discussion_comment:
+    types: [created]
+
+jobs:
+  answer:
+    # Same control model as the issue/PR workflow: only act when "@claude" appears.
+    if: |
+      (github.event_name == 'discussion' && (contains(github.event.discussion.body, '@claude') || contains(github.event.discussion.title, '@claude'))) ||
+      (github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      discussions: write   # required so the GraphQL addDiscussionComment can post the reply
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Draft the answer
+        env:
+          # Headless auth for CI: the same OAuth token the issue/PR workflow uses.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Passed via env (NOT inlined into the script) so untrusted Discussion
+          # text cannot be interpreted as shell. "$VAR" expansion does not re-run
+          # command substitution found inside the value, so this is injection-safe.
+          TITLE: ${{ github.event.discussion.title }}
+          QUESTION: ${{ github.event.comment.body || github.event.discussion.body }}
+        run: |
+          set -euo pipefail
+          PROMPT="A user asked the following in a GitHub Discussion titled \"$TITLE\" on this repository. Answer helpfully and concisely in GitHub-flavored markdown. You may read the repository (read-only) to ground your answer. Output ONLY the answer, with no preamble.
+
+          ---
+          $QUESTION
+          ---"
+          claude -p "$PROMPT" \
+            --allowedTools "Read,Grep,Glob,Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(rg:*)" \
+            > reply.md
+          echo "Drafted $(wc -c < reply.md) bytes."
+
+      - name: Post the answer back to the Discussion
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+        run: |
+          set -euo pipefail
+          gh api graphql \
+            -f discussionId="$DISCUSSION_ID" \
+            -F body=@reply.md \
+            -f query='mutation($discussionId: ID!, $body: String!) {
+              addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                comment { url }
+              }
+            }'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,22 +1,36 @@
 name: Claude Code
 
+# How triggering works:
+# Claude runs ONLY when a human writes "@claude" in an issue, pull request,
+# comment, or review (see the `if:` gate below). This keeps usage controlled.
+#
+# "All branches" is automatic: the events below (issues, issue_comment,
+# pull_request_review, pull_request_review_comment) are NOT tied to a feature
+# branch, so GitHub always evaluates THIS workflow from the DEFAULT branch
+# (main). Once this file is on main, mentioning @claude works on issues and on
+# PRs from every branch with no per-branch copy needed. (The `pull_request`
+# opened/reopened event is the one exception — it uses the workflow from the PR's
+# head branch — so keep this file in sync when you branch off main.)
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened, assigned]
+  issue_comment:            # also fires for comments on a PR's conversation tab
+    types: [created]
+  pull_request:
+    types: [opened, reopened]
   pull_request_review:
     types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   claude:
     if: |
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@claude') || contains(github.event.pull_request.title, '@claude'))) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,3 +49,17 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Playwright browser automation:
+          # - --mcp-config registers the Playwright MCP server.
+          # - One allow rule, `mcp__playwright`, grants ALL of its tools at once
+          #   (the bare server name matches every tool on that server), so there
+          #   is no need to list browser_navigate, browser_click, ... one by one.
+          # The browser binary installs on demand the first time Claude actually
+          # uses it (via the server's own browser_install tool), so plain code
+          # tasks pay no overhead. If a browser ever fails to launch on the runner
+          # for missing system libs, add a step: `npx playwright install --with-deps chromium`.
+          # These tools are ADDED to the action's defaults (it keeps its built-in
+          # Edit/Read/Bash and GitHub commenting tools).
+          claude_args: |
+            --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}'
+            --allowedTools "mcp__playwright"


### PR DESCRIPTION
Enables @claude mentions in issues, PRs, and review comments to trigger the Claude Code action using the existing CLAUDE_CODE_OAUTH_TOKEN secret.

## Summary

<!-- Briefly describe the changes in this PR. -->

## Related Issues

<!-- Link related issues: "Closes #123", "Fixes #456", "Related to #789" -->

## Changes

<!-- List the key changes: -->
-

## Type of Change

<!-- Check the relevant options: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1.
2.
3.

### What you personally verified

<!-- What did you test beyond CI? Include edge cases checked and anything you did NOT verify. -->

-

### Evidence

<!-- Attach at least one: logs, screenshots, recordings, or before/after comparisons. -->

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [ ] My changes do not introduce new warnings
