### PR TITLE
fix(scene-content): stream content generation requests

### DIFF
--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { callLLM } from '@/lib/ai/llm';
+import { streamLLM } from '@/lib/ai/llm';
 import {
   applyOutlineFallbacks,
   generateSceneContent,
@@ -29,6 +29,14 @@ import { resolveVocationalActive } from '@/lib/config/feature-flags';
 const log = createLogger('Scene Content API');
 
 export const maxDuration = 300;
+
+async function readTextStream(stream: AsyncIterable<string>): Promise<string> {
+  let text = '';
+  for await (const chunk of stream) {
+    text += chunk;
+  }
+  return text;
+}
 
 export async function POST(req: NextRequest) {
   let outlineTitle: string | undefined;
@@ -101,7 +109,7 @@ export async function POST(req: NextRequest) {
       images?: Array<{ id: string; src: string }>,
     ): Promise<string> => {
       if (images?.length && hasVision) {
-        const result = await callLLM(
+        const result = streamLLM(
           {
             model: languageModel,
             system: systemPrompt,
@@ -115,12 +123,11 @@ export async function POST(req: NextRequest) {
             maxRetries: 0,
           },
           'scene-content',
-          undefined,
           thinkingConfig,
         );
-        return result.text;
+        return readTextStream(result.textStream);
       }
-      const result = await callLLM(
+      const result = streamLLM(
         {
           model: languageModel,
           system: systemPrompt,
@@ -129,10 +136,9 @@ export async function POST(req: NextRequest) {
           maxRetries: 0,
         },
         'scene-content',
-        undefined,
         thinkingConfig,
       );
-      return result.text;
+      return readTextStream(result.textStream);
     };
 
     // ── Apply fallbacks ──

--- a/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
@@ -1,5 +1,5 @@
-/* eslint-disable max-lines */
-/* eslint-disable no-console */
+ 
+ 
 import {
   parse as parsePptxDefault,
   type Shape,

--- a/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
@@ -1,5 +1,3 @@
- 
- 
 import {
   parse as parsePptxDefault,
   type Shape,

--- a/packages/@openmaic/renderer/src/snapshot/index.ts
+++ b/packages/@openmaic/renderer/src/snapshot/index.ts
@@ -196,7 +196,7 @@ export async function slideToPng(
     );
 
     if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
+       
       console.debug('[slideToPng] container ready', {
         innerHTMLLength: container.innerHTML.length,
         imgCount: container.querySelectorAll('img').length,

--- a/packages/@openmaic/renderer/src/snapshot/index.ts
+++ b/packages/@openmaic/renderer/src/snapshot/index.ts
@@ -196,7 +196,6 @@ export async function slideToPng(
     );
 
     if (process.env.NODE_ENV !== 'production') {
-       
       console.debug('[slideToPng] container ready', {
         innerHTMLLength: container.innerHTML.length,
         imgCount: container.querySelectorAll('img').length,

--- a/tests/generation/scene-api-retry-boundary.test.ts
+++ b/tests/generation/scene-api-retry-boundary.test.ts
@@ -3,6 +3,7 @@ import type { SceneOutline } from '@/lib/types/generation';
 
 const mocks = vi.hoisted(() => ({
   callLLM: vi.fn(),
+  streamLLM: vi.fn(),
   resolveModelFromRequest: vi.fn(),
   applyOutlineFallbacks: vi.fn(),
   generateSceneContent: vi.fn(),
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/ai/llm', () => ({
   callLLM: mocks.callLLM,
+  streamLLM: mocks.streamLLM,
 }));
 
 vi.mock('@/lib/server/resolve-model', () => ({
@@ -63,6 +65,11 @@ describe('scene API retry boundary', () => {
     });
     mocks.applyOutlineFallbacks.mockImplementation((value) => value);
     mocks.callLLM.mockResolvedValue({ text: 'ok' });
+    mocks.streamLLM.mockReturnValue({
+      textStream: (async function* () {
+        yield 'ok';
+      })(),
+    });
     mocks.resolveVocationalActive.mockReturnValue(false);
   });
 
@@ -78,7 +85,7 @@ describe('scene API retry boundary', () => {
     const body = await response.json();
 
     expect(body.success).toBe(true);
-    expect(mocks.callLLM.mock.calls[0][0].maxRetries).toBe(0);
+    expect(mocks.streamLLM.mock.calls[0][0].maxRetries).toBe(0);
   });
 
   it('disables AI SDK retries for scene-actions model calls', async () => {
@@ -115,7 +122,11 @@ describe('scene API retry boundary', () => {
       await aiCall('system', 'user');
       return { elements: [], remark: 'ok' };
     });
-    mocks.callLLM.mockRejectedValueOnce(unauthorized);
+    mocks.streamLLM.mockReturnValueOnce({
+      textStream: (async function* () {
+        throw unauthorized;
+      })(),
+    });
 
     const { POST } = await import('@/app/api/generate/scene-content/route');
     const response = await POST(mockRequest());
@@ -136,7 +147,11 @@ describe('scene API retry boundary', () => {
       await aiCall('system', 'user');
       return { elements: [], remark: 'ok' };
     });
-    mocks.callLLM.mockRejectedValueOnce(unavailable);
+    mocks.streamLLM.mockReturnValueOnce({
+      textStream: (async function* () {
+        throw unavailable;
+      })(),
+    });
 
     const { POST } = await import('@/app/api/generate/scene-content/route');
     const response = await POST(mockRequest());


### PR DESCRIPTION

## Summary

This PR fixes scene content generation failures where long-running model calls can hit a provider-side headers timeout before returning a complete response.

The scene-content route now uses the existing `streamLLM` wrapper and aggregates `textStream` back into the same complete-string shape expected by the existing JSON parsers. The API response contract remains unchanged.

AI-assisted PR.

## Related Issues

Fixes #847

## Changes

- Switch `/api/generate/scene-content` model calls from `callLLM` to `streamLLM`.
- Aggregate streamed text server-side before passing it to the existing scene content parser.
- Preserve `maxRetries: 0` so scene-content retry behavior stays controlled by the existing outer generation retry flow.
- Update retry-boundary tests to cover the streaming call path and upstream 401/503 error propagation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Configure a model route for scene content, for example `glm:glm-5.1`.
2. Generate a course scene that previously waited for a full non-streaming response and failed with `Headers Timeout Error`.
3. Confirm `/api/generate/scene-content` now uses the streaming model path while still returning the same JSON response shape.

### What you personally verified

- The route still returns the existing `apiSuccess({ content, effectiveOutline })` shape.
- Vision and non-vision scene-content paths both use streaming.
- Upstream 401 and 503 errors are still surfaced through the existing `llmApiError` handling.
- `maxRetries: 0` is still passed to the model call to avoid retry multiplication.
- No UI behavior or user-facing text was changed.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

Local verification run:

```bash
pnpm exec prettier --check app/api/generate/scene-content/route.ts tests/generation/scene-api-retry-boundary.test.ts
pnpm exec eslint --fix app/api/generate/scene-content/route.ts tests/generation/scene-api-retry-boundary.test.ts
npx tsc --noEmit
pnpm vitest run tests/generation/scene-api-retry-boundary.test.ts
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
