### PR TITLE
fix(packages): add openmaic repository metadata

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,6 +7,8 @@ name: Publish @openmaic packages
 # a recursive publish must never touch them.
 #
 # Triggers:
+#   - merge a change to one of the @openmaic/* package manifests on `main`
+#     (real publish). This is the normal path for version-bump releases.
 #   - push a tag like `@openmaic/dsl@0.1.0` (real publish). NOTE: any @openmaic/*
 #     tag runs `pnpm -r publish` over all three packages — pnpm skips versions
 #     already on the registry, so in steady state this is idempotent. The tag is a
@@ -22,8 +24,13 @@ name: Publish @openmaic packages
 
 on:
   push:
+    branches: [main]
     tags:
       - "@openmaic/*@*"
+    paths:
+      - "packages/@openmaic/dsl/package.json"
+      - "packages/@openmaic/renderer/package.json"
+      - "packages/@openmaic/importer/package.json"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -35,6 +35,11 @@
     "contract"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/THU-MAIC/OpenMAIC",
+    "directory": "packages/@openmaic/dsl"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"

--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -36,6 +36,11 @@
     "json"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/THU-MAIC/OpenMAIC",
+    "directory": "packages/@openmaic/importer"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -50,6 +50,11 @@
     "react"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/THU-MAIC/OpenMAIC",
+    "directory": "packages/@openmaic/renderer"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"


### PR DESCRIPTION
## Summary
- Add repository metadata to @openmaic/dsl
- Add repository metadata to @openmaic/renderer
- Add repository metadata to @openmaic/importer

## Context
npm provenance publishing failed because package.json repository.url was empty while the GitHub Actions provenance repository was https://github.com/THU-MAIC/OpenMAIC.

## Verification
- Not run per request