### PR TITLE
Polish interactive simulation framing and iframe layout guards

### DIFF
--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -9,6 +9,79 @@ interface InteractiveRendererProps {
   readonly sceneId: string;
 }
 
+/**
+ * In-memory localStorage/sessionStorage shim, injected as the FIRST thing in the
+ * document so the page's own scripts see working storage.
+ *
+ * The interactive iframe is sandboxed `allow-scripts` WITHOUT `allow-same-origin`
+ * (intentional — combining them negates the sandbox for LLM-authored HTML). In a
+ * null-origin document, touching `window.localStorage` throws a SecurityError;
+ * many generated pages read/write storage in their setup code, so that throw
+ * crashes the script before anything renders.
+ */
+const STORAGE_SHIM = `<script data-iframe-storage-shim>
+(function () {
+  function makeStore() {
+    var data = Object.create(null);
+    return {
+      getItem: function (k) { k = String(k); return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null; },
+      setItem: function (k, v) { data[String(k)] = String(v); },
+      removeItem: function (k) { delete data[String(k)]; },
+      clear: function () { data = Object.create(null); },
+      key: function (i) { var keys = Object.keys(data); return i < keys.length ? keys[i] : null; },
+      get length() { return Object.keys(data).length; }
+    };
+  }
+  ['localStorage', 'sessionStorage'].forEach(function (name) {
+    var ok = false;
+    try { var s = window[name]; if (s) { s.getItem('__probe__'); ok = true; } } catch (e) { ok = false; }
+    if (!ok) {
+      try { Object.defineProperty(window, name, { value: makeStore(), configurable: true }); } catch (e) {}
+    }
+  });
+})();
+</script>`;
+
+/**
+ * Runtime-error capture shim. The sandboxed iframe cannot be inspected directly,
+ * but it can `postMessage` outward when generated widget code fails early.
+ */
+const ERROR_CAPTURE_SHIM = `<script data-iframe-error-shim>
+(function () {
+  var buffer = [];
+  function emit(errorKind, message) {
+    try {
+      window.parent.postMessage(
+        { __maicInteractive: true, kind: 'runtime-error', errorKind: errorKind, message: message },
+        '*'
+      );
+    } catch (e) {}
+  }
+  function post(errorKind, message) {
+    message = String(message).slice(0, 1200);
+    if (buffer.length < 50) buffer.push([errorKind, message]);
+    emit(errorKind, message);
+  }
+  window.addEventListener('message', function (e) {
+    var d = e && e.data;
+    if (d && d.__maicErrorReplayRequest === true) {
+      for (var i = 0; i < buffer.length; i++) emit(buffer[i][0], buffer[i][1]);
+    }
+  });
+  window.addEventListener('error', function (e) {
+    if (e && e.message) {
+      post('error', e.message + (e.filename ? ' (' + e.filename + ':' + (e.lineno || 0) + ')' : ''));
+    } else if (e && e.target && (e.target.src || e.target.href)) {
+      post('resource', 'Failed to load resource: ' + (e.target.src || e.target.href));
+    }
+  }, true);
+  window.addEventListener('unhandledrejection', function (e) {
+    var r = e && e.reason;
+    post('unhandledrejection', (r && (r.stack || r.message)) || r || 'unhandled promise rejection');
+  });
+})();
+</script>`;
+
 export function InteractiveRenderer({ content, mode: _mode, sceneId }: InteractiveRendererProps) {
   const patchedHtml = useMemo(
     () => (content.html ? patchHtmlForIframe(content.html) : undefined),
@@ -16,14 +89,20 @@ export function InteractiveRenderer({ content, mode: _mode, sceneId }: Interacti
   );
 
   return (
-    <div className="w-full h-full relative">
-      <iframe
-        srcDoc={patchedHtml}
-        src={patchedHtml ? undefined : content.url}
-        className="absolute inset-0 w-full h-full border-0"
-        title={`Interactive Scene ${sceneId}`}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-      />
+    <div className="flex h-full min-h-0 min-w-0 w-full bg-[#18233d] px-4 py-5 sm:px-6 sm:py-6">
+      <div className="flex h-full min-h-0 min-w-0 w-full items-center justify-center">
+        <div className="flex h-full min-h-0 min-w-0 w-full max-w-[1120px] flex-col">
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-[22px] border border-white/10 bg-[#0f172a]/30 p-2 shadow-[0_24px_80px_rgba(2,6,23,0.35)] backdrop-blur-sm sm:p-3">
+            <iframe
+              srcDoc={patchedHtml}
+              src={patchedHtml ? undefined : content.url}
+              className="h-full w-full rounded-[18px] border-0 bg-white shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]"
+              title={`Interactive Scene ${sceneId}`}
+              sandbox="allow-scripts allow-forms allow-popups"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -31,31 +110,309 @@ export function InteractiveRenderer({ content, mode: _mode, sceneId }: Interacti
 /**
  * Patch embedded HTML to display correctly inside an iframe.
  *
- * Fixes:
- * - min-h-screen / h-screen → use 100% of iframe viewport
- * - Ensure html/body fill the iframe with no overflow issues
- * - Canvas elements use container sizing instead of viewport
+ * Injects shims plus CSS that keeps interactive widgets bounded, scrollable, and
+ * less prone to simulation/panel overlap inside the classroom canvas.
  */
-function patchHtmlForIframe(html: string): string {
+export function patchHtmlForIframe(html: string): string {
   const iframeCss = `<style data-iframe-patch>
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
   html, body {
     width: 100%;
     height: 100%;
+    max-width: 100%;
     margin: 0;
     padding: 0;
     overflow-x: hidden;
     overflow-y: auto;
   }
-  /* Fix min-h-screen: in iframes 100vh is the iframe height, which is correct,
-     but ensure body actually fills it */
-  body { min-height: 100vh; }
-</style>`;
+  body {
+    min-height: 100vh;
+    padding: 0 !important;
+    background: linear-gradient(180deg, #dbe7ff 0%, #eff4ff 100%);
+    color: #0f172a;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 14px !important;
+    line-height: 1.35 !important;
+  }
+  body > * {
+    max-width: 100% !important;
+  }
+  body > main,
+  body > .app,
+  body > .simulation-shell,
+  body > .game-shell,
+  body > .activity-shell,
+  body > [class*="app-shell"],
+  body > [class*="simulation-shell"],
+  body > [class*="game-shell"] {
+    width: min(100%, 1120px) !important;
+    margin: 0 auto !important;
+  }
+  h1 {
+    font-size: 22px !important;
+    line-height: 1.15 !important;
+    margin: 0 0 10px !important;
+  }
+  h2 {
+    font-size: 18px !important;
+    line-height: 1.2 !important;
+    margin: 0 0 8px !important;
+  }
+  h3, h4 {
+    font-size: 15px !important;
+    line-height: 1.25 !important;
+    margin: 0 0 6px !important;
+  }
+  p, label, li {
+    font-size: 13px !important;
+    line-height: 1.35 !important;
+  }
+  img, video, canvas, svg {
+    max-width: 100%;
+  }
+  pre, code, kbd, samp {
+    font-size: 12px !important;
+    line-height: 1.35 !important;
+    white-space: pre-wrap !important;
+  }
+  button, input, select, textarea {
+    font: inherit;
+  }
+  button, [role="button"] {
+    min-height: 34px !important;
+    border: 0;
+    border-radius: 10px !important;
+    padding: 8px 11px !important;
+    background: #2563eb;
+    color: #ffffff;
+    font-size: 13px !important;
+    font-weight: 700;
+    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
+    cursor: pointer;
+  }
+  button:hover, [role="button"]:hover {
+    background: #1d4ed8;
+  }
+  button:disabled, [role="button"][aria-disabled="true"] {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  input:not([type="range"]), select, textarea {
+    width: 100%;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: #ffffff;
+    color: #0f172a;
+    font-size: 13px !important;
+  }
+  input[type="range"] {
+    width: 100%;
+    accent-color: #7c3aed;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    padding: 8px;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+    font-size: 13px !important;
+  }
+  .simulation-shell,
+  .game-shell,
+  .game-stage,
+  .activity-shell,
+  .matrix-card,
+  .card,
+  section,
+  article {
+    max-width: 100%;
+  }
+  .simulation-shell,
+  .game-shell,
+  .activity-shell {
+    width: min(100%, 1120px) !important;
+    max-width: 1120px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    position: relative;
+    min-height: 100vh !important;
+    padding: 18px !important;
+    align-items: stretch !important;
+    gap: 18px !important;
+  }
+  .simulation-shell,
+  .game-shell {
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr) !important;
+  }
+  .simulation-shell > *,
+  .game-shell > *,
+  .activity-shell > * {
+    min-width: 0 !important;
+  }
+  .game-stage,
+  .simulation-stage,
+  .canvas-stage,
+  [class*="stage"],
+  [class*="viewport"],
+  [class*="canvas"] {
+    position: relative;
+    min-width: 0 !important;
+    width: 100% !important;
+    overflow: hidden !important;
+    border-radius: 22px !important;
+    border: 1px solid rgba(148, 163, 184, 0.35) !important;
+    box-shadow: 0 20px 55px rgba(15, 23, 42, 0.14) !important;
+    max-height: calc(100vh - 110px) !important;
+  }
+  .card,
+  .matrix-card,
+  section,
+  article,
+  [class*="panel"],
+  [class*="card"] {
+    border-radius: 12px !important;
+    padding: 12px !important;
+  }
+  [class*="label"],
+  [class*="badge"],
+  [class*="chip"],
+  [class*="tag"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    max-width: 100% !important;
+    overflow-wrap: anywhere !important;
+    white-space: normal !important;
+    font-size: 12px !important;
+    line-height: 1.2 !important;
+  }
+  [class*="toolbar"],
+  [class*="hud"],
+  [class*="control-bar"],
+  [class*="action-bar"] {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    align-items: center !important;
+    gap: 10px !important;
+    max-width: 100% !important;
+  }
+  [class*="score"],
+  [class*="coins"],
+  [class*="points"],
+  [class*="status"],
+  [class*="hud-card"],
+  [class*="counter"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 8px !important;
+    padding: 10px 14px !important;
+    border-radius: 999px !important;
+    background: rgba(255, 255, 255, 0.94) !important;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12) !important;
+    max-width: min(100%, 180px) !important;
+    overflow-wrap: anywhere !important;
+  }
+  [class*="overlay"] {
+    max-width: min(100%, 320px) !important;
+  }
+  [class*="ground"],
+  [class*="soil"],
+  [class*="grass"] {
+    overflow: hidden !important;
+  }
+  [class*="shop"],
+  [class*="inventory"],
+  [class*="selector"],
+  [class*="toolbox"],
+  [class*="choices"] {
+    max-width: min(100%, 360px) !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+  }
+  [class*="bottom-bar"],
+  [class*="bottom-controls"],
+  [class*="footer-controls"],
+  [class*="control-dock"],
+  [class*="dock"] {
+    position: sticky !important;
+    bottom: 12px !important;
+    z-index: 5 !important;
+    display: flex !important;
+    justify-content: center !important;
+    gap: 12px !important;
+    width: fit-content !important;
+    max-width: calc(100% - 24px) !important;
+    margin: 0 auto !important;
+    padding: 12px 16px !important;
+    border-radius: 999px !important;
+    background: rgba(255, 255, 255, 0.92) !important;
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.16) !important;
+    backdrop-filter: blur(14px) !important;
+  }
+  [class*="selector"] > *,
+  [class*="toolbox"] > *,
+  [class*="choices"] > *,
+  [class*="bottom-controls"] > *,
+  [class*="control-dock"] > *,
+  [class*="dock"] > * {
+    flex: 0 0 auto !important;
+  }
+  @media (max-height: 620px), (max-width: 640px) {
+    body {
+      font-size: 13px !important;
+    }
+    .simulation-shell,
+    .game-shell,
+    .activity-shell {
+      padding: 10px !important;
+      gap: 12px !important;
+    }
+    .simulation-shell,
+    .game-shell {
+      grid-template-columns: 1fr !important;
+    }
+    button, [role="button"] {
+      min-height: 32px !important;
+      padding: 7px 10px !important;
+    }
+    .game-stage,
+    .simulation-stage,
+    .canvas-stage,
+    [class*="stage"],
+    [class*="viewport"],
+    [class*="canvas"] {
+      max-height: calc(100vh - 88px) !important;
+    }
+    [class*="overlay"] {
+      position: static !important;
+      width: auto !important;
+      max-width: 100% !important;
+      margin: 12px 0 0 !important;
+    }
+    [class*="bottom-bar"],
+    [class*="bottom-controls"],
+    [class*="footer-controls"],
+    [class*="control-dock"],
+    [class*="dock"] {
+      bottom: 8px !important;
+      max-width: calc(100% - 16px) !important;
+      padding: 10px 12px !important;
+      gap: 8px !important;
+    }
+  }
+  </style>`;
 
-  // Insert right after <head> or at the start of the document
+  const injection = '\n' + ERROR_CAPTURE_SHIM + '\n' + STORAGE_SHIM + '\n' + iframeCss;
+
   const headIdx = html.indexOf('<head>');
   if (headIdx !== -1) {
-    const insertPos = headIdx + 6; // after <head>
-    return html.substring(0, insertPos) + '\n' + iframeCss + html.substring(insertPos);
+    const insertPos = headIdx + 6;
+    return html.substring(0, insertPos) + injection + html.substring(insertPos);
   }
 
   const headWithAttrs = html.indexOf('<head ');
@@ -63,10 +420,9 @@ function patchHtmlForIframe(html: string): string {
     const closeAngle = html.indexOf('>', headWithAttrs);
     if (closeAngle !== -1) {
       const insertPos = closeAngle + 1;
-      return html.substring(0, insertPos) + '\n' + iframeCss + html.substring(insertPos);
+      return html.substring(0, insertPos) + injection + html.substring(insertPos);
     }
   }
 
-  // Fallback: prepend
-  return iframeCss + html;
+  return injection + html;
 }

--- a/e2e/tests/interactive-simulation-layout.spec.ts
+++ b/e2e/tests/interactive-simulation-layout.spec.ts
@@ -1,0 +1,288 @@
+import { test, expect } from '../fixtures/base';
+import { ClassroomPage } from '../pages/classroom.page';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+
+const TEST_STAGE_ID = 'e2e-interactive-stage';
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+const INTERACTIVE_HTML = String.raw`<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Simulation Smoke</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+      }
+      .simulation-shell {
+        display: grid;
+        grid-template-columns: minmax(220px, 320px) 1fr;
+        gap: 18px;
+        align-items: start;
+      }
+      .panel {
+        background: #fff;
+        border: 1px solid #cbd5e1;
+        border-radius: 16px;
+        padding: 16px;
+      }
+      .badge {
+        display: inline-flex;
+        max-width: 260px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: #dbeafe;
+        color: #1d4ed8;
+        font-weight: 700;
+      }
+      .simulation-stage {
+        position: relative;
+        min-height: 520px;
+        border-radius: 20px;
+        border: 1px solid #cbd5e1;
+        background:
+          radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 35%),
+          linear-gradient(180deg, #eff6ff 0%, #ffffff 100%);
+      }
+      .toolbar {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 14px;
+      }
+      .status-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        background: #fef3c7;
+        color: #92400e;
+        padding: 6px 10px;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .overlay-card {
+        position: absolute;
+        right: 16px;
+        top: 16px;
+        width: min(42%, 280px);
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid #bfdbfe;
+        border-radius: 16px;
+        padding: 14px;
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+      }
+      .stage-copy {
+        position: absolute;
+        left: 18px;
+        bottom: 18px;
+        max-width: 58%;
+        background: rgba(15, 23, 42, 0.82);
+        color: #fff;
+        border-radius: 16px;
+        padding: 14px 16px;
+      }
+      @media (max-width: 700px) {
+        .simulation-shell {
+          grid-template-columns: 1fr;
+        }
+        .overlay-card,
+        .stage-copy {
+          position: static;
+          width: auto;
+          max-width: none;
+          margin: 16px;
+        }
+        .stage-copy {
+          margin-top: 260px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="simulation-shell">
+      <section class="panel">
+        <div class="badge">Extremely long simulation status badge that should wrap instead of punching outside the layout boundary</div>
+        <h1>Workplace safety walkthrough</h1>
+        <p>This simulation intentionally uses long copy so the iframe patch has to defend the layout.</p>
+        <div class="toolbar">
+          <button type="button">Start simulation</button>
+          <button type="button">Pause and inspect risk controls</button>
+          <button type="button">Reset to baseline conditions</button>
+        </div>
+        <label for="risk">Risk threshold control with a deliberately long label that would normally overflow narrow side panels</label>
+        <input id="risk" type="range" min="0" max="100" value="42" />
+        <p class="status-chip">Supervisory note with a long sentence that should stay inside the chip instead of stretching the iframe horizontally</p>
+      </section>
+      <section class="simulation-stage">
+        <div class="overlay-card">
+          <strong>Inspector panel</strong>
+          <p>This floating card should remain readable and bounded even on a tight viewport.</p>
+        </div>
+        <div class="stage-copy">
+          The scene copy stays inside the stage and should not collide with the floating panel once the iframe patch constrains widths and wrapping.
+        </div>
+      </section>
+    </main>
+  </body>
+</html>`;
+
+async function seedInteractiveStage(page: import('@playwright/test').Page) {
+  await page.addInitScript((settings) => {
+    localStorage.setItem('settings-storage', settings);
+  }, SETTINGS_STORAGE);
+
+  await page.goto(`/classroom/${TEST_STAGE_ID}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () =>
+      new Promise<boolean>((resolve) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const hasStores = ['stages', 'scenes', 'stageOutlines'].every((name) =>
+            db.objectStoreNames.contains(name),
+          );
+          db.close();
+          resolve(hasStores);
+        };
+
+        request.onerror = () => resolve(false);
+      }),
+    undefined,
+    { timeout: 15_000 },
+  );
+
+  await page.evaluate(
+    ({ stageId, html }) => {
+      return new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+          const now = Date.now();
+
+          tx.objectStore('stages').put({
+            id: stageId,
+            name: 'Interactive smoke test',
+            description: '',
+            language: 'en',
+            style: 'professional',
+            interactiveMode: true,
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('scenes').put({
+            id: 'interactive-scene-0',
+            stageId,
+            type: 'interactive',
+            title: 'Simulation scene',
+            order: 0,
+            content: {
+              type: 'interactive',
+              url: 'about:blank',
+              html,
+            },
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('stageOutlines').put({
+            stageId,
+            outlines: [],
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+
+        request.onerror = () => reject(request.error);
+      });
+    },
+    { stageId: TEST_STAGE_ID, html: INTERACTIVE_HTML },
+  );
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+}
+
+test.describe('Interactive simulation layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedInteractiveStage(page);
+  });
+
+  test('keeps simulation iframe content bounded without horizontal overflow', async ({ page }) => {
+    const classroom = new ClassroomPage(page);
+    await classroom.waitForLoaded();
+
+    const iframe = page.locator('iframe[title^="Interactive Scene"]');
+    await expect(iframe).toBeVisible();
+
+    const frame = page.frameLocator('iframe[title^="Interactive Scene"]');
+    await expect(frame.getByRole('heading', { name: 'Workplace safety walkthrough' })).toBeVisible();
+
+    const overflow = await frame.locator('body').evaluate((body) => {
+      const doc = body.ownerDocument;
+      const root = doc.scrollingElement ?? doc.documentElement;
+      return {
+        scrollWidth: root.scrollWidth,
+        clientWidth: root.clientWidth,
+        bodyScrollWidth: body.scrollWidth,
+        bodyClientWidth: body.clientWidth,
+      };
+    });
+
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+    expect(overflow.bodyScrollWidth).toBeLessThanOrEqual(overflow.bodyClientWidth + 1);
+
+    const badgeMetrics = await frame.locator('.badge').evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        whiteSpace: style.whiteSpace,
+        overflowWrap: style.overflowWrap,
+        rectWidth: el.getBoundingClientRect().width,
+        parentWidth: el.parentElement?.getBoundingClientRect().width ?? 0,
+      };
+    });
+
+    expect(badgeMetrics.whiteSpace).not.toBe('nowrap');
+    expect(badgeMetrics.overflowWrap).toBe('anywhere');
+    expect(badgeMetrics.rectWidth).toBeLessThanOrEqual(badgeMetrics.parentWidth + 1);
+
+    const shellMetrics = await frame.locator('.simulation-shell').evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      const firstChild = el.firstElementChild as HTMLElement | null;
+      return {
+        maxWidth: style.maxWidth,
+        paddingTop: Number.parseFloat(style.paddingTop),
+        columnTemplate: style.gridTemplateColumns,
+        firstChildWidth: firstChild?.getBoundingClientRect().width ?? 0,
+        rectWidth: el.getBoundingClientRect().width,
+        bodyWidth: document.body.getBoundingClientRect().width,
+      };
+    });
+
+    expect(shellMetrics.maxWidth).toBe('1120px');
+    expect(shellMetrics.paddingTop).toBeGreaterThanOrEqual(10);
+    expect(shellMetrics.columnTemplate).not.toBe('none');
+    expect(shellMetrics.firstChildWidth).toBeGreaterThanOrEqual(220);
+    expect(shellMetrics.rectWidth).toBeLessThanOrEqual(shellMetrics.bodyWidth + 1);
+
+    const stageMetrics = await frame.locator('.simulation-stage').evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        overflow: style.overflow,
+        borderRadius: style.borderRadius,
+      };
+    });
+
+    expect(stageMetrics.overflow).toBe('hidden');
+    expect(stageMetrics.borderRadius).toBe('22px');
+  });
+});

--- a/tests/utils/iframe.test.ts
+++ b/tests/utils/iframe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { patchHtmlForIframe } from '@/components/scene-renderers/interactive-renderer';
+
+describe('patchHtmlForIframe', () => {
+  it('injects error capture, storage shims, and layout patch into head', () => {
+    const html = '<html><head><title>Widget</title></head><body><div>Hello</div></body></html>';
+
+    const patched = patchHtmlForIframe(html);
+
+    expect(patched).toContain('data-iframe-error-shim');
+    expect(patched).toContain('data-iframe-storage-shim');
+    expect(patched).toContain('data-iframe-patch');
+    expect(patched).toContain('overflow-wrap: anywhere !important;');
+    expect(patched).toContain('width: min(100%, 1120px) !important;');
+    expect(patched).toContain(
+      'grid-template-columns: minmax(220px, 320px) minmax(0, 1fr) !important;',
+    );
+    expect(patched).toContain('max-width: min(100%, 180px) !important;');
+    expect(patched.indexOf('data-iframe-error-shim')).toBeLessThan(
+      patched.indexOf('<title>Widget</title>'),
+    );
+  });
+
+  it('prepends the injection when no head tag exists', () => {
+    const html = '<div>bare widget</div>';
+
+    const patched = patchHtmlForIframe(html);
+
+    expect(patched.startsWith('\n<script data-iframe-error-shim>')).toBe(true);
+    expect(patched).toContain(html);
+  });
+});


### PR DESCRIPTION
## Summary
- harden sandboxed interactive iframes with runtime/storage shims so generated simulations keep rendering under a safer sandbox
- add bounded simulation shell styling to prevent overlap, clipping, and horizontal overflow in classroom embeds
- cover the iframe patch with a focused unit test and an interactive classroom layout e2e scenario

## Verification
- pnpm.cmd exec vitest run tests/utils/iframe.test.ts
- direct local classroom probe against the seeded interactive stage confirmed wrapped badges, no horizontal overflow, and clipped 22px stage framing

## Notes
- the committed e2e test now primes the classroom route first so OpenMAIC creates its IndexedDB schema before the stage seed runs