### PR TITLE
fix(generation): don't regenerate a deleted slide on a finished deck

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -154,11 +154,14 @@ export default function ClassroomDetailPage() {
     if (loading || error || generationStartedRef.current) return;
 
     const state = useStageStore.getState();
-    const { outlines, scenes, stage } = state;
+    const { outlines, scenes, stage, generationComplete } = state;
 
-    // Check if there are pending outlines
+    // Check if there are pending outlines. A finished deck is frozen for
+    // editing: deleting a slide leaves its outline orphaned, but that must not
+    // be treated as an interrupted generation and regenerated. Only resume
+    // when generation has not completed.
     const completedOrders = new Set(scenes.map((s) => s.order));
-    const hasPending = outlines.some((o) => !completedOrders.has(o.order));
+    const hasPending = !generationComplete && outlines.some((o) => !completedOrders.has(o.order));
 
     if (hasPending && stage) {
       generationStartedRef.current = true;
@@ -191,7 +194,19 @@ export default function ClassroomDetailPage() {
       // Resume media generation for any tasks not yet in IndexedDB.
       // generateMediaForOutlines skips already-completed tasks automatically.
       generationStartedRef.current = true;
-      generateMediaForOutlines(outlines, stage.id).catch((err) => {
+      // The deck reached the classroom already fully materialized (e.g. a
+      // single-slide course, or a deck whose last slide finished in
+      // generation-preview), so generateRemaining's completion path never
+      // ran. Record completion now so a later edit/delete is not treated as
+      // an interrupted generation. No-op if already complete or not all
+      // outlines have scenes.
+      useStageStore.getState().markGenerationCompleteIfDone();
+      // Resume media only for outlines that still have a scene. On a finished
+      // deck the user may have deleted a slide, leaving an orphaned outline;
+      // generating its media would waste API calls on a slide that is gone.
+      const materializedOrders = new Set(scenes.map((s) => s.order));
+      const materializedOutlines = outlines.filter((o) => materializedOrders.has(o.order));
+      generateMediaForOutlines(materializedOutlines, stage.id).catch((err) => {
         log.warn('[Classroom] Media generation resume error:', err);
       });
     }

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -82,6 +82,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       outlines,
     } = useStageStore();
     const failedOutlines = useStageStore.use.failedOutlines();
+    const generationComplete = useStageStore.use.generationComplete();
 
     const currentScene = getCurrentScene();
 
@@ -806,9 +807,13 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     // currently generating — signals the classroom has finished and the user
     // can see a completion page. Comparing scenes.length === outlines.length
     // (rather than just `scenes.length > 0`) means a partial generation with
-    // some failed outlines does not falsely trigger completion.
+    // some failed outlines does not falsely trigger completion. The persisted
+    // generationComplete flag also marks completion directly, so an edited
+    // finished deck (e.g. a deleted slide, leaving outlines.length > scenes)
+    // still reads as complete.
     const isCourseComplete =
-      outlines.length > 0 && scenes.length === outlines.length && generatingOutlines.length === 0;
+      generationComplete ||
+      (outlines.length > 0 && scenes.length === outlines.length && generatingOutlines.length === 0);
     const canAdvanceToPendingSlot = hasNextPending || isCourseComplete;
 
     // previous scene (gated)

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -316,6 +316,7 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
       if (pending.length === 0) {
         store.getState().setGenerationStatus('completed');
         store.getState().setGeneratingOutlines([]);
+        store.getState().setGenerationComplete(true);
         options.onComplete?.();
         generatingRef.current = false;
         return;
@@ -533,6 +534,7 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
           } else {
             store.getState().setGenerationStatus('completed');
             store.getState().setGeneratingOutlines([]);
+            store.getState().setGenerationComplete(true);
             options.onComplete?.();
           }
         }
@@ -681,6 +683,12 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
         // Resume remaining generation if there are pending outlines
         if (store.getState().generatingOutlines.length > 0 && lastParamsRef.current) {
           generateRemainingRef.current?.(lastParamsRef.current);
+        } else {
+          // This retry may have materialized the final outstanding slide. The
+          // generateRemaining completion path is not reached on the retry flow,
+          // so mark completion here too — otherwise a later delete would treat
+          // the orphaned outline as pending and regenerate it.
+          store.getState().markGenerationCompleteIfDone();
         }
       } catch (err) {
         if (!(err instanceof DOMException && err.name === 'AbortError')) {

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -61,6 +61,10 @@ interface StageState {
   // Persisted outlines for resume-on-refresh
   outlines: SceneOutline[];
 
+  // Persisted (with outlines): true once generation finished for this stage.
+  // Gates resume-on-mount so an edited finished deck is not regenerated.
+  generationComplete: boolean;
+
   // Transient generation tracking (not persisted)
   generationEpoch: number;
   generationStatus: 'idle' | 'generating' | 'paused' | 'completed' | 'error';
@@ -80,6 +84,9 @@ interface StageState {
   setToolbarState: (state: ToolbarState) => void;
   setGeneratingOutlines: (outlines: SceneOutline[]) => void;
   setOutlines: (outlines: SceneOutline[]) => void;
+  setGenerationComplete: (complete: boolean) => void;
+  /** Mark generation complete iff every outline has a scene and none failed. */
+  markGenerationCompleteIfDone: () => void;
   setGenerationStatus: (status: 'idle' | 'generating' | 'paused' | 'completed' | 'error') => void;
   setCurrentGeneratingOrder: (order: number) => void;
   bumpGenerationEpoch: () => void;
@@ -93,7 +100,7 @@ interface StageState {
   getSceneIndex: (sceneId: string) => number;
 
   // Storage
-  saveToStorage: () => Promise<void>;
+  saveToStorage: () => Promise<boolean>;
   loadFromStorage: (stageId: string) => Promise<void>;
   clearStore: () => void;
 }
@@ -108,6 +115,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
   toolbarState: 'ai',
   generatingOutlines: [],
   outlines: [],
+  generationComplete: false,
   generationEpoch: 0,
   generationStatus: 'idle' as const,
   currentGeneratingOrder: -1,
@@ -120,6 +128,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       scenes: [],
       currentSceneId: null,
       chats: [],
+      generationComplete: false,
       generationEpoch: s.generationEpoch + 1,
     }));
     debouncedSave();
@@ -191,6 +200,19 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
   },
 
   deleteScene: (sceneId) => {
+    // A deck that is complete right now (every outline has a scene) stays
+    // complete after a deletion. Capture that BEFORE removing the scene so the
+    // completion (end) page and resume-suppression survive even for decks whose
+    // generationComplete flag was never recorded — e.g. generated before the
+    // flag existed, or edited without a reload so loadFromStorage's self-heal
+    // never ran. Without this, the deletion breaks the scenes===outlines count
+    // and the "Course complete" page disappears.
+    const wasComplete =
+      !get().generationComplete &&
+      get().outlines.length > 0 &&
+      get().failedOutlines.length === 0 &&
+      get().outlines.every((o) => get().scenes.some((s) => s.order === o.order));
+
     const scenes = get().scenes.filter((scene) => scene.id !== sceneId);
     const currentSceneId = get().currentSceneId;
 
@@ -205,6 +227,9 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     } else {
       set({ scenes });
     }
+
+    if (wasComplete) get().setGenerationComplete(true);
+
     debouncedSave();
   },
 
@@ -233,18 +258,60 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
 
   setOutlines: (outlines) => {
     set({ outlines });
-    // Persist outlines to IndexedDB
+    // Persist outlines to IndexedDB. Carry generationComplete so writing
+    // outlines never clobbers a previously-recorded completion flag.
     const stageId = get().stage?.id;
     if (stageId) {
+      const generationComplete = get().generationComplete;
       import('@/lib/utils/database').then(({ db }) => {
         db.stageOutlines.put({
           stageId,
           outlines,
+          generationComplete,
           createdAt: Date.now(),
           updatedAt: Date.now(),
         });
       });
     }
+  },
+
+  setGenerationComplete: (generationComplete) => {
+    set({ generationComplete });
+    // Persist alongside the outlines record so resume-on-mount can read it.
+    const stageId = get().stage?.id;
+    if (stageId) {
+      const outlines = get().outlines;
+      // Flush the current scenes BEFORE recording completion, and only record
+      // it once that flush is verified. Scenes save through a 500ms debounce,
+      // so writing the flag eagerly could let a reload see
+      // generationComplete=true with the final slide still unsaved — which
+      // would then be suppressed (not pending) and lost. If the scene flush
+      // fails, skip the flag: the deck stays resumable and recovers on reload.
+      void get()
+        .saveToStorage()
+        .then((saved) => {
+          if (!saved) return;
+          return import('@/lib/utils/database').then(({ db }) => {
+            db.stageOutlines.put({
+              stageId,
+              outlines,
+              generationComplete,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            });
+          });
+        });
+    }
+  },
+
+  markGenerationCompleteIfDone: () => {
+    const { outlines, scenes, failedOutlines, generationComplete } = get();
+    if (generationComplete) return;
+    const done =
+      outlines.length > 0 &&
+      failedOutlines.length === 0 &&
+      outlines.every((o) => scenes.some((s) => s.order === o.order));
+    if (done) get().setGenerationComplete(true);
   },
 
   setGenerationStatus: (generationStatus) => set({ generationStatus }),
@@ -282,12 +349,14 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     return get().scenes.findIndex((s) => s.id === sceneId);
   },
 
-  // Storage methods
+  // Storage methods. Returns true on a verified write so callers that gate on
+  // durability (e.g. setGenerationComplete) can avoid recording state that
+  // outruns the scene data.
   saveToStorage: async () => {
     const { stage, scenes, currentSceneId, chats } = get();
     if (!stage?.id) {
       log.warn('Cannot save: stage.id is required');
-      return;
+      return false;
     }
 
     try {
@@ -298,8 +367,10 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
         currentSceneId,
         chats,
       });
+      return true;
     } catch (error) {
       log.error('Failed to save to storage:', error);
+      return false;
     }
   },
 
@@ -320,20 +391,52 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       const { db } = await import('@/lib/utils/database');
       const outlinesRecord = await db.stageOutlines.get(stageId);
       const outlines = outlinesRecord?.outlines || [];
+      const persistedComplete = outlinesRecord?.generationComplete ?? false;
 
       if (data) {
         // Normalize legacy slide content (missing schemaVersion) at the load
         // boundary, same as setScenes/addScene — IndexedDB snapshots predate
         // the schema field, so they must be migrated on the way in.
         const migrated = data.scenes.map(migrateScene);
+
+        // Self-heal decks generated before generationComplete was tracked: if
+        // every outline already has a matching scene, generation must have
+        // finished, so treat the deck as complete and persist the flag. This
+        // prevents a pre-existing finished deck from regenerating a slide the
+        // user deletes before the flag was ever recorded.
+        //
+        // Matching is by `order`, consistent with the rest of the resume
+        // pipeline. For a never-edited deck order is a faithful key; the only
+        // way it diverges is Pro-mode insert/reorder, which is blocked while
+        // outlines are still pending (see stage-mode edit gating), so an
+        // interrupted deck cannot be edited into a false "all materialized".
+        const allMaterialized =
+          outlines.length > 0 && outlines.every((o) => migrated.some((s) => s.order === o.order));
+        const generationComplete = persistedComplete || allMaterialized;
+        if (generationComplete && !persistedComplete) {
+          db.stageOutlines.put({
+            stageId,
+            outlines,
+            generationComplete: true,
+            createdAt: outlinesRecord?.createdAt ?? Date.now(),
+            updatedAt: Date.now(),
+          });
+        }
+
         set({
           stage: data.stage,
           scenes: migrated,
           currentSceneId: data.currentSceneId,
           chats: data.chats,
           outlines,
-          // Compute generatingOutlines from persisted outlines minus completed scenes
-          generatingOutlines: outlines.filter((o) => !migrated.some((s) => s.order === o.order)),
+          generationComplete,
+          // Compute generatingOutlines from persisted outlines minus completed
+          // scenes. Once generation is complete the deck is frozen for editing,
+          // so an orphaned outline (e.g. from a deleted slide) must NOT surface
+          // as a pending placeholder or drive resume regeneration.
+          generatingOutlines: generationComplete
+            ? []
+            : outlines.filter((o) => !migrated.some((s) => s.order === o.order)),
           // `mode` is transient UI state, not persisted with the stage.
           // Reset to 'playback' on every load so SPA navigation between
           // classrooms doesn't carry Pro-mode state across — e.g. user
@@ -359,6 +462,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       currentSceneId: null,
       chats: [],
       outlines: [],
+      generationComplete: false,
       generationEpoch: s.generationEpoch + 1,
       generationStatus: 'idle' as const,
       currentGeneratingOrder: -1,

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -132,6 +132,10 @@ export interface PlaybackStateRecord {
 export interface StageOutlinesRecord {
   stageId: string; // Primary key (FK -> stages.id)
   outlines: SceneOutline[];
+  // True once generation finished for this stage. Gates resume-on-mount so an
+  // edited (e.g. slide-deleted) finished deck is not treated as "interrupted"
+  // and regenerated. Optional for backward compat with pre-existing records.
+  generationComplete?: boolean;
   createdAt: number;
   updatedAt: number;
 }

--- a/tests/store/stage-generation-complete.test.ts
+++ b/tests/store/stage-generation-complete.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// IndexedDB / stage-storage modules are imported dynamically inside the
+// store's save/load actions. Mock them so we can drive load inputs and
+// observe persistence without a real IndexedDB. Spies go through vi.hoisted
+// so they exist before the hoisted vi.mock factories run.
+const { loadStageDataMock, saveStageDataMock, stageOutlinesGet, stageOutlinesPut } = vi.hoisted(
+  () => ({
+    loadStageDataMock: vi.fn(),
+    saveStageDataMock: vi.fn().mockResolvedValue(undefined),
+    stageOutlinesGet: vi.fn(),
+    stageOutlinesPut: vi.fn(),
+  }),
+);
+vi.mock('@/lib/utils/stage-storage', () => ({
+  saveStageData: (...args: unknown[]) => saveStageDataMock(...args),
+  loadStageData: (...args: unknown[]) => loadStageDataMock(...args),
+}));
+vi.mock('@/lib/utils/database', () => ({
+  db: { stageOutlines: { put: stageOutlinesPut, get: stageOutlinesGet } },
+}));
+
+import { useStageStore } from '@/lib/store/stage';
+import type { Scene, Stage } from '@/lib/types/stage';
+import type { SceneOutline } from '@/lib/types/generation';
+
+function makeStage(): Stage {
+  return { id: 'stage-1', name: 'Test stage', createdAt: 1, updatedAt: 1 };
+}
+
+function makeSlideScene(id: string, order: number, stageId = 'stage-1'): Scene {
+  return {
+    id,
+    stageId,
+    type: 'slide',
+    title: id,
+    order,
+    content: {
+      type: 'slide',
+      canvas: {
+        id: `canvas-${id}`,
+        viewportSize: 1000,
+        viewportRatio: 0.5625,
+        theme: {
+          backgroundColor: '#fff',
+          themeColors: ['#000'],
+          fontColor: '#000',
+          fontName: 'Inter',
+        },
+        elements: [],
+      },
+    },
+  };
+}
+
+function makeOutline(order: number): SceneOutline {
+  return {
+    id: `outline-${order}`,
+    type: 'slide',
+    title: `outline ${order}`,
+    description: 'desc',
+    keyPoints: ['k1'],
+    order,
+  };
+}
+
+beforeEach(() => {
+  useStageStore.getState().clearStore();
+  stageOutlinesGet.mockReset();
+  stageOutlinesPut.mockReset();
+  loadStageDataMock.mockReset();
+});
+
+afterEach(() => {
+  useStageStore.getState().clearStore();
+});
+
+describe('generationComplete', () => {
+  it('defaults to false', () => {
+    expect(useStageStore.getState().generationComplete).toBe(false);
+  });
+
+  it('setGenerationComplete(true) flips the flag and persists it alongside outlines', async () => {
+    useStageStore.setState({ stage: makeStage(), outlines: [makeOutline(1), makeOutline(2)] });
+    useStageStore.getState().setGenerationComplete(true);
+    expect(useStageStore.getState().generationComplete).toBe(true);
+    // Persisted via an async dynamic import.
+    await vi.waitFor(() => expect(stageOutlinesPut).toHaveBeenCalled());
+    const record = stageOutlinesPut.mock.calls.at(-1)![0] as {
+      generationComplete?: boolean;
+      outlines: SceneOutline[];
+    };
+    expect(record.generationComplete).toBe(true);
+    expect(record.outlines.map((o) => o.order)).toEqual([1, 2]);
+  });
+
+  // Guards a persistence race: the final scene saves through a 500ms debounce,
+  // so the flag must not reach IndexedDB before the scenes do — else a reload
+  // would trust the flag and drop the unsaved final slide.
+  it('flushes scenes before persisting the completion flag', async () => {
+    useStageStore.setState({ stage: makeStage(), outlines: [makeOutline(1)] });
+    saveStageDataMock.mockClear();
+    stageOutlinesPut.mockClear();
+
+    useStageStore.getState().setGenerationComplete(true);
+
+    await vi.waitFor(() => expect(stageOutlinesPut).toHaveBeenCalled());
+    expect(saveStageDataMock).toHaveBeenCalled();
+    // Scene flush must be ordered before the flag write.
+    expect(saveStageDataMock.mock.invocationCallOrder[0]).toBeLessThan(
+      stageOutlinesPut.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not persist the completion flag when the scene flush fails', async () => {
+    useStageStore.setState({ stage: makeStage(), outlines: [makeOutline(1)] });
+    saveStageDataMock.mockRejectedValueOnce(new Error('disk full'));
+    stageOutlinesPut.mockClear();
+
+    useStageStore.getState().setGenerationComplete(true);
+    // In-memory flag still flips (UI), but the durable record must not be
+    // written ahead of the scenes — else a reload would drop the unsaved slide.
+    expect(useStageStore.getState().generationComplete).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(stageOutlinesPut).not.toHaveBeenCalled();
+  });
+
+  it('starting a new stage resets generationComplete to false', () => {
+    useStageStore.setState({ generationComplete: true });
+    useStageStore.getState().setStage(makeStage());
+    expect(useStageStore.getState().generationComplete).toBe(false);
+  });
+
+  describe('deleteScene preserves completion', () => {
+    // A deck complete-by-count but missing the flag (e.g. generated before the
+    // flag existed, or edited without a reload so self-heal never ran) must
+    // record completion when a slide is deleted — otherwise the count breaks
+    // and the "Course complete" end page disappears.
+    it('marks complete when deleting from a fully-materialized deck whose flag was unset', () => {
+      useStageStore.setState({
+        stage: makeStage(),
+        scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2), makeSlideScene('c', 3)],
+        outlines: [makeOutline(1), makeOutline(2), makeOutline(3)],
+        failedOutlines: [],
+        generationComplete: false,
+        currentSceneId: 'b',
+      });
+      useStageStore.getState().deleteScene('b');
+      expect(useStageStore.getState().generationComplete).toBe(true);
+      expect(useStageStore.getState().scenes.map((s) => s.order)).toEqual([1, 3]);
+    });
+
+    it('does not mark complete when deleting from a still-incomplete deck', () => {
+      useStageStore.setState({
+        stage: makeStage(),
+        scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2)], // outline order 3 not materialized
+        outlines: [makeOutline(1), makeOutline(2), makeOutline(3)],
+        failedOutlines: [],
+        generationComplete: false,
+        currentSceneId: 'a',
+      });
+      useStageStore.getState().deleteScene('b');
+      expect(useStageStore.getState().generationComplete).toBe(false);
+    });
+
+    it('keeps generationComplete true when deleting from an already-complete deck', () => {
+      useStageStore.setState({
+        stage: makeStage(),
+        scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2)],
+        outlines: [makeOutline(1), makeOutline(2)],
+        failedOutlines: [],
+        generationComplete: true,
+        currentSceneId: 'a',
+      });
+      useStageStore.getState().deleteScene('b');
+      expect(useStageStore.getState().generationComplete).toBe(true);
+    });
+  });
+
+  describe('markGenerationCompleteIfDone', () => {
+    it('marks complete when every outline has a scene and none failed', () => {
+      useStageStore.setState({
+        stage: makeStage(),
+        scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2)],
+        outlines: [makeOutline(1), makeOutline(2)],
+        failedOutlines: [],
+        generationComplete: false,
+      });
+      useStageStore.getState().markGenerationCompleteIfDone();
+      expect(useStageStore.getState().generationComplete).toBe(true);
+    });
+
+    it('does not mark complete while an outline is still unmaterialized', () => {
+      useStageStore.setState({
+        stage: makeStage(),
+        scenes: [makeSlideScene('a', 1)],
+        outlines: [makeOutline(1), makeOutline(2)],
+        failedOutlines: [],
+        generationComplete: false,
+      });
+      useStageStore.getState().markGenerationCompleteIfDone();
+      expect(useStageStore.getState().generationComplete).toBe(false);
+    });
+
+    it('does not mark complete while an outline is still failed', () => {
+      useStageStore.setState({
+        stage: makeStage(),
+        scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2)],
+        outlines: [makeOutline(1), makeOutline(2)],
+        failedOutlines: [makeOutline(2)],
+        generationComplete: false,
+      });
+      useStageStore.getState().markGenerationCompleteIfDone();
+      expect(useStageStore.getState().generationComplete).toBe(false);
+    });
+  });
+
+  // The core regression: a completed deck must not resurrect a deleted slide.
+  // On reload the orphaned outline (no matching scene) must NOT become a
+  // generating placeholder, and the flag must round-trip.
+  it('drops generating placeholders on load when generation already completed', async () => {
+    loadStageDataMock.mockResolvedValue({
+      stage: makeStage(),
+      scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2)], // order 3 was deleted
+      currentSceneId: 'a',
+      chats: [],
+    });
+    stageOutlinesGet.mockResolvedValue({
+      stageId: 'stage-1',
+      outlines: [makeOutline(1), makeOutline(2), makeOutline(3)], // orphan order 3
+      generationComplete: true,
+    });
+
+    await useStageStore.getState().loadFromStorage('stage-1');
+
+    expect(useStageStore.getState().generationComplete).toBe(true);
+    expect(useStageStore.getState().generatingOutlines).toEqual([]);
+  });
+
+  // Backward-compat: a deck generated before the flag existed has no
+  // generationComplete in its record. If every outline already has a scene it
+  // is fully generated, so it must self-heal to complete (and persist) — else
+  // the first deletion would regenerate the slide.
+  it('infers and persists completion for a legacy fully-generated deck', async () => {
+    loadStageDataMock.mockResolvedValue({
+      stage: makeStage(),
+      scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2), makeSlideScene('c', 3)],
+      currentSceneId: 'a',
+      chats: [],
+    });
+    stageOutlinesGet.mockResolvedValue({
+      stageId: 'stage-1',
+      outlines: [makeOutline(1), makeOutline(2), makeOutline(3)], // all materialized, no flag
+    });
+
+    await useStageStore.getState().loadFromStorage('stage-1');
+
+    expect(useStageStore.getState().generationComplete).toBe(true);
+    expect(useStageStore.getState().generatingOutlines).toEqual([]);
+    // Healed flag is written back so the next load is authoritative.
+    const healed = stageOutlinesPut.mock.calls.at(-1)![0] as { generationComplete?: boolean };
+    expect(healed.generationComplete).toBe(true);
+  });
+
+  // Resume-on-refresh for a genuinely interrupted generation is preserved:
+  // when not complete, the missing outline still drives a placeholder.
+  it('keeps generating placeholders on load when generation is not complete', async () => {
+    loadStageDataMock.mockResolvedValue({
+      stage: makeStage(),
+      scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2)],
+      currentSceneId: 'a',
+      chats: [],
+    });
+    stageOutlinesGet.mockResolvedValue({
+      stageId: 'stage-1',
+      outlines: [makeOutline(1), makeOutline(2), makeOutline(3)],
+      generationComplete: false,
+    });
+
+    await useStageStore.getState().loadFromStorage('stage-1');
+
+    expect(useStageStore.getState().generationComplete).toBe(false);
+    expect(useStageStore.getState().generatingOutlines.map((o) => o.order)).toEqual([3]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #768.

Deleting a slide in Pro/Edit mode removed it from `scenes` but left its entry in the persisted `outlines` plan. On the next classroom mount the resume-generation pass treats the now-missing `order` as a pending outline and regenerates the slide, appending it as the last page.

## Approach

Pruning outlines by `order` was rejected: `order` is rebalanced by Pro-mode insert/duplicate/reorder, so it is not a stable key — pruning could mis-target another slide's outline and would break delete-undo (the recycle entry only restores the scene). Instead, resume is gated on a persisted `generationComplete` flag:

- The flag is recorded (alongside outlines, in the `stageOutlines` record) when generation finishes — the two `generateRemaining` completion paths, the retry-to-completion path (`markGenerationCompleteIfDone`), and the already-materialized-at-mount path. It is restored on load. The flag is written only **after** a verified scene flush, so it can never outrun the deck's scenes.
- A finished deck is frozen for editing: `loadFromStorage` no longer derives pending placeholders from orphaned outlines, the classroom resume effect skips `generateRemaining`, media resume is filtered to outlines that still have a scene, and `isCourseComplete` honours the flag — so a deleted slide neither regenerates nor leaves a phantom pending page.
- Decks generated before the flag existed self-heal: if every outline already has a matching scene, the deck is inferred complete and the flag is persisted, so the first deletion does not regenerate.

`outlines` are never pruned, so order-rebalancing and delete-undo are unaffected. Genuinely interrupted generations (not complete) still resume as before.

## Test plan

- [x] 11 new unit tests for the store flag / persistence / self-heal / completion paths (`tests/store/stage-generation-complete.test.ts`).
- [x] Full suite green (864 tests), lint clean.
- [x] Manual browser E2E (real headless browser, upstream app): on `origin/main`, deleting a middle slide in Pro mode and reopening the course regenerates the deleted slide at the end (bug reproduced); on this branch, the deleted slide stays deleted and is not regenerated after reopen.
