### PR TITLE
fix(editor): skip voiced lines during bulk TTS regeneration

### DIFF
--- a/components/edit/ActionsBar/ActionsBar.tsx
+++ b/components/edit/ActionsBar/ActionsBar.tsx
@@ -73,6 +73,7 @@ import {
   audioExists,
   audioObjectUrl,
   discardSpeechAudio,
+  filterSpeechActionsNeedingAudio,
   regenerateSpeechAudio,
   resolveSpeechAudioId,
   speechAudioId,
@@ -914,17 +915,25 @@ export function ActionsBar({ sceneId }: { sceneId: string }) {
     [sceneId],
   );
 
-  // Regenerate TTS for every speech line in the scene, then stamp audioIds.
+  // Regenerate TTS only for speech lines missing usable audio, then stamp audioIds.
   // Reads the latest actions from the store at each step so a concurrent edit
   // isn't clobbered, and stamps by id (index-stale-safe).
   const regenerateAllAudio = useCallback(async () => {
     if (regenAll) return;
     const latest = () => useStageStore.getState().scenes.find((s) => s.id === sceneId);
-    const speeches = (latest()?.actions ?? []).filter(
-      (a) => a.type === 'speech' && ((a as { text?: string }).text ?? '').trim(),
-    );
-    if (!speeches.length) return;
     const order = latest()?.order ?? 0;
+    const speechActions = (latest()?.actions ?? []).filter(
+      (
+        a,
+      ): a is Action & {
+        id: string;
+        text?: string;
+        audioId?: string;
+        audioUrl?: string;
+      } => a.type === 'speech' && typeof a.id === 'string',
+    );
+    const speeches = await filterSpeechActionsNeedingAudio(speechActions);
+    if (!speeches.length) return;
     setRegenAll(true);
     // Stamp audioId only for lines that actually synthesized — a skipped/failed
     // line must not get an id pointing at a blob that was never written.

--- a/lib/audio/regenerate-speech-tts.ts
+++ b/lib/audio/regenerate-speech-tts.ts
@@ -10,6 +10,13 @@ import { db } from '@/lib/utils/database';
 import { useSettingsStore } from '@/lib/store/settings';
 import { generateAndStoreTTS } from '@/lib/hooks/use-scene-generator';
 
+export interface SpeechAudioTarget {
+  id?: string;
+  text?: string;
+  audioId?: string;
+  audioUrl?: string;
+}
+
 /** Canonical audio cache key — matches the generation pipeline. */
 export function speechAudioId(sceneOrder: number, actionId: string): string {
   return `tts_s${sceneOrder}_${actionId}`;
@@ -47,6 +54,21 @@ export async function audioExistsBulk(audioIds: string[]): Promise<Set<string>> 
     if (r) have.add(audioIds[i]);
   });
   return have;
+}
+
+/** Speech lines that still need generated audio for playback. */
+export async function filterSpeechActionsNeedingAudio<T extends SpeechAudioTarget>(
+  actions: readonly T[],
+): Promise<T[]> {
+  const candidates = actions.filter(
+    (action) => action.text?.trim() && !action.audioUrl && typeof action.id === 'string',
+  );
+  const audioIds = candidates
+    .map((action) => action.audioId)
+    .filter((audioId): audioId is string => typeof audioId === 'string' && audioId.length > 0);
+  const cachedAudioIds = await audioExistsBulk([...new Set(audioIds)]);
+
+  return candidates.filter((action) => !action.audioId || !cachedAudioIds.has(action.audioId));
 }
 
 /** Object URL for the audio cached under this exact audioId (caller revokes). */

--- a/tests/audio/regenerate-speech-tts.test.ts
+++ b/tests/audio/regenerate-speech-tts.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  bulkGet: vi.fn(),
+  get: vi.fn(),
+  bulkDelete: vi.fn(),
+  settingsState: vi.fn(),
+  generateAndStoreTTS: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/database', () => ({
+  db: {
+    audioFiles: {
+      bulkGet: mocks.bulkGet,
+      get: mocks.get,
+      bulkDelete: mocks.bulkDelete,
+    },
+  },
+}));
+
+vi.mock('@/lib/store/settings', () => ({
+  useSettingsStore: {
+    getState: mocks.settingsState,
+  },
+}));
+
+vi.mock('@/lib/hooks/use-scene-generator', () => ({
+  generateAndStoreTTS: mocks.generateAndStoreTTS,
+}));
+
+import { filterSpeechActionsNeedingAudio } from '@/lib/audio/regenerate-speech-tts';
+
+describe('filterSpeechActionsNeedingAudio', () => {
+  beforeEach(() => {
+    mocks.bulkGet.mockReset();
+    mocks.get.mockReset();
+    mocks.bulkDelete.mockReset();
+    mocks.settingsState.mockReset();
+    mocks.generateAndStoreTTS.mockReset();
+    mocks.bulkGet.mockResolvedValue([]);
+  });
+
+  it('skips empty text', async () => {
+    const result = await filterSpeechActionsNeedingAudio([{ id: 'a1', text: '   ' }]);
+
+    expect(result).toEqual([]);
+    expect(mocks.bulkGet).not.toHaveBeenCalled();
+  });
+
+  it('skips lines with audioUrl', async () => {
+    const result = await filterSpeechActionsNeedingAudio([
+      { id: 'a1', text: 'Hello', audioUrl: '/audio/a1.mp3' },
+    ]);
+
+    expect(result).toEqual([]);
+    expect(mocks.bulkGet).not.toHaveBeenCalled();
+  });
+
+  it('skips lines with cached stamped audioId', async () => {
+    mocks.bulkGet.mockResolvedValue([{ id: 'tts-a1' }]);
+
+    const result = await filterSpeechActionsNeedingAudio([
+      { id: 'a1', text: 'Hello', audioId: 'tts-a1' },
+    ]);
+
+    expect(result).toEqual([]);
+    expect(mocks.bulkGet).toHaveBeenCalledWith(['tts-a1']);
+  });
+
+  it('includes lines with missing stamped audioId cache', async () => {
+    mocks.bulkGet.mockResolvedValue([undefined]);
+    const action = { id: 'a1', text: 'Hello', audioId: 'tts-a1' };
+
+    const result = await filterSpeechActionsNeedingAudio([action]);
+
+    expect(result).toEqual([action]);
+    expect(mocks.bulkGet).toHaveBeenCalledWith(['tts-a1']);
+  });
+
+  it('includes non-empty lines without audioId or audioUrl', async () => {
+    const action = { id: 'a1', text: 'Hello' };
+
+    const result = await filterSpeechActionsNeedingAudio([action]);
+
+    expect(result).toEqual([action]);
+    expect(mocks.bulkGet).not.toHaveBeenCalled();
+  });
+
+  it('returns only the lines bulk Voice all should regenerate', async () => {
+    mocks.bulkGet.mockResolvedValue([{ id: 'tts-ready' }, undefined]);
+    const readyByUrl = { id: 'url', text: 'Already voiced', audioUrl: '/audio/url.mp3' };
+    const readyByCache = { id: 'ready', text: 'Already voiced', audioId: 'tts-ready' };
+    const missingCache = { id: 'missing-cache', text: 'Needs audio', audioId: 'tts-missing' };
+    const missingAudioId = { id: 'missing-id', text: 'Needs audio' };
+    const empty = { id: 'empty', text: '' };
+    const noStringId = { text: 'No id' };
+
+    const result = await filterSpeechActionsNeedingAudio([
+      readyByUrl,
+      readyByCache,
+      missingCache,
+      missingAudioId,
+      empty,
+      noStringId,
+    ]);
+
+    expect(result).toEqual([missingCache, missingAudioId]);
+    expect(mocks.bulkGet).toHaveBeenCalledWith(['tts-ready', 'tts-missing']);
+  });
+});


### PR DESCRIPTION
## Summary

Improves the existing Pro Mode narration workflow by making bulk **Voice all** regeneration skip narration lines that already have usable audio.

Pro Mode already supports narration editing and per-line TTS regeneration through the existing `ActionsBar`, so this PR keeps the current UI and focuses only on making bulk regeneration target changed/unvoiced lines.

## Related Issues

Refs #821

## Changes

- Added helper logic to determine whether a speech action needs generated audio
- Treats a narration line as already voiced when:
  - `audioUrl` exists, or
  - `audioId` exists and cached audio exists for that exact `audioId`
- Treats a narration line as needing audio when:
  - it has non-empty text, and
  - it has no `audioUrl`, and
  - it has no `audioId` or cached audio for `audioId` is missing
- Updated bulk **Voice all** to regenerate only narration lines that need audio
- Kept per-line regenerate behavior unchanged
- Preserved existing speech `voice` and `speed` fields
- Added focused tests for the audio-needs filtering behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open a classroom in Pro Mode.
2. Edit or regenerate narration so only some narration cards become `Not voiced`.
3. Open DevTools Network and filter for `generate/tts`.
4. Click **Voice all**.
5. Verify only unvoiced/missing-audio narration lines trigger `/api/generate/tts` requests.
6. Verify already voiced narration lines are skipped.
7. Verify regenerated narration cards return to `Voiced`.

### What you personally verified

- Verified Pro Mode narration cards can become `Not voiced` after narration text changes
- Verified bulk **Voice all** only regenerates narration lines needing audio
- Verified a scene with 7 narration cues sent only 5 `/api/generate/tts` requests when only 5 lines needed audio
- Verified another case where only 1 narration line needed audio and **Voice all** sent exactly 1 `/api/generate/tts` request
- Verified regenerated narration cards returned to `Voiced`
- Verified already voiced narration lines were skipped
- Verified per-line regenerate behavior remains unchanged

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally/server
- [x] Screenshots attached showing only changed/unvoiced lines triggering TTS regeneration

Screenshots:

1. Bulk **Voice all** with 7 narration cues where only 5 lines needed audio  
   - Expected: 5 `/api/generate/tts` requests  
   - Verified: 5 `/api/generate/tts` requests were sent, not all 7
   
<img width="1367" height="750" alt="image" src="https://github.com/user-attachments/assets/4dfda555-4725-4ae9-8e11-274dcec3d94a" />


2. Bulk **Voice all** after only 1 narration line was changed/unvoiced  
   - Expected: 1 `/api/generate/tts` request  
   - Verified: exactly 1 `/api/generate/tts` request was sent
   
<img width="1512" height="828" alt="image" src="https://github.com/user-attachments/assets/3f2b37d2-f48e-4e3e-a2e0-48db5bf55205" />



Local verification run:

```bash
pnpm test tests/audio/regenerate-speech-tts.test.ts
pnpm test tests/edit/actions-edit.test.ts
pnpm exec tsc --noEmit
pnpm build
pnpm lint
pnpm check
```

Results:

- `pnpm test tests/audio/regenerate-speech-tts.test.ts` passed
- `pnpm test tests/edit/actions-edit.test.ts` passed
- `pnpm exec tsc --noEmit` passed
- `pnpm build` passed
- `pnpm lint` completed with 0 errors
- `pnpm check` passed
- Manually tested on server with real classroom playback

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings