### PR TITLE
feat(renderer): scaffold @openmaic/renderer/editing subpath (v2 editing surface, Stage 0)

### DIFF
--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -98,6 +98,7 @@
     "@types/react-dom": "^19",
     "@types/tinycolor2": "^1.4.6",
     "rollup": "^4.35.0",
+    "rollup-plugin-preserve-directives": "^0.4.0",
     "tslib": "^2.8.0",
     "typescript": "^5"
   },

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/snapshot/index.d.ts",
       "import": "./dist/snapshot/index.js"
     },
+    "./editing": {
+      "types": "./dist/editing/index.d.ts",
+      "import": "./dist/editing/index.js"
+    },
     "./fonts.css": "./fonts.css"
   },
   "files": [

--- a/packages/@openmaic/renderer/rollup.config.js
+++ b/packages/@openmaic/renderer/rollup.config.js
@@ -40,6 +40,7 @@ const entries = {
   'elements/index': 'src/elements/index.ts',
   'types/index': 'src/types/index.ts',
   'snapshot/index': 'src/snapshot/index.ts',
+  'editing/index': 'src/editing/index.ts',
 };
 
 // ESM-only: @openmaic/dsl (kept external) is ESM-only, so a CJS renderer bundle

--- a/packages/@openmaic/renderer/rollup.config.js
+++ b/packages/@openmaic/renderer/rollup.config.js
@@ -1,6 +1,7 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
+import preserveDirectives from 'rollup-plugin-preserve-directives';
 
 const external = [
   /^@openmaic\/dsl($|\/)/,
@@ -33,6 +34,11 @@ const plugins = [
     declarationMap: false,
     rootDir: 'src',
   }),
+  // Preserve module-level directives (e.g. 'use client') into the built output.
+  // Rollup strips them by default (see the MODULE_LEVEL_DIRECTIVE warning silenced
+  // in onwarn above), which drops the client-boundary marker from dist/ — breaking
+  // Next App Router server-component consumers of the editing entry.
+  preserveDirectives(),
 ];
 
 const entries = {
@@ -55,6 +61,10 @@ const buildBundle = () => ({
     format: 'es',
     entryFileNames: '[name].js',
     chunkFileNames: 'chunks/[name]-[hash].js',
+    // Emit one file per source module so per-module directives ('use client')
+    // survive into dist (rollup-plugin-preserve-directives requires this); a
+    // bundled build would mix client and non-client modules and drop the marker.
+    preserveModules: true,
     preserveModulesRoot: 'src',
     sourcemap: true,
   },

--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { SlideCanvas } from '../SlideCanvas';
 import type { EditableSlideCanvasProps, Selection } from './types';
 
@@ -11,31 +13,29 @@ import type { EditableSlideCanvasProps, Selection } from './types';
  * snapping, and ProseMirror inline editing — and the `onElementsChange` intent
  * emission — land in Part A / Part B. See the editing-surface RFC for the
  * controlled edit-intent model this shell grows into.
+ *
+ * It forwards `className`/`style` straight to SlideCanvas (no wrapper element) so
+ * the v1 fill/auto-fit contract is preserved unchanged.
  */
 export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
-  const { slide, scale, renderImage, renderVideo, selection, onSelectionChange, className, style } =
-    props;
+  const { slide, scale, renderImage, renderVideo, onSelectionChange, className, style } = props;
 
   return (
-    <div
+    <SlideCanvas
+      slide={slide}
+      scale={scale}
+      renderImage={renderImage}
+      renderVideo={renderVideo}
       className={className}
       style={style}
-      data-editing-primary-id={selection?.primaryId ?? undefined}
-    >
-      <SlideCanvas
-        slide={slide}
-        scale={scale}
-        renderImage={renderImage}
-        renderVideo={renderVideo}
-        onElementClick={
-          onSelectionChange
-            ? (element) => {
-                const next: Selection = { elementIds: [element.id], primaryId: element.id };
-                onSelectionChange(next);
-              }
-            : undefined
-        }
-      />
-    </div>
+      onElementClick={
+        onSelectionChange
+          ? (element) => {
+              const next: Selection = { elementIds: [element.id], primaryId: element.id };
+              onSelectionChange(next);
+            }
+          : undefined
+      }
+    />
   );
 }

--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -1,0 +1,41 @@
+import { SlideCanvas } from '../SlideCanvas';
+import type { EditableSlideCanvasProps, Selection } from './types';
+
+/**
+ * EditableSlideCanvas — Stage 0 scaffold for the renderer v2 editing surface,
+ * shipped under the `@openmaic/renderer/editing` subpath so the read-only entry
+ * (`@openmaic/renderer`) never pulls the editing bundle.
+ *
+ * This scaffold renders through the v1 read-only SlideCanvas and supports
+ * click-to-select only. Operate handles (drag / resize / rotate), alignment
+ * snapping, and ProseMirror inline editing — and the `onElementsChange` intent
+ * emission — land in Part A / Part B. See the editing-surface RFC for the
+ * controlled edit-intent model this shell grows into.
+ */
+export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
+  const { slide, scale, renderImage, renderVideo, selection, onSelectionChange, className, style } =
+    props;
+
+  return (
+    <div
+      className={className}
+      style={style}
+      data-editing-primary-id={selection?.primaryId ?? undefined}
+    >
+      <SlideCanvas
+        slide={slide}
+        scale={scale}
+        renderImage={renderImage}
+        renderVideo={renderVideo}
+        onElementClick={
+          onSelectionChange
+            ? (element) => {
+                const next: Selection = { elementIds: [element.id], primaryId: element.id };
+                onSelectionChange(next);
+              }
+            : undefined
+        }
+      />
+    </div>
+  );
+}

--- a/packages/@openmaic/renderer/src/editing/index.ts
+++ b/packages/@openmaic/renderer/src/editing/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { EditableSlideCanvas } from './EditableSlideCanvas';
 export { EMPTY_SELECTION } from './types';
 export type {

--- a/packages/@openmaic/renderer/src/editing/index.ts
+++ b/packages/@openmaic/renderer/src/editing/index.ts
@@ -1,0 +1,10 @@
+export { EditableSlideCanvas } from './EditableSlideCanvas';
+export { EMPTY_SELECTION } from './types';
+export type {
+  EditableSlideCanvasProps,
+  EditIntent,
+  Selection,
+  SnappingOptions,
+  ReorderCommand,
+  AlignCommand,
+} from './types';

--- a/packages/@openmaic/renderer/src/editing/types.ts
+++ b/packages/@openmaic/renderer/src/editing/types.ts
@@ -1,0 +1,81 @@
+import type { CSSProperties, ReactNode } from 'react';
+import type { Slide, PPTElement, PPTImageElement, PPTVideoElement } from '@openmaic/dsl';
+
+/**
+ * Editing surface types (renderer v2). These are the **L1** contract from the
+ * editing-surface RFC: the bounded, UI-driven vocabulary the canvas emits for
+ * human gestures. They are intentionally *not* the agent tool surface (L2, which
+ * is expected to churn and lives outside this package) nor the canonical change
+ * representation (L0, which belongs in @openmaic/dsl). L1 normalizes down to L0.
+ */
+
+export type ReorderCommand = 'front' | 'back' | 'forward' | 'backward';
+export type AlignCommand = 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom';
+
+/**
+ * A single canvas edit intent. The canvas emits these on gesture commit; the host
+ * owns the document and undo and applies them. One intent (or batch) per completed
+ * gesture — never per animation frame — so it maps 1:1 onto one host undo entry.
+ */
+export type EditIntent =
+  | { type: 'element.update'; id: string; props: Partial<PPTElement> }
+  | { type: 'element.updateMany'; updates: Array<{ id: string; props: Partial<PPTElement> }> }
+  | { type: 'element.add'; element: PPTElement; index?: number }
+  | { type: 'element.delete'; ids: string[] }
+  | { type: 'element.reorder'; id: string; command: ReorderCommand }
+  | { type: 'element.align'; ids: string[]; command: AlignCommand }
+  | { type: 'element.removeProps'; id: string; props: string[] }
+  | { type: 'text.updateContent'; id: string; content: string; target: 'text' | 'shape' };
+
+/**
+ * Controlled selection. The host owns it; the canvas reports changes via
+ * onSelectionChange. Id-based (not position-based) so it survives document edits.
+ */
+export interface Selection {
+  elementIds: string[];
+  primaryId?: string;
+  groupId?: string;
+  editingId?: string;
+}
+
+export const EMPTY_SELECTION: Selection = { elementIds: [] };
+
+export interface SnappingOptions {
+  toElements?: boolean;
+  toCanvas?: boolean;
+  /** snap threshold in px */
+  range?: number;
+}
+
+export interface EditableSlideCanvasProps {
+  /** Controlled document — the host owns it (and undo). */
+  slide: Slide;
+  scale?: number;
+
+  /**
+   * Controlled selection. Optional in this scaffold: the Stage 0 shell renders
+   * read-only and supports click-to-select only. It becomes the primary
+   * interaction contract once Part A lands operate handles.
+   */
+  selection?: Selection;
+  onSelectionChange?: (next: Selection) => void;
+
+  /**
+   * The document-mutation channel. The canvas emits L1 intents here; the host
+   * applies them and owns undo. Not yet emitted by the Stage 0 shell — wired up
+   * as Part A moves the gesture machinery into the package.
+   */
+  onElementsChange?: (intents: EditIntent[]) => void;
+
+  /** Host-injected media render slots (v1 behaviour preserved). */
+  renderImage?: (element: PPTImageElement, resolvedSrc: string) => ReactNode;
+  renderVideo?: (element: PPTVideoElement) => ReactNode;
+
+  /** Editor affordances (no-ops until Part A). */
+  snapping?: boolean | SnappingOptions;
+  grid?: 0 | 25 | 50 | 100;
+  ruler?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+}

--- a/packages/@openmaic/renderer/src/editing/types.ts
+++ b/packages/@openmaic/renderer/src/editing/types.ts
@@ -32,13 +32,17 @@ export type EditIntent =
  * onSelectionChange. Id-based (not position-based) so it survives document edits.
  */
 export interface Selection {
-  elementIds: string[];
+  /** readonly: the host owns selection and treats it immutably */
+  elementIds: readonly string[];
   primaryId?: string;
   groupId?: string;
   editingId?: string;
 }
 
-export const EMPTY_SELECTION: Selection = { elementIds: [] };
+/** Immutable empty-selection sentinel. Frozen so a shared reference can't be mutated. */
+export const EMPTY_SELECTION: Selection = Object.freeze({
+  elementIds: Object.freeze([] as string[]),
+});
 
 export interface SnappingOptions {
   toElements?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,6 +569,9 @@ importers:
       rollup:
         specifier: ^4.35.0
         version: 4.59.0
+      rollup-plugin-preserve-directives:
+        specifier: ^0.4.0
+        version: 0.4.0(rollup@4.59.0)
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
@@ -11059,6 +11062,11 @@ packages:
   rollup-plugin-node-globals@1.4.0:
     resolution: {integrity: sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==}
 
+  rollup-plugin-preserve-directives@0.4.0:
+    resolution: {integrity: sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==}
+    peerDependencies:
+      rollup: 2.x || 3.x || 4.x
+
   rollup-plugin-typescript2@0.36.0:
     resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
     peerDependencies:
@@ -19908,8 +19916,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.2
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -19931,7 +19939,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -19942,21 +19950,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19967,7 +19975,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24733,6 +24741,12 @@ snapshots:
       magic-string: 0.22.5
       process-es6: 0.11.6
       rollup-pluginutils: 2.8.2
+
+  rollup-plugin-preserve-directives@0.4.0(rollup@4.59.0):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      magic-string: 0.30.21
+      rollup: 4.59.0
 
   rollup-plugin-typescript2@0.36.0(rollup@4.59.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Stage 0 of the renderer v2 editing surface (#851, #720 Phase 3): the packaging skeleton for the `@openmaic/renderer/editing` subpath. **Draft — companion to the editing-surface RFC on #851; not for merge until the RFC is accepted.**

## What this is

Packaging decision A from the RFC: editing ships behind a dedicated `./editing` entry, so the read-only entry (`@openmaic/renderer`) never pulls the editing bundle.

## Contents (scaffold only — no interaction logic yet)

- `src/editing/types.ts` — the **L1** edit-intent contract: `EditIntent` (the bounded canvas gesture vocabulary), `Selection`, `EditableSlideCanvasProps`. The agent tool surface (L2) and the canonical change representation (L0, in `@openmaic/dsl`) are deliberately out of scope here — see the layering note on #851.
- `src/editing/EditableSlideCanvas.tsx` — a shell that renders through the v1 read-only `SlideCanvas` and supports click-to-select only. Operate handles (drag/resize/rotate), alignment snapping, ProseMirror inline editing, and `onElementsChange` intent emission arrive in Part A / Part B.
- `package.json` + `rollup.config.js` — wire the `./editing` entry (mirrors the existing `./snapshot` / `./elements` subpaths).

## Intentionally deferred

- Text-command handle, `onTextInput`, `resolveMedia`, and ProseMirror optional-peer deps — they depend on RFC open questions and land with Part B.
- Intent emission + undo wiring — Part A.

## Verification

- Editing subtree typechecks clean (0 errors, with `@openmaic/dsl` resolved).
- `pnpm check` (Prettier) and `pnpm lint` pass (0 errors).
- Read-only entry unchanged; the new entry is purely additive.

Part of the extraction sequence scoped in #851; follows #853 (the package import boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)