### PR TITLE
fix(619): keep-alive e2e aligns with #777 edit-mode visibility (+ pi-ai server-external)

### DIFF
--- a/e2e/tests/interactive-iframe-keepalive-619.spec.ts
+++ b/e2e/tests/interactive-iframe-keepalive-619.spec.ts
@@ -182,11 +182,15 @@ test.describe('#619 interactive iframe keep-alive', () => {
     await resetMutations(page);
 
     // `.first()` because the ~280ms mode cross-fade briefly mounts both chrome
-    // layers (each with its own Pro switch). iframe visibility is the unambiguous
-    // "transition settled" signal.
-    // --- Trigger A: Pro mode toggle (edit chrome unmounts playback chrome) ---
+    // layers (each with its own Pro switch).
+    // --- Trigger A: Pro mode toggle (edit chrome remounts the placeholder) ---
     await page.getByRole('switch').first().click();
-    await expect(iframeEl).toBeHidden(); // hidden in edit mode, not unmounted
+    // Since #777 the interactive iframe stays VISIBLE in edit mode — the editor
+    // agent ("Edit with AI") fixes interactive HTML, so the teacher must see the
+    // live page while editing. The keep-alive proof is that it is neither
+    // unmounted nor reloaded: the in-iframe counter state survives the toggle.
+    await expect(iframeEl).toBeVisible();
+    await expect(count).toHaveText('3'); // state preserved across the mode toggle
     await page.screenshot({ path: `${SHOTS}/02-pro-mode.png`, fullPage: true });
 
     await page.getByRole('switch').first().click();

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,14 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   output: process.env.VERCEL ? undefined : 'standalone',
   transpilePackages: ['mathml2omml', 'pptxgenjs', '@maic/importer'],
-  serverExternalPackages: [],
+  // These agent packages do a runtime `import(specifier)` with a computed
+  // specifier (to lazily load node:fs/os/path without breaking browser/Vite
+  // builds). webpack can't statically analyze that and bundling it throws
+  // "Cannot find module as expression is too dynamic" at runtime on the server
+  // (the "Edit with AI" Pro-mode path), which broke the #619 keep-alive e2e.
+  // Mark them server-external so Next loads them natively and the dynamic
+  // import resolves as a real Node call.
+  serverExternalPackages: ['@earendil-works/pi-ai', '@earendil-works/pi-agent-core'],
   experimental: {
     proxyClientMaxBodySize: '200mb',
   },


### PR DESCRIPTION
Fixes the `interactive-iframe-keepalive-619.spec.ts` e2e that has been red on `main` since #777. Two related #777-fallout fixes.

## 1. The actual e2e cause: test asserted pre-#777 behavior (primary)

#777 deliberately changed `InteractiveIframeHost.tsx` — it dropped the `mode !== 'edit'` guard so the interactive iframe **stays visible in Pro/edit mode**:

```diff
- visible={mode !== 'edit' && entry.owner !== null && sceneId === activeSceneId}
+ visible={entry.owner !== null && sceneId === activeSceneId}
```

with an explicit rationale in the doc comment it added: *"the editor agent fixes interactive HTML, so the teacher must see the live page while editing."* That is the intended behavior — but the #619 keep-alive e2e was never updated, so its `toBeHidden()` at line 189 ("hidden in edit mode") failed on every run since #777.

Fix: update Trigger A to the new contract — after the Pro-mode toggle the iframe is **visible** and its in-iframe counter state is preserved (the real keep-alive proof: neither unmounted nor reloaded). Trigger B (scene switch to a slide → ownership released → hidden) is unchanged.

## 2. Server-side dynamic-import error spam from #777's agent libs (cleanup)

While investigating, the CI logs showed repeated `Cannot find module as expression is too dynamic` unhandled rejections. These come from `@earendil-works/pi-ai` / `pi-agent-core` (added in #777), which lazily load node builtins via a computed `import(specifier)` that webpack can't statically analyze. They are **not** the e2e cause (the error persisted/cleared independently of the test result), but they are real server-side unhandled rejections. Marking both packages `serverExternalPackages` makes Next load them natively so the dynamic import resolves as a real Node call.

Refs #619, #777.
