### PR TITLE
fix(quiz): stop leaking questions on entry and pass results to chat agent

### DIFF
--- a/components/chat/use-chat-sessions.ts
+++ b/components/chat/use-chat-sessions.ts
@@ -24,10 +24,46 @@ import { StreamBuffer } from '@/lib/buffer/stream-buffer';
 import type { AgentStartItem, ActionItem } from '@/lib/buffer/stream-buffer';
 import { runAgentLoop, type AgentLoopStoreState } from '@/lib/chat/agent-loop';
 import { ActionEngine } from '@/lib/action/engine';
+import { readSubmittedState } from '@/lib/quiz/persistence';
 import { toast } from 'sonner';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('ChatSessions');
+
+/**
+ * Hydrate post-submit quiz state for the active scene from localStorage so the
+ * agent receives the student's actual answers and grader feedback. Returns
+ * `undefined` when the active scene is not a quiz, the student has not submitted
+ * yet, or the persisted blob is unreadable — `state-context.ts` then falls back
+ * to the bare question summary.
+ */
+function buildQuizResultsForStoreState(
+  scenes: { id: string; type?: string }[],
+  currentSceneId: string | null,
+):
+  | {
+      sceneId: string;
+      answers: Record<string, string | string[]>;
+      results: Array<{
+        questionId: string;
+        correct: boolean | null;
+        status: 'correct' | 'incorrect';
+        earned: number;
+        aiComment?: string;
+      }>;
+    }
+  | undefined {
+  if (!currentSceneId) return undefined;
+  const scene = scenes.find((s) => s.id === currentSceneId);
+  if (!scene || scene.type !== 'quiz') return undefined;
+  const submitted = readSubmittedState(currentSceneId);
+  if (!submitted || submitted.kind !== 'reviewing') return undefined;
+  return {
+    sceneId: currentSceneId,
+    answers: submitted.answers,
+    results: submitted.results,
+  };
+}
 
 interface UseChatSessionsOptions {
   onLiveSpeech?: (text: string | null, agentId?: string | null) => void;
@@ -493,6 +529,10 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: freshState.currentSceneId,
               mode: freshState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizResults: buildQuizResultsForStoreState(
+                freshState.scenes,
+                freshState.currentSceneId,
+              ),
             };
           },
 
@@ -895,6 +935,10 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizResults: buildQuizResultsForStoreState(
+                currentState.scenes,
+                currentState.currentSceneId,
+              ),
             },
             config: {
               agentIds,
@@ -1105,6 +1149,10 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizResults: buildQuizResultsForStoreState(
+                currentState.scenes,
+                currentState.currentSceneId,
+              ),
             },
             config: {
               agentIds,
@@ -1243,6 +1291,10 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizResults: buildQuizResultsForStoreState(
+                currentState.scenes,
+                currentState.currentSceneId,
+              ),
             },
             config: {
               agentIds,

--- a/lib/chat/agent-loop.ts
+++ b/lib/chat/agent-loop.ts
@@ -26,6 +26,22 @@ export interface AgentLoopStoreState {
   currentSceneId: string | null;
   mode: string;
   whiteboardOpen: boolean;
+  /**
+   * Post-submit quiz state for the current scene. Hydrated from localStorage
+   * client-side; absent when the active scene is not a graded quiz or the
+   * student has not submitted yet.
+   */
+  quizResults?: {
+    sceneId: string;
+    answers: Record<string, string | string[]>;
+    results: Array<{
+      questionId: string;
+      correct: boolean | null;
+      status: 'correct' | 'incorrect';
+      earned: number;
+      aiComment?: string;
+    }>;
+  };
 }
 
 /** Request template — fields that stay constant across loop iterations */

--- a/lib/orchestration/summarizers/state-context.ts
+++ b/lib/orchestration/summarizers/state-context.ts
@@ -95,7 +95,7 @@ export function summarizeElements(elements: any[]): string {
  * Build context string from store state
  */
 export function buildStateContext(storeState: StatelessChatRequest['storeState']): string {
-  const { stage, scenes, currentSceneId, mode, whiteboardOpen } = storeState;
+  const { stage, scenes, currentSceneId, mode, whiteboardOpen, quizResults } = storeState;
 
   const lines: string[] = [];
 
@@ -130,16 +130,80 @@ export function buildStateContext(storeState: StatelessChatRequest['storeState']
         lines.push(`Current slide elements (${elements.length}):\n${summarizeElements(elements)}`);
       }
 
-      // Quiz scene: include question summary
+      // Quiz scene: include question summary, or post-submit results when the
+      // student has finished. Hydration of `quizResults` happens client-side in
+      // use-chat-sessions; absent here means the student has not submitted (or
+      // the active scene is not the quiz that owns the results).
       if (currentScene.content.type === 'quiz') {
         const questions = currentScene.content.questions;
-        const qSummary = questions
-          .slice(0, 5)
-          .map((q, i) => `  ${i + 1}. [${q.type}] ${q.question.slice(0, 80)}`)
-          .join('\n');
-        lines.push(
-          `Quiz questions (${questions.length}):\n${qSummary}${questions.length > 5 ? `\n  ... and ${questions.length - 5} more` : ''}`,
-        );
+        const hasGradedResults =
+          !!quizResults &&
+          quizResults.sceneId === currentSceneId &&
+          quizResults.results.length > 0;
+
+        if (hasGradedResults && quizResults) {
+          // Student has submitted. Surface their answers, correctness, the
+          // grader's comment on short-answer questions, and the canonical
+          // analysis so the agent can give targeted feedback on the actual
+          // mistakes instead of re-teaching everything.
+          const resultsById = new Map(quizResults.results.map((r) => [r.questionId, r]));
+          const answersById = quizResults.answers;
+          const lineEntries = questions.map((q, i) => {
+            const r = resultsById.get(q.id);
+            const ans = answersById?.[q.id];
+            const studentAnswer = Array.isArray(ans) ? ans.join(', ') : (ans ?? '');
+            const correctAnswer =
+              Array.isArray(q.answer) && q.answer.length > 0
+                ? q.answer.join(', ')
+                : '(open-ended)';
+            const verdict = r ? r.status.toUpperCase() : 'UNGRADED';
+            const points = q.points ?? 1;
+            const earned = r?.earned ?? 0;
+            const entry: string[] = [
+              `  ${i + 1}. [${q.type}] ${q.question}`,
+              `     Student answer: ${studentAnswer || '(empty)'}`,
+              `     Correct answer: ${correctAnswer}`,
+              `     Verdict: ${verdict} (${earned}/${points} pts)`,
+            ];
+            if (q.analysis) entry.push(`     Reference analysis: ${q.analysis}`);
+            if (r?.aiComment) entry.push(`     AI grader comment: ${r.aiComment}`);
+            return entry.join('\n');
+          });
+          const score = quizResults.results.reduce((acc, r) => acc + (r.earned ?? 0), 0);
+          const total = questions.reduce((acc, q) => acc + (q.points ?? 1), 0);
+          lines.push(
+            `Quiz results — the student JUST submitted (${score}/${total} pts). Use these to address THIS student's specific mistakes; do not re-teach what they already got right. Walk through wrong answers, acknowledge correct ones briefly, and tie feedback back to the underlying concept.\n${lineEntries.join('\n')}`,
+          );
+        } else {
+          // Student has NOT submitted yet. Surface the questions in full so the
+          // agent CAN help when the student asks about a specific item — but
+          // strict rules below forbid using them proactively. The split matters:
+          // suppressing the text entirely makes the agent useless for clarifying
+          // questions; exposing it without rules let it recite the whole quiz
+          // the moment a user said "I'm done". We want both — visibility AND
+          // restraint.
+          const qSummary = questions
+            .map((q, i) => {
+              const optionsPart =
+                q.options && q.options.length > 0
+                  ? `\n     Options: ${q.options.map((o) => `${o.value}. ${o.label}`).join(' | ')}`
+                  : '';
+              return `  ${i + 1}. [${q.type}] ${q.question}${optionsPart}`;
+            })
+            .join('\n');
+          lines.push(
+            [
+              `Quiz scene — the student has NOT submitted yet. ${questions.length} question(s) below. You have this so you can clarify when the student asks about a specific item — NOT so you can teach them through it preemptively.`,
+              'Strict rules while the quiz is unsubmitted (override everything else):',
+              "- Do NOT proactively list, recite, paraphrase, summarise, or walk through the questions. Mentioning them at all on your own initiative is a leak.",
+              "- Do NOT reveal the correct answer, eliminate options, or hint strongly enough that the answer is obvious. Even a leading phrase like \"think about whether x is really an integer\" is too much when it points at the answer.",
+              '- Do NOT teach the underlying concept end-to-end here. The concepts were already taught earlier; re-teaching them now is equivalent to giving the answers.',
+              '- If the student claims to be done but no submitted results have arrived in this context, treat the absence of `Quiz results` above as authoritative — they have NOT submitted. Point them at the Submit button on the right-hand panel; do not start grading or summarising from memory.',
+              '- If the student asks for help on a SPECIFIC question (by number, by option, or by quoting the stem), you MAY ask a single Socratic question or clarify a concept WITHOUT naming the correct option. Otherwise stay encouraging and meta ("看不懂哪一题？" / "Take it one question at a time").',
+              '- You MAY answer how-the-quiz-works questions (how to submit, how many questions, what types) and offer encouragement.',
+            ].join('\n') + `\n${qSummary}`,
+          );
+        }
       }
     }
   } else if (scenes.length > 0) {

--- a/lib/orchestration/summarizers/state-context.ts
+++ b/lib/orchestration/summarizers/state-context.ts
@@ -137,9 +137,7 @@ export function buildStateContext(storeState: StatelessChatRequest['storeState']
       if (currentScene.content.type === 'quiz') {
         const questions = currentScene.content.questions;
         const hasGradedResults =
-          !!quizResults &&
-          quizResults.sceneId === currentSceneId &&
-          quizResults.results.length > 0;
+          !!quizResults && quizResults.sceneId === currentSceneId && quizResults.results.length > 0;
 
         if (hasGradedResults && quizResults) {
           // Student has submitted. Surface their answers, correctness, the
@@ -153,9 +151,7 @@ export function buildStateContext(storeState: StatelessChatRequest['storeState']
             const ans = answersById?.[q.id];
             const studentAnswer = Array.isArray(ans) ? ans.join(', ') : (ans ?? '');
             const correctAnswer =
-              Array.isArray(q.answer) && q.answer.length > 0
-                ? q.answer.join(', ')
-                : '(open-ended)';
+              Array.isArray(q.answer) && q.answer.length > 0 ? q.answer.join(', ') : '(open-ended)';
             const verdict = r ? r.status.toUpperCase() : 'UNGRADED';
             const points = q.points ?? 1;
             const earned = r?.earned ?? 0;
@@ -195,8 +191,8 @@ export function buildStateContext(storeState: StatelessChatRequest['storeState']
             [
               `Quiz scene — the student has NOT submitted yet. ${questions.length} question(s) below. You have this so you can clarify when the student asks about a specific item — NOT so you can teach them through it preemptively.`,
               'Strict rules while the quiz is unsubmitted (override everything else):',
-              "- Do NOT proactively list, recite, paraphrase, summarise, or walk through the questions. Mentioning them at all on your own initiative is a leak.",
-              "- Do NOT reveal the correct answer, eliminate options, or hint strongly enough that the answer is obvious. Even a leading phrase like \"think about whether x is really an integer\" is too much when it points at the answer.",
+              '- Do NOT proactively list, recite, paraphrase, summarise, or walk through the questions. Mentioning them at all on your own initiative is a leak.',
+              '- Do NOT reveal the correct answer, eliminate options, or hint strongly enough that the answer is obvious. Even a leading phrase like "think about whether x is really an integer" is too much when it points at the answer.',
               '- Do NOT teach the underlying concept end-to-end here. The concepts were already taught earlier; re-teaching them now is equivalent to giving the answers.',
               '- If the student claims to be done but no submitted results have arrived in this context, treat the absence of `Quiz results` above as authoritative — they have NOT submitted. Point them at the Submit button on the right-hand panel; do not start grading or summarising from memory.',
               '- If the student asks for help on a SPECIFIC question (by number, by option, or by quoting the stem), you MAY ask a single Socratic question or clarify a concept WITHOUT naming the correct option. Otherwise stay encouraging and meta ("看不懂哪一题？" / "Take it one question at a time").',

--- a/lib/prompts/templates/quiz-actions/system.md
+++ b/lib/prompts/templates/quiz-actions/system.md
@@ -1,34 +1,22 @@
 # Quiz Action Generator
 
-You are a professional instructional designer responsible for generating teaching action sequences for quiz scenes.
+You are a professional instructional designer responsible for generating the brief teacher opening for a quiz scene.
 
 ## Core Task
 
-Based on the quiz's question list, key points, and description, generate a series of teaching speech actions to guide students through the quiz and provide explanations.
+Generate a short opening monologue that frames the upcoming quiz and invites the student to attempt it INDEPENDENTLY. You are NOT explaining the questions, NOT discussing answers, and NOT triggering any group discussion here. Any teaching feedback happens AFTER the student submits — handled by a separate post-quiz conversation flow, not by these actions.
 
 ---
 
 ## Output Format
 
-You MUST output a JSON array directly. Each element is an object with a `type` field:
+You MUST output a JSON array directly. Each element is a text object:
 
 ```json
 [
   {
     "type": "text",
-    "content": "Now let's test your understanding of what we just covered..."
-  },
-  {
-    "type": "text",
-    "content": "Take your time to read each question carefully..."
-  },
-  {
-    "type": "action",
-    "name": "discussion",
-    "params": {
-      "topic": "What key concepts did these questions test?",
-      "prompt": "Reflect on areas you need to improve"
-    }
+    "content": "Now let's test what we just covered. Take your time and try each one on your own — I'll be right here after you submit to walk through anything that tripped you up."
   }
 ]
 ```
@@ -36,71 +24,59 @@ You MUST output a JSON array directly. Each element is an object with a `type` f
 ### Format Rules
 
 1. Output a single JSON array — no explanation, no code fences
-2. `type:"action"` objects contain `name` and `params`
-3. `type:"text"` objects contain `content` (speech text)
-4. Action and text objects can freely interleave in any order
-5. The `]` closing bracket marks the end of your response
+2. Every element MUST be `{"type":"text","content":"..."}`
+3. The `]` closing bracket marks the end of your response
+
+### Allowed Action Types
+
+ONLY `type:"text"` is permitted. You MUST NOT emit any `type:"action"` object — not `discussion`, not any other named action. The post-quiz conversation is triggered separately by the platform when the student finishes; do not script it here.
 
 ---
 
-## Action Types
+## CRITICAL — Answer Safety Rules
 
-### discussion (Interactive Discussion)
+These override everything else. Violating them ruins the quiz, because the student must work through the questions on their own before any teaching feedback.
 
-Initiate classroom discussion, suitable for post-quiz reflection.
+- **NEVER reveal or hint at the correct answer** to any quiz question.
+- **NEVER preview, paraphrase, or analyse the questions or their options**. Do not introduce what a specific question is about, or compare options, before the student has answered.
+- **NEVER teach the underlying concept in detail here**. The concepts were already covered in the preceding slides; do not re-explain them now — re-explaining is equivalent to handing over the answers. Detailed review belongs to the post-quiz conversation, not this opening.
+- **NEVER ask a leading rhetorical question** that points at a specific answer.
+- **Speak only at the meta level**: frame the activity, encourage independent attempt, set expectations for what happens after submitting.
 
-```json
-{
-  "type": "action",
-  "name": "discussion",
-  "params": {
-    "topic": "Discussion topic",
-    "prompt": "Guiding prompt",
-    "agentId": "student_agent_id"
-  }
-}
-```
+Safe phrasing example:
 
-- `topic`: Core question for discussion
-- `prompt`: Prompt to guide student thinking (optional)
-- `agentId`: ID of the student agent who initiates the discussion. Pick a student from the agent list whose personality best matches the discussion topic. If no student agents are available, omit this field.
-- **IMPORTANT**: discussion MUST be the **last** action in the array. Do NOT place any text or action objects after a discussion. Wrap up your speech BEFORE the discussion action.
-- **FREQUENCY**: Discussion is optional and should be used sparingly. Only add one when the quiz content genuinely invites deeper reflection. Most quiz pages should have NO discussion.
+- "Let's see how the ideas we just covered settled in. Take a shot at each one, and I'll join you after you submit."
+
+Unsafe phrasing (do NOT emit):
+
+- Anything that analyses the quiz content, previews a specific question, or compares answer options.
 
 ---
 
 ## Quiz Flow Design
 
-### Typical Flow
+### What you produce
 
-1. **Opening Introduction** (text object): Purpose of quiz, instructions, encouragement
-2. **Answer Explanation** (text object): Key concepts, common mistakes
-3. **Discussion** (action object with discussion): Optional deeper exploration
+1. **Opening Introduction** (1 text object, sometimes 2): set the context for the quiz and invite the student to attempt it independently. Mention that you'll discuss results with them after they submit. That's it.
 
 ### Speech Content
 
-Generate natural teaching speech. The user prompt includes a **Course Outline** and **Position** indicator — use them to determine the tone.
+Generate natural teacher speech. The user prompt includes a **Course Outline** and **Position** indicator — use them to determine the tone, but never use them as an excuse to break the safety rules above.
 
-**CRITICAL — Single voice, teacher only.** Every `text` segment is spoken by the teacher, in one continuous voice (a monologue, not a dialogue). You MUST NOT write dialogue or lines for anyone other than the teacher (students, assistant, or any named agent), MUST NOT prefix speech with a speaker name/label in parentheses (NEVER `（AI助教）：…`, `（显眼包）：…`, `（学生）：…`), and MUST NOT insert parenthetical stage directions / emotion / action cues (NEVER `（好奇发出）`, `（抢答）`, `（插话）`). The `Classroom Agents` list is provided only so you can pick an `agentId` for a `discussion` action — those agents do not speak in your `text`. The teacher may ask an open rhetorical question, but must never voice the answer or impersonate a student; to have a specific student respond, use a `discussion` action instead.
+**CRITICAL — Single voice, teacher only.** Every `text` segment is spoken by the teacher, in one continuous voice (a monologue, not a dialogue). You MUST NOT write dialogue or lines for anyone other than the teacher (students, assistant, or any named agent), MUST NOT prefix speech with a speaker name/label in parentheses (NEVER `（AI助教）：…`, `（显眼包）：…`, `（学生）：…`), and MUST NOT insert parenthetical stage directions / emotion / action cues (NEVER `（好奇发出）`, `（抢答）`, `（插话）`). The teacher may ask an open rhetorical question only if it stays meta and does NOT hint at any specific answer.
 
 **CRITICAL — Same-session continuity**: All pages belong to the **same class session**. This is NOT a series of separate classes.
 
 - **First page**: Open with a greeting before introducing the quiz. This is the ONLY page that should greet.
 - **Middle pages**: Transition naturally from the previous page. Do NOT greet, re-introduce yourself, or say "welcome". Use phrases like "Now let's check what we've learned..." / "Time for a quick quiz on what we just covered..."
-- **Last page**: Frame the quiz as a final review and provide a closing remark after.
+- **Last page**: Frame the quiz as a final review and provide a brief closing nudge to attempt it. Detailed wrap-up still belongs to the post-quiz conversation, not this opening.
 - **Referencing earlier content**: Say "we just covered" or "as mentioned on page N". NEVER say "last class" or "previous session" — there is no previous session.
-
-Content:
-
-- Opening/Transition: Based on page position (see above)
-- Explanation: Key knowledge points, common mistakes
-- Discussion topic should connect to quiz concepts
 
 ---
 
 ## Important Notes
 
-1. **Generate 3-6 segments**: Quiz scenes need moderate pacing
-2. **Generate speech content**: Write natural teaching speech based on the key points and description
-3. **Discussion is optional**: Add based on question complexity
-4. **No timestamp/duration fields**: These are not needed
+1. **Generate 1-2 short segments**: A quiz opening should be brief — students are here to attempt the questions, not to listen to a lecture.
+2. **No discussion actions**: Discussion is handled by the post-quiz conversation flow, not by anything you output here.
+3. **No timestamp/duration fields**: These are not needed.
+4. **When in doubt, say less**: A safe, encouraging one-liner is always better than a detailed framing that risks giving anything away.

--- a/lib/prompts/templates/quiz-actions/user.md
+++ b/lib/prompts/templates/quiz-actions/user.md
@@ -7,5 +7,5 @@ Description: {{description}}
 
 **Language Directive**: {{languageDirective}}
 
-Output as a JSON array directly (no explanation, no code fences, 3-6 segments):
+Output as a JSON array directly (no explanation, no code fences, 1-2 short text segments). No discussion or other action types — text only:
 [{"type":"text","content":"Let's test your understanding"}]

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -241,6 +241,25 @@ export interface StatelessChatRequest {
     currentSceneId: string | null;
     mode: StageMode;
     whiteboardOpen: boolean;
+    /**
+     * Post-submit quiz state for the CURRENT scene, hydrated by the client
+     * from localStorage when the active scene is a graded quiz. Lets the
+     * agent give targeted feedback on the student's actual answers
+     * (correct/incorrect, written response, AI grader comment) instead of
+     * guessing. Absent when the student has not submitted yet, or when the
+     * active scene is not a quiz.
+     */
+    quizResults?: {
+      sceneId: string;
+      answers: Record<string, string | string[]>;
+      results: Array<{
+        questionId: string;
+        correct: boolean | null;
+        status: 'correct' | 'incorrect';
+        earned: number;
+        aiComment?: string;
+      }>;
+    };
   };
   /** Agent configuration */
   config: {


### PR DESCRIPTION
## Summary

Fixes #822.

- **Quiz opening monologue no longer previews the quiz.** The `quiz-actions` generator is collapsed to a brief 1–2 segment opening (transition + invitation to attempt independently). It can no longer emit an `Answer Explanation` paragraph or a `discussion` action that triggers an agent walkthrough before the learner has submitted.
- **Post-submit feedback gets the actual answers.** `storeState.quizResults` is hydrated client-side from the `quizAnswers:<sceneId>` / `quizResults:<sceneId>` blobs that `QuizView` already writes to localStorage, and `buildStateContext` surfaces per-question student answer / correct answer / verdict / canonical `analysis` / grader `aiComment` to the chat agent.
- **Pre-submit still allows targeted help.** The agent keeps visibility into the question stems so a learner asking "I don't get Q2" can be guided — but strict no-leak rules in the same context block forbid proactive recitation, option analysis, or treating "I'm done" as authoritative (the absence of submitted results is authoritative instead).

The multi-agent discussion round-robin, ProactiveCard flow, and the rest of the playback/session lifecycle are intentionally **not** touched.

### Files

| File | What changed |
|------|--------------|
| `lib/prompts/templates/quiz-actions/{system,user}.md` | Opening-only flow, no `discussion`, explicit safety rules. |
| `lib/types/chat.ts` + `lib/chat/agent-loop.ts` | Optional `quizResults` on `storeState` / `AgentLoopStoreState`. |
| `components/chat/use-chat-sessions.ts` | `buildQuizResultsForStoreState` helper reading `readSubmittedState(sceneId)` from `lib/quiz/persistence.ts`; wired into the initial dispatch and every `getStoreState` callback so retries propagate. |
| `lib/orchestration/summarizers/state-context.ts` | Split into post-submit (rich feedback context) and pre-submit (visible questions + 6 hard no-leak rules) branches. |

## Test plan

- [ ] Generate a new course with a quiz scene; verify the teacher opening on entry is short and does NOT preview question stems, compare options, or trigger an agent walkthrough.
- [ ] Verify newly generated quiz scenes contain no `discussion` action in `scene.actions` (old courses won't change — their actions are persisted).
- [ ] On the quiz scene, before submitting, open chat and ask "what's the answer to Q1?". Agent should refuse / redirect rather than reveal.
- [ ] Before submitting, say "I'm done" without actually submitting. Agent should point you at the Submit button rather than start grading from memory.
- [ ] Before submitting, ask a specific clarifying question ("what does Q2 mean?"). Agent should engage at the concept level without naming the correct option.
- [ ] Submit the quiz (with at least one wrong answer + at least one short-answer with `aiComment`). Open chat. Agent should reference YOUR specific answers, acknowledge correct items briefly, and walk through wrong ones with the `analysis` / `aiComment` context.
- [ ] Click "Retry", change an answer, submit again. The next agent turn should see the new results (every agent-loop iteration re-reads localStorage).
- [ ] Switch to a slide / interactive / PBL scene; verify chat continues to behave as before (no quiz-specific text contaminates non-quiz scenes).
- [ ] Run `npx tsc --noEmit -p tsconfig.json` — should pass.