### PR TITLE
Update Doubao Seed model catalog

### DIFF
--- a/lib/ai/model-metadata.ts
+++ b/lib/ai/model-metadata.ts
@@ -331,6 +331,10 @@ const THINKING_CAPABILITIES: Record<string, ThinkingCapability> = {
   [getModelMetadataKey('siliconflow', 'THUDM/GLM-4.1V-9B-Thinking')]: siliconflowBudget,
   [getModelMetadataKey('siliconflow', 'THUDM/GLM-Z1-Rumination-32B-0414')]: siliconflowBudget,
 
+  [getModelMetadataKey('doubao', 'doubao-seed-2-1-pro-260628')]: doubaoSeed20Effort,
+  [getModelMetadataKey('doubao', 'doubao-seed-2-1-turbo-260628')]: doubaoSeed20Effort,
+  [getModelMetadataKey('doubao', 'doubao-seed-evolving')]: doubaoSeed20Effort,
+  [getModelMetadataKey('doubao', 'doubao-seed-character-260628')]: toggleCapability('doubao'),
   [getModelMetadataKey('doubao', 'doubao-seed-2-0-pro-260215')]: doubaoSeed20Effort,
   [getModelMetadataKey('doubao', 'doubao-seed-2-0-lite-260215')]: doubaoSeed20Effort,
   [getModelMetadataKey('doubao', 'doubao-seed-2-0-mini-260215')]: doubaoSeed20Effort,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -870,6 +870,34 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     icon: '/logos/doubao.svg',
     models: [
       {
+        id: 'doubao-seed-2-1-pro-260628',
+        name: 'Doubao Seed 2.1 Pro',
+        contextWindow: 256000,
+        outputWindow: 32768,
+        capabilities: { streaming: true, tools: true, vision: true },
+      },
+      {
+        id: 'doubao-seed-2-1-turbo-260628',
+        name: 'Doubao Seed 2.1 Turbo',
+        contextWindow: 256000,
+        outputWindow: 32768,
+        capabilities: { streaming: true, tools: true, vision: true },
+      },
+      {
+        id: 'doubao-seed-evolving',
+        name: 'Doubao Seed Evolving',
+        contextWindow: 256000,
+        outputWindow: 32768,
+        capabilities: { streaming: true, tools: true, vision: true },
+      },
+      {
+        id: 'doubao-seed-character-260628',
+        name: 'Doubao Seed Character',
+        contextWindow: 256000,
+        outputWindow: 32768,
+        capabilities: { streaming: true, tools: true, vision: true },
+      },
+      {
         id: 'doubao-seed-2-0-pro-260215',
         name: 'Doubao Seed 2.0 Pro',
         contextWindow: 128000,

--- a/lib/media/adapters/seedance-adapter.ts
+++ b/lib/media/adapters/seedance-adapter.ts
@@ -7,7 +7,7 @@
  * Request format (text-to-video):
  *   POST /api/v3/contents/generations/tasks
  *   {
- *     "model": "doubao-seedance-1-5-pro-251215",
+ *     "model": "doubao-seedance-2-0-260128",
  *     "content": [{ "type": "text", "text": "prompt here" }],
  *     "ratio": "16:9",
  *     "duration": 5,
@@ -16,10 +16,13 @@
  *   }
  *
  * Supported models:
- * - doubao-seedance-1-5-pro-251215     (latest, 4~12s)
- * - doubao-seedance-1-0-pro-250528     (stable, 2~12s)
- * - doubao-seedance-1-0-pro-fast-251015 (faster, 2~12s)
- * - doubao-seedance-1-0-lite-t2v-250428 (lightweight, 2~12s)
+ * - doubao-seedance-2-0-260128
+ * - doubao-seedance-2-0-fast-260128
+ * - doubao-seedance-2-0-mini-260615
+ * - doubao-seedance-1-5-pro-251215
+ * - doubao-seedance-1-0-pro-250528
+ * - doubao-seedance-1-0-pro-fast-251015
+ * - doubao-seedance-1-0-lite-t2v-250428
  *
  * API docs: https://www.volcengine.com/docs/6492/2165104
  */
@@ -30,7 +33,7 @@ import type {
   VideoGenerationResult,
 } from '../types';
 
-const DEFAULT_MODEL = 'doubao-seedance-1-5-pro-251215';
+const DEFAULT_MODEL = 'doubao-seedance-2-0-260128';
 const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com';
 const POLL_INTERVAL_MS = 5000;
 const MAX_POLL_ATTEMPTS = 60; // 5 minutes max

--- a/lib/media/adapters/seedream-adapter.ts
+++ b/lib/media/adapters/seedream-adapter.ts
@@ -6,6 +6,7 @@
  *
  * Supported models:
  * - doubao-seedream-5-0-260128  (latest / Lite, text2img + img2img + multi-ref + group)
+ * - doubao-seedream-5-0-lite-260128  (explicit Lite alias)
  * - doubao-seedream-4-5-251128
  * - doubao-seedream-4-0-250828
  * - doubao-seedream-3-0-t2i-250415

--- a/lib/media/image-providers.ts
+++ b/lib/media/image-providers.ts
@@ -34,6 +34,7 @@ export const IMAGE_PROVIDERS: Record<ImageProviderId, ImageProviderConfig> = {
     defaultBaseUrl: 'https://ark.cn-beijing.volces.com',
     models: [
       { id: 'doubao-seedream-5-0-260128', name: 'Seedream 5.0 Lite' },
+      { id: 'doubao-seedream-5-0-lite-260128', name: 'Seedream 5.0 Lite (Alias)' },
       { id: 'doubao-seedream-4-5-251128', name: 'Seedream 4.5' },
       { id: 'doubao-seedream-4-0-250828', name: 'Seedream 4.0' },
       { id: 'doubao-seedream-3-0-t2i-250415', name: 'Seedream 3.0' },

--- a/lib/media/video-providers.ts
+++ b/lib/media/video-providers.ts
@@ -26,6 +26,15 @@ export const VIDEO_PROVIDERS: Record<VideoProviderId, VideoProviderConfig> = {
     requiresApiKey: true,
     defaultBaseUrl: 'https://ark.cn-beijing.volces.com',
     models: [
+      { id: 'doubao-seedance-2-0-260128', name: 'Seedance 2.0' },
+      {
+        id: 'doubao-seedance-2-0-fast-260128',
+        name: 'Seedance 2.0 Fast',
+      },
+      {
+        id: 'doubao-seedance-2-0-mini-260615',
+        name: 'Seedance 2.0 Mini',
+      },
       { id: 'doubao-seedance-1-5-pro-251215', name: 'Seedance 1.5 Pro' },
       { id: 'doubao-seedance-1-0-pro-250528', name: 'Seedance 1.0 Pro' },
       {

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -470,7 +470,7 @@ const getDefaultImageConfig = () => ({
 // Initialize default Video config
 const getDefaultVideoConfig = () => ({
   videoProviderId: 'seedance' as VideoProviderId,
-  videoModelId: 'doubao-seedance-1-5-pro-251215',
+  videoModelId: 'doubao-seedance-2-0-260128',
   videoProvidersConfig: {
     seedance: { apiKey: '', baseUrl: '', enabled: false },
     kling: { apiKey: '', baseUrl: '', enabled: false },

--- a/tests/ai/openai-provider.test.ts
+++ b/tests/ai/openai-provider.test.ts
@@ -141,6 +141,53 @@ describe('OpenAI provider defaults', () => {
     });
   });
 
+  it('includes latest official Doubao Seed chat models', () => {
+    expect(getModelInfo('doubao', 'doubao-seed-2-1-pro-260628')).toMatchObject({
+      id: 'doubao-seed-2-1-pro-260628',
+      name: 'Doubao Seed 2.1 Pro',
+      contextWindow: 256000,
+      outputWindow: 32768,
+      capabilities: {
+        streaming: true,
+        tools: true,
+        vision: true,
+      },
+    });
+    expect(getModelInfo('doubao', 'doubao-seed-2-1-turbo-260628')).toMatchObject({
+      id: 'doubao-seed-2-1-turbo-260628',
+      name: 'Doubao Seed 2.1 Turbo',
+      contextWindow: 256000,
+      outputWindow: 32768,
+      capabilities: {
+        streaming: true,
+        tools: true,
+        vision: true,
+      },
+    });
+    expect(getModelInfo('doubao', 'doubao-seed-evolving')).toMatchObject({
+      id: 'doubao-seed-evolving',
+      name: 'Doubao Seed Evolving',
+      contextWindow: 256000,
+      outputWindow: 32768,
+      capabilities: {
+        streaming: true,
+        tools: true,
+        vision: true,
+      },
+    });
+    expect(getModelInfo('doubao', 'doubao-seed-character-260628')).toMatchObject({
+      id: 'doubao-seed-character-260628',
+      name: 'Doubao Seed Character',
+      contextWindow: 256000,
+      outputWindow: 32768,
+      capabilities: {
+        streaming: true,
+        tools: true,
+        vision: true,
+      },
+    });
+  });
+
   it.each([
     ['kimi', 'kimi-k2.6', { mode: 'disabled' }, { thinking: { type: 'disabled' } }],
     ['glm', 'glm-5.1', { mode: 'enabled' }, { thinking: { type: 'enabled' } }],
@@ -181,6 +228,24 @@ describe('OpenAI provider defaults', () => {
       'doubao-seed-2-0-pro-260215',
       { mode: 'enabled', effort: 'high' },
       { reasoning_effort: 'high' },
+    ],
+    [
+      'doubao',
+      'doubao-seed-2-1-pro-260628',
+      { mode: 'enabled', effort: 'high' },
+      { reasoning_effort: 'high' },
+    ],
+    [
+      'doubao',
+      'doubao-seed-evolving',
+      { mode: 'enabled', effort: 'medium' },
+      { reasoning_effort: 'medium' },
+    ],
+    [
+      'doubao',
+      'doubao-seed-character-260628',
+      { mode: 'disabled' },
+      { thinking: { type: 'disabled' } },
     ],
     [
       'openrouter',

--- a/tests/ai/thinking-config.test.ts
+++ b/tests/ai/thinking-config.test.ts
@@ -215,6 +215,9 @@ describe('thinking config normalization', () => {
 
   it('normalizes Doubao Seed 2.0 thinking as reasoning effort levels', () => {
     const thinking = getThinking('doubao', 'doubao-seed-2-0-pro-260215');
+    const seed21Thinking = getThinking('doubao', 'doubao-seed-2-1-pro-260628');
+    const seed21TurboThinking = getThinking('doubao', 'doubao-seed-2-1-turbo-260628');
+    const evolvingThinking = getThinking('doubao', 'doubao-seed-evolving');
 
     expect(getDefaultThinkingConfig(thinking)).toEqual({
       mode: 'enabled',
@@ -225,6 +228,21 @@ describe('thinking config normalization', () => {
       effort: 'high',
     });
     expect(thinking?.effortValues).toEqual(['minimal', 'low', 'medium', 'high']);
+    expect(seed21Thinking?.effortValues).toEqual(['minimal', 'low', 'medium', 'high']);
+    expect(seed21TurboThinking?.effortValues).toEqual(['minimal', 'low', 'medium', 'high']);
+    expect(evolvingThinking?.effortValues).toEqual(['minimal', 'low', 'medium', 'high']);
+  });
+
+  it('normalizes Doubao Seed Character thinking as a mode toggle', () => {
+    const thinking = getThinking('doubao', 'doubao-seed-character-260628');
+
+    expect(getDefaultThinkingConfig(thinking)).toEqual({
+      mode: 'enabled',
+    });
+    expect(normalizeThinkingConfig(thinking, { mode: 'disabled' })).toEqual({
+      mode: 'disabled',
+    });
+    expect(thinking?.control).toBe('toggle');
   });
 
   it('preserves dynamic Gemini budgets and display labels', () => {

--- a/tests/media/seed-provider-catalog.test.ts
+++ b/tests/media/seed-provider-catalog.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { IMAGE_PROVIDERS } from '@/lib/media/image-providers';
+import { VIDEO_PROVIDERS } from '@/lib/media/video-providers';
+
+describe('Seed media provider catalog', () => {
+  it('includes the official Seedream 5.0 Lite model aliases', () => {
+    const modelIds = IMAGE_PROVIDERS.seedream.models.map((model) => model.id);
+
+    expect(modelIds).toEqual(
+      expect.arrayContaining(['doubao-seedream-5-0-260128', 'doubao-seedream-5-0-lite-260128']),
+    );
+  });
+
+  it('includes official Seedance 2.0 video generation models', () => {
+    const modelIds = VIDEO_PROVIDERS.seedance.models.map((model) => model.id);
+
+    expect(modelIds).toEqual(
+      expect.arrayContaining([
+        'doubao-seedance-2-0-260128',
+        'doubao-seedance-2-0-fast-260128',
+        'doubao-seedance-2-0-mini-260615',
+      ]),
+    );
+  });
+});

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -145,7 +145,7 @@ vi.mock('@/lib/media/video-providers', () => ({
     seedance: {
       id: 'seedance',
       requiresApiKey: true,
-      models: [{ id: 'doubao-seedance-1-5-pro-251215', name: 'Seedance 1.5 Pro' }],
+      models: [{ id: 'doubao-seedance-2-0-260128', name: 'Seedance 2.0' }],
     },
     kling: {
       id: 'kling',
@@ -991,7 +991,7 @@ describe('fetchServerProviders — Video stale selection', () => {
     mockServerResponse({ video: { seedance: {} } });
     await store.getState().fetchServerProviders();
     store.getState().setVideoProvider('seedance');
-    store.getState().setVideoModelId('doubao-seedance-1-5-pro-251215');
+    store.getState().setVideoModelId('doubao-seedance-2-0-260128');
 
     mockServerResponse({});
     await store.getState().fetchServerProviders();
@@ -1031,7 +1031,7 @@ describe('fetchServerProviders — Video stale selection', () => {
     mockServerResponse({ video: { seedance: {}, kling: {} } });
     await store.getState().fetchServerProviders();
     store.getState().setVideoProvider('seedance');
-    store.getState().setVideoModelId('doubao-seedance-1-5-pro-251215');
+    store.getState().setVideoModelId('doubao-seedance-2-0-260128');
 
     mockServerResponse({ video: { kling: {} } });
     await store.getState().fetchServerProviders();
@@ -1055,7 +1055,7 @@ describe('fetchServerProviders — Video stale selection', () => {
     await store.getState().fetchServerProviders();
 
     expect(store.getState().videoProviderId).toBe('seedance');
-    expect(store.getState().videoModelId).toBe('doubao-seedance-1-5-pro-251215');
+    expect(store.getState().videoModelId).toBe('doubao-seedance-2-0-260128');
     // Provider recovered but generation stays off — user enables manually
     expect(store.getState().videoGenerationEnabled).toBe(false);
   });
@@ -1247,7 +1247,7 @@ describe('usable provider ⇒ concrete model invariant (#580)', () => {
 
     store.getState().setVideoProviderConfig('seedance', { customModels: [] });
 
-    expect(store.getState().videoModelId).toBe('doubao-seedance-1-5-pro-251215');
+    expect(store.getState().videoModelId).toBe('doubao-seedance-2-0-260128');
   });
 
   it('deleting the selected provider (bulk setProvidersConfig) does not keep an invalid selection', async () => {


### PR DESCRIPTION
## Summary

Updates the built-in Doubao Seed catalog for the latest Ark model IDs that fit existing OpenMAIC provider surfaces.

## Related Issues

Closes #826

## Changes

- Added Doubao Seed 2.1 Pro, Seed 2.1 Turbo, Seed Evolving, and Seed Character to the Doubao chat provider catalog.
- Added thinking metadata for the new Doubao chat models using the existing Doubao request adapter.
- Added the explicit Seedream 5.0 Lite alias to the Seedream image provider catalog.
- Added Seedance 2.0, Seedance 2.0 Fast, and Seedance 2.0 Mini to the Seedance video provider catalog.
- Updated the built-in Seedance default model to Seedance 2.0.
- Added regression coverage for provider catalog entries, thinking request injection, media model lists, and settings sync defaults.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run the targeted provider catalog and settings tests.
2. Run TypeScript with incremental output disabled.

### What you personally verified

- `pnpm exec vitest run tests/ai/openai-provider.test.ts tests/ai/thinking-config.test.ts tests/media/seed-provider-catalog.test.ts tests/store/settings-server-sync.test.ts`
- `pnpm exec tsc --noEmit --pretty false --incremental false`

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
