### PR TITLE
Optimize PBL v2 planner evaluation harness

### DIFF
--- a/eval/pbl-v2-planner/compare-html.ts
+++ b/eval/pbl-v2-planner/compare-html.ts
@@ -191,6 +191,11 @@ function renderProject(p){
     for (const t of (m.microtasks||[])){
       h += '<div class="mt"><div class="t">'+esc(t.title)+'</div>';
       if (t.description) h += '<div class="d">'+esc(t.description)+'</div>';
+      if (t.learnerBrief) h += '<div class="script"><b>learnerBrief</b> '+esc(t.learnerBrief)+'</div>';
+      if (t.successWhen) h += '<div class="script"><b>successWhen</b> '+esc(t.successWhen)+'</div>';
+      if (t.characterObjective) h += '<div class="script"><b>characterObjective</b> '+esc(t.characterObjective)+'</div>';
+      if (t.skillFocus) h += '<div class="script"><b>skillFocus</b> '+esc(t.skillFocus)+'</div>';
+      if (t.narration) h += '<div class="script"><b>narration</b> '+esc(t.narration)+'</div>';
       if (t.hints && t.hints.length){ h += '<ul>'+t.hints.map(x=>'<li>'+esc(x)+'</li>').join('')+'</ul>'; }
       h += '</div>';
     }

--- a/eval/pbl-v2-planner/judge-prompt-scenario.md
+++ b/eval/pbl-v2-planner/judge-prompt-scenario.md
@@ -19,13 +19,13 @@ A beat's "deliverable" is almost never a file. Judge it on two axes:
 
 ## Generated scenario (JSON)
 
-The project carries a top-level `scenario` block (setting / rules / learnerRole / characters) and milestones tagged `scenarioStage` (`prep` → `roleplay`×1..N → `wrapup`). Roleplay microtasks are beats carrying `successWhen` / `characterObjective` / `skillFocus` / `narration`.
+The project carries a top-level `scenario` block (setting / rules / learnerRole / characters) and milestones tagged `scenarioStage` (`prep` → `roleplay`×1..N → `wrapup`). Roleplay microtasks are beats carrying `successWhen` / `characterObjective` / `skillFocus` / `learnerBrief` / `narration`.
 
 {{project}}
 
 ## What is learner-visible vs private (read before judging spoilers / channels)
 
-- **Learner-visible** (the learner reads these — spoilers here are S4): `setting`, `rules`, `learnerRole`, each character's `name` / `persona` / `situation` / `openingLine`, the prep `briefing`, and each roleplay beat's `description` / `narration`.
+- **Learner-visible** (the learner reads these — spoilers here are S4): `setting`, `rules`, `learnerRole`, each character's `name` / `persona` / `situation` / `openingLine`, the prep `briefing`, and each roleplay beat's `description` / `learnerBrief` / `narration`.
 - **Private by design** (NEVER shown to the learner, never narrated, never spoken): a beat's `characterObjective`. This is the **intended hiding place** for a fact the learner must uncover. A hidden cause / secret / opponent's cards living in `characterObjective` is CORRECT design, NOT a spoiler — do not flag S4 for it.
 - `successWhen` is the **advance gate** — the observable in-scene action that lets the beat progress. It is NOT required to embed the full grading rubric; HOW WELL the action was done is judged separately at runtime against the scenario's criteria. Do not flag S3 merely because `successWhen` names the action without spelling out a quality bar.
 - The authored `briefing` / `debrief` are design-time scripts; at runtime the debrief is grounded in the learner's actual performance. A pre-written debrief that reads as if the learner did well is a normal placeholder, not a defect — judge closure on whether the wrapup is SHAPED to deliver specific performance-based feedback, not on the placeholder wording.
@@ -63,7 +63,7 @@ Scenario-specific red lines (the ones that matter most here):
 - **S1** wrong skeleton: not exactly prep → roleplay(s) → wrapup, or `coreConcept` set on any scenario stage.
 - **S2** prep gates or guesses: prep has a do-before-advance task, has more than one microtask, or asks the learner to guess/invent the premise instead of being told it. (A prep `completionCriteria` that just says "you've read the background" is NOT a gate — prep is allowed its briefing/completionCriteria text.)
 - **S3** missing/empty beat success — **ROLEPLAY beats only**: a roleplay beat lacks a `successWhen`, or its `successWhen` names no observable in-scene action (it is literally "they chatted / discussed"). A `successWhen` that names a concrete action without spelling out the quality bar is FINE (quality is judged separately). Prep and wrapup correctly have NO `successWhen` — never flag S3 for them.
-- **S4** spoiler — **learner-visible fields only** (`setting` / `rules` / `learnerRole` / a character's `persona` / `situation` / `openingLine` / prep `briefing` / a beat's `description` / `narration`): one of these reveals a fact meant to be uncovered later, or pre-states a later beat's situation. A hidden fact placed in the private `characterObjective` is CORRECT and is NOT S4.
+- **S4** spoiler — **learner-visible fields only** (`setting` / `rules` / `learnerRole` / a character's `persona` / `situation` / `openingLine` / prep `briefing` / a beat's `description` / `learnerBrief` / `narration`): one of these reveals a fact meant to be uncovered later, or pre-states a later beat's situation. A hidden fact placed in the private `characterObjective` is CORRECT and is NOT S4.
 - **S5** character-as-coach / channel bleed: a character is written to coach the LEARNER — grade them, ask them to justify their reasoning, give strategy/meta hints, narrate the scene, or say "your turn". An in-world evaluative motive (an interviewer privately assessing the candidate, an opponent reading the table) is the character's legitimate drive and is NOT S5; the violation is meta-talk aimed at the learner. A character implying it can see hidden info it shouldn't (e.g. the learner's hole cards) is S5.
 - **S6** missing rules: a rule-based scenario (game / interview / debate / structured negotiation) omits the concrete `rules` the Instructor needs to teach the premise in prep.
 - **S7** flattened performance: a beat that should be a live spoken exchange is forced into a written artifact or a quiz with no in-scene reason (delivery-form mismatch).
@@ -94,4 +94,3 @@ Output **exactly one JSON object** and nothing else (no prose, no code fences):
 }
 
 `redLines` may contain B-codes and S-codes; set it to [] when none are violated. "overall" is your holistic ship/no-ship judgement; any red line should pull it down hard.
-</content>

--- a/eval/pbl-v2-planner/judge-prompt.md
+++ b/eval/pbl-v2-planner/judge-prompt.md
@@ -104,5 +104,3 @@ Output **exactly one JSON object** and nothing else (no prose, no code fences):
 }
 
 `redLines` lists the violated B-codes; set it to [] when none are violated. "overall" is your holistic ship/no-ship judgement; any red line should pull it down hard.
-</content>
-</invoke>

--- a/eval/pbl-v2-planner/runner.ts
+++ b/eval/pbl-v2-planner/runner.ts
@@ -261,10 +261,7 @@ function loadTestCases(): TestCase[] {
 // Outline builder
 // ---------------------------------------------------------------------------
 
-let outlineCounter = 0;
-
-function buildOutline(tc: TestCase): SceneOutline {
-  outlineCounter += 1;
+function buildOutline(tc: TestCase, order: number): SceneOutline {
   return {
     id: `eval-pbl-${tc.id}`,
     type: 'pbl',
@@ -272,7 +269,7 @@ function buildOutline(tc: TestCase): SceneOutline {
     description: tc.pblConfig.projectDescription,
     keyPoints: tc.pblConfig.targetSkills.map((s) => `Learn ${s}`),
     teachingObjective: `完成 ${tc.pblConfig.projectTopic} 项目`,
-    order: outlineCounter,
+    order,
     pblConfig: tc.pblConfig,
     languageNote: tc.languageDirective,
   };
@@ -349,6 +346,7 @@ function projectForJudge(project: PBLProjectV2): unknown {
         ...(t.successWhen ? { successWhen: t.successWhen } : {}),
         ...(t.characterObjective ? { characterObjective: t.characterObjective } : {}),
         ...(t.skillFocus ? { skillFocus: t.skillFocus } : {}),
+        ...(t.learnerBrief ? { learnerBrief: t.learnerBrief } : {}),
         ...(t.narration ? { narration: t.narration } : {}),
       })),
       documents: (m.documents ?? []).map((d) => ({ title: d.title })),
@@ -464,11 +462,12 @@ function runVariant(
 async function runOne(
   tc: TestCase,
   variant: Variant,
+  outlineOrder: number,
   model: LanguageModel,
   judgeModel: LanguageModel,
   thinkingConfig?: ThinkingConfig,
 ): Promise<RunResult> {
-  const outline = buildOutline(tc);
+  const outline = buildOutline(tc, outlineOrder);
   const input = buildInput(tc, outline);
   const isScenario = tc.pblConfig.scenarioRoleplay === true;
   const startedAt = performance.now();
@@ -842,10 +841,10 @@ async function main(): Promise<void> {
   const executing = new Set<Promise<void>>();
   let done = 0;
   for (let j = 0; j < jobs.length; j++) {
-    const { tc, variant } = jobs[j];
+    const { tc, variant, n } = jobs[j];
     if (j > 0) await sleep(staggerMs);
     const p = (async () => {
-      const result = await runOne(tc, variant, model, judgeModel, thinkingConfig);
+      const result = await runOne(tc, variant, n, model, judgeModel, thinkingConfig);
       results[j] = result;
 
       if (result.project) {

--- a/tests/eval/pbl-v2-planner/judge-prompt-integrity.test.ts
+++ b/tests/eval/pbl-v2-planner/judge-prompt-integrity.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+
+const promptPaths = [
+  'eval/pbl-v2-planner/judge-prompt.md',
+  'eval/pbl-v2-planner/judge-prompt-scenario.md',
+  'eval/pbl-v2-planner/judge-prompt-completability.md',
+];
+
+function readPrompt(path: string): string {
+  return readFileSync(path, 'utf-8');
+}
+
+describe('PBL v2 judge prompt integrity', () => {
+  it('does not contain stale XML/tool wrapper tags', () => {
+    for (const path of promptPaths) {
+      const text = readPrompt(path);
+
+      expect(text).not.toContain('</content>');
+      expect(text).not.toContain('</invoke>');
+    }
+  });
+
+  it('treats scenario learnerBrief as learner-visible judge input', () => {
+    const text = readPrompt('eval/pbl-v2-planner/judge-prompt-scenario.md');
+
+    expect(text).toContain(
+      'successWhen` / `characterObjective` / `skillFocus` / `learnerBrief` / `narration`',
+    );
+    expect(text).toContain('`description` / `learnerBrief` / `narration`');
+    expect(text).toContain("a beat's `description` / `learnerBrief` / `narration`");
+  });
+});


### PR DESCRIPTION
## Summary

Optimize the PBL v2 planner evaluation harness so A/B runs are better controlled, scenario judging sees all learner-visible beat text, and judge prompts stay clean.

## Related Issues

Closes #804

## Changes

- Use stable per-case outline ordering when running `loop` and `single-call` variants.
- Include scenario `learnerBrief` in judge-facing project JSON and the scenario judge rubric.
- Show scenario beat fields in the compare viewer for easier manual audit.
- Remove stale judge prompt wrapper tags and add integrity tests to prevent regressions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run targeted PBL v2 eval prompt tests.
2. Run TypeScript typecheck.
3. Run eslint/prettier checks for touched files.

### What you personally verified

- `pnpm test tests/eval/pbl-v2-planner/completability-judge-prompt.test.ts tests/eval/pbl-v2-planner/judge-prompt-integrity.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint eval/pbl-v2-planner/runner.ts eval/pbl-v2-planner/compare-html.ts tests/eval/pbl-v2-planner/judge-prompt-integrity.test.ts`
- `pnpm exec prettier --check eval/pbl-v2-planner/runner.ts eval/pbl-v2-planner/compare-html.ts eval/pbl-v2-planner/judge-prompt.md eval/pbl-v2-planner/judge-prompt-scenario.md tests/eval/pbl-v2-planner/judge-prompt-integrity.test.ts`
- `git diff --check`

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
