### PR TITLE
fix(quiz): render formulas in quiz text

### DIFF
--- a/components/scene-renderers/quiz-view.tsx
+++ b/components/scene-renderers/quiz-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { memo, useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
   PieChart,
@@ -23,6 +23,7 @@ import type { QuizQuestion } from '@/lib/types/stage';
 import { useDraftCache } from '@/lib/hooks/use-draft-cache';
 import { SpeechButton } from '@/components/audio/speech-button';
 import { gradeChoiceQuestions, isShortAnswer, type QuestionResult } from '@/lib/quiz/grading';
+import { renderQuizMathText } from '@/lib/quiz/math-text';
 import {
   clearSubmitted,
   draftKey,
@@ -40,6 +41,43 @@ interface QuizViewProps {
   readonly questions: QuizQuestion[];
   readonly sceneId: string;
 }
+
+const QuizMathText = memo(function QuizMathText({
+  text,
+  className,
+  allowDisplayMode = false,
+}: {
+  text: string;
+  className?: string;
+  allowDisplayMode?: boolean;
+}) {
+  const segments = useMemo(() => renderQuizMathText(text), [text]);
+  if (segments.length === 1 && segments[0].type === 'text') {
+    return <span className={className}>{segments[0].value}</span>;
+  }
+
+  return (
+    <span className={className}>
+      {segments.map((segment, index) => {
+        if (segment.type === 'text') {
+          return <span key={index}>{segment.value}</span>;
+        }
+
+        return (
+          <span
+            key={index}
+            className={cn(
+              allowDisplayMode && segment.displayMode
+                ? 'block my-1 overflow-x-auto [&_.katex-display]:!my-0'
+                : 'inline-block align-baseline [&_.katex-display]:!my-0',
+            )}
+            dangerouslySetInnerHTML={{ __html: segment.html }}
+          />
+        );
+      })}
+    </span>
+  );
+});
 
 /** Call /api/quiz-grade for a single short-answer question. */
 async function gradeShortAnswerQuestion(
@@ -255,7 +293,7 @@ function SingleChoiceQuestion({
                   isReview && !isCorrectOpt && !selected && 'text-gray-400 dark:text-gray-500',
                 )}
               >
-                {opt.label}
+                <QuizMathText text={opt.label} />
               </span>
               {isReview && isCorrectOpt && (
                 <CheckCircle2 className="w-5 h-5 text-emerald-500 shrink-0" />
@@ -360,7 +398,7 @@ function MultipleChoiceQuestion({
                   isReview && !isCorrectOpt && !isSelected && 'text-gray-400 dark:text-gray-500',
                 )}
               >
-                {opt.label}
+                <QuizMathText text={opt.label} />
               </span>
               {isReview && isCorrectOpt && (
                 <CheckCircle2 className="w-5 h-5 text-emerald-500 shrink-0" />
@@ -425,7 +463,9 @@ function ShortAnswerQuestion({
         <div className="space-y-3">
           <div className="p-3 rounded-xl bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700 text-sm text-gray-700 dark:text-gray-300">
             <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">{t('quiz.yourAnswer')}</p>
-            {value || (
+            {value ? (
+              <QuizMathText text={value} />
+            ) : (
               <span className="text-gray-400 dark:text-gray-500 italic">
                 {t('quiz.notAnswered')}
               </span>
@@ -439,7 +479,7 @@ function ShortAnswerQuestion({
                   {t('quiz.aiComment')}
                 </p>
                 <p className="text-xs text-violet-600/80 dark:text-violet-400/80">
-                  {result.aiComment}
+                  <QuizMathText text={result.aiComment} />
                 </p>
               </div>
               <span className="ml-auto text-xs font-bold text-violet-600 dark:text-violet-400 shrink-0">
@@ -514,9 +554,9 @@ function QuestionCard({
             {index + 1}
           </span>
           <div>
-            <p className="text-sm font-medium text-gray-800 dark:text-gray-100 leading-relaxed">
-              {question.question}
-            </p>
+            <div className="text-sm font-medium text-gray-800 dark:text-gray-100 leading-relaxed">
+              <QuizMathText text={question.question} allowDisplayMode />
+            </div>
             <p className="text-xs text-gray-400 mt-0.5">
               {question.type === 'single'
                 ? t('quiz.singleChoice')
@@ -543,7 +583,7 @@ function QuestionCard({
       {isReview && question.analysis && (
         <div className="mt-3 p-3 rounded-lg bg-blue-50/70 dark:bg-blue-900/30 border border-blue-100 dark:border-blue-800 text-xs text-blue-700 dark:text-blue-300 leading-relaxed">
           <span className="font-medium">{t('quiz.analysis')}</span>
-          {question.analysis}
+          <QuizMathText text={question.analysis} allowDisplayMode />
         </div>
       )}
     </motion.div>

--- a/lib/quiz/math-text.ts
+++ b/lib/quiz/math-text.ts
@@ -1,0 +1,209 @@
+import katex from 'katex';
+
+export type QuizMathTextSegment =
+  | {
+      type: 'text';
+      value: string;
+    }
+  | {
+      type: 'math';
+      value: string;
+      html: string;
+      displayMode: boolean;
+    };
+
+interface Delimiter {
+  open: string;
+  close: string;
+  displayMode: boolean;
+}
+
+const DELIMITERS: Delimiter[] = [
+  { open: '$$', close: '$$', displayMode: true },
+  { open: '\\[', close: '\\]', displayMode: true },
+  { open: '\\(', close: '\\)', displayMode: false },
+  { open: '$', close: '$', displayMode: false },
+];
+
+const LATEX_COMMAND_RE = /\\[a-zA-Z]+/;
+const INLINE_OPERATOR_RE = /[A-Za-z0-9)\]}]\s*[+\-*/]\s*[A-Za-z0-9({\\]/;
+const FORMULA_CHAR_RE = /^[\s0-9A-Za-z\\{}()[\]^_+\-*/=<>≤≥≈.,:;|!%√πθαβγδελμνρσφωΑΒΓΔΘΛΜΝΠΡΣΦΩ]+$/;
+const WORD_RE = /[A-Za-z]{3,}/g;
+const EXPLICIT_DELIMITER_RE = /\\\[|\\\(|(?:^|[^\\])\$\$?/;
+const LETTER_OR_COMMAND_RE = /[A-Za-z\\πθαβγδελμνρσφωΑΒΓΔΘΛΜΝΠΡΣΦΩ]/;
+const EQUATION_OR_POWER_RE = /[=<>≤≥≈^_]/;
+const SINGLE_SYMBOL_RE = /^(?:[A-Za-z]|\\[a-zA-Z]+|\d+(?:\.\d+)?)$/;
+
+export function isLikelyStandaloneMathText(value: string): boolean {
+  const text = value.trim();
+  if (text.length < 3) return false;
+  if (!FORMULA_CHAR_RE.test(text)) return false;
+  if (!LETTER_OR_COMMAND_RE.test(text) && !EQUATION_OR_POWER_RE.test(text)) return false;
+  if (!LATEX_COMMAND_RE.test(text) && !EQUATION_OR_POWER_RE.test(text)) return false;
+
+  const words = text.match(WORD_RE) ?? [];
+  if (!LATEX_COMMAND_RE.test(text) && words.length > 2) return false;
+
+  return true;
+}
+
+export function renderLatexToHtml(value: string, displayMode = false): string | null {
+  try {
+    return katex.renderToString(value, {
+      displayMode,
+      output: 'html',
+      strict: false,
+      throwOnError: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function parseQuizMathText(value: string): QuizMathTextSegment[] {
+  const segments: QuizMathTextSegment[] = [];
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const opening = findNextDelimiter(value, cursor);
+    if (!opening) break;
+
+    if (opening.index > cursor) {
+      segments.push({ type: 'text', value: value.slice(cursor, opening.index) });
+    }
+
+    const mathStart = opening.index + opening.delimiter.open.length;
+    const closeIndex = findClosingDelimiter(value, opening.delimiter.close, mathStart);
+    if (closeIndex === -1) {
+      segments.push({ type: 'text', value: value.slice(opening.index) });
+      cursor = value.length;
+      break;
+    }
+
+    const latex = value.slice(mathStart, closeIndex).trim();
+    if (latex) {
+      const shouldRender = opening.delimiter.open !== '$' || isLikelyDelimitedMathText(latex);
+      const html = shouldRender ? renderLatexToHtml(latex, opening.delimiter.displayMode) : null;
+      if (html) {
+        segments.push({
+          type: 'math',
+          value: latex,
+          html,
+          displayMode: opening.delimiter.displayMode,
+        });
+      } else {
+        segments.push({
+          type: 'text',
+          value: value.slice(opening.index, closeIndex + opening.delimiter.close.length),
+        });
+      }
+    } else {
+      segments.push({
+        type: 'text',
+        value: value.slice(opening.index, closeIndex + opening.delimiter.close.length),
+      });
+    }
+
+    cursor = closeIndex + opening.delimiter.close.length;
+  }
+
+  if (cursor < value.length) {
+    segments.push({ type: 'text', value: value.slice(cursor) });
+  }
+
+  return mergeTextSegments(segments);
+}
+
+function isLikelyDelimitedMathText(value: string): boolean {
+  const text = value.trim();
+  if (!text) return false;
+  if (!FORMULA_CHAR_RE.test(text)) return false;
+  if (SINGLE_SYMBOL_RE.test(text)) return true;
+  if (LATEX_COMMAND_RE.test(text) || EQUATION_OR_POWER_RE.test(text)) return true;
+  if (INLINE_OPERATOR_RE.test(text) && (text.match(WORD_RE) ?? []).length <= 1) return true;
+  return false;
+}
+
+export function renderQuizMathText(value: string): QuizMathTextSegment[] {
+  const likelyStandalone = isLikelyStandaloneMathText(value);
+  if (!EXPLICIT_DELIMITER_RE.test(value) && !likelyStandalone) {
+    return [{ type: 'text', value }];
+  }
+
+  const delimited = parseQuizMathText(value);
+  if (delimited.some((segment) => segment.type === 'math')) return delimited;
+
+  if (!likelyStandalone) return [{ type: 'text', value }];
+
+  const latex = value.trim();
+  const html = renderLatexToHtml(latex, false);
+  if (!html) return [{ type: 'text', value }];
+
+  const prefix = value.slice(0, value.indexOf(latex));
+  const suffix = value.slice(value.indexOf(latex) + latex.length);
+
+  return mergeTextSegments([
+    ...(prefix ? ([{ type: 'text', value: prefix }] as QuizMathTextSegment[]) : []),
+    { type: 'math', value: latex, html, displayMode: false },
+    ...(suffix ? ([{ type: 'text', value: suffix }] as QuizMathTextSegment[]) : []),
+  ]);
+}
+
+function findNextDelimiter(
+  value: string,
+  startIndex: number,
+): { delimiter: Delimiter; index: number } | null {
+  let match: { delimiter: Delimiter; index: number } | null = null;
+
+  for (const delimiter of DELIMITERS) {
+    const index = findUnescaped(value, delimiter.open, startIndex);
+    if (index === -1) continue;
+    if (
+      !match ||
+      index < match.index ||
+      (index === match.index && delimiter.open.length > match.delimiter.open.length)
+    ) {
+      match = { delimiter, index };
+    }
+  }
+
+  return match;
+}
+
+function findClosingDelimiter(value: string, delimiter: string, startIndex: number): number {
+  return findUnescaped(value, delimiter, startIndex);
+}
+
+function findUnescaped(value: string, search: string, startIndex: number): number {
+  let index = value.indexOf(search, startIndex);
+  while (index !== -1) {
+    if (!isEscaped(value, index)) return index;
+    index = value.indexOf(search, index + search.length);
+  }
+  return -1;
+}
+
+function isEscaped(value: string, index: number): boolean {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function mergeTextSegments(segments: QuizMathTextSegment[]): QuizMathTextSegment[] {
+  const merged: QuizMathTextSegment[] = [];
+
+  for (const segment of segments) {
+    const last = merged[merged.length - 1];
+    if (segment.type === 'text' && last?.type === 'text') {
+      last.value += segment.value;
+    } else if (segment.type === 'text' && segment.value === '') {
+      continue;
+    } else {
+      merged.push(segment);
+    }
+  }
+
+  return merged.length > 0 ? merged : [{ type: 'text', value: '' }];
+}

--- a/lib/quiz/math-text.ts
+++ b/lib/quiz/math-text.ts
@@ -26,6 +26,7 @@ const DELIMITERS: Delimiter[] = [
 ];
 
 const LATEX_COMMAND_RE = /\\[a-zA-Z]+/;
+const LATEX_COMMAND_GLOBAL_RE = /\\[a-zA-Z]+/g;
 const INLINE_OPERATOR_RE = /[A-Za-z0-9)\]}]\s*[+\-*/]\s*[A-Za-z0-9({\\]/;
 const FORMULA_CHAR_RE = /^[\s0-9A-Za-z\\{}()[\]^_+\-*/=<>≤≥≈.,:;|!%√πθαβγδελμνρσφωΑΒΓΔΘΛΜΝΠΡΣΦΩ]+$/;
 const WORD_RE = /[A-Za-z]{3,}/g;
@@ -33,6 +34,11 @@ const EXPLICIT_DELIMITER_RE = /\\\[|\\\(|(?:^|[^\\])\$\$?/;
 const LETTER_OR_COMMAND_RE = /[A-Za-z\\πθαβγδελμνρσφωΑΒΓΔΘΛΜΝΠΡΣΦΩ]/;
 const EQUATION_OR_POWER_RE = /[=<>≤≥≈^_]/;
 const SINGLE_SYMBOL_RE = /^(?:[A-Za-z]|\\[a-zA-Z]+|\d+(?:\.\d+)?)$/;
+const CODE_LIKE_BOOLEAN_ASSIGNMENT_RE =
+  /^[A-Za-z_][A-Za-z0-9_]*\s*=\s*(?:true|false|null|undefined|none)$/i;
+const CODE_LIKE_INCREMENT_RE = /^([ijk])\s*=\s*\1\s*[+-]\s*1$/i;
+const SENTENCE_BOUNDARY_CHAR_RE = /^[.,!?;:]$/;
+const TOKEN_RE = /\S+/g;
 
 export function isLikelyStandaloneMathText(value: string): boolean {
   const text = value.trim();
@@ -41,15 +47,16 @@ export function isLikelyStandaloneMathText(value: string): boolean {
   if (!LETTER_OR_COMMAND_RE.test(text) && !EQUATION_OR_POWER_RE.test(text)) return false;
   if (!LATEX_COMMAND_RE.test(text) && !EQUATION_OR_POWER_RE.test(text)) return false;
 
-  const words = text.match(WORD_RE) ?? [];
-  if (!LATEX_COMMAND_RE.test(text) && words.length > 2) return false;
+  const proseWords = text.replace(LATEX_COMMAND_GLOBAL_RE, ' ').match(WORD_RE) ?? [];
+  if (proseWords.length > 0) return false;
+  if (isCodeLikeAssignment(text)) return false;
 
   return true;
 }
 
 export function renderLatexToHtml(value: string, displayMode = false): string | null {
   try {
-    return katex.renderToString(value, {
+    return katex.renderToString(escapeLiteralPercents(value), {
       displayMode,
       output: 'html',
       strict: false,
@@ -58,6 +65,19 @@ export function renderLatexToHtml(value: string, displayMode = false): string | 
   } catch {
     return null;
   }
+}
+
+function escapeLiteralPercents(value: string): string {
+  let escaped = '';
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== '%') {
+      escaped += value[index];
+      continue;
+    }
+
+    escaped += isEscaped(value, index) ? '%' : '\\%';
+  }
+  return escaped;
 }
 
 export function parseQuizMathText(value: string): QuizMathTextSegment[] {
@@ -114,6 +134,80 @@ export function parseQuizMathText(value: string): QuizMathTextSegment[] {
   return mergeTextSegments(segments);
 }
 
+function parseEmbeddedMathText(value: string): QuizMathTextSegment[] | null {
+  const segments: QuizMathTextSegment[] = [];
+  let cursor = 0;
+  let hasMath = false;
+  TOKEN_RE.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = TOKEN_RE.exec(value)) !== null) {
+    const tokenStart = match.index;
+    const tokenEnd = tokenStart + match[0].length;
+    const candidate = trimEmbeddedMathCandidate(value, tokenStart, tokenEnd);
+    if (!candidate || candidate.start < cursor) continue;
+    if (!isLikelyEmbeddedMathText(candidate.value)) continue;
+
+    const html = renderLatexToHtml(candidate.value, false);
+    if (!html) continue;
+
+    if (candidate.start > cursor) {
+      segments.push({ type: 'text', value: value.slice(cursor, candidate.start) });
+    }
+
+    segments.push({
+      type: 'math',
+      value: candidate.value,
+      html,
+      displayMode: false,
+    });
+    hasMath = true;
+    cursor = candidate.end;
+  }
+
+  if (!hasMath) return null;
+  if (cursor < value.length) {
+    segments.push({ type: 'text', value: value.slice(cursor) });
+  }
+
+  return mergeTextSegments(segments);
+}
+
+function trimEmbeddedMathCandidate(
+  value: string,
+  start: number,
+  end: number,
+): { start: number; end: number; value: string } | null {
+  let candidateStart = start;
+  let candidateEnd = end;
+
+  while (candidateStart < candidateEnd && /["'“”‘’]/.test(value[candidateStart])) {
+    candidateStart += 1;
+  }
+
+  while (candidateEnd > candidateStart && SENTENCE_BOUNDARY_CHAR_RE.test(value[candidateEnd - 1])) {
+    candidateEnd -= 1;
+  }
+
+  const candidate = value.slice(candidateStart, candidateEnd);
+  if (!candidate) return null;
+  return { start: candidateStart, end: candidateEnd, value: candidate };
+}
+
+function isLikelyEmbeddedMathText(value: string): boolean {
+  const text = value.trim();
+  if (text.length < 6) return false;
+  if (!FORMULA_CHAR_RE.test(text)) return false;
+  if (!LETTER_OR_COMMAND_RE.test(text)) return false;
+  if (isCodeLikeAssignment(text)) return false;
+
+  const proseWords = text.replace(LATEX_COMMAND_GLOBAL_RE, ' ').match(WORD_RE) ?? [];
+  if (proseWords.length > 0) return false;
+  if (!EQUATION_OR_POWER_RE.test(text)) return false;
+
+  return INLINE_OPERATOR_RE.test(text) || LATEX_COMMAND_RE.test(text) || text.length >= 12;
+}
+
 function isLikelyDelimitedMathText(value: string): boolean {
   const text = value.trim();
   if (!text) return false;
@@ -126,8 +220,10 @@ function isLikelyDelimitedMathText(value: string): boolean {
 
 export function renderQuizMathText(value: string): QuizMathTextSegment[] {
   const likelyStandalone = isLikelyStandaloneMathText(value);
-  if (!EXPLICIT_DELIMITER_RE.test(value) && !likelyStandalone) {
-    return [{ type: 'text', value }];
+  const hasExplicitDelimiter = EXPLICIT_DELIMITER_RE.test(value);
+
+  if (!hasExplicitDelimiter && !likelyStandalone) {
+    return parseEmbeddedMathText(value) ?? [{ type: 'text', value }];
   }
 
   const delimited = parseQuizMathText(value);
@@ -189,6 +285,11 @@ function isEscaped(value: string, index: number): boolean {
     slashCount += 1;
   }
   return slashCount % 2 === 1;
+}
+
+function isCodeLikeAssignment(value: string): boolean {
+  const text = value.trim();
+  return CODE_LIKE_BOOLEAN_ASSIGNMENT_RE.test(text) || CODE_LIKE_INCREMENT_RE.test(text);
 }
 
 function mergeTextSegments(segments: QuizMathTextSegment[]): QuizMathTextSegment[] {

--- a/tests/quiz/math-text.test.ts
+++ b/tests/quiz/math-text.test.ts
@@ -58,6 +58,24 @@ describe('isLikelyStandaloneMathText', () => {
     expect(isLikelyStandaloneMathText('Chapter 2 review question')).toBe(false);
   });
 
+  it('does not classify short instruction prompts as standalone math', () => {
+    expect(isLikelyStandaloneMathText('Solve x=2')).toBe(false);
+    expect(isLikelyStandaloneMathText('Simplify x^2')).toBe(false);
+  });
+
+  it('does not classify prose that mentions a LaTeX command as standalone math', () => {
+    expect(isLikelyStandaloneMathText('Use \\sqrt{2} not 2 here')).toBe(false);
+  });
+
+  it('does not classify code-like answer options as standalone math', () => {
+    expect(isLikelyStandaloneMathText('i = i + 1')).toBe(false);
+    expect(isLikelyStandaloneMathText('Answer = True')).toBe(false);
+  });
+
+  it('still recognizes delimiter-free LaTeX command expressions', () => {
+    expect(isLikelyStandaloneMathText('\\sqrt{2}')).toBe(true);
+  });
+
   it('does not classify slash, protocol, date, or hyphenated prose as math', () => {
     expect(isLikelyStandaloneMathText('A/B test')).toBe(false);
     expect(isLikelyStandaloneMathText('HTTP/2')).toBe(false);
@@ -82,5 +100,45 @@ describe('renderQuizMathText', () => {
     expect(renderQuizMathText('Which option is correct?')).toEqual([
       { type: 'text', value: 'Which option is correct?' },
     ]);
+  });
+
+  it('preserves percent content in delimiter-free math', () => {
+    const segments = renderQuizMathText('25%*4 = 100%');
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      type: 'math',
+      value: '25%*4 = 100%',
+      displayMode: false,
+    });
+    expect(segments[0].type === 'math' ? segments[0].html : '').toContain('%');
+    expect(segments[0].type === 'math' ? segments[0].html : '').toContain('100');
+  });
+
+  it('preserves prose prompts as plain text even with math-looking expressions', () => {
+    expect(renderQuizMathText('Solve x=2')).toEqual([{ type: 'text', value: 'Solve x=2' }]);
+    expect(renderQuizMathText('Simplify x^2')).toEqual([{ type: 'text', value: 'Simplify x^2' }]);
+    expect(renderQuizMathText('Use \\sqrt{2} not 2 here')).toEqual([
+      { type: 'text', value: 'Use \\sqrt{2} not 2 here' },
+    ]);
+  });
+
+  it('preserves code-like answer options as plain text', () => {
+    expect(renderQuizMathText('i = i + 1')).toEqual([{ type: 'text', value: 'i = i + 1' }]);
+    expect(renderQuizMathText('Answer = True')).toEqual([{ type: 'text', value: 'Answer = True' }]);
+  });
+
+  it('renders embedded algebra without consuming surrounding prose', () => {
+    const formula = 'a(x-2)+b(2-x)^2=a(x-2)+b(x-2)^2';
+    const segments = renderQuizMathText(`The simplification is ${formula}.`);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ type: 'text', value: 'The simplification is ' });
+    expect(segments[1]).toMatchObject({
+      type: 'math',
+      value: formula,
+      displayMode: false,
+    });
+    expect(segments[2]).toEqual({ type: 'text', value: '.' });
   });
 });

--- a/tests/quiz/math-text.test.ts
+++ b/tests/quiz/math-text.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isLikelyStandaloneMathText,
+  parseQuizMathText,
+  renderQuizMathText,
+} from '@/lib/quiz/math-text';
+
+describe('parseQuizMathText', () => {
+  it('splits explicit inline math from surrounding prose', () => {
+    const segments = parseQuizMathText('Solve $x^2=4$ before moving on.');
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ type: 'text', value: 'Solve ' });
+    expect(segments[1]).toMatchObject({ type: 'math', value: 'x^2=4', displayMode: false });
+    expect(segments[1].type === 'math' ? segments[1].html : '').toContain('katex');
+    expect(segments[2]).toEqual({ type: 'text', value: ' before moving on.' });
+  });
+
+  it('renders explicit inline math with subtraction', () => {
+    const segments = parseQuizMathText('Solve $x-2$ before moving on.');
+
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toMatchObject({ type: 'math', value: 'x-2', displayMode: false });
+  });
+
+  it('supports display delimiters', () => {
+    const segments = parseQuizMathText('$$\\frac{1}{2}$$');
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ type: 'math', value: '\\frac{1}{2}', displayMode: true });
+  });
+
+  it('leaves escaped dollars as text', () => {
+    const segments = parseQuizMathText('Cost is \\$5, not math.');
+
+    expect(segments).toEqual([{ type: 'text', value: 'Cost is \\$5, not math.' }]);
+  });
+
+  it('does not treat ordinary currency as dollar-delimited math', () => {
+    const segments = parseQuizMathText('Cost is $5 and $7');
+
+    expect(segments).toEqual([{ type: 'text', value: 'Cost is $5 and $7' }]);
+  });
+
+  it('falls back to the original delimited text when KaTeX rejects it', () => {
+    const segments = parseQuizMathText('Bad $\\definitelyunknown{1}$ input');
+
+    expect(segments).toEqual([{ type: 'text', value: 'Bad $\\definitelyunknown{1}$ input' }]);
+  });
+});
+
+describe('isLikelyStandaloneMathText', () => {
+  it('recognizes delimiter-free algebra like the issue report', () => {
+    expect(isLikelyStandaloneMathText('a(x-2)+b(2-x)^2=a(x-2)+b(x-2)^2')).toBe(true);
+  });
+
+  it('does not classify ordinary quiz prose as math', () => {
+    expect(isLikelyStandaloneMathText('Chapter 2 review question')).toBe(false);
+  });
+
+  it('does not classify slash, protocol, date, or hyphenated prose as math', () => {
+    expect(isLikelyStandaloneMathText('A/B test')).toBe(false);
+    expect(isLikelyStandaloneMathText('HTTP/2')).toBe(false);
+    expect(isLikelyStandaloneMathText('COVID-19')).toBe(false);
+    expect(isLikelyStandaloneMathText('2026-07-01')).toBe(false);
+  });
+});
+
+describe('renderQuizMathText', () => {
+  it('renders delimiter-free algebra as one math segment', () => {
+    const segments = renderQuizMathText('a(x-2)+b(2-x)^2=a(x-2)+b(x-2)^2');
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      type: 'math',
+      value: 'a(x-2)+b(2-x)^2=a(x-2)+b(x-2)^2',
+      displayMode: false,
+    });
+  });
+
+  it('preserves non-math text as plain text', () => {
+    expect(renderQuizMathText('Which option is correct?')).toEqual([
+      { type: 'text', value: 'Which option is correct?' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Render math in quiz question text, options, submitted answers, AI comments, and analysis blocks instead of displaying formula-like strings as plain text.
- Add a focused quiz math-text helper that supports explicit LaTeX delimiters and conservative delimiter-free standalone algebra detection.
- AI-assisted contribution; self-review and independent Codex review completed before submission.

## Related Issues

Fixes #771.

## Changes

- Add quiz math-text segmentation/rendering with KaTeX fallback behavior.
- Wire readonly quiz display fields through the renderer while preserving answer state, grading, and persistence behavior.
- Add focused tests for explicit delimiters, delimiter-free algebra, malformed math fallback, currency/prose preservation, and subtraction in dollar-delimited math.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Render a quiz scene with formula-like question text such as `a(x-2)+b(2-x)^2=a(x-2)+b(x-2)^2=(x-2)(a+b(x-2))`.
2. Verify the quiz display renders math instead of raw formula text.
3. Verify ordinary quiz prose, currency-like text, and malformed math remain readable as text.

### What you personally verified

- `pnpm exec prettier --check lib/quiz/math-text.ts tests/quiz/math-text.test.ts components/scene-renderers/quiz-view.tsx`
- `pnpm vitest run tests/quiz/math-text.test.ts` (11 tests)
- `pnpm lint` (0 errors; 15 existing warnings outside touched files)
- `pnpm exec tsc --noEmit`
- `pnpm test` (223 files, 1844 tests)
- `pnpm check`
- `git diff --check`

### Evidence

- [x] CI-style local checks passed (`pnpm check`, `pnpm lint`, and TypeScript type checking)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

Note: I did not attach browser screenshots or recordings yet; verification is from helper coverage plus lint, TypeScript, and Vitest. I can add visual evidence before marking this draft ready if maintainers prefer.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings

## Scope / non-goals

- Does not change quiz generation, grading, answer persistence, or model prompts.
- Does not introduce new user-facing copy.
- Display-mode math is enabled only for question stems and analysis blocks; option labels, submitted answers, and comments render inline to avoid compact-layout breaks.
