### PR TITLE
fix(lecture-notes): render interactive-webpage widget actions in notes area

### DIFF
--- a/components/chat/chat-area.tsx
+++ b/components/chat/chat-area.tsx
@@ -141,7 +141,11 @@ export const ChatArea = forwardRef<ChatAreaRef, ChatAreaProps>(
                   a.type === 'spotlight' ||
                   a.type === 'laser' ||
                   a.type === 'play_video' ||
-                  a.type === 'discussion',
+                  a.type === 'discussion' ||
+                  a.type === 'widget_highlight' ||
+                  a.type === 'widget_setState' ||
+                  a.type === 'widget_annotation' ||
+                  a.type === 'widget_reveal',
               )
               .map((a) => {
                 if (a.type === 'speech') {

--- a/components/chat/lecture-notes-view.tsx
+++ b/components/chat/lecture-notes-view.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { BookOpen, MessageSquare, Flashlight, MousePointer2, Play } from 'lucide-react';
+import {
+  BookOpen,
+  MessageSquare,
+  Flashlight,
+  MousePointer2,
+  Play,
+  Highlighter,
+  SlidersHorizontal,
+  StickyNote,
+  Eye,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import type { LectureNoteEntry } from '@/lib/types/chat';
@@ -21,6 +31,26 @@ const ACTION_ICON_ONLY: Record<string, { Icon: typeof Flashlight; style: string 
     Icon: Play,
     style:
       'bg-yellow-50 dark:bg-yellow-500/15 border-yellow-300/40 dark:border-yellow-500/30 text-yellow-700 dark:text-yellow-300',
+  },
+  widget_highlight: {
+    Icon: Highlighter,
+    style:
+      'bg-amber-50 dark:bg-amber-500/15 border-amber-300/40 dark:border-amber-500/30 text-amber-700 dark:text-amber-300',
+  },
+  widget_setState: {
+    Icon: SlidersHorizontal,
+    style:
+      'bg-indigo-50 dark:bg-indigo-500/15 border-indigo-300/40 dark:border-indigo-500/30 text-indigo-700 dark:text-indigo-300',
+  },
+  widget_annotation: {
+    Icon: StickyNote,
+    style:
+      'bg-sky-50 dark:bg-sky-500/15 border-sky-300/40 dark:border-sky-500/30 text-sky-700 dark:text-sky-300',
+  },
+  widget_reveal: {
+    Icon: Eye,
+    style:
+      'bg-emerald-50 dark:bg-emerald-500/15 border-emerald-300/40 dark:border-emerald-500/30 text-emerald-700 dark:text-emerald-300',
   },
 };
 


### PR DESCRIPTION
## Problem
During lecture playback, interactive-webpage scenes (`SceneType === 'interactive'`) emit four `widget_*` action types (`widget_highlight`, `widget_setState`, `widget_annotation`, `widget_reveal`), each typically followed by a `speech` action. These execute correctly on stage (the iframe shows the effect), but none of them appeared in the Lecture Notes timeline.

## Root cause
Two compounding gaps in the notes display path:

1. `components/chat/chat-area.tsx` built `lectureNotes` with an allowlist that only admitted `speech / spotlight / laser / play_video / discussion` — all four `widget_*` types were filtered out before ever reaching the notes data.
2. `components/chat/lecture-notes-view.tsx` `ACTION_ICON_ONLY` had no entry for `widget_*`, and unknown types render as `null`, so even with data they'd be invisible.

## Fix
- Add the four `widget_*` types to the `lectureNotes` allowlist.
- Extend `ACTION_ICON_ONLY` with icon/style entries (`Highlighter` / `SlidersHorizontal` / `StickyNote` / `Eye`), reusing the existing inline icon-only badge pattern already used by `spotlight` / `laser` / `play_video`.

Each `widget_*` action is already followed by a `speech` narration action (see `convertTeacherActionsToActions`), so the existing `pendingInline` → next-speech grouping renders them as "badge + text" rows, consistent with the rest of the notes.