### PR TITLE
chore(renderer): machine-enforce the @openmaic/renderer import boundary

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,11 +49,18 @@ const eslintConfig = defineConfig([
     },
   },
   // Package boundary (machine-enforced): @openmaic/renderer is a standalone,
-  // app-agnostic package that depends only on @openmaic/dsl plus its declared
-  // peers. It must never reach back into the host app through the `@/…` path
-  // alias, so a deadline can't punch a "temporary" store/undo/media dependency
-  // through the package API. Host concerns (document + undo ownership, media
-  // resolution, i18n, hotkeys) are injected via props/callbacks instead.
+  // app-agnostic package. It must never reach back into the host app through
+  // the `@/…` path alias, so a deadline can't punch a "temporary"
+  // store/undo/media dependency through the package API. Host concerns
+  // (document + undo ownership, media resolution, i18n, hotkeys) are injected
+  // via props/callbacks instead.
+  //
+  // Coverage: `no-restricted-imports` handles static `import` / `export … from`
+  // (including `import type`); `no-restricted-syntax` closes the dynamic
+  // `import('@/…')` and `require('@/…')` bypasses, which the base rule does not
+  // catch (it registers no ImportExpression/CallExpression handler). Relative
+  // parent escapes (`../../app`) are outside this alias rule's scope; the
+  // package's own standalone `tsc` (rootDir: src) rejects those at build time.
   {
     files: ['packages/@openmaic/renderer/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
     rules: {
@@ -67,6 +74,19 @@ const eslintConfig = defineConfig([
                 '@openmaic/renderer must not import from the host app (@/…). Depend only on @openmaic/dsl and declared peers; inject host concerns (stores, undo, media resolution, i18n, hotkeys) via props/callbacks.',
             },
           ],
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'ImportExpression[source.value=/^@\\//]',
+          message:
+            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector: "CallExpression[callee.name='require'][arguments.0.value=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,8 @@ const eslintConfig = defineConfig([
             '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
         },
         {
-          selector: "CallExpression[callee.name='require'][arguments.0.quasis.0.value.cooked=/^@\\//]",
+          selector:
+            "CallExpression[callee.name='require'][arguments.0.quasis.0.value.cooked=/^@\\//]",
           message:
             '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,29 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // Package boundary (machine-enforced): @openmaic/renderer is a standalone,
+  // app-agnostic package that depends only on @openmaic/dsl plus its declared
+  // peers. It must never reach back into the host app through the `@/…` path
+  // alias, so a deadline can't punch a "temporary" store/undo/media dependency
+  // through the package API. Host concerns (document + undo ownership, media
+  // resolution, i18n, hotkeys) are injected via props/callbacks instead.
+  {
+    files: ['packages/@openmaic/renderer/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/*', '@/**'],
+              message:
+                '@openmaic/renderer must not import from the host app (@/…). Depend only on @openmaic/dsl and declared peers; inject host concerns (stores, undo, media resolution, i18n, hotkeys) via props/callbacks.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,9 +61,11 @@ const eslintConfig = defineConfig([
   //
   // - `no-restricted-imports` covers static `import` / `export … from`
   //   (including `import type`).
-  // - `no-restricted-syntax` covers the dynamic call forms the base rule can't
-  //   see — `import()`, `require()`, `require.resolve()` — on single string- or
-  //   template-literal specifiers.
+  // - `no-restricted-syntax` covers the resolve/import call forms the base rule
+  //   can't see — `import()`, `require()`, `require.resolve()`,
+  //   `import.meta.resolve()` — on single string- or template-literal specifiers.
+  //   Together with the static forms above, this is the complete set of ways to
+  //   reference a module by a single literal specifier.
   //
   // Deliberately out of scope (not decidable by lint, and evasion-only): a
   // specifier assembled from non-literal parts — `import('@/lib/' + x)`,
@@ -119,6 +121,18 @@ const eslintConfig = defineConfig([
             "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
           message:
             '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.type='MetaProperty'][callee.property.name='resolve'][arguments.0.value=/^@\\//]",
+          message:
+            '@openmaic/renderer must not import.meta.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.type='MetaProperty'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
+          message:
+            '@openmaic/renderer must not import.meta.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,12 +55,21 @@ const eslintConfig = defineConfig([
   // (document + undo ownership, media resolution, i18n, hotkeys) are injected
   // via props/callbacks instead.
   //
-  // Coverage: `no-restricted-imports` handles static `import` / `export … from`
-  // (including `import type`) with an import-specific message; `no-restricted-syntax`
-  // then matches any `@/…` string the package authors, which covers dynamic
-  // import()/require()/require.resolve() in any quote style and string-concatenation
-  // operands. Relative parent escapes (`../../app`) are outside this alias rule's
-  // scope; the package's own standalone `tsc` (rootDir: src) rejects those at build time.
+  // Scope: reject *app imports* via the `@/…` alias — precisely, in import
+  // contexts only, so a legitimate `@/…` string that is not an import is not a
+  // false positive.
+  //
+  // - `no-restricted-imports` covers static `import` / `export … from`
+  //   (including `import type`).
+  // - `no-restricted-syntax` covers the dynamic call forms the base rule can't
+  //   see — `import()`, `require()`, `require.resolve()` — on single string- or
+  //   template-literal specifiers.
+  //
+  // Deliberately out of scope (not decidable by lint, and evasion-only): a
+  // specifier assembled from non-literal parts — `import('@/lib/' + x)`,
+  // `import(dynamicVar)`, an aliased `require` — and relative parent escapes
+  // (`../../app`). These are caught by building/publishing the package in
+  // isolation (only `@openmaic/dsl` + declared peers external), not by this rule.
   {
     files: ['packages/@openmaic/renderer/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
     rules: {
@@ -76,31 +85,40 @@ const eslintConfig = defineConfig([
           ],
         },
       ],
-      // Cover every statically-analyzable `@/…` dynamic form: string-literal and
-      // template-literal sources, for `import()`, `require()` and `require.resolve()`.
-      // (Genuinely computed sources like `import(someVar)` are undecidable by lint
-      // and out of scope for any rule — the boundary catches all static forms.)
-      // Everything the import rule can't see: match the `@/…` string prefix
-      // wherever it is authored, rather than chasing individual call shapes.
-      // This covers dynamic `import()` / `require()` / `require.resolve()` in any
-      // quote style AND string-concatenation operands (`'@/lib/' + x` — the
-      // `'@/lib/'` literal is itself flagged). The package has zero legitimate
-      // `@/…` strings, so there are no false positives. The only residual is a
-      // specifier assembled entirely from non-`@/` pieces (`'@' + '/x'`, or a
-      // variable) — undecidable by any lint rule and reachable only by deliberate
-      // evasion, which `eslint-disable` allows anyway; the package's standalone
-      // build is the backstop there.
       'no-restricted-syntax': [
         'error',
         {
-          selector: 'Literal[value=/^@\\//]',
+          selector: 'ImportExpression[source.value=/^@\\//]',
           message:
-            '@openmaic/renderer must not reference a host-app path (@/…) — this also covers dynamic import()/require()/require.resolve() and string-concatenation operands, not only static imports. Inject host concerns via props/callbacks.',
+            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
         },
         {
-          selector: 'TemplateElement[value.cooked=/^@\\//]',
+          selector: 'ImportExpression[source.quasis.0.value.cooked=/^@\\//]',
           message:
-            '@openmaic/renderer must not reference a host-app path (@/…) in a template literal. Inject host concerns via props/callbacks.',
+            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector: "CallExpression[callee.name='require'][arguments.0.value=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.name='require'][arguments.0.quasis.0.value.cooked=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.value=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,6 +76,10 @@ const eslintConfig = defineConfig([
           ],
         },
       ],
+      // Cover every statically-analyzable `@/…` dynamic form: string-literal and
+      // template-literal sources, for `import()`, `require()` and `require.resolve()`.
+      // (Genuinely computed sources like `import(someVar)` are undecidable by lint
+      // and out of scope for any rule — the boundary catches all static forms.)
       'no-restricted-syntax': [
         'error',
         {
@@ -84,9 +88,31 @@ const eslintConfig = defineConfig([
             '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
         },
         {
+          selector: 'ImportExpression[source.quasis.0.value.cooked=/^@\\//]',
+          message:
+            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
           selector: "CallExpression[callee.name='require'][arguments.0.value=/^@\\//]",
           message:
             '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector: "CallExpression[callee.name='require'][arguments.0.quasis.0.value.cooked=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.value=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
+          message:
+            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,84 +55,34 @@ const eslintConfig = defineConfig([
   // (document + undo ownership, media resolution, i18n, hotkeys) are injected
   // via props/callbacks instead.
   //
-  // Scope: reject *app imports* via the `@/…` alias — precisely, in import
-  // contexts only, so a legitimate `@/…` string that is not an import is not a
-  // false positive.
+  // Policy: the package must contain NO `@/…` path-alias string at all. `@/` is
+  // exclusively the host-app import alias, and the package authors zero such
+  // strings, so we match the string prefix wherever it appears rather than
+  // chasing individual call shapes. This is complete against every single-literal
+  // module-reference form — static / `import type` / `export … from`, dynamic
+  // `import()`, `require()`, `require.resolve()`, `import.meta.resolve()`, their
+  // computed-property (`require['resolve']`) and template-literal variants, and
+  // string-concatenation operands (`'@/lib/' + x`) — because all of them contain
+  // a `@/` literal. One rule, one report per violation.
   //
-  // - `no-restricted-imports` covers static `import` / `export … from`
-  //   (including `import type`).
-  // - `no-restricted-syntax` covers the resolve/import call forms the base rule
-  //   can't see — `import()`, `require()`, `require.resolve()`,
-  //   `import.meta.resolve()` — on single string- or template-literal specifiers.
-  //   Together with the static forms above, this is the complete set of ways to
-  //   reference a module by a single literal specifier.
-  //
-  // Deliberately out of scope (not decidable by lint, and evasion-only): a
-  // specifier assembled from non-literal parts — `import('@/lib/' + x)`,
-  // `import(dynamicVar)`, an aliased `require` — and relative parent escapes
-  // (`../../app`). These are caught by building/publishing the package in
+  // Out of scope (undecidable by lint, evasion-only): a specifier assembled
+  // entirely from non-`@/` pieces (`'@' + '/x'`, a variable) and relative parent
+  // escapes (`../../app`). Those are caught by building/publishing the package in
   // isolation (only `@openmaic/dsl` + declared peers external), not by this rule.
   {
     files: ['packages/@openmaic/renderer/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
     rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['@/*', '@/**'],
-              message:
-                '@openmaic/renderer must not import from the host app (@/…). Depend only on @openmaic/dsl and declared peers; inject host concerns (stores, undo, media resolution, i18n, hotkeys) via props/callbacks.',
-            },
-          ],
-        },
-      ],
       'no-restricted-syntax': [
         'error',
         {
-          selector: 'ImportExpression[source.value=/^@\\//]',
+          selector: 'Literal[value=/^@\\//]',
           message:
-            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
+            '@openmaic/renderer must not reference a host-app path (@/…). This package authors no `@/…` strings — depend only on @openmaic/dsl and declared peers, and inject host concerns (stores, undo, media resolution, i18n, hotkeys) via props/callbacks.',
         },
         {
-          selector: 'ImportExpression[source.quasis.0.value.cooked=/^@\\//]',
+          selector: 'TemplateElement[value.cooked=/^@\\//]',
           message:
-            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector: "CallExpression[callee.name='require'][arguments.0.value=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.name='require'][arguments.0.quasis.0.value.cooked=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.value=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.object.type='MetaProperty'][callee.property.name='resolve'][arguments.0.value=/^@\\//]",
-          message:
-            '@openmaic/renderer must not import.meta.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.object.type='MetaProperty'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
-          message:
-            '@openmaic/renderer must not import.meta.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
+            '@openmaic/renderer must not reference a host-app path (@/…) in a template literal. Depend only on @openmaic/dsl and declared peers; inject host concerns via props/callbacks.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,11 +56,11 @@ const eslintConfig = defineConfig([
   // via props/callbacks instead.
   //
   // Coverage: `no-restricted-imports` handles static `import` / `export … from`
-  // (including `import type`); `no-restricted-syntax` closes the dynamic
-  // `import('@/…')` and `require('@/…')` bypasses, which the base rule does not
-  // catch (it registers no ImportExpression/CallExpression handler). Relative
-  // parent escapes (`../../app`) are outside this alias rule's scope; the
-  // package's own standalone `tsc` (rootDir: src) rejects those at build time.
+  // (including `import type`) with an import-specific message; `no-restricted-syntax`
+  // then matches any `@/…` string the package authors, which covers dynamic
+  // import()/require()/require.resolve() in any quote style and string-concatenation
+  // operands. Relative parent escapes (`../../app`) are outside this alias rule's
+  // scope; the package's own standalone `tsc` (rootDir: src) rejects those at build time.
   {
     files: ['packages/@openmaic/renderer/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
     rules: {
@@ -80,40 +80,27 @@ const eslintConfig = defineConfig([
       // template-literal sources, for `import()`, `require()` and `require.resolve()`.
       // (Genuinely computed sources like `import(someVar)` are undecidable by lint
       // and out of scope for any rule — the boundary catches all static forms.)
+      // Everything the import rule can't see: match the `@/…` string prefix
+      // wherever it is authored, rather than chasing individual call shapes.
+      // This covers dynamic `import()` / `require()` / `require.resolve()` in any
+      // quote style AND string-concatenation operands (`'@/lib/' + x` — the
+      // `'@/lib/'` literal is itself flagged). The package has zero legitimate
+      // `@/…` strings, so there are no false positives. The only residual is a
+      // specifier assembled entirely from non-`@/` pieces (`'@' + '/x'`, or a
+      // variable) — undecidable by any lint rule and reachable only by deliberate
+      // evasion, which `eslint-disable` allows anyway; the package's standalone
+      // build is the backstop there.
       'no-restricted-syntax': [
         'error',
         {
-          selector: 'ImportExpression[source.value=/^@\\//]',
+          selector: 'Literal[value=/^@\\//]',
           message:
-            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
+            '@openmaic/renderer must not reference a host-app path (@/…) — this also covers dynamic import()/require()/require.resolve() and string-concatenation operands, not only static imports. Inject host concerns via props/callbacks.',
         },
         {
-          selector: 'ImportExpression[source.quasis.0.value.cooked=/^@\\//]',
+          selector: 'TemplateElement[value.cooked=/^@\\//]',
           message:
-            '@openmaic/renderer must not dynamically import from the host app (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector: "CallExpression[callee.name='require'][arguments.0.value=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.name='require'][arguments.0.quasis.0.value.cooked=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require() from the host app (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.value=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
-        },
-        {
-          selector:
-            "CallExpression[callee.object.name='require'][callee.property.name='resolve'][arguments.0.quasis.0.value.cooked=/^@\\//]",
-          message:
-            '@openmaic/renderer must not require.resolve() a host-app path (@/…). Inject host concerns via props/callbacks.',
+            '@openmaic/renderer must not reference a host-app path (@/…) in a template literal. Inject host concerns via props/callbacks.',
         },
       ],
     },


### PR DESCRIPTION
Adds a package-scoped ESLint boundary for `@openmaic/renderer`: a `files`-scoped `no-restricted-imports` rule that bans host-app imports via the `@/…` path alias inside `packages/@openmaic/renderer/**`, enforced by the existing `pnpm lint` CI step.

## Why

`@openmaic/renderer` depends only on `@openmaic/dsl` and its declared peers. Host concerns (document/undo ownership, media resolution, i18n, hotkeys) are injected via props/callbacks, not imported. This is the machine-enforced counterpart of the renderer v2 editing-surface boundary (#720 Phase 3, scoped in #851): with the rule in place, a deadline can't punch a "temporary" store dependency through the package API later.

This is gate item 2 of #851 ("package-side lint/CI rule rejects app imports (`@/…`)").

## Scope

The package imports zero `@/…` today, so the rule is purely additive — no source changes required.

## Verification

- In-package `@/…` imports (deep `@/lib/store` and shallow `@/foo`) now fail lint.
- App-land files importing `@/…` are unaffected — the rule is scoped to `packages/@openmaic/renderer/**`.
- Existing package source lints clean under the rule.

Refs #851, #720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)