### PR TITLE
feat(playback): resume scene playback position

### DIFF
--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -18,7 +18,13 @@ import { SceneSidebar } from '@/components/stage/scene-sidebar';
 import { Header } from '@/components/header';
 import { CanvasArea } from '@/components/canvas/canvas-area';
 import { Roundtable } from '@/components/roundtable';
-import { PlaybackEngine, computePlaybackView } from '@/lib/playback';
+import {
+  PlaybackEngine,
+  clearPlaybackResumePosition,
+  computePlaybackView,
+  loadPlaybackResumePosition,
+  savePlaybackResumePosition,
+} from '@/lib/playback';
 import type { EngineMode, TriggerEvent, Effect } from '@/lib/playback';
 import { ActionEngine } from '@/lib/action/engine';
 import { createAudioPlayer } from '@/lib/utils/audio-player';
@@ -27,7 +33,6 @@ import { useWidgetIframeStore } from '@/lib/store/widget-iframe';
 import type { AudioIndicatorState } from '@/components/roundtable/audio-indicator';
 import type { Action, DiscussionAction, SpeechAction } from '@/lib/types/action';
 import { cn } from '@/lib/utils';
-// Playback state persistence removed — refresh always starts from the beginning
 import { ChatArea, type ChatAreaRef } from '@/components/chat/chat-area';
 import { agentsToParticipants, useAgentRegistry } from '@/lib/orchestration/registry/store';
 import type { AgentConfig } from '@/lib/orchestration/registry/types';
@@ -80,6 +85,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       setCurrentSceneId,
       generatingOutlines,
       outlines,
+      stage,
     } = useStageStore();
     const failedOutlines = useStageStore.use.failedOutlines();
     const generationComplete = useStageStore.use.generationComplete();
@@ -457,6 +463,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       // on a scene's first visit and silently drop every widget action. Looking it
       // up per-send always sees the live registration.
       const sceneIdForWidget = currentScene.id;
+      const playbackResumeScopeId = stage?.id ?? currentScene.stageId;
       const widgetSendMessage = (type: string, payload: Record<string, unknown>) =>
         useWidgetIframeStore.getState().getSendMessage(sceneIdForWidget)?.(type, payload);
 
@@ -563,7 +570,11 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
           return ids.includes(agentId);
         },
         getPlaybackSpeed: () => useSettingsStore.getState().playbackSpeed || 1,
+        onProgress: (snapshot) => {
+          savePlaybackResumePosition(playbackResumeScopeId, currentScene, snapshot);
+        },
         onComplete: () => {
+          clearPlaybackResumePosition(playbackResumeScopeId, currentScene.id);
           // lectureSpeech intentionally NOT cleared — last sentence stays visible
           // until scene transition (auto-play) or user restarts. Scene change
           // effect handles the reset.
@@ -626,7 +637,10 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
           engine.start();
         })();
       } else {
-        // Load saved playback state and restore position (but never auto-play).
+        const resumePosition = loadPlaybackResumePosition(playbackResumeScopeId, currentScene);
+        if (resumePosition) {
+          engine.restoreActionPosition(resumePosition.actionIndex);
+        }
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps -- Only re-run when scene changes, functions are stable refs
     }, [currentScene]);

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -122,6 +122,18 @@ export class PlaybackEngine {
     this.consumedDiscussions = new Set(snapshot.consumedDiscussions);
   }
 
+  /** Restore to an action boundary within the current scene. */
+  restoreActionPosition(actionIndex: number): boolean {
+    if (this.mode !== 'idle') return false;
+    const actions = this.scenes[0]?.actions ?? [];
+    if (!Number.isInteger(actionIndex) || actionIndex < 0 || actionIndex >= actions.length) {
+      return false;
+    }
+    this.sceneIndex = 0;
+    this.actionIndex = actionIndex;
+    return true;
+  }
+
   /** idle → playing (from beginning) */
   start(): void {
     if (this.mode !== 'idle') {

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './engine';
 export * from './derived-state';
+export * from './resume-position';

--- a/lib/playback/resume-position.ts
+++ b/lib/playback/resume-position.ts
@@ -1,0 +1,178 @@
+import type { Action } from '@/lib/types/action';
+import type { Scene } from '@/lib/types/stage';
+import type { PlaybackSnapshot } from './types';
+
+const STORAGE_PREFIX = 'openmaic:playback-resume-position:v1';
+const STORE_VERSION = 1;
+
+interface StoredResumePosition {
+  sceneId: string;
+  actionIndex: number;
+  actionId: string;
+  actionType: Action['type'];
+  textFingerprint?: string;
+}
+
+interface ResumeStore {
+  version: typeof STORE_VERSION;
+  scopeId: string;
+  positions: Record<string, StoredResumePosition>;
+}
+
+export interface PlaybackResumePosition {
+  sceneId: string;
+  actionIndex: number;
+  actionId: string;
+  actionType: Action['type'];
+}
+
+function storageKey(scopeId: string): string {
+  return `${STORAGE_PREFIX}:${scopeId}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function actionTextFingerprint(action: Action): string | undefined {
+  if (action.type !== 'speech') return undefined;
+  return action.text.trim().slice(0, 120);
+}
+
+function isUnsafeResumeAction(action: Action): boolean {
+  return (
+    action.type === 'discussion' ||
+    action.type === 'play_video' ||
+    action.type.startsWith('widget_') ||
+    action.type.startsWith('wb_')
+  );
+}
+
+function hasUnsafeResumeBoundary(actions: readonly Action[], actionIndex: number): boolean {
+  return actions.slice(0, actionIndex + 1).some(isUnsafeResumeAction);
+}
+
+function parseStore(raw: string | null, scopeId: string): ResumeStore | null {
+  if (!raw) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (parsed.version !== STORE_VERSION || parsed.scopeId !== scopeId) return null;
+    if (!isRecord(parsed.positions)) return null;
+
+    const positions: Record<string, StoredResumePosition> = {};
+    for (const [sceneId, value] of Object.entries(parsed.positions)) {
+      if (!isRecord(value)) continue;
+      if (
+        typeof value.sceneId !== 'string' ||
+        value.sceneId !== sceneId ||
+        typeof value.actionIndex !== 'number' ||
+        !Number.isInteger(value.actionIndex) ||
+        value.actionIndex < 0 ||
+        typeof value.actionId !== 'string' ||
+        typeof value.actionType !== 'string'
+      ) {
+        continue;
+      }
+      if (value.textFingerprint !== undefined && typeof value.textFingerprint !== 'string') {
+        continue;
+      }
+      positions[sceneId] = {
+        sceneId: value.sceneId,
+        actionIndex: value.actionIndex,
+        actionId: value.actionId,
+        actionType: value.actionType as Action['type'],
+        textFingerprint: value.textFingerprint,
+      };
+    }
+
+    return { version: STORE_VERSION, scopeId, positions };
+  } catch {
+    return null;
+  }
+}
+
+function readStore(scopeId: string): ResumeStore {
+  if (typeof window === 'undefined') {
+    return { version: STORE_VERSION, scopeId, positions: {} };
+  }
+
+  try {
+    return (
+      parseStore(window.sessionStorage.getItem(storageKey(scopeId)), scopeId) ?? {
+        version: STORE_VERSION,
+        scopeId,
+        positions: {},
+      }
+    );
+  } catch {
+    return { version: STORE_VERSION, scopeId, positions: {} };
+  }
+}
+
+function writeStore(scopeId: string, store: ResumeStore): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.sessionStorage.setItem(storageKey(scopeId), JSON.stringify(store));
+  } catch {
+    // Session storage can be unavailable or quota-limited; resume is best-effort.
+  }
+}
+
+export function savePlaybackResumePosition(
+  scopeId: string | null | undefined,
+  scene: Scene,
+  snapshot: PlaybackSnapshot,
+): void {
+  if (!scopeId || snapshot.sceneId !== scene.id) return;
+
+  const actions = scene.actions ?? [];
+  const action = actions[snapshot.actionIndex];
+  if (!action || hasUnsafeResumeBoundary(actions, snapshot.actionIndex)) return;
+
+  const store = readStore(scopeId);
+  store.positions[scene.id] = {
+    sceneId: scene.id,
+    actionIndex: snapshot.actionIndex,
+    actionId: action.id,
+    actionType: action.type,
+    textFingerprint: actionTextFingerprint(action),
+  };
+  writeStore(scopeId, store);
+}
+
+export function loadPlaybackResumePosition(
+  scopeId: string | null | undefined,
+  scene: Scene,
+): PlaybackResumePosition | null {
+  if (!scopeId) return null;
+
+  const stored = readStore(scopeId).positions[scene.id];
+  if (!stored) return null;
+
+  const actions = scene.actions ?? [];
+  const action = actions[stored.actionIndex];
+  if (!action || hasUnsafeResumeBoundary(actions, stored.actionIndex)) return null;
+  if (action.id !== stored.actionId || action.type !== stored.actionType) return null;
+  if (actionTextFingerprint(action) !== stored.textFingerprint) return null;
+
+  return {
+    sceneId: stored.sceneId,
+    actionIndex: stored.actionIndex,
+    actionId: stored.actionId,
+    actionType: stored.actionType,
+  };
+}
+
+export function clearPlaybackResumePosition(
+  scopeId: string | null | undefined,
+  sceneId: string,
+): void {
+  if (!scopeId) return;
+
+  const store = readStore(scopeId);
+  delete store.positions[sceneId];
+  writeStore(scopeId, store);
+}

--- a/lib/playback/types.ts
+++ b/lib/playback/types.ts
@@ -2,9 +2,12 @@
  * Playback Types - Types for lecture playback and live discussion engine
  */
 
-import type { PlaybackSnapshot } from '@/lib/utils/playback-storage';
-
-export type { PlaybackSnapshot };
+export interface PlaybackSnapshot {
+  sceneIndex: number;
+  actionIndex: number;
+  consumedDiscussions: string[];
+  sceneId?: string;
+}
 
 /** Visual effects (for onEffectFire callback) */
 export type Effect =

--- a/tests/playback/resume-position.test.ts
+++ b/tests/playback/resume-position.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearPlaybackResumePosition,
+  loadPlaybackResumePosition,
+  savePlaybackResumePosition,
+  PlaybackEngine,
+} from '@/lib/playback';
+import type { Action } from '@/lib/types/action';
+import type { Scene } from '@/lib/types/stage';
+import type { ActionEngine } from '@/lib/action/engine';
+import type { AudioPlayer } from '@/lib/utils/audio-player';
+
+const scopeId = 'stage-1';
+
+function scene(id: string, actions: Action[]): Scene {
+  return {
+    id,
+    stageId: scopeId,
+    type: 'slide',
+    title: id,
+    order: 0,
+    content: { type: 'slide', canvas: { elements: [] } },
+    actions,
+  } as unknown as Scene;
+}
+
+function speech(id: string, text = id): Action {
+  return { id, type: 'speech', text } as Action;
+}
+
+function fakeActionEngine(): ActionEngine {
+  return {
+    clearEffects: vi.fn(),
+    execute: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ActionEngine;
+}
+
+function fakeAudio(overrides: Partial<AudioPlayer> = {}): AudioPlayer {
+  return {
+    play: vi.fn().mockResolvedValue(false),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    resume: vi.fn(),
+    isPlaying: vi.fn(() => false),
+    hasActiveAudio: vi.fn(() => false),
+    onEnded: vi.fn(),
+    setMuted: vi.fn(),
+    setVolume: vi.fn(),
+    setPlaybackRate: vi.fn(),
+    destroy: vi.fn(),
+    ...overrides,
+  } as unknown as AudioPlayer;
+}
+
+function stubSessionStorage() {
+  const values = new Map<string, string>();
+  const sessionStorage = {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    clear: vi.fn(() => {
+      values.clear();
+    }),
+  };
+  vi.stubGlobal('window', { sessionStorage });
+  return { sessionStorage, values };
+}
+
+describe('playback resume position', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('saves action-level resume position per scene', () => {
+    const { values } = stubSessionStorage();
+    const currentScene = scene('scene-1', [speech('a'), speech('b', 'Second line')]);
+
+    savePlaybackResumePosition(scopeId, currentScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 1,
+      consumedDiscussions: [],
+    });
+
+    const raw = [...values.values()][0];
+    expect(raw).toContain('"sceneId":"scene-1"');
+    expect(raw).toContain('"actionIndex":1');
+    expect(loadPlaybackResumePosition(scopeId, currentScene)).toMatchObject({
+      sceneId: 'scene-1',
+      actionIndex: 1,
+      actionId: 'b',
+      actionType: 'speech',
+    });
+  });
+
+  it('restores action-level position for the same scene', () => {
+    stubSessionStorage();
+    const currentScene = scene('scene-1', [speech('a', 'First line'), speech('b', 'Second line')]);
+    savePlaybackResumePosition(scopeId, currentScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 1,
+      consumedDiscussions: [],
+    });
+    const resume = loadPlaybackResumePosition(scopeId, currentScene);
+    const onSpeechStart = vi.fn();
+    const engine = new PlaybackEngine([currentScene], fakeActionEngine(), fakeAudio(), {
+      onSpeechStart,
+    });
+
+    expect(resume).not.toBeNull();
+    expect(engine.restoreActionPosition(resume!.actionIndex)).toBe(true);
+    engine.continuePlayback();
+
+    expect(onSpeechStart).toHaveBeenCalledWith('Second line');
+  });
+
+  it('does not store timing or scrubber fields', () => {
+    const { values } = stubSessionStorage();
+    const currentScene = scene('scene-1', [speech('a')]);
+
+    savePlaybackResumePosition(scopeId, currentScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 0,
+      consumedDiscussions: [],
+    });
+
+    const raw = [...values.values()][0];
+    expect(raw).not.toContain('milliseconds');
+    expect(raw).not.toContain('currentTime');
+    expect(raw).not.toContain('duration');
+    expect(raw).not.toContain('percentage');
+    expect(raw).not.toContain('progress');
+  });
+
+  it('drops malformed sessionStorage data safely', () => {
+    const { sessionStorage } = stubSessionStorage();
+    sessionStorage.getItem.mockReturnValue('{bad json');
+
+    expect(loadPlaybackResumePosition(scopeId, scene('scene-1', [speech('a')]))).toBeNull();
+  });
+
+  it('drops stale action index after scene actions change', () => {
+    stubSessionStorage();
+    const originalScene = scene('scene-1', [speech('a'), speech('b')]);
+    savePlaybackResumePosition(scopeId, originalScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 1,
+      consumedDiscussions: [],
+    });
+
+    expect(loadPlaybackResumePosition(scopeId, scene('scene-1', [speech('a')]))).toBeNull();
+  });
+
+  it('drops stale action identity after scene actions change', () => {
+    stubSessionStorage();
+    const originalScene = scene('scene-1', [speech('a', 'Original')]);
+    savePlaybackResumePosition(scopeId, originalScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 0,
+      consumedDiscussions: [],
+    });
+
+    expect(
+      loadPlaybackResumePosition(scopeId, scene('scene-1', [speech('a', 'Edited')])),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['widget', { id: 'widget-1', type: 'widget_reveal', target: 'part-a' } as Action],
+    ['discussion', { id: 'discussion-1', type: 'discussion', topic: 'Question?' } as Action],
+    ['video', { id: 'video-1', type: 'play_video', elementId: 'video-1' } as Action],
+    ['whiteboard', { id: 'wb-1', type: 'wb_open' } as Action],
+  ])('does not resume through %s actions', (_label, unsafeAction) => {
+    stubSessionStorage();
+    const currentScene = scene('scene-1', [speech('a'), unsafeAction, speech('b')]);
+
+    savePlaybackResumePosition(scopeId, currentScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 2,
+      consumedDiscussions: [],
+    });
+
+    expect(loadPlaybackResumePosition(scopeId, currentScene)).toBeNull();
+  });
+
+  it('clears a completed scene resume position', () => {
+    stubSessionStorage();
+    const currentScene = scene('scene-1', [speech('a')]);
+    savePlaybackResumePosition(scopeId, currentScene, {
+      sceneId: 'scene-1',
+      sceneIndex: 0,
+      actionIndex: 0,
+      consumedDiscussions: [],
+    });
+
+    clearPlaybackResumePosition(scopeId, 'scene-1');
+
+    expect(loadPlaybackResumePosition(scopeId, currentScene)).toBeNull();
+  });
+
+  it('does not add timestamp seek behavior to the engine', () => {
+    const engine = new PlaybackEngine(
+      [scene('scene-1', [speech('a')])],
+      fakeActionEngine(),
+      fakeAudio(),
+    );
+
+    expect('seekTo' in engine).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This splits the per-scene resume behavior out of #820 into a smaller focused PR.

After maintainer feedback, this intentionally avoids the continuous-time scrubber model. Resume is aligned with the discrete classroom playback engine by storing an action-level position rather than a millisecond timestamp.

## Behavior

- Saves the last meaningful playback action position per scene.
- Restores that action-level position when returning to a scene during the same browser session.
- Uses `sessionStorage` only.
- Validates stored resume data before applying it.
- Ignores stale/invalid resume entries safely.
- Avoids timestamp-based resume, duration estimates, and continuous progress scrubbing.
- Clears saved resume for a scene once that scene completes.

## Safety

This PR intentionally keeps resume conservative for cumulative/live action families.

Resume is skipped for saved positions that would require reconstructing prior unsafe state, including:

- `widget_*`
- `discussion`
- `play_video`
- `wb_*` before the saved point

The scene can still be revisited and played normally. The conservative behavior only means this PR does not resume from the middle of those stateful scenes yet.

This avoids duplicating widgets/discussion sessions/video state or reconstructing partial whiteboard state without the reset/fast-forward infrastructure planned for the later sentence/action-level navigation work.

## Not included

- No scene-wide seek slider.
- No continuous-time scrubbing.
- No total duration timeline.
- No transcript-line click navigation yet.
- No prev/next sentence controls yet.
- No millisecond/audio-currentTime resume.

Transcript-line jumps and prev/next sentence navigation can be handled in a follow-up aligned with #818.

## Validation

Automated:

- `git diff --check` passed
- `pnpm test tests/playback/resume-position.test.ts` passed
- `pnpm test tests/lib/playback/engine-cursor.test.ts` passed
- `pnpm exec tsc --noEmit` passed
- `pnpm build` passed
- `pnpm lint` passed with existing warnings only
- `pnpm check` passed

Manual server validation:

- Safe speech-only scene resumes from the saved action boundary.
- Completed scenes clear saved resume and start from the beginning.
- Widget scenes do not resume into the middle of widget state.
- Discussion scenes do not resume into the middle of live/session state.
- Video scenes do not restore video `currentTime` or resume mid-video.