### PR TITLE
feat(storage): scaffold @openmaic/storage — KV + asset primitives (browser) (#857)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,6 +87,30 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // Package boundary (machine-enforced): @openmaic/storage is a standalone,
+  // app-agnostic persistence package. Same policy as the @openmaic/renderer
+  // boundary above — it must contain NO `@/…` host-app path-alias string, so a
+  // deadline can't punch a "temporary" host dependency through the package API.
+  // It depends only on @openmaic/dsl; host wiring (which store persists where)
+  // lives in the app, which imports the package, never the reverse.
+  {
+    files: ['packages/@openmaic/storage/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/^@\\//]',
+          message:
+            '@openmaic/storage must not reference a host-app path (@/…). This package authors no `@/…` strings — depend only on @openmaic/dsl. The app wires its stores through the package, not the reverse.',
+        },
+        {
+          selector: 'TemplateElement[value.cooked=/^@\\//]',
+          message:
+            '@openmaic/storage must not reference a host-app path (@/…) in a template literal. Depend only on @openmaic/dsl.',
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.9.0"
   },
   "scripts": {
-    "postinstall": "cd packages/mathml2omml && npm run build && cd ../pptxgenjs && npm run build && cd ../@openmaic/dsl && pnpm run build && cd ../importer && pnpm run build && cd ../renderer && pnpm run build && cd ../../.. && node scripts/sync-maic-importer.mjs",
+    "postinstall": "cd packages/mathml2omml && npm run build && cd ../pptxgenjs && npm run build && cd ../@openmaic/dsl && pnpm run build && cd ../storage && pnpm run build && cd ../importer && pnpm run build && cd ../renderer && pnpm run build && cd ../../.. && node scripts/sync-maic-importer.mjs",
     "sync:maic-importer": "node scripts/sync-maic-importer.mjs",
     "dev": "next dev",
     "build": "node scripts/assert-vendor-maic-importer.mjs && next build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.9.0"
   },
   "scripts": {
-    "postinstall": "cd packages/mathml2omml && npm run build && cd ../pptxgenjs && npm run build && cd ../@openmaic/dsl && pnpm run build && cd ../storage && pnpm run build && cd ../importer && pnpm run build && cd ../renderer && pnpm run build && cd ../../.. && node scripts/sync-maic-importer.mjs",
+    "postinstall": "cd packages/mathml2omml && npm run build && cd ../pptxgenjs && npm run build && cd ../@openmaic/dsl && pnpm run build && cd ../importer && pnpm run build && cd ../renderer && pnpm run build && cd ../../.. && node scripts/sync-maic-importer.mjs",
     "sync:maic-importer": "node scripts/sync-maic-importer.mjs",
     "dev": "next dev",
     "build": "node scripts/assert-vendor-maic-importer.mjs && next build",

--- a/packages/@openmaic/dsl/src/index.ts
+++ b/packages/@openmaic/dsl/src/index.ts
@@ -30,3 +30,4 @@ export * from './action.js';
 export * from './validate.js';
 export * from './normalize.js';
 export * from './version.js';
+export * from './storage.js';

--- a/packages/@openmaic/dsl/src/storage.ts
+++ b/packages/@openmaic/dsl/src/storage.ts
@@ -1,0 +1,61 @@
+/**
+ * The asset-storage seam the DSL owns the *shape* of.
+ *
+ * Large binaries (generated images / audio / video) never live inside a DSL
+ * document — a document embeds only a stable {@link AssetRef}, and a
+ * {@link StorageProvider} resolves that ref to a URL at render time. The
+ * indirection is what keeps a document portable: a raw URL would bake in a
+ * particular provider and an expiry assumption, so it cannot travel with the
+ * document to another runtime. `@openmaic/renderer` already consumes resolved
+ * URLs via its media slots; `@openmaic/exporter` will consume the set of refs a
+ * document touches as its asset manifest.
+ *
+ * The DSL owns only this interface (the contract). Concrete backends —
+ * IndexedDB + object URLs in the browser, object storage / CDN on a server —
+ * live in `@openmaic/storage`, keeping this package dependency- and DOM-free.
+ */
+
+/**
+ * A stable, backend-agnostic handle to a stored asset. A plain string so it
+ * embeds cleanly in DSL documents (e.g. `PPTImageElement.src`,
+ * `PPTVideoElement.mediaRef`). Opaque to consumers: only the issuing
+ * {@link StorageProvider} interprets it.
+ */
+export type AssetRef = string;
+
+/** Optional metadata recorded alongside an asset. */
+export interface AssetMeta {
+  /** MIME type, e.g. `image/png`. */
+  contentType?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The minimal structural view of a binary blob the storage contract needs,
+ * satisfied by the platform `Blob` (browser and Node ≥18) without binding this
+ * pure package to the DOM lib. Backends in `@openmaic/storage` accept a real
+ * `Blob`; the DSL stays `lib: ES2022` (no DOM) as designed.
+ */
+export interface BinaryBlob {
+  /** Size in bytes. */
+  readonly size: number;
+  /** MIME type (`''` when unknown), mirroring `Blob.type`. */
+  readonly type: string;
+  /** The blob's bytes. */
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+/**
+ * The blob-resolution contract: store bytes, get back a stable ref, and resolve
+ * a ref to a URL usable as an `<img>` / `<audio>` / `<video>` `src`.
+ * Implementations decide the ref scheme (content-addressed hashing is
+ * recommended so identical bytes de-duplicate).
+ */
+export interface StorageProvider {
+  /** Store bytes and return a stable ref to them. */
+  put(data: BinaryBlob, meta?: AssetMeta): Promise<AssetRef>;
+  /** Resolve a ref to a URL, or `null` if no asset is stored under it. */
+  resolve(ref: AssetRef): Promise<string | null>;
+  /** Remove the asset stored under a ref (a no-op if none exists). */
+  remove(ref: AssetRef): Promise<void>;
+}

--- a/packages/@openmaic/storage/.gitignore
+++ b/packages/@openmaic/storage/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+*.tsbuildinfo

--- a/packages/@openmaic/storage/LICENSE
+++ b/packages/@openmaic/storage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 THU-MAIC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -1,0 +1,60 @@
+# @openmaic/storage
+
+The MAIC pluggable persistence layer: small, swappable-backend primitives for
+persisting app state, depending only on [`@openmaic/dsl`](../dsl).
+
+The DSL owns _what_ persists (document / runtime shape + validation + migration +
+the asset `StorageProvider` interface). This package owns _where / how_ it
+persists — the primitives and their backends. The pluggable seam is the
+**backend**, not the database driver: a browser backend (zero server, the
+`clone-and-run` default) and, later, an HTTP backend whose server owns a
+database.
+
+## Dependency arrow (acyclic)
+
+```
+@openmaic/storage -> @openmaic/dsl
+```
+
+No dependency on React, zustand, or any host app. Backends take their `Storage`
+/ `IDBFactory` by injection, so the package is app-agnostic and testable without
+a browser.
+
+## What's in here (Part 1)
+
+| Export | Role | Browser backend |
+| --- | --- | --- |
+| `KVStore` | small `device` / `account`-scoped values not owned by the DSL | `BrowserKVStore` over `localStorage` |
+| `StorageProvider` (from `@openmaic/dsl`) | the asset seam: `put(blob) → ref`, `resolve(ref) → url`, `remove(ref)` | `BrowserAssetProvider` over IndexedDB + object URLs |
+| `kvPersistStorage` | adapt a `KVStore` into a zustand `persist` storage | — |
+
+- **Scopes.** `account` values are user data a server-backed deployment syncs
+  across devices; `device` values (theme, locale, layout) never leave the
+  device — every backend honours that, so the scope is part of the primitive,
+  not the backend choice.
+- **Content-addressed assets.** `BrowserAssetProvider` refs are `sha256-<hex>`,
+  so identical bytes de-duplicate to one stored asset. A document embeds only
+  the stable ref; the provider resolves it to a URL at render time (a raw URL
+  would bake in a provider + expiry and break portability).
+
+## Backend equivalence
+
+Each primitive has one implementation-agnostic contract suite
+(`test/kv-contract.ts`, `test/asset-contract.ts`). Every backend is proven by
+running the same suite against it, so a new backend (the coming HTTP one) cannot
+silently diverge from the primitive's semantics.
+
+## Roadmap
+
+- [x] `KVStore` + browser backend; zustand `persist` adapter
+- [x] `StorageProvider` (in `@openmaic/dsl`) + browser `BrowserAssetProvider`
+- [x] implementation-agnostic contract suites
+- [ ] wire the app's zustand stores + ad-hoc `localStorage` through `KVStore`
+- [ ] `DocumentStore` (aggregate ↔ normalized adapter, migrate-on-read via the
+      DSL migration registry, validation gate)
+- [ ] `RuntimeStore`
+- [ ] HTTP backend + reference server + one HTTP contract
+
+## License
+
+MIT

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@openmaic/storage",
+  "version": "0.0.1",
+  "description": "The MAIC pluggable persistence layer: KV / asset primitives with swappable backends (browser default, HTTP later), depending only on @openmaic/dsl.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "pnpm run build"
+  },
+  "keywords": [
+    "maic",
+    "storage",
+    "persistence",
+    "kv",
+    "indexeddb"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/THU-MAIC/OpenMAIC",
+    "directory": "packages/@openmaic/storage"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "dependencies": {
+    "@openmaic/dsl": "workspace:*"
+  },
+  "devDependencies": {
+    "fake-indexeddb": "^6.0.0",
+    "typescript": "^5",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/@openmaic/storage/src/asset/browser.ts
+++ b/packages/@openmaic/storage/src/asset/browser.ts
@@ -1,0 +1,99 @@
+import type { AssetMeta, AssetRef, BinaryBlob, StorageProvider } from '@openmaic/dsl';
+
+export interface BrowserAssetProviderOptions {
+  /** IndexedDB factory. Defaults to the ambient `indexedDB`. Injectable for tests. */
+  indexedDB?: IDBFactory;
+  /** Database name. Defaults to `maic-assets`. */
+  dbName?: string;
+}
+
+const STORE = 'assets';
+
+interface StoredAsset {
+  bytes: ArrayBuffer;
+  contentType: string;
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  const view = new Uint8Array(buffer);
+  let hex = '';
+  for (let i = 0; i < view.length; i++) hex += view[i].toString(16).padStart(2, '0');
+  return hex;
+}
+
+/**
+ * Browser `StorageProvider` backend: bytes live in IndexedDB, and `resolve`
+ * hands back a `blob:` object URL for use as a media `src`. Refs are
+ * content-addressed (`sha256-<hex>`), so identical bytes de-duplicate to one
+ * stored asset and one stable ref.
+ */
+export class BrowserAssetProvider implements StorageProvider {
+  private readonly idb: IDBFactory;
+  private readonly dbName: string;
+  private dbPromise?: Promise<IDBDatabase>;
+  /** ref → object URL, so repeated `resolve` returns one stable URL per asset. */
+  private readonly urls = new Map<AssetRef, string>();
+
+  constructor(options: BrowserAssetProviderOptions = {}) {
+    this.idb = options.indexedDB ?? globalThis.indexedDB;
+    this.dbName = options.dbName ?? 'maic-assets';
+  }
+
+  private openDb(): Promise<IDBDatabase> {
+    this.dbPromise ??= new Promise((resolve, reject) => {
+      const req = this.idb.open(this.dbName, 1);
+      req.onupgradeneeded = () => {
+        if (!req.result.objectStoreNames.contains(STORE)) req.result.createObjectStore(STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    return this.dbPromise;
+  }
+
+  private async tx<T>(
+    mode: IDBTransactionMode,
+    run: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    const db = await this.openDb();
+    return new Promise<T>((resolve, reject) => {
+      const transaction = db.transaction(STORE, mode);
+      const req = run(transaction.objectStore(STORE));
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+      transaction.onabort = () => reject(transaction.error);
+    });
+  }
+
+  private async computeRef(data: BinaryBlob): Promise<{ ref: AssetRef; bytes: ArrayBuffer }> {
+    const bytes = await data.arrayBuffer();
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return { ref: `sha256-${toHex(digest)}`, bytes };
+  }
+
+  async put(data: BinaryBlob, meta?: AssetMeta): Promise<AssetRef> {
+    const { ref, bytes } = await this.computeRef(data);
+    const asset: StoredAsset = { bytes, contentType: meta?.contentType ?? data.type ?? '' };
+    await this.tx('readwrite', (store) => store.put(asset, ref));
+    return ref;
+  }
+
+  async resolve(ref: AssetRef): Promise<string | null> {
+    const cached = this.urls.get(ref);
+    if (cached) return cached;
+    const asset = await this.tx<StoredAsset | undefined>('readonly', (store) => store.get(ref));
+    if (!asset) return null;
+    const url = URL.createObjectURL(new Blob([asset.bytes], { type: asset.contentType }));
+    this.urls.set(ref, url);
+    return url;
+  }
+
+  async remove(ref: AssetRef): Promise<void> {
+    await this.tx('readwrite', (store) => store.delete(ref));
+    const url = this.urls.get(ref);
+    if (url) {
+      URL.revokeObjectURL(url);
+      this.urls.delete(ref);
+    }
+  }
+}

--- a/packages/@openmaic/storage/src/asset/browser.ts
+++ b/packages/@openmaic/storage/src/asset/browser.ts
@@ -92,7 +92,22 @@ export class BrowserAssetProvider implements StorageProvider {
     const { ref, bytes } = await this.computeRef(data);
     const asset: StoredAsset = { bytes, contentType: meta?.contentType ?? data.type ?? '' };
     await this.tx('readwrite', (store) => store.put(asset, ref));
+    // A re-put with the same bytes but different metadata (e.g. a corrected
+    // contentType) overwrites the stored asset; drop any cached object URL for
+    // this ref so resolve() reflects the latest write instead of a stale one.
+    // Without this, resolved MIME would depend on cache warmth (a fresh
+    // provider would see the new type, this one the old).
+    await this.invalidateUrl(ref);
     return ref;
+  }
+
+  /** Revoke and forget the cached object URL for a ref, if any. */
+  private async invalidateUrl(ref: AssetRef): Promise<void> {
+    const pending = this.urls.get(ref);
+    if (!pending) return;
+    this.urls.delete(ref);
+    const url = await pending.catch(() => null);
+    if (url) URL.revokeObjectURL(url);
   }
 
   async resolve(ref: AssetRef): Promise<string | null> {
@@ -122,11 +137,6 @@ export class BrowserAssetProvider implements StorageProvider {
 
   async remove(ref: AssetRef): Promise<void> {
     await this.tx('readwrite', (store) => store.delete(ref));
-    const pending = this.urls.get(ref);
-    if (pending) {
-      this.urls.delete(ref);
-      const url = await pending.catch(() => null);
-      if (url) URL.revokeObjectURL(url);
-    }
+    await this.invalidateUrl(ref);
   }
 }

--- a/packages/@openmaic/storage/src/asset/browser.ts
+++ b/packages/@openmaic/storage/src/asset/browser.ts
@@ -31,8 +31,12 @@ export class BrowserAssetProvider implements StorageProvider {
   private readonly idb: IDBFactory;
   private readonly dbName: string;
   private dbPromise?: Promise<IDBDatabase>;
-  /** ref → object URL, so repeated `resolve` returns one stable URL per asset. */
-  private readonly urls = new Map<AssetRef, string>();
+  /**
+   * ref → the in-flight/settled object-URL resolution. Keyed on the promise so
+   * concurrent `resolve(ref)` calls share one `URL.createObjectURL` (never
+   * orphaning a second URL), and repeated `resolve` returns one stable URL.
+   */
+  private readonly urls = new Map<AssetRef, Promise<string | null>>();
 
   constructor(options: BrowserAssetProviderOptions = {}) {
     this.idb = options.indexedDB ?? globalThis.indexedDB;
@@ -40,13 +44,19 @@ export class BrowserAssetProvider implements StorageProvider {
   }
 
   private openDb(): Promise<IDBDatabase> {
-    this.dbPromise ??= new Promise((resolve, reject) => {
+    // Do NOT cache a rejected open: a transient failure (private-mode IDB, a
+    // one-off VersionError) would otherwise brick the provider for the whole
+    // session. Clear the memo on failure so the next call retries.
+    this.dbPromise ??= new Promise<IDBDatabase>((resolve, reject) => {
       const req = this.idb.open(this.dbName, 1);
       req.onupgradeneeded = () => {
         if (!req.result.objectStoreNames.contains(STORE)) req.result.createObjectStore(STORE);
       };
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
+    }).catch((err) => {
+      this.dbPromise = undefined;
+      throw err;
     });
     return this.dbPromise;
   }
@@ -59,9 +69,16 @@ export class BrowserAssetProvider implements StorageProvider {
     return new Promise<T>((resolve, reject) => {
       const transaction = db.transaction(STORE, mode);
       const req = run(transaction.objectStore(STORE));
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error);
-      transaction.onabort = () => reject(transaction.error);
+      let result: T;
+      req.onsuccess = () => {
+        result = req.result;
+      };
+      // Resolve on commit, not on the request success: a write that succeeds
+      // as a request can still abort at commit (e.g. QuotaExceededError), and
+      // reporting that as success would claim durability the store never gave.
+      transaction.oncomplete = () => resolve(result);
+      transaction.onerror = () => reject(transaction.error ?? req.error);
+      transaction.onabort = () => reject(transaction.error ?? req.error);
     });
   }
 
@@ -81,19 +98,28 @@ export class BrowserAssetProvider implements StorageProvider {
   async resolve(ref: AssetRef): Promise<string | null> {
     const cached = this.urls.get(ref);
     if (cached) return cached;
+    const pending = this.readAsUrl(ref);
+    this.urls.set(ref, pending);
+    // Don't cache a miss: a later put(sameBytes) + resolve must be able to
+    // succeed. Only a real URL stays memoized (and is revoked on remove).
+    const url = await pending;
+    if (url === null) this.urls.delete(ref);
+    return url;
+  }
+
+  private async readAsUrl(ref: AssetRef): Promise<string | null> {
     const asset = await this.tx<StoredAsset | undefined>('readonly', (store) => store.get(ref));
     if (!asset) return null;
-    const url = URL.createObjectURL(new Blob([asset.bytes], { type: asset.contentType }));
-    this.urls.set(ref, url);
-    return url;
+    return URL.createObjectURL(new Blob([asset.bytes], { type: asset.contentType }));
   }
 
   async remove(ref: AssetRef): Promise<void> {
     await this.tx('readwrite', (store) => store.delete(ref));
-    const url = this.urls.get(ref);
-    if (url) {
-      URL.revokeObjectURL(url);
+    const pending = this.urls.get(ref);
+    if (pending) {
       this.urls.delete(ref);
+      const url = await pending.catch(() => null);
+      if (url) URL.revokeObjectURL(url);
     }
   }
 }

--- a/packages/@openmaic/storage/src/asset/browser.ts
+++ b/packages/@openmaic/storage/src/asset/browser.ts
@@ -100,11 +100,18 @@ export class BrowserAssetProvider implements StorageProvider {
     if (cached) return cached;
     const pending = this.readAsUrl(ref);
     this.urls.set(ref, pending);
-    // Don't cache a miss: a later put(sameBytes) + resolve must be able to
-    // succeed. Only a real URL stays memoized (and is revoked on remove).
-    const url = await pending;
-    if (url === null) this.urls.delete(ref);
-    return url;
+    try {
+      const url = await pending;
+      // Don't cache a miss: a later put(sameBytes) + resolve must succeed. Only
+      // a real URL stays memoized (and is revoked on remove).
+      if (url === null) this.urls.delete(ref);
+      return url;
+    } catch (err) {
+      // Don't cache a transient failure either — otherwise every later
+      // resolve(ref) replays the same rejection, defeating openDb's retry.
+      this.urls.delete(ref);
+      throw err;
+    }
   }
 
   private async readAsUrl(ref: AssetRef): Promise<string | null> {

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @openmaic/storage — the MAIC pluggable persistence layer.
+ *
+ * Dependency arrow (kept acyclic): `@openmaic/storage -> @openmaic/dsl` only.
+ * The DSL owns *what* persists (document/runtime shape + validation + migration
+ * + the asset `StorageProvider` interface); this package owns *where/how* it
+ * persists — the KV / asset primitives and their swappable backends. The
+ * pluggable seam is the backend, not the database driver.
+ *
+ * Part 1 ships the browser backends (zero server) and the primitive contracts;
+ * the HTTP backend + reference server and the DocumentStore / RuntimeStore
+ * follow in later parts (see the tracking issue).
+ */
+export type { KVScope, KVStore } from './kv/types.js';
+export { DEFAULT_KV_SCOPE } from './kv/types.js';
+export { BrowserKVStore, type BrowserKVStoreOptions } from './kv/browser.js';
+export { BrowserAssetProvider, type BrowserAssetProviderOptions } from './asset/browser.js';
+
+export {
+  kvPersistStorage,
+  type PersistedValue,
+  type PersistStorageLike,
+} from './zustand/persist.js';
+
+// Re-export the DSL-owned asset contract for convenience, so consumers can get
+// the interface and a backend from one import without reaching into the DSL.
+export type { AssetRef, AssetMeta, BinaryBlob, StorageProvider } from '@openmaic/dsl';

--- a/packages/@openmaic/storage/src/kv/browser.ts
+++ b/packages/@openmaic/storage/src/kv/browser.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_KV_SCOPE, type KVScope, type KVStore } from './types.js';
+
+export interface BrowserKVStoreOptions {
+  /**
+   * Backing `Storage`. Defaults to the ambient `localStorage`. Injectable so
+   * tests pass an isolated instance and callers can point at `sessionStorage`.
+   */
+  storage?: Storage;
+  /**
+   * Key namespace prefix, keeping KV entries from colliding with other
+   * `localStorage` keys the app writes. Defaults to `maic`.
+   */
+  namespace?: string;
+}
+
+/**
+ * Browser `KVStore` backend over a `Storage` (localStorage by default). Both
+ * scopes live in the same `Storage`; the scope is encoded in the key prefix so
+ * `device` and `account` never collide. In a server-backed deployment the
+ * `account` scope is served by a different backend, but `device` stays on a
+ * backend like this one — hence the scope is part of the primitive, not the
+ * backend choice.
+ */
+export class BrowserKVStore implements KVStore {
+  private readonly storage: Storage;
+  private readonly namespace: string;
+
+  constructor(options: BrowserKVStoreOptions = {}) {
+    this.storage = options.storage ?? globalThis.localStorage;
+    this.namespace = options.namespace ?? 'maic';
+  }
+
+  private prefix(scope: KVScope): string {
+    return `${this.namespace}:${scope}:`;
+  }
+
+  private storageKey(key: string, scope: KVScope): string {
+    return this.prefix(scope) + key;
+  }
+
+  async get<T>(key: string, scope: KVScope = DEFAULT_KV_SCOPE): Promise<T | null> {
+    const raw = this.storage.getItem(this.storageKey(key, scope));
+    if (raw === null) return null;
+    return JSON.parse(raw) as T;
+  }
+
+  async set<T>(key: string, value: T, scope: KVScope = DEFAULT_KV_SCOPE): Promise<void> {
+    this.storage.setItem(this.storageKey(key, scope), JSON.stringify(value));
+  }
+
+  async remove(key: string, scope: KVScope = DEFAULT_KV_SCOPE): Promise<void> {
+    this.storage.removeItem(this.storageKey(key, scope));
+  }
+
+  async keys(prefix = '', scope: KVScope = DEFAULT_KV_SCOPE): Promise<string[]> {
+    const scopePrefix = this.prefix(scope);
+    const out: string[] = [];
+    for (let i = 0; i < this.storage.length; i++) {
+      const full = this.storage.key(i);
+      if (full === null || !full.startsWith(scopePrefix)) continue;
+      const key = full.slice(scopePrefix.length);
+      if (key.startsWith(prefix)) out.push(key);
+    }
+    return out;
+  }
+}

--- a/packages/@openmaic/storage/src/kv/browser.ts
+++ b/packages/@openmaic/storage/src/kv/browser.ts
@@ -45,7 +45,15 @@ export class BrowserKVStore implements KVStore {
   }
 
   async set<T>(key: string, value: T, scope: KVScope = DEFAULT_KV_SCOPE): Promise<void> {
-    this.storage.setItem(this.storageKey(key, scope), JSON.stringify(value));
+    const json = JSON.stringify(value);
+    // `JSON.stringify` yields `undefined` for values JSON can't represent
+    // (`undefined`, a function, a symbol). Storing that coerces to the literal
+    // string "undefined", which then throws on read — so treat it as a removal
+    // rather than writing an unreadable entry.
+    if (json === undefined) {
+      return this.remove(key, scope);
+    }
+    this.storage.setItem(this.storageKey(key, scope), json);
   }
 
   async remove(key: string, scope: KVScope = DEFAULT_KV_SCOPE): Promise<void> {

--- a/packages/@openmaic/storage/src/kv/types.ts
+++ b/packages/@openmaic/storage/src/kv/types.ts
@@ -1,0 +1,23 @@
+/**
+ * KV scope. `account` values are user/account data that a server-backed
+ * deployment syncs across devices (provider/model config, profile). `device`
+ * values are machine-local UI state (theme, locale, layout) that must never
+ * leave the device — every backend honours that, so a `device` write stays
+ * local even when `account` writes go to a server.
+ */
+export type KVScope = 'device' | 'account';
+
+/**
+ * Small keyed values not owned by the DSL. The scope defaults to `account`;
+ * pass `device` for machine-local preferences. Values must be JSON-serializable
+ * — the store owns (de)serialization so callers pass and receive plain values.
+ */
+export interface KVStore {
+  get<T>(key: string, scope?: KVScope): Promise<T | null>;
+  set<T>(key: string, value: T, scope?: KVScope): Promise<void>;
+  remove(key: string, scope?: KVScope): Promise<void>;
+  keys(prefix?: string, scope?: KVScope): Promise<string[]>;
+}
+
+/** The default scope used when a caller omits one. */
+export const DEFAULT_KV_SCOPE: KVScope = 'account';

--- a/packages/@openmaic/storage/src/zustand/persist.ts
+++ b/packages/@openmaic/storage/src/zustand/persist.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_KV_SCOPE, type KVScope, type KVStore } from '../kv/types.js';
+
+/**
+ * The `{ state, version }` envelope zustand's `persist` middleware reads and
+ * writes. Mirrored structurally here so this package doesn't depend on zustand —
+ * the returned adapter is assignable to persist's `storage` option by shape.
+ */
+export interface PersistedValue<S> {
+  state: S;
+  version?: number;
+}
+
+/** The subset of zustand's `PersistStorage<S>` this adapter provides. */
+export interface PersistStorageLike<S> {
+  getItem(name: string): Promise<PersistedValue<S> | null>;
+  setItem(name: string, value: PersistedValue<S>): Promise<void>;
+  removeItem(name: string): Promise<void>;
+}
+
+/**
+ * Adapt a {@link KVStore} into a zustand `persist` storage, so a store's
+ * business logic (including its own `version` / `migrate` / `merge`) is
+ * untouched while its bytes move from raw `localStorage` to a KV backend that a
+ * server-backed deployment can sync. Wire it as:
+ *
+ * ```ts
+ * persist(fn, { name: 'settings-storage', storage: kvPersistStorage(kv, 'account') })
+ * ```
+ *
+ * The KVStore owns serialization, so the whole envelope is stored as a
+ * structured value (no double JSON encoding). Scope defaults to `account`; pass
+ * `device` for machine-local stores.
+ */
+export function kvPersistStorage<S>(
+  kv: KVStore,
+  scope: KVScope = DEFAULT_KV_SCOPE,
+): PersistStorageLike<S> {
+  return {
+    getItem: (name) => kv.get<PersistedValue<S>>(name, scope),
+    setItem: (name, value) => kv.set(name, value, scope),
+    removeItem: (name) => kv.remove(name, scope),
+  };
+}

--- a/packages/@openmaic/storage/test/asset-browser.test.ts
+++ b/packages/@openmaic/storage/test/asset-browser.test.ts
@@ -1,0 +1,14 @@
+import { IDBFactory } from 'fake-indexeddb';
+import { BrowserAssetProvider } from '../src/index.js';
+import { blobForObjectUrl } from './setup.js';
+import { runStorageProviderContract } from './asset-contract.js';
+
+runStorageProviderContract(
+  'BrowserAssetProvider',
+  () => new BrowserAssetProvider({ indexedDB: new IDBFactory(), dbName: 'test-assets' }),
+  async (url) => {
+    const b = blobForObjectUrl(url);
+    if (!b) throw new Error(`no blob registered for object URL ${url}`);
+    return new Uint8Array(await b.arrayBuffer());
+  },
+);

--- a/packages/@openmaic/storage/test/asset-browser.test.ts
+++ b/packages/@openmaic/storage/test/asset-browser.test.ts
@@ -1,4 +1,5 @@
 import { IDBFactory } from 'fake-indexeddb';
+import { expect, test } from 'vitest';
 import { BrowserAssetProvider } from '../src/index.js';
 import { blobForObjectUrl } from './setup.js';
 import { runStorageProviderContract } from './asset-contract.js';
@@ -12,3 +13,24 @@ runStorageProviderContract(
     return new Uint8Array(await b.arrayBuffer());
   },
 );
+
+// Backend-specific: the content-addressing contract asserts identical bytes
+// yield the same ref; this asserts they actually collapse to ONE stored row,
+// so a backend that appended duplicates couldn't pass silently.
+test('BrowserAssetProvider stores identical bytes exactly once', async () => {
+  const idb = new IDBFactory();
+  const provider = new BrowserAssetProvider({ indexedDB: idb, dbName: 'dedup-db' });
+  await provider.put(new Blob(['dup me'], { type: 'text/plain' }));
+  await provider.put(new Blob(['dup me'], { type: 'text/plain' }));
+
+  const count = await new Promise<number>((resolve, reject) => {
+    const open = idb.open('dedup-db', 1);
+    open.onsuccess = () => {
+      const req = open.result.transaction('assets', 'readonly').objectStore('assets').count();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    };
+    open.onerror = () => reject(open.error);
+  });
+  expect(count).toBe(1);
+});

--- a/packages/@openmaic/storage/test/asset-browser.test.ts
+++ b/packages/@openmaic/storage/test/asset-browser.test.ts
@@ -14,6 +14,34 @@ runStorageProviderContract(
   },
 );
 
+// A transient failure in resolve() must not be cached: the next resolve(ref)
+// has to retry, not replay the rejection.
+test('BrowserAssetProvider recovers after a transient resolve failure', async () => {
+  const real = new IDBFactory();
+  const ref = await new BrowserAssetProvider({ indexedDB: real, dbName: 'flaky-db' }).put(
+    new Blob(['seed'], { type: 'text/plain' }),
+  );
+
+  let failNextOpen = true;
+  const flaky = {
+    open: (name: string, version?: number) => {
+      if (failNextOpen) {
+        failNextOpen = false;
+        throw new Error('transient open failure');
+      }
+      return real.open(name, version);
+    },
+    deleteDatabase: real.deleteDatabase.bind(real),
+    cmp: real.cmp.bind(real),
+    databases: real.databases?.bind(real),
+  } as unknown as IDBFactory;
+
+  const provider = new BrowserAssetProvider({ indexedDB: flaky, dbName: 'flaky-db' });
+  await expect(provider.resolve(ref)).rejects.toThrow(); // first open throws
+  const url = await provider.resolve(ref); // retry must succeed, not replay the rejection
+  expect(url).not.toBeNull();
+});
+
 // Backend-specific: the content-addressing contract asserts identical bytes
 // yield the same ref; this asserts they actually collapse to ONE stored row,
 // so a backend that appended duplicates couldn't pass silently.

--- a/packages/@openmaic/storage/test/asset-browser.test.ts
+++ b/packages/@openmaic/storage/test/asset-browser.test.ts
@@ -14,6 +14,20 @@ runStorageProviderContract(
   },
 );
 
+// Re-putting the same bytes with a corrected contentType must not leave a
+// stale cached object URL: resolve() has to reflect the latest write, not
+// whatever was cached first (otherwise MIME depends on cache warmth).
+test('BrowserAssetProvider re-put updates the resolved contentType', async () => {
+  const provider = new BrowserAssetProvider({ indexedDB: new IDBFactory(), dbName: 'mime-db' });
+  const ref = await provider.put(new Blob(['pixels'], { type: '' }));
+  const first = await provider.resolve(ref);
+  expect(blobForObjectUrl(first!)?.type).toBe('');
+
+  await provider.put(new Blob(['pixels'], { type: 'image/png' }));
+  const second = await provider.resolve(ref);
+  expect(blobForObjectUrl(second!)?.type).toBe('image/png');
+});
+
 // A transient failure in resolve() must not be cached: the next resolve(ref)
 // has to retry, not replay the rejection.
 test('BrowserAssetProvider recovers after a transient resolve failure', async () => {

--- a/packages/@openmaic/storage/test/asset-contract.ts
+++ b/packages/@openmaic/storage/test/asset-contract.ts
@@ -8,7 +8,11 @@ import type { StorageProvider } from '@openmaic/dsl';
 type ReadUrl = (url: string) => Promise<Uint8Array>;
 
 const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
-const blob = (s: string, type = 'text/plain'): Blob => new Blob([bytes(s)], { type });
+// Build the Blob from the string directly (a string is a valid BlobPart). A
+// `Uint8Array` BlobPart trips TS 5.7+'s `Uint8Array<ArrayBufferLike>` vs
+// `ArrayBufferView<ArrayBuffer>` narrowing under the root tsconfig; the bytes
+// are UTF-8 either way, so `bytes(s)` stays the source of truth for comparison.
+const blob = (s: string, type = 'text/plain'): Blob => new Blob([s], { type });
 
 export function runStorageProviderContract(
   name: string,
@@ -43,6 +47,16 @@ export function runStorageProviderContract(
       const url = await p.resolve(ref);
       expect(url).not.toBeNull();
       expect(await readUrl(url!)).toEqual(bytes('round-trip me'));
+    });
+
+    test('concurrent resolve of the same ref yields one shared URL', async () => {
+      const p = makeProvider();
+      const ref = await p.put(blob('shared'));
+      // Two in-flight resolves must not each mint a URL (the second would orphan
+      // the first, which only `remove` could ever revoke). They share one.
+      const [a, b] = await Promise.all([p.resolve(ref), p.resolve(ref)]);
+      expect(a).not.toBeNull();
+      expect(a).toBe(b);
     });
 
     test('resolve returns null for an unknown ref', async () => {

--- a/packages/@openmaic/storage/test/asset-contract.ts
+++ b/packages/@openmaic/storage/test/asset-contract.ts
@@ -1,0 +1,60 @@
+// Implementation-agnostic contract for a `StorageProvider` (the DSL-owned asset
+// seam). `resolve` yields a URL whose *bytes* must equal what was `put`; how a
+// URL is read back differs per backend (object URL vs HTTP), so the reader is
+// injected, keeping the assertions universal across backends.
+import { describe, expect, test } from 'vitest';
+import type { StorageProvider } from '@openmaic/dsl';
+
+type ReadUrl = (url: string) => Promise<Uint8Array>;
+
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+const blob = (s: string, type = 'text/plain'): Blob => new Blob([bytes(s)], { type });
+
+export function runStorageProviderContract(
+  name: string,
+  makeProvider: () => StorageProvider,
+  readUrl: ReadUrl,
+): void {
+  describe(`StorageProvider contract: ${name}`, () => {
+    test('put returns a non-empty ref', async () => {
+      const p = makeProvider();
+      const ref = await p.put(blob('hello'));
+      expect(typeof ref).toBe('string');
+      expect(ref.length).toBeGreaterThan(0);
+    });
+
+    test('is content-addressed: identical bytes yield the same ref', async () => {
+      const p = makeProvider();
+      const a = await p.put(blob('same-content'));
+      const b = await p.put(blob('same-content'));
+      expect(a).toBe(b);
+    });
+
+    test('distinct bytes yield distinct refs', async () => {
+      const p = makeProvider();
+      const a = await p.put(blob('one'));
+      const b = await p.put(blob('two'));
+      expect(a).not.toBe(b);
+    });
+
+    test('resolve yields a URL whose bytes equal the stored blob', async () => {
+      const p = makeProvider();
+      const ref = await p.put(blob('round-trip me'));
+      const url = await p.resolve(ref);
+      expect(url).not.toBeNull();
+      expect(await readUrl(url!)).toEqual(bytes('round-trip me'));
+    });
+
+    test('resolve returns null for an unknown ref', async () => {
+      const p = makeProvider();
+      expect(await p.resolve('sha256-deadbeef')).toBeNull();
+    });
+
+    test('resolve returns null after remove', async () => {
+      const p = makeProvider();
+      const ref = await p.put(blob('temporary'));
+      await p.remove(ref);
+      expect(await p.resolve(ref)).toBeNull();
+    });
+  });
+}

--- a/packages/@openmaic/storage/test/kv-browser.test.ts
+++ b/packages/@openmaic/storage/test/kv-browser.test.ts
@@ -1,0 +1,5 @@
+import { BrowserKVStore } from '../src/index.js';
+import { MemoryStorage } from './setup.js';
+import { runKVStoreContract } from './kv-contract.js';
+
+runKVStoreContract('BrowserKVStore', () => new BrowserKVStore({ storage: new MemoryStorage() }));

--- a/packages/@openmaic/storage/test/kv-contract.ts
+++ b/packages/@openmaic/storage/test/kv-contract.ts
@@ -1,0 +1,82 @@
+// Implementation-agnostic contract for `KVStore`. Every backend (browser today,
+// HTTP later) is proven equivalent by running this same suite against it, so a
+// new backend cannot silently diverge from the primitive's semantics.
+import { describe, expect, test } from 'vitest';
+import type { KVStore } from '../src/index.js';
+
+export function runKVStoreContract(name: string, makeStore: () => KVStore): void {
+  describe(`KVStore contract: ${name}`, () => {
+    test('round-trips a value set then get', async () => {
+      const kv = makeStore();
+      await kv.set('greeting', 'hello');
+      expect(await kv.get<string>('greeting')).toBe('hello');
+    });
+
+    test('returns null for a missing key', async () => {
+      const kv = makeStore();
+      expect(await kv.get('nope')).toBeNull();
+    });
+
+    test('round-trips structured JSON values', async () => {
+      const kv = makeStore();
+      const value = { a: 1, b: ['x', 'y'], c: { nested: true } };
+      await kv.set('obj', value);
+      expect(await kv.get('obj')).toEqual(value);
+    });
+
+    test('overwrites an existing key', async () => {
+      const kv = makeStore();
+      await kv.set('k', 'first');
+      await kv.set('k', 'second');
+      expect(await kv.get<string>('k')).toBe('second');
+    });
+
+    test('remove deletes a key', async () => {
+      const kv = makeStore();
+      await kv.set('k', 'v');
+      await kv.remove('k');
+      expect(await kv.get('k')).toBeNull();
+    });
+
+    test('defaults to the account scope', async () => {
+      const kv = makeStore();
+      await kv.set('k', 'v'); // no scope → account
+      expect(await kv.get('k', 'account')).toBe('v');
+      expect(await kv.get('k', 'device')).toBeNull();
+    });
+
+    test('isolates the device and account scopes', async () => {
+      const kv = makeStore();
+      await kv.set('k', 'device-val', 'device');
+      await kv.set('k', 'account-val', 'account');
+      expect(await kv.get('k', 'device')).toBe('device-val');
+      expect(await kv.get('k', 'account')).toBe('account-val');
+    });
+
+    test('keys() lists keys in a scope, filtered by prefix', async () => {
+      const kv = makeStore();
+      await kv.set('ui:width', 1, 'device');
+      await kv.set('ui:height', 2, 'device');
+      await kv.set('other', 3, 'device');
+      await kv.set('ui:acct', 4, 'account');
+      const uiKeys = await kv.keys('ui:', 'device');
+      expect([...uiKeys].sort()).toEqual(['ui:height', 'ui:width']);
+    });
+
+    test('keys() with no prefix lists every key in the scope', async () => {
+      const kv = makeStore();
+      await kv.set('a', 1);
+      await kv.set('b', 2);
+      expect([...(await kv.keys())].sort()).toEqual(['a', 'b']);
+    });
+
+    test('remove is scoped', async () => {
+      const kv = makeStore();
+      await kv.set('k', 'device-val', 'device');
+      await kv.set('k', 'account-val', 'account');
+      await kv.remove('k', 'device');
+      expect(await kv.get('k', 'device')).toBeNull();
+      expect(await kv.get('k', 'account')).toBe('account-val');
+    });
+  });
+}

--- a/packages/@openmaic/storage/test/kv-contract.ts
+++ b/packages/@openmaic/storage/test/kv-contract.ts
@@ -70,6 +70,16 @@ export function runKVStoreContract(name: string, makeStore: () => KVStore): void
       expect([...(await kv.keys())].sort()).toEqual(['a', 'b']);
     });
 
+    test('set(undefined) clears the key instead of corrupting it', async () => {
+      const kv = makeStore();
+      await kv.set('k', 'v');
+      await kv.set('k', undefined);
+      // Must return null, not throw — a stored literal "undefined" would throw
+      // on the JSON.parse in get().
+      expect(await kv.get('k')).toBeNull();
+      expect(await kv.keys()).not.toContain('k');
+    });
+
     test('remove is scoped', async () => {
       const kv = makeStore();
       await kv.set('k', 'device-val', 'device');

--- a/packages/@openmaic/storage/test/persist-adapter.test.ts
+++ b/packages/@openmaic/storage/test/persist-adapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { BrowserKVStore, kvPersistStorage } from '../src/index.js';
+import { MemoryStorage } from './setup.js';
+
+const makeKv = () => new BrowserKVStore({ storage: new MemoryStorage() });
+
+describe('kvPersistStorage (zustand persist adapter)', () => {
+  test('getItem returns null for an unwritten store', async () => {
+    const storage = kvPersistStorage(makeKv());
+    expect(await storage.getItem('settings-storage')).toBeNull();
+  });
+
+  test('round-trips the persisted { state, version } envelope', async () => {
+    const storage = kvPersistStorage<{ nickname: string }>(makeKv());
+    const value = { state: { nickname: 'Ada' }, version: 4 };
+    await storage.setItem('settings-storage', value);
+    expect(await storage.getItem('settings-storage')).toEqual(value);
+  });
+
+  test('removeItem clears the persisted store', async () => {
+    const storage = kvPersistStorage(makeKv());
+    await storage.setItem('k', { state: { x: 1 } });
+    await storage.removeItem('k');
+    expect(await storage.getItem('k')).toBeNull();
+  });
+
+  test('writes under the given KV scope', async () => {
+    const kv = makeKv();
+    const deviceStorage = kvPersistStorage(kv, 'device');
+    await deviceStorage.setItem('layout', { state: { width: 320 } });
+    // Same key under the account scope is untouched.
+    expect(await kv.get('layout', 'account')).toBeNull();
+    expect(await kv.get('layout', 'device')).toEqual({ state: { width: 320 } });
+  });
+
+  test('defaults to the account scope', async () => {
+    const kv = makeKv();
+    const storage = kvPersistStorage(kv);
+    await storage.setItem('profile', { state: { nickname: 'Ada' } });
+    expect(await kv.get('profile', 'account')).toEqual({ state: { nickname: 'Ada' } });
+  });
+});

--- a/packages/@openmaic/storage/test/setup.ts
+++ b/packages/@openmaic/storage/test/setup.ts
@@ -4,6 +4,7 @@
 // shims only cover the ambient APIs (object URLs, IndexedDB factory type,
 // crypto) a real browser supplies.
 import { webcrypto } from 'node:crypto';
+import { beforeEach } from 'vitest';
 
 // Node ≥20 exposes `globalThis.crypto`, but guard for older/edge runners so
 // content-hashing (crypto.subtle.digest) works the same as in a browser.
@@ -30,6 +31,13 @@ URL.revokeObjectURL = (url: string): void => {
 export function blobForObjectUrl(url: string): Blob | undefined {
   return objectUrls.get(url);
 }
+
+// Reset the object-URL registry between tests so nothing bleeds across cases
+// (the override is a global; without this the map grows for the whole run).
+beforeEach(() => {
+  objectUrls.clear();
+  seq = 0;
+});
 
 /**
  * Test-only in-memory `Storage` (localStorage-shaped) for injecting into the

--- a/packages/@openmaic/storage/test/setup.ts
+++ b/packages/@openmaic/storage/test/setup.ts
@@ -1,0 +1,60 @@
+// Test shims for the handful of browser globals the backends touch that Node
+// does not provide natively. The backends themselves take their `Storage` /
+// `IDBFactory` by injection, so tests pass fresh isolated instances; these
+// shims only cover the ambient APIs (object URLs, IndexedDB factory type,
+// crypto) a real browser supplies.
+import { webcrypto } from 'node:crypto';
+
+// Node ≥20 exposes `globalThis.crypto`, but guard for older/edge runners so
+// content-hashing (crypto.subtle.digest) works the same as in a browser.
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+}
+
+// object-URL registry: `createObjectURL(blob)` mints a unique `blob:` URL and
+// remembers the blob so tests can resolve the URL back to its bytes (the real
+// browser provides both natively; Node provides neither).
+const objectUrls = new Map<string, Blob>();
+let seq = 0;
+
+URL.createObjectURL = (obj: Blob | MediaSource): string => {
+  const url = `blob:maic-test/${seq++}`;
+  objectUrls.set(url, obj as Blob);
+  return url;
+};
+URL.revokeObjectURL = (url: string): void => {
+  objectUrls.delete(url);
+};
+
+/** Test-only: resolve an object URL minted by the polyfill back to its blob. */
+export function blobForObjectUrl(url: string): Blob | undefined {
+  return objectUrls.get(url);
+}
+
+/**
+ * Test-only in-memory `Storage` (localStorage-shaped) for injecting into the
+ * browser KV backend. A fresh instance per test keeps cases isolated without
+ * touching any ambient global.
+ */
+export class MemoryStorage implements Storage {
+  private readonly m = new Map<string, string>();
+  get length(): number {
+    return this.m.size;
+  }
+  clear(): void {
+    this.m.clear();
+  }
+  getItem(key: string): string | null {
+    return this.m.has(key) ? this.m.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return [...this.m.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.m.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.m.set(key, String(value));
+  }
+  [name: string]: unknown;
+}

--- a/packages/@openmaic/storage/tsconfig.json
+++ b/packages/@openmaic/storage/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "preserveConstEnums": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/@openmaic/storage/vitest.config.ts
+++ b/packages/@openmaic/storage/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Resolve `@openmaic/storage` self-imports and the `@openmaic/dsl` dependency to
+// their package sources, so `pnpm test` is standalone on a clean checkout (no
+// `dist` build required). Consumers still resolve via each package's `exports`
+// map → `dist` as before.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@openmaic/storage': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+      '@openmaic/dsl': fileURLToPath(new URL('../dsl/src/index.ts', import.meta.url)),
+    },
+  },
+  test: {
+    // Node env + explicit shims (test/setup.ts) for the few browser globals the
+    // backends touch (IndexedDB, URL.createObjectURL, crypto.subtle). The
+    // backends take their `Storage` / `IDBFactory` by injection, so tests pass
+    // fresh isolated instances rather than leaning on ambient globals.
+    environment: 'node',
+    setupFiles: ['./test/setup.ts'],
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,22 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  packages/@openmaic/storage:
+    dependencies:
+      '@openmaic/dsl':
+        specifier: workspace:*
+        version: link:../dsl
+    devDependencies:
+      fake-indexeddb:
+        specifier: ^6.0.0
+        version: 6.2.5
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@9.12.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/mathml2omml:
     devDependencies:
       '@biomejs/biome':
@@ -7532,6 +7548,10 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
+
   fancy-log@1.3.3:
     resolution: {integrity: sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==}
     engines: {node: '>= 0.10'}
@@ -11708,10 +11728,6 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -15533,7 +15549,7 @@ snapshots:
       semver: 7.7.4
       string-width: 4.2.3
       supports-color: 8.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -17945,7 +17961,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -20441,6 +20457,8 @@ snapshots:
       tmp: 0.0.33
 
   extsprintf@1.3.0: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fancy-log@1.3.3:
     dependencies:
@@ -25577,11 +25595,6 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
-  tinyglobby@0.2.16:
-    dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
@@ -26169,11 +26182,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
@@ -26198,11 +26211,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
First executable slice of the `@openmaic/storage` RFC (#779) — **Part 1**, tracked in #857. A pure, app-agnostic persistence package that depends only on `@openmaic/dsl`, mirroring how `@openmaic/renderer` / `@openmaic/importer` sit on the DSL.

The DSL owns *what* persists; this package owns *where/how*. The pluggable seam is the **backend**, not the DB driver: this PR ships the browser backends (zero server) + the primitive contracts.

## What's in it

- **`StorageProvider` asset seam added to `@openmaic/dsl`** — `put(blob)→ref` / `resolve(ref)→url` / `remove(ref)`. Typed against a structural `BinaryBlob` (`size`/`type`/`arrayBuffer()`) so the pure DSL keeps `lib: ES2022` (no DOM) while owning the contract. A document embeds only a stable ref; a raw URL would bake in a provider + expiry and break portability.
- **`KVStore`** (`device` / `account` scopes) + **`BrowserKVStore`** over `localStorage`. `device` values (theme/locale/layout) never leave the device — the scope is part of the primitive, so it survives a future server backend.
- **`BrowserAssetProvider`** — content-addressed (`sha256-<hex>`) bytes in IndexedDB, resolved to object URLs; identical bytes de-duplicate to one asset/one ref.
- **`kvPersistStorage`** — adapts a `KVStore` into a zustand `persist` storage, so a store's own `version`/`migrate`/`merge` stay untouched while its bytes move off raw `localStorage`. Pure util here; **wiring the app's stores is a follow-up** (see below).
- **Implementation-agnostic contract suites** (`test/kv-contract.ts`, `test/asset-contract.ts`) run against the browser backends — the coming HTTP backend proves equivalence against the same cases.
- **Machine-enforced import boundary** in eslint (no `@/…` host-app paths), mirroring the `@openmaic/renderer` boundary (#853).

Backends take their `Storage` / `IDBFactory` by **injection**, so the package is testable without a browser (Node + `fake-indexeddb`).

## Notes for review

- **`BinaryBlob` vs `Blob` in the DSL.** I used a minimal structural type rather than pulling `"DOM"` into the DSL's `lib`, to preserve its env-agnostic purity. Happy to switch to `Blob` + DOM lib if you'd rather.
- **Naming.** `@openmaic/*` scope (RFC #779 has been updated from `@maic/*`).
- **Two-PR split.** This is the pure package with **zero app behavior change**. The zustand/`localStorage` reroute is deliberately *not* here: it renames the live `settings-storage` / `user-profile-storage` / `agent-registry-storage` keys, so it needs a legacy-key compat migration to avoid dropping existing users' settings — that carries real regression risk and deserves its own review.

## Deferred (later Part-1 / later parts, tracked in #857)

- Wire the app's zustand stores + ad-hoc `localStorage` through `KVStore` (with the legacy-key compat migration).
- `DocumentStore` (aggregate ↔ normalized adapter, migrate-on-read via the DSL migration registry, validation gate) — Part 2.
- `RuntimeStore` — needs a DSL-native runtime message type (still open in #720).
- HTTP backend + reference server + one HTTP contract.

## Verification

- `@openmaic/storage`: `pnpm test` → 21 passing (10 KV + 6 asset + 5 persist-adapter); `pnpm typecheck` + `pnpm build` clean.
- `@openmaic/dsl`: `pnpm test` → 126 passing (the `storage.ts` addition is purely additive); `pnpm build` regenerates schema unchanged.
- Repo `pnpm check` (prettier) clean; `pnpm lint` clean on the new package; the import-boundary rule verified to fire on a `@/…` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)