### PR TITLE
Upgrade Playwright and align home dashboard with the all-projects admin layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,19 +5,27 @@ import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'motion/react';
 import {
   ArrowUp,
+  Bell,
+  BriefcaseBusiness,
   Check,
   ChevronDown,
-  Clock,
   Copy,
+  FileText,
+  FolderKanban,
+  Home,
   ImagePlus,
+  MessageSquareText,
+  MoreVertical,
   Pencil,
+  Search,
+  Shield,
+  ShoppingBag,
+  Sparkles,
   Trash2,
   Settings,
-  Sun,
-  Moon,
-  Monitor,
   BotOff,
   ChevronUp,
+  Users,
 } from 'lucide-react';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { createLogger } from '@/lib/logger';
@@ -27,7 +35,6 @@ import { cn } from '@/lib/utils';
 import { SettingsDialog } from '@/components/settings';
 import { GenerationToolbar } from '@/components/generation/generation-toolbar';
 import { AgentBar } from '@/components/agent/agent-bar';
-import { useTheme } from '@/lib/hooks/use-theme';
 import { nanoid } from 'nanoid';
 import { storePdfBlob } from '@/lib/utils/image-storage';
 import type { UserRequirements } from '@/lib/types/generation';
@@ -51,13 +58,24 @@ const log = createLogger('Home');
 
 const WEB_SEARCH_STORAGE_KEY = 'webSearchEnabled';
 const LANGUAGE_STORAGE_KEY = 'generationLanguage';
-const RECENT_OPEN_STORAGE_KEY = 'recentClassroomsOpen';
 
 interface FormState {
   pdfFile: File | null;
   requirement: string;
   language: 'zh-CN' | 'en-US';
   webSearch: boolean;
+}
+
+interface SidebarItem {
+  label: string;
+  icon: typeof Home;
+  active: boolean;
+  inset?: boolean;
+}
+
+interface SidebarGroup {
+  title: string;
+  items: SidebarItem[];
 }
 
 const initialFormState: FormState = {
@@ -67,9 +85,40 @@ const initialFormState: FormState = {
   webSearch: false,
 };
 
+const SIDEBAR_GROUPS: SidebarGroup[] = [
+  {
+    title: 'Home',
+    items: [{ label: 'Home', icon: Home, active: false }],
+  },
+  {
+    title: 'Pages',
+    items: [
+      { label: 'Profile', icon: FileText, active: false },
+      { label: 'Profile overview', icon: Home, active: false, inset: true },
+      { label: 'Teams', icon: Users, active: false, inset: true },
+      { label: 'All projects', icon: FolderKanban, active: true, inset: true },
+    ],
+  },
+  {
+    title: 'Workspace',
+    items: [
+      { label: 'Users', icon: Users, active: false },
+      { label: 'Projects', icon: BriefcaseBusiness, active: false },
+      { label: 'Notification', icon: Bell, active: false },
+      { label: 'Chat', icon: MessageSquareText, active: false },
+    ],
+  },
+  {
+    title: 'Admin',
+    items: [
+      { label: 'Applications', icon: ShoppingBag, active: false },
+      { label: 'Authentication', icon: Shield, active: false },
+    ],
+  },
+];
+
 function HomePage() {
-  const { t, locale, setLocale } = useI18n();
-  const { theme, setTheme } = useTheme();
+  const { t } = useI18n();
   const router = useRouter();
   const [form, setForm] = useState<FormState>(initialFormState);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -83,17 +132,14 @@ function HomePage() {
 
   // Model setup state
   const currentModelId = useSettingsStore((s) => s.modelId);
-  const [recentOpen, setRecentOpen] = useState(true);
+  const profileAvatar = useUserProfileStore((s) => s.avatar);
+  const profileName = useUserProfileStore((s) => s.nickname) || t('profile.defaultNickname');
+  const profileBio = useUserProfileStore((s) => s.bio) || 'Interactive classroom builder';
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Hydrate client-only state after mount (avoids SSR mismatch)
   /* eslint-disable react-hooks/set-state-in-effect -- Hydration from localStorage must happen in effect */
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem(RECENT_OPEN_STORAGE_KEY);
-      if (saved !== null) setRecentOpen(saved !== 'false');
-    } catch {
-      /* localStorage unavailable */
-    }
     try {
       const savedWebSearch = localStorage.getItem(WEB_SEARCH_STORAGE_KEY);
       const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -123,27 +169,11 @@ function HomePage() {
     }
   }
 
-  const [languageOpen, setLanguageOpen] = useState(false);
-  const [themeOpen, setThemeOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [classrooms, setClassrooms] = useState<StageListItem[]>([]);
   const [thumbnails, setThumbnails] = useState<Record<string, Slide>>({});
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const toolbarRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  // Close dropdowns when clicking outside
-  useEffect(() => {
-    if (!languageOpen && !themeOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (toolbarRef.current && !toolbarRef.current.contains(e.target as Node)) {
-        setLanguageOpen(false);
-        setThemeOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [languageOpen, themeOpen]);
 
   const loadClassrooms = async () => {
     try {
@@ -311,6 +341,53 @@ function HomePage() {
   };
 
   const canGenerate = !!form.requirement.trim();
+  const filteredClassrooms = classrooms.filter((classroom) => {
+    const needle = searchQuery.trim().toLowerCase();
+    if (!needle) return true;
+    return classroom.name.toLowerCase().includes(needle);
+  });
+  const latestClassroom = classrooms[0];
+  const dashboardActions = [
+    {
+      label: 'Student enroll',
+      caption: 'Open agent and roster setup',
+      icon: Users,
+      onClick: () => {
+        setSettingsSection('agents');
+        setSettingsOpen(true);
+      },
+    },
+    {
+      label: 'Upload content',
+      caption: 'Jump straight into source intake',
+      icon: FileText,
+      onClick: () => textareaRef.current?.focus(),
+    },
+    {
+      label: 'Export data',
+      caption: 'Open the latest classroom export lane',
+      icon: BriefcaseBusiness,
+      onClick: () => {
+        if (latestClassroom) {
+          router.push(`/classroom/${latestClassroom.id}`);
+        } else {
+          toast.message('Create a classroom first, then export from the classroom header.');
+        }
+      },
+    },
+    {
+      label: 'One on one',
+      caption: 'Resume the newest classroom session',
+      icon: MessageSquareText,
+      onClick: () => {
+        if (latestClassroom) {
+          router.push(`/classroom/${latestClassroom.id}`);
+        } else {
+          toast.message('Your 1:1 flow starts after the first classroom is generated.');
+        }
+      },
+    },
+  ] as const;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
@@ -320,130 +397,7 @@ function HomePage() {
   };
 
   return (
-    <div className="min-h-[100dvh] w-full bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 flex flex-col items-center p-4 pt-16 md:p-8 md:pt-16 overflow-x-hidden">
-      {/* ═══ Top-right pill (unchanged) ═══ */}
-      <div
-        ref={toolbarRef}
-        className="fixed top-4 right-4 z-50 flex items-center gap-1 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md px-2 py-1.5 rounded-full border border-gray-100/50 dark:border-gray-700/50 shadow-sm"
-      >
-        {/* Language Selector */}
-        <div className="relative">
-          <button
-            onClick={() => {
-              setLanguageOpen(!languageOpen);
-              setThemeOpen(false);
-            }}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-bold text-gray-500 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200 hover:shadow-sm transition-all"
-          >
-            {locale === 'zh-CN' ? 'CN' : 'EN'}
-          </button>
-          {languageOpen && (
-            <div className="absolute top-full mt-2 right-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg overflow-hidden z-50 min-w-[120px]">
-              <button
-                onClick={() => {
-                  setLocale('zh-CN');
-                  setLanguageOpen(false);
-                }}
-                className={cn(
-                  'w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
-                  locale === 'zh-CN' &&
-                    'bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400',
-                )}
-              >
-                简体中文
-              </button>
-              <button
-                onClick={() => {
-                  setLocale('en-US');
-                  setLanguageOpen(false);
-                }}
-                className={cn(
-                  'w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
-                  locale === 'en-US' &&
-                    'bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400',
-                )}
-              >
-                English
-              </button>
-            </div>
-          )}
-        </div>
-
-        <div className="w-[1px] h-4 bg-gray-200 dark:bg-gray-700" />
-
-        {/* Theme Selector */}
-        <div className="relative">
-          <button
-            onClick={() => {
-              setThemeOpen(!themeOpen);
-              setLanguageOpen(false);
-            }}
-            className="p-2 rounded-full text-gray-400 dark:text-gray-500 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200 hover:shadow-sm transition-all"
-          >
-            {theme === 'light' && <Sun className="w-4 h-4" />}
-            {theme === 'dark' && <Moon className="w-4 h-4" />}
-            {theme === 'system' && <Monitor className="w-4 h-4" />}
-          </button>
-          {themeOpen && (
-            <div className="absolute top-full mt-2 right-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg overflow-hidden z-50 min-w-[140px]">
-              <button
-                onClick={() => {
-                  setTheme('light');
-                  setThemeOpen(false);
-                }}
-                className={cn(
-                  'w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2',
-                  theme === 'light' &&
-                    'bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400',
-                )}
-              >
-                <Sun className="w-4 h-4" />
-                {t('settings.themeOptions.light')}
-              </button>
-              <button
-                onClick={() => {
-                  setTheme('dark');
-                  setThemeOpen(false);
-                }}
-                className={cn(
-                  'w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2',
-                  theme === 'dark' &&
-                    'bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400',
-                )}
-              >
-                <Moon className="w-4 h-4" />
-                {t('settings.themeOptions.dark')}
-              </button>
-              <button
-                onClick={() => {
-                  setTheme('system');
-                  setThemeOpen(false);
-                }}
-                className={cn(
-                  'w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2',
-                  theme === 'system' &&
-                    'bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400',
-                )}
-              >
-                <Monitor className="w-4 h-4" />
-                {t('settings.themeOptions.system')}
-              </button>
-            </div>
-          )}
-        </div>
-
-        <div className="w-[1px] h-4 bg-gray-200 dark:bg-gray-700" />
-
-        {/* Settings Button */}
-        <div className="relative">
-          <button
-            onClick={() => setSettingsOpen(true)}
-            className="p-2 rounded-full text-gray-400 dark:text-gray-500 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200 hover:shadow-sm transition-all group"
-          >
-            <Settings className="w-4 h-4 group-hover:rotate-90 transition-transform duration-500" />
-          </button>
-        </div>
-      </div>
+    <div className="min-h-[100dvh] bg-[#f5f6fb] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <SettingsDialog
         open={settingsOpen}
         onOpenChange={(open) => {
@@ -452,224 +406,271 @@ function HomePage() {
         }}
         initialSection={settingsSection}
       />
-
-      {/* ═══ Background Decor ═══ */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div
-          className="absolute top-0 left-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse"
-          style={{ animationDuration: '4s' }}
-        />
-        <div
-          className="absolute bottom-0 right-1/4 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse"
-          style={{ animationDuration: '6s' }}
-        />
-      </div>
-
-      {/* ═══ Hero section: title + input (centered, wider) ═══ */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: 'easeOut' }}
-        className={cn(
-          'relative z-20 w-full max-w-[800px] flex flex-col items-center',
-          classrooms.length === 0 ? 'justify-center min-h-[calc(100dvh-8rem)]' : 'mt-[10vh]',
-        )}
-      >
-        {/* ── Logo ── */}
-        <motion.img
-          src="/logo-horizontal.png"
-          alt="OpenMAIC"
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{
-            delay: 0.1,
-            type: 'spring',
-            stiffness: 200,
-            damping: 20,
-          }}
-          className="h-12 md:h-16 mb-2 -ml-2 md:-ml-3"
-        />
-
-        {/* ── Slogan ── */}
-        <motion.p
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.25 }}
-          className="text-sm text-muted-foreground/60 mb-8"
-        >
-          {t('home.slogan')}
-        </motion.p>
-
-        {/* ── Unified input area ── */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.97 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.35 }}
-          className="w-full"
-        >
-          <div className="w-full rounded-2xl border border-border/60 bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl shadow-xl shadow-black/[0.03] dark:shadow-black/20 transition-shadow focus-within:shadow-2xl focus-within:shadow-violet-500/[0.06]">
-            {/* ── Greeting + Profile + Agents ── */}
-            <div className="relative z-20 flex items-start justify-between">
-              <GreetingBar />
-              <div className="pr-3 pt-3.5 shrink-0">
-                <AgentBar />
-              </div>
-            </div>
-
-            {/* Textarea */}
-            <textarea
-              ref={textareaRef}
-              placeholder={t('upload.requirementPlaceholder')}
-              className="w-full resize-none border-0 bg-transparent px-4 pt-1 pb-2 text-[13px] leading-relaxed placeholder:text-muted-foreground/40 focus:outline-none min-h-[140px] max-h-[300px]"
-              value={form.requirement}
-              onChange={(e) => updateForm('requirement', e.target.value)}
-              onKeyDown={handleKeyDown}
-              rows={4}
-            />
-
-            {/* Toolbar row */}
-            <div className="px-3 pb-3 flex items-end gap-2">
-              <div className="flex-1 min-w-0">
-                <GenerationToolbar
-                  language={form.language}
-                  onLanguageChange={(lang) => updateForm('language', lang)}
-                  webSearch={form.webSearch}
-                  onWebSearchChange={(v) => updateForm('webSearch', v)}
-                  onSettingsOpen={(section) => {
-                    setSettingsSection(section);
-                    setSettingsOpen(true);
-                  }}
-                  pdfFile={form.pdfFile}
-                  onPdfFileChange={(f) => updateForm('pdfFile', f)}
-                  onPdfError={setError}
-                />
-              </div>
-
-              {/* Voice input */}
-              <SpeechButton
-                size="md"
-                onTranscription={(text) => {
-                  setForm((prev) => {
-                    const next = prev.requirement + (prev.requirement ? ' ' : '') + text;
-                    updateRequirementCache(next);
-                    return { ...prev, requirement: next };
-                  });
-                }}
-              />
-
-              {/* Send button */}
-              <button
-                onClick={handleGenerate}
-                disabled={!canGenerate}
-                className={cn(
-                  'shrink-0 h-8 rounded-lg flex items-center justify-center gap-1.5 transition-all px-3',
-                  canGenerate
-                    ? 'bg-primary text-primary-foreground hover:opacity-90 shadow-sm cursor-pointer'
-                    : 'bg-muted text-muted-foreground/40 cursor-not-allowed',
-                )}
-              >
-                <span className="text-xs font-medium">{t('toolbar.enterClassroom')}</span>
-                <ArrowUp className="size-3.5" />
-              </button>
-            </div>
+      <div className="flex min-h-[100dvh]">
+        <aside className="hidden w-[218px] shrink-0 border-r border-slate-200/80 bg-white/96 px-3 py-6 dark:border-slate-800 dark:bg-slate-900/95 lg:flex lg:flex-col">
+          <div className="px-4 pb-8 pt-2">
+            <img src="/logo-horizontal.png" alt="OpenMAIC" className="h-11 w-auto" />
           </div>
-        </motion.div>
 
-        {/* ── Error ── */}
-        <AnimatePresence>
-          {error && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              className="mt-3 w-full p-3 bg-destructive/10 border border-destructive/20 rounded-lg"
-            >
-              <p className="text-sm text-destructive">{error}</p>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </motion.div>
-
-      {/* ═══ Recent classrooms — collapsible ═══ */}
-      {classrooms.length > 0 && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.5 }}
-          className="relative z-10 mt-10 w-full max-w-6xl flex flex-col items-center"
-        >
-          {/* Trigger — divider-line with centered text */}
-          <button
-            onClick={() => {
-              const next = !recentOpen;
-              setRecentOpen(next);
-              try {
-                localStorage.setItem(RECENT_OPEN_STORAGE_KEY, String(next));
-              } catch {
-                /* ignore */
-              }
-            }}
-            className="group w-full flex items-center gap-4 py-2 cursor-pointer"
-          >
-            <div className="flex-1 h-px bg-border/40 group-hover:bg-border/70 transition-colors" />
-            <span className="shrink-0 flex items-center gap-2 text-[13px] text-muted-foreground/60 group-hover:text-foreground/70 transition-colors select-none">
-              <Clock className="size-3.5" />
-              {t('classroom.recentClassrooms')}
-              <span className="text-[11px] tabular-nums opacity-60">{classrooms.length}</span>
-              <motion.div
-                animate={{ rotate: recentOpen ? 180 : 0 }}
-                transition={{ duration: 0.3, ease: 'easeInOut' }}
-              >
-                <ChevronDown className="size-3.5" />
-              </motion.div>
-            </span>
-            <div className="flex-1 h-px bg-border/40 group-hover:bg-border/70 transition-colors" />
-          </button>
-
-          {/* Expandable content */}
-          <AnimatePresence>
-            {recentOpen && (
-              <motion.div
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: 'auto', opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
-                className="w-full overflow-hidden"
-              >
-                <div className="pt-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-5 gap-y-8">
-                  {classrooms.map((classroom, i) => (
-                    <motion.div
-                      key={classroom.id}
-                      initial={{ opacity: 0, y: 16 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{
-                        delay: i * 0.04,
-                        duration: 0.35,
-                        ease: 'easeOut',
-                      }}
-                    >
-                      <ClassroomCard
-                        classroom={classroom}
-                        slide={thumbnails[classroom.id]}
-                        formatDate={formatDate}
-                        onDelete={handleDelete}
-                        confirmingDelete={pendingDeleteId === classroom.id}
-                        onConfirmDelete={() => confirmDelete(classroom.id)}
-                        onCancelDelete={() => setPendingDeleteId(null)}
-                        onClick={() => router.push(`/classroom/${classroom.id}`)}
-                      />
-                    </motion.div>
-                  ))}
+          <div className="flex-1 space-y-7 overflow-y-auto pr-1">
+            {SIDEBAR_GROUPS.map((group) => (
+              <div key={group.title} className="space-y-3">
+                <div
+                  className={cn(
+                    'flex items-center justify-between rounded-xl px-4 py-3 text-sm font-medium',
+                    group.title === 'Pages'
+                      ? 'bg-[#d9c7ff] text-[#5f2bd8]'
+                      : 'text-slate-700 dark:text-slate-300',
+                  )}
+                >
+                  <span className="flex items-center gap-3">
+                    <FolderKanban className="size-4" />
+                    {group.title}
+                  </span>
+                  <ChevronDown className="size-4" />
                 </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </motion.div>
-      )}
+                <div className="space-y-1 px-2">
+                  {group.items.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <div
+                        key={item.label}
+                        className={cn(
+                          'flex items-center gap-3 rounded-lg px-3 py-2.5 text-[14px] transition-colors',
+                          item.inset && 'ml-6',
+                          item.active
+                            ? 'text-[#6c39de]'
+                            : 'text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800/70',
+                        )}
+                      >
+                        <Icon className={cn('size-4', item.active && 'text-[#6c39de]')} />
+                        <span>{item.label}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
 
-      {/* Footer — flows with content, at the very end */}
-      <div className="mt-auto pt-12 pb-4 text-center text-xs text-muted-foreground/40">
-        OpenMAIC Open Source Project
+          <div className="mt-6">
+            <GreetingBar />
+          </div>
+        </aside>
+
+        <main className="min-w-0 flex-1">
+          <div className="px-5 pb-8 pt-7 sm:px-8 lg:px-10">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-[18px] font-semibold tracking-[-0.03em] text-[#6c39de] sm:text-[20px]">
+                  Profile/All projects
+                </p>
+              </div>
+              <label className="flex h-12 w-full max-w-[330px] items-center gap-3 rounded-full border border-slate-200 bg-white px-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+                <Search className="size-4 text-slate-400" />
+                <input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search anything here..."
+                  className="w-full border-0 bg-transparent text-sm text-slate-600 outline-none placeholder:text-slate-400 dark:text-slate-200"
+                />
+              </label>
+            </div>
+
+            <motion.section
+              initial={{ opacity: 0, y: 18 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.45, ease: 'easeOut' }}
+              className="mt-6 rounded-[20px] border border-slate-200 bg-white p-5 shadow-[0_16px_48px_rgba(15,23,42,0.05)] dark:border-slate-800 dark:bg-slate-900"
+            >
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="flex items-center gap-3">
+                  <img
+                    src={profileAvatar}
+                    alt=""
+                    className="size-10 rounded-full border border-slate-200 object-cover dark:border-slate-700"
+                  />
+                  <div>
+                    <p className="text-[14px] font-semibold text-slate-900 dark:text-slate-100">
+                      {profileName}
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{profileBio}</p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <button className="rounded-md bg-[#6c39de] px-7 py-2 text-sm font-medium text-white shadow-sm">
+                    App
+                  </button>
+                  <button className="rounded-md border border-[#b999ff] px-7 py-2 text-sm font-medium text-[#6c39de]">
+                    Messages
+                  </button>
+                  <button
+                    onClick={() => setSettingsOpen(true)}
+                    className="rounded-md border border-[#b999ff] px-7 py-2 text-sm font-medium text-[#6c39de]"
+                  >
+                    Settings
+                  </button>
+                </div>
+              </div>
+
+              <div className="mt-5 rounded-[16px] border border-slate-100 bg-[#fafaff] p-4 shadow-inner dark:border-slate-800 dark:bg-slate-950/60">
+                <div className="flex flex-col gap-4 rounded-[14px] bg-[#f3f1ff] p-5 dark:bg-slate-900/80">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <p className="text-[15px] font-medium text-slate-900 dark:text-slate-100">
+                        Some of Our Awesome classrooms
+                      </p>
+                      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                        Swap the kit demo data for real OpenMAIC classrooms and launch the next one
+                        from here.
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <Sparkles className="size-4 text-[#6c39de]" />
+                      {filteredClassrooms.length} active spaces
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                    {dashboardActions.map((action) => {
+                      const Icon = action.icon;
+                      return (
+                        <button
+                          key={action.label}
+                          onClick={action.onClick}
+                          className="flex items-start gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-[#c5b1ff] dark:border-slate-800 dark:bg-slate-900"
+                        >
+                          <div className="flex size-10 shrink-0 items-center justify-center rounded-[12px] bg-[#f1ebff] text-[#6c39de]">
+                            <Icon className="size-4" />
+                          </div>
+                          <div>
+                            <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                              {action.label}
+                            </p>
+                            <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                              {action.caption}
+                            </p>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div className="rounded-[18px] border border-white/90 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <img src="/logo-horizontal.png" alt="" aria-hidden="true" className="h-8 w-auto" />
+                        <p className="mt-4 text-[18px] font-semibold text-slate-900 dark:text-slate-100">
+                          Create a new classroom
+                        </p>
+                        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                          Keep the dashboard light, but wire it to the real generation flow.
+                        </p>
+                      </div>
+                      <div className="hidden pt-1 lg:block">
+                        <AgentBar />
+                      </div>
+                    </div>
+
+                    <div className="mt-4 overflow-hidden rounded-[16px] border border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-950/80">
+                      <textarea
+                        ref={textareaRef}
+                        placeholder={t('upload.requirementPlaceholder')}
+                        className="min-h-[128px] w-full resize-none border-0 bg-transparent px-4 py-4 text-[13px] leading-relaxed text-slate-700 outline-none placeholder:text-slate-400 dark:text-slate-200"
+                        value={form.requirement}
+                        onChange={(e) => updateForm('requirement', e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        rows={4}
+                      />
+                      <div className="flex flex-col gap-3 border-t border-slate-200 px-3 py-3 dark:border-slate-800 xl:flex-row xl:items-end">
+                        <div className="min-w-0 flex-1">
+                          <GenerationToolbar
+                            language={form.language}
+                            onLanguageChange={(lang) => updateForm('language', lang)}
+                            webSearch={form.webSearch}
+                            onWebSearchChange={(v) => updateForm('webSearch', v)}
+                            onSettingsOpen={(section) => {
+                              setSettingsSection(section);
+                              setSettingsOpen(true);
+                            }}
+                            pdfFile={form.pdfFile}
+                            onPdfFileChange={(f) => updateForm('pdfFile', f)}
+                            onPdfError={setError}
+                          />
+                        </div>
+                        <div className="flex items-center justify-end gap-2">
+                          <SpeechButton
+                            size="md"
+                            onTranscription={(text) => {
+                              setForm((prev) => {
+                                const next = prev.requirement + (prev.requirement ? ' ' : '') + text;
+                                updateRequirementCache(next);
+                                return { ...prev, requirement: next };
+                              });
+                            }}
+                          />
+                          <button
+                            onClick={handleGenerate}
+                            disabled={!canGenerate}
+                            className={cn(
+                              'inline-flex h-10 items-center justify-center gap-2 rounded-md px-4 text-sm font-medium transition-all',
+                              canGenerate
+                                ? 'bg-[#6c39de] text-white shadow-sm hover:bg-[#5f2bd8]'
+                                : 'bg-slate-200 text-slate-400 dark:bg-slate-800 dark:text-slate-500',
+                            )}
+                          >
+                            {t('toolbar.enterClassroom')}
+                            <ArrowUp className="size-4" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+
+                    <AnimatePresence>
+                      {error && (
+                        <motion.div
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: 'auto' }}
+                          exit={{ opacity: 0, height: 0 }}
+                          className="mt-3 rounded-xl border border-destructive/20 bg-destructive/10 px-4 py-3"
+                        >
+                          <p className="text-sm text-destructive">{error}</p>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+                </div>
+
+                <div className="mt-5 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                  {filteredClassrooms.map((classroom) => (
+                    <ClassroomCard
+                      key={classroom.id}
+                      classroom={classroom}
+                      slide={thumbnails[classroom.id]}
+                      formatDate={formatDate}
+                      onDelete={handleDelete}
+                      confirmingDelete={pendingDeleteId === classroom.id}
+                      onConfirmDelete={() => confirmDelete(classroom.id)}
+                      onCancelDelete={() => setPendingDeleteId(null)}
+                      onClick={() => router.push(`/classroom/${classroom.id}`)}
+                    />
+                  ))}
+                  {filteredClassrooms.length === 0 && (
+                    <div className="col-span-full rounded-[18px] border border-dashed border-slate-300 bg-white px-6 py-16 text-center dark:border-slate-700 dark:bg-slate-900">
+                      <p className="text-base font-medium text-slate-700 dark:text-slate-200">
+                        No classrooms match that search yet.
+                      </p>
+                      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                        Try another title or create a fresh classroom from the composer above.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </motion.section>
+          </div>
+        </main>
       </div>
     </div>
   );
@@ -988,6 +989,11 @@ function ClassroomCard({
   const { t } = useI18n();
   const thumbRef = useRef<HTMLDivElement>(null);
   const [thumbWidth, setThumbWidth] = useState(0);
+  const classroomInitials = classroom.name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
 
   useEffect(() => {
     const el = thumbRef.current;
@@ -1000,11 +1006,13 @@ function ClassroomCard({
   }, []);
 
   return (
-    <div className="group cursor-pointer" onClick={confirmingDelete ? undefined : onClick}>
-      {/* Thumbnail — large radius, no border, subtle bg */}
+    <div
+      className="group relative rounded-[18px] border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#c5b1ff] dark:border-slate-800 dark:bg-slate-900"
+      onClick={confirmingDelete ? undefined : onClick}
+    >
       <div
         ref={thumbRef}
-        className="relative w-full aspect-[16/9] rounded-2xl bg-slate-100 dark:bg-slate-800/80 overflow-hidden transition-transform duration-200 group-hover:scale-[1.02]"
+        className="relative mb-4 h-[184px] overflow-hidden rounded-[14px] border border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-950"
       >
         {slide && thumbWidth > 0 ? (
           <ThumbnailSlide
@@ -1014,14 +1022,15 @@ function ClassroomCard({
             viewportRatio={slide.viewportRatio ?? 0.5625}
           />
         ) : !slide ? (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="size-12 rounded-2xl bg-gradient-to-br from-violet-100 to-blue-100 dark:from-violet-900/30 dark:to-blue-900/30 flex items-center justify-center">
-              <span className="text-xl opacity-50">📄</span>
+          <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-[#fff1f5] via-white to-[#f2eeff] dark:from-slate-900 dark:via-slate-950 dark:to-slate-900">
+            <div className="flex size-12 items-center justify-center rounded-2xl bg-[#ffdfe9] text-sm font-semibold uppercase tracking-[0.18em] text-[#ff5c8a]">
+              {classroomInitials || 'CL'}
             </div>
           </div>
         ) : null}
 
-        {/* Delete — top-right, only on hover */}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-white/92 via-white/35 to-transparent dark:from-slate-950/92" />
+
         <AnimatePresence>
           {!confirmingDelete && (
             <motion.div
@@ -1033,19 +1042,18 @@ function ClassroomCard({
               <Button
                 size="icon"
                 variant="ghost"
-                className="absolute top-2 right-2 size-7 opacity-0 group-hover:opacity-100 transition-opacity bg-black/30 hover:bg-destructive/80 text-white hover:text-white backdrop-blur-sm rounded-full"
+                className="absolute right-2 top-2 size-8 rounded-full border border-white/80 bg-white/90 text-slate-500 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive dark:border-slate-700 dark:bg-slate-900/90"
                 onClick={(e) => {
                   e.stopPropagation();
                   onDelete(classroom.id, e);
                 }}
               >
-                <Trash2 className="size-3.5" />
+                <MoreVertical className="size-4" />
               </Button>
             </motion.div>
           )}
         </AnimatePresence>
 
-        {/* Inline delete confirmation overlay */}
         <AnimatePresence>
           {confirmingDelete && (
             <motion.div
@@ -1053,7 +1061,7 @@ function ClassroomCard({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.15 }}
-              className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/50 backdrop-blur-[6px]"
+              className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-slate-950/60 backdrop-blur-[6px]"
               onClick={(e) => e.stopPropagation()}
             >
               <span className="text-[13px] font-medium text-white/90">
@@ -1078,37 +1086,73 @@ function ClassroomCard({
         </AnimatePresence>
       </div>
 
-      {/* Info — outside the thumbnail */}
-      <div className="mt-2.5 px-1 flex items-center gap-2">
-        <span className="shrink-0 inline-flex items-center rounded-full bg-violet-100 dark:bg-violet-900/30 px-2 py-0.5 text-[11px] font-medium text-violet-600 dark:text-violet-400">
-          {classroom.sceneCount} {t('classroom.slides')} · {formatDate(classroom.updatedAt)}
-        </span>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <p className="font-medium text-[15px] truncate text-foreground/90 min-w-0">
-              {classroom.name}
-            </p>
-          </TooltipTrigger>
-          <TooltipContent
-            side="bottom"
-            sideOffset={4}
-            className="!max-w-[min(90vw,32rem)] break-words whitespace-normal"
-          >
-            <div className="flex items-center gap-1.5">
-              <span className="break-all">{classroom.name}</span>
-              <button
-                className="shrink-0 p-0.5 rounded hover:bg-foreground/10 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigator.clipboard.writeText(classroom.name);
-                  toast.success(t('classroom.nameCopied'));
-                }}
+      <div className="flex items-start gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-[12px] bg-[#ffe5ee] text-xs font-semibold uppercase tracking-[0.18em] text-[#ff5c8a]">
+          {classroomInitials || 'CL'}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <p className="truncate text-[18px] font-medium tracking-[-0.02em] text-slate-900 dark:text-slate-100">
+                  {classroom.name}
+                </p>
+              </TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                sideOffset={4}
+                className="!max-w-[min(90vw,32rem)] break-words whitespace-normal"
               >
-                <Copy className="size-3 opacity-60" />
-              </button>
+                <div className="flex items-center gap-1.5">
+                  <span className="break-all">{classroom.name}</span>
+                  <button
+                    className="shrink-0 rounded p-0.5 transition-colors hover:bg-foreground/10"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigator.clipboard.writeText(classroom.name);
+                      toast.success(t('classroom.nameCopied'));
+                    }}
+                  >
+                    <Copy className="size-3 opacity-60" />
+                  </button>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
+          <div className="mt-2 flex -space-x-1.5">
+            {AVATAR_OPTIONS.slice(0, 4).map((avatar, index) => (
+              <img
+                key={`${classroom.id}-${avatar}-${index}`}
+                src={avatar}
+                alt=""
+                className="size-5 rounded-full border border-white object-cover dark:border-slate-900"
+              />
+            ))}
+          </div>
+
+          <p className="mt-3 min-h-[44px] text-[13px] leading-5 text-slate-500 dark:text-slate-400">
+            {classroom.sceneCount} {t('classroom.slides')} ready for presentation, discussion, and
+            interactive simulation flow.
+          </p>
+
+          <div className="mt-4 border-t border-slate-200 pt-3 text-[12px] text-slate-500 dark:border-slate-800 dark:text-slate-400">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-[18px] leading-none text-slate-800 dark:text-slate-100">
+                  {classroom.sceneCount}
+                </p>
+                <p className="mt-1">{t('classroom.slides')}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-[15px] leading-none text-slate-800 dark:text-slate-100">
+                  {formatDate(classroom.updatedAt)}
+                </p>
+                <p className="mt-1">Updated</p>
+              </div>
             </div>
-          </TooltipContent>
-        </Tooltip>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -9,6 +9,79 @@ interface InteractiveRendererProps {
   readonly sceneId: string;
 }
 
+/**
+ * In-memory localStorage/sessionStorage shim, injected as the FIRST thing in the
+ * document so the page's own scripts see working storage.
+ *
+ * The interactive iframe is sandboxed `allow-scripts` WITHOUT `allow-same-origin`
+ * (intentional — combining them negates the sandbox for LLM-authored HTML). In a
+ * null-origin document, touching `window.localStorage` throws a SecurityError;
+ * many generated pages read/write storage in their setup code, so that throw
+ * crashes the script before anything renders.
+ */
+const STORAGE_SHIM = `<script data-iframe-storage-shim>
+(function () {
+  function makeStore() {
+    var data = Object.create(null);
+    return {
+      getItem: function (k) { k = String(k); return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null; },
+      setItem: function (k, v) { data[String(k)] = String(v); },
+      removeItem: function (k) { delete data[String(k)]; },
+      clear: function () { data = Object.create(null); },
+      key: function (i) { var keys = Object.keys(data); return i < keys.length ? keys[i] : null; },
+      get length() { return Object.keys(data).length; }
+    };
+  }
+  ['localStorage', 'sessionStorage'].forEach(function (name) {
+    var ok = false;
+    try { var s = window[name]; if (s) { s.getItem('__probe__'); ok = true; } } catch (e) { ok = false; }
+    if (!ok) {
+      try { Object.defineProperty(window, name, { value: makeStore(), configurable: true }); } catch (e) {}
+    }
+  });
+})();
+</script>`;
+
+/**
+ * Runtime-error capture shim. The sandboxed iframe cannot be inspected directly,
+ * but it can `postMessage` outward when generated widget code fails early.
+ */
+const ERROR_CAPTURE_SHIM = `<script data-iframe-error-shim>
+(function () {
+  var buffer = [];
+  function emit(errorKind, message) {
+    try {
+      window.parent.postMessage(
+        { __maicInteractive: true, kind: 'runtime-error', errorKind: errorKind, message: message },
+        '*'
+      );
+    } catch (e) {}
+  }
+  function post(errorKind, message) {
+    message = String(message).slice(0, 1200);
+    if (buffer.length < 50) buffer.push([errorKind, message]);
+    emit(errorKind, message);
+  }
+  window.addEventListener('message', function (e) {
+    var d = e && e.data;
+    if (d && d.__maicErrorReplayRequest === true) {
+      for (var i = 0; i < buffer.length; i++) emit(buffer[i][0], buffer[i][1]);
+    }
+  });
+  window.addEventListener('error', function (e) {
+    if (e && e.message) {
+      post('error', e.message + (e.filename ? ' (' + e.filename + ':' + (e.lineno || 0) + ')' : ''));
+    } else if (e && e.target && (e.target.src || e.target.href)) {
+      post('resource', 'Failed to load resource: ' + (e.target.src || e.target.href));
+    }
+  }, true);
+  window.addEventListener('unhandledrejection', function (e) {
+    var r = e && e.reason;
+    post('unhandledrejection', (r && (r.stack || r.message)) || r || 'unhandled promise rejection');
+  });
+})();
+</script>`;
+
 export function InteractiveRenderer({ content, mode: _mode, sceneId }: InteractiveRendererProps) {
   const patchedHtml = useMemo(
     () => (content.html ? patchHtmlForIframe(content.html) : undefined),
@@ -16,14 +89,20 @@ export function InteractiveRenderer({ content, mode: _mode, sceneId }: Interacti
   );
 
   return (
-    <div className="w-full h-full relative">
-      <iframe
-        srcDoc={patchedHtml}
-        src={patchedHtml ? undefined : content.url}
-        className="absolute inset-0 w-full h-full border-0"
-        title={`Interactive Scene ${sceneId}`}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-      />
+    <div className="flex h-full min-h-0 min-w-0 w-full bg-[#18233d] px-4 py-5 sm:px-6 sm:py-6">
+      <div className="flex h-full min-h-0 min-w-0 w-full items-center justify-center">
+        <div className="flex h-full min-h-0 min-w-0 w-full max-w-[1120px] flex-col">
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-[22px] border border-white/10 bg-[#0f172a]/30 p-2 shadow-[0_24px_80px_rgba(2,6,23,0.35)] backdrop-blur-sm sm:p-3">
+            <iframe
+              srcDoc={patchedHtml}
+              src={patchedHtml ? undefined : content.url}
+              className="h-full w-full rounded-[18px] border-0 bg-white shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]"
+              title={`Interactive Scene ${sceneId}`}
+              sandbox="allow-scripts allow-forms allow-popups"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -31,31 +110,309 @@ export function InteractiveRenderer({ content, mode: _mode, sceneId }: Interacti
 /**
  * Patch embedded HTML to display correctly inside an iframe.
  *
- * Fixes:
- * - min-h-screen / h-screen → use 100% of iframe viewport
- * - Ensure html/body fill the iframe with no overflow issues
- * - Canvas elements use container sizing instead of viewport
+ * Injects shims plus CSS that keeps interactive widgets bounded, scrollable, and
+ * less prone to simulation/panel overlap inside the classroom canvas.
  */
-function patchHtmlForIframe(html: string): string {
+export function patchHtmlForIframe(html: string): string {
   const iframeCss = `<style data-iframe-patch>
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
   html, body {
     width: 100%;
     height: 100%;
+    max-width: 100%;
     margin: 0;
     padding: 0;
     overflow-x: hidden;
     overflow-y: auto;
   }
-  /* Fix min-h-screen: in iframes 100vh is the iframe height, which is correct,
-     but ensure body actually fills it */
-  body { min-height: 100vh; }
-</style>`;
+  body {
+    min-height: 100vh;
+    padding: 0 !important;
+    background: linear-gradient(180deg, #dbe7ff 0%, #eff4ff 100%);
+    color: #0f172a;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 14px !important;
+    line-height: 1.35 !important;
+  }
+  body > * {
+    max-width: 100% !important;
+  }
+  body > main,
+  body > .app,
+  body > .simulation-shell,
+  body > .game-shell,
+  body > .activity-shell,
+  body > [class*="app-shell"],
+  body > [class*="simulation-shell"],
+  body > [class*="game-shell"] {
+    width: min(100%, 1120px) !important;
+    margin: 0 auto !important;
+  }
+  h1 {
+    font-size: 22px !important;
+    line-height: 1.15 !important;
+    margin: 0 0 10px !important;
+  }
+  h2 {
+    font-size: 18px !important;
+    line-height: 1.2 !important;
+    margin: 0 0 8px !important;
+  }
+  h3, h4 {
+    font-size: 15px !important;
+    line-height: 1.25 !important;
+    margin: 0 0 6px !important;
+  }
+  p, label, li {
+    font-size: 13px !important;
+    line-height: 1.35 !important;
+  }
+  img, video, canvas, svg {
+    max-width: 100%;
+  }
+  pre, code, kbd, samp {
+    font-size: 12px !important;
+    line-height: 1.35 !important;
+    white-space: pre-wrap !important;
+  }
+  button, input, select, textarea {
+    font: inherit;
+  }
+  button, [role="button"] {
+    min-height: 34px !important;
+    border: 0;
+    border-radius: 10px !important;
+    padding: 8px 11px !important;
+    background: #2563eb;
+    color: #ffffff;
+    font-size: 13px !important;
+    font-weight: 700;
+    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
+    cursor: pointer;
+  }
+  button:hover, [role="button"]:hover {
+    background: #1d4ed8;
+  }
+  button:disabled, [role="button"][aria-disabled="true"] {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  input:not([type="range"]), select, textarea {
+    width: 100%;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: #ffffff;
+    color: #0f172a;
+    font-size: 13px !important;
+  }
+  input[type="range"] {
+    width: 100%;
+    accent-color: #7c3aed;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    padding: 8px;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+    font-size: 13px !important;
+  }
+  .simulation-shell,
+  .game-shell,
+  .game-stage,
+  .activity-shell,
+  .matrix-card,
+  .card,
+  section,
+  article {
+    max-width: 100%;
+  }
+  .simulation-shell,
+  .game-shell,
+  .activity-shell {
+    width: min(100%, 1120px) !important;
+    max-width: 1120px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    position: relative;
+    min-height: 100vh !important;
+    padding: 18px !important;
+    align-items: stretch !important;
+    gap: 18px !important;
+  }
+  .simulation-shell,
+  .game-shell {
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr) !important;
+  }
+  .simulation-shell > *,
+  .game-shell > *,
+  .activity-shell > * {
+    min-width: 0 !important;
+  }
+  .game-stage,
+  .simulation-stage,
+  .canvas-stage,
+  [class*="stage"],
+  [class*="viewport"],
+  [class*="canvas"] {
+    position: relative;
+    min-width: 0 !important;
+    width: 100% !important;
+    overflow: hidden !important;
+    border-radius: 22px !important;
+    border: 1px solid rgba(148, 163, 184, 0.35) !important;
+    box-shadow: 0 20px 55px rgba(15, 23, 42, 0.14) !important;
+    max-height: calc(100vh - 110px) !important;
+  }
+  .card,
+  .matrix-card,
+  section,
+  article,
+  [class*="panel"],
+  [class*="card"] {
+    border-radius: 12px !important;
+    padding: 12px !important;
+  }
+  [class*="label"],
+  [class*="badge"],
+  [class*="chip"],
+  [class*="tag"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    max-width: 100% !important;
+    overflow-wrap: anywhere !important;
+    white-space: normal !important;
+    font-size: 12px !important;
+    line-height: 1.2 !important;
+  }
+  [class*="toolbar"],
+  [class*="hud"],
+  [class*="control-bar"],
+  [class*="action-bar"] {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    align-items: center !important;
+    gap: 10px !important;
+    max-width: 100% !important;
+  }
+  [class*="score"],
+  [class*="coins"],
+  [class*="points"],
+  [class*="status"],
+  [class*="hud-card"],
+  [class*="counter"] {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 8px !important;
+    padding: 10px 14px !important;
+    border-radius: 999px !important;
+    background: rgba(255, 255, 255, 0.94) !important;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12) !important;
+    max-width: min(100%, 180px) !important;
+    overflow-wrap: anywhere !important;
+  }
+  [class*="overlay"] {
+    max-width: min(100%, 320px) !important;
+  }
+  [class*="ground"],
+  [class*="soil"],
+  [class*="grass"] {
+    overflow: hidden !important;
+  }
+  [class*="shop"],
+  [class*="inventory"],
+  [class*="selector"],
+  [class*="toolbox"],
+  [class*="choices"] {
+    max-width: min(100%, 360px) !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+  }
+  [class*="bottom-bar"],
+  [class*="bottom-controls"],
+  [class*="footer-controls"],
+  [class*="control-dock"],
+  [class*="dock"] {
+    position: sticky !important;
+    bottom: 12px !important;
+    z-index: 5 !important;
+    display: flex !important;
+    justify-content: center !important;
+    gap: 12px !important;
+    width: fit-content !important;
+    max-width: calc(100% - 24px) !important;
+    margin: 0 auto !important;
+    padding: 12px 16px !important;
+    border-radius: 999px !important;
+    background: rgba(255, 255, 255, 0.92) !important;
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.16) !important;
+    backdrop-filter: blur(14px) !important;
+  }
+  [class*="selector"] > *,
+  [class*="toolbox"] > *,
+  [class*="choices"] > *,
+  [class*="bottom-controls"] > *,
+  [class*="control-dock"] > *,
+  [class*="dock"] > * {
+    flex: 0 0 auto !important;
+  }
+  @media (max-height: 620px), (max-width: 640px) {
+    body {
+      font-size: 13px !important;
+    }
+    .simulation-shell,
+    .game-shell,
+    .activity-shell {
+      padding: 10px !important;
+      gap: 12px !important;
+    }
+    .simulation-shell,
+    .game-shell {
+      grid-template-columns: 1fr !important;
+    }
+    button, [role="button"] {
+      min-height: 32px !important;
+      padding: 7px 10px !important;
+    }
+    .game-stage,
+    .simulation-stage,
+    .canvas-stage,
+    [class*="stage"],
+    [class*="viewport"],
+    [class*="canvas"] {
+      max-height: calc(100vh - 88px) !important;
+    }
+    [class*="overlay"] {
+      position: static !important;
+      width: auto !important;
+      max-width: 100% !important;
+      margin: 12px 0 0 !important;
+    }
+    [class*="bottom-bar"],
+    [class*="bottom-controls"],
+    [class*="footer-controls"],
+    [class*="control-dock"],
+    [class*="dock"] {
+      bottom: 8px !important;
+      max-width: calc(100% - 16px) !important;
+      padding: 10px 12px !important;
+      gap: 8px !important;
+    }
+  }
+  </style>`;
 
-  // Insert right after <head> or at the start of the document
+  const injection = '\n' + ERROR_CAPTURE_SHIM + '\n' + STORAGE_SHIM + '\n' + iframeCss;
+
   const headIdx = html.indexOf('<head>');
   if (headIdx !== -1) {
-    const insertPos = headIdx + 6; // after <head>
-    return html.substring(0, insertPos) + '\n' + iframeCss + html.substring(insertPos);
+    const insertPos = headIdx + 6;
+    return html.substring(0, insertPos) + injection + html.substring(insertPos);
   }
 
   const headWithAttrs = html.indexOf('<head ');
@@ -63,10 +420,9 @@ function patchHtmlForIframe(html: string): string {
     const closeAngle = html.indexOf('>', headWithAttrs);
     if (closeAngle !== -1) {
       const insertPos = closeAngle + 1;
-      return html.substring(0, insertPos) + '\n' + iframeCss + html.substring(insertPos);
+      return html.substring(0, insertPos) + injection + html.substring(insertPos);
     }
   }
 
-  // Fallback: prepend
-  return iframeCss + html;
+  return injection + html;
 }

--- a/e2e/fixtures/browser-storage.ts
+++ b/e2e/fixtures/browser-storage.ts
@@ -1,0 +1,44 @@
+import type { Page } from '@playwright/test';
+
+export async function primeOrigin(page: Page) {
+  await page.goto('/', { waitUntil: 'networkidle' });
+}
+
+export async function setSettingsStorage(page: Page, settings: string) {
+  await primeOrigin(page);
+  await page.localStorage.setItem('settings-storage', settings);
+}
+
+export async function setSettingsAndGenerationSession(
+  page: Page,
+  options: {
+    settings: string;
+    session: string;
+  },
+) {
+  await primeOrigin(page);
+  await page.localStorage.setItem('settings-storage', options.settings);
+  await page.sessionStorage.setItem('generationSession', options.session);
+}
+
+export async function ensureMaicDatabase(page: Page) {
+  await page.waitForFunction(
+    () =>
+      new Promise<boolean>((resolve) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const hasStores = ['stages', 'scenes', 'stageOutlines'].every((name) =>
+            db.objectStoreNames.contains(name),
+          );
+          db.close();
+          resolve(hasStores);
+        };
+
+        request.onerror = () => resolve(false);
+      }),
+    undefined,
+    { timeout: 15_000 },
+  );
+}

--- a/e2e/tests/classroom-interaction.spec.ts
+++ b/e2e/tests/classroom-interaction.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures/base';
 import { ClassroomPage } from '../pages/classroom.page';
 import { createSettingsStorage } from '../fixtures/test-data/settings';
 import { defaultTheme } from '../fixtures/test-data/scene-content';
+import { ensureMaicDatabase, setSettingsStorage } from '../fixtures/browser-storage';
 
 const TEST_STAGE_ID = 'e2e-test-stage';
 
@@ -9,14 +10,8 @@ const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
 
 /** Seed IndexedDB with stage + 3 scenes using raw IndexedDB API */
 async function seedDatabase(page: import('@playwright/test').Page) {
-  // Inject settings before navigating so it's available immediately on load
-  await page.addInitScript((settings) => {
-    localStorage.setItem('settings-storage', settings);
-  }, SETTINGS_STORAGE);
-
-  // Navigate to home page first — this causes Dexie to open/create the DB at v8
-  // with the correct schema. We wait for network idle to ensure Dexie is done.
-  await page.goto('/', { waitUntil: 'networkidle' });
+  await setSettingsStorage(page, SETTINGS_STORAGE);
+  await ensureMaicDatabase(page);
 
   // Now seed data by opening the DB at its current version (no upgrade).
   // Opening without a version number returns the current version without triggering

--- a/e2e/tests/generation-flow.spec.ts
+++ b/e2e/tests/generation-flow.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/base';
 import { GenerationPreviewPage } from '../pages/generation-preview.page';
 import { createSettingsStorage } from '../fixtures/test-data/settings';
+import { setSettingsAndGenerationSession } from '../fixtures/browser-storage';
 
 const SETTINGS_STORAGE = createSettingsStorage();
 
@@ -19,13 +20,10 @@ const GENERATION_SESSION = JSON.stringify({
 
 test.describe('Generation Flow', () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(
-      ({ settings, session }) => {
-        localStorage.setItem('settings-storage', settings);
-        sessionStorage.setItem('generationSession', session);
-      },
-      { settings: SETTINGS_STORAGE, session: GENERATION_SESSION },
-    );
+    await setSettingsAndGenerationSession(page, {
+      settings: SETTINGS_STORAGE,
+      session: GENERATION_SESSION,
+    });
   });
 
   test('completes generation pipeline and redirects to classroom', async ({ page, mockApi }) => {

--- a/e2e/tests/home-to-generation.spec.ts
+++ b/e2e/tests/home-to-generation.spec.ts
@@ -1,15 +1,14 @@
 import { test, expect } from '../fixtures/base';
 import { HomePage } from '../pages/home.page';
 import { createSettingsStorage } from '../fixtures/test-data/settings';
+import { setSettingsStorage } from '../fixtures/browser-storage';
 
 // Inject settings with modelId so the "enter classroom" button works
 const SETTINGS_STORAGE = createSettingsStorage();
 
 test.describe('Home → Generation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript((settings) => {
-      localStorage.setItem('settings-storage', settings);
-    }, SETTINGS_STORAGE);
+    await setSettingsStorage(page, SETTINGS_STORAGE);
   });
 
   test('home page loads with core UI elements and submits requirement', async ({ page }) => {

--- a/e2e/tests/interactive-simulation-layout.spec.ts
+++ b/e2e/tests/interactive-simulation-layout.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/base';
 import { ClassroomPage } from '../pages/classroom.page';
 import { createSettingsStorage } from '../fixtures/test-data/settings';
+import { ensureMaicDatabase, setSettingsStorage } from '../fixtures/browser-storage';
 
 const TEST_STAGE_ID = 'e2e-interactive-stage';
 const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
@@ -128,30 +129,8 @@ const INTERACTIVE_HTML = String.raw`<!doctype html>
 </html>`;
 
 async function seedInteractiveStage(page: import('@playwright/test').Page) {
-  await page.addInitScript((settings) => {
-    localStorage.setItem('settings-storage', settings);
-  }, SETTINGS_STORAGE);
-
-  await page.goto(`/classroom/${TEST_STAGE_ID}`, { waitUntil: 'domcontentloaded' });
-  await page.waitForFunction(
-    () =>
-      new Promise<boolean>((resolve) => {
-        const request = indexedDB.open('MAIC-Database');
-
-        request.onsuccess = (event) => {
-          const db = (event.target as IDBOpenDBRequest).result;
-          const hasStores = ['stages', 'scenes', 'stageOutlines'].every((name) =>
-            db.objectStoreNames.contains(name),
-          );
-          db.close();
-          resolve(hasStores);
-        };
-
-        request.onerror = () => resolve(false);
-      }),
-    undefined,
-    { timeout: 15_000 },
-  );
+  await setSettingsStorage(page, SETTINGS_STORAGE);
+  await ensureMaicDatabase(page);
 
   await page.evaluate(
     ({ stageId, html }) => {
@@ -209,7 +188,7 @@ async function seedInteractiveStage(page: import('@playwright/test').Page) {
     { stageId: TEST_STAGE_ID, html: INTERACTIVE_HTML },
   );
 
-  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.goto(`/classroom/${TEST_STAGE_ID}`, { waitUntil: 'domcontentloaded' });
 }
 
 test.describe('Interactive simulation layout', () => {

--- a/e2e/tests/interactive-simulation-layout.spec.ts
+++ b/e2e/tests/interactive-simulation-layout.spec.ts
@@ -1,0 +1,288 @@
+import { test, expect } from '../fixtures/base';
+import { ClassroomPage } from '../pages/classroom.page';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+
+const TEST_STAGE_ID = 'e2e-interactive-stage';
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+const INTERACTIVE_HTML = String.raw`<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Simulation Smoke</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+      }
+      .simulation-shell {
+        display: grid;
+        grid-template-columns: minmax(220px, 320px) 1fr;
+        gap: 18px;
+        align-items: start;
+      }
+      .panel {
+        background: #fff;
+        border: 1px solid #cbd5e1;
+        border-radius: 16px;
+        padding: 16px;
+      }
+      .badge {
+        display: inline-flex;
+        max-width: 260px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: #dbeafe;
+        color: #1d4ed8;
+        font-weight: 700;
+      }
+      .simulation-stage {
+        position: relative;
+        min-height: 520px;
+        border-radius: 20px;
+        border: 1px solid #cbd5e1;
+        background:
+          radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 35%),
+          linear-gradient(180deg, #eff6ff 0%, #ffffff 100%);
+      }
+      .toolbar {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 14px;
+      }
+      .status-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        background: #fef3c7;
+        color: #92400e;
+        padding: 6px 10px;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .overlay-card {
+        position: absolute;
+        right: 16px;
+        top: 16px;
+        width: min(42%, 280px);
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid #bfdbfe;
+        border-radius: 16px;
+        padding: 14px;
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+      }
+      .stage-copy {
+        position: absolute;
+        left: 18px;
+        bottom: 18px;
+        max-width: 58%;
+        background: rgba(15, 23, 42, 0.82);
+        color: #fff;
+        border-radius: 16px;
+        padding: 14px 16px;
+      }
+      @media (max-width: 700px) {
+        .simulation-shell {
+          grid-template-columns: 1fr;
+        }
+        .overlay-card,
+        .stage-copy {
+          position: static;
+          width: auto;
+          max-width: none;
+          margin: 16px;
+        }
+        .stage-copy {
+          margin-top: 260px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="simulation-shell">
+      <section class="panel">
+        <div class="badge">Extremely long simulation status badge that should wrap instead of punching outside the layout boundary</div>
+        <h1>Workplace safety walkthrough</h1>
+        <p>This simulation intentionally uses long copy so the iframe patch has to defend the layout.</p>
+        <div class="toolbar">
+          <button type="button">Start simulation</button>
+          <button type="button">Pause and inspect risk controls</button>
+          <button type="button">Reset to baseline conditions</button>
+        </div>
+        <label for="risk">Risk threshold control with a deliberately long label that would normally overflow narrow side panels</label>
+        <input id="risk" type="range" min="0" max="100" value="42" />
+        <p class="status-chip">Supervisory note with a long sentence that should stay inside the chip instead of stretching the iframe horizontally</p>
+      </section>
+      <section class="simulation-stage">
+        <div class="overlay-card">
+          <strong>Inspector panel</strong>
+          <p>This floating card should remain readable and bounded even on a tight viewport.</p>
+        </div>
+        <div class="stage-copy">
+          The scene copy stays inside the stage and should not collide with the floating panel once the iframe patch constrains widths and wrapping.
+        </div>
+      </section>
+    </main>
+  </body>
+</html>`;
+
+async function seedInteractiveStage(page: import('@playwright/test').Page) {
+  await page.addInitScript((settings) => {
+    localStorage.setItem('settings-storage', settings);
+  }, SETTINGS_STORAGE);
+
+  await page.goto(`/classroom/${TEST_STAGE_ID}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () =>
+      new Promise<boolean>((resolve) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const hasStores = ['stages', 'scenes', 'stageOutlines'].every((name) =>
+            db.objectStoreNames.contains(name),
+          );
+          db.close();
+          resolve(hasStores);
+        };
+
+        request.onerror = () => resolve(false);
+      }),
+    undefined,
+    { timeout: 15_000 },
+  );
+
+  await page.evaluate(
+    ({ stageId, html }) => {
+      return new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+          const now = Date.now();
+
+          tx.objectStore('stages').put({
+            id: stageId,
+            name: 'Interactive smoke test',
+            description: '',
+            language: 'en',
+            style: 'professional',
+            interactiveMode: true,
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('scenes').put({
+            id: 'interactive-scene-0',
+            stageId,
+            type: 'interactive',
+            title: 'Simulation scene',
+            order: 0,
+            content: {
+              type: 'interactive',
+              url: 'about:blank',
+              html,
+            },
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('stageOutlines').put({
+            stageId,
+            outlines: [],
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+
+        request.onerror = () => reject(request.error);
+      });
+    },
+    { stageId: TEST_STAGE_ID, html: INTERACTIVE_HTML },
+  );
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+}
+
+test.describe('Interactive simulation layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedInteractiveStage(page);
+  });
+
+  test('keeps simulation iframe content bounded without horizontal overflow', async ({ page }) => {
+    const classroom = new ClassroomPage(page);
+    await classroom.waitForLoaded();
+
+    const iframe = page.locator('iframe[title^="Interactive Scene"]');
+    await expect(iframe).toBeVisible();
+
+    const frame = page.frameLocator('iframe[title^="Interactive Scene"]');
+    await expect(frame.getByRole('heading', { name: 'Workplace safety walkthrough' })).toBeVisible();
+
+    const overflow = await frame.locator('body').evaluate((body) => {
+      const doc = body.ownerDocument;
+      const root = doc.scrollingElement ?? doc.documentElement;
+      return {
+        scrollWidth: root.scrollWidth,
+        clientWidth: root.clientWidth,
+        bodyScrollWidth: body.scrollWidth,
+        bodyClientWidth: body.clientWidth,
+      };
+    });
+
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+    expect(overflow.bodyScrollWidth).toBeLessThanOrEqual(overflow.bodyClientWidth + 1);
+
+    const badgeMetrics = await frame.locator('.badge').evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        whiteSpace: style.whiteSpace,
+        overflowWrap: style.overflowWrap,
+        rectWidth: el.getBoundingClientRect().width,
+        parentWidth: el.parentElement?.getBoundingClientRect().width ?? 0,
+      };
+    });
+
+    expect(badgeMetrics.whiteSpace).not.toBe('nowrap');
+    expect(badgeMetrics.overflowWrap).toBe('anywhere');
+    expect(badgeMetrics.rectWidth).toBeLessThanOrEqual(badgeMetrics.parentWidth + 1);
+
+    const shellMetrics = await frame.locator('.simulation-shell').evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      const firstChild = el.firstElementChild as HTMLElement | null;
+      return {
+        maxWidth: style.maxWidth,
+        paddingTop: Number.parseFloat(style.paddingTop),
+        columnTemplate: style.gridTemplateColumns,
+        firstChildWidth: firstChild?.getBoundingClientRect().width ?? 0,
+        rectWidth: el.getBoundingClientRect().width,
+        bodyWidth: document.body.getBoundingClientRect().width,
+      };
+    });
+
+    expect(shellMetrics.maxWidth).toBe('1120px');
+    expect(shellMetrics.paddingTop).toBeGreaterThanOrEqual(10);
+    expect(shellMetrics.columnTemplate).not.toBe('none');
+    expect(shellMetrics.firstChildWidth).toBeGreaterThanOrEqual(220);
+    expect(shellMetrics.rectWidth).toBeLessThanOrEqual(shellMetrics.bodyWidth + 1);
+
+    const stageMetrics = await frame.locator('.simulation-stage').evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        overflow: style.overflow,
+        borderRadius: style.borderRadius,
+      };
+    });
+
+    expect(stageMetrics.overflow).toBe('hidden');
+    expect(stageMetrics.borderRadius).toBe('22px');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "zustand": "^5.0.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.61.1",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 1.2.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@copilotkit/backend':
         specifier: ^0.37.0
-        version: 0.37.0(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(playwright@1.58.2)(ws@8.19.0)
+        version: 0.37.0(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(playwright@1.61.1)(ws@8.19.0)
       '@copilotkit/runtime':
         specifier: ^1.51.2
         version: 1.53.0(@ag-ui/encoder@0.0.47)(@cfworker/json-schema@4.1.1)(@copilotkitnext/shared@1.53.0)(@langchain/core@1.1.31(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@4.3.6)))(@langchain/langgraph-sdk@1.7.1(@langchain/core@1.1.31(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)
@@ -97,7 +97,7 @@ importers:
         version: 2.0.5
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 1.7.0(next@16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       immer:
         specifier: ^11.1.3
         version: 11.1.4
@@ -133,7 +133,7 @@ importers:
         version: 5.1.6
       next:
         specifier: 16.1.2
-        version: 16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -244,8 +244,8 @@ importers:
         version: 5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.61.1
+        version: 1.61.1
       '@rollup/plugin-commonjs':
         specifier: ^28.0.1
         version: 28.0.9(rollup@4.59.0)
@@ -1969,8 +1969,8 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7501,13 +7501,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9708,14 +9708,14 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@copilotkit/backend@0.37.0(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(playwright@1.58.2)(ws@8.19.0)':
+  '@copilotkit/backend@0.37.0(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(playwright@1.61.1)(ws@8.19.0)':
     dependencies:
       '@copilotkit/shared': 0.37.0
       '@google/generative-ai': 0.11.5
       '@langchain/core': 0.1.63(openai@4.104.0(ws@8.19.0)(zod@4.3.6))
       '@langchain/openai': 0.0.28(ws@8.19.0)
       js-tiktoken: 1.0.21
-      langchain: 0.1.37(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(playwright@1.58.2)(ws@8.19.0)
+      langchain: 0.1.37(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(playwright@1.61.1)(ws@8.19.0)
       openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -10938,9 +10938,9 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.61.1
 
   '@protobuf-ts/protoc@2.11.1': {}
 
@@ -14484,9 +14484,9 @@ snapshots:
 
   fzf@0.5.2: {}
 
-  geist@1.7.0(next@16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  geist@1.7.0(next@16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
-      next: 16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   generator-function@2.0.1: {}
 
@@ -15739,7 +15739,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  langchain@0.1.37(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(playwright@1.58.2)(ws@8.19.0):
+  langchain@0.1.37(axios@1.13.6)(ignore@5.3.2)(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(playwright@1.61.1)(ws@8.19.0):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1
       '@langchain/community': 0.0.57(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)
@@ -15762,7 +15762,7 @@ snapshots:
     optionalDependencies:
       axios: 1.13.6
       ignore: 5.3.2
-      playwright: 1.58.2
+      playwright: 1.61.1
       ws: 8.19.0
     transitivePeerDependencies:
       - '@aws-crypto/sha256-js'
@@ -16730,7 +16730,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.2
       '@swc/helpers': 0.5.15
@@ -16750,7 +16750,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.1.2
       '@next/swc-win32-x64-msvc': 16.1.2
       '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.58.2
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -17168,11 +17168,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.58.2:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/tests/utils/iframe.test.ts
+++ b/tests/utils/iframe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { patchHtmlForIframe } from '@/components/scene-renderers/interactive-renderer';
+
+describe('patchHtmlForIframe', () => {
+  it('injects error capture, storage shims, and layout patch into head', () => {
+    const html = '<html><head><title>Widget</title></head><body><div>Hello</div></body></html>';
+
+    const patched = patchHtmlForIframe(html);
+
+    expect(patched).toContain('data-iframe-error-shim');
+    expect(patched).toContain('data-iframe-storage-shim');
+    expect(patched).toContain('data-iframe-patch');
+    expect(patched).toContain('overflow-wrap: anywhere !important;');
+    expect(patched).toContain('width: min(100%, 1120px) !important;');
+    expect(patched).toContain(
+      'grid-template-columns: minmax(220px, 320px) minmax(0, 1fr) !important;',
+    );
+    expect(patched).toContain('max-width: min(100%, 180px) !important;');
+    expect(patched.indexOf('data-iframe-error-shim')).toBeLessThan(
+      patched.indexOf('<title>Widget</title>'),
+    );
+  });
+
+  it('prepends the injection when no head tag exists', () => {
+    const html = '<div>bare widget</div>';
+
+    const patched = patchHtmlForIframe(html);
+
+    expect(patched.startsWith('\n<script data-iframe-error-shim>')).toBe(true);
+    expect(patched).toContain(html);
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade @playwright/test from 1.58.x to 1.61.1 and streamline the e2e storage setup around Playwright's newer storage APIs
- reshape the home surface to match the Figma all-projects admin dashboard, while keeping the real OpenMAIC composer and classroom navigation live
- swap demo project cards for real classroom data and add quick actions for student enroll, upload content, export data, and one-on-one resume flows

## Verification
- pnpm.cmd exec tsc --noEmit
- pnpm.cmd exec playwright test e2e/tests/home-to-generation.spec.ts --project=chromium
- pnpm.cmd exec playwright test e2e/tests/classroom-interaction.spec.ts --project=chromium
- pnpm.cmd exec playwright test e2e/tests/interactive-simulation-layout.spec.ts --project=chromium
- pnpm.cmd exec playwright test e2e/tests/generation-flow.spec.ts --project=chromium

## Notes
- the dashboard quick actions are wired to existing live flows in this app today, rather than placeholder admin routes
- the home screen now follows the selected Figma all-projects frame and uses real classroom records in place of the kit's sample cards