### PR TITLE
fix(editor): keep emptied/zero-action scenes playable, bind outline by stable id, surface meaningless content

### DIFF
--- a/components/edit/ActionsBar/ActionsBar.tsx
+++ b/components/edit/ActionsBar/ActionsBar.tsx
@@ -79,6 +79,16 @@ import {
 } from '@/lib/audio/regenerate-speech-tts';
 
 const EMPTY: Action[] = [];
+
+/**
+ * Soft "needs attention" treatment for a timeline clip whose content is still
+ * incomplete (blank narration, a cue bound to nothing, a discussion with no
+ * topic): a warm amber dashed border + a faint tint. Calm and non-blocking —
+ * lint-style. Alarm red is reserved for the one hard block (outline → generate),
+ * not these inline draft hints.
+ */
+const INCOMPLETE_BOX = 'border-dashed border-amber-400/70 bg-amber-50/50 dark:bg-amber-500/5';
+
 const MIN_H = 168;
 const MAX_H = 520;
 const DEFAULT_H = 224;
@@ -398,6 +408,8 @@ function SpeechClip({
   onFocused: () => void;
 }) {
   const { t } = useI18n();
+  // A narration line with no text is meaningless — flag it inline (lint-style).
+  const needsText = !text.trim();
   const ref = useRef<HTMLTextAreaElement>(null);
   const [val, setVal] = useState(text);
   // Has the user typed since the last external sync? If not, external text
@@ -428,7 +440,12 @@ function SpeechClip({
   const SpeechIcon = cueMeta('speech').icon;
 
   return (
-    <div className="group/clip relative flex h-full w-[228px] shrink-0 flex-col overflow-hidden rounded-xl border border-gray-200/80 bg-white/70 shadow-sm transition-colors focus-within:border-violet-400 hover:border-violet-300/70 dark:border-gray-700/60 dark:bg-slate-800/50 dark:hover:border-violet-500/40">
+    <div
+      className={cn(
+        'group/clip relative flex h-full w-[228px] shrink-0 flex-col overflow-hidden rounded-xl border border-gray-200/80 bg-white/70 shadow-sm transition-colors focus-within:border-violet-400 hover:border-violet-300/70 dark:border-gray-700/60 dark:bg-slate-800/50 dark:hover:border-violet-500/40',
+        needsText && INCOMPLETE_BOX,
+      )}
+    >
       <span className="absolute inset-x-0 top-0 h-[3px] bg-primary/30 transition-colors group-hover/clip:bg-primary/60" />
       <div className="flex items-center gap-1.5 border-b border-gray-100 bg-gray-50/70 px-2 py-1 dark:border-gray-700/50 dark:bg-slate-900/40">
         <span
@@ -532,10 +549,12 @@ function DiscussionClip({
       className={cn(
         'group/disc relative flex h-full w-[228px] shrink-0 flex-col overflow-hidden rounded-xl border bg-white/70 shadow-sm transition-colors dark:bg-slate-800/50',
         needsTopic
-          ? 'border-dashed border-amber-400/70'
+          ? INCOMPLETE_BOX
           : 'border-gray-200/80 focus-within:border-yellow-400 hover:border-yellow-300/70 dark:border-gray-700/60 dark:hover:border-yellow-500/40',
       )}
     >
+      {/* The empty state reads from the amber dashed box + the "topic (required)"
+          placeholder; the discussion's own Flag glyph stays its identity. */}
       <span className={cn('absolute inset-x-0 top-0 h-[3px]', m.accent)} />
       <div className="flex items-center gap-1.5 border-b border-yellow-300/50 bg-yellow-400/15 px-2 py-1 dark:border-yellow-500/25 dark:bg-yellow-500/10">
         <span className="flex size-4 items-center justify-center rounded-md bg-yellow-400 text-yellow-950 dark:bg-yellow-500 dark:text-slate-900">
@@ -680,9 +699,7 @@ function CueMarker({
         bound
           ? 'cursor-pointer hover:border-violet-300/70 dark:hover:border-violet-500/40'
           : 'cursor-grab active:cursor-grabbing',
-        needsTarget
-          ? 'border-dashed border-amber-400/70'
-          : 'border-gray-200/80 dark:border-gray-700/60',
+        needsTarget ? INCOMPLETE_BOX : 'border-gray-200/80 dark:border-gray-700/60',
       )}
       aria-label={label}
     >

--- a/components/edit/ActionsBar/ActionsBar.tsx
+++ b/components/edit/ActionsBar/ActionsBar.tsx
@@ -81,15 +81,6 @@ import {
 const EMPTY: Action[] = [];
 
 /**
- * Soft "needs attention" treatment for a timeline clip whose content is still
- * incomplete (blank narration, a cue bound to nothing, a discussion with no
- * topic): a warm amber dashed border + a faint tint. Calm and non-blocking —
- * lint-style. Alarm red is reserved for the one hard block (outline → generate),
- * not these inline draft hints.
- */
-const INCOMPLETE_BOX = 'border-dashed border-amber-400/70 bg-amber-50/50 dark:bg-amber-500/5';
-
-/**
  * Clear the canvas spotlight/laser preview when a cue glyph unmounts while it is
  * being hovered — most importantly when the user deletes the cue. React does not
  * fire `onMouseLeave` on unmount, so without this the previewed effect would stay
@@ -98,6 +89,15 @@ const INCOMPLETE_BOX = 'border-dashed border-amber-400/70 bg-amber-50/50 dark:bg
 function useClearCuePreviewOnUnmount() {
   useEffect(() => () => clearCuePreview(), []);
 }
+
+/**
+ * Soft amber dashed border marking a still-incomplete clip card — an empty
+ * narration line, a cue bound to no element, a discussion with no topic. A clip
+ * is a card, so a dashed frame reads as "draft / unfinished" better than a dot;
+ * the calmer amber stays clear of the blue interactive controls and is dropped
+ * the moment the clip is filled.
+ */
+const INCOMPLETE_CLIP = 'border-dashed border-amber-400/70';
 
 const MIN_H = 168;
 const MAX_H = 520;
@@ -418,8 +418,6 @@ function SpeechClip({
   onFocused: () => void;
 }) {
   const { t } = useI18n();
-  // A narration line with no text is meaningless — flag it inline (lint-style).
-  const needsText = !text.trim();
   const ref = useRef<HTMLTextAreaElement>(null);
   const [val, setVal] = useState(text);
   // Has the user typed since the last external sync? If not, external text
@@ -448,12 +446,13 @@ function SpeechClip({
   };
 
   const SpeechIcon = cueMeta('speech').icon;
+  const needsText = !text.trim();
 
   return (
     <div
       className={cn(
         'group/clip relative flex h-full w-[228px] shrink-0 flex-col overflow-hidden rounded-xl border border-gray-200/80 bg-white/70 shadow-sm transition-colors focus-within:border-violet-400 hover:border-violet-300/70 dark:border-gray-700/60 dark:bg-slate-800/50 dark:hover:border-violet-500/40',
-        needsText && INCOMPLETE_BOX,
+        needsText && INCOMPLETE_CLIP,
       )}
     >
       <span className="absolute inset-x-0 top-0 h-[3px] bg-primary/30 transition-colors group-hover/clip:bg-primary/60" />
@@ -538,7 +537,6 @@ function DiscussionClip({
   const { t } = useI18n();
   const m = cueMeta('discussion');
   const needsTopic = !topic.trim();
-
   // Local drafts committed on blur; synced from props when not mid-edit so a
   // concurrent store update can't clobber an in-flight edit (mirrors SpeechClip).
   const [topicVal, setTopicVal] = useState(topic);
@@ -557,14 +555,12 @@ function DiscussionClip({
   return (
     <div
       className={cn(
-        'group/disc relative flex h-full w-[228px] shrink-0 flex-col overflow-hidden rounded-xl border bg-white/70 shadow-sm transition-colors dark:bg-slate-800/50',
-        needsTopic
-          ? INCOMPLETE_BOX
-          : 'border-gray-200/80 focus-within:border-yellow-400 hover:border-yellow-300/70 dark:border-gray-700/60 dark:hover:border-yellow-500/40',
+        'group/disc relative flex h-full w-[228px] shrink-0 flex-col overflow-hidden rounded-xl border border-gray-200/80 bg-white/70 shadow-sm transition-colors focus-within:border-yellow-400 hover:border-yellow-300/70 dark:border-gray-700/60 dark:bg-slate-800/50 dark:hover:border-yellow-500/40',
+        needsTopic && INCOMPLETE_CLIP,
       )}
     >
-      {/* The empty state reads from the amber dashed box + the "topic (required)"
-          placeholder; the discussion's own Flag glyph stays its identity. */}
+      {/* The empty state reads from the amber dashed frame + the "topic
+          (required)" placeholder; the discussion keeps its Flag glyph identity. */}
       <span className={cn('absolute inset-x-0 top-0 h-[3px]', m.accent)} />
       <div className="flex items-center gap-1.5 border-b border-yellow-300/50 bg-yellow-400/15 px-2 py-1 dark:border-yellow-500/25 dark:bg-yellow-500/10">
         <span className="flex size-4 items-center justify-center rounded-md bg-yellow-400 text-yellow-950 dark:bg-yellow-500 dark:text-slate-900">
@@ -706,11 +702,11 @@ function CueMarker({
         if (bound) onPick();
       }}
       className={cn(
-        'group/cue relative flex h-full w-[108px] shrink-0 flex-col overflow-hidden rounded-xl border bg-white/65 shadow-sm transition-colors dark:bg-slate-800/40',
+        'group/cue relative flex h-full w-[108px] shrink-0 flex-col overflow-hidden rounded-xl border border-gray-200/80 bg-white/65 shadow-sm transition-colors dark:border-gray-700/60 dark:bg-slate-800/40',
         bound
           ? 'cursor-pointer hover:border-violet-300/70 dark:hover:border-violet-500/40'
           : 'cursor-grab active:cursor-grabbing',
-        needsTarget ? INCOMPLETE_BOX : 'border-gray-200/80 dark:border-gray-700/60',
+        needsTarget && INCOMPLETE_CLIP,
       )}
       aria-label={label}
     >

--- a/components/edit/ActionsBar/ActionsBar.tsx
+++ b/components/edit/ActionsBar/ActionsBar.tsx
@@ -89,6 +89,16 @@ const EMPTY: Action[] = [];
  */
 const INCOMPLETE_BOX = 'border-dashed border-amber-400/70 bg-amber-50/50 dark:bg-amber-500/5';
 
+/**
+ * Clear the canvas spotlight/laser preview when a cue glyph unmounts while it is
+ * being hovered — most importantly when the user deletes the cue. React does not
+ * fire `onMouseLeave` on unmount, so without this the previewed effect would stay
+ * stuck on the slide after its cue is gone.
+ */
+function useClearCuePreviewOnUnmount() {
+  useEffect(() => () => clearCuePreview(), []);
+}
+
 const MIN_H = 168;
 const MAX_H = 520;
 const DEFAULT_H = 224;
@@ -671,6 +681,7 @@ function CueMarker({
   onDragEnd: () => void;
 }) {
   const { t } = useI18n();
+  useClearCuePreviewOnUnmount();
   const m = cueMeta(action.type);
   const label = cueLabel(action.type, t);
   const Icon = m.icon;
@@ -764,6 +775,7 @@ function NodeDot({
   canDrag?: boolean;
 }) {
   const { t } = useI18n();
+  useClearCuePreviewOnUnmount();
   const isSpeech = action.type === 'speech';
   // A discussion is the scene's terminal anchor — give its node a distinct
   // marker (square, filled yellow) so it reads as the end stop, not a regular

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -428,7 +428,17 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       // Reset all roundtable/live state so scenes are fully isolated
       resetSceneState();
 
-      if (!currentScene || !currentScene.actions || currentScene.actions.length === 0) {
+      // A slide scene with no actions is still playable: the engine dwells on it
+      // (see resolvePlaybackCursor) so a freshly inserted / emptied blank slide
+      // shows for a beat and auto-play advances past it. Non-slide scenes
+      // (quiz / interactive / pbl) without timeline actions get no lecture engine
+      // as before. Don't touch `autoStartRef` here: in the PENDING_SCENE_ID
+      // handoff `currentScene` is null while a pending auto-start legitimately
+      // waits for the next generated scene to materialize.
+      const hasPlayableActions =
+        !!currentScene?.actions &&
+        (currentScene.actions.length > 0 || currentScene.type === 'slide');
+      if (!currentScene || !hasPlayableActions) {
         engineRef.current = null;
         setEngineMode('idle');
 

--- a/components/edit/SlideNavRail/ThumbItem.tsx
+++ b/components/edit/SlideNavRail/ThumbItem.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { SceneThumbnailContent } from '@/components/stage/scene-thumbnail-content';
 import { SCENE_CREATION_ENABLED } from '@/lib/edit/scene-creation-enabled';
+import { sceneHasIssues } from '@/lib/edit/content-validation';
 import type { Scene } from '@/lib/types/stage';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useStageStore } from '@/lib/store/stage';
@@ -125,6 +126,16 @@ function ThumbItemComponent({
             : 'hover:bg-zinc-50/80 dark:hover:bg-zinc-800/50',
         )}
       >
+        {/* Page-level "incomplete content" dot — surfaces a scene with any
+            content issue (blank narration / no actions / unbound cue …) so the
+            user can spot it in the rail without opening every page. */}
+        {sceneHasIssues(scene) && (
+          <span
+            title={t('edit.nav.sceneIncomplete')}
+            aria-label={t('edit.nav.sceneIncomplete')}
+            className="absolute right-1 top-1 z-10 size-2 rounded-full bg-amber-400 shadow-sm ring-2 ring-white dark:ring-slate-900"
+          />
+        )}
         {/* Scene header — index badge + title. Title doubles as the
             inline rename surface when `renaming` is true. */}
         <div className="flex items-center justify-between gap-1 px-2 pt-0.5">

--- a/components/generation/outlines-editor.tsx
+++ b/components/generation/outlines-editor.tsx
@@ -3,7 +3,6 @@
 import { Fragment, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
-  AlertTriangle,
   Check,
   ChevronDown,
   GripVertical,
@@ -129,9 +128,12 @@ export function OutlinesEditor({
   const lastOutlineId = outlines.length > 0 ? outlines[outlines.length - 1].id : null;
 
   // Generation gate: an outline with a blank title is meaningless to generate,
-  // so block "Confirm & generate" until every section has a title. The reason
-  // chip below the button jumps to the first offending section.
+  // so block "Confirm & generate" until every section has a title. A neutral
+  // "N / M ready" counter by the button explains the gate and jumps to the
+  // first offending section.
   const blockingCount = countBlockingOutlines(outlines);
+  const totalCount = outlines.length;
+  const readyCount = totalCount - blockingCount;
   const firstBlockingId =
     blockingCount > 0 ? outlines.find((o) => validateOutline(o).length > 0)?.id : undefined;
   const scrollToFirstBlocking = () => {
@@ -384,10 +386,16 @@ export function OutlinesEditor({
             <button
               type="button"
               onClick={scrollToFirstBlocking}
-              className="inline-flex items-center gap-1 text-xs font-medium text-rose-600 transition-colors hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
+              title={t('generation.jumpToBlankTitle')}
+              className="inline-flex items-center gap-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
-              <AlertTriangle className="size-3.5" />
-              {t('generation.blockedByBlankTitles', { count: blockingCount })}
+              <span className="block h-1 w-[84px] overflow-hidden rounded-full bg-muted">
+                <span
+                  className="block h-full rounded-full bg-muted-foreground/45 transition-[width]"
+                  style={{ width: `${totalCount > 0 ? (readyCount / totalCount) * 100 : 0}%` }}
+                />
+              </span>
+              {t('generation.outlinesReadyCount', { ready: readyCount, total: totalCount })}
             </button>
           )}
           <Button
@@ -590,6 +598,11 @@ function SceneRow({
         <div className="min-w-0 flex-1 space-y-1.5">
           {/* Title row */}
           <div className="flex items-start justify-between gap-2">
+            {!disabled && !outline.title.trim() && (
+              // Incomplete marker — a soft amber dot before a blank title. A
+              // blank title blocks generation; the gate below counts how many.
+              <span aria-hidden className="mt-[11px] h-2 w-2 shrink-0 rounded-full bg-amber-400" />
+            )}
             <textarea
               ref={titleRef}
               value={outline.title}
@@ -603,10 +616,6 @@ function SceneRow({
                 'placeholder:font-normal placeholder:text-muted-foreground/40',
                 'focus:outline-none focus:ring-0 md:text-lg',
                 disabled && 'cursor-default',
-                // A blank title is incomplete — flag it softly with an amber
-                // placeholder (no box: the title stays borderless). The hard
-                // red signal is the disabled generate button + its reason chip.
-                !disabled && !outline.title.trim() && 'placeholder:text-amber-500/80',
               )}
             />
             <div className="flex shrink-0 items-center gap-1.5 pt-0.5">

--- a/components/generation/outlines-editor.tsx
+++ b/components/generation/outlines-editor.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
+  AlertTriangle,
   Check,
   ChevronDown,
   GripVertical,
@@ -29,6 +30,7 @@ import { cn } from '@/lib/utils';
 import type { SceneOutline } from '@/lib/types/generation';
 import type { WidgetType } from '@/lib/types/widgets';
 import { changeOutlineType } from '@/lib/generation/outline-type';
+import { countBlockingOutlines, validateOutline } from '@/lib/edit/content-validation';
 
 type SceneType = SceneOutline['type'];
 
@@ -125,6 +127,18 @@ export function OutlinesEditor({
   const lastScrollTargetRef = useRef<string | null>(null);
   const editingDisabled = isLoading || isStreaming;
   const lastOutlineId = outlines.length > 0 ? outlines[outlines.length - 1].id : null;
+
+  // Generation gate: an outline with a blank title is meaningless to generate,
+  // so block "Confirm & generate" until every section has a title. The reason
+  // chip below the button jumps to the first offending section.
+  const blockingCount = countBlockingOutlines(outlines);
+  const firstBlockingId =
+    blockingCount > 0 ? outlines.find((o) => validateOutline(o).length > 0)?.id : undefined;
+  const scrollToFirstBlocking = () => {
+    if (!firstBlockingId) return;
+    const node = document.getElementById(`outline-scene-${firstBlockingId}`);
+    node?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
 
   // Auto-scroll to the latest streamed scene so streaming feels alive.
   useEffect(() => {
@@ -366,9 +380,19 @@ export function OutlinesEditor({
           >
             {t('generation.backToRequirements')}
           </Button>
+          {!editingDisabled && blockingCount > 0 && (
+            <button
+              type="button"
+              onClick={scrollToFirstBlocking}
+              className="inline-flex items-center gap-1 text-xs font-medium text-rose-600 transition-colors hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
+            >
+              <AlertTriangle className="size-3.5" />
+              {t('generation.blockedByBlankTitles', { count: blockingCount })}
+            </button>
+          )}
           <Button
             onClick={onConfirm}
-            disabled={isLoading || isStreaming || outlines.length === 0}
+            disabled={isLoading || isStreaming || outlines.length === 0 || blockingCount > 0}
             className="rounded-full px-6 shadow-lg shadow-blue-500/20"
           >
             {isLoading ? (
@@ -579,6 +603,10 @@ function SceneRow({
                 'placeholder:font-normal placeholder:text-muted-foreground/40',
                 'focus:outline-none focus:ring-0 md:text-lg',
                 disabled && 'cursor-default',
+                // A blank title is incomplete — flag it softly with an amber
+                // placeholder (no box: the title stays borderless). The hard
+                // red signal is the disabled generate button + its reason chip.
+                !disabled && !outline.title.trim() && 'placeholder:text-amber-500/80',
               )}
             />
             <div className="flex shrink-0 items-center gap-1.5 pt-0.5">

--- a/lib/agent/client/resolve-scene-outline.ts
+++ b/lib/agent/client/resolve-scene-outline.ts
@@ -1,0 +1,30 @@
+import type { SceneOutline } from '@/lib/types/generation';
+import type { Scene } from '@/lib/types/stage';
+
+/**
+ * Resolve a scene's generation outline by stable identity (`outlineId`) rather
+ * than by the mutable `order`.
+ *
+ * Pro-mode insert / reorder / delete rebalances `scene.order` while the
+ * persisted `outlines` array keeps the original generation plan, so matching an
+ * outline by `order` attaches **another slide's** outline (wrong title / type /
+ * key points) to the scene being edited once the deck has been reordered.
+ * Matching by the stamped `outlineId` is reorder-stable.
+ *
+ * Scenes built before `outlineId` existed, or freshly inserted scenes that have
+ * no originating outline, fall back to an outline derived from the scene itself
+ * — never another slide's outline.
+ */
+export function resolveSceneOutline(scene: Scene, outlines: SceneOutline[]): SceneOutline {
+  const matched = scene.outlineId ? outlines.find((o) => o.id === scene.outlineId) : undefined;
+  return (
+    matched ?? {
+      id: scene.id,
+      type: scene.type,
+      title: scene.title,
+      description: '',
+      keyPoints: [],
+      order: scene.order,
+    }
+  );
+}

--- a/lib/agent/client/use-agent-runtime.ts
+++ b/lib/agent/client/use-agent-runtime.ts
@@ -26,6 +26,7 @@ import { useStageStore } from '@/lib/store/stage';
 import { getCurrentModelConfig } from '@/lib/utils/model-config';
 import type { SceneContextMap } from '@/app/api/agent/edit/route';
 import { mergeAssistantParts, type PiPart } from './merge-assistant-parts';
+import { resolveSceneOutline } from './resolve-scene-outline';
 import { planRegenerateApply, type RegenerateDetails } from './apply-regenerate';
 import { applyScenePatchInSync } from './apply-slide-content';
 import { useRegenSnapshots } from './regen-snapshots';
@@ -488,29 +489,19 @@ export function useAgentRuntime(opts: UseAgentRuntimeOptions) {
         // into the tool deps so the model never fabricates outline/content.
         const storeState = useStageStore.getState();
         const { scenes, outlines, stage } = storeState;
+        // The full outline list in CURRENT scene order — each scene resolved by
+        // its stable `outlineId` (reorder/insert/delete rebalances `order`, and
+        // inserted/duplicated scenes have no persisted outline). The persisted
+        // `outlines` array is the original generation plan, so handing it over
+        // raw would give regenerate-scene/-actions a stale page index / order /
+        // title list. See resolveSceneOutline.
+        const allOutlines = scenes.map((s) => resolveSceneOutline(s, outlines));
         const sceneContextMap: SceneContextMap = {};
         for (const scene of scenes) {
-          const outline = outlines.find((o) => o.order === scene.order) ?? {
-            id: scene.id,
-            type: scene.type,
-            title: scene.title,
-            description: '',
-            keyPoints: [],
-            order: scene.order,
-          };
+          const outline = resolveSceneOutline(scene, outlines);
           sceneContextMap[scene.id] = {
             outline,
-            allOutlines:
-              outlines.length > 0
-                ? outlines
-                : scenes.map((s) => ({
-                    id: s.id,
-                    type: s.type,
-                    title: s.title,
-                    description: '',
-                    keyPoints: [],
-                    order: s.order,
-                  })),
+            allOutlines,
             content: scene.content,
             stageId: scene.stageId,
             languageDirective: stage?.languageDirective,

--- a/lib/api/stage-api-scene.ts
+++ b/lib/api/stage-api-scene.ts
@@ -64,6 +64,7 @@ export function createSceneAPI(store: StageStore) {
           order,
           content,
           actions: params.actions,
+          ...(params.outlineId !== undefined && { outlineId: params.outlineId }),
           createdAt: Date.now(),
           updatedAt: Date.now(),
         };

--- a/lib/api/stage-api-types.ts
+++ b/lib/api/stage-api-types.ts
@@ -28,6 +28,8 @@ export interface CreateSceneParams {
   content?: Partial<SceneContent>;
   order?: number;
   actions?: Action[];
+  /** Stable id of the generation outline this scene was built from (see {@link Scene.outlineId}). */
+  outlineId?: string;
 }
 
 /**

--- a/lib/edit/content-validation.ts
+++ b/lib/edit/content-validation.ts
@@ -1,0 +1,74 @@
+import type { Action } from '@/lib/types/action';
+import type { Scene } from '@/lib/types/stage';
+import type { SceneOutline } from '@/lib/types/generation';
+import { ELEMENT_BOUND } from '@/components/edit/ActionsBar/cue-meta';
+
+/**
+ * Pure content-validity checks for the editor. These surface *meaningless* edit
+ * states — an empty speech line, a cue pointing at nothing, a scene with no
+ * actions, a titleless outline — so the UI can mark them (scenes, lint-style)
+ * or gate a forward step (outline → generate). No UI or store dependencies.
+ *
+ * Empties are tolerated while editing; this module only *describes* them. Whom
+ * to block and where is the caller's policy.
+ */
+
+/** A meaningless state tied to a specific action in a scene's timeline. */
+export type ActionIssue =
+  | { kind: 'emptySpeech'; actionId: string }
+  | { kind: 'unboundCue'; actionId: string }
+  | { kind: 'emptyDiscussion'; actionId: string };
+
+/** A meaningless state found on a single scene (action-level issues + empty list). */
+export type SceneIssue = { kind: 'emptyActions' } | ActionIssue;
+
+/** A meaningless state found on a single outline. */
+export type OutlineIssue = { kind: 'emptyTitle' };
+
+const isBlank = (s: string | undefined): boolean => !s || s.trim() === '';
+
+/**
+ * Per-action content issues, in timeline order: a blank speech line, a cue that
+ * points at no element, a discussion with no topic. Drives the inline marks on
+ * the ActionsBar clips.
+ */
+export function validateActions(actions: Action[]): ActionIssue[] {
+  const issues: ActionIssue[] = [];
+  for (const a of actions) {
+    if (a.type === 'speech' && isBlank((a as { text?: string }).text)) {
+      issues.push({ kind: 'emptySpeech', actionId: a.id });
+    } else if (ELEMENT_BOUND.has(a.type) && isBlank((a as { elementId?: string }).elementId)) {
+      issues.push({ kind: 'unboundCue', actionId: a.id });
+    } else if (a.type === 'discussion' && isBlank((a as { topic?: string }).topic)) {
+      issues.push({ kind: 'emptyDiscussion', actionId: a.id });
+    }
+  }
+  return issues;
+}
+
+/** All content-validity issues on a scene, in action order (empty list first). */
+export function validateScene(scene: Scene): SceneIssue[] {
+  const actions = (scene.actions ?? []) as Action[];
+  if (actions.length === 0) return [{ kind: 'emptyActions' }];
+  return validateActions(actions);
+}
+
+/** Whether a scene has any content-validity issue. */
+export function sceneHasIssues(scene: Scene): boolean {
+  return validateScene(scene).length > 0;
+}
+
+/** Content-validity issues on an outline (blank title is the only blocking one). */
+export function validateOutline(outline: SceneOutline): OutlineIssue[] {
+  return isBlank(outline.title) ? [{ kind: 'emptyTitle' }] : [];
+}
+
+/** Whether any outline carries a blocking issue (used to gate generation). */
+export function outlinesHaveBlockingIssues(outlines: SceneOutline[]): boolean {
+  return outlines.some((o) => validateOutline(o).length > 0);
+}
+
+/** Count of outlines with a blocking issue (drives the gate's reason text). */
+export function countBlockingOutlines(outlines: SceneOutline[]): number {
+  return outlines.reduce((n, o) => n + (validateOutline(o).length > 0 ? 1 : 0), 0);
+}

--- a/lib/edit/scene-creation-enabled.ts
+++ b/lib/edit/scene-creation-enabled.ts
@@ -4,8 +4,9 @@
  *
  * Enabled now that the editor can author a scene's playback `actions`:
  * duplicated slides carry the source's actions (playable as-is), and a blank
- * inserted slide is seeded with one empty speech clip (createBlankSlideScene)
- * so it stays playable — the user fills in the narration via the script
- * timeline / MAIC Agent. Reorder / delete / rename were always playback-safe.
+ * inserted slide starts with no actions (createBlankSlideScene) — the engine
+ * dwells on it so it stays playable while the user fills in the narration via
+ * the script timeline / MAIC Agent. Reorder / delete / rename were always
+ * playback-safe.
  */
 export const SCENE_CREATION_ENABLED = true;

--- a/lib/edit/slide-defaults.ts
+++ b/lib/edit/slide-defaults.ts
@@ -111,6 +111,11 @@ export function duplicateSlideScene(source: Scene, copySuffix: string, order: nu
   return {
     ...source,
     id: nanoid(),
+    // A duplicate is NOT generated from the source's outline, so it must not
+    // inherit `outlineId` — otherwise the editor agent would resolve the copy's
+    // context to the original slide's outline. Cleared so resolveSceneOutline
+    // falls back to the copy's own title / content.
+    outlineId: undefined,
     title,
     order,
     content,

--- a/lib/edit/slide-defaults.ts
+++ b/lib/edit/slide-defaults.ts
@@ -19,11 +19,11 @@ const DEFAULT_THEME: SlideTheme = {
  * Matches the SceneBuilder default theme so user-added slides look the
  * same as AI-generated ones until customized.
  *
- * Seeded with a single empty speech action so the slide is playable from the
- * moment it's inserted: the playback engine skips a scene with *zero* actions,
- * which would make a freshly inserted slide silently vanish on play. The empty
- * clip also surfaces as the first editable line in the script timeline — an
- * obvious "fill me in" cue for the user / MAIC Agent.
+ * Starts with NO actions: the playback engine dwells on a zero-action scene
+ * (showing the slide for a short beat) rather than skipping it, so a fresh
+ * slide is playable without seeding a meaningless empty speech clip. The empty
+ * script timeline surfaces inline as a "fill me in" cue for the user / MAIC
+ * Agent instead.
  */
 export function createBlankSlideScene(stageId: string, title: string, order: number): Scene {
   const slide: Slide = {
@@ -41,7 +41,7 @@ export function createBlankSlideScene(stageId: string, title: string, order: num
     canvas: slide,
   };
 
-  const actions: Action[] = [{ id: nanoid(), type: 'speech', text: '' }];
+  const actions: Action[] = [];
 
   return {
     id: nanoid(),

--- a/lib/generation/scene-builder.ts
+++ b/lib/generation/scene-builder.ts
@@ -124,9 +124,27 @@ export async function buildSceneFromOutline(
 }
 
 /**
- * Build complete Scene object (without API/store)
+ * Build complete Scene object (without API/store).
+ *
+ * Stamps `outlineId` with the originating outline's id so editor agent tools
+ * can later resolve this scene's generation outline by identity rather than by
+ * the mutable `order` (which Pro-mode reorder/insert/delete rebalances).
  */
 export function buildCompleteScene(
+  outline: SceneOutline,
+  content:
+    | GeneratedSlideContent
+    | GeneratedQuizContent
+    | GeneratedInteractiveContent
+    | GeneratedPBLContent,
+  actions: Action[],
+  stageId: string,
+): Scene | null {
+  const scene = buildCompleteSceneInner(outline, content, actions, stageId);
+  return scene && { ...scene, outlineId: outline.id };
+}
+
+function buildCompleteSceneInner(
   outline: SceneOutline,
   content:
     | GeneratedSlideContent

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -1687,6 +1687,7 @@ export function createSceneWithActions(
         canvas: slide,
       },
       actions,
+      outlineId: outline.id,
     });
 
     return sceneResult.success ? (sceneResult.data ?? null) : null;
@@ -1702,6 +1703,7 @@ export function createSceneWithActions(
         questions: content.questions,
       },
       actions,
+      outlineId: outline.id,
     });
 
     return sceneResult.success ? (sceneResult.data ?? null) : null;
@@ -1721,6 +1723,7 @@ export function createSceneWithActions(
         widgetConfig: content.widgetConfig,
       },
       actions,
+      outlineId: outline.id,
     });
 
     return sceneResult.success ? (sceneResult.data ?? null) : null;
@@ -1737,6 +1740,7 @@ export function createSceneWithActions(
         ...(content.projectV2 ? { projectV2: content.projectV2 } : {}),
       },
       actions,
+      outlineId: outline.id,
     });
 
     return sceneResult.success ? (sceneResult.data ?? null) : null;

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -220,7 +220,8 @@
       "dragHandle": "اسحب لإعادة الترتيب",
       "deckLabel": "المشاهد",
       "moreActions": "إجراءات إضافية",
-      "rename": "إعادة تسمية"
+      "rename": "إعادة تسمية",
+      "sceneIncomplete": "محتوى هذه الصفحة غير مكتمل"
     },
     "zorder": {
       "toFront": "إحضار إلى الأمام",
@@ -915,7 +916,8 @@
     "generatingInProgress": "جارٍ التوليد...",
     "webSearching": "بحث في الإنترنت",
     "webSearchingDesc": "جارٍ البحث في الإنترنت عن معلومات محدّثة",
-    "webSearchFailed": "فشل البحث في الإنترنت"
+    "webSearchFailed": "فشل البحث في الإنترنت",
+    "blockedByBlankTitles": "{{count}} أقسام بحاجة إلى عنوان"
   },
   "settings": {
     "title": "الإعدادات",

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -917,7 +917,8 @@
     "webSearching": "بحث في الإنترنت",
     "webSearchingDesc": "جارٍ البحث في الإنترنت عن معلومات محدّثة",
     "webSearchFailed": "فشل البحث في الإنترنت",
-    "blockedByBlankTitles": "{{count}} أقسام بحاجة إلى عنوان"
+    "outlinesReadyCount": "{{ready}} / {{total}} أقسام جاهزة",
+    "jumpToBlankTitle": "الانتقال إلى قسم بحاجة إلى عنوان"
   },
   "settings": {
     "title": "الإعدادات",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -220,7 +220,8 @@
       "dragHandle": "Drag to reorder",
       "deckLabel": "Scenes",
       "moreActions": "More actions",
-      "rename": "Rename"
+      "rename": "Rename",
+      "sceneIncomplete": "This page has incomplete content"
     },
     "zorder": {
       "toFront": "Bring to front",
@@ -915,7 +916,8 @@
     "generatingInProgress": "Generating...",
     "webSearching": "Web Search",
     "webSearchingDesc": "Searching the web for up-to-date information",
-    "webSearchFailed": "Web search failed"
+    "webSearchFailed": "Web search failed",
+    "blockedByBlankTitles": "{{count}} sections still need a title"
   },
   "settings": {
     "title": "Settings",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -917,7 +917,8 @@
     "webSearching": "Web Search",
     "webSearchingDesc": "Searching the web for up-to-date information",
     "webSearchFailed": "Web search failed",
-    "blockedByBlankTitles": "{{count}} sections still need a title"
+    "outlinesReadyCount": "{{ready}} / {{total}} sections ready",
+    "jumpToBlankTitle": "Jump to a section that still needs a title"
   },
   "settings": {
     "title": "Settings",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -917,7 +917,8 @@
     "webSearching": "ウェブ検索",
     "webSearchingDesc": "ウェブで最新情報を検索しています",
     "webSearchFailed": "ウェブ検索に失敗しました",
-    "blockedByBlankTitles": "{{count}} 個のセクションにタイトルが必要です"
+    "outlinesReadyCount": "{{ready}} / {{total}} セクション準備完了",
+    "jumpToBlankTitle": "タイトルが未入力のセクションへ移動"
   },
   "settings": {
     "title": "設定",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -220,7 +220,8 @@
       "dragHandle": "ドラッグして並べ替え",
       "deckLabel": "シーン",
       "moreActions": "その他の操作",
-      "rename": "名前を変更"
+      "rename": "名前を変更",
+      "sceneIncomplete": "このページの内容が未完成です"
     },
     "zorder": {
       "toFront": "最前面へ移動",
@@ -915,7 +916,8 @@
     "generatingInProgress": "生成中...",
     "webSearching": "ウェブ検索",
     "webSearchingDesc": "ウェブで最新情報を検索しています",
-    "webSearchFailed": "ウェブ検索に失敗しました"
+    "webSearchFailed": "ウェブ検索に失敗しました",
+    "blockedByBlankTitles": "{{count}} 個のセクションにタイトルが必要です"
   },
   "settings": {
     "title": "設定",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -917,7 +917,8 @@
     "webSearching": "웹 검색",
     "webSearchingDesc": "최신 정보를 웹에서 검색하고 있어요",
     "webSearchFailed": "웹 검색에 실패했습니다",
-    "blockedByBlankTitles": "{{count}}개 섹션에 제목이 필요합니다"
+    "outlinesReadyCount": "{{ready}} / {{total}}개 섹션 준비됨",
+    "jumpToBlankTitle": "제목이 필요한 섹션으로 이동"
   },
   "settings": {
     "title": "설정",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -220,7 +220,8 @@
       "dragHandle": "드래그하여 순서 변경",
       "deckLabel": "장면",
       "moreActions": "더 보기",
-      "rename": "이름 바꾸기"
+      "rename": "이름 바꾸기",
+      "sceneIncomplete": "이 페이지의 내용이 미완성입니다"
     },
     "cue": {
       "speech": "내레이션",
@@ -915,7 +916,8 @@
     "generatingInProgress": "생성 중...",
     "webSearching": "웹 검색",
     "webSearchingDesc": "최신 정보를 웹에서 검색하고 있어요",
-    "webSearchFailed": "웹 검색에 실패했습니다"
+    "webSearchFailed": "웹 검색에 실패했습니다",
+    "blockedByBlankTitles": "{{count}}개 섹션에 제목이 필요합니다"
   },
   "settings": {
     "title": "설정",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -205,7 +205,8 @@
       "dragHandle": "Arraste para reordenar",
       "deckLabel": "Cenas",
       "moreActions": "Mais ações",
-      "rename": "Renomear"
+      "rename": "Renomear",
+      "sceneIncomplete": "Esta página tem conteúdo incompleto"
     },
     "zorder": {
       "toFront": "Trazer para a frente",
@@ -915,7 +916,8 @@
     "generatingInProgress": "Gerando...",
     "webSearching": "Buscando na Web",
     "webSearchingDesc": "Pesquisando informações atualizadas na web",
-    "webSearchFailed": "Falha na pesquisa na web"
+    "webSearchFailed": "Falha na pesquisa na web",
+    "blockedByBlankTitles": "{{count}} seções ainda precisam de um título"
   },
   "settings": {
     "title": "Configurações",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -917,7 +917,8 @@
     "webSearching": "Buscando na Web",
     "webSearchingDesc": "Pesquisando informações atualizadas na web",
     "webSearchFailed": "Falha na pesquisa na web",
-    "blockedByBlankTitles": "{{count}} seções ainda precisam de um título"
+    "outlinesReadyCount": "{{ready}} / {{total}} seções prontas",
+    "jumpToBlankTitle": "Ir para uma seção que ainda precisa de título"
   },
   "settings": {
     "title": "Configurações",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -220,7 +220,8 @@
       "dragHandle": "Перетащите, чтобы переупорядочить",
       "deckLabel": "Сцены",
       "moreActions": "Ещё действия",
-      "rename": "Переименовать"
+      "rename": "Переименовать",
+      "sceneIncomplete": "Содержимое этой страницы не заполнено"
     },
     "zorder": {
       "toFront": "На передний план",
@@ -915,7 +916,8 @@
     "generatingInProgress": "Генерация...",
     "webSearching": "Поиск в интернете",
     "webSearchingDesc": "Поиск актуальной информации в сети",
-    "webSearchFailed": "Ошибка веб-поиска"
+    "webSearchFailed": "Ошибка веб-поиска",
+    "blockedByBlankTitles": "У {{count}} разделов нет заголовка"
   },
   "settings": {
     "title": "Настройки",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -917,7 +917,8 @@
     "webSearching": "Поиск в интернете",
     "webSearchingDesc": "Поиск актуальной информации в сети",
     "webSearchFailed": "Ошибка веб-поиска",
-    "blockedByBlankTitles": "У {{count}} разделов нет заголовка"
+    "outlinesReadyCount": "Готово разделов: {{ready}} / {{total}}",
+    "jumpToBlankTitle": "Перейти к разделу без заголовка"
   },
   "settings": {
     "title": "Настройки",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -917,7 +917,8 @@
     "webSearching": "网络搜索",
     "webSearchingDesc": "正在搜索网络获取最新资料",
     "webSearchFailed": "网络搜索失败",
-    "blockedByBlankTitles": "还有 {{count}} 个章节缺少标题"
+    "outlinesReadyCount": "{{ready}} / {{total}} 章节就绪",
+    "jumpToBlankTitle": "跳到待补充标题的章节"
   },
   "settings": {
     "title": "设置",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -220,7 +220,8 @@
       "dragHandle": "拖动",
       "deckLabel": "场景",
       "moreActions": "更多操作",
-      "rename": "重命名"
+      "rename": "重命名",
+      "sceneIncomplete": "本页内容不完整"
     },
     "zorder": {
       "toFront": "置于顶层",
@@ -915,7 +916,8 @@
     "generatingInProgress": "生成中...",
     "webSearching": "网络搜索",
     "webSearchingDesc": "正在搜索网络获取最新资料",
-    "webSearchFailed": "网络搜索失败"
+    "webSearchFailed": "网络搜索失败",
+    "blockedByBlankTitles": "还有 {{count}} 个章节缺少标题"
   },
   "settings": {
     "title": "设置",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -220,7 +220,8 @@
       "dragHandle": "拖曳重新排序",
       "deckLabel": "場景",
       "moreActions": "更多操作",
-      "rename": "重新命名"
+      "rename": "重新命名",
+      "sceneIncomplete": "本頁內容不完整"
     },
     "zorder": {
       "toFront": "移至最上層",
@@ -900,7 +901,8 @@
     "generatingInProgress": "生成中...",
     "webSearching": "網路搜尋",
     "webSearchingDesc": "正在搜尋網路取得最新資料",
-    "webSearchFailed": "網路搜尋失敗"
+    "webSearchFailed": "網路搜尋失敗",
+    "blockedByBlankTitles": "還有 {{count}} 個章節缺少標題"
   },
   "settings": {
     "title": "設定",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -902,7 +902,8 @@
     "webSearching": "網路搜尋",
     "webSearchingDesc": "正在搜尋網路取得最新資料",
     "webSearchFailed": "網路搜尋失敗",
-    "blockedByBlankTitles": "還有 {{count}} 個章節缺少標題"
+    "outlinesReadyCount": "{{ready}} / {{total}} 章節就緒",
+    "jumpToBlankTitle": "跳到待補充標題的章節"
   },
   "settings": {
     "title": "設定",

--- a/lib/playback/engine-cursor.ts
+++ b/lib/playback/engine-cursor.ts
@@ -1,0 +1,64 @@
+import type { Action } from '@/lib/types/action';
+import type { Scene } from '@/lib/types/stage';
+
+/**
+ * Synthetic dwell beat yielded for a scene that carries no actions. It is an
+ * empty-text speech, so the engine routes it through the same reading-timer
+ * dwell a blank speech clip already uses — the slide shows for a short beat
+ * instead of being skipped (which would make it vanish from playback). A scene
+ * with `actions: []` thus behaves exactly like one carrying a single blank
+ * speech clip.
+ */
+export const EMPTY_SCENE_DWELL: Action = {
+  id: '__empty_scene_dwell__',
+  type: 'speech',
+  text: '',
+} as Action;
+
+export interface CursorResult {
+  action: Action;
+  sceneId: string;
+  /** The (possibly advanced) scene cursor the engine should adopt. */
+  sceneIndex: number;
+  /** The (possibly advanced) action cursor the engine should adopt. */
+  actionIndex: number;
+}
+
+/**
+ * Resolve the current playback action from a `(sceneIndex, actionIndex)` cursor,
+ * advancing past scenes whose actions are exhausted. A scene with no actions
+ * yields one {@link EMPTY_SCENE_DWELL} beat (when its action cursor is still 0)
+ * rather than being skipped. Returns `null` once every scene is consumed.
+ *
+ * Pure: it does not mutate inputs; the caller adopts the returned cursor.
+ */
+export function resolvePlaybackCursor(
+  scenes: Scene[],
+  sceneIndex: number,
+  actionIndex: number,
+): CursorResult | null {
+  let si = sceneIndex;
+  let ai = actionIndex;
+  while (si < scenes.length) {
+    const actions = scenes[si].actions ?? [];
+    if (actions.length === 0) {
+      if (ai === 0) {
+        return {
+          action: EMPTY_SCENE_DWELL,
+          sceneId: scenes[si].id,
+          sceneIndex: si,
+          actionIndex: ai,
+        };
+      }
+      si++;
+      ai = 0;
+      continue;
+    }
+    if (ai < actions.length) {
+      return { action: actions[ai], sceneId: scenes[si].id, sceneIndex: si, actionIndex: ai };
+    }
+    si++;
+    ai = 0;
+  }
+  return null;
+}

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -35,6 +35,7 @@ import type {
 } from './types';
 import type { AudioPlayer } from '@/lib/utils/audio-player';
 import { ActionEngine } from '@/lib/action/engine';
+import { resolvePlaybackCursor } from './engine-cursor';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useSettingsStore } from '@/lib/store/settings';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
@@ -404,21 +405,15 @@ export class PlaybackEngine {
   /**
    * Get the current action, or null if playback is complete.
    * Advances sceneIndex automatically when a scene's actions are exhausted.
+   * A scene with no actions yields one synthetic dwell beat (so the slide still
+   * shows) instead of being skipped — see {@link resolvePlaybackCursor}.
    */
   private getCurrentAction(): { action: Action; sceneId: string } | null {
-    while (this.sceneIndex < this.scenes.length) {
-      const scene = this.scenes[this.sceneIndex];
-      const actions = scene.actions || [];
-
-      if (this.actionIndex < actions.length) {
-        return { action: actions[this.actionIndex], sceneId: scene.id };
-      }
-
-      // Move to next scene
-      this.sceneIndex++;
-      this.actionIndex = 0;
-    }
-    return null;
+    const res = resolvePlaybackCursor(this.scenes, this.sceneIndex, this.actionIndex);
+    if (!res) return null;
+    this.sceneIndex = res.sceneIndex;
+    this.actionIndex = res.actionIndex;
+    return { action: res.action, sceneId: res.sceneId };
   }
 
   /**

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -102,5 +102,16 @@ export type SceneContent = AppSceneContent;
  * callers keep their original semantics (actions are `Action[]`, content spans
  * all four kinds).
  */
-export type AppScene = DslScene<Action, SceneContent>;
+export type AppScene = DslScene<Action, SceneContent> & {
+  /**
+   * Stable id of the generation outline this scene was built from. Lets editor
+   * agent tools resolve a scene's outline by identity instead of by the mutable
+   * `order`, which Pro-mode insert / reorder / delete rebalances (matching by
+   * `order` after a reorder attaches another slide's outline). An app-layer
+   * annotation only — not part of the `@openmaic/dsl` Scene contract. Absent on
+   * inserted scenes and pre-existing data, where callers fall back to a
+   * scene-derived outline.
+   */
+  outlineId?: string;
+};
 export type Scene = AppScene;

--- a/tests/edit/content-validation.test.ts
+++ b/tests/edit/content-validation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+import {
+  validateScene,
+  sceneHasIssues,
+  validateOutline,
+  outlinesHaveBlockingIssues,
+  countBlockingOutlines,
+} from '@/lib/edit/content-validation';
+import type { Action } from '@/lib/types/action';
+import type { Scene } from '@/lib/types/stage';
+import type { SceneOutline } from '@/lib/types/generation';
+
+const scene = (actions: Action[]): Scene =>
+  ({
+    id: 's',
+    stageId: 'stage',
+    type: 'slide',
+    title: 'T',
+    order: 1,
+    content: { type: 'slide', canvas: {} },
+    actions,
+  }) as unknown as Scene;
+
+const speech = (id: string, text: string): Action => ({ id, type: 'speech', text }) as Action;
+const spotlight = (id: string, elementId: string): Action =>
+  ({ id, type: 'spotlight', elementId }) as Action;
+const discussion = (id: string, topic: string): Action =>
+  ({ id, type: 'discussion', topic }) as unknown as Action;
+
+const outline = (over: Partial<SceneOutline>): SceneOutline =>
+  ({
+    id: 'o',
+    order: 1,
+    type: 'slide',
+    title: 'X',
+    description: '',
+    keyPoints: [],
+    ...over,
+  }) as SceneOutline;
+
+describe('validateScene', () => {
+  test('a fully-filled scene has no issues', () => {
+    expect(validateScene(scene([speech('a', 'hi'), spotlight('b', 'el_1')]))).toEqual([]);
+    expect(sceneHasIssues(scene([speech('a', 'hi')]))).toBe(false);
+  });
+
+  test('empty action list → emptyActions', () => {
+    expect(validateScene(scene([]))).toEqual([{ kind: 'emptyActions' }]);
+    expect(sceneHasIssues(scene([]))).toBe(true);
+  });
+
+  test('blank / whitespace-only speech text → emptySpeech with the action id', () => {
+    expect(validateScene(scene([speech('a', '')]))).toEqual([
+      { kind: 'emptySpeech', actionId: 'a' },
+    ]);
+    expect(validateScene(scene([speech('a', '   ')]))).toEqual([
+      { kind: 'emptySpeech', actionId: 'a' },
+    ]);
+  });
+
+  test('element-bound cue with no elementId → unboundCue', () => {
+    expect(validateScene(scene([speech('a', 'hi'), spotlight('b', '')]))).toEqual([
+      { kind: 'unboundCue', actionId: 'b' },
+    ]);
+  });
+
+  test('discussion with blank topic → emptyDiscussion', () => {
+    expect(validateScene(scene([speech('a', 'hi'), discussion('d', '  ')]))).toEqual([
+      { kind: 'emptyDiscussion', actionId: 'd' },
+    ]);
+  });
+
+  test('reports one issue per offending action, in order', () => {
+    expect(validateScene(scene([speech('a', ''), spotlight('b', '')]))).toEqual([
+      { kind: 'emptySpeech', actionId: 'a' },
+      { kind: 'unboundCue', actionId: 'b' },
+    ]);
+  });
+});
+
+describe('validateOutline / blocking helpers', () => {
+  test('blank title → emptyTitle; filled title → no issue', () => {
+    expect(validateOutline(outline({ title: '' }))).toEqual([{ kind: 'emptyTitle' }]);
+    expect(validateOutline(outline({ title: '   ' }))).toEqual([{ kind: 'emptyTitle' }]);
+    expect(validateOutline(outline({ title: 'Intro' }))).toEqual([]);
+  });
+
+  test('outlinesHaveBlockingIssues / countBlockingOutlines count blank titles', () => {
+    const os = [outline({ title: 'A' }), outline({ title: '' }), outline({ title: ' ' })];
+    expect(outlinesHaveBlockingIssues(os)).toBe(true);
+    expect(countBlockingOutlines(os)).toBe(2);
+    expect(outlinesHaveBlockingIssues([outline({ title: 'A' })])).toBe(false);
+    expect(countBlockingOutlines([outline({ title: 'A' })])).toBe(0);
+  });
+});

--- a/tests/edit/slide-defaults.test.ts
+++ b/tests/edit/slide-defaults.test.ts
@@ -110,6 +110,12 @@ describe('duplicateSlideScene', () => {
     expect(dup.content.canvas).not.toBe(source.content.canvas);
   });
 
+  it('does not inherit the source outlineId (a copy is not generated from it)', () => {
+    const source = makeSlideScene({ outlineId: 'src-outline' } as Partial<Scene>);
+    const dup = duplicateSlideScene(source, '(copy)', 2);
+    expect(dup.outlineId).toBeUndefined();
+  });
+
   it('reassigns every element id so React keys cannot collide', () => {
     const source = makeSlideScene();
     const dup = duplicateSlideScene(source, '(copy)', 2);

--- a/tests/edit/slide-defaults.test.ts
+++ b/tests/edit/slide-defaults.test.ts
@@ -86,6 +86,11 @@ describe('createBlankSlideScene', () => {
     expect(s.content.canvas.background?.type).toBe('solid');
   });
 
+  it('starts with no actions (engine dwells; no seeded blank speech)', () => {
+    const s = createBlankSlideScene('stage-1', 'Untitled', 1);
+    expect(s.actions).toEqual([]);
+  });
+
   it('mints a fresh scene id + slide id on every call', () => {
     const a = createBlankSlideScene('stage-1', 'A', 1);
     const b = createBlankSlideScene('stage-1', 'B', 2);

--- a/tests/lib/agent/client/resolve-scene-outline.test.ts
+++ b/tests/lib/agent/client/resolve-scene-outline.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSceneOutline } from '@/lib/agent/client/resolve-scene-outline';
+import type { SceneOutline } from '@/lib/types/generation';
+import type { Scene } from '@/lib/types/stage';
+
+const outline = (id: string, order: number, title: string): SceneOutline =>
+  ({ id, order, title, type: 'slide', description: '', keyPoints: [] }) as SceneOutline;
+
+const scene = (over: Partial<Scene>): Scene =>
+  ({
+    id: 's',
+    stageId: 'stage',
+    type: 'slide',
+    title: 'Scene',
+    order: 1,
+    content: { type: 'slide', canvas: {} },
+    actions: [],
+    ...over,
+  }) as unknown as Scene;
+
+describe('resolveSceneOutline', () => {
+  it('matches by stable outlineId — survives a reorder that rebalances order', () => {
+    // Generation plan: outline A is slide 1, outline B is slide 2.
+    const outlines = [outline('oA', 1, 'Intro'), outline('oB', 2, 'Deep dive')];
+    // After the user drags slide B to the front, B's scene.order is now 1 — but
+    // it was generated from outline B. An order match would wrongly return oA.
+    const reordered = scene({ id: 'sB', outlineId: 'oB', order: 1, title: 'Deep dive' });
+
+    const resolved = resolveSceneOutline(reordered, outlines);
+
+    expect(resolved.id).toBe('oB');
+    expect(resolved.title).toBe('Deep dive');
+  });
+
+  it('falls back to a scene-derived outline when the scene has no outlineId', () => {
+    const outlines = [outline('oA', 1, 'Intro')];
+    const inserted = scene({ id: 'sNew', outlineId: undefined, order: 1, title: 'Fresh slide' });
+
+    const resolved = resolveSceneOutline(inserted, outlines);
+
+    // Never another slide's outline — derived from the scene itself.
+    expect(resolved.id).toBe('sNew');
+    expect(resolved.title).toBe('Fresh slide');
+    expect(resolved.keyPoints).toEqual([]);
+  });
+
+  it('falls back to scene-derived when outlineId points at a removed outline', () => {
+    const outlines = [outline('oA', 1, 'Intro')];
+    const orphan = scene({ id: 'sX', outlineId: 'gone', order: 2, title: 'Orphan' });
+
+    const resolved = resolveSceneOutline(orphan, outlines);
+
+    expect(resolved.id).toBe('sX');
+    expect(resolved.title).toBe('Orphan');
+  });
+});

--- a/tests/lib/playback/engine-cursor.test.ts
+++ b/tests/lib/playback/engine-cursor.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+import { resolvePlaybackCursor, EMPTY_SCENE_DWELL } from '@/lib/playback/engine-cursor';
+import type { Action } from '@/lib/types/action';
+import type { Scene } from '@/lib/types/stage';
+
+const a = (id: string): Action => ({ id, type: 'speech', text: id }) as Action;
+const sc = (id: string, actions: Action[]): Scene =>
+  ({
+    id,
+    stageId: 's',
+    type: 'slide',
+    title: id,
+    order: 1,
+    content: { type: 'slide', canvas: {} },
+    actions,
+  }) as unknown as Scene;
+
+describe('resolvePlaybackCursor', () => {
+  test('returns the action at the cursor within a scene', () => {
+    const scenes = [sc('S0', [a('a0'), a('a1')])];
+    expect(resolvePlaybackCursor(scenes, 0, 0)).toMatchObject({
+      action: { id: 'a0' },
+      sceneId: 'S0',
+      sceneIndex: 0,
+      actionIndex: 0,
+    });
+    expect(resolvePlaybackCursor(scenes, 0, 1)).toMatchObject({
+      action: { id: 'a1' },
+      sceneId: 'S0',
+      actionIndex: 1,
+    });
+  });
+
+  test('advances past an exhausted scene to the next scene', () => {
+    const scenes = [sc('S0', [a('a0')]), sc('S1', [a('b0')])];
+    expect(resolvePlaybackCursor(scenes, 0, 1)).toMatchObject({
+      action: { id: 'b0' },
+      sceneId: 'S1',
+      sceneIndex: 1,
+      actionIndex: 0,
+    });
+  });
+
+  test('returns null when all scenes are consumed', () => {
+    expect(resolvePlaybackCursor([sc('S0', [a('a0')])], 0, 1)).toBeNull();
+    expect(resolvePlaybackCursor([], 0, 0)).toBeNull();
+  });
+
+  test('a zero-action scene yields ONE synthetic dwell beat (not skipped)', () => {
+    const scenes = [sc('S0', [])];
+    expect(resolvePlaybackCursor(scenes, 0, 0)).toMatchObject({
+      action: EMPTY_SCENE_DWELL,
+      sceneId: 'S0',
+      sceneIndex: 0,
+      actionIndex: 0,
+    });
+    // After the dwell beat is consumed (actionIndex advanced), the scene is done.
+    expect(resolvePlaybackCursor(scenes, 0, 1)).toBeNull();
+  });
+
+  test('the dwell beat is an empty-text speech (routes to the reading-timer dwell)', () => {
+    expect(EMPTY_SCENE_DWELL).toMatchObject({ type: 'speech', text: '' });
+  });
+
+  test('a zero-action scene shows, then playback continues to the next scene', () => {
+    const scenes = [sc('S0', []), sc('S1', [a('b0')])];
+    expect(resolvePlaybackCursor(scenes, 0, 0)).toMatchObject({
+      action: EMPTY_SCENE_DWELL,
+      sceneId: 'S0',
+    });
+    expect(resolvePlaybackCursor(scenes, 0, 1)).toMatchObject({
+      action: { id: 'b0' },
+      sceneId: 'S1',
+      sceneIndex: 1,
+      actionIndex: 0,
+    });
+  });
+
+  test('a zero-action scene in the middle still dwells when reached from the prior scene', () => {
+    const scenes = [sc('S0', [a('a0')]), sc('S1', []), sc('S2', [a('c0')])];
+    // Finished S0 (actionIndex past its single action) → advance into empty S1 → dwell.
+    expect(resolvePlaybackCursor(scenes, 0, 1)).toMatchObject({
+      action: EMPTY_SCENE_DWELL,
+      sceneId: 'S1',
+      sceneIndex: 1,
+      actionIndex: 0,
+    });
+    // After S1's dwell → C0 on S2.
+    expect(resolvePlaybackCursor(scenes, 1, 1)).toMatchObject({
+      action: { id: 'c0' },
+      sceneId: 'S2',
+      sceneIndex: 2,
+    });
+  });
+});


### PR DESCRIPTION
Editor empty-state robustness: fix silent slide loss at the playback root, bind a scene's outline by stable id, and surface incomplete content calmly. Five commits.

## 1. `fix(agent-edit)` — resolve a scene's outline by stable id, not mutable order
The editor agent matched an outline to a scene by `outline.order === scene.order`, so after a Pro-mode insert / reorder / delete (which rebalances `scene.order`) it attached **another slide's** outline to the scene being edited. Scenes now carry the stable `outlineId` of the outline they were built from (an app-layer annotation — not part of the `@openmaic/dsl` Scene contract); `resolveSceneOutline` matches by it, falling back to a scene-derived outline for inserted/duplicated/legacy scenes. `allOutlines` (the page list handed to the regenerate tools) is also rebuilt in current scene order, and a duplicated scene clears its inherited `outlineId`.

## 2. `fix(playback)` — dwell on zero-action scenes instead of skipping them
A scene with no actions was skipped, so an emptied / freshly inserted blank slide silently dropped from playback (and forced a meaningless seeded empty-speech clip to stay visible). `resolvePlaybackCursor` now yields one synthetic dwell beat for a zero-action scene, and `PlaybackChromeRoot` builds the engine for a zero-action **slide** scene (non-slide scenes are unchanged) so it actually dwells and auto-play advances past it. `createBlankSlideScene` no longer seeds a fake empty speech.

## 3. `fix(edit)` — clear the cue preview when its glyph unmounts (e.g. on delete)
Hovering a spotlight/laser cue replays it on the canvas; deleting the hovered cue unmounted its glyph without firing `onMouseLeave`, leaving the effect stuck on the slide. Both cue glyphs now clear the preview on unmount.

## 4. `feat(edit)` + `refine(edit)` — surface incomplete content, calmly
`content-validation.ts` (pure, tested) flags incomplete scenes/outlines. Incomplete timeline clips get a soft amber **dashed frame**; a blank outline title gets a small amber **dot**; the slide rail shows an amber dot per incomplete scene; fields keep their normal gray placeholder. The outline → generate gate is a neutral **"N / M sections ready"** counter + meter that jumps to the first blank title (no red error chip). Color stays out of the way of the blue interactive controls. New i18n keys across all 8 locales.

## Review
- `tsc --noEmit` clean · Prettier clean · i18n key parity (8 locales) · full suite **1778 passing**.
- New unit tests: `content-validation`, `engine-cursor`, `resolve-scene-outline`, `slide-defaults` (blank actions + duplicate drops outlineId).
- Cross-reviewed (Codex + an independent Claude reviewer). Five review rounds; all P1/P2 correctness findings fixed and re-verified to a clean final pass — including the playback engine being reachable, duplicate/reorder outline context, and the pending-generation autoplay handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
