### PR TITLE
fix(generation): show full key-point text in outline editor

### DIFF
--- a/components/generation/outlines-editor.tsx
+++ b/components/generation/outlines-editor.tsx
@@ -642,7 +642,9 @@ function SceneRow({
                     'bg-muted/70 text-foreground/80',
                   )}
                 >
-                  <span className="truncate">{point}</span>
+                  <span className="whitespace-normal break-words" title={point}>
+                    {point}
+                  </span>
                   {!disabled && (
                     <button
                       type="button"


### PR DESCRIPTION
## Problem

In the pre-generation outline editor, each scene's key points are rendered as chips. The chip text used a single-line `truncate`, so any key point longer than the chip width was cut off with an ellipsis (`…`). When reviewing the outline before generating the course, users could not read the full text of a truncated key point.

## Fix

Let the key-point text wrap within the chip's max width (`whitespace-normal break-words`) instead of being clamped to a single line, and add a native `title` tooltip as a fallback.

## Scope

- `components/generation/outlines-editor.tsx` — one line.
- CSS-only behavior change; no logic / data / API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)