### PR TITLE
feat(dsl): JSON Schema artifacts + pure validators (#787 Part B-1)

### DIFF
--- a/lib/agent/client/apply-regenerate.ts
+++ b/lib/agent/client/apply-regenerate.ts
@@ -9,7 +9,7 @@
  */
 import { nanoid } from 'nanoid';
 import type { Action } from '@/lib/types/action';
-import type { Scene, SceneContent, InteractiveContent } from '@/lib/types/stage';
+import type { Scene, ScenePatch, SceneContent, InteractiveContent } from '@/lib/types/stage';
 import type { GeneratedSlideContent } from '@/lib/types/generation';
 import { CURRENT_SLIDE_CONTENT_SCHEMA_VERSION } from '@/lib/edit/slide-schema';
 
@@ -79,7 +79,7 @@ export interface RegenerateApplyPlan {
     actionsOnly?: boolean;
   } | null;
   /** Partial scene update to apply, or null if nothing should change. */
-  patch: Partial<Scene> | null;
+  patch: ScenePatch | null;
 }
 
 /**
@@ -127,7 +127,7 @@ export function planRegenerateApply(
       | undefined;
     const existingCanvas = sceneContent?.type === 'slide' ? sceneContent.canvas : undefined;
     const runtime = toRuntimeSlideContent(details.content, existingCanvas);
-    const patch: Partial<Scene> = {
+    const patch: ScenePatch = {
       content: runtime,
       ...(actions.length > 0 ? { actions } : {}),
     };

--- a/lib/agent/client/apply-slide-content.ts
+++ b/lib/agent/client/apply-slide-content.ts
@@ -9,11 +9,11 @@
  */
 import { useStageStore } from '@/lib/store/stage';
 import { useSlideEditSession } from '@/components/edit/surfaces/slide/slide-edit-session';
-import type { Scene, SlideContent } from '@/lib/types/stage';
+import type { ScenePatch, SlideContent } from '@/lib/types/stage';
 
 /** Apply a scene patch to the stage store and keep the OPEN slide edit session
  *  in lockstep (else the canvas renders stale history and clobbers the change). */
-export function applyScenePatchInSync(sceneId: string, patch: Partial<Scene>): void {
+export function applyScenePatchInSync(sceneId: string, patch: ScenePatch): void {
   useStageStore.getState().updateScene(sceneId, patch);
   const es = useSlideEditSession.getState();
   if (patch.content && es.sceneId === sceneId) {

--- a/lib/api/stage-api-scene.ts
+++ b/lib/api/stage-api-scene.ts
@@ -4,7 +4,7 @@
  * Factory function that creates the scene namespace of the Stage API.
  */
 
-import type { Scene, SceneContent } from '@/lib/types/stage';
+import { makeScene, type Scene, type SceneContent } from '@/lib/types/stage';
 import type { StageStore, APIResult, CreateSceneParams } from './stage-api-types';
 import { generateId, validateSceneId, getScene, createDefaultContent } from './stage-api-defaults';
 
@@ -56,17 +56,18 @@ export function createSceneAPI(store: StageStore) {
           content = createDefaultContent(params.type);
         }
 
-        const newScene: Scene = {
-          id: sceneId,
-          stageId: state.stage.id,
-          type: params.type,
-          title: params.title,
-          order,
+        const newScene: Scene = makeScene(
+          {
+            id: sceneId,
+            stageId: state.stage.id,
+            title: params.title,
+            order,
+            actions: params.actions,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
           content,
-          actions: params.actions,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        };
+        );
 
         const newScenes = [...state.scenes, newScene].sort((a, b) => a.order - b.order);
 

--- a/lib/api/stage-api-scene.ts
+++ b/lib/api/stage-api-scene.ts
@@ -4,7 +4,7 @@
  * Factory function that creates the scene namespace of the Stage API.
  */
 
-import { makeScene, type Scene, type SceneContent } from '@/lib/types/stage';
+import { makeScene, type Scene, type ScenePatch, type SceneContent } from '@/lib/types/stage';
 import type { StageStore, APIResult, CreateSceneParams } from './stage-api-types';
 import { generateId, validateSceneId, getScene, createDefaultContent } from './stage-api-defaults';
 
@@ -119,7 +119,7 @@ export function createSceneAPI(store: StageStore) {
      * @param updates - Fields to update
      * @returns Whether successful
      */
-    update(sceneId: string, updates: Partial<Scene>): APIResult<boolean> {
+    update(sceneId: string, updates: ScenePatch): APIResult<boolean> {
       try {
         const state = store.getState();
 
@@ -127,9 +127,13 @@ export function createSceneAPI(store: StageStore) {
           return { success: false, error: `Scene not found: ${sceneId}` };
         }
 
-        const newScenes = state.scenes.map((scene) =>
-          scene.id === sceneId ? { ...scene, ...updates, updatedAt: Date.now() } : scene,
-        );
+        const newScenes = state.scenes.map((scene) => {
+          if (scene.id !== sceneId) return scene;
+          // Rebind `type` to the (possibly updated) content's kind so a
+          // content-only or type-only patch can't desync the discriminant.
+          const content = updates.content ?? scene.content;
+          return makeScene({ ...scene, ...updates, updatedAt: Date.now() }, content);
+        });
 
         store.setState({ scenes: newScenes });
 

--- a/lib/api/stage-api-scene.ts
+++ b/lib/api/stage-api-scene.ts
@@ -45,12 +45,22 @@ export function createSceneAPI(store: StageStore) {
         // Determine order
         const order = params.order ?? state.scenes.length;
 
-        // Create default content or use the provided content
+        // Create default content or use the provided content. `params.type` is
+        // authoritative: reject a `content.type` that disagrees, and pin the
+        // merged content's `type` to it so the scene's discriminant can't be
+        // silently overridden by a partial content override.
         let content: SceneContent;
         if (params.content) {
+          if (params.content.type !== undefined && params.content.type !== params.type) {
+            return {
+              success: false,
+              error: `content.type '${params.content.type}' does not match scene type '${params.type}'`,
+            };
+          }
           content = {
             ...createDefaultContent(params.type),
             ...params.content,
+            type: params.type,
           } as SceneContent;
         } else {
           content = createDefaultContent(params.type);

--- a/lib/edit/slide-schema.ts
+++ b/lib/edit/slide-schema.ts
@@ -13,7 +13,13 @@
  *     guarantee that the field is present.
  */
 
-import type { InteractiveContent, Scene, SceneContent, SlideContent } from '@/lib/types/stage';
+import {
+  makeScene,
+  type InteractiveContent,
+  type Scene,
+  type SceneContent,
+  type SlideContent,
+} from '@/lib/types/stage';
 
 export const CURRENT_SLIDE_CONTENT_SCHEMA_VERSION = 1;
 
@@ -81,7 +87,7 @@ export function migrateScene(scene: Scene): Scene {
   if (migratedContent === scene.content) {
     return scene;
   }
-  return { ...scene, content: migratedContent };
+  return makeScene(scene, migratedContent);
 }
 
 function migrateSceneContent(content: SceneContent): SceneContent {

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -1,5 +1,13 @@
 import { create } from 'zustand';
-import type { PBLContent, Stage, Scene, SceneContent, StageMode } from '@/lib/types/stage';
+import {
+  makeScene,
+  type PBLContent,
+  type Stage,
+  type Scene,
+  type SceneContent,
+  type ScenePatch,
+  type StageMode,
+} from '@/lib/types/stage';
 import { createSelectors } from '@/lib/utils/create-selectors';
 import type { ChatSession } from '@/lib/types/chat';
 import type { SceneOutline } from '@/lib/types/generation';
@@ -91,7 +99,7 @@ interface StageState {
   setScenes: (scenes: Scene[]) => void;
   addScene: (scene: Scene) => void;
   insertSceneAfter: (anchorSceneId: string, scene: Scene) => void;
-  updateScene: (sceneId: string, updates: Partial<Scene>) => void;
+  updateScene: (sceneId: string, updates: ScenePatch) => void;
   deleteScene: (sceneId: string) => void;
   setCurrentSceneId: (sceneId: string | null) => void;
   setChats: (chats: ChatSession[]) => void;
@@ -209,11 +217,10 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
   updateScene: (sceneId, updates) => {
     const scenes = get().scenes.map((scene) => {
       if (scene.id !== sceneId) return scene;
-      return {
-        ...scene,
-        ...updates,
-        content: mergeSceneContentForUpdate(scene.content, updates.content) ?? scene.content,
-      };
+      const content = mergeSceneContentForUpdate(scene.content, updates.content) ?? scene.content;
+      // Rebind `type` to the merged content's kind (a type-only patch can no
+      // longer desync the discriminant from the content).
+      return makeScene({ ...scene, ...updates }, content);
     });
     set({ scenes });
     debouncedSave();

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -10,7 +10,7 @@
 // `Scene` is re-exported as an alias of the app's fully-instantiated
 // `Scene<Action, AppSceneContent>`, so existing `import { Scene }` callers keep
 // the same semantics (actions are `Action[]`, content spans all four kinds).
-import type { Scene as DslScene, SceneContent as DslSceneContent } from '@openmaic/dsl';
+import type { Scene as DslScene, SceneContent as DslSceneContent, SceneCore } from '@openmaic/dsl';
 import type { Action } from '@/lib/types/action';
 import type { WidgetType, WidgetConfig } from '@/lib/types/widgets';
 import type { PBLProjectConfig } from '@/lib/pbl/types';
@@ -104,3 +104,40 @@ export type SceneContent = AppSceneContent;
  */
 export type AppScene = DslScene<Action, SceneContent>;
 export type Scene = AppScene;
+
+/**
+ * A partial update for {@link AppScene} — the patch shape used by `updateScene` /
+ * `applyScenePatchInSync` / the regenerate-apply plan.
+ *
+ * `Partial<AppScene>` is unusable here: `AppScene` is a discriminated union, and
+ * `Partial<>` *distributes* over it into a union of per-kind partials
+ * (`Partial<SlideScene> | Partial<QuizScene> | …`). A generic patch such as
+ * `{ content }`, where `content: SceneContent` spans all four kinds, then matches
+ * none of those members. `ScenePatch` is a single (non-distributive) object type
+ * that keeps `type` and `content` as independently-optional wide unions, which is
+ * exactly what a shallow-merge patch needs.
+ */
+export type ScenePatch = Partial<SceneCore<Action>> & {
+  type?: SceneContent['type'];
+  content?: SceneContent;
+};
+
+/**
+ * Build an {@link AppScene} from its kind-independent {@link SceneCore} plus a
+ * concrete content payload, binding `type` to `content.type`.
+ *
+ * The lone `as` is unavoidable and is the *only* cast in the scene-construction
+ * path: `AppScene` is a distributive discriminated union, and TS cannot prove
+ * that the freshly-built `{ ...core, type, content }` literal lands in the member
+ * matching `content`'s kind when that kind is only known through a generic. The
+ * generic return type re-narrows the result to the single member whose `type`
+ * equals `content.type`, so every call site still sees a correctly discriminated
+ * scene. `type` is always derived from `content.type`, which makes the binding
+ * impossible to violate at a call site.
+ */
+export function makeScene<C extends SceneContent>(
+  core: SceneCore<Action>,
+  content: C,
+): Extract<AppScene, { type: C['type'] }> {
+  return { ...core, type: content.type, content } as Extract<AppScene, { type: C['type'] }>;
+}

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -5,7 +5,7 @@
  * Each stage has its own storage key based on stageId
  */
 
-import { Stage, Scene } from '../types/stage';
+import { makeScene, Stage, Scene } from '../types/stage';
 import { ChatSession } from '../types/chat';
 import { db } from './database';
 import { saveChatSessions, loadChatSessions, deleteChatSessions } from './chat-storage';
@@ -106,7 +106,10 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
 
     return {
       stage,
-      scenes,
+      // `SceneRecord` is the loose persisted shape (independent `type` + `content`);
+      // re-bind each to a discriminated `AppScene`, deriving `type` from the stored
+      // `content.type`. Spreads the full record, so `whiteboard` etc. are preserved.
+      scenes: scenes.map((s) => makeScene(s, s.content)),
       currentSceneId: stage.currentSceneId || scenes[0]?.id || null,
       chats,
     };

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -38,11 +38,14 @@ import { isTextElement, DSL_VERSION, SYNC_ACTIONS } from '@openmaic/dsl';
 
 ## Runtime layer (schema + validators)
 
-The contract is enforceable in two complementary ways — both honoring the
-zero-runtime-dependency invariant:
+The contract is enforceable at two layers — an authoritative schema plus a
+cheap structural pre-check — both generated from / aligned to the same public TS
+types, and both honoring the zero-runtime-dependency invariant:
 
-1. **JSON Schema artifacts** — `Stage`, the default `Scene<Action, SceneContent>`,
-   and `Action` are emitted as standalone JSON Schema at build time and shipped:
+1. **JSON Schema artifacts (authoritative)** — `Stage`, the default
+   `Scene<Action, SceneContent>`, and `Action` are emitted as standalone JSON
+   Schema at build time and shipped. This is the exhaustive, per-field validator
+   — use it at real trust boundaries (untrusted LLM / agent output, persistence):
 
    ```ts
    import stageSchema from '@openmaic/dsl/schema/stage.schema.json' with { type: 'json' };
@@ -55,15 +58,16 @@ zero-runtime-dependency invariant:
    `ts-json-schema-generator`, a **devDependency** — it never enters the runtime
    dependency set.
 
-2. **Pure validators** — for the common in-process case, `validate*` are
-   hand-written, zero-dependency, fail-loud structural checks layered on the
-   guards. They verify object shape, the structural envelope's required fields,
-   known discriminants, and that a scene's `type` agrees with its
-   `content.type` — ideal as a gate on untrusted input (LLM / agent output) or
-   at a persistence boundary. They intentionally do **not** check per-variant
-   fields, and the app-side `interactive` / `pbl` content kinds are validated
-   only at the envelope level; for exhaustive per-field validation of the
-   contract-owned kinds, use the JSON Schema above.
+2. **Pure validators (cheap pre-check)** — `validate*` are hand-written,
+   zero-dependency structural checks layered on the guards: object shape, the
+   envelope's required fields, and known contract discriminants. They are a
+   deliberate **strict subset** of the JSON Schema above — a fast, dependency-free
+   in-process sanity check. Passing one does **not** prove a document is
+   schema-valid (they do not check variant-specific fields such as an action's
+   `elementId`), and they describe the same contract shape as the schema rather
+   than a stricter or different one — so for an authoritative check, use the
+   schema. They do not bind a scene's `type` to its `content.type` (the public
+   `Scene` type does not either).
 
    ```ts
    import { validateStage, validateScene, validateAction } from '@openmaic/dsl';

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -1,7 +1,7 @@
 # @openmaic/dsl
 
 The **contract keystone** of the MAIC SDK family. `@openmaic/dsl` is *pure spec* — the
-slide object-model types, (planned) JSON Schema, pure validators / type-guards,
+slide object-model types, build-time JSON Schema artifacts, pure validators / type-guards,
 and version/migration helpers — with **zero runtime dependencies** (no React, no
 pptx, no echarts).
 
@@ -26,14 +26,51 @@ nothing.
 | ------------- | ------------------------------------------------------------------- |
 | `slides.ts`   | The slide object model: `Slide`, `PPTElement` and all variants, theme, background, animation, table/chart/code types, plus `ElementTypes` / `ShapePathFormulasKeys` enums. |
 | `stage.ts`    | The lesson skeleton: `Stage`, generic `Scene<TAction, TContent>`, `SceneType`, `StageMode`, `Whiteboard`, `VideoManifest`, `SlideContent`, `QuizContent`, `MultiAgentConfig`, `GeneratedAgentConfig`, plus `isSlideContent` / `isQuizContent` guards. |
-| `action.ts`   | The playback verb set: `Action` and all variants (spotlight, laser, speech, the `Wb*` whiteboard family, `play_video`, `discussion`, and the `widget_*` interaction actions), `ActionType`, the `FIRE_AND_FORGET_ACTIONS` / `SLIDE_ONLY_ACTIONS` / `SYNC_ACTIONS` category lists, plus the `PercentageGeometry` overlay type. |
+| `action.ts`   | The playback verb set: `Action` and all variants (spotlight, laser, speech, the `Wb*` whiteboard family, `play_video`, `discussion`, and the `widget_*` interaction actions), `ActionType`, the frozen `ACTION_TYPES` set + `isActionType` guard, the `FIRE_AND_FORGET_ACTIONS` / `SLIDE_ONLY_ACTIONS` / `SYNC_ACTIONS` category lists, plus the `PercentageGeometry` overlay type. |
 | `guards.ts`   | Pure discriminant type-guards (`isTextElement`, …) and `PPT_ELEMENT_TYPES`. |
+| `validate.ts` | Pure, zero-dep structural validators — `validateStage` / `validateScene` / `validateAction` returning an error-collecting `ValidationResult`. |
 | `version.ts`  | `DSL_VERSION` + the `DslMigration` shape and (empty) migration registry. |
 
 ```ts
 import type { Slide, PPTElement, Action } from '@openmaic/dsl';
 import { isTextElement, DSL_VERSION, SYNC_ACTIONS } from '@openmaic/dsl';
 ```
+
+## Runtime layer (schema + validators)
+
+The contract is enforceable in two complementary ways — both honoring the
+zero-runtime-dependency invariant:
+
+1. **JSON Schema artifacts** — `Stage`, the default `Scene<Action, SceneContent>`,
+   and `Action` are emitted as standalone JSON Schema at build time and shipped:
+
+   ```ts
+   import stageSchema from '@openmaic/dsl/schema/stage.schema.json' with { type: 'json' };
+   import sceneSchema from '@openmaic/dsl/schema/scene.schema.json' with { type: 'json' };
+   import actionSchema from '@openmaic/dsl/schema/action.schema.json' with { type: 'json' };
+   // feed to any JSON Schema validator (ajv, or a non-TS / non-JS consumer)
+   ```
+
+   The schema is generated from the TS types (the single source of truth) by
+   `ts-json-schema-generator`, a **devDependency** — it never enters the runtime
+   dependency set.
+
+2. **Pure validators** — for the common in-process case, `validate*` are
+   hand-written, zero-dependency, fail-loud structural checks layered on the
+   guards. They verify discriminants, required fields, and known nested
+   discriminants — ideal as a gate on untrusted input (LLM / agent output) or at
+   a persistence boundary. Exhaustive per-field validation is delegated to the
+   JSON Schema above.
+
+   ```ts
+   import { validateStage, validateScene, validateAction } from '@openmaic/dsl';
+
+   const result = validateScene(input);
+   if (!result.valid) throw new Error(result.errors.map((e) => `${e.path}: ${e.message}`).join('; '));
+   ```
+
+   `ValidationResult` is `{ valid: true } | { valid: false; errors: { path; message }[] }` —
+   it collects every issue rather than failing on the first.
 
 ## Status
 
@@ -52,7 +89,9 @@ of the slide types:
 
 - [x] Wire `@openmaic/importer` to import types from `@openmaic/dsl` (vendored copy deleted).
 - [x] Wire `@openmaic/renderer` to import types from `@openmaic/dsl` (vendored copy deleted).
-- [ ] Add the JSON Schema for the slide contract + a pure schema validator.
+- [x] Add the JSON Schema for the slide contract + a pure schema validator
+      (build-time `dist/schema/*.json` via a devDep generator; zero-dep
+      `validate*` functions). See **Runtime layer** below.
 - [x] Promote the `stage` / `scene` / `scene-content` types into the DSL (the
       universal skeleton now lives in `stage.ts`).
 - [x] Bring the `Action` playback verb set into the DSL (`action.ts`); the
@@ -115,11 +154,14 @@ didn't previously declare).
 
 ## Build
 
-Pure TypeScript compiled with `tsc` to ESM + `.d.ts`:
+Pure TypeScript compiled with `tsc` to ESM + `.d.ts`, then the JSON Schema
+artifacts are generated into `dist/schema/`:
 
 ```bash
-pnpm --filter @openmaic/dsl build      # -> dist/ (index.js, index.d.ts, …)
+pnpm --filter @openmaic/dsl build         # -> dist/ (index.js, index.d.ts, …) + dist/schema/*.json
+pnpm --filter @openmaic/dsl build:schema  # regenerate only dist/schema/*.json
 pnpm --filter @openmaic/dsl typecheck
+pnpm --filter @openmaic/dsl test
 ```
 
 ## License

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -38,14 +38,15 @@ import { isTextElement, DSL_VERSION, SYNC_ACTIONS } from '@openmaic/dsl';
 
 ## Runtime layer (schema + validators)
 
-The contract is enforceable at two layers — an authoritative schema plus a
-cheap structural pre-check — both generated from / aligned to the same public TS
-types, and both honoring the zero-runtime-dependency invariant:
+The contract is enforceable two ways — a zero-dependency in-process validator
+and a cross-language JSON Schema — both generated from / aligned to the same
+public TS types, and both honoring the zero-runtime-dependency invariant:
 
-1. **JSON Schema artifacts (authoritative)** — `Stage`, the default
+1. **JSON Schema artifacts (cross-language mirror)** — `Stage`, the default
    `Scene<Action, SceneContent>`, and `Action` are emitted as standalone JSON
-   Schema at build time and shipped. This is the exhaustive, per-field validator
-   — use it at real trust boundaries (untrusted LLM / agent output, persistence):
+   Schema at build time and shipped. This is the language-neutral mirror of the
+   contract for non-TS consumers, and the place to go for exhaustive value-level
+   (type / format) checking:
 
    ```ts
    import stageSchema from '@openmaic/dsl/schema/stage.schema.json' with { type: 'json' };
@@ -58,16 +59,17 @@ types, and both honoring the zero-runtime-dependency invariant:
    `ts-json-schema-generator`, a **devDependency** — it never enters the runtime
    dependency set.
 
-2. **Pure validators (cheap pre-check)** — `validate*` are hand-written,
-   zero-dependency structural checks layered on the guards: object shape, the
-   envelope's required fields, and known contract discriminants. They are a
-   deliberate **strict subset** of the JSON Schema above — a fast, dependency-free
-   in-process sanity check. Passing one does **not** prove a document is
-   schema-valid (they do not check variant-specific fields such as an action's
-   `elementId`), and they describe the same contract shape as the schema rather
-   than a stricter or different one — so for an authoritative check, use the
-   schema. They do not bind a scene's `type` to its `content.type` (the public
-   `Scene` type does not either).
+2. **Pure validators (in-process boundary)** — `validate*` are hand-written,
+   zero-dependency checks layered on the guards: object shape, required fields
+   (including each action variant's, e.g. a `spotlight`'s `elementId`), known
+   discriminants, and the scene `type` <-> `content` binding the public `Scene`
+   type enforces. Because they add no dependency, in-process (TS / JS) producers
+   and consumers — generators, importers, the runtime engine — can rely on them
+   directly without shipping a schema validator. They are a structural subset of
+   the schema (presence + discriminants; the schema additionally checks each
+   field's value shape), and describe the same contract. Both are kept in lockstep
+   by a test that pins the validators' per-variant required fields to the
+   generated schema.
 
    ```ts
    import { validateStage, validateScene, validateAction } from '@openmaic/dsl';

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -57,10 +57,13 @@ zero-runtime-dependency invariant:
 
 2. **Pure validators** — for the common in-process case, `validate*` are
    hand-written, zero-dependency, fail-loud structural checks layered on the
-   guards. They verify discriminants, required fields, and known nested
-   discriminants — ideal as a gate on untrusted input (LLM / agent output) or at
-   a persistence boundary. Exhaustive per-field validation is delegated to the
-   JSON Schema above.
+   guards. They verify object shape, the structural envelope's required fields,
+   known discriminants, and that a scene's `type` agrees with its
+   `content.type` — ideal as a gate on untrusted input (LLM / agent output) or
+   at a persistence boundary. They intentionally do **not** check per-variant
+   fields, and the app-side `interactive` / `pbl` content kinds are validated
+   only at the envelope level; for exhaustive per-field validation of the
+   contract-owned kinds, use the JSON Schema above.
 
    ```ts
    import { validateStage, validateScene, validateAction } from '@openmaic/dsl';

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/dsl",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "The MAIC slide DSL: the pure, dependency-free contract (types + JSON Schema + validators + version/migration helpers) that @openmaic/renderer and @openmaic/importer both depend on.",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./schema/*": "./dist/schema/*"
   },
   "files": [
     "dist",
@@ -20,7 +21,8 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "build": "rm -rf dist && tsc -p tsconfig.json && node scripts/gen-schema.mjs",
+    "build:schema": "node scripts/gen-schema.mjs",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
@@ -45,6 +47,8 @@
     "access": "public"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
+    "ts-json-schema-generator": "^2.3.0",
     "typescript": "^5",
     "vitest": "^4.1.8"
   }

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "ajv": "^8.17.1",
-    "ts-json-schema-generator": "^2.3.0",
+    "ts-json-schema-generator": "~2.4.0",
     "typescript": "^5",
     "vitest": "^4.1.8"
   }

--- a/packages/@openmaic/dsl/scripts/gen-schema.mjs
+++ b/packages/@openmaic/dsl/scripts/gen-schema.mjs
@@ -1,0 +1,46 @@
+// Build-time JSON Schema codegen for @openmaic/dsl.
+//
+// Runs ts-json-schema-generator (a devDependency) over the TS contract and
+// emits static dist/schema/*.json for non-TS / bring-your-own-validator
+// consumers. The generator is BUILD-ONLY — the package keeps zero runtime deps.
+import { createGenerator } from 'ts-json-schema-generator';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+
+/** Schema root type -> { file: source it lives in, out: emitted filename }. */
+export const ROOTS = {
+  Stage: { file: 'src/stage.ts', out: 'stage.schema.json' },
+  SerializedScene: { file: 'src/schema-roots.ts', out: 'scene.schema.json' },
+  Action: { file: 'src/action.ts', out: 'action.schema.json' },
+};
+
+/** Generate the JSON Schema object for one root type (in-memory). */
+export function generateSchema(typeName) {
+  const root = ROOTS[typeName];
+  if (!root) throw new Error(`unknown schema root: ${typeName}`);
+  return createGenerator({
+    path: resolve(pkgRoot, root.file),
+    tsconfig: resolve(pkgRoot, 'tsconfig.json'),
+    type: typeName,
+    skipTypeCheck: true,
+    topRef: true,
+  }).createSchema(typeName);
+}
+
+function main() {
+  const outDir = resolve(pkgRoot, 'dist/schema');
+  mkdirSync(outDir, { recursive: true });
+  for (const [typeName, { out }] of Object.entries(ROOTS)) {
+    writeFileSync(resolve(outDir, out), JSON.stringify(generateSchema(typeName), null, 2) + '\n');
+    console.log(`wrote dist/schema/${out}`);
+  }
+}
+
+// Run only when invoked directly (`node scripts/gen-schema.mjs`).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/packages/@openmaic/dsl/scripts/gen-schema.mjs
+++ b/packages/@openmaic/dsl/scripts/gen-schema.mjs
@@ -4,43 +4,58 @@
 // emits static dist/schema/*.json for non-TS / bring-your-own-validator
 // consumers. The generator is BUILD-ONLY — the package keeps zero runtime deps.
 import { createGenerator } from 'ts-json-schema-generator';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, '..');
 
-/** Schema root type -> { file: source it lives in, out: emitted filename }. */
+/** Schema root type -> emitted filename. */
 export const ROOTS = {
-  Stage: { file: 'src/stage.ts', out: 'stage.schema.json' },
-  SerializedScene: { file: 'src/schema-roots.ts', out: 'scene.schema.json' },
-  Action: { file: 'src/action.ts', out: 'action.schema.json' },
+  Stage: 'stage.schema.json',
+  SerializedScene: 'scene.schema.json',
+  Action: 'action.schema.json',
 };
+
+// One generator over the whole tsconfig program, built lazily and reused for
+// every root — parses/type-builds the program once instead of per type.
+// `createSchema(typeName)` still walks from each root, so each schema only
+// carries the definitions reachable from that type.
+let generator;
+function getGenerator() {
+  generator ??= createGenerator({
+    tsconfig: resolve(pkgRoot, 'tsconfig.json'),
+    skipTypeCheck: true,
+    topRef: true,
+  });
+  return generator;
+}
 
 /** Generate the JSON Schema object for one root type (in-memory). */
 export function generateSchema(typeName) {
-  const root = ROOTS[typeName];
-  if (!root) throw new Error(`unknown schema root: ${typeName}`);
-  return createGenerator({
-    path: resolve(pkgRoot, root.file),
-    tsconfig: resolve(pkgRoot, 'tsconfig.json'),
-    type: typeName,
-    skipTypeCheck: true,
-    topRef: true,
-  }).createSchema(typeName);
+  if (!(typeName in ROOTS)) throw new Error(`unknown schema root: ${typeName}`);
+  return getGenerator().createSchema(typeName);
 }
 
 function main() {
   const outDir = resolve(pkgRoot, 'dist/schema');
   mkdirSync(outDir, { recursive: true });
-  for (const [typeName, { out }] of Object.entries(ROOTS)) {
+  for (const [typeName, out] of Object.entries(ROOTS)) {
     writeFileSync(resolve(outDir, out), JSON.stringify(generateSchema(typeName), null, 2) + '\n');
     console.log(`wrote dist/schema/${out}`);
   }
 }
 
-// Run only when invoked directly (`node scripts/gen-schema.mjs`).
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  main();
+// Run only when invoked directly (`node scripts/gen-schema.mjs`). Compare real
+// paths so a symlinked invocation (bin shim, pnpm link) still matches.
+function invokedDirectly() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
 }
+
+if (invokedDirectly()) main();

--- a/packages/@openmaic/dsl/src/action.ts
+++ b/packages/@openmaic/dsl/src/action.ts
@@ -276,6 +276,36 @@ export const SYNC_ACTIONS: ActionType[] = [
   'widget_reveal',
 ];
 
+/** Frozen set of every valid {@link ActionType}, for cheap membership checks. */
+export const ACTION_TYPES = [
+  'spotlight',
+  'laser',
+  'play_video',
+  'speech',
+  'wb_open',
+  'wb_draw_text',
+  'wb_draw_shape',
+  'wb_draw_chart',
+  'wb_draw_latex',
+  'wb_draw_table',
+  'wb_draw_line',
+  'wb_draw_code',
+  'wb_edit_code',
+  'wb_clear',
+  'wb_delete',
+  'wb_close',
+  'discussion',
+  'widget_highlight',
+  'widget_setState',
+  'widget_annotation',
+  'widget_reveal',
+] as const satisfies readonly ActionType[];
+
+/** Narrow an unknown value to a valid {@link ActionType}. Pure, no runtime deps. */
+export function isActionType(value: unknown): value is ActionType {
+  return typeof value === 'string' && (ACTION_TYPES as readonly string[]).includes(value);
+}
+
 // ==================== Canvas utility types (non-action) ====================
 
 /**

--- a/packages/@openmaic/dsl/src/action.ts
+++ b/packages/@openmaic/dsl/src/action.ts
@@ -301,6 +301,14 @@ export const ACTION_TYPES = [
   'widget_reveal',
 ] as const satisfies readonly ActionType[];
 
+// Compile-time exhaustiveness: every ActionType must appear in ACTION_TYPES.
+// `satisfies` above proves the converse (each entry is a valid ActionType); this
+// fails the build if the Action union gains a member the tuple is missing — so
+// the validators never silently reject a valid, newly-added action type.
+type _ActionTypesExhaustive = [ActionType] extends [(typeof ACTION_TYPES)[number]] ? true : never;
+const _actionTypesExhaustive: _ActionTypesExhaustive = true;
+void _actionTypesExhaustive;
+
 /** Narrow an unknown value to a valid {@link ActionType}. Pure, no runtime deps. */
 export function isActionType(value: unknown): value is ActionType {
   return typeof value === 'string' && (ACTION_TYPES as readonly string[]).includes(value);

--- a/packages/@openmaic/dsl/src/index.ts
+++ b/packages/@openmaic/dsl/src/index.ts
@@ -7,9 +7,11 @@
  *   @openmaic/importer  -> @openmaic/dsl
  *   @openmaic/exporter  -> @openmaic/dsl   (reserved, future)
  *
- * This package contains ONLY the spec: types, (future) JSON Schema, pure
+ * This package contains ONLY the spec: types, JSON Schema artifacts, pure
  * validators / type-guards, and version/migration helpers. It must never gain
- * a runtime dependency on React, pptx, echarts, etc.
+ * a runtime dependency on React, pptx, echarts, etc. The JSON Schema is
+ * generated at build time (devDependency only) and shipped under
+ * `@openmaic/dsl/schema/*`; the pure `validate*` functions stay zero-dep.
  *
  * The lesson skeleton (`Stage` / `Scene` / `SceneContent`) and the playback
  * verb set (`Action` and its variants) both live here. `Scene` is generic: the
@@ -22,4 +24,5 @@ export * from './slides.js';
 export * from './guards.js';
 export * from './stage.js';
 export * from './action.js';
+export * from './validate.js';
 export * from './version.js';

--- a/packages/@openmaic/dsl/src/schema-roots.ts
+++ b/packages/@openmaic/dsl/src/schema-roots.ts
@@ -1,26 +1,19 @@
 /**
- * Concrete schema-codegen entry points.
+ * Concrete schema-codegen entry point.
  *
  * JSON Schema is not generic, so the build-time generator needs a concrete
- * instantiation of the generic {@link Scene}. This aliases the contract's
- * default `Scene<Action, SceneContent>`. Internal to schema codegen — it is
- * intentionally NOT re-exported from `index.ts`, so it does not widen the
- * public type surface.
+ * instantiation of the generic {@link Scene}. This is exactly the contract's
+ * default `Scene<Action, SceneContent>` — it adds no constraint the public type
+ * doesn't already express. It is kept here only so the generator has a named,
+ * non-generic root; it is intentionally NOT re-exported from `index.ts`, so it
+ * does not widen the public type surface.
  *
  * Scope: `SceneContent` is the contract-owned union (`SlideContent | QuizContent`),
- * so the generated `scene.schema.json` covers those kinds. The app-side
- * `interactive` / `pbl` content kinds are not part of the contract — apps that
+ * so the generated `scene.schema.json` covers those content kinds. App-side
+ * `interactive` / `pbl` content shapes are not part of the contract — apps that
  * widen `Scene`'s `TContent` own the schema for their own content shapes.
  */
-import type { Scene, SlideContent, QuizContent } from './stage.js';
+import type { Scene, SceneContent } from './stage.js';
 import type { Action } from './action.js';
 
-// Discriminated per scene kind so the generated schema ties `type` to the
-// matching `content.type` (a slide-typed scene must carry slide content, a
-// quiz-typed scene quiz content). This keeps scene.schema.json consistent with
-// `validateScene`'s scene/content agreement check, instead of accepting any
-// `SceneType` × `SlideContent | QuizContent` cross-product.
-type SlideScene = Omit<Scene<Action, SlideContent>, 'type'> & { type: 'slide' };
-type QuizScene = Omit<Scene<Action, QuizContent>, 'type'> & { type: 'quiz' };
-
-export type SerializedScene = SlideScene | QuizScene;
+export type SerializedScene = Scene<Action, SceneContent>;

--- a/packages/@openmaic/dsl/src/schema-roots.ts
+++ b/packages/@openmaic/dsl/src/schema-roots.ts
@@ -1,0 +1,13 @@
+/**
+ * Concrete schema-codegen entry points.
+ *
+ * JSON Schema is not generic, so the build-time generator needs a concrete
+ * instantiation of the generic {@link Scene}. This aliases the contract's
+ * default `Scene<Action, SceneContent>`. Internal to schema codegen — it is
+ * intentionally NOT re-exported from `index.ts`, so it does not widen the
+ * public type surface.
+ */
+import type { Scene, SceneContent } from './stage.js';
+import type { Action } from './action.js';
+
+export type SerializedScene = Scene<Action, SceneContent>;

--- a/packages/@openmaic/dsl/src/schema-roots.ts
+++ b/packages/@openmaic/dsl/src/schema-roots.ts
@@ -1,19 +1,24 @@
 /**
  * Concrete schema-codegen entry point.
  *
- * JSON Schema is not generic, so the build-time generator needs a concrete
- * instantiation of the generic {@link Scene}. This is exactly the contract's
- * default `Scene<Action, SceneContent>` — it adds no constraint the public type
- * doesn't already express. It is kept here only so the generator has a named,
- * non-generic root; it is intentionally NOT re-exported from `index.ts`, so it
- * does not widen the public type surface.
+ * JSON Schema is not generic, so the build-time generator needs a concrete,
+ * non-generic root. This is the contract's default `Scene<Action, SceneContent>`
+ * — it adds no constraint the public {@link Scene} type doesn't already express
+ * (the `type` <-> `content` binding lives in `Scene` itself). It is intentionally
+ * NOT re-exported from `index.ts`, so it does not widen the public type surface.
+ *
+ * The default distributes to one member per content kind. We spell that union
+ * out explicitly (`Scene<…, SlideContent> | Scene<…, QuizContent>`) rather than
+ * writing `Scene<Action, SceneContent>`, because the schema generator collapses
+ * the bare form into a single object with an unbound `type`, whereas the
+ * spelled-out union emits a discriminated `anyOf` that preserves the binding.
  *
  * Scope: `SceneContent` is the contract-owned union (`SlideContent | QuizContent`),
- * so the generated `scene.schema.json` covers those content kinds. App-side
- * `interactive` / `pbl` content shapes are not part of the contract — apps that
- * widen `Scene`'s `TContent` own the schema for their own content shapes.
+ * so `scene.schema.json` covers those kinds. App-side `interactive` / `pbl`
+ * content shapes are not part of the contract — apps that widen `Scene`'s
+ * `TContent` own the schema for their own content shapes.
  */
-import type { Scene, SceneContent } from './stage.js';
+import type { Scene, SlideContent, QuizContent } from './stage.js';
 import type { Action } from './action.js';
 
-export type SerializedScene = Scene<Action, SceneContent>;
+export type SerializedScene = Scene<Action, SlideContent> | Scene<Action, QuizContent>;

--- a/packages/@openmaic/dsl/src/schema-roots.ts
+++ b/packages/@openmaic/dsl/src/schema-roots.ts
@@ -12,7 +12,15 @@
  * `interactive` / `pbl` content kinds are not part of the contract — apps that
  * widen `Scene`'s `TContent` own the schema for their own content shapes.
  */
-import type { Scene, SceneContent } from './stage.js';
+import type { Scene, SlideContent, QuizContent } from './stage.js';
 import type { Action } from './action.js';
 
-export type SerializedScene = Scene<Action, SceneContent>;
+// Discriminated per scene kind so the generated schema ties `type` to the
+// matching `content.type` (a slide-typed scene must carry slide content, a
+// quiz-typed scene quiz content). This keeps scene.schema.json consistent with
+// `validateScene`'s scene/content agreement check, instead of accepting any
+// `SceneType` × `SlideContent | QuizContent` cross-product.
+type SlideScene = Omit<Scene<Action, SlideContent>, 'type'> & { type: 'slide' };
+type QuizScene = Omit<Scene<Action, QuizContent>, 'type'> & { type: 'quiz' };
+
+export type SerializedScene = SlideScene | QuizScene;

--- a/packages/@openmaic/dsl/src/schema-roots.ts
+++ b/packages/@openmaic/dsl/src/schema-roots.ts
@@ -6,6 +6,11 @@
  * default `Scene<Action, SceneContent>`. Internal to schema codegen — it is
  * intentionally NOT re-exported from `index.ts`, so it does not widen the
  * public type surface.
+ *
+ * Scope: `SceneContent` is the contract-owned union (`SlideContent | QuizContent`),
+ * so the generated `scene.schema.json` covers those kinds. The app-side
+ * `interactive` / `pbl` content kinds are not part of the contract — apps that
+ * widen `Scene`'s `TContent` own the schema for their own content shapes.
  */
 import type { Scene, SceneContent } from './stage.js';
 import type { Action } from './action.js';

--- a/packages/@openmaic/dsl/src/stage.ts
+++ b/packages/@openmaic/dsl/src/stage.ts
@@ -20,7 +20,12 @@ import type { Action } from './action.js';
 export type SceneType = 'slide' | 'quiz' | 'interactive' | 'pbl';
 
 /** Frozen set of every valid {@link SceneType}, for cheap membership checks. */
-export const SCENE_TYPES = ['slide', 'quiz', 'interactive', 'pbl'] as const satisfies readonly SceneType[];
+export const SCENE_TYPES = [
+  'slide',
+  'quiz',
+  'interactive',
+  'pbl',
+] as const satisfies readonly SceneType[];
 
 // Compile-time exhaustiveness: every SceneType must appear in SCENE_TYPES.
 // `satisfies` above proves the converse (each entry is a valid SceneType); this

--- a/packages/@openmaic/dsl/src/stage.ts
+++ b/packages/@openmaic/dsl/src/stage.ts
@@ -173,43 +173,15 @@ export interface QuizContent {
 export type SceneContent = SlideContent | QuizContent;
 
 /**
- * Scene - Represents a single page/scene in the course.
- *
- * Generic so the contract owns the universal skeleton + the standard action
- * set, while the app widens the content union (and, if needed, the action
- * union) for its richer feature kinds:
- *
- * ```ts
- * // app side — widen content; widen actions only if the app adds its own
- * type AppScene = Scene<Action, AppSceneContent>;
- * ```
- *
- * Defaults (`TAction = Action`, `TContent = SlideContent | QuizContent`) yield a
- * scene whose `actions` are the contract's standard {@link Action} union and
- * whose content spans the two universal kinds — what the runtime engine and
- * playback consumers want out of the box. Skeleton-only consumers that reject
- * actions entirely can still opt out with `Scene<never, …>`. The `TContent`
- * constraint is structural — any union of objects tagged with a `type:
- * SceneType` discriminant satisfies it — so an app can pass its own wider
- * content union (slide | quiz | interactive | pbl).
- *
- * @template TAction  - The playback action type (defaults to the standard {@link Action} union).
- * @template TContent - The scene-content union; any object union tagged with a
- *                      `type: {@link SceneType}` discriminant (defaults to the
- *                      two universal kinds).
+ * The content-kind-independent fields of a {@link Scene}. Everything except the
+ * `type` discriminant and the `content` payload, which {@link Scene} binds
+ * together per kind.
  */
-export interface Scene<
-  TAction = Action,
-  TContent extends { type: SceneType } = SlideContent | QuizContent,
-> {
+export interface SceneCore<TAction = Action> {
   id: string;
   stageId: string; // ID of the parent stage (for data integrity checks)
-  type: SceneType;
   title: string;
   order: number; // Display order
-
-  // Type-specific content
-  content: TContent;
 
   // Actions to execute during playback (app-injected)
   actions?: TAction[];
@@ -224,6 +196,41 @@ export interface Scene<
   createdAt?: number;
   updatedAt?: number;
 }
+
+/**
+ * Scene - Represents a single page/scene in the course.
+ *
+ * The scene-level `type` discriminant is **bound to its `content`**: a
+ * slide-typed scene must carry `SlideContent`, a quiz-typed scene `QuizContent`,
+ * and so on. This is a real invariant — consumers branch on `scene.type` and
+ * then read `scene.content` as the matching shape — so the contract enforces it
+ * at the type level rather than leaving the two free to disagree.
+ *
+ * Implemented as a distributive conditional over `TContent`: the binding holds
+ * per member of the content union, so the default `Scene<Action, SlideContent |
+ * QuizContent>` is `({ type: 'slide'; content: SlideContent } | { type: 'quiz';
+ * content: QuizContent }) & SceneCore`, and an app can still widen `TContent`
+ * with its own content kinds — each new kind ties its own `type` to its shape.
+ *
+ * ```ts
+ * // app side — widen content; widen actions only if the app adds its own
+ * type AppScene = Scene<Action, AppSceneContent>;
+ * ```
+ *
+ * Skeleton-only consumers that reject actions entirely can still opt out with
+ * `Scene<never, …>`.
+ *
+ * @template TAction  - The playback action type (defaults to the standard {@link Action} union).
+ * @template TContent - The scene-content union; any object union tagged with a
+ *                      `type: {@link SceneType}` discriminant (defaults to the
+ *                      two universal kinds). Each member binds its own `type`.
+ */
+export type Scene<
+  TAction = Action,
+  TContent extends { type: SceneType } = SlideContent | QuizContent,
+> = TContent extends unknown
+  ? SceneCore<TAction> & { type: TContent['type']; content: TContent }
+  : never;
 
 // ---------------------------------------------------------------------------
 // Pure discriminant guards

--- a/packages/@openmaic/dsl/src/stage.ts
+++ b/packages/@openmaic/dsl/src/stage.ts
@@ -19,6 +19,21 @@ import type { Action } from './action.js';
 /** All scene kinds the contract is aware of. Feature kinds (interactive/pbl) are still valid `type` values — their *content* shapes live in the app and are composed in via {@link Scene}'s `TContent` parameter. */
 export type SceneType = 'slide' | 'quiz' | 'interactive' | 'pbl';
 
+/** Frozen set of every valid {@link SceneType}, for cheap membership checks. */
+export const SCENE_TYPES = ['slide', 'quiz', 'interactive', 'pbl'] as const satisfies readonly SceneType[];
+
+// Compile-time exhaustiveness: every SceneType must appear in SCENE_TYPES.
+// `satisfies` above proves the converse (each entry is a valid SceneType); this
+// fails the build if the union gains a member the tuple is missing.
+type _SceneTypesExhaustive = [SceneType] extends [(typeof SCENE_TYPES)[number]] ? true : never;
+const _sceneTypesExhaustive: _SceneTypesExhaustive = true;
+void _sceneTypesExhaustive;
+
+/** Narrow an unknown value to a valid {@link SceneType}. Pure, no runtime deps. */
+export function isSceneType(value: unknown): value is SceneType {
+  return typeof value === 'string' && (SCENE_TYPES as readonly string[]).includes(value);
+}
+
 /** Lifecycle / interaction mode a {@link Stage} can be operated in. */
 export type StageMode = 'autonomous' | 'playback' | 'edit';
 

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -20,20 +20,30 @@ export interface ValidationIssue {
   message: string;
 }
 
-export type ValidationResult =
-  | { valid: true }
-  | { valid: false; errors: ValidationIssue[] };
+export type ValidationResult = { valid: true } | { valid: false; errors: ValidationIssue[] };
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-function reqString(o: Record<string, unknown>, key: string, path: string, errors: ValidationIssue[]): void {
-  if (typeof o[key] !== 'string') errors.push({ path: `${path}/${key}`, message: `expected string \`${key}\`` });
+function reqString(
+  o: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: ValidationIssue[],
+): void {
+  if (typeof o[key] !== 'string')
+    errors.push({ path: `${path}/${key}`, message: `expected string \`${key}\`` });
 }
 
-function reqNumber(o: Record<string, unknown>, key: string, path: string, errors: ValidationIssue[]): void {
-  if (typeof o[key] !== 'number') errors.push({ path: `${path}/${key}`, message: `expected number \`${key}\`` });
+function reqNumber(
+  o: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: ValidationIssue[],
+): void {
+  if (typeof o[key] !== 'number')
+    errors.push({ path: `${path}/${key}`, message: `expected number \`${key}\`` });
 }
 
 function done(errors: ValidationIssue[]): ValidationResult {
@@ -47,7 +57,10 @@ function checkAction(doc: unknown, path: string, errors: ValidationIssue[]): voi
   }
   reqString(doc, 'id', path, errors);
   if (!isActionType(doc.type)) {
-    errors.push({ path: `${path}/type`, message: `unknown action type: ${JSON.stringify(doc.type)}` });
+    errors.push({
+      path: `${path}/type`,
+      message: `unknown action type: ${JSON.stringify(doc.type)}`,
+    });
   }
 }
 
@@ -63,14 +76,20 @@ function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void
 
   const sceneType = doc.type;
   if (!isSceneType(sceneType)) {
-    errors.push({ path: `${path}/type`, message: `unknown scene type: ${JSON.stringify(sceneType)}` });
+    errors.push({
+      path: `${path}/type`,
+      message: `unknown scene type: ${JSON.stringify(sceneType)}`,
+    });
   }
 
   const content = doc.content;
   if (!isObject(content)) {
     errors.push({ path: `${path}/content`, message: 'scene `content` must be an object' });
   } else if (!isSceneType(content.type)) {
-    errors.push({ path: `${path}/content/type`, message: `unknown content type: ${JSON.stringify(content.type)}` });
+    errors.push({
+      path: `${path}/content/type`,
+      message: `unknown content type: ${JSON.stringify(content.type)}`,
+    });
   } else {
     // Scene-level and content-level discriminants must agree.
     if (isSceneType(sceneType) && content.type !== sceneType) {
@@ -83,9 +102,15 @@ function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void
     // app-side kinds (interactive/pbl) carry app-defined shapes that this
     // envelope-level validator deliberately leaves to the consuming app.
     if (content.type === 'slide' && !isObject(content.canvas)) {
-      errors.push({ path: `${path}/content/canvas`, message: 'slide content requires an object `canvas`' });
+      errors.push({
+        path: `${path}/content/canvas`,
+        message: 'slide content requires an object `canvas`',
+      });
     } else if (content.type === 'quiz' && !Array.isArray(content.questions)) {
-      errors.push({ path: `${path}/content/questions`, message: 'quiz content requires a `questions` array' });
+      errors.push({
+        path: `${path}/content/questions`,
+        message: 'quiz content requires a `questions` array',
+      });
     }
   }
 
@@ -101,7 +126,8 @@ function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void
 /** Validate a {@link Stage} aggregate (course metadata; scenes are separate). */
 export function validateStage(doc: unknown): ValidationResult {
   const errors: ValidationIssue[] = [];
-  if (!isObject(doc)) return { valid: false, errors: [{ path: '/', message: 'stage must be an object' }] };
+  if (!isObject(doc))
+    return { valid: false, errors: [{ path: '/', message: 'stage must be an object' }] };
   reqString(doc, 'id', '', errors);
   reqString(doc, 'name', '', errors);
   reqNumber(doc, 'createdAt', '', errors);

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure, dependency-free structural validators for the slide DSL contract.
+ *
+ * Lightweight, fail-loud boundary checks (LLM / agent output, persistence):
+ * they verify discriminants, required fields, and that nested discriminants are
+ * known values. Exhaustive per-field validation is delegated to the shipped
+ * JSON Schema (`@openmaic/dsl/schema/*`) for consumers that bring their own
+ * validator (e.g. ajv). No runtime dependencies.
+ */
+import { isActionType } from './action.js';
+import type { SceneType } from './stage.js';
+
+export interface ValidationIssue {
+  /** JSON-pointer-ish path to the offending value, e.g. `/actions/0/type`. */
+  path: string;
+  message: string;
+}
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; errors: ValidationIssue[] };
+
+const SCENE_TYPES = ['slide', 'quiz', 'interactive', 'pbl'] as const satisfies readonly SceneType[];
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function reqString(o: Record<string, unknown>, key: string, path: string, errors: ValidationIssue[]): void {
+  if (typeof o[key] !== 'string') errors.push({ path: `${path}/${key}`, message: `expected string \`${key}\`` });
+}
+
+function reqNumber(o: Record<string, unknown>, key: string, path: string, errors: ValidationIssue[]): void {
+  if (typeof o[key] !== 'number') errors.push({ path: `${path}/${key}`, message: `expected number \`${key}\`` });
+}
+
+function done(errors: ValidationIssue[]): ValidationResult {
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+function checkAction(doc: unknown, path: string, errors: ValidationIssue[]): void {
+  if (!isObject(doc)) {
+    errors.push({ path: path || '/', message: 'action must be an object' });
+    return;
+  }
+  reqString(doc, 'id', path, errors);
+  if (!isActionType(doc.type)) {
+    errors.push({ path: `${path}/type`, message: `unknown action type: ${JSON.stringify(doc.type)}` });
+  }
+}
+
+function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void {
+  if (!isObject(doc)) {
+    errors.push({ path: path || '/', message: 'scene must be an object' });
+    return;
+  }
+  reqString(doc, 'id', path, errors);
+  reqString(doc, 'stageId', path, errors);
+  reqString(doc, 'title', path, errors);
+  reqNumber(doc, 'order', path, errors);
+
+  if (typeof doc.type !== 'string' || !(SCENE_TYPES as readonly string[]).includes(doc.type)) {
+    errors.push({ path: `${path}/type`, message: `unknown scene type: ${JSON.stringify(doc.type)}` });
+  }
+
+  const content = doc.content;
+  if (!isObject(content)) {
+    errors.push({ path: `${path}/content`, message: 'scene `content` must be an object' });
+  } else if (typeof content.type !== 'string' || !(SCENE_TYPES as readonly string[]).includes(content.type)) {
+    errors.push({ path: `${path}/content/type`, message: `unknown content type: ${JSON.stringify(content.type)}` });
+  } else if (content.type === 'slide' && !isObject(content.canvas)) {
+    errors.push({ path: `${path}/content/canvas`, message: 'slide content requires an object `canvas`' });
+  } else if (content.type === 'quiz' && !Array.isArray(content.questions)) {
+    errors.push({ path: `${path}/content/questions`, message: 'quiz content requires a `questions` array' });
+  }
+
+  if (doc.actions !== undefined) {
+    if (!Array.isArray(doc.actions)) {
+      errors.push({ path: `${path}/actions`, message: '`actions` must be an array' });
+    } else {
+      doc.actions.forEach((a, i) => checkAction(a, `${path}/actions/${i}`, errors));
+    }
+  }
+}
+
+/** Validate a {@link Stage} aggregate (course metadata; scenes are separate). */
+export function validateStage(doc: unknown): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  if (!isObject(doc)) return { valid: false, errors: [{ path: '/', message: 'stage must be an object' }] };
+  reqString(doc, 'id', '', errors);
+  reqString(doc, 'name', '', errors);
+  reqNumber(doc, 'createdAt', '', errors);
+  reqNumber(doc, 'updatedAt', '', errors);
+  return done(errors);
+}
+
+/** Validate a {@link Scene} aggregate, including its nested content + actions. */
+export function validateScene(doc: unknown): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  checkScene(doc, '', errors);
+  return done(errors);
+}
+
+/** Validate a single {@link Action}. */
+export function validateAction(doc: unknown): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  checkAction(doc, '', errors);
+  return done(errors);
+}

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -1,27 +1,59 @@
 /**
  * Pure, dependency-free structural validators for the slide DSL contract.
  *
- * These are cheap, zero-dependency *structural pre-checks*: they verify object
- * shape, the envelope's required fields, and that discriminants are known
- * contract values. They are a deliberate **strict subset** of the shipped JSON
- * Schema (`@openmaic/dsl/schema/*`): passing a validator does NOT prove a
- * document is schema-valid. The JSON Schema is the authoritative, exhaustive
- * per-field validator (it checks variant-specific fields like an action's
- * `elementId`); reach for it, with your own validator (e.g. ajv), at real trust
- * boundaries (untrusted LLM / agent output, persistence). These functions add
- * no dependency and describe the same contract shape — the schema just checks
- * more of it. No runtime dependencies.
+ * This is the contract's authoritative, zero-dependency validation boundary for
+ * in-process (TS / JS) producers and consumers — generators, importers, the
+ * runtime engine. It checks object shape, required fields (including each action
+ * variant's), known discriminants, and the scene `type` <-> `content` binding
+ * that the public {@link Scene} type enforces. Producers can rely on it without
+ * shipping a schema validator, because it adds no runtime dependency.
+ *
+ * The shipped JSON Schema (`@openmaic/dsl/schema/*`) is the cross-language
+ * mirror of the same contract — reach for it from non-TS consumers, or when you
+ * want exhaustive value-level (type / format) checking. These validators are a
+ * structural subset (presence + discriminants); the schema additionally checks
+ * each field's value shape. Both describe the same contract. No runtime
+ * dependencies.
  */
 import { isActionType } from './action.js';
-import { isSceneType } from './stage.js';
+import type { ActionType } from './action.js';
 
 export interface ValidationIssue {
-  /** JSON-pointer-ish path to the offending value, e.g. `/actions/0/type`. */
+  /** JSON-pointer-ish path to the offending value, e.g. `/actions/0/elementId`. */
   path: string;
   message: string;
 }
 
 export type ValidationResult = { valid: true } | { valid: false; errors: ValidationIssue[] };
+
+/**
+ * Required fields beyond `ActionBase` (`id`) for each action variant, used for a
+ * presence check. Kept in lockstep with the generated `action.schema.json` by a
+ * test — the schema, derived from the TS types, is the source of truth.
+ */
+const ACTION_REQUIRED_FIELDS: Record<ActionType, readonly string[]> = {
+  spotlight: ['elementId'],
+  laser: ['elementId'],
+  play_video: ['elementId'],
+  speech: ['text'],
+  wb_open: [],
+  wb_draw_text: ['content', 'x', 'y'],
+  wb_draw_shape: ['shape', 'x', 'y', 'width', 'height'],
+  wb_draw_chart: ['chartType', 'x', 'y', 'width', 'height', 'data'],
+  wb_draw_latex: ['latex', 'x', 'y'],
+  wb_draw_table: ['x', 'y', 'width', 'height', 'data'],
+  wb_draw_line: ['startX', 'startY', 'endX', 'endY'],
+  wb_draw_code: ['language', 'code', 'x', 'y'],
+  wb_edit_code: ['elementId', 'operation'],
+  wb_clear: [],
+  wb_delete: ['elementId'],
+  wb_close: [],
+  discussion: ['topic'],
+  widget_highlight: ['target'],
+  widget_setState: ['state'],
+  widget_annotation: ['target'],
+  widget_reveal: ['target'],
+};
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -62,6 +94,14 @@ function checkAction(doc: unknown, path: string, errors: ValidationIssue[]): voi
       path: `${path}/type`,
       message: `unknown action type: ${JSON.stringify(doc.type)}`,
     });
+    return; // can't check variant fields without a known type
+  }
+  for (const field of ACTION_REQUIRED_FIELDS[doc.type]) {
+    if (doc[field] === undefined)
+      errors.push({
+        path: `${path}/${field}`,
+        message: `${doc.type} action requires \`${field}\``,
+      });
   }
 }
 
@@ -75,38 +115,37 @@ function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void
   reqString(doc, 'title', path, errors);
   reqNumber(doc, 'order', path, errors);
 
-  if (!isSceneType(doc.type)) {
+  // The scene `type` is bound to its `content` (see `Scene`): a slide scene
+  // carries slide content, a quiz scene quiz content. The contract owns the
+  // slide/quiz kinds; app-widened kinds validate their own scenes.
+  const t = doc.type;
+  if (t !== 'slide' && t !== 'quiz') {
     errors.push({
       path: `${path}/type`,
-      message: `unknown scene type: ${JSON.stringify(doc.type)}`,
+      message: `unknown scene type: ${JSON.stringify(t)} (the contract owns 'slide' and 'quiz')`,
     });
   }
 
-  // `content` must be one of the contract-owned content kinds (slide/quiz),
-  // mirroring `SceneContent` in the public type and the generated schema. App
-  // widened content kinds (interactive/pbl) are the consuming app's to validate.
-  // The scene-level `type` and `content.type` are validated independently — the
-  // public `Scene` type does not bind them, so neither does this validator.
   const content = doc.content;
   if (!isObject(content)) {
     errors.push({ path: `${path}/content`, message: 'scene `content` must be an object' });
-  } else if (content.type === 'slide') {
-    if (!isObject(content.canvas))
+  } else if (t === 'slide' || t === 'quiz') {
+    if (content.type !== t) {
+      errors.push({
+        path: `${path}/content/type`,
+        message: `content type ${JSON.stringify(content.type)} does not match scene type ${JSON.stringify(t)}`,
+      });
+    } else if (t === 'slide' && !isObject(content.canvas)) {
       errors.push({
         path: `${path}/content/canvas`,
         message: 'slide content requires an object `canvas`',
       });
-  } else if (content.type === 'quiz') {
-    if (!Array.isArray(content.questions))
+    } else if (t === 'quiz' && !Array.isArray(content.questions)) {
       errors.push({
         path: `${path}/content/questions`,
         message: 'quiz content requires a `questions` array',
       });
-  } else {
-    errors.push({
-      path: `${path}/content/type`,
-      message: `unknown content type: ${JSON.stringify(content.type)} (expected 'slide' or 'quiz')`,
-    });
+    }
   }
 
   if (doc.actions !== undefined) {
@@ -137,7 +176,7 @@ export function validateScene(doc: unknown): ValidationResult {
   return done(errors);
 }
 
-/** Validate a single {@link Action}. */
+/** Validate a single {@link Action}, including its variant-required fields. */
 export function validateAction(doc: unknown): ValidationResult {
   const errors: ValidationIssue[] = [];
   checkAction(doc, '', errors);

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -26,34 +26,51 @@ export interface ValidationIssue {
 
 export type ValidationResult = { valid: true } | { valid: false; errors: ValidationIssue[] };
 
+/** Runtime kind of a required field, checked with `typeof` / `Array.isArray`. */
+type FieldKind = 'string' | 'number' | 'boolean' | 'object' | 'array';
+
 /**
- * Required fields beyond `ActionBase` (`id`) for each action variant, used for a
- * presence check. Kept in lockstep with the generated `action.schema.json` by a
+ * Required fields beyond `ActionBase` (`id`) for each action variant, with the
+ * runtime kind each must have. Checked for presence AND shape. Kept in lockstep
+ * (both directions, names + kinds) with the generated `action.schema.json` by a
  * test — the schema, derived from the TS types, is the source of truth.
  */
-const ACTION_REQUIRED_FIELDS: Record<ActionType, readonly string[]> = {
-  spotlight: ['elementId'],
-  laser: ['elementId'],
-  play_video: ['elementId'],
-  speech: ['text'],
-  wb_open: [],
-  wb_draw_text: ['content', 'x', 'y'],
-  wb_draw_shape: ['shape', 'x', 'y', 'width', 'height'],
-  wb_draw_chart: ['chartType', 'x', 'y', 'width', 'height', 'data'],
-  wb_draw_latex: ['latex', 'x', 'y'],
-  wb_draw_table: ['x', 'y', 'width', 'height', 'data'],
-  wb_draw_line: ['startX', 'startY', 'endX', 'endY'],
-  wb_draw_code: ['language', 'code', 'x', 'y'],
-  wb_edit_code: ['elementId', 'operation'],
-  wb_clear: [],
-  wb_delete: ['elementId'],
-  wb_close: [],
-  discussion: ['topic'],
-  widget_highlight: ['target'],
-  widget_setState: ['state'],
-  widget_annotation: ['target'],
-  widget_reveal: ['target'],
+const ACTION_REQUIRED_FIELDS: Record<ActionType, Readonly<Record<string, FieldKind>>> = {
+  spotlight: { elementId: 'string' },
+  laser: { elementId: 'string' },
+  play_video: { elementId: 'string' },
+  speech: { text: 'string' },
+  wb_open: {},
+  wb_draw_text: { content: 'string', x: 'number', y: 'number' },
+  wb_draw_shape: { shape: 'string', x: 'number', y: 'number', width: 'number', height: 'number' },
+  wb_draw_chart: {
+    chartType: 'string',
+    x: 'number',
+    y: 'number',
+    width: 'number',
+    height: 'number',
+    data: 'object',
+  },
+  wb_draw_latex: { latex: 'string', x: 'number', y: 'number' },
+  wb_draw_table: { x: 'number', y: 'number', width: 'number', height: 'number', data: 'array' },
+  wb_draw_line: { startX: 'number', startY: 'number', endX: 'number', endY: 'number' },
+  wb_draw_code: { language: 'string', code: 'string', x: 'number', y: 'number' },
+  wb_edit_code: { elementId: 'string', operation: 'string' },
+  wb_clear: {},
+  wb_delete: { elementId: 'string' },
+  wb_close: {},
+  discussion: { topic: 'string' },
+  widget_highlight: { target: 'string' },
+  widget_setState: { state: 'object' },
+  widget_annotation: { target: 'string' },
+  widget_reveal: { target: 'string' },
 };
+
+function matchesKind(value: unknown, kind: FieldKind): boolean {
+  if (kind === 'array') return Array.isArray(value);
+  if (kind === 'object') return isObject(value);
+  return typeof value === kind;
+}
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -96,12 +113,19 @@ function checkAction(doc: unknown, path: string, errors: ValidationIssue[]): voi
     });
     return; // can't check variant fields without a known type
   }
-  for (const field of ACTION_REQUIRED_FIELDS[doc.type]) {
-    if (doc[field] === undefined)
+  for (const [field, kind] of Object.entries(ACTION_REQUIRED_FIELDS[doc.type])) {
+    const value = doc[field];
+    if (value === undefined) {
       errors.push({
         path: `${path}/${field}`,
         message: `${doc.type} action requires \`${field}\``,
       });
+    } else if (!matchesKind(value, kind)) {
+      errors.push({
+        path: `${path}/${field}`,
+        message: `${doc.type} action field \`${field}\` must be ${kind}`,
+      });
+    }
   }
 }
 

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -1,15 +1,16 @@
 /**
  * Pure, dependency-free structural validators for the slide DSL contract.
  *
- * Lightweight, fail-loud boundary checks (LLM / agent output, persistence):
- * they verify object shape, the structural envelope's required fields, that
- * discriminants are known, and that a scene's `type` agrees with its
- * `content.type`. They do NOT exhaustively check per-variant fields, and the
- * app-side `interactive` / `pbl` content kinds (whose shapes live in the
- * consuming app, not this contract) are validated only at the envelope level.
- * For exhaustive per-field validation of the contract-owned kinds, use the
- * shipped JSON Schema (`@openmaic/dsl/schema/*`) with your own validator
- * (e.g. ajv). No runtime dependencies.
+ * These are cheap, zero-dependency *structural pre-checks*: they verify object
+ * shape, the envelope's required fields, and that discriminants are known
+ * contract values. They are a deliberate **strict subset** of the shipped JSON
+ * Schema (`@openmaic/dsl/schema/*`): passing a validator does NOT prove a
+ * document is schema-valid. The JSON Schema is the authoritative, exhaustive
+ * per-field validator (it checks variant-specific fields like an action's
+ * `elementId`); reach for it, with your own validator (e.g. ajv), at real trust
+ * boundaries (untrusted LLM / agent output, persistence). These functions add
+ * no dependency and describe the same contract shape — the schema just checks
+ * more of it. No runtime dependencies.
  */
 import { isActionType } from './action.js';
 import { isSceneType } from './stage.js';
@@ -74,44 +75,38 @@ function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void
   reqString(doc, 'title', path, errors);
   reqNumber(doc, 'order', path, errors);
 
-  const sceneType = doc.type;
-  if (!isSceneType(sceneType)) {
+  if (!isSceneType(doc.type)) {
     errors.push({
       path: `${path}/type`,
-      message: `unknown scene type: ${JSON.stringify(sceneType)}`,
+      message: `unknown scene type: ${JSON.stringify(doc.type)}`,
     });
   }
 
+  // `content` must be one of the contract-owned content kinds (slide/quiz),
+  // mirroring `SceneContent` in the public type and the generated schema. App
+  // widened content kinds (interactive/pbl) are the consuming app's to validate.
+  // The scene-level `type` and `content.type` are validated independently — the
+  // public `Scene` type does not bind them, so neither does this validator.
   const content = doc.content;
   if (!isObject(content)) {
     errors.push({ path: `${path}/content`, message: 'scene `content` must be an object' });
-  } else if (!isSceneType(content.type)) {
-    errors.push({
-      path: `${path}/content/type`,
-      message: `unknown content type: ${JSON.stringify(content.type)}`,
-    });
-  } else {
-    // Scene-level and content-level discriminants must agree.
-    if (isSceneType(sceneType) && content.type !== sceneType) {
-      errors.push({
-        path: `${path}/content/type`,
-        message: `content type ${JSON.stringify(content.type)} does not match scene type ${JSON.stringify(sceneType)}`,
-      });
-    }
-    // Only the contract-owned content kinds (slide/quiz) are validated here;
-    // app-side kinds (interactive/pbl) carry app-defined shapes that this
-    // envelope-level validator deliberately leaves to the consuming app.
-    if (content.type === 'slide' && !isObject(content.canvas)) {
+  } else if (content.type === 'slide') {
+    if (!isObject(content.canvas))
       errors.push({
         path: `${path}/content/canvas`,
         message: 'slide content requires an object `canvas`',
       });
-    } else if (content.type === 'quiz' && !Array.isArray(content.questions)) {
+  } else if (content.type === 'quiz') {
+    if (!Array.isArray(content.questions))
       errors.push({
         path: `${path}/content/questions`,
         message: 'quiz content requires a `questions` array',
       });
-    }
+  } else {
+    errors.push({
+      path: `${path}/content/type`,
+      message: `unknown content type: ${JSON.stringify(content.type)} (expected 'slide' or 'quiz')`,
+    });
   }
 
   if (doc.actions !== undefined) {

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -2,13 +2,17 @@
  * Pure, dependency-free structural validators for the slide DSL contract.
  *
  * Lightweight, fail-loud boundary checks (LLM / agent output, persistence):
- * they verify discriminants, required fields, and that nested discriminants are
- * known values. Exhaustive per-field validation is delegated to the shipped
- * JSON Schema (`@openmaic/dsl/schema/*`) for consumers that bring their own
- * validator (e.g. ajv). No runtime dependencies.
+ * they verify object shape, the structural envelope's required fields, that
+ * discriminants are known, and that a scene's `type` agrees with its
+ * `content.type`. They do NOT exhaustively check per-variant fields, and the
+ * app-side `interactive` / `pbl` content kinds (whose shapes live in the
+ * consuming app, not this contract) are validated only at the envelope level.
+ * For exhaustive per-field validation of the contract-owned kinds, use the
+ * shipped JSON Schema (`@openmaic/dsl/schema/*`) with your own validator
+ * (e.g. ajv). No runtime dependencies.
  */
 import { isActionType } from './action.js';
-import type { SceneType } from './stage.js';
+import { isSceneType } from './stage.js';
 
 export interface ValidationIssue {
   /** JSON-pointer-ish path to the offending value, e.g. `/actions/0/type`. */
@@ -19,8 +23,6 @@ export interface ValidationIssue {
 export type ValidationResult =
   | { valid: true }
   | { valid: false; errors: ValidationIssue[] };
-
-const SCENE_TYPES = ['slide', 'quiz', 'interactive', 'pbl'] as const satisfies readonly SceneType[];
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -59,19 +61,32 @@ function checkScene(doc: unknown, path: string, errors: ValidationIssue[]): void
   reqString(doc, 'title', path, errors);
   reqNumber(doc, 'order', path, errors);
 
-  if (typeof doc.type !== 'string' || !(SCENE_TYPES as readonly string[]).includes(doc.type)) {
-    errors.push({ path: `${path}/type`, message: `unknown scene type: ${JSON.stringify(doc.type)}` });
+  const sceneType = doc.type;
+  if (!isSceneType(sceneType)) {
+    errors.push({ path: `${path}/type`, message: `unknown scene type: ${JSON.stringify(sceneType)}` });
   }
 
   const content = doc.content;
   if (!isObject(content)) {
     errors.push({ path: `${path}/content`, message: 'scene `content` must be an object' });
-  } else if (typeof content.type !== 'string' || !(SCENE_TYPES as readonly string[]).includes(content.type)) {
+  } else if (!isSceneType(content.type)) {
     errors.push({ path: `${path}/content/type`, message: `unknown content type: ${JSON.stringify(content.type)}` });
-  } else if (content.type === 'slide' && !isObject(content.canvas)) {
-    errors.push({ path: `${path}/content/canvas`, message: 'slide content requires an object `canvas`' });
-  } else if (content.type === 'quiz' && !Array.isArray(content.questions)) {
-    errors.push({ path: `${path}/content/questions`, message: 'quiz content requires a `questions` array' });
+  } else {
+    // Scene-level and content-level discriminants must agree.
+    if (isSceneType(sceneType) && content.type !== sceneType) {
+      errors.push({
+        path: `${path}/content/type`,
+        message: `content type ${JSON.stringify(content.type)} does not match scene type ${JSON.stringify(sceneType)}`,
+      });
+    }
+    // Only the contract-owned content kinds (slide/quiz) are validated here;
+    // app-side kinds (interactive/pbl) carry app-defined shapes that this
+    // envelope-level validator deliberately leaves to the consuming app.
+    if (content.type === 'slide' && !isObject(content.canvas)) {
+      errors.push({ path: `${path}/content/canvas`, message: 'slide content requires an object `canvas`' });
+    } else if (content.type === 'quiz' && !Array.isArray(content.questions)) {
+      errors.push({ path: `${path}/content/questions`, message: 'quiz content requires a `questions` array' });
+    }
   }
 
   if (doc.actions !== undefined) {

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -4,9 +4,16 @@ import Ajv from 'ajv';
 // @ts-expect-error untyped .mjs helper
 import { generateSchema } from '../scripts/gen-schema.mjs';
 
-function validator(root: 'Stage' | 'SerializedScene' | 'Action') {
-  const ajv = new Ajv({ allErrors: true, strict: false });
-  return ajv.compile(generateSchema(root));
+// Generate every root schema once (the generator parses the TS program a single
+// time and is reused), then compile per case — no repeated heavy codegen.
+const schemas = {
+  Stage: generateSchema('Stage'),
+  Action: generateSchema('Action'),
+  SerializedScene: generateSchema('SerializedScene'),
+} as const;
+
+function validator(root: keyof typeof schemas) {
+  return new Ajv({ allErrors: true, strict: false }).compile(schemas[root]);
 }
 
 describe('generated JSON Schema — Stage', () => {

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -61,7 +61,7 @@ describe('generated JSON Schema — SerializedScene', () => {
   it('rejects a scene missing required fields', () => {
     expect(v({ id: 'sc' })).toBe(false);
   });
-  it('rejects a scene whose type disagrees with its content (discriminants bound)', () => {
-    expect(v({ ...slideScene, type: 'quiz' })).toBe(false);
+  it('rejects content that is not a contract content kind (slide/quiz)', () => {
+    expect(v({ ...slideScene, content: { type: 'pbl' } })).toBe(false);
   });
 });

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -72,29 +72,62 @@ describe('generated JSON Schema — SerializedScene', () => {
 
 describe('validateAction variant fields stay in lockstep with the Action schema', () => {
   // The schema is generated from the TS types, so it is the source of truth for
-  // each variant's required fields. This pins the hand-written required-field
-  // map in validate.ts to it: if an interface gains/loses a required field, the
-  // schema changes and this fails until validate.ts is updated.
+  // each variant's required fields and their types. These checks pin the
+  // hand-written required-field map in validate.ts to it BOTH ways: it cannot
+  // under-list (a schema-required field validateAction ignores), over-list (an
+  // optional field validateAction wrongly demands), or mis-type a field.
   const schema = schemas.Action as {
     definitions: Record<
       string,
       {
         anyOf?: { $ref: string }[];
-        properties?: Record<string, { const?: string }>;
+        properties?: Record<string, { const?: string; type?: string }>;
         required?: string[];
       }
     >;
   };
+  const GOOD: Record<string, unknown> = {
+    string: 's',
+    number: 1,
+    boolean: true,
+    object: {},
+    array: [],
+  };
+  const BAD: Record<string, unknown> = {
+    string: 1,
+    number: 's',
+    boolean: 's',
+    object: 's',
+    array: {},
+  };
+  const paths = (doc: unknown) => {
+    const r = validateAction(doc);
+    return r.valid ? [] : r.errors.map((e) => e.path);
+  };
+
   const branches = schema.definitions.Action.anyOf ?? [];
   for (const branch of branches) {
     const def = schema.definitions[branch.$ref.split('/').pop() as string];
     const type = def.properties?.type?.const;
     if (!type) continue;
     const required = (def.required ?? []).filter((f) => f !== 'id' && f !== 'type');
-    it(`validateAction enforces ${type}'s required fields [${required.join(', ')}]`, () => {
-      const r = validateAction({ id: 'a', type });
-      const paths = r.valid ? [] : r.errors.map((e) => e.path);
-      for (const f of required) expect(paths).toContain(`/${f}`);
+    const kinds = Object.fromEntries(required.map((f) => [f, def.properties?.[f]?.type]));
+
+    it(`validateAction accepts a fully-typed ${type} (no over-listing)`, () => {
+      const good = Object.fromEntries(required.map((f) => [f, GOOD[kinds[f] ?? 'string']]));
+      expect(validateAction({ id: 'a', type, ...good })).toEqual({ valid: true });
+    });
+
+    it(`validateAction flags ${type}'s missing/mis-typed required fields [${required.join(', ')}]`, () => {
+      for (const f of required) {
+        // missing → flagged
+        expect(paths({ id: 'a', type })).toContain(`/${f}`);
+        // present but wrong-typed → flagged
+        const st = kinds[f];
+        if (typeof st === 'string' && st in BAD) {
+          expect(paths({ id: 'a', type, [f]: BAD[st] })).toContain(`/${f}`);
+        }
+      }
     });
   }
 });

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+// JS codegen helper — no .d.ts; vitest/esbuild resolves it at runtime.
+// @ts-expect-error untyped .mjs helper
+import { generateSchema } from '../scripts/gen-schema.mjs';
+
+function validator(root: 'Stage' | 'SerializedScene' | 'Action') {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  return ajv.compile(generateSchema(root));
+}
+
+describe('generated JSON Schema — Stage', () => {
+  const v = validator('Stage');
+  it('accepts a well-formed stage', () => {
+    expect(v({ id: 's', name: 'n', createdAt: 1, updatedAt: 2 })).toBe(true);
+  });
+  it('rejects a stage missing required fields', () => {
+    expect(v({ id: 's' })).toBe(false);
+  });
+});
+
+describe('generated JSON Schema — Action', () => {
+  const v = validator('Action');
+  it('accepts a spotlight action', () => {
+    expect(v({ id: 'a', type: 'spotlight', elementId: 'e' })).toBe(true);
+  });
+  it('rejects an action missing its required discriminated fields', () => {
+    expect(v({ id: 'a', type: 'spotlight' /* missing elementId */ })).toBe(false);
+  });
+});
+
+describe('generated JSON Schema — SerializedScene', () => {
+  const v = validator('SerializedScene');
+  it('rejects a scene missing required fields', () => {
+    expect(v({ id: 'sc' })).toBe(false);
+  });
+});

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import Ajv from 'ajv';
-// JS codegen helper — no .d.ts; vitest/esbuild resolves it at runtime.
-// @ts-expect-error untyped .mjs helper
+// JS codegen helper (the build-only generator); vitest/esbuild resolves it at
+// runtime and tsc infers its exports via allowJs.
 import { generateSchema } from '../scripts/gen-schema.mjs';
 
 // Generate every root schema once (the generator parses the TS program a single
@@ -44,7 +44,16 @@ describe('generated JSON Schema — SerializedScene', () => {
     type: 'slide',
     title: 't',
     order: 0,
-    content: { type: 'slide', canvas: { id: 'c', viewportSize: 1920, viewportRatio: 0.5625, theme: { themeColors: [], fontColor: '#000', fontName: 'Arial', backgroundColor: '#fff' }, elements: [] } },
+    content: {
+      type: 'slide',
+      canvas: {
+        id: 'c',
+        viewportSize: 1920,
+        viewportRatio: 0.5625,
+        theme: { themeColors: [], fontColor: '#000', fontName: 'Arial', backgroundColor: '#fff' },
+        elements: [],
+      },
+    },
   };
   it('accepts a well-formed slide scene', () => {
     expect(v(slideScene)).toBe(true);

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import Ajv from 'ajv';
+import { validateAction } from '@openmaic/dsl';
 // JS codegen helper (the build-only generator); vitest/esbuild resolves it at
 // runtime and tsc infers its exports via allowJs.
 import { generateSchema } from '../scripts/gen-schema.mjs';
@@ -64,4 +65,36 @@ describe('generated JSON Schema — SerializedScene', () => {
   it('rejects content that is not a contract content kind (slide/quiz)', () => {
     expect(v({ ...slideScene, content: { type: 'pbl' } })).toBe(false);
   });
+  it('rejects a scene whose type disagrees with its content (type<->content bound)', () => {
+    expect(v({ ...slideScene, type: 'quiz' })).toBe(false);
+  });
+});
+
+describe('validateAction variant fields stay in lockstep with the Action schema', () => {
+  // The schema is generated from the TS types, so it is the source of truth for
+  // each variant's required fields. This pins the hand-written required-field
+  // map in validate.ts to it: if an interface gains/loses a required field, the
+  // schema changes and this fails until validate.ts is updated.
+  const schema = schemas.Action as {
+    definitions: Record<
+      string,
+      {
+        anyOf?: { $ref: string }[];
+        properties?: Record<string, { const?: string }>;
+        required?: string[];
+      }
+    >;
+  };
+  const branches = schema.definitions.Action.anyOf ?? [];
+  for (const branch of branches) {
+    const def = schema.definitions[branch.$ref.split('/').pop() as string];
+    const type = def.properties?.type?.const;
+    if (!type) continue;
+    const required = (def.required ?? []).filter((f) => f !== 'id' && f !== 'type');
+    it(`validateAction enforces ${type}'s required fields [${required.join(', ')}]`, () => {
+      const r = validateAction({ id: 'a', type });
+      const paths = r.valid ? [] : r.errors.map((e) => e.path);
+      for (const f of required) expect(paths).toContain(`/${f}`);
+    });
+  }
 });

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -38,7 +38,21 @@ describe('generated JSON Schema — Action', () => {
 
 describe('generated JSON Schema — SerializedScene', () => {
   const v = validator('SerializedScene');
+  const slideScene = {
+    id: 'sc',
+    stageId: 'st',
+    type: 'slide',
+    title: 't',
+    order: 0,
+    content: { type: 'slide', canvas: { id: 'c', viewportSize: 1920, viewportRatio: 0.5625, theme: { themeColors: [], fontColor: '#000', fontName: 'Arial', backgroundColor: '#fff' }, elements: [] } },
+  };
+  it('accepts a well-formed slide scene', () => {
+    expect(v(slideScene)).toBe(true);
+  });
   it('rejects a scene missing required fields', () => {
     expect(v({ id: 'sc' })).toBe(false);
+  });
+  it('rejects a scene whose type disagrees with its content (discriminants bound)', () => {
+    expect(v({ ...slideScene, type: 'quiz' })).toBe(false);
   });
 });

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -82,6 +82,11 @@ describe('validateAction', () => {
     const d = validateAction({ id: 'a', type: 'discussion' });
     expect(errors(d)).toContain('/topic');
   });
+  it('flags a variant-required field of the wrong type', () => {
+    // present but mis-typed: elementId must be a string, not a number.
+    const r = validateAction({ id: 'a', type: 'spotlight', elementId: 123 });
+    expect(errors(r)).toContain('/elementId');
+  });
   it('requires a string id', () => {
     const r = validateAction({ type: 'laser', elementId: 'e' });
     expect(errors(r)).toContain('/id');

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateStage,
+  validateScene,
+  validateAction,
+  type ValidationResult,
+} from '@openmaic/dsl';
+
+function errors(r: ValidationResult): string[] {
+  return r.valid ? [] : r.errors.map((e) => e.path);
+}
+
+describe('validateStage', () => {
+  it('accepts a well-formed stage', () => {
+    expect(validateStage({ id: 's', name: 'n', createdAt: 1, updatedAt: 2 })).toEqual({ valid: true });
+  });
+  it('collects every missing required field', () => {
+    const r = validateStage({ id: 's' });
+    expect(r.valid).toBe(false);
+    expect(errors(r)).toEqual(expect.arrayContaining(['/name', '/createdAt', '/updatedAt']));
+  });
+  it('rejects non-objects', () => {
+    expect(validateStage(null).valid).toBe(false);
+    expect(validateStage('x').valid).toBe(false);
+  });
+});
+
+describe('validateScene', () => {
+  const ok = {
+    id: 'sc1',
+    stageId: 'st1',
+    type: 'slide',
+    title: 'Intro',
+    order: 0,
+    content: { type: 'slide', canvas: { id: 'c' } },
+  };
+  it('accepts a well-formed slide scene', () => {
+    expect(validateScene(ok)).toEqual({ valid: true });
+  });
+  it('flags an unknown content type', () => {
+    const r = validateScene({ ...ok, content: { type: 'bogus' } });
+    expect(errors(r)).toContain('/content/type');
+  });
+  it('flags a quiz scene missing its questions array', () => {
+    const r = validateScene({ ...ok, type: 'quiz', content: { type: 'quiz' } });
+    expect(errors(r)).toContain('/content/questions');
+  });
+  it('validates nested actions and points at the bad one', () => {
+    const r = validateScene({ ...ok, actions: [{ id: 'a', type: 'speech' }, { id: 'b', type: 'nope' }] });
+    expect(errors(r)).toContain('/actions/1/type');
+  });
+});
+
+describe('validateAction', () => {
+  it('accepts a known action type', () => {
+    expect(validateAction({ id: 'a', type: 'spotlight' })).toEqual({ valid: true });
+  });
+  it('rejects an unknown action type', () => {
+    const r = validateAction({ id: 'a', type: 'frobnicate' });
+    expect(errors(r)).toContain('/type');
+  });
+  it('requires a string id', () => {
+    const r = validateAction({ type: 'laser' });
+    expect(errors(r)).toContain('/id');
+  });
+});

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -42,24 +42,24 @@ describe('validateScene', () => {
     const r = validateScene({ ...ok, type: 'quiz', content: { type: 'quiz' } });
     expect(errors(r)).toContain('/content/questions');
   });
-  it('flags app-widened content kinds (contract owns only slide/quiz)', () => {
+  it('flags app-widened scene kinds (contract owns only slide/quiz)', () => {
     const r = validateScene({ ...ok, type: 'pbl', content: { type: 'pbl' } });
-    expect(errors(r)).toContain('/content/type');
+    expect(errors(r)).toContain('/type');
   });
-  it('does not bind scene.type to content.type (the public Scene type does not either)', () => {
-    // The contract leaves scene/content agreement out of the type, so the
-    // structural validator does too; per-shape rules live in the JSON Schema.
-    expect(
-      validateScene({ ...ok, type: 'quiz', content: { type: 'slide', canvas: { id: 'c' } } }),
-    ).toEqual({
-      valid: true,
+  it('flags a scene whose content.type disagrees with its type', () => {
+    const r = validateScene({
+      ...ok,
+      type: 'quiz',
+      content: { type: 'slide', canvas: { id: 'c' } },
     });
+    expect(r.valid).toBe(false);
+    expect(errors(r)).toContain('/content/type');
   });
   it('validates nested actions and points at the bad one', () => {
     const r = validateScene({
       ...ok,
       actions: [
-        { id: 'a', type: 'speech' },
+        { id: 'a', type: 'speech', text: 'hi' },
         { id: 'b', type: 'nope' },
       ],
     });
@@ -68,15 +68,22 @@ describe('validateScene', () => {
 });
 
 describe('validateAction', () => {
-  it('accepts a known action type', () => {
-    expect(validateAction({ id: 'a', type: 'spotlight' })).toEqual({ valid: true });
+  it('accepts a well-formed action (variant fields present)', () => {
+    expect(validateAction({ id: 'a', type: 'spotlight', elementId: 'e' })).toEqual({ valid: true });
   });
   it('rejects an unknown action type', () => {
     const r = validateAction({ id: 'a', type: 'frobnicate' });
     expect(errors(r)).toContain('/type');
   });
+  it('flags a known action type missing a variant-required field', () => {
+    // cosarah's example: a spotlight with no elementId is unusable at runtime.
+    const r = validateAction({ id: 'a', type: 'spotlight' });
+    expect(errors(r)).toContain('/elementId');
+    const d = validateAction({ id: 'a', type: 'discussion' });
+    expect(errors(d)).toContain('/topic');
+  });
   it('requires a string id', () => {
-    const r = validateAction({ type: 'laser' });
+    const r = validateAction({ type: 'laser', elementId: 'e' });
     expect(errors(r)).toContain('/id');
   });
 });

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -42,10 +42,18 @@ describe('validateScene', () => {
     const r = validateScene({ ...ok, type: 'quiz', content: { type: 'quiz' } });
     expect(errors(r)).toContain('/content/questions');
   });
-  it('flags a scene whose content.type disagrees with its type', () => {
-    const r = validateScene({ ...ok, type: 'slide', content: { type: 'quiz', questions: [] } });
-    expect(r.valid).toBe(false);
+  it('flags app-widened content kinds (contract owns only slide/quiz)', () => {
+    const r = validateScene({ ...ok, type: 'pbl', content: { type: 'pbl' } });
     expect(errors(r)).toContain('/content/type');
+  });
+  it('does not bind scene.type to content.type (the public Scene type does not either)', () => {
+    // The contract leaves scene/content agreement out of the type, so the
+    // structural validator does too; per-shape rules live in the JSON Schema.
+    expect(
+      validateScene({ ...ok, type: 'quiz', content: { type: 'slide', canvas: { id: 'c' } } }),
+    ).toEqual({
+      valid: true,
+    });
   });
   it('validates nested actions and points at the bad one', () => {
     const r = validateScene({

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  validateStage,
-  validateScene,
-  validateAction,
-  type ValidationResult,
-} from '@openmaic/dsl';
+import { validateStage, validateScene, validateAction, type ValidationResult } from '@openmaic/dsl';
 
 function errors(r: ValidationResult): string[] {
   return r.valid ? [] : r.errors.map((e) => e.path);
@@ -12,7 +7,9 @@ function errors(r: ValidationResult): string[] {
 
 describe('validateStage', () => {
   it('accepts a well-formed stage', () => {
-    expect(validateStage({ id: 's', name: 'n', createdAt: 1, updatedAt: 2 })).toEqual({ valid: true });
+    expect(validateStage({ id: 's', name: 'n', createdAt: 1, updatedAt: 2 })).toEqual({
+      valid: true,
+    });
   });
   it('collects every missing required field', () => {
     const r = validateStage({ id: 's' });
@@ -51,7 +48,13 @@ describe('validateScene', () => {
     expect(errors(r)).toContain('/content/type');
   });
   it('validates nested actions and points at the bad one', () => {
-    const r = validateScene({ ...ok, actions: [{ id: 'a', type: 'speech' }, { id: 'b', type: 'nope' }] });
+    const r = validateScene({
+      ...ok,
+      actions: [
+        { id: 'a', type: 'speech' },
+        { id: 'b', type: 'nope' },
+      ],
+    });
     expect(errors(r)).toContain('/actions/1/type');
   });
 });

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -45,6 +45,11 @@ describe('validateScene', () => {
     const r = validateScene({ ...ok, type: 'quiz', content: { type: 'quiz' } });
     expect(errors(r)).toContain('/content/questions');
   });
+  it('flags a scene whose content.type disagrees with its type', () => {
+    const r = validateScene({ ...ok, type: 'slide', content: { type: 'quiz', questions: [] } });
+    expect(r.valid).toBe(false);
+    expect(errors(r)).toContain('/content/type');
+  });
   it('validates nested actions and points at the bad one', () => {
     const r = validateScene({ ...ok, actions: [{ id: 'a', type: 'speech' }, { id: 'b', type: 'nope' }] });
     expect(errors(r)).toContain('/actions/1/type');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,12 @@ importers:
 
   packages/@openmaic/dsl:
     devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.18.0
+      ts-json-schema-generator:
+        specifier: ^2.3.0
+        version: 2.9.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -7898,6 +7904,10 @@ packages:
     resolution: {integrity: sha512-wGM28Ehmcnk2NqRORXFOTOR064L4imSw3EeOqU5bIwUf62eXGwg89WivH6VMahL8zlQHeodzvHpXplrqzrz3Nw==}
     engines: {node: '>= 10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -9511,6 +9521,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -9829,6 +9843,10 @@ packages:
   minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -10357,6 +10375,10 @@ packages:
   path-root@0.1.1:
     resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
     engines: {node: '>=0.10.0'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -11743,6 +11765,11 @@ packages:
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
+
+  ts-json-schema-generator@2.9.0:
+    resolution: {integrity: sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -19862,8 +19889,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.2
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -19885,7 +19912,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -19896,21 +19923,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19921,7 +19948,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20805,6 +20832,12 @@ snapshots:
     dependencies:
       async-done: 2.0.0
       chokidar: 3.6.0
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -22634,6 +22667,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -23166,6 +23201,8 @@ snapshots:
       yallist: 4.0.0
 
   minipass@4.2.8: {}
+
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -23729,6 +23766,11 @@ snapshots:
   path-root@0.1.1:
     dependencies:
       path-root-regex: 0.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -25567,6 +25609,17 @@ snapshots:
       typescript: 5.9.3
 
   ts-dedent@2.3.0: {}
+
+  ts-json-schema-generator@2.9.0:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      commander: 14.0.3
+      glob: 13.0.6
+      json5: 2.2.3
+      normalize-path: 3.0.0
+      safe-stable-stringify: 2.5.0
+      tslib: 2.8.1
+      typescript: 5.9.3
 
   ts-morph@26.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,8 +394,8 @@ importers:
         specifier: ^8.17.1
         version: 8.18.0
       ts-json-schema-generator:
-        specifier: ^2.3.0
-        version: 2.9.0
+        specifier: ~2.4.0
+        version: 2.4.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -2517,6 +2517,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -7702,6 +7706,10 @@ packages:
   foreach@2.0.6:
     resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -7904,9 +7912,11 @@ packages:
     resolution: {integrity: sha512-wGM28Ehmcnk2NqRORXFOTOR064L4imSw3EeOqU5bIwUf62eXGwg89WivH6VMahL8zlQHeodzvHpXplrqzrz3Nw==}
     engines: {node: '>= 10.13.0'}
 
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -8695,6 +8705,10 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -10286,6 +10300,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -11766,9 +11783,9 @@ packages:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
 
-  ts-json-schema-generator@2.9.0:
-    resolution: {integrity: sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==}
-    engines: {node: '>=22.0.0'}
+  ts-json-schema-generator@2.4.0:
+    resolution: {integrity: sha512-HbmNsgs58CfdJq0gpteRTxPXG26zumezOs+SB9tgky6MpqiFgQwieCn2MW70+sxpHouZ/w9LW0V6L4ZQO4y1Ug==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   ts-morph@26.0.0:
@@ -14949,6 +14966,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
     optional: true
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -20620,6 +20639,11 @@ snapshots:
 
   foreach@2.0.6: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forever-agent@0.6.1: {}
 
   form-data-encoder@1.7.2: {}
@@ -20833,10 +20857,13 @@ snapshots:
       async-done: 2.0.0
       chokidar: 3.6.0
 
-  glob@13.0.6:
+  glob@11.1.0:
     dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
       minimatch: 10.2.4
       minipass: 7.1.3
+      package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
   glob@7.2.3:
@@ -21727,6 +21754,10 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jake@10.9.4:
     dependencies:
@@ -23688,6 +23719,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.6.0: {}
 
   pako@1.0.11: {}
@@ -25610,11 +25643,11 @@ snapshots:
 
   ts-dedent@2.3.0: {}
 
-  ts-json-schema-generator@2.9.0:
+  ts-json-schema-generator@2.4.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      commander: 14.0.3
-      glob: 13.0.6
+      commander: 13.1.0
+      glob: 11.1.0
       json5: 2.2.3
       normalize-path: 3.0.0
       safe-stable-stringify: 2.5.0

--- a/tests/api/stage-api-scene.test.ts
+++ b/tests/api/stage-api-scene.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { createSceneAPI } from '@/lib/api/stage-api-scene';
+import type { StageStore } from '@/lib/api/stage-api-types';
+import type { Scene, Stage, StageMode } from '@/lib/types/stage';
+
+function mockStore() {
+  const state = {
+    stage: { id: 'stage-1', name: 'S', createdAt: 1, updatedAt: 1 } as Stage,
+    scenes: [] as Scene[],
+    currentSceneId: null as string | null,
+    mode: 'edit' as StageMode,
+  };
+  const store: StageStore = {
+    getState: () => state,
+    setState: (partial) => Object.assign(state, partial),
+    subscribe: () => () => {},
+  };
+  return { api: createSceneAPI(store), scenes: () => state.scenes };
+}
+
+describe('stage api scene.create — type/content authority', () => {
+  it('keeps params.type authoritative and pins content.type to it', () => {
+    const { api, scenes } = mockStore();
+    const r = api.create({ type: 'slide', title: 'T' });
+    expect(r.success).toBe(true);
+    const scene = scenes()[0];
+    expect(scene.type).toBe('slide');
+    expect(scene.content.type).toBe('slide');
+  });
+
+  it('rejects a content.type that disagrees with the scene type (no silent override)', () => {
+    const { api, scenes } = mockStore();
+    const r = api.create({
+      type: 'slide',
+      title: 'T',
+      content: { type: 'interactive', html: 'x' },
+    });
+    expect(r.success).toBe(false);
+    expect(scenes()).toHaveLength(0);
+  });
+});

--- a/tests/edit/slide-defaults.test.ts
+++ b/tests/edit/slide-defaults.test.ts
@@ -71,7 +71,9 @@ function makeSlideScene(overrides: Partial<Scene> = {}): Scene {
     createdAt: 1,
     updatedAt: 1,
     ...overrides,
-  };
+    // Fixture builder spreads a loose `Partial<Scene>` over a fixed-kind literal,
+    // which widens the discriminant; the cast is contained to this test helper.
+  } as Scene;
 }
 
 describe('createBlankSlideScene', () => {

--- a/tests/edit/slide-schema.test.ts
+++ b/tests/edit/slide-schema.test.ts
@@ -44,7 +44,9 @@ function makeSlideScene(overrides: Partial<Scene> = {}): Scene {
     order: 1,
     content: makeSlideContent(),
     ...overrides,
-  };
+    // Fixture spreads a loose `Partial<Scene>` over a fixed-kind literal; cast
+    // contained to the test helper.
+  } as Scene;
 }
 
 function makeInteractiveContent(
@@ -67,7 +69,9 @@ function makeInteractiveScene(overrides: Partial<Scene> = {}): Scene {
     order: 1,
     content: makeInteractiveContent(),
     ...overrides,
-  };
+    // Fixture spreads a loose `Partial<Scene>` over a fixed-kind literal; cast
+    // contained to the test helper.
+  } as Scene;
 }
 
 describe('migrateSlideContent', () => {


### PR DESCRIPTION
Implements **Part B-1** of #787 (Phase 2 — grow the DSL): the validators + JSON Schema half. Builds on #811 (Part A — Action verbs in the contract). The migration-registry half (`version.ts` activation) is a separate follow-up, **Part B-2**.

`@openmaic/dsl` shipped TS types + type-guards only — compile-time safety, nothing enforceable at runtime or across language boundaries. This PR makes the contract enforceable while keeping the **zero-runtime-dependency** invariant intact (new packages are `devDependencies` only).

## What's here

**1. Build-time JSON Schema artifacts** — `ts-json-schema-generator` (devDep, build-only) emits `dist/schema/{stage,scene,action}.schema.json` from the TS types (the single source of truth), shipped under a new `./schema/*` export. Serves non-TS / bring-your-own-validator consumers.
- Roots: `Stage`, `Action`, and `SerializedScene` (a concrete `Scene<Action, SceneContent>` — JSON Schema isn't generic, so a concrete instantiation is needed; kept internal via `src/schema-roots.ts`, not re-exported).

**2. Pure validators** — `validateStage` / `validateScene` / `validateAction` in `src/validate.ts`: hand-written, zero-dependency, fail-loud structural checks layered on the existing guards. They verify discriminants, required fields, and known nested discriminants — a gate for untrusted input (LLM/agent output) and persistence boundaries. Exhaustive per-field validation is delegated to the JSON Schema. `ValidationResult` collects every issue with a JSON-pointer-ish path rather than failing on the first.

**3. Supporting** — a frozen `ACTION_TYPES` set + `isActionType` guard (mirrors `PPT_ELEMENT_TYPES` / `isPPTElementType`); README "Runtime layer" section documenting both consumption modes; minor version bump `0.0.2 → 0.1.0`.

## Tests

- `test/validate.test.ts` — good/bad fixtures through each validator, asserting the offending paths.
- `test/schema.test.ts` — compiles the generated schema with `ajv` (devDep) in-memory and validates fixtures, proving the artifact is real and that `vitest run` stays self-contained on a clean checkout.

`pnpm --filter @openmaic/dsl build && typecheck && test` all green (26 tests).

## Acceptance (this PR — the schema/validator boxes of #787)

- [x] JSON Schema artifacts exposed + pure validators, still zero-runtime-dep
- [x] `test/` covers the action guards and validators
- [x] README updated with the runtime layer + dependency topology

Deferred to **Part B-2**: `DSL_MIGRATIONS` first migration end-to-end + `version.ts` no longer a stub (the `SlideContent.schemaVersion` content-level precedent will be reconciled there).

## Notes for review

- Zero runtime deps preserved: `package.json` has no `dependencies`; generator + ajv are devDependencies.
- The generator parses TS source directly, so codegen works pre-build and the schema test needs no compiled `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
