### PR TITLE
feat(dsl): activate the migration registry + runner (#787 Part B-2)

### DIFF
--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -29,7 +29,7 @@ nothing.
 | `action.ts`   | The playback verb set: `Action` and all variants (spotlight, laser, speech, the `Wb*` whiteboard family, `play_video`, `discussion`, and the `widget_*` interaction actions), `ActionType`, the frozen `ACTION_TYPES` set + `isActionType` guard, the `FIRE_AND_FORGET_ACTIONS` / `SLIDE_ONLY_ACTIONS` / `SYNC_ACTIONS` category lists, plus the `PercentageGeometry` overlay type. |
 | `guards.ts`   | Pure discriminant type-guards (`isTextElement`, …) and `PPT_ELEMENT_TYPES`. |
 | `validate.ts` | Pure, zero-dep structural validators — `validateStage` / `validateScene` / `validateAction` returning an error-collecting `ValidationResult`. |
-| `version.ts`  | `DSL_VERSION` + the `DslMigration` shape and (empty) migration registry. |
+| `version.ts`  | Serialized-contract version + migration registry: `DSL_VERSION`, the `DSL_MIGRATIONS` ladder, and the pure `migrate` / `dslVersionOf` / `needsMigration` runner. |
 
 ```ts
 import type { Slide, PPTElement, Action } from '@openmaic/dsl';
@@ -81,6 +81,48 @@ public TS types, and both honoring the zero-runtime-dependency invariant:
    `ValidationResult` is `{ valid: true } | { valid: false; errors: { path; message }[] }` —
    it collects every issue rather than failing on the first.
 
+## Version & migration
+
+Two version numbers live in this package and do **not** track each other:
+
+- the **npm package version** (`package.json`) — the semver of the *code/API*
+  artifact; bumps when exports or behavior change.
+- **`DSL_VERSION`** — the version of the *serialized* slide contract (the
+  on-disk document shape). It bumps only when a persisted document's shape
+  changes, independent of package releases. (A third, finer axis —
+  `SlideContent.schemaVersion` — versions the PPTist canvas *inside* a slide and
+  is migrated app-side; it is orthogonal to `DSL_VERSION`.)
+
+`version.ts` owns the document-level migration mechanism, zero-dependency and
+pure like the validators:
+
+```ts
+import { DSL_VERSION, migrate, dslVersionOf, needsMigration } from '@openmaic/dsl';
+
+const current = migrate(doc); // walks doc from its written version up to DSL_VERSION
+```
+
+- `DSL_MIGRATIONS` is an ordered ladder of `{ from, to, migrate }` steps; each
+  step's `to` is the next step's `from`, and the last reaches `DSL_VERSION`.
+- `migrate(doc)` reads the document's version from its `dslVersion` envelope
+  field (absent ⇒ treated as legacy/unversioned), walks the ladder applying each
+  pure transform, and stamps the result. It is **idempotent** (a current
+  document is returned as-is), **forward-compatible** (a document stamped newer
+  than `DSL_VERSION` is returned untouched, never silently downgraded), and
+  **fail-loud** (a gap in the ladder throws rather than yielding a half-migrated
+  document).
+
+The first ladder entry is a no-op transform that stamps legacy documents up to
+the current `DSL_VERSION`: promoting `Action` into the contract and adding
+validators did not change any serialized shape, so the current on-disk shape
+already *is* `0.1.0`. The entry wires the pipeline end to end and gives real
+documents a version to migrate forward from; the first real transform is
+appended (and `DSL_VERSION` bumped) when the serialized shape first changes.
+
+Which aggregate carries the `dslVersion` field — a whole `Stage`, a single Scene
+row, or a bundle — is left to the store that first consumes this pipeline; the
+runner only needs the envelope field.
+
 ## Status
 
 Both consumers are now wired to `@openmaic/dsl` and no longer vendor their own copy
@@ -108,6 +150,9 @@ of the slide types:
       from widget configs, so the standard `Action` union now covers them too.
       `Scene<TAction>` defaults to that union; PBL configs and the app's richer
       content kinds still plug in via `Scene`'s generics.
+- [x] Activate the migration registry: `version.ts` ships the `DSL_MIGRATIONS`
+      ladder and a pure `migrate` runner (idempotent, forward-compatible,
+      fail-loud), no longer a stub. See **Version & migration** above.
 - [ ] Reserve `@openmaic/exporter` as the 4th family member.
 
 ### Stage / Scene split

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/dsl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The MAIC slide DSL: the pure, dependency-free contract (types + JSON Schema + validators + version/migration helpers) that @openmaic/renderer and @openmaic/importer both depend on.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -29,9 +29,19 @@ export type DslVersion = typeof DSL_VERSION;
 /**
  * The version a document is treated as when it carries no {@link DSL_VERSION_KEY}
  * stamp: everything written before the version field existed. The first
- * migration lifts these legacy documents to {@link DSL_VERSION}.
+ * migration lifts these legacy documents forward.
  */
 export const UNVERSIONED_DSL_VERSION = '0.0.0' as const;
+
+/**
+ * The first shipped serialized-contract version — a **pinned literal**, not the
+ * moving {@link DSL_VERSION}. Migration endpoints must be immutable: they name a
+ * fixed point in the ladder, so they cannot reference `DSL_VERSION` (which moves
+ * every time the shape changes). It equals `DSL_VERSION` today; the two diverge
+ * the moment the first real shape change bumps `DSL_VERSION` and appends a step
+ * from here.
+ */
+export const INITIAL_DSL_VERSION = '0.1.0' as const;
 
 /**
  * Envelope property that carries the serialized-contract version on a document.
@@ -66,18 +76,22 @@ export interface DslMigration {
 
 /**
  * Ordered migration ladder. Each entry's `to` is the next entry's `from`, and
- * the last entry's `to` is {@link DSL_VERSION} (both checked by a test).
+ * the last entry's `to` is {@link DSL_VERSION} (both checked by a test). Every
+ * `from` / `to` is a **pinned literal** — never the moving `DSL_VERSION`
+ * constant — so appending a future step can't retroactively re-target an
+ * existing one.
  *
- * The first entry stamps legacy (pre-`dslVersion`) documents up to the current
- * contract version. It is intentionally a no-op *transform*: bringing `Action`
- * into the contract (#811) and adding validators (#817) did not alter any
- * serialized document, so the current on-disk shape already *is* 0.1.0. The
+ * The first entry stamps legacy (pre-`dslVersion`) documents up to
+ * {@link INITIAL_DSL_VERSION}. It is intentionally a no-op *transform*: bringing
+ * `Action` into the contract (#811) and adding validators (#817) did not alter
+ * any serialized document, so the current on-disk shape already *is* 0.1.0. The
  * entry exists to wire the pipeline end to end and to give real documents a
  * version stamp to migrate forward from. When the serialized shape first
- * changes, bump {@link DSL_VERSION} *then* and append a real transform.
+ * changes, bump {@link DSL_VERSION} *then* and append a real transform from
+ * `INITIAL_DSL_VERSION` to the new pinned version.
  */
 export const DSL_MIGRATIONS: readonly DslMigration[] = [
-  { from: UNVERSIONED_DSL_VERSION, to: DSL_VERSION, migrate: (doc) => doc },
+  { from: UNVERSIONED_DSL_VERSION, to: INITIAL_DSL_VERSION, migrate: (doc) => doc },
 ];
 
 function isObject(v: unknown): v is Record<string, unknown> {

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -1,13 +1,24 @@
 /**
- * DSL version + migration scaffolding.
+ * DSL version + migration registry.
  *
  * The DSL version is independent of the npm package version: it identifies the
- * shape of the serialized slide contract so that persisted documents can be
- * migrated forward as the schema evolves.
+ * shape of the *serialized* slide contract so that persisted documents can be
+ * migrated forward as the schema evolves. A package release can bump for
+ * code/API reasons (new exports, refactors) without touching the serialized
+ * shape — in which case {@link DSL_VERSION} stays put; conversely the first
+ * breaking change to the on-disk shape bumps {@link DSL_VERSION} and appends a
+ * migration, regardless of where the package version happens to be.
  *
- * This is intentionally a stub: the real migration registry is filled in once
- * the first breaking schema change lands. The types below pin down the shape
- * that registry will take so callers can already code against it.
+ * This module owns the *mechanism*: the ordered {@link DSL_MIGRATIONS} ladder,
+ * plus the pure {@link migrate} runner that walks a document from whatever
+ * version it was written at up to {@link DSL_VERSION}. It carries no runtime
+ * dependency, and — like every migration transform — is pure and idempotent.
+ *
+ * The migratable unit (a {@link Stage} aggregate, a single Scene row, or a
+ * bundle of them) is deliberately left open: the runner only needs the
+ * {@link DSL_VERSION_KEY} envelope field to read the current version and stamp
+ * the new one. Which aggregate carries that field is decided when a normalized
+ * store first consumes this pipeline.
  */
 
 /** Current version of the serialized slide contract. */
@@ -16,8 +27,33 @@ export const DSL_VERSION = '0.1.0' as const;
 export type DslVersion = typeof DSL_VERSION;
 
 /**
+ * The version a document is treated as when it carries no {@link DSL_VERSION_KEY}
+ * stamp: everything written before the version field existed. The first
+ * migration lifts these legacy documents to {@link DSL_VERSION}.
+ */
+export const UNVERSIONED_DSL_VERSION = '0.0.0' as const;
+
+/**
+ * Envelope property that carries the serialized-contract version on a document.
+ * Named so producers / stores stamp the same field the runner reads.
+ */
+export const DSL_VERSION_KEY = 'dslVersion' as const;
+
+/**
+ * A document that may carry a DSL contract-version stamp. `@openmaic/dsl` does
+ * not bind this to a specific aggregate (see the module note) — it is the
+ * minimal envelope the {@link migrate} runner reads and writes.
+ */
+export interface DslVersioned {
+  /** Serialized-contract version this document was written at. Absent on legacy data. */
+  dslVersion?: string;
+}
+
+/**
  * A pure, synchronous transform from one DSL version to the next. Migrations
- * MUST NOT have side effects and MUST NOT depend on any runtime library.
+ * MUST NOT have side effects and MUST NOT depend on any runtime library. They
+ * receive and return the whole document; the runner stamps the `to` version, so
+ * a transform need only reshape the payload.
  */
 export interface DslMigration {
   /** Version this migration upgrades *from*. */
@@ -29,7 +65,100 @@ export interface DslMigration {
 }
 
 /**
- * Ordered list of migrations. Empty until the first breaking change ships.
- * Keep entries sorted so `from(n).to === from(n+1).from`.
+ * Ordered migration ladder. Each entry's `to` is the next entry's `from`, and
+ * the last entry's `to` is {@link DSL_VERSION} (both checked by a test).
+ *
+ * The first entry stamps legacy (pre-`dslVersion`) documents up to the current
+ * contract version. It is intentionally a no-op *transform*: bringing `Action`
+ * into the contract (#811) and adding validators (#817) did not alter any
+ * serialized document, so the current on-disk shape already *is* 0.1.0. The
+ * entry exists to wire the pipeline end to end and to give real documents a
+ * version stamp to migrate forward from. When the serialized shape first
+ * changes, bump {@link DSL_VERSION} *then* and append a real transform.
  */
-export const DSL_MIGRATIONS: readonly DslMigration[] = [];
+export const DSL_MIGRATIONS: readonly DslMigration[] = [
+  { from: UNVERSIONED_DSL_VERSION, to: DSL_VERSION, migrate: (doc) => doc },
+];
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Parse an `x.y.z` version into numeric parts; non-numeric parts become 0. */
+function parseVersion(v: string): [number, number, number] {
+  const parts = v.split('.').map((p) => Number.parseInt(p, 10));
+  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+}
+
+/** Pure semver-ish compare over `x.y.z`. Returns <0, 0, or >0. */
+function compareVersions(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+/**
+ * Read the serialized-contract version a document was written at. Documents
+ * with no {@link DSL_VERSION_KEY} stamp are treated as {@link UNVERSIONED_DSL_VERSION}.
+ */
+export function dslVersionOf(doc: unknown): string {
+  if (isObject(doc) && typeof doc[DSL_VERSION_KEY] === 'string') {
+    return doc[DSL_VERSION_KEY] as string;
+  }
+  return UNVERSIONED_DSL_VERSION;
+}
+
+/** True when `doc` is written at an older version than {@link DSL_VERSION}. */
+export function needsMigration(doc: unknown): boolean {
+  return compareVersions(dslVersionOf(doc), DSL_VERSION) < 0;
+}
+
+/** Purely stamp a document's version, returning a new object (never mutating). */
+function stampVersion(doc: unknown, version: string): unknown {
+  return isObject(doc) ? { ...doc, [DSL_VERSION_KEY]: version } : doc;
+}
+
+/**
+ * Migrate a document forward to {@link DSL_VERSION}.
+ *
+ * - Idempotent: a document already at {@link DSL_VERSION} is returned unchanged.
+ * - Forward-compatible: a document stamped *newer* than {@link DSL_VERSION} is
+ *   returned untouched rather than silently downgraded (mirrors the app's
+ *   `migrateSlideContent`). The caller may not render it correctly, but its
+ *   on-disk shape survives for the next compatible reader.
+ * - Fail-loud: if the ladder has no contiguous path from the document's version
+ *   up to {@link DSL_VERSION}, this throws rather than returning a half-migrated
+ *   document.
+ *
+ * Pure: never mutates the input; each step returns a fresh object stamped with
+ * its target version.
+ */
+export function migrate(doc: unknown): unknown {
+  let version = dslVersionOf(doc);
+
+  // Already current, or written ahead of us — leave the document as-is.
+  if (compareVersions(version, DSL_VERSION) >= 0) return doc;
+
+  let current = doc;
+  // Walk the ladder one step at a time. Guard against a malformed (cyclic /
+  // non-advancing) registry so a bad entry can't spin forever.
+  for (let step = 0; step < DSL_MIGRATIONS.length + 1; step++) {
+    if (version === DSL_VERSION) return current;
+    const next = DSL_MIGRATIONS.find((m) => m.from === version);
+    if (!next) {
+      throw new Error(`@openmaic/dsl: no migration path from "${version}" to "${DSL_VERSION}"`);
+    }
+    current = stampVersion(next.migrate(current), next.to);
+    version = next.to;
+  }
+
+  if (version !== DSL_VERSION) {
+    throw new Error(
+      `@openmaic/dsl: migration ladder did not reach "${DSL_VERSION}" (stuck at "${version}")`,
+    );
+  }
+  return current;
+}

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -98,10 +98,15 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-/** Parse an `x.y.z` version into numeric parts; non-numeric parts become 0. */
+/** A well-formed `x.y.z` version: exactly three non-negative integer parts. */
+function isValidVersion(v: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(v);
+}
+
+/** Parse a validated `x.y.z` version into numeric parts. */
 function parseVersion(v: string): [number, number, number] {
-  const parts = v.split('.').map((p) => Number.parseInt(p, 10));
-  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+  const [x, y, z] = v.split('.').map((p) => Number.parseInt(p, 10));
+  return [x, y, z];
 }
 
 /** Pure semver-ish compare over `x.y.z`. Returns <0, 0, or >0. */
@@ -115,18 +120,36 @@ function compareVersions(a: string, b: string): number {
 }
 
 /**
- * Read the serialized-contract version a document was written at. Documents
- * with no {@link DSL_VERSION_KEY} stamp are treated as {@link UNVERSIONED_DSL_VERSION}.
+ * Read the serialized-contract version a document was written at.
+ *
+ * - A non-object, or an object with no {@link DSL_VERSION_KEY} field, is treated
+ *   as {@link UNVERSIONED_DSL_VERSION} (legacy / pre-versioning data).
+ * - A **present but malformed** stamp (not a well-formed `x.y.z` string) is
+ *   corrupt data making a false version claim, so this **throws** rather than
+ *   letting a bad stamp silently compare as some arbitrary version and bypass
+ *   migration.
  */
 export function dslVersionOf(doc: unknown): string {
-  if (isObject(doc) && typeof doc[DSL_VERSION_KEY] === 'string') {
-    return doc[DSL_VERSION_KEY] as string;
+  if (!isObject(doc)) return UNVERSIONED_DSL_VERSION;
+  const raw = doc[DSL_VERSION_KEY];
+  if (raw === undefined) return UNVERSIONED_DSL_VERSION;
+  if (typeof raw !== 'string' || !isValidVersion(raw)) {
+    throw new Error(
+      `@openmaic/dsl: invalid ${DSL_VERSION_KEY} stamp ${JSON.stringify(raw)} (expected "x.y.z")`,
+    );
   }
-  return UNVERSIONED_DSL_VERSION;
+  return raw;
 }
 
-/** True when `doc` is written at an older version than {@link DSL_VERSION}. */
+/**
+ * True when `doc` is a migratable document written at an older version than
+ * {@link DSL_VERSION}. A non-object is not a migratable document, so this is
+ * `false` for it — mirroring {@link migrate}'s no-op, so the two never disagree
+ * (a caller looping `while (needsMigration(x)) x = migrate(x)` always terminates).
+ * Throws on an object carrying a malformed stamp (see {@link dslVersionOf}).
+ */
 export function needsMigration(doc: unknown): boolean {
+  if (!isObject(doc)) return false;
   return compareVersions(dslVersionOf(doc), DSL_VERSION) < 0;
 }
 
@@ -143,20 +166,25 @@ function stampVersion(doc: unknown, version: string): unknown {
  *   returned untouched rather than silently downgraded (mirrors the app's
  *   `migrateSlideContent`). The caller may not render it correctly, but its
  *   on-disk shape survives for the next compatible reader.
- * - Fail-loud: if the ladder has no contiguous path from the document's version
- *   up to {@link DSL_VERSION}, this throws rather than returning a half-migrated
- *   document.
+ * - Fail-loud: throws (rather than returning a half-migrated document) if the
+ *   ladder has no contiguous path from the document's version up to
+ *   {@link DSL_VERSION}, or if the document carries a malformed version stamp
+ *   (see {@link dslVersionOf}).
+ * - A non-object is not a migratable document: it is returned unchanged (and
+ *   {@link needsMigration} agrees it needs nothing).
  *
  * Pure: never mutates the input; each step returns a fresh object stamped with
  * its target version.
  */
 export function migrate(doc: unknown): unknown {
+  if (!isObject(doc)) return doc;
+
   let version = dslVersionOf(doc);
 
   // Already current, or written ahead of us — leave the document as-is.
   if (compareVersions(version, DSL_VERSION) >= 0) return doc;
 
-  let current = doc;
+  let current: unknown = doc;
   // Walk the ladder one step at a time. Guard against a malformed (cyclic /
   // non-advancing) registry so a bad entry can't spin forever.
   for (let step = 0; step < DSL_MIGRATIONS.length + 1; step++) {

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   DSL_VERSION,
   UNVERSIONED_DSL_VERSION,
+  INITIAL_DSL_VERSION,
   DSL_VERSION_KEY,
   DSL_MIGRATIONS,
   dslVersionOf,
@@ -19,8 +20,13 @@ describe('DSL_MIGRATIONS ladder invariants', () => {
     expect(DSL_MIGRATIONS[DSL_MIGRATIONS.length - 1].to).toBe(DSL_VERSION);
   });
 
-  it('begins by lifting legacy (unversioned) documents', () => {
+  it('begins by lifting legacy (unversioned) documents to a pinned endpoint', () => {
     expect(DSL_MIGRATIONS[0].from).toBe(UNVERSIONED_DSL_VERSION);
+    // The endpoint is the *pinned* initial version, not the moving DSL_VERSION —
+    // so a future step appended from INITIAL_DSL_VERSION isn't skipped once
+    // DSL_VERSION moves past it. (They're equal today; the assertion guards the
+    // intent, not the current value.)
+    expect(DSL_MIGRATIONS[0].to).toBe(INITIAL_DSL_VERSION);
   });
 });
 

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -39,6 +39,14 @@ describe('dslVersionOf', () => {
     expect(dslVersionOf(null)).toBe(UNVERSIONED_DSL_VERSION);
     expect(dslVersionOf('nope')).toBe(UNVERSIONED_DSL_VERSION);
   });
+  it('throws on a present-but-malformed stamp (no silent bypass)', () => {
+    // "1", "0.1", "0.1.0-beta" would otherwise parse into a comparable version
+    // and skip migration entirely.
+    for (const bad of ['1', '0.1', '0.1.0-beta', 'x.y.z', '']) {
+      expect(() => dslVersionOf({ [DSL_VERSION_KEY]: bad })).toThrow(/invalid dslVersion/);
+    }
+    expect(() => dslVersionOf({ [DSL_VERSION_KEY]: 3 })).toThrow(/invalid dslVersion/);
+  });
 });
 
 describe('needsMigration', () => {
@@ -46,6 +54,16 @@ describe('needsMigration', () => {
     expect(needsMigration({ id: 'legacy' })).toBe(true);
     expect(needsMigration({ [DSL_VERSION_KEY]: DSL_VERSION })).toBe(false);
     expect(needsMigration({ [DSL_VERSION_KEY]: '99.0.0' })).toBe(false);
+  });
+  it('is false for non-objects (mirrors migrate no-op — never disagree)', () => {
+    for (const v of [42, null, undefined, 'x', []]) {
+      expect(needsMigration(v)).toBe(false);
+      // the invariant: needsMigration and migrate agree on every input
+      expect(needsMigration(migrate(v))).toBe(false);
+    }
+  });
+  it('throws on a malformed stamp rather than silently reporting no migration', () => {
+    expect(() => needsMigration({ [DSL_VERSION_KEY]: '0.1.0-beta' })).toThrow(/invalid dslVersion/);
   });
 });
 
@@ -82,6 +100,13 @@ describe('migrate', () => {
   it('fails loud when the ladder has no path from the document version', () => {
     // A version older than DSL_VERSION but with no matching `from` entry.
     expect(() => migrate({ id: 'x', [DSL_VERSION_KEY]: '0.0.5' })).toThrow(/no migration path/);
+  });
+
+  it('fails loud on a malformed version stamp (no silent no-op)', () => {
+    expect(() => migrate({ id: 'x', [DSL_VERSION_KEY]: '0.1' })).toThrow(/invalid dslVersion/);
+    expect(() => migrate({ id: 'x', [DSL_VERSION_KEY]: '0.1.0-beta' })).toThrow(
+      /invalid dslVersion/,
+    );
   });
 
   it('returns non-object inputs unchanged', () => {

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DSL_VERSION,
+  UNVERSIONED_DSL_VERSION,
+  DSL_VERSION_KEY,
+  DSL_MIGRATIONS,
+  dslVersionOf,
+  needsMigration,
+  migrate,
+} from '@openmaic/dsl';
+
+describe('DSL_MIGRATIONS ladder invariants', () => {
+  it('is a contiguous chain ending at DSL_VERSION', () => {
+    expect(DSL_MIGRATIONS.length).toBeGreaterThan(0);
+    for (let i = 1; i < DSL_MIGRATIONS.length; i++) {
+      // each step's `to` is the next step's `from`
+      expect(DSL_MIGRATIONS[i].from).toBe(DSL_MIGRATIONS[i - 1].to);
+    }
+    expect(DSL_MIGRATIONS[DSL_MIGRATIONS.length - 1].to).toBe(DSL_VERSION);
+  });
+
+  it('begins by lifting legacy (unversioned) documents', () => {
+    expect(DSL_MIGRATIONS[0].from).toBe(UNVERSIONED_DSL_VERSION);
+  });
+});
+
+describe('dslVersionOf', () => {
+  it('reads a stamped version', () => {
+    expect(dslVersionOf({ [DSL_VERSION_KEY]: '9.9.9' })).toBe('9.9.9');
+  });
+  it('treats an unstamped document as unversioned', () => {
+    expect(dslVersionOf({ id: 'x' })).toBe(UNVERSIONED_DSL_VERSION);
+    expect(dslVersionOf(null)).toBe(UNVERSIONED_DSL_VERSION);
+    expect(dslVersionOf('nope')).toBe(UNVERSIONED_DSL_VERSION);
+  });
+});
+
+describe('needsMigration', () => {
+  it('is true for legacy documents and false at/ahead of the current version', () => {
+    expect(needsMigration({ id: 'legacy' })).toBe(true);
+    expect(needsMigration({ [DSL_VERSION_KEY]: DSL_VERSION })).toBe(false);
+    expect(needsMigration({ [DSL_VERSION_KEY]: '99.0.0' })).toBe(false);
+  });
+});
+
+describe('migrate', () => {
+  it('stamps a legacy document up to the current version', () => {
+    const out = migrate({ id: 'legacy', name: 'course' }) as Record<string, unknown>;
+    expect(out[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+    // payload is preserved
+    expect(out.id).toBe('legacy');
+    expect(out.name).toBe('course');
+  });
+
+  it('is idempotent (running twice equals running once)', () => {
+    const once = migrate({ id: 'x' });
+    const twice = migrate(once);
+    expect(twice).toEqual(once);
+    // an already-current document is returned by reference (no needless copy)
+    expect(migrate(once)).toBe(once);
+  });
+
+  it('does not mutate its input', () => {
+    const input = { id: 'x' };
+    const frozen = Object.freeze({ ...input });
+    const out = migrate(frozen);
+    expect(out).not.toBe(frozen);
+    expect(frozen).toEqual({ id: 'x' }); // untouched, no dslVersion added
+  });
+
+  it('leaves a forward-versioned document untouched (no silent downgrade)', () => {
+    const future = { id: 'x', [DSL_VERSION_KEY]: '99.0.0', shinyNewField: true };
+    expect(migrate(future)).toBe(future);
+  });
+
+  it('fails loud when the ladder has no path from the document version', () => {
+    // A version older than DSL_VERSION but with no matching `from` entry.
+    expect(() => migrate({ id: 'x', [DSL_VERSION_KEY]: '0.0.5' })).toThrow(/no migration path/);
+  });
+
+  it('returns non-object inputs unchanged', () => {
+    expect(migrate(42)).toBe(42);
+    expect(migrate(null)).toBe(null);
+  });
+});


### PR DESCRIPTION
Implements **Part B-2** of #787 (Phase 2 — grow the DSL): activate the migration registry. Builds on #811 (Action verbs in the contract) and #817 (JSON Schema + validators). This is the last open box under #787.

`version.ts` shipped a stub — `DSL_MIGRATIONS = []`, `DSL_VERSION` defined but unused, no runner. This PR fills in the **document-level migration mechanism** while keeping `@openmaic/dsl` **zero-runtime-dependency** (pure functions only, no new deps).

## What's here

**1. The `migrate` runner** (`src/version.ts`)
- `migrate(doc)` reads the document's `dslVersion` envelope field (absent ⇒ treated as legacy/`0.0.0`), walks the `DSL_MIGRATIONS` ladder up to `DSL_VERSION`, applying each pure transform and stamping the result.
- **Idempotent** — a document already at `DSL_VERSION` is returned by reference.
- **Forward-compatible** — a document stamped *newer* than `DSL_VERSION` is returned untouched, never silently downgraded (mirrors the app's `migrateSlideContent`).
- **Fail-loud** — a gap in the ladder throws rather than yielding a half-migrated document.
- **Pure** — never mutates its input; each step returns a fresh stamped object.
- Plus `dslVersionOf` / `needsMigration` readers, the `DslVersioned` envelope type, and `UNVERSIONED_DSL_VERSION` / `DSL_VERSION_KEY` constants.

**2. First ladder entry** — `{ from: '0.0.0', to: '0.1.0', migrate: (doc) => doc }`: a no-op *transform* that stamps legacy (pre-`dslVersion`) documents up to the current version. Promoting `Action` into the contract (#811) and adding validators (#817) did **not** change any serialized document shape, so the current on-disk shape already *is* `0.1.0`. This entry wires the pipeline end to end and gives real documents a version to migrate forward from — without faking a shape bump.

**3. Two independent version axes (documented in the README)**
- `DSL_VERSION` (serialized-contract shape) stays `0.1.0` — no on-disk shape changed.
- the **npm package** version minor-bumps `0.1.0 → 0.2.0` for the new API surface.
- (the finer app-side `SlideContent.schemaVersion`, which versions the PPTist canvas *inside* a slide, is orthogonal and untouched.)

**4. Tests** (`test/version.test.ts`) — ladder invariants (contiguous chain ending at `DSL_VERSION`), stamp/idempotence/purity, forward-compat, fail-loud, non-object passthrough.

## Where the version field lives

The runner only needs the `dslVersion` envelope field to read/stamp; **which aggregate carries it** (a whole `Stage`, a Scene row, or a bundle) is deliberately left open — that's decided when a normalized store first consumes this pipeline, matching the open question in #787. So this PR lands the *mechanism* + proves it end to end via tests; app-side store wiring is a follow-up.

## Verification

- `pnpm --filter @openmaic/dsl test` → 86 passed (incl. new `version.test.ts`)
- `pnpm --filter @openmaic/dsl typecheck` → clean
- `pnpm --filter @openmaic/dsl build` → `dist/schema/*.json` still generated
- `prettier --check` → clean

## Acceptance (#787)

- [x] `DSL_MIGRATIONS` runs a first migration end to end; `version.ts` is no longer a stub
- [x] zero-runtime-dep invariant held (pure functions, no new deps)
- [x] `test/` covers the migration runner
- [x] README updated with the version/migration mechanism + the version-axis topology
