### PR TITLE
feat(playback): add seek bar and resume position

### DIFF
--- a/components/canvas/canvas-area.tsx
+++ b/components/canvas/canvas-area.tsx
@@ -43,6 +43,8 @@ export function CanvasArea({
   onTogglePresentation,
   showStopDiscussion,
   onStopDiscussion,
+  playbackProgress,
+  onSeek,
   hideToolbar,
   isPendingScene,
   isCourseComplete,
@@ -267,6 +269,8 @@ export function CanvasArea({
           onTogglePresentation={onTogglePresentation}
           showStopDiscussion={showStopDiscussion}
           onStopDiscussion={onStopDiscussion}
+          playbackProgress={playbackProgress}
+          onSeek={onSeek}
         />
       )}
     </div>

--- a/components/canvas/canvas-toolbar.tsx
+++ b/components/canvas/canvas-toolbar.tsx
@@ -20,6 +20,8 @@ import { cn } from '@/lib/utils';
 import { useStageStore } from '@/lib/store';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Slider } from '@/components/ui/slider';
+import type { PlaybackProgress } from '@/lib/playback';
 
 export interface CanvasToolbarProps {
   readonly currentSceneIndex: number;
@@ -50,6 +52,8 @@ export interface CanvasToolbarProps {
   readonly onToggleAutoPlay?: () => void;
   readonly playbackSpeed?: number;
   readonly onCycleSpeed?: () => void;
+  readonly playbackProgress?: PlaybackProgress | null;
+  readonly onSeek?: (timeMs: number) => void;
 }
 
 /* Compact control button */
@@ -62,6 +66,13 @@ const ctrlBtn = cn(
 /* Subtle separator */
 function CtrlDivider() {
   return <div className="w-px h-3 bg-gray-200/80 dark:bg-gray-700/60 mx-0.5 shrink-0" />;
+}
+
+function formatPlaybackTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(timeMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
 /* Volume icon based on level */
@@ -108,6 +119,8 @@ export function CanvasToolbar({
   onToggleAutoPlay,
   playbackSpeed = 1,
   onCycleSpeed,
+  playbackProgress,
+  onSeek,
 }: CanvasToolbarProps) {
   const { t } = useI18n();
   const canGoPrev = currentSceneIndex > 0;
@@ -120,6 +133,7 @@ export function CanvasToolbar({
 
   // Volume slider hover state
   const [volumeHover, setVolumeHover] = useState(false);
+  const [seekDraft, setSeekDraft] = useState<number | null>(null);
   const volumeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const volumeContainerRef = useRef<HTMLDivElement>(null);
 
@@ -138,6 +152,19 @@ export function CanvasToolbar({
   // Effective volume for display
   const effectiveVolume = ttsMuted ? 0 : ttsVolume;
   const presentationLabel = isPresenting ? t('stage.exitFullscreen') : t('stage.fullscreen');
+  const hasPlaybackProgress = !!playbackProgress;
+  const seekable =
+    !!playbackProgress?.seekable && playbackProgress.durationMs > 0 && !!onSeek && !isLiveSession;
+  const seekValue = Math.min(
+    seekDraft ?? playbackProgress?.currentTimeMs ?? 0,
+    playbackProgress?.durationMs ?? 0,
+  );
+  const currentTimeLabel = formatPlaybackTime(seekValue);
+  const durationLabel = formatPlaybackTime(playbackProgress?.durationMs ?? 0);
+  const playbackTimeLabel = t('stage.playbackTime', {
+    current: currentTimeLabel,
+    duration: durationLabel,
+  });
 
   return (
     <div className={cn('flex items-center gap-2', className)}>
@@ -168,7 +195,7 @@ export function CanvasToolbar({
       <CtrlDivider />
 
       {/* ── Center: unified playback controls ── */}
-      <div className="flex-1 flex items-center justify-center min-w-0">
+      <div className="flex-1 flex items-center justify-center min-w-0 gap-2">
         <div
           className={cn(
             'inline-flex items-center gap-0.5 px-1 h-7',
@@ -394,6 +421,33 @@ export function CanvasToolbar({
             )}
           </button>
         </div>
+
+        {hasPlaybackProgress && (
+          <div className="hidden sm:flex items-center gap-2 min-w-[140px] w-[min(28vw,260px)]">
+            <Slider
+              value={[seekValue]}
+              min={0}
+              max={Math.max(1, playbackProgress?.durationMs ?? 1)}
+              step={250}
+              disabled={!seekable}
+              aria-label={t('stage.playbackSeekLabel')}
+              aria-valuetext={playbackTimeLabel}
+              onValueChange={([value]) => {
+                if (typeof value === 'number') setSeekDraft(value);
+              }}
+              onValueCommit={([value]) => {
+                setSeekDraft(null);
+                if (typeof value === 'number' && seekable) onSeek?.(value);
+              }}
+              className={cn(!seekable && 'opacity-45')}
+            />
+            <span className="w-[72px] shrink-0 text-[10px] leading-none tabular-nums text-gray-400 dark:text-gray-500 select-none">
+              {currentTimeLabel}
+              <span className="opacity-35 mx-px">/</span>
+              {durationLabel}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* ── Right: fullscreen + chat toggle ── */}

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -714,7 +714,11 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
         // Restore this scene's session-only position, but never auto-play.
         const savedPositionMs = scenePlaybackPositionsRef.current[currentScene.id] ?? 0;
         if (savedPositionMs > 0) {
-          updatePlaybackProgress(engine.seekTo(savedPositionMs));
+          void engine.seekTo(savedPositionMs).then((progress) => {
+            if (engineRef.current === engine) {
+              updatePlaybackProgress(progress);
+            }
+          });
         } else {
           updatePlaybackProgress(engine.getProgress());
         }
@@ -920,11 +924,13 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
         const engine = engineRef.current;
         if (!engine) return;
         setPlaybackCompleted(false);
-        const progress = engine.seekTo(timeMs);
-        updatePlaybackProgress(progress);
-        if (lectureSessionIdRef.current) {
-          chatAreaRef.current?.pauseBuffer(lectureSessionIdRef.current);
-        }
+        void engine.seekTo(timeMs).then((progress) => {
+          if (engineRef.current !== engine) return;
+          updatePlaybackProgress(progress);
+          if (lectureSessionIdRef.current && engine.getMode() !== 'playing') {
+            chatAreaRef.current?.pauseBuffer(lectureSessionIdRef.current);
+          }
+        });
       },
       [updatePlaybackProgress],
     );

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -19,7 +19,7 @@ import { Header } from '@/components/header';
 import { CanvasArea } from '@/components/canvas/canvas-area';
 import { Roundtable } from '@/components/roundtable';
 import { PlaybackEngine, computePlaybackView } from '@/lib/playback';
-import type { EngineMode, TriggerEvent, Effect } from '@/lib/playback';
+import type { EngineMode, PlaybackProgress, TriggerEvent, Effect } from '@/lib/playback';
 import { ActionEngine } from '@/lib/action/engine';
 import { createAudioPlayer } from '@/lib/utils/audio-player';
 import { useDiscussionTTS } from '@/lib/hooks/use-discussion-tts';
@@ -41,6 +41,42 @@ import {
 } from '@/components/ui/alert-dialog';
 import { AlertTriangle } from 'lucide-react';
 import { VisuallyHidden } from 'radix-ui';
+
+const PLAYBACK_POSITIONS_STORAGE_PREFIX = 'openmaic:classroom-playback-positions';
+const PLAYBACK_POSITION_END_PADDING_MS = 250;
+
+function getStoredPlaybackPositions(storageKey: string | null): Record<string, number> {
+  if (!storageKey || typeof window === 'undefined') return {};
+
+  try {
+    const parsed = JSON.parse(window.sessionStorage.getItem(storageKey) || '{}') as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, number] =>
+          typeof entry[0] === 'string' &&
+          typeof entry[1] === 'number' &&
+          Number.isFinite(entry[1]) &&
+          entry[1] >= 0,
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function setStoredPlaybackPositions(
+  storageKey: string | null,
+  positions: Record<string, number>,
+): void {
+  if (!storageKey || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(storageKey, JSON.stringify(positions));
+  } catch {
+    // Session resume is best-effort; playback should keep working without storage.
+  }
+}
 
 /**
  * Imperative handle exposed via `ref` so the parent (`Stage`) can tear
@@ -73,6 +109,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
   function PlaybackChromeRoot({ onRetryOutline, canEnterProMode, onEnterProMode }, ref) {
     const { t } = useI18n();
     const {
+      stage,
       mode,
       getCurrentScene,
       scenes,
@@ -85,6 +122,10 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     const generationComplete = useStageStore.use.generationComplete();
 
     const currentScene = getCurrentScene();
+    const playbackPositionsStorageKey = useMemo(
+      () => (stage?.id ? `${PLAYBACK_POSITIONS_STORAGE_PREFIX}:${stage.id}` : null),
+      [stage?.id],
+    );
 
     // Layout state from settings store (persisted via localStorage)
     const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
@@ -102,6 +143,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     const [lectureSpeech, setLectureSpeech] = useState<string | null>(null); // From PlaybackEngine (lecture)
     const [liveSpeech, setLiveSpeech] = useState<string | null>(null); // From buffer (discussion/QA)
     const [speechProgress, setSpeechProgress] = useState<number | null>(null); // StreamBuffer reveal progress (0–1)
+    const [playbackProgress, setPlaybackProgress] = useState<PlaybackProgress | null>(null);
     const [discussionTrigger, setDiscussionTrigger] = useState<TriggerEvent | null>(null);
 
     // Speaking agent tracking (Issue 2)
@@ -200,6 +242,8 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     const discussionAbortRef = useRef<AbortController | null>(null);
     const presentationIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const stageRef = useRef<HTMLDivElement>(null);
+    const playbackProgressRef = useRef<PlaybackProgress | null>(null);
+    const scenePlaybackPositionsRef = useRef<Record<string, number>>({});
     // Guard to prevent double flash when manual stop triggers onDiscussionEnd
     const manualStopRef = useRef(false);
     // Monotonic counter incremented on each scene switch — used to discard stale SSE callbacks
@@ -208,6 +252,44 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     const autoStartRef = useRef(false);
     // Discussion buffer-level pause state (distinct from soft-pause which aborts SSE)
     const [isDiscussionPaused, setIsDiscussionPaused] = useState(false);
+
+    const updatePlaybackProgress = useCallback(
+      (progress: PlaybackProgress | null) => {
+        playbackProgressRef.current = progress;
+        setPlaybackProgress(progress);
+        if (progress?.sceneId && progress.durationMs > 0) {
+          scenePlaybackPositionsRef.current[progress.sceneId] = Math.max(
+            0,
+            Math.min(
+              progress.currentTimeMs,
+              Math.max(0, progress.durationMs - PLAYBACK_POSITION_END_PADDING_MS),
+            ),
+          );
+          setStoredPlaybackPositions(
+            playbackPositionsStorageKey,
+            scenePlaybackPositionsRef.current,
+          );
+        }
+      },
+      [playbackPositionsStorageKey],
+    );
+
+    const savePlaybackProgress = useCallback(() => {
+      const progress = playbackProgressRef.current;
+      if (!progress?.sceneId || progress.durationMs <= 0) return;
+      scenePlaybackPositionsRef.current[progress.sceneId] = Math.max(
+        0,
+        Math.min(
+          progress.currentTimeMs,
+          Math.max(0, progress.durationMs - PLAYBACK_POSITION_END_PADDING_MS),
+        ),
+      );
+      setStoredPlaybackPositions(playbackPositionsStorageKey, scenePlaybackPositionsRef.current);
+    }, [playbackPositionsStorageKey]);
+
+    useEffect(() => {
+      scenePlaybackPositionsRef.current = getStoredPlaybackPositions(playbackPositionsStorageKey);
+    }, [playbackPositionsStorageKey]);
 
     /**
      * Resume a soft-paused topic: re-call /chat with existing session messages.
@@ -297,6 +379,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       ref,
       () => ({
         teardown: async () => {
+          savePlaybackProgress();
           await chatAreaRef.current?.endActiveSession();
           if (discussionAbortRef.current) {
             discussionAbortRef.current.abort();
@@ -307,7 +390,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
           resetSceneState();
         },
       }),
-      [discussionTTS, resetSceneState],
+      [discussionTTS, resetSceneState, savePlaybackProgress],
     );
 
     const clearPresentationIdleTimer = useCallback(() => {
@@ -408,6 +491,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
 
     // Initialize playback engine when scene changes
     useEffect(() => {
+      savePlaybackProgress();
       // Bump epoch so any stale SSE callbacks from the previous scene are discarded
       sceneEpochRef.current++;
 
@@ -441,6 +525,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       if (!currentScene || !hasPlayableActions) {
         engineRef.current = null;
         setEngineMode('idle');
+        updatePlaybackProgress(null);
 
         return;
       }
@@ -626,7 +711,13 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
           engine.start();
         })();
       } else {
-        // Load saved playback state and restore position (but never auto-play).
+        // Restore this scene's session-only position, but never auto-play.
+        const savedPositionMs = scenePlaybackPositionsRef.current[currentScene.id] ?? 0;
+        if (savedPositionMs > 0) {
+          updatePlaybackProgress(engine.seekTo(savedPositionMs));
+        } else {
+          updatePlaybackProgress(engine.getProgress());
+        }
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps -- Only re-run when scene changes, functions are stable refs
     }, [currentScene]);
@@ -636,6 +727,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       const audioPlayer = audioPlayerRef.current;
       const chatArea = chatAreaRef.current;
       return () => {
+        savePlaybackProgress();
         if (engineRef.current) {
           engineRef.current.stop();
         }
@@ -668,6 +760,15 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     useEffect(() => {
       audioPlayerRef.current.setPlaybackRate(playbackSpeed);
     }, [playbackSpeed]);
+
+    useEffect(() => {
+      const timer = setInterval(() => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        updatePlaybackProgress(engine.getProgress());
+      }, 250);
+      return () => clearInterval(timer);
+    }, [updatePlaybackProgress]);
 
     /**
      * Handle discussion SSE — POST /api/chat and push events to engine
@@ -786,6 +887,10 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
           chatAreaRef.current?.pauseBuffer(lectureSessionIdRef.current);
         }
       } else if (mode === 'paused') {
+        if (!lectureSessionIdRef.current && currentScene && chatAreaRef.current) {
+          const sessionId = await chatAreaRef.current.startLecture(currentScene.id);
+          lectureSessionIdRef.current = sessionId;
+        }
         engine.resume();
         // Resume lecture buffer
         if (lectureSessionIdRef.current) {
@@ -809,6 +914,20 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
         }
       }
     }, [playbackCompleted, currentScene]);
+
+    const handleSeek = useCallback(
+      (timeMs: number) => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        setPlaybackCompleted(false);
+        const progress = engine.seekTo(timeMs);
+        updatePlaybackProgress(progress);
+        if (lectureSessionIdRef.current) {
+          chatAreaRef.current?.pauseBuffer(lectureSessionIdRef.current);
+        }
+      },
+      [updatePlaybackProgress],
+    );
 
     // get scene information
     const isPendingScene = currentSceneId === PENDING_SCENE_ID;
@@ -1096,6 +1215,8 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
                 (chatIsStreaming && (chatSessionType === 'qa' || chatSessionType === 'discussion'))
               }
               onStopDiscussion={handleStopDiscussion}
+              playbackProgress={playbackProgress}
+              onSeek={handleSeek}
               hideToolbar={mode === 'playback' || (isPresenting && !controlsVisible)}
               isPendingScene={isPendingScene}
               isCourseComplete={isCourseComplete}
@@ -1245,6 +1366,8 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
                 isPresenting={isPresenting}
                 controlsVisible={controlsVisible}
                 onTogglePresentation={togglePresentation}
+                playbackProgress={playbackProgress}
+                onSeek={handleSeek}
                 onPresentationInteractionChange={setIsPresentationInteractionActive}
                 fullscreenContainerRef={stageRef}
               />

--- a/components/roundtable/index.tsx
+++ b/components/roundtable/index.tsx
@@ -30,7 +30,7 @@ import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/h
 import { useAgentRegistry } from '@/lib/orchestration/registry/store';
 import { DEFAULT_TEACHER_AVATAR, DEFAULT_USER_AVATAR } from '@/components/roundtable/constants';
 import type { DiscussionAction } from '@/lib/types/action';
-import type { EngineMode, PlaybackView } from '@/lib/playback';
+import type { EngineMode, PlaybackProgress, PlaybackView } from '@/lib/playback';
 import type { Participant } from '@/lib/types/roundtable';
 
 export interface DiscussionRequest {
@@ -87,6 +87,8 @@ interface RoundtableProps {
   readonly isPresenting?: boolean;
   readonly controlsVisible?: boolean;
   readonly onTogglePresentation?: () => void;
+  readonly playbackProgress?: PlaybackProgress | null;
+  readonly onSeek?: (timeMs: number) => void;
   readonly onPresentationInteractionChange?: (active: boolean) => void;
   /** Ref to the fullscreen container — passed to ProactiveCard so its portal
    *  renders inside the top-layer during presentation mode. */
@@ -172,6 +174,8 @@ export function Roundtable({
   isPresenting,
   controlsVisible,
   onTogglePresentation,
+  playbackProgress,
+  onSeek,
   onPresentationInteractionChange,
   fullscreenContainerRef,
 }: RoundtableProps) {
@@ -648,6 +652,8 @@ export function Roundtable({
       onToggleAutoPlay={() => setAutoPlayLecture(!autoPlayLecture)}
       playbackSpeed={playbackSpeed}
       onCycleSpeed={handleCycleSpeed}
+      playbackProgress={playbackProgress}
+      onSeek={onSeek}
     />
   );
 

--- a/lib/action/engine.ts
+++ b/lib/action/engine.ts
@@ -77,6 +77,11 @@ const EFFECT_AUTO_CLEAR_MS = 5000;
 /** Callback for sending messages to widget iframe */
 export type WidgetMessageCallback = (type: string, payload: Record<string, unknown>) => void;
 
+export interface ActionExecutionOptions {
+  /** Apply state changes needed for seek reconstruction without delays/media/transient effects. */
+  silent?: boolean;
+}
+
 export class ActionEngine {
   private stageStore: StageStore;
   private stageAPI: ReturnType<typeof createStageAPI>;
@@ -113,63 +118,71 @@ export class ActionEngine {
    * Fire-and-forget actions return immediately.
    * Synchronous actions return a Promise that resolves when the action is complete.
    */
-  async execute(action: Action): Promise<void> {
+  async execute(action: Action, options: ActionExecutionOptions = {}): Promise<void> {
     // Auto-open whiteboard if a draw/clear/delete action is attempted while it's closed
     if (action.type.startsWith('wb_') && action.type !== 'wb_open' && action.type !== 'wb_close') {
-      await this.ensureWhiteboardOpen();
+      await this.ensureWhiteboardOpen(options);
     }
 
     switch (action.type) {
       // Fire-and-forget
       case 'spotlight':
+        if (options.silent) return;
         this.executeSpotlight(action);
         return;
       case 'laser':
+        if (options.silent) return;
         this.executeLaser(action);
         return;
       // Synchronous — Video
       case 'play_video':
+        if (options.silent) return;
         return this.executePlayVideo(action as PlayVideoAction);
 
       // Synchronous
       case 'speech':
+        if (options.silent) return;
         return this.executeSpeech(action);
       case 'wb_open':
-        return this.executeWbOpen();
+        return this.executeWbOpen(options);
       case 'wb_draw_text':
-        return this.executeWbDrawText(action);
+        return this.executeWbDrawText(action, options);
       case 'wb_draw_shape':
-        return this.executeWbDrawShape(action);
+        return this.executeWbDrawShape(action, options);
       case 'wb_draw_chart':
-        return this.executeWbDrawChart(action);
+        return this.executeWbDrawChart(action, options);
       case 'wb_draw_latex':
-        return this.executeWbDrawLatex(action);
+        return this.executeWbDrawLatex(action, options);
       case 'wb_draw_table':
-        return this.executeWbDrawTable(action);
+        return this.executeWbDrawTable(action, options);
       case 'wb_draw_line':
-        return this.executeWbDrawLine(action as WbDrawLineAction);
+        return this.executeWbDrawLine(action as WbDrawLineAction, options);
       case 'wb_draw_code':
-        return this.executeWbDrawCode(action as WbDrawCodeAction);
+        return this.executeWbDrawCode(action as WbDrawCodeAction, options);
       case 'wb_edit_code':
-        return this.executeWbEditCode(action as WbEditCodeAction);
+        return this.executeWbEditCode(action as WbEditCodeAction, options);
       case 'wb_clear':
-        return this.executeWbClear();
+        return this.executeWbClear(options);
       case 'wb_delete':
-        return this.executeWbDelete(action as WbDeleteAction);
+        return this.executeWbDelete(action as WbDeleteAction, options);
       case 'wb_close':
-        return this.executeWbClose();
+        return this.executeWbClose(options);
       case 'discussion':
         // Discussion lifecycle is managed externally via engine callbacks
         return;
 
       // Widget actions — post message to iframe
       case 'widget_highlight':
+        if (options.silent) return;
         return this.executeWidgetHighlight(action as WidgetHighlightAction);
       case 'widget_setState':
+        if (options.silent) return;
         return this.executeWidgetSetState(action as WidgetSetStateAction);
       case 'widget_annotation':
+        if (options.silent) return;
         return this.executeWidgetAnnotation(action as WidgetAnnotationAction);
       case 'widget_reveal':
+        if (options.silent) return;
         return this.executeWidgetReveal(action as WidgetRevealAction);
     }
   }
@@ -181,6 +194,27 @@ export class ActionEngine {
       this.effectTimer = null;
     }
     useCanvasStore.getState().clearAllEffects();
+  }
+
+  /** Reset playback-owned visual state before seek reconstruction. */
+  resetPlaybackVisualState(): void {
+    this.clearEffects();
+    const canvas = useCanvasStore.getState();
+    canvas.pauseVideo();
+    canvas.setWhiteboardOpen(false);
+    canvas.setWhiteboardClearing(false);
+
+    const state = this.stageStore.getState();
+    if (!state.stage?.whiteboard?.length) return;
+    this.stageStore.setState({
+      stage: {
+        ...state.stage,
+        whiteboard: state.stage.whiteboard.map((whiteboard) => ({
+          ...whiteboard,
+          elements: [],
+        })),
+      },
+    });
   }
 
   /** Schedule auto-clear for fire-and-forget effects */
@@ -326,21 +360,25 @@ export class ActionEngine {
   // ==================== Synchronous — Whiteboard ====================
 
   /** Auto-open the whiteboard if it's not already open */
-  private async ensureWhiteboardOpen(): Promise<void> {
+  private async ensureWhiteboardOpen(options: ActionExecutionOptions = {}): Promise<void> {
     if (!useCanvasStore.getState().whiteboardOpen) {
-      await this.executeWbOpen();
+      await this.executeWbOpen(options);
     }
   }
 
-  private async executeWbOpen(): Promise<void> {
+  private async executeWbOpen(options: ActionExecutionOptions = {}): Promise<void> {
     // Ensure a whiteboard exists
     this.stageAPI.whiteboard.get();
     useCanvasStore.getState().setWhiteboardOpen(true);
+    if (options.silent) return;
     // Wait for open animation to complete (slow spring: stiffness 120, damping 18, mass 1.2)
     await delay(2000);
   }
 
-  private async executeWbDrawText(action: WbDrawTextAction): Promise<void> {
+  private async executeWbDrawText(
+    action: WbDrawTextAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -368,11 +406,15 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     // Wait for element fade-in animation
     await delay(800);
   }
 
-  private async executeWbDrawShape(action: WbDrawShapeAction): Promise<void> {
+  private async executeWbDrawShape(
+    action: WbDrawShapeAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -394,11 +436,15 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     // Wait for element fade-in animation
     await delay(800);
   }
 
-  private async executeWbDrawChart(action: WbDrawChartAction): Promise<void> {
+  private async executeWbDrawChart(
+    action: WbDrawChartAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -419,10 +465,14 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     await delay(800);
   }
 
-  private async executeWbDrawLatex(action: WbDrawLatexAction): Promise<void> {
+  private async executeWbDrawLatex(
+    action: WbDrawLatexAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -455,10 +505,14 @@ export class ActionEngine {
       return;
     }
 
+    if (options.silent) return;
     await delay(800);
   }
 
-  private async executeWbDrawTable(action: WbDrawTableAction): Promise<void> {
+  private async executeWbDrawTable(
+    action: WbDrawTableAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -511,10 +565,14 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     await delay(800);
   }
 
-  private async executeWbDrawLine(action: WbDrawLineAction): Promise<void> {
+  private async executeWbDrawLine(
+    action: WbDrawLineAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -543,11 +601,15 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     // Wait for element fade-in animation
     await delay(800);
   }
 
-  private async executeWbDrawCode(action: WbDrawCodeAction): Promise<void> {
+  private async executeWbDrawCode(
+    action: WbDrawCodeAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -572,12 +634,16 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     // Wait for typing animation: base 800ms + 50ms per line, capped at 3s
     const animMs = Math.min(800 + lines.length * 50, 3000);
     await delay(animMs);
   }
 
-  private async executeWbEditCode(action: WbEditCodeAction): Promise<void> {
+  private async executeWbEditCode(
+    action: WbEditCodeAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
@@ -635,24 +701,35 @@ export class ActionEngine {
       wb.data.id,
     );
 
+    if (options.silent) return;
     // Wait for edit animation
     await delay(600);
   }
 
-  private async executeWbDelete(action: WbDeleteAction): Promise<void> {
+  private async executeWbDelete(
+    action: WbDeleteAction,
+    options: ActionExecutionOptions = {},
+  ): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
     this.stageAPI.whiteboard.deleteElement(action.elementId, wb.data.id);
+    if (options.silent) return;
     await delay(300);
   }
 
-  private async executeWbClear(): Promise<void> {
+  private async executeWbClear(options: ActionExecutionOptions = {}): Promise<void> {
     const wb = this.stageAPI.whiteboard.get();
     if (!wb.success || !wb.data) return;
 
     const elementCount = wb.data.elements?.length || 0;
     if (elementCount === 0) return;
+
+    if (options.silent) {
+      this.stageAPI.whiteboard.update({ elements: [] }, wb.data.id);
+      useCanvasStore.getState().setWhiteboardClearing(false);
+      return;
+    }
 
     // Save snapshot before AI clear (mirrors UI handleClear in index.tsx)
     useWhiteboardHistoryStore.getState().pushSnapshot(wb.data.elements!);
@@ -669,8 +746,9 @@ export class ActionEngine {
     useCanvasStore.getState().setWhiteboardClearing(false);
   }
 
-  private async executeWbClose(): Promise<void> {
+  private async executeWbClose(options: ActionExecutionOptions = {}): Promise<void> {
     useCanvasStore.getState().setWhiteboardOpen(false);
+    if (options.silent) return;
     // Wait for close animation (500ms ease-out tween)
     await delay(700);
   }

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -156,6 +156,8 @@
     "courseComplete": "اكتملت الدورة",
     "fullscreen": "ملء الشاشة",
     "exitFullscreen": "الخروج من ملء الشاشة",
+    "playbackSeekLabel": "موضع التشغيل",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "تحرير الدورة",
     "doneEditing": "إنهاء التحرير",
     "proModeDisabledHint": "التحرير غير متاح في هذه الصفحة — افتح شريحة من الدورة للتحرير باستخدام وضع Pro."

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -156,6 +156,8 @@
     "courseComplete": "Course complete",
     "fullscreen": "Fullscreen",
     "exitFullscreen": "Exit Fullscreen",
+    "playbackSeekLabel": "Playback position",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "Edit course",
     "doneEditing": "Done editing",
     "proModeDisabledHint": "Editing isn't available on this page — open a course slide to edit with Pro mode."

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -156,6 +156,8 @@
     "courseComplete": "コース完了",
     "fullscreen": "全画面表示",
     "exitFullscreen": "全画面表示を終了",
+    "playbackSeekLabel": "再生位置",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "コースを編集",
     "doneEditing": "編集を完了",
     "proModeDisabledHint": "このページでは編集できません。コースのスライドを開くと Pro モードで編集できます。"

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -156,6 +156,8 @@
     "courseComplete": "강좌 완료",
     "fullscreen": "전체화면",
     "exitFullscreen": "전체화면 종료",
+    "playbackSeekLabel": "재생 위치",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "강좌 편집",
     "doneEditing": "편집 완료",
     "proModeDisabledHint": "이 페이지에서는 편집할 수 없습니다 — 코스 슬라이드를 열면 Pro 모드로 편집할 수 있습니다."

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -413,6 +413,8 @@
     "courseComplete": "Curso concluído",
     "fullscreen": "Tela cheia",
     "exitFullscreen": "Sair da tela cheia",
+    "playbackSeekLabel": "Posição da reprodução",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "Editar curso",
     "doneEditing": "Concluir edição",
     "proModeDisabledHint": "A edição não está disponível nesta página — abra um slide do curso para editar no modo Pro."

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -156,6 +156,8 @@
     "courseComplete": "Курс завершён",
     "fullscreen": "Полный экран",
     "exitFullscreen": "Свернуть",
+    "playbackSeekLabel": "Позиция воспроизведения",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "Редактировать курс",
     "doneEditing": "Завершить редактирование",
     "proModeDisabledHint": "Редактирование недоступно на этой странице — откройте слайд курса, чтобы редактировать в Pro-режиме."

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -156,6 +156,8 @@
     "courseComplete": "课程完成",
     "fullscreen": "全屏",
     "exitFullscreen": "退出全屏",
+    "playbackSeekLabel": "播放位置",
+    "playbackTime": "{{current}} / {{duration}}",
     "editCourse": "编辑课程",
     "doneEditing": "完成编辑",
     "proModeDisabledHint": "本页不支持编辑——打开任意课程页即可使用 Pro 模式编辑。"

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -155,6 +155,8 @@
     "generatingNextPage": "場景正在生成，請稍候...",
     "fullscreen": "全螢幕",
     "exitFullscreen": "離開全螢幕",
+    "playbackSeekLabel": "播放位置",
+    "playbackTime": "{{current}} / {{duration}}",
     "courseComplete": "課程完成",
     "editCourse": "編輯課程",
     "doneEditing": "完成編輯",

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -110,6 +110,7 @@ export class PlaybackEngine {
   private pendingSpeechSeekOffsetMs: number = 0;
   private seekProgressOverrideMs: number | null = null;
   private playbackGeneration: number = 0;
+  private knownSpeechDurationsMs: Map<string, number> = new Map();
 
   constructor(
     scenes: Scene[],
@@ -201,6 +202,7 @@ export class PlaybackEngine {
       this.audioPlayer.seekTo(offsetMs)
     ) {
       const generation = this.invalidatePlaybackWork();
+      this.actionEngine.clearEffects();
       this.audioPlayer.onEnded(() => {
         if (!this.isCurrentGeneration(generation)) return;
         this.callbacks.onSpeechEnd?.();
@@ -617,13 +619,22 @@ export class PlaybackEngine {
     return rawMs / speed;
   }
 
+  private getSpeechDurationKey(action: SpeechAction, actionIndex?: number): string {
+    return `${action.id || 'speech'}:${actionIndex ?? -1}`;
+  }
+
   private getActionDurationMs(action: Action, actionIndex?: number): number {
     if (action.type === 'speech') {
+      const speechAction = action as SpeechAction;
+      const durationKey = this.getSpeechDurationKey(speechAction, actionIndex);
       if (this.activeActionIndex === actionIndex) {
         const audioDuration = this.audioPlayer.getDuration();
-        if (audioDuration > 0) return audioDuration;
+        if (audioDuration > 0) {
+          this.knownSpeechDurationsMs.set(durationKey, audioDuration);
+          return audioDuration;
+        }
       }
-      return this.getSpeechDurationMs(action as SpeechAction);
+      return this.knownSpeechDurationsMs.get(durationKey) ?? this.getSpeechDurationMs(speechAction);
     }
     if (action.type === 'discussion') return DISCUSSION_PROMPT_DELAY_MS;
     return INSTANT_ACTION_DURATION_MS;
@@ -674,7 +685,7 @@ export class PlaybackEngine {
 
       if (action?.type === 'speech') {
         const audioCurrent = this.audioPlayer.getCurrentTime();
-        if (audioCurrent > 0 || this.audioPlayer.hasActiveAudio()) {
+        if (audioCurrent > 0) {
           elapsedMs = audioCurrent;
         } else if (this.speechTimerRemaining > 0 && !this.speechTimer) {
           elapsedMs = Math.max(0, this.activeActionEstimatedMs - this.speechTimerRemaining);

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -29,6 +29,7 @@ import type {
   EngineMode,
   TopicState,
   PlaybackEngineCallbacks,
+  PlaybackProgress,
   PlaybackSnapshot,
   TriggerEvent,
   Effect,
@@ -42,6 +43,9 @@ import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('PlaybackEngine');
+const DISCUSSION_PROMPT_DELAY_MS = 3000;
+const MIN_SPEECH_DURATION_MS = 2000;
+const INSTANT_ACTION_DURATION_MS = 0;
 
 /**
  * If more than 30% of characters are CJK, treat the text as Chinese.
@@ -84,6 +88,11 @@ export class PlaybackEngine {
   private browserTTSChunkIndex: number = 0; // current chunk being spoken
   private browserTTSPausedChunks: string[] = []; // remaining chunks saved on pause (for cancel+re-speak)
   private speechTimerRemaining: number = 0; // remaining ms (set on pause)
+  private activeActionIndex: number | null = null;
+  private activeActionStartedAt: number = 0;
+  private activeActionEstimatedMs: number = 0;
+  private pendingSpeechSeekOffsetMs: number = 0;
+  private seekProgressOverrideMs: number | null = null;
 
   constructor(
     scenes: Scene[],
@@ -122,6 +131,70 @@ export class PlaybackEngine {
     this.consumedDiscussions = new Set(snapshot.consumedDiscussions);
   }
 
+  /** Get current scene-level playback progress. */
+  getProgress(): PlaybackProgress {
+    return this.computeProgress();
+  }
+
+  /**
+   * Seek within the current scene timeline.
+   *
+   * Seeking is action-boundary based for non-audio actions. For generated
+   * speech that is already active, the underlying audio element is seeked
+   * precisely; otherwise the offset is applied when the speech action starts.
+   */
+  seekTo(timeMs: number): PlaybackProgress {
+    const durationMs = this.getSceneDurationMs();
+    const targetMs = Math.max(0, durationMs > 0 ? Math.min(timeMs, durationMs) : timeMs);
+    const timeline = this.getTimeline();
+    const wasPlaying = this.mode === 'playing';
+
+    if (durationMs <= 0 || timeline.length === 0) {
+      return this.getProgress();
+    }
+
+    if (targetMs >= durationMs) {
+      this.cancelActivePlayback();
+      this.sceneIndex = 0;
+      this.actionIndex = this.scenes[0]?.actions?.length ?? 0;
+      this.activeActionIndex = null;
+      this.seekProgressOverrideMs = durationMs;
+      this.setMode('idle');
+      return this.getProgress();
+    }
+
+    const target =
+      timeline.find((entry) => targetMs >= entry.startMs && targetMs < entry.endMs) ??
+      timeline[timeline.length - 1];
+    const offsetMs = Math.max(0, targetMs - target.startMs);
+
+    if (
+      this.activeActionIndex === target.actionIndex &&
+      target.action.type === 'speech' &&
+      this.audioPlayer.seekTo(offsetMs)
+    ) {
+      this.pendingSpeechSeekOffsetMs = 0;
+      this.seekProgressOverrideMs = null;
+      return this.getProgress();
+    }
+
+    this.cancelActivePlayback();
+    this.sceneIndex = 0;
+    this.actionIndex = target.actionIndex;
+    this.activeActionIndex = null;
+    this.pendingSpeechSeekOffsetMs = target.action.type === 'speech' ? offsetMs : 0;
+    this.seekProgressOverrideMs = target.startMs + this.pendingSpeechSeekOffsetMs;
+
+    if (wasPlaying) {
+      this.setMode('playing');
+      this.processNext();
+    } else {
+      this.setMode('paused');
+    }
+
+    return this.getProgress();
+  }
+
   /** idle → playing (from beginning) */
   start(): void {
     if (this.mode !== 'idle') {
@@ -131,6 +204,8 @@ export class PlaybackEngine {
 
     this.sceneIndex = 0;
     this.actionIndex = 0;
+    this.pendingSpeechSeekOffsetMs = 0;
+    this.seekProgressOverrideMs = null;
     this.setMode('playing');
     this.processNext();
   }
@@ -141,6 +216,7 @@ export class PlaybackEngine {
       log.warn('Cannot continue: not idle, current mode:', this.mode);
       return;
     }
+    this.seekProgressOverrideMs = null;
     this.setMode('playing');
     this.processNext();
   }
@@ -148,6 +224,7 @@ export class PlaybackEngine {
   /** playing → paused | live → paused (abort SSE, truncate, topic pending) */
   pause(): void {
     if (this.mode === 'playing') {
+      const pausedAtMs = this.computeProgress().currentTimeMs;
       // Cancel pending timers
       if (this.triggerDelayTimer) {
         clearTimeout(this.triggerDelayTimer);
@@ -176,6 +253,7 @@ export class PlaybackEngine {
           this.audioPlayer.pause();
         }
       }
+      this.seekProgressOverrideMs = pausedAtMs;
     } else if (this.mode === 'live') {
       this.setMode('paused');
       this.currentTopicState = 'pending';
@@ -201,6 +279,7 @@ export class PlaybackEngine {
       this.setMode('playing');
     } else {
       // Resume lecture
+      const resumeProgressMs = this.seekProgressOverrideMs;
       this.setMode('playing');
       if (this.browserTTSPausedChunks.length > 0) {
         // Browser TTS was paused via cancel — re-speak remaining chunks
@@ -208,12 +287,25 @@ export class PlaybackEngine {
         this.browserTTSChunks = this.browserTTSPausedChunks;
         this.browserTTSChunkIndex = 0;
         this.browserTTSPausedChunks = [];
+        if (resumeProgressMs !== null && this.activeActionIndex !== null) {
+          this.activeActionStartedAt =
+            Date.now() -
+            Math.max(0, resumeProgressMs - this.getActionStartMs(this.activeActionIndex));
+        }
+        this.seekProgressOverrideMs = null;
         this.playBrowserTTSChunk();
       } else if (this.audioPlayer.hasActiveAudio()) {
         // Audio is paused — resume it; TTS onend will call processNext
+        this.seekProgressOverrideMs = null;
         this.audioPlayer.resume();
       } else if (this.speechTimerRemaining > 0) {
         // Reading timer was paused — reschedule with remaining time
+        if (resumeProgressMs !== null && this.activeActionIndex !== null) {
+          this.activeActionStartedAt =
+            Date.now() -
+            Math.max(0, resumeProgressMs - this.getActionStartMs(this.activeActionIndex));
+        }
+        this.seekProgressOverrideMs = null;
         this.speechTimerStart = Date.now();
         this.speechTimer = setTimeout(() => {
           this.speechTimer = null;
@@ -223,6 +315,7 @@ export class PlaybackEngine {
         }, this.speechTimerRemaining);
       } else {
         // TTS finished while paused, continue to next event
+        this.seekProgressOverrideMs = null;
         this.processNext();
       }
     }
@@ -245,6 +338,11 @@ export class PlaybackEngine {
       this.speechTimer = null;
     }
     this.speechTimerRemaining = 0;
+    this.activeActionIndex = null;
+    this.activeActionStartedAt = 0;
+    this.activeActionEstimatedMs = 0;
+    this.pendingSpeechSeekOffsetMs = 0;
+    this.seekProgressOverrideMs = null;
     this.sceneIndex = 0;
     this.actionIndex = 0;
     this.savedSceneIndex = null;
@@ -393,6 +491,125 @@ export class PlaybackEngine {
     this.callbacks.onModeChange?.(mode);
   }
 
+  private cancelActivePlayback(): void {
+    this.setMode('idle');
+    this.audioPlayer.stop();
+    this.cancelBrowserTTS();
+    if (this.triggerDelayTimer) {
+      clearTimeout(this.triggerDelayTimer);
+      this.triggerDelayTimer = null;
+    }
+    if (this.speechTimer) {
+      clearTimeout(this.speechTimer);
+      this.speechTimer = null;
+    }
+    this.speechTimerRemaining = 0;
+    this.activeActionIndex = null;
+    this.activeActionStartedAt = 0;
+    this.activeActionEstimatedMs = 0;
+    if (this.currentTrigger) {
+      this.currentTrigger = null;
+      this.callbacks.onProactiveHide?.();
+    }
+    this.actionEngine.clearEffects();
+  }
+
+  private getSpeechDurationMs(action: SpeechAction): number {
+    const text = action.text;
+    const cjkCount = (
+      text.match(/[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || []
+    ).length;
+    const isCJK = text.length > 0 && cjkCount > text.length * CJK_LANG_THRESHOLD;
+    const speed = this.callbacks.getPlaybackSpeed?.() ?? 1;
+    const rawMs = isCJK
+      ? Math.max(MIN_SPEECH_DURATION_MS, text.length * 150)
+      : Math.max(MIN_SPEECH_DURATION_MS, text.split(/\s+/).filter(Boolean).length * 240);
+    return rawMs / speed;
+  }
+
+  private getActionDurationMs(action: Action, actionIndex?: number): number {
+    if (action.type === 'speech') {
+      if (this.activeActionIndex === actionIndex) {
+        const audioDuration = this.audioPlayer.getDuration();
+        if (audioDuration > 0) return audioDuration;
+      }
+      return this.getSpeechDurationMs(action as SpeechAction);
+    }
+    if (action.type === 'discussion') return DISCUSSION_PROMPT_DELAY_MS;
+    return INSTANT_ACTION_DURATION_MS;
+  }
+
+  private getTimeline(): Array<{
+    action: Action;
+    actionIndex: number;
+    startMs: number;
+    endMs: number;
+  }> {
+    const actions = this.scenes[0]?.actions ?? [];
+    let cursorMs = 0;
+    return actions.map((action, actionIndex) => {
+      const durationMs = this.getActionDurationMs(action, actionIndex);
+      const entry = {
+        action,
+        actionIndex,
+        startMs: cursorMs,
+        endMs: cursorMs + durationMs,
+      };
+      cursorMs += durationMs;
+      return entry;
+    });
+  }
+
+  private getSceneDurationMs(): number {
+    const timeline = this.getTimeline();
+    return timeline[timeline.length - 1]?.endMs ?? 0;
+  }
+
+  private getActionStartMs(actionIndex: number): number {
+    const timeline = this.getTimeline();
+    return timeline.find((entry) => entry.actionIndex === actionIndex)?.startMs ?? 0;
+  }
+
+  private computeProgress(): PlaybackProgress {
+    const actions = this.scenes[0]?.actions ?? [];
+    const durationMs = this.getSceneDurationMs();
+    let currentTimeMs = 0;
+
+    if (this.seekProgressOverrideMs !== null) {
+      currentTimeMs = this.seekProgressOverrideMs;
+    } else if (this.activeActionIndex !== null) {
+      const action = actions[this.activeActionIndex];
+      const actionStartMs = this.getActionStartMs(this.activeActionIndex);
+      let elapsedMs = Math.max(0, Date.now() - this.activeActionStartedAt);
+
+      if (action?.type === 'speech') {
+        const audioCurrent = this.audioPlayer.getCurrentTime();
+        if (audioCurrent > 0 || this.audioPlayer.hasActiveAudio()) {
+          elapsedMs = audioCurrent;
+        } else if (this.speechTimerRemaining > 0 && !this.speechTimer) {
+          elapsedMs = Math.max(0, this.activeActionEstimatedMs - this.speechTimerRemaining);
+        }
+      }
+
+      const actionDurationMs = action
+        ? this.getActionDurationMs(action, this.activeActionIndex)
+        : 0;
+      currentTimeMs = actionStartMs + Math.min(elapsedMs, actionDurationMs);
+    } else if (this.actionIndex >= actions.length && actions.length > 0) {
+      currentTimeMs = durationMs;
+    } else {
+      currentTimeMs = this.getActionStartMs(this.actionIndex);
+    }
+
+    return {
+      sceneId: this.sceneId,
+      currentTimeMs: Math.max(0, durationMs > 0 ? Math.min(currentTimeMs, durationMs) : 0),
+      durationMs,
+      seekable: durationMs > 0,
+      actionIndex: this.activeActionIndex ?? this.actionIndex,
+    };
+  }
+
   private restoreSavedLectureState(): void {
     if (this.savedSceneIndex !== null && this.savedActionIndex !== null) {
       this.sceneIndex = this.savedSceneIndex;
@@ -434,6 +651,8 @@ export class PlaybackEngine {
     if (!current) {
       // All scenes complete
       this.actionEngine.clearEffects();
+      this.activeActionIndex = null;
+      this.seekProgressOverrideMs = this.getSceneDurationMs();
       this.setMode('idle');
       this.callbacks.onComplete?.();
       return;
@@ -446,6 +665,11 @@ export class PlaybackEngine {
     // is the desired behaviour for speech (user may have only heard half).
     this.callbacks.onProgress?.(this.getSnapshot());
 
+    const actionOffsetMs = action.type === 'speech' ? this.pendingSpeechSeekOffsetMs : 0;
+    this.activeActionIndex = this.actionIndex;
+    this.activeActionEstimatedMs = this.getActionDurationMs(action, this.actionIndex);
+    this.activeActionStartedAt = Date.now() - actionOffsetMs;
+    this.seekProgressOverrideMs = null;
     this.actionIndex++;
 
     switch (action.type) {
@@ -466,24 +690,17 @@ export class PlaybackEngine {
         // Non-CJK text: ~240ms/word (≈250 WPM).
         // Min 2s. Cancelled on pause; resume() calls processNext directly.
         const scheduleReadingTimer = () => {
-          const text = speechAction.text;
-          const cjkCount = (
-            text.match(/[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || []
-          ).length;
-          const isCJK = cjkCount > text.length * 0.3;
-          const speed = this.callbacks.getPlaybackSpeed?.() ?? 1;
-          const rawMs = isCJK
-            ? Math.max(2000, text.length * 150)
-            : Math.max(2000, text.split(/\s+/).filter(Boolean).length * 240);
-          const readingMs = rawMs / speed;
+          const readingMs = this.getSpeechDurationMs(speechAction);
+          const remainingMs = Math.max(0, readingMs - actionOffsetMs);
           this.speechTimerStart = Date.now();
-          this.speechTimerRemaining = readingMs;
+          this.speechTimerRemaining = remainingMs;
+          this.pendingSpeechSeekOffsetMs = 0;
           this.speechTimer = setTimeout(() => {
             this.speechTimer = null;
             this.speechTimerRemaining = 0;
             this.callbacks.onSpeechEnd?.();
             if (this.mode === 'playing') this.processNext();
-          }, readingMs);
+          }, remainingMs);
         };
 
         // A speech line with no text (e.g. a freshly inserted blank slide's
@@ -494,7 +711,7 @@ export class PlaybackEngine {
         const hasText = !!speechAction.text.trim();
 
         this.audioPlayer
-          .play(speechAction.audioId || '', speechAction.audioUrl)
+          .play(speechAction.audioId || '', speechAction.audioUrl, actionOffsetMs)
           .then((audioStarted) => {
             if (!audioStarted) {
               // No pre-generated audio — try browser-native TTS only when it is
@@ -511,10 +728,12 @@ export class PlaybackEngine {
                 typeof window !== 'undefined' &&
                 window.speechSynthesis
               ) {
-                this.playBrowserTTS(speechAction);
+                this.playBrowserTTS(speechAction, actionOffsetMs);
               } else {
                 scheduleReadingTimer();
               }
+            } else if (actionOffsetMs > 0) {
+              this.pendingSpeechSeekOffsetMs = 0;
             }
           })
           .catch((err) => {
@@ -560,7 +779,7 @@ export class PlaybackEngine {
           return;
         }
 
-        // 3s delay before showing ProactiveCard (allows previous speech to finish naturally)
+        // Short delay before showing ProactiveCard (allows previous speech to finish naturally)
         const trigger: TriggerEvent = {
           id: discussionAction.id,
           question: discussionAction.topic,
@@ -574,7 +793,7 @@ export class PlaybackEngine {
           this.currentTrigger = trigger;
           this.callbacks.onProactiveShow?.(trigger);
           // Engine pauses here — user calls confirmDiscussion() or skipDiscussion()
-        }, 3000);
+        }, DISCUSSION_PROMPT_DELAY_MS);
         break;
       }
 
@@ -632,10 +851,34 @@ export class PlaybackEngine {
    * Splits text into sentence-level chunks to avoid Chrome's ~15s cutoff.
    * Uses cancel+re-speak for pause/resume (Firefox compatibility).
    */
-  private playBrowserTTS(speechAction: SpeechAction): void {
+  private getBrowserTTSStartChunkIndex(
+    chunks: string[],
+    offsetMs: number,
+    totalMs: number,
+  ): number {
+    if (offsetMs <= 0 || totalMs <= 0 || chunks.length <= 1) return 0;
+
+    const totalUnits = chunks.reduce((sum, chunk) => sum + Math.max(1, chunk.length), 0);
+    let elapsedMs = 0;
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunkMs = (Math.max(1, chunks[i].length) / totalUnits) * totalMs;
+      if (offsetMs < elapsedMs + chunkMs) return i;
+      elapsedMs += chunkMs;
+    }
+
+    return Math.max(0, chunks.length - 1);
+  }
+
+  private playBrowserTTS(speechAction: SpeechAction, offsetMs = 0): void {
     this.browserTTSChunks = this.splitIntoChunks(speechAction.text);
-    this.browserTTSChunkIndex = 0;
+    this.browserTTSChunkIndex = this.getBrowserTTSStartChunkIndex(
+      this.browserTTSChunks,
+      offsetMs,
+      this.getSpeechDurationMs(speechAction),
+    );
     this.browserTTSPausedChunks = [];
+    this.pendingSpeechSeekOffsetMs = 0;
     this.browserTTSActive = true;
     this.playBrowserTTSChunk();
   }

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -46,6 +46,22 @@ const log = createLogger('PlaybackEngine');
 const DISCUSSION_PROMPT_DELAY_MS = 3000;
 const MIN_SPEECH_DURATION_MS = 2000;
 const INSTANT_ACTION_DURATION_MS = 0;
+const SEEK_UNSAFE_ACTION_TYPES = new Set<Action['type']>([
+  'discussion',
+  'play_video',
+  'widget_highlight',
+  'widget_setState',
+  'widget_annotation',
+  'widget_reveal',
+]);
+
+export function isPlaybackSceneSeekable(actions: readonly Action[] = []): boolean {
+  return !actions.some((action) => SEEK_UNSAFE_ACTION_TYPES.has(action.type));
+}
+
+function isSeekReplayAction(action: Action): boolean {
+  return action.type.startsWith('wb_');
+}
 
 /**
  * If more than 30% of characters are CJK, treat the text as Chinese.
@@ -93,6 +109,7 @@ export class PlaybackEngine {
   private activeActionEstimatedMs: number = 0;
   private pendingSpeechSeekOffsetMs: number = 0;
   private seekProgressOverrideMs: number | null = null;
+  private playbackGeneration: number = 0;
 
   constructor(
     scenes: Scene[],
@@ -143,7 +160,11 @@ export class PlaybackEngine {
    * speech that is already active, the underlying audio element is seeked
    * precisely; otherwise the offset is applied when the speech action starts.
    */
-  seekTo(timeMs: number): PlaybackProgress {
+  async seekTo(timeMs: number): Promise<PlaybackProgress> {
+    if (this.mode === 'live' || !this.isCurrentSceneSeekable()) {
+      return this.getProgress();
+    }
+
     const durationMs = this.getSceneDurationMs();
     const targetMs = Math.max(0, durationMs > 0 ? Math.min(timeMs, durationMs) : timeMs);
     const timeline = this.getTimeline();
@@ -154,7 +175,13 @@ export class PlaybackEngine {
     }
 
     if (targetMs >= durationMs) {
-      this.cancelActivePlayback();
+      const generation = this.cancelActivePlayback();
+      this.actionEngine.resetPlaybackVisualState();
+      const replayed = await this.replaySeekStateBefore(
+        this.scenes[0]?.actions?.length ?? 0,
+        generation,
+      );
+      if (!replayed) return this.getProgress();
       this.sceneIndex = 0;
       this.actionIndex = this.scenes[0]?.actions?.length ?? 0;
       this.activeActionIndex = null;
@@ -173,12 +200,24 @@ export class PlaybackEngine {
       target.action.type === 'speech' &&
       this.audioPlayer.seekTo(offsetMs)
     ) {
+      const generation = this.invalidatePlaybackWork();
+      this.audioPlayer.onEnded(() => {
+        if (!this.isCurrentGeneration(generation)) return;
+        this.callbacks.onSpeechEnd?.();
+        if (this.mode === 'playing') {
+          this.processNext();
+        }
+      });
+      this.activeActionStartedAt = Date.now() - offsetMs;
       this.pendingSpeechSeekOffsetMs = 0;
       this.seekProgressOverrideMs = null;
       return this.getProgress();
     }
 
-    this.cancelActivePlayback();
+    const generation = this.cancelActivePlayback();
+    this.actionEngine.resetPlaybackVisualState();
+    const replayed = await this.replaySeekStateBefore(target.actionIndex, generation);
+    if (!replayed) return this.getProgress();
     this.sceneIndex = 0;
     this.actionIndex = target.actionIndex;
     this.activeActionIndex = null;
@@ -206,6 +245,7 @@ export class PlaybackEngine {
     this.actionIndex = 0;
     this.pendingSpeechSeekOffsetMs = 0;
     this.seekProgressOverrideMs = null;
+    this.invalidatePlaybackWork();
     this.setMode('playing');
     this.processNext();
   }
@@ -217,6 +257,7 @@ export class PlaybackEngine {
       return;
     }
     this.seekProgressOverrideMs = null;
+    this.invalidatePlaybackWork();
     this.setMode('playing');
     this.processNext();
   }
@@ -224,6 +265,7 @@ export class PlaybackEngine {
   /** playing → paused | live → paused (abort SSE, truncate, topic pending) */
   pause(): void {
     if (this.mode === 'playing') {
+      this.invalidatePlaybackWork();
       const pausedAtMs = this.computeProgress().currentTimeMs;
       // Cancel pending timers
       if (this.triggerDelayTimer) {
@@ -255,6 +297,7 @@ export class PlaybackEngine {
       }
       this.seekProgressOverrideMs = pausedAtMs;
     } else if (this.mode === 'live') {
+      this.invalidatePlaybackWork();
       this.setMode('paused');
       this.currentTopicState = 'pending';
       // Caller is responsible for aborting SSE
@@ -279,6 +322,7 @@ export class PlaybackEngine {
       this.setMode('playing');
     } else {
       // Resume lecture
+      const generation = this.invalidatePlaybackWork();
       const resumeProgressMs = this.seekProgressOverrideMs;
       this.setMode('playing');
       if (this.browserTTSPausedChunks.length > 0) {
@@ -293,10 +337,17 @@ export class PlaybackEngine {
             Math.max(0, resumeProgressMs - this.getActionStartMs(this.activeActionIndex));
         }
         this.seekProgressOverrideMs = null;
-        this.playBrowserTTSChunk();
+        this.playBrowserTTSChunk(generation);
       } else if (this.audioPlayer.hasActiveAudio()) {
         // Audio is paused — resume it; TTS onend will call processNext
         this.seekProgressOverrideMs = null;
+        this.audioPlayer.onEnded(() => {
+          if (!this.isCurrentGeneration(generation)) return;
+          this.callbacks.onSpeechEnd?.();
+          if (this.mode === 'playing') {
+            this.processNext();
+          }
+        });
         this.audioPlayer.resume();
       } else if (this.speechTimerRemaining > 0) {
         // Reading timer was paused — reschedule with remaining time
@@ -308,6 +359,7 @@ export class PlaybackEngine {
         this.seekProgressOverrideMs = null;
         this.speechTimerStart = Date.now();
         this.speechTimer = setTimeout(() => {
+          if (!this.isCurrentGeneration(generation)) return;
           this.speechTimer = null;
           this.speechTimerRemaining = 0;
           this.callbacks.onSpeechEnd?.();
@@ -323,11 +375,13 @@ export class PlaybackEngine {
 
   /** → idle */
   stop(): void {
+    this.invalidatePlaybackWork();
     // Set mode BEFORE stopping audio to prevent spurious processNext from
     // synchronous onend callbacks (see handleUserInterrupt for details).
     this.setMode('idle');
     this.audioPlayer.stop();
     this.cancelBrowserTTS();
+    useCanvasStore.getState().pauseVideo();
     this.actionEngine.clearEffects();
     if (this.triggerDelayTimer) {
       clearTimeout(this.triggerDelayTimer);
@@ -396,6 +450,7 @@ export class PlaybackEngine {
 
   /** End discussion → restore lecture → idle (user clicks "start" to continue) */
   handleEndDiscussion(): void {
+    this.invalidatePlaybackWork();
     this.actionEngine.clearEffects();
     this.currentTopicState = 'closed';
 
@@ -424,6 +479,7 @@ export class PlaybackEngine {
       return;
     }
 
+    this.invalidatePlaybackWork();
     this.actionEngine.clearEffects();
     useCanvasStore.getState().setWhiteboardOpen(false);
     this.currentTopicState = 'closed';
@@ -434,6 +490,7 @@ export class PlaybackEngine {
 
   /** User sends a message during playback → interrupt → live mode */
   handleUserInterrupt(text: string): void {
+    this.invalidatePlaybackWork();
     if (this.mode === 'playing' || this.mode === 'paused') {
       // Save lecture state BEFORE stopping audio — actionIndex was already
       // incremented by processNext, so subtract 1 to replay the interrupted
@@ -491,10 +548,42 @@ export class PlaybackEngine {
     this.callbacks.onModeChange?.(mode);
   }
 
-  private cancelActivePlayback(): void {
+  private invalidatePlaybackWork(): number {
+    this.playbackGeneration += 1;
+    return this.playbackGeneration;
+  }
+
+  private isCurrentGeneration(generation: number): boolean {
+    return generation === this.playbackGeneration;
+  }
+
+  private getSceneActions(): Action[] {
+    return this.scenes[0]?.actions ?? [];
+  }
+
+  private isCurrentSceneSeekable(): boolean {
+    return isPlaybackSceneSeekable(this.getSceneActions());
+  }
+
+  private async replaySeekStateBefore(actionIndex: number, generation: number): Promise<boolean> {
+    const actions = this.getSceneActions();
+    const replayUntil = Math.min(actionIndex, actions.length);
+    for (let index = 0; index < replayUntil; index++) {
+      if (!this.isCurrentGeneration(generation)) return false;
+      const action = actions[index];
+      if (!isSeekReplayAction(action)) continue;
+      await this.actionEngine.execute(action, { silent: true });
+      if (!this.isCurrentGeneration(generation)) return false;
+    }
+    return true;
+  }
+
+  private cancelActivePlayback(): number {
+    const generation = this.invalidatePlaybackWork();
     this.setMode('idle');
     this.audioPlayer.stop();
     this.cancelBrowserTTS();
+    useCanvasStore.getState().pauseVideo();
     if (this.triggerDelayTimer) {
       clearTimeout(this.triggerDelayTimer);
       this.triggerDelayTimer = null;
@@ -512,6 +601,7 @@ export class PlaybackEngine {
       this.callbacks.onProactiveHide?.();
     }
     this.actionEngine.clearEffects();
+    return generation;
   }
 
   private getSpeechDurationMs(action: SpeechAction): number {
@@ -605,7 +695,7 @@ export class PlaybackEngine {
       sceneId: this.sceneId,
       currentTimeMs: Math.max(0, durationMs > 0 ? Math.min(currentTimeMs, durationMs) : 0),
       durationMs,
-      seekable: durationMs > 0,
+      seekable: durationMs > 0 && this.isCurrentSceneSeekable(),
       actionIndex: this.activeActionIndex ?? this.actionIndex,
     };
   }
@@ -638,6 +728,7 @@ export class PlaybackEngine {
    */
   private async processNext(): Promise<void> {
     if (this.mode !== 'playing') return;
+    const generation = this.playbackGeneration;
 
     // Check for scene boundary (fire scene change callback at start of each new scene)
     if (this.actionIndex === 0 && this.sceneIndex < this.scenes.length) {
@@ -648,6 +739,7 @@ export class PlaybackEngine {
     }
 
     const current = this.getCurrentAction();
+    if (!this.isCurrentGeneration(generation)) return;
     if (!current) {
       // All scenes complete
       this.actionEngine.clearEffects();
@@ -679,6 +771,7 @@ export class PlaybackEngine {
 
         // onEnded → processNext; if paused, resume() will call processNext
         this.audioPlayer.onEnded(() => {
+          if (!this.isCurrentGeneration(generation)) return;
           this.callbacks.onSpeechEnd?.();
           if (this.mode === 'playing') {
             this.processNext();
@@ -690,12 +783,14 @@ export class PlaybackEngine {
         // Non-CJK text: ~240ms/word (≈250 WPM).
         // Min 2s. Cancelled on pause; resume() calls processNext directly.
         const scheduleReadingTimer = () => {
+          if (!this.isCurrentGeneration(generation)) return;
           const readingMs = this.getSpeechDurationMs(speechAction);
           const remainingMs = Math.max(0, readingMs - actionOffsetMs);
           this.speechTimerStart = Date.now();
           this.speechTimerRemaining = remainingMs;
           this.pendingSpeechSeekOffsetMs = 0;
           this.speechTimer = setTimeout(() => {
+            if (!this.isCurrentGeneration(generation)) return;
             this.speechTimer = null;
             this.speechTimerRemaining = 0;
             this.callbacks.onSpeechEnd?.();
@@ -713,6 +808,7 @@ export class PlaybackEngine {
         this.audioPlayer
           .play(speechAction.audioId || '', speechAction.audioUrl, actionOffsetMs)
           .then((audioStarted) => {
+            if (!this.isCurrentGeneration(generation)) return;
             if (!audioStarted) {
               // No pre-generated audio — try browser-native TTS only when it is
               // the selected provider AND actually enabled (opt-in, #665).
@@ -728,7 +824,7 @@ export class PlaybackEngine {
                 typeof window !== 'undefined' &&
                 window.speechSynthesis
               ) {
-                this.playBrowserTTS(speechAction, actionOffsetMs);
+                this.playBrowserTTS(speechAction, actionOffsetMs, generation);
               } else {
                 scheduleReadingTimer();
               }
@@ -737,6 +833,7 @@ export class PlaybackEngine {
             }
           })
           .catch((err) => {
+            if (!this.isCurrentGeneration(generation)) return;
             log.error('TTS error:', err);
             scheduleReadingTimer();
           });
@@ -757,7 +854,9 @@ export class PlaybackEngine {
         // Don't block — continue immediately (use queueMicrotask to avoid
         // stack overflow from deep synchronous recursion when many consecutive
         // spotlight/laser actions appear in sequence)
-        queueMicrotask(() => this.processNext());
+        queueMicrotask(() => {
+          if (this.isCurrentGeneration(generation)) this.processNext();
+        });
         break;
       }
 
@@ -765,7 +864,7 @@ export class PlaybackEngine {
         const discussionAction = action as DiscussionAction;
         // Check if already consumed
         if (this.consumedDiscussions.has(discussionAction.id)) {
-          this.processNext();
+          if (this.isCurrentGeneration(generation)) this.processNext();
           return;
         }
         // Skip if the discussion's agent isn't in the user's selected list
@@ -775,7 +874,7 @@ export class PlaybackEngine {
           !this.callbacks.isAgentSelected(discussionAction.agentId)
         ) {
           this.consumedDiscussions.add(discussionAction.id);
-          this.processNext();
+          if (this.isCurrentGeneration(generation)) this.processNext();
           return;
         }
 
@@ -788,6 +887,7 @@ export class PlaybackEngine {
         };
 
         this.triggerDelayTimer = setTimeout(() => {
+          if (!this.isCurrentGeneration(generation)) return;
           this.triggerDelayTimer = null;
           if (this.mode !== 'playing') return; // Cancelled if user paused/stopped
           this.currentTrigger = trigger;
@@ -804,6 +904,9 @@ export class PlaybackEngine {
       case 'wb_draw_chart':
       case 'wb_draw_latex':
       case 'wb_draw_table':
+      case 'wb_draw_line':
+      case 'wb_draw_code':
+      case 'wb_edit_code':
       case 'wb_clear':
       case 'wb_delete':
       case 'wb_close':
@@ -813,6 +916,7 @@ export class PlaybackEngine {
       case 'widget_reveal': {
         // Synchronous actions — await completion, then continue
         await this.actionEngine.execute(action);
+        if (!this.isCurrentGeneration(generation)) return;
         if (this.mode === 'playing') {
           this.processNext();
         }
@@ -821,7 +925,7 @@ export class PlaybackEngine {
 
       default:
         // Unknown action, skip
-        this.processNext();
+        if (this.isCurrentGeneration(generation)) this.processNext();
         break;
     }
   }
@@ -870,7 +974,12 @@ export class PlaybackEngine {
     return Math.max(0, chunks.length - 1);
   }
 
-  private playBrowserTTS(speechAction: SpeechAction, offsetMs = 0): void {
+  private playBrowserTTS(
+    speechAction: SpeechAction,
+    offsetMs = 0,
+    generation = this.playbackGeneration,
+  ): void {
+    if (!this.isCurrentGeneration(generation)) return;
     this.browserTTSChunks = this.splitIntoChunks(speechAction.text);
     this.browserTTSChunkIndex = this.getBrowserTTSStartChunkIndex(
       this.browserTTSChunks,
@@ -880,17 +989,18 @@ export class PlaybackEngine {
     this.browserTTSPausedChunks = [];
     this.pendingSpeechSeekOffsetMs = 0;
     this.browserTTSActive = true;
-    this.playBrowserTTSChunk();
+    this.playBrowserTTSChunk(generation);
   }
 
   /** Speak the current chunk; on completion, advance to next or finish. */
-  private async playBrowserTTSChunk(): Promise<void> {
+  private async playBrowserTTSChunk(generation = this.playbackGeneration): Promise<void> {
+    if (!this.isCurrentGeneration(generation)) return;
     if (this.browserTTSChunkIndex >= this.browserTTSChunks.length) {
       // All chunks done
       this.browserTTSActive = false;
       this.browserTTSChunks = [];
       this.callbacks.onSpeechEnd?.();
-      if (this.mode === 'playing') this.processNext();
+      if (this.mode === 'playing' && this.isCurrentGeneration(generation)) this.processNext();
       return;
     }
 
@@ -905,6 +1015,7 @@ export class PlaybackEngine {
 
     // Ensure voices are loaded (Chrome loads them asynchronously)
     const voices = await this.ensureVoicesLoaded();
+    if (!this.isCurrentGeneration(generation)) return;
 
     // Set voice: try user's configured voice, fall back to auto-detect language
     let voiceFound = false;
@@ -927,20 +1038,22 @@ export class PlaybackEngine {
     }
 
     utterance.onend = () => {
+      if (!this.isCurrentGeneration(generation)) return;
       this.browserTTSChunkIndex++;
       if (this.mode === 'playing') {
-        this.playBrowserTTSChunk(); // next chunk
+        this.playBrowserTTSChunk(generation); // next chunk
       }
     };
 
     utterance.onerror = (event) => {
+      if (!this.isCurrentGeneration(generation)) return;
       // 'canceled' is expected when stop/pause is called — not a real error
       if (event.error !== 'canceled') {
         log.warn('Browser TTS chunk error:', event.error);
         // Skip failed chunk, try next
         this.browserTTSChunkIndex++;
         if (this.mode === 'playing') {
-          this.playBrowserTTSChunk();
+          this.playBrowserTTSChunk(generation);
         }
       }
       // On 'canceled': do nothing — pause handler already saved state
@@ -948,6 +1061,7 @@ export class PlaybackEngine {
 
     // Chrome bug workaround: cancel() before speak() to clear stale synthesis
     // state that can produce garbled/broken audio output.
+    if (!this.isCurrentGeneration(generation)) return;
     window.speechSynthesis.cancel();
     window.speechSynthesis.speak(utterance);
   }

--- a/lib/playback/types.ts
+++ b/lib/playback/types.ts
@@ -6,6 +6,15 @@ import type { PlaybackSnapshot } from '@/lib/utils/playback-storage';
 
 export type { PlaybackSnapshot };
 
+/** Playback progress for the active classroom scene. */
+export interface PlaybackProgress {
+  sceneId?: string;
+  currentTimeMs: number;
+  durationMs: number;
+  seekable: boolean;
+  actionIndex: number;
+}
+
 /** Visual effects (for onEffectFire callback) */
 export type Effect =
   | { kind: 'spotlight'; targetId: string; dimOpacity?: number }

--- a/lib/utils/audio-player.ts
+++ b/lib/utils/audio-player.ts
@@ -25,9 +25,10 @@ export class AudioPlayer {
    * Play audio (from URL or IndexedDB pre-generated cache)
    * @param audioId Audio ID
    * @param audioUrl Optional server-generated audio URL (takes priority over IndexedDB)
+   * @param startTimeMs Optional start offset in milliseconds
    * @returns true if audio started playing, false if no audio (TTS disabled or not generated)
    */
-  public async play(audioId: string, audioUrl?: string): Promise<boolean> {
+  public async play(audioId: string, audioUrl?: string, startTimeMs = 0): Promise<boolean> {
     try {
       // 1. Try audioUrl first (server-generated TTS)
       if (audioUrl) {
@@ -41,6 +42,7 @@ export class AudioPlayer {
         this.audio.addEventListener('ended', () => {
           this.onEndedCallback?.();
         });
+        this.seekTo(startTimeMs);
         await this.audio.play();
         this.audio.playbackRate = this.playbackRate;
         return true;
@@ -69,6 +71,7 @@ export class AudioPlayer {
       // Apply playback rate
       this.audio.defaultPlaybackRate = this.playbackRate;
       this.audio.playbackRate = this.playbackRate;
+      this.seekTo(startTimeMs);
 
       // Set ended callback
       this.audio.addEventListener('ended', () => {
@@ -156,6 +159,22 @@ export class AudioPlayer {
    */
   public getDuration(): number {
     return this.audio && !isNaN(this.audio.duration) ? this.audio.duration * 1000 : 0;
+  }
+
+  /**
+   * Seek active audio to a position in milliseconds.
+   */
+  public seekTo(timeMs: number): boolean {
+    if (!this.audio) return false;
+    const durationMs = this.getDuration();
+    const clampedMs =
+      durationMs > 0 ? Math.max(0, Math.min(timeMs, durationMs)) : Math.max(0, timeMs);
+    try {
+      this.audio.currentTime = clampedMs / 1000;
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/lib/utils/audio-player.ts
+++ b/lib/utils/audio-player.ts
@@ -20,6 +20,20 @@ export class AudioPlayer {
   private muted: boolean = false;
   private volume: number = 1;
   private playbackRate: number = 1;
+  private playRequestId: number = 0;
+
+  private clearAudio(resetTime = true): void {
+    if (!this.audio) return;
+    this.audio.pause();
+    if (resetTime) {
+      this.audio.currentTime = 0;
+    }
+    this.audio = null;
+  }
+
+  private isCurrentRequest(requestId: number): boolean {
+    return requestId === this.playRequestId;
+  }
 
   /**
    * Play audio (from URL or IndexedDB pre-generated cache)
@@ -29,53 +43,65 @@ export class AudioPlayer {
    * @returns true if audio started playing, false if no audio (TTS disabled or not generated)
    */
   public async play(audioId: string, audioUrl?: string, startTimeMs = 0): Promise<boolean> {
+    const requestId = ++this.playRequestId;
+    this.clearAudio();
+
     try {
       // 1. Try audioUrl first (server-generated TTS)
       if (audioUrl) {
-        this.stop();
-        this.audio = new Audio();
-        this.audio.src = audioUrl;
-        if (this.muted) this.audio.volume = 0;
-        else this.audio.volume = this.volume;
-        this.audio.defaultPlaybackRate = this.playbackRate;
-        this.audio.playbackRate = this.playbackRate;
-        this.audio.addEventListener('ended', () => {
+        const audio = new Audio();
+        this.audio = audio;
+        audio.src = audioUrl;
+        if (this.muted) audio.volume = 0;
+        else audio.volume = this.volume;
+        audio.defaultPlaybackRate = this.playbackRate;
+        audio.playbackRate = this.playbackRate;
+        audio.addEventListener('ended', () => {
+          if (!this.isCurrentRequest(requestId) || this.audio !== audio) return;
+          this.audio = null;
           this.onEndedCallback?.();
         });
         this.seekTo(startTimeMs);
-        await this.audio.play();
-        this.audio.playbackRate = this.playbackRate;
+        await audio.play();
+        if (!this.isCurrentRequest(requestId) || this.audio !== audio) {
+          audio.pause();
+          return false;
+        }
+        audio.playbackRate = this.playbackRate;
         return true;
       }
 
       // 2. Fall back to IndexedDB (client-generated TTS)
       const audioRecord = await db.audioFiles.get(audioId);
+      if (!this.isCurrentRequest(requestId)) {
+        return false;
+      }
 
       if (!audioRecord) {
         // Pre-generated audio does not exist (generation failed), skip silently
         return false;
       }
 
-      // Stop current playback
-      this.stop();
-
       // Create audio element
-      this.audio = new Audio();
+      const audio = new Audio();
+      this.audio = audio;
 
       // Set audio source
       const blobUrl = URL.createObjectURL(audioRecord.blob);
-      this.audio.src = blobUrl;
-      if (this.muted) this.audio.volume = 0;
-      else this.audio.volume = this.volume;
+      audio.src = blobUrl;
+      if (this.muted) audio.volume = 0;
+      else audio.volume = this.volume;
 
       // Apply playback rate
-      this.audio.defaultPlaybackRate = this.playbackRate;
-      this.audio.playbackRate = this.playbackRate;
+      audio.defaultPlaybackRate = this.playbackRate;
+      audio.playbackRate = this.playbackRate;
       this.seekTo(startTimeMs);
 
       // Set ended callback
-      this.audio.addEventListener('ended', () => {
+      audio.addEventListener('ended', () => {
         URL.revokeObjectURL(blobUrl);
+        if (!this.isCurrentRequest(requestId) || this.audio !== audio) return;
+        this.audio = null;
         this.onEndedCallback?.();
       });
 
@@ -83,15 +109,26 @@ export class AudioPlayer {
       // load) the 'ended' listener never fires, so revoke the blob URL here to
       // avoid leaking it for the lifetime of the document.
       try {
-        await this.audio.play();
+        await audio.play();
       } catch (playError) {
         URL.revokeObjectURL(blobUrl);
+        if (this.isCurrentRequest(requestId) && this.audio === audio) {
+          this.audio = null;
+        }
         throw playError;
       }
+      if (!this.isCurrentRequest(requestId) || this.audio !== audio) {
+        audio.pause();
+        URL.revokeObjectURL(blobUrl);
+        return false;
+      }
       // Re-apply after play() — some browsers reset during load
-      this.audio.playbackRate = this.playbackRate;
+      audio.playbackRate = this.playbackRate;
       return true;
     } catch (error) {
+      if (!this.isCurrentRequest(requestId)) {
+        return false;
+      }
       log.error('Failed to play audio:', error);
       throw error;
     }
@@ -110,11 +147,8 @@ export class AudioPlayer {
    * Stop playback
    */
   public stop(): void {
-    if (this.audio) {
-      this.audio.pause();
-      this.audio.currentTime = 0;
-      this.audio = null;
-    }
+    this.playRequestId += 1;
+    this.clearAudio();
     // Note: onEndedCallback intentionally NOT cleared here because play()
     // calls stop() internally — clearing would break the callback chain.
     // Stale callbacks are harmless: engine mode check prevents processNext().

--- a/tests/audio/audio-player-leak.test.ts
+++ b/tests/audio/audio-player-leak.test.ts
@@ -57,4 +57,30 @@ describe('AudioPlayer blob URL lifecycle', () => {
     await expect(new AudioPlayer().play('audio-1')).resolves.toBe(true);
     expect(revokeObjectURL).not.toHaveBeenCalled();
   });
+
+  it('does not let a stale IndexedDB lookup create audio after a newer play request', async () => {
+    let resolveFirstLookup: (record: { blob: Blob }) => void = () => {};
+    getMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ blob: Blob }>((resolve) => {
+            resolveFirstLookup = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+    const { createObjectURL } = stubObjectUrl();
+    const play = vi.fn(() => Promise.resolve());
+    stubAudio(play);
+
+    const { AudioPlayer } = await import('@/lib/utils/audio-player');
+    const player = new AudioPlayer();
+
+    const stalePlay = player.play('old-audio');
+    await expect(player.play('missing-audio')).resolves.toBe(false);
+    resolveFirstLookup({ blob: new Blob(['old audio']) });
+
+    await expect(stalePlay).resolves.toBe(false);
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(play).not.toHaveBeenCalled();
+  });
 });

--- a/tests/playback/engine-seek.test.ts
+++ b/tests/playback/engine-seek.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { PlaybackEngine } from '@/lib/playback/engine';
+import { PlaybackEngine, isPlaybackSceneSeekable } from '@/lib/playback/engine';
 import type { ActionEngine } from '@/lib/action/engine';
 import type { AudioPlayer } from '@/lib/utils/audio-player';
 import type { Scene } from '@/lib/types/stage';
@@ -25,6 +25,7 @@ function scene(actions: NonNullable<Scene['actions']>): Scene {
 function fakeActionEngine(): ActionEngine {
   return {
     clearEffects: vi.fn(),
+    resetPlaybackVisualState: vi.fn(),
     execute: vi.fn().mockResolvedValue(undefined),
   } as unknown as ActionEngine;
 }
@@ -50,6 +51,35 @@ function fakeAudio(overrides: Partial<AudioPlayer> = {}): AudioPlayer {
 }
 
 describe('PlaybackEngine seek', () => {
+  it('classifies speech and whiteboard scenes as seekable', () => {
+    expect(
+      isPlaybackSceneSeekable([
+        { id: 'speech-1', type: 'speech', text: 'A line.' },
+        { id: 'wb-1', type: 'wb_open' },
+        {
+          id: 'wb-2',
+          type: 'wb_draw_text',
+          content: 'Written state',
+          x: 0,
+          y: 0,
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['widget action', { id: 'widget-1', type: 'widget_reveal', target: 'part-a' }],
+    ['discussion action', { id: 'discussion-1', type: 'discussion', topic: 'Question?' }],
+    ['play_video action', { id: 'video-1', type: 'play_video', elementId: 'video-1' }],
+  ])('classifies a scene with %s as not seekable', (_label, unsafeAction) => {
+    expect(
+      isPlaybackSceneSeekable([
+        { id: 'speech-1', type: 'speech', text: 'A line.' },
+        unsafeAction,
+      ] as NonNullable<Scene['actions']>),
+    ).toBe(false);
+  });
+
   it('freezes estimated progress immediately when paused', () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -81,7 +111,7 @@ describe('PlaybackEngine seek', () => {
     }
   });
 
-  it('seeks to an estimated action boundary while paused', () => {
+  it('seeks to an estimated action boundary while paused', async () => {
     const engine = new PlaybackEngine(
       [
         scene([
@@ -100,7 +130,7 @@ describe('PlaybackEngine seek', () => {
       seekable: true,
     });
 
-    const progress = engine.seekTo(2500);
+    const progress = await engine.seekTo(2500);
 
     expect(engine.getMode()).toBe('paused');
     expect(progress).toMatchObject({
@@ -111,7 +141,7 @@ describe('PlaybackEngine seek', () => {
     expect(engine.getSnapshot().actionIndex).toBe(1);
   });
 
-  it('delegates precise seek to the active generated speech audio', () => {
+  it('delegates precise seek to the active generated speech audio', async () => {
     let currentTimeMs = 1000;
     const seekTo = vi.fn((timeMs: number) => {
       currentTimeMs = timeMs;
@@ -132,14 +162,14 @@ describe('PlaybackEngine seek', () => {
     );
 
     engine.start();
-    const progress = engine.seekTo(5000);
+    const progress = await engine.seekTo(5000);
 
     expect(seekTo).toHaveBeenCalledWith(5000);
     expect(progress.currentTimeMs).toBe(5000);
     expect(progress.durationMs).toBe(10000);
   });
 
-  it('starts generated speech audio at the pending seek offset', () => {
+  it('starts generated speech audio at the pending seek offset', async () => {
     const play = vi.fn().mockResolvedValue(true);
     const engine = new PlaybackEngine(
       [
@@ -158,9 +188,177 @@ describe('PlaybackEngine seek', () => {
       { getPlaybackSpeed: () => 1 },
     );
 
-    engine.seekTo(1000);
+    await engine.seekTo(1000);
     engine.resume();
 
     expect(play).toHaveBeenCalledWith('tts-1', '/audio/tts-1.mp3', 1000);
+  });
+
+  it('marks unsafe scene progress as not seekable and no-ops seekTo', async () => {
+    const actionEngine = fakeActionEngine();
+    const engine = new PlaybackEngine(
+      [
+        scene([
+          { id: 'speech-1', type: 'speech', text: 'First line.' },
+          { id: 'widget-1', type: 'widget_reveal', target: 'part-a' },
+          { id: 'speech-2', type: 'speech', text: 'Second line.' },
+        ] as NonNullable<Scene['actions']>),
+      ],
+      actionEngine,
+      fakeAudio(),
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    expect(engine.getProgress()).toMatchObject({ currentTimeMs: 0, seekable: false });
+
+    const progress = await engine.seekTo(2500);
+
+    expect(progress).toMatchObject({ currentTimeMs: 0, seekable: false });
+    expect(engine.getSnapshot().actionIndex).toBe(0);
+    expect(actionEngine.resetPlaybackVisualState).not.toHaveBeenCalled();
+  });
+
+  it('silently replays whiteboard actions before the target speech', async () => {
+    const actionEngine = fakeActionEngine();
+    const engine = new PlaybackEngine(
+      [
+        scene([
+          { id: 'speech-1', type: 'speech', text: 'First line.' },
+          { id: 'wb-1', type: 'wb_open' },
+          {
+            id: 'wb-2',
+            type: 'wb_draw_text',
+            content: 'Important state',
+            x: 10,
+            y: 20,
+          },
+          { id: 'spotlight-1', type: 'spotlight', elementId: 'shape-1' },
+          { id: 'speech-2', type: 'speech', text: 'Second line.' },
+        ] as NonNullable<Scene['actions']>),
+      ],
+      actionEngine,
+      fakeAudio(),
+      {
+        getPlaybackSpeed: () => 1,
+        onEffectFire: vi.fn(),
+        onSpeechStart: vi.fn(),
+      },
+    );
+
+    const progress = await engine.seekTo(2500);
+
+    expect(progress).toMatchObject({ currentTimeMs: 2500, actionIndex: 4, seekable: true });
+    expect(actionEngine.resetPlaybackVisualState).toHaveBeenCalledTimes(1);
+    expect(actionEngine.execute).toHaveBeenCalledTimes(2);
+    expect(actionEngine.execute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ type: 'wb_open' }),
+      { silent: true },
+    );
+    expect(actionEngine.execute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ type: 'wb_draw_text' }),
+      { silent: true },
+    );
+  });
+
+  it('seeking backward resets whiteboard state without replaying later whiteboard actions', async () => {
+    const actionEngine = fakeActionEngine();
+    const engine = new PlaybackEngine(
+      [
+        scene([
+          { id: 'speech-1', type: 'speech', text: 'First line.' },
+          { id: 'wb-1', type: 'wb_open' },
+          {
+            id: 'wb-2',
+            type: 'wb_draw_text',
+            content: 'Important state',
+            x: 10,
+            y: 20,
+          },
+          { id: 'speech-2', type: 'speech', text: 'Second line.' },
+        ] as NonNullable<Scene['actions']>),
+      ],
+      actionEngine,
+      fakeAudio(),
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    await engine.seekTo(2500);
+    vi.mocked(actionEngine.execute).mockClear();
+
+    const progress = await engine.seekTo(0);
+
+    expect(progress).toMatchObject({ currentTimeMs: 0, actionIndex: 0 });
+    expect(actionEngine.resetPlaybackVisualState).toHaveBeenCalledTimes(2);
+    expect(actionEngine.execute).not.toHaveBeenCalled();
+  });
+
+  it('does not schedule an old reading timer when stale audio play resolves after seek', async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveFirstPlay: (value: boolean) => void = () => {};
+      const play = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<boolean>((resolve) => {
+              resolveFirstPlay = resolve;
+            }),
+        )
+        .mockImplementationOnce(() => new Promise<boolean>(() => {}));
+      const onSpeechEnd = vi.fn();
+      const engine = new PlaybackEngine(
+        [
+          scene([
+            { id: 'speech-1', type: 'speech', text: 'First line.' },
+            { id: 'speech-2', type: 'speech', text: 'Second line.' },
+          ]),
+        ],
+        fakeActionEngine(),
+        fakeAudio({ play }),
+        { getPlaybackSpeed: () => 1, onSpeechEnd },
+      );
+
+      engine.start();
+      await engine.seekTo(2500);
+      resolveFirstPlay(false);
+      await vi.runAllTicks();
+      vi.advanceTimersByTime(3000);
+
+      expect(onSpeechEnd).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('pause invalidates a pending audio play fallback timer', async () => {
+    vi.useFakeTimers();
+    try {
+      let resolvePlay: (value: boolean) => void = () => {};
+      const play = vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolvePlay = resolve;
+          }),
+      );
+      const onSpeechEnd = vi.fn();
+      const engine = new PlaybackEngine(
+        [scene([{ id: 'speech-1', type: 'speech', text: 'First line.' }])],
+        fakeActionEngine(),
+        fakeAudio({ play }),
+        { getPlaybackSpeed: () => 1, onSpeechEnd },
+      );
+
+      engine.start();
+      engine.pause();
+      resolvePlay(false);
+      await vi.runAllTicks();
+      vi.advanceTimersByTime(3000);
+
+      expect(onSpeechEnd).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/playback/engine-seek.test.ts
+++ b/tests/playback/engine-seek.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PlaybackEngine } from '@/lib/playback/engine';
+import type { ActionEngine } from '@/lib/action/engine';
+import type { AudioPlayer } from '@/lib/utils/audio-player';
+import type { Scene } from '@/lib/types/stage';
+
+function scene(actions: NonNullable<Scene['actions']>): Scene {
+  return {
+    id: 'scene-1',
+    stageId: 'stage-1',
+    type: 'slide',
+    title: 'Scene 1',
+    order: 0,
+    content: {
+      type: 'slide',
+      canvas: {
+        viewportSize: { width: 1600, height: 900 },
+        elements: [],
+      },
+    },
+    actions,
+  } as unknown as Scene;
+}
+
+function fakeActionEngine(): ActionEngine {
+  return {
+    clearEffects: vi.fn(),
+    execute: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ActionEngine;
+}
+
+function fakeAudio(overrides: Partial<AudioPlayer> = {}): AudioPlayer {
+  return {
+    play: vi.fn().mockResolvedValue(false),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    resume: vi.fn(),
+    isPlaying: vi.fn(() => false),
+    hasActiveAudio: vi.fn(() => false),
+    getCurrentTime: vi.fn(() => 0),
+    getDuration: vi.fn(() => 0),
+    seekTo: vi.fn(() => false),
+    onEnded: vi.fn(),
+    setMuted: vi.fn(),
+    setVolume: vi.fn(),
+    setPlaybackRate: vi.fn(),
+    destroy: vi.fn(),
+    ...overrides,
+  } as unknown as AudioPlayer;
+}
+
+describe('PlaybackEngine seek', () => {
+  it('freezes estimated progress immediately when paused', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    try {
+      const engine = new PlaybackEngine(
+        [
+          scene([
+            { id: 'speech-1', type: 'speech', text: 'A longer line for estimated progress.' },
+          ]),
+        ],
+        fakeActionEngine(),
+        fakeAudio({
+          play: vi.fn(() => new Promise<boolean>(() => {})),
+        }),
+        { getPlaybackSpeed: () => 1 },
+      );
+
+      engine.start();
+      vi.setSystemTime(3000);
+      engine.pause();
+      const pausedProgress = engine.getProgress().currentTimeMs;
+
+      vi.setSystemTime(9000);
+
+      expect(engine.getProgress().currentTimeMs).toBe(pausedProgress);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('seeks to an estimated action boundary while paused', () => {
+    const engine = new PlaybackEngine(
+      [
+        scene([
+          { id: 'speech-1', type: 'speech', text: 'First line.' },
+          { id: 'speech-2', type: 'speech', text: 'Second line.' },
+        ]),
+      ],
+      fakeActionEngine(),
+      fakeAudio(),
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    expect(engine.getProgress()).toMatchObject({
+      currentTimeMs: 0,
+      durationMs: 4000,
+      seekable: true,
+    });
+
+    const progress = engine.seekTo(2500);
+
+    expect(engine.getMode()).toBe('paused');
+    expect(progress).toMatchObject({
+      currentTimeMs: 2500,
+      durationMs: 4000,
+      actionIndex: 1,
+    });
+    expect(engine.getSnapshot().actionIndex).toBe(1);
+  });
+
+  it('delegates precise seek to the active generated speech audio', () => {
+    let currentTimeMs = 1000;
+    const seekTo = vi.fn((timeMs: number) => {
+      currentTimeMs = timeMs;
+      return true;
+    });
+    const audio = fakeAudio({
+      play: vi.fn().mockResolvedValue(true),
+      hasActiveAudio: vi.fn(() => true),
+      getCurrentTime: vi.fn(() => currentTimeMs),
+      getDuration: vi.fn(() => 10000),
+      seekTo,
+    });
+    const engine = new PlaybackEngine(
+      [scene([{ id: 'speech-1', type: 'speech', text: 'Generated audio line.' }])],
+      fakeActionEngine(),
+      audio,
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    engine.start();
+    const progress = engine.seekTo(5000);
+
+    expect(seekTo).toHaveBeenCalledWith(5000);
+    expect(progress.currentTimeMs).toBe(5000);
+    expect(progress.durationMs).toBe(10000);
+  });
+
+  it('starts generated speech audio at the pending seek offset', () => {
+    const play = vi.fn().mockResolvedValue(true);
+    const engine = new PlaybackEngine(
+      [
+        scene([
+          {
+            id: 'speech-1',
+            type: 'speech',
+            text: 'Generated audio line with enough words for seeking.',
+            audioId: 'tts-1',
+            audioUrl: '/audio/tts-1.mp3',
+          },
+        ]),
+      ],
+      fakeActionEngine(),
+      fakeAudio({ play }),
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    engine.seekTo(1000);
+    engine.resume();
+
+    expect(play).toHaveBeenCalledWith('tts-1', '/audio/tts-1.mp3', 1000);
+  });
+});

--- a/tests/playback/engine-seek.test.ts
+++ b/tests/playback/engine-seek.test.ts
@@ -169,6 +169,88 @@ describe('PlaybackEngine seek', () => {
     expect(progress.durationMs).toBe(10000);
   });
 
+  it('clears transient effects during precise seek within active generated speech', async () => {
+    let onEnded: () => void = () => {};
+    const actionEngine = fakeActionEngine();
+    const audio = fakeAudio({
+      play: vi.fn().mockResolvedValue(true),
+      hasActiveAudio: vi.fn(() => true),
+      getDuration: vi.fn(() => 10000),
+      seekTo: vi.fn(() => true),
+      onEnded: vi.fn((callback) => {
+        onEnded = callback;
+      }),
+    });
+    const engine = new PlaybackEngine(
+      [
+        scene([
+          { id: 'speech-1', type: 'speech', text: 'First line.' },
+          { id: 'spotlight-1', type: 'spotlight', elementId: 'shape-1' },
+          { id: 'speech-2', type: 'speech', text: 'Second line.' },
+        ]),
+      ],
+      actionEngine,
+      audio,
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    engine.start();
+    onEnded();
+    await Promise.resolve();
+    await Promise.resolve();
+    vi.mocked(actionEngine.clearEffects).mockClear();
+
+    await engine.seekTo(11000);
+
+    expect(actionEngine.clearEffects).toHaveBeenCalledTimes(1);
+    expect(actionEngine.execute).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'spotlight' }),
+      { silent: true },
+    );
+  });
+
+  it('keeps seek progress at the selected offset while active audio currentTime is still zero', async () => {
+    const audio = fakeAudio({
+      play: vi.fn().mockResolvedValue(true),
+      hasActiveAudio: vi.fn(() => true),
+      getCurrentTime: vi.fn(() => 0),
+      getDuration: vi.fn(() => 10000),
+      seekTo: vi.fn(() => true),
+    });
+    const engine = new PlaybackEngine(
+      [scene([{ id: 'speech-1', type: 'speech', text: 'Generated audio line.' }])],
+      fakeActionEngine(),
+      audio,
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    engine.start();
+    const progress = await engine.seekTo(5000);
+
+    expect(progress.currentTimeMs).toBe(5000);
+    expect(progress.durationMs).toBe(10000);
+  });
+
+  it('keeps observed generated-audio duration stable after the action is no longer active', () => {
+    const engine = new PlaybackEngine(
+      [scene([{ id: 'speech-1', type: 'speech', text: 'Short estimate.' }])],
+      fakeActionEngine(),
+      fakeAudio({
+        play: vi.fn().mockResolvedValue(true),
+        hasActiveAudio: vi.fn(() => true),
+        getDuration: vi.fn(() => 10000),
+      }),
+      { getPlaybackSpeed: () => 1 },
+    );
+
+    engine.start();
+    expect(engine.getProgress().durationMs).toBe(10000);
+
+    engine.stop();
+
+    expect(engine.getProgress().durationMs).toBe(10000);
+  });
+
   it('starts generated speech audio at the pending seek offset', async () => {
     const play = vi.fn().mockResolvedValue(true);
     const engine = new PlaybackEngine(


### PR DESCRIPTION
## Summary

Adds a seek/progress bar to classroom playback so users can move forward/backward within the active slide/scene and resume from the last known position when returning to a slide/scene.

Generated TTS audio supports precise seeking through the shared audio player. Browser Native TTS uses a best-effort sentence/chunk fallback because the Web Speech API does not expose precise media-style seeking APIs.

## Related Issues

Closes #818

## Changes

- Added scene-level playback progress tracking in the playback engine
- Added `seekTo` support for classroom playback
- Added generated-audio seeking through the shared audio player
- Added a compact seek/progress slider to the classroom playback toolbar
- Stores last playback position per scene in `sessionStorage`, scoped to the current classroom/stage
- Restores the previous scene position when returning to a slide/scene
- Added i18n strings for seek/progress accessibility labels
- Added playback seek tests

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open a generated classroom in playback mode.
2. Start playback and verify the progress slider updates while the scene is playing.
3. Pause playback and verify the progress position freezes.
4. Drag the seek bar forward/backward and verify playback resumes from the selected position.
5. Navigate to another slide/scene, then return to the previous scene and verify the saved playback position is restored.
6. Verify existing play/pause and slide navigation behavior still works.

### What you personally verified

- Verified the seek bar appears during classroom playback
- Verified playback progress updates while playing
- Verified pause freezes progress
- Verified seeking forward/backward works
- Verified returning to a previous scene restores the saved playback position
- Verified existing play/pause and slide navigation still work
- Verified generated-audio seek behavior through the shared audio player
- Verified Browser Native TTS uses a best-effort fallback path
- Verified the feature on my server with real classroom playback
- `pnpm lint` reports 0 errors. The remaining warnings appear unrelated to this PR.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots / recordings attached (if UI changes)

Screenshots:

1. Seek/progress bar displayed during classroom playback

<img width="1512" height="864" alt="Screenshot 2026-06-30 at 3 47 20 PM" src="https://github.com/user-attachments/assets/54ce029f-f65c-4187-a90e-8d0b4416bb13" />

2. Playback position updated after seeking

<img width="1512" height="862" alt="Screenshot 2026-06-30 at 3 47 33 PM" src="https://github.com/user-attachments/assets/c87002f5-bafc-4d5a-b598-7393d5227e4a" />

3. Previous scene resumes from the saved playback position

<img width="1512" height="862" alt="Screenshot 2026-06-30 at 3 47 38 PM" src="https://github.com/user-attachments/assets/1f697ad1-287d-41d2-9f84-0d81755866ae" />
<img width="1512" height="860" alt="Screenshot 2026-06-30 at 3 46 37 PM" src="https://github.com/user-attachments/assets/0e6458df-b6e5-42b4-a6c5-db17f4d7e2f9" />

Local verification run:

```bash
pnpm check
pnpm lint
npx tsc --noEmit
pnpm test tests/playback/engine-seek.test.ts
pnpm build
```

Results:

- `pnpm check` passed
- `pnpm lint` completed with 0 errors and existing warnings
- `npx tsc --noEmit` passed
- `pnpm test tests/playback/engine-seek.test.ts` passed: 4 tests
- `pnpm build` passed
- Manually tested on server with real classroom playback

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [ ] My changes do not introduce new warnings