### PR TITLE
feat(storage): DocumentStore — normalized document aggregate (browser backend)

### DIFF
--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -39,8 +39,8 @@ a browser.
   would bake in a provider + expiry and break portability).
 - **Document normalization.** The DSL `document` is a portable embedded
   aggregate; `DocumentStore` normalizes it into per-entity rows so scene-level
-  saves stay cheap (writes diff and touch only changed scenes) and reassembles
-  it on read. Each document is stamped with a `dslVersion`; reads run the DSL
+  writes (`putScene`) stay cheap, and reassembles it on read. Each document is
+  stamped with a `dslVersion`; reads run the DSL
   migration ladder forward, and writes are validated against the DSL gate
   (`validateStage` / `validateScene`) so schema drift fails loud. The outline is
   an opaque, app-owned snapshot carried alongside — persisted verbatim, neither

--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -20,13 +20,14 @@ No dependency on React, zustand, or any host app. Backends take their `Storage`
 / `IDBFactory` by injection, so the package is app-agnostic and testable without
 a browser.
 
-## What's in here (Part 1)
+## What's in here
 
 | Export | Role | Browser backend |
 | --- | --- | --- |
 | `KVStore` | small `device` / `account`-scoped values not owned by the DSL | `BrowserKVStore` over `localStorage` |
 | `StorageProvider` (from `@openmaic/dsl`) | the asset seam: `put(blob) → ref`, `resolve(ref) → url`, `remove(ref)` | `BrowserAssetProvider` over IndexedDB + object URLs |
 | `kvPersistStorage` | adapt a `KVStore` into a zustand `persist` storage | — |
+| `DocumentStore` | persist the DSL `document` aggregate (stage + scenes + embedded agents / quiz / actions + an outline snapshot) | `BrowserDocumentStore` over IndexedDB (normalized `stages` / `scenes` / `outlines`) |
 
 - **Scopes.** `account` values are user data a server-backed deployment syncs
   across devices; `device` values (theme, locale, layout) never leave the
@@ -36,22 +37,35 @@ a browser.
   so identical bytes de-duplicate to one stored asset. A document embeds only
   the stable ref; the provider resolves it to a URL at render time (a raw URL
   would bake in a provider + expiry and break portability).
+- **Document normalization.** The DSL `document` is a portable embedded
+  aggregate; `DocumentStore` normalizes it into per-entity rows so scene-level
+  saves stay cheap (writes diff and touch only changed scenes) and reassembles
+  it on read. Each document is stamped with a `dslVersion`; reads run the DSL
+  migration ladder forward, and writes are validated against the DSL gate
+  (`validateStage` / `validateScene`) so schema drift fails loud. The outline is
+  an opaque, app-owned snapshot carried alongside — persisted verbatim, neither
+  validated nor migrated.
+- **Generic over scene type.** `DocumentStore<TScene>` defaults to the DSL
+  `Scene` (universal `slide` / `quiz`). An app that widens `Scene` with its own
+  kinds (`interactive` / `pbl`, content the DSL does not own) parameterizes the
+  store over its scene union and injects a matching `validateScene`, so those
+  scenes persist and the gate stays fail-loud for the app's shapes.
 
 ## Backend equivalence
 
 Each primitive has one implementation-agnostic contract suite
-(`test/kv-contract.ts`, `test/asset-contract.ts`). Every backend is proven by
-running the same suite against it, so a new backend (the coming HTTP one) cannot
-silently diverge from the primitive's semantics.
+(`test/kv-contract.ts`, `test/asset-contract.ts`, `test/document-contract.ts`).
+Every backend is proven by running the same suite against it, so a new backend
+(the coming HTTP one) cannot silently diverge from the primitive's semantics.
 
 ## Roadmap
 
 - [x] `KVStore` + browser backend; zustand `persist` adapter
 - [x] `StorageProvider` (in `@openmaic/dsl`) + browser `BrowserAssetProvider`
 - [x] implementation-agnostic contract suites
+- [x] `DocumentStore` (aggregate ↔ normalized adapter, migrate-on-read via the
+      DSL migration registry, validation gate) + browser backend
 - [ ] wire the app's zustand stores + ad-hoc `localStorage` through `KVStore`
-- [ ] `DocumentStore` (aggregate ↔ normalized adapter, migrate-on-read via the
-      DSL migration registry, validation gate)
 - [ ] `RuntimeStore`
 - [ ] HTTP backend + reference server + one HTTP contract
 

--- a/packages/@openmaic/storage/src/document/adapter.ts
+++ b/packages/@openmaic/storage/src/document/adapter.ts
@@ -1,0 +1,65 @@
+/**
+ * The aggregate ↔ normalized adapter: the one translation point between the
+ * portable, embedded {@link MaicDocument} and the per-entity rows a backend
+ * stores. Pure and dependency-free (beyond DSL constants) so every backend —
+ * browser today, HTTP later — shares the same split/reassemble semantics.
+ *
+ * The document is stamped at the root: the version envelope lives on the stage
+ * (root) row, so a document has exactly one version, never a per-scene skew.
+ */
+import { DSL_VERSION, DSL_VERSION_KEY } from '@openmaic/dsl';
+import type { Stage } from '@openmaic/dsl';
+import type { MaicDocument, SceneLike } from './types.js';
+
+/** The stage (root) row: stage metadata plus the document's version stamp. */
+export type StageRow = Stage & { [DSL_VERSION_KEY]: string };
+
+/** The outline row: one opaque snapshot per stage, stored only when present. */
+export interface OutlineRow {
+  stageId: string;
+  outline: unknown;
+}
+
+/** The normalized rows a document splits into. */
+export interface DocumentRows<TScene extends SceneLike> {
+  stageRow: StageRow;
+  sceneRows: TScene[];
+  /** Present only when the document carries an outline. */
+  outlineRow?: OutlineRow;
+}
+
+/**
+ * Split an embedded document into normalized rows, stamping the stage row at the
+ * current DSL version (a fresh write is always current). The outline row is
+ * emitted only when the document actually carries an outline — a document with
+ * no outline produces no outline row (and the backend removes any stale one).
+ */
+export function splitDocument<TScene extends SceneLike>(
+  doc: MaicDocument<TScene>,
+): DocumentRows<TScene> {
+  const stageRow: StageRow = { ...doc.stage, [DSL_VERSION_KEY]: DSL_VERSION };
+  const rows: DocumentRows<TScene> = { stageRow, sceneRows: doc.scenes };
+  if (doc.outline !== undefined) {
+    rows.outlineRow = { stageId: doc.stage.id, outline: doc.outline };
+  }
+  return rows;
+}
+
+/**
+ * Reassemble normalized rows into an embedded document — the inverse of
+ * {@link splitDocument}. Scenes are returned sorted by `order`, the version is
+ * lifted from the stage row to the document root (where the migrate() runner
+ * reads it), and the outline is attached only when a row exists. This is the
+ * pre-migration document; the backend runs `migrate()` on the result.
+ */
+export function reassembleDocument<TScene extends SceneLike>(
+  stageRow: StageRow,
+  sceneRows: TScene[],
+  outlineRow?: OutlineRow,
+): MaicDocument<TScene> {
+  const { [DSL_VERSION_KEY]: dslVersion, ...stage } = stageRow;
+  const scenes = [...sceneRows].sort((a, b) => a.order - b.order);
+  const doc: MaicDocument<TScene> = { stage, scenes, dslVersion };
+  if (outlineRow) doc.outline = outlineRow.outline;
+  return doc;
+}

--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -95,6 +95,74 @@ function assertStorableScene(scene: SceneLike, stageId: string): void {
   }
 }
 
+function isPlainObject(v: object): boolean {
+  const proto = Object.getPrototypeOf(v) as unknown;
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Structural deep-equality used *only* to decide whether the write-diff may skip
+ * re-writing an unchanged scene. It must never report two different values as
+ * equal — a false positive would silently drop an edit — so anything it does not
+ * confidently recognize (a class instance, a Blob, a typed array) is treated as
+ * NOT equal, biasing the diff toward a harmless spurious write.
+ *
+ * A plain `JSON.stringify` compare is unsafe here because the store is generic
+ * over opaque app scene content, and IndexedDB persists structured-clone values
+ * (`Map` / `Set` / `Date`, `NaN`, `undefined` members, …) that JSON flattens or
+ * drops — so two genuinely different scenes could stringify identically. This
+ * recognizes the common cases (primitives incl. `NaN`, plain objects, arrays,
+ * `Map`, `Set`, `Date`) and declines to prove equality for anything else.
+ */
+function structuralEquals(a: unknown, b: unknown, depth = 0): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+  // Bound recursion: cyclic or pathologically deep content is treated as "not
+  // provably equal" (→ write) rather than risking a stack overflow. Safe, since a
+  // spurious write never loses data; ordinary scene content is shallow.
+  if (depth > 100) return false;
+
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
+  }
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (!structuralEquals(a[i], b[i], depth + 1)) return false;
+    return true;
+  }
+
+  if (a instanceof Map || b instanceof Map) {
+    if (!(a instanceof Map) || !(b instanceof Map) || a.size !== b.size) return false;
+    // Object keys from two separate structured-clone copies are distinct refs, so
+    // `b.has(k)` fails for them → NOT equal → write (a safe spurious write, never
+    // a false positive). Primitive keys compare correctly.
+    for (const [k, v] of a)
+      if (!b.has(k) || !structuralEquals(v, b.get(k), depth + 1)) return false;
+    return true;
+  }
+
+  if (a instanceof Set || b instanceof Set) {
+    if (!(a instanceof Set) || !(b instanceof Set) || a.size !== b.size) return false;
+    for (const v of a) if (!b.has(v)) return false;
+    return true;
+  }
+
+  // Plain objects only. A non-plain object (class instance, typed array, Blob)
+  // may carry state not visible through own-enumerable keys, so decline to prove
+  // equality and let the diff write.
+  if (!isPlainObject(a) || !isPlainObject(b)) return false;
+  const ra = a as Record<string, unknown>;
+  const rb = b as Record<string, unknown>;
+  const keys = Object.keys(ra);
+  if (keys.length !== Object.keys(rb).length) return false;
+  for (const k of keys) {
+    if (!Object.prototype.hasOwnProperty.call(rb, k) || !structuralEquals(ra[k], rb[k], depth + 1))
+      return false;
+  }
+  return true;
+}
+
 /**
  * True when a document / stage row is stamped *ahead* of this client's
  * `DSL_VERSION` (`needsMigration` false means version >= current; a version that
@@ -265,16 +333,18 @@ export class BrowserDocumentStore<
       }
       stages.put(stageRow);
 
-      // Diff scenes: write only new/changed rows, delete removed ones. Bias to
-      // write when equality is uncertain — a spurious identical write is
-      // harmless (idempotent); a missed write would lose an edit.
+      // Diff scenes: write only new/changed rows, delete removed ones. Equality
+      // is decided by `structuralEquals`, which is safe for opaque app scene
+      // content (unlike a JSON compare) and biases to write when uncertain — a
+      // spurious identical write is harmless (idempotent); a missed write would
+      // lose an edit.
       const scenes = tx.objectStore(SCENES);
       const existing = await reqP<TScene[]>(scenes.index(SCENES_BY_STAGE).getAll(stageId));
       const existingById = new Map(existing.map((s) => [s.id, s]));
       const incomingIds = new Set(sceneRows.map((s) => s.id));
       for (const scene of sceneRows) {
         const prev = existingById.get(scene.id);
-        if (!prev || JSON.stringify(prev) !== JSON.stringify(scene)) scenes.put(scene);
+        if (!prev || !structuralEquals(prev, scene)) scenes.put(scene);
       }
       for (const prev of existing) {
         if (!incomingIds.has(prev.id)) scenes.delete([stageId, prev.id]);
@@ -306,6 +376,10 @@ export class BrowserDocumentStore<
   }
 
   async listDocuments(): Promise<DocumentSummary[]> {
+    // Deliberately version-agnostic: the summary fields do not depend on the DSL
+    // version and no content is migrated or returned here, so a corrupt/unknown
+    // `dslVersion` stamp is not read — one bad row must not break the whole list
+    // (it still fails loud when the document itself is loaded).
     return this.txRun([STAGES, SCENES], 'readonly', async (tx) => {
       const stageRows = await reqP<StageRow[]>(tx.objectStore(STAGES).getAll());
       const index = tx.objectStore(SCENES).index(SCENES_BY_STAGE);

--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -69,8 +69,9 @@ function assertValid(result: ReturnType<typeof validateStage>, label: string): v
  *   mismatch would store the scene where no read path for `stageId` can find it
  *   (silent data loss).
  * - `id` must be a string: the other half of the compound key.
- * - `order` must be a number: the read-time sort key; a non-number sorts as `NaN`
- *   and silently scrambles scene order on read.
+ * - `order` must be a finite number: the read-time sort key. A non-number — or
+ *   `NaN` / `Infinity`, which are `typeof number` — makes `a.order - b.order`
+ *   return `NaN` and silently scrambles scene order on read.
  *
  * The DSL `validateScene` happens to check all three, but an app that injects its
  * own validator may not — so the store re-asserts them rather than trust the
@@ -87,9 +88,9 @@ function assertStorableScene(scene: SceneLike, stageId: string): void {
         `${JSON.stringify(s.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
     );
   }
-  if (typeof s.order !== 'number') {
+  if (typeof s.order !== 'number' || !Number.isFinite(s.order)) {
     throw new Error(
-      `@openmaic/storage: scene ${JSON.stringify(s.id)} order must be a number, got ` +
+      `@openmaic/storage: scene ${JSON.stringify(s.id)} order must be a finite number, got ` +
         `${JSON.stringify(s.order)}`,
     );
   }

--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -1,0 +1,409 @@
+/**
+ * Browser {@link DocumentStore} backend: `document` aggregates normalized across
+ * three IndexedDB object stores (`stages` / `scenes` / `outlines`). Writes
+ * validate against the scene gate (the DSL `validateScene` by default, or an
+ * injected validator for app-widened scene kinds) and diff scene rows (touching
+ * only what changed); reads reassemble and migrate the document forward. Matches
+ * the Part 1 asset backend's idiom — an injectable `IDBFactory`, a memoized open
+ * that clears on failure, and transactions that resolve on commit (not on the
+ * request) so a write claims durability only once the store actually kept it.
+ */
+import {
+  DSL_VERSION,
+  dslVersionOf,
+  migrate,
+  needsMigration,
+  validateScene,
+  validateStage,
+} from '@openmaic/dsl';
+import type { Scene } from '@openmaic/dsl';
+import type {
+  DocumentStore,
+  DocumentSummary,
+  MaicDocument,
+  SceneLike,
+  SceneValidator,
+} from './types.js';
+import { reassembleDocument, splitDocument, type OutlineRow, type StageRow } from './adapter.js';
+
+const STAGES = 'stages';
+const SCENES = 'scenes';
+const OUTLINES = 'outlines';
+const SCENES_BY_STAGE = 'by-stage';
+
+export interface BrowserDocumentStoreOptions {
+  /** IndexedDB factory. Defaults to the ambient `indexedDB`. Injectable for tests. */
+  indexedDB?: IDBFactory;
+  /** Database name. Defaults to `maic-documents`. */
+  dbName?: string;
+  /**
+   * Scene validator run at the write boundary. Defaults to the DSL
+   * `validateScene` (universal `slide` / `quiz` kinds). An app persisting a
+   * widened scene union (interactive / pbl / …) injects a validator that also
+   * accepts its own kinds, so the gate stays fail-loud for them.
+   */
+  validateScene?: SceneValidator;
+}
+
+/** Promisify a single IndexedDB request. */
+function reqP<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Throw a fail-loud error listing every validation issue, or pass. */
+function assertValid(result: ReturnType<typeof validateStage>, label: string): void {
+  if (result.valid) return;
+  const detail = result.errors.map((e) => `${e.path || '/'}: ${e.message}`).join('; ');
+  throw new Error(`@openmaic/storage: invalid ${label}: ${detail}`);
+}
+
+/**
+ * Fail loud unless a scene is structurally storable in `stageId`'s partition —
+ * the store's own key/sort invariants, enforced independently of the (possibly
+ * app-injected) content validator:
+ *
+ * - `stageId` must match: it is the compound-key partition the row lands in, so a
+ *   mismatch would store the scene where no read path for `stageId` can find it
+ *   (silent data loss).
+ * - `id` must be a string: the other half of the compound key.
+ * - `order` must be a number: the read-time sort key; a non-number sorts as `NaN`
+ *   and silently scrambles scene order on read.
+ *
+ * The DSL `validateScene` happens to check all three, but an app that injects its
+ * own validator may not — so the store re-asserts them rather than trust the
+ * content validator with its key/sort invariants.
+ */
+function assertStorableScene(scene: SceneLike, stageId: string): void {
+  const s = scene as { id: unknown; stageId: unknown; order: unknown };
+  if (typeof s.id !== 'string') {
+    throw new Error(`@openmaic/storage: scene id must be a string, got ${JSON.stringify(s.id)}`);
+  }
+  if (s.stageId !== stageId) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(s.id)} has stageId ` +
+        `${JSON.stringify(s.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
+    );
+  }
+  if (typeof s.order !== 'number') {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(s.id)} order must be a number, got ` +
+        `${JSON.stringify(s.order)}`,
+    );
+  }
+}
+
+/**
+ * True when a document / stage row is stamped *ahead* of this client's
+ * `DSL_VERSION` (`needsMigration` false means version >= current; a version that
+ * is also not equal to current is strictly greater). Such data was written by a
+ * newer client; an older client must not overwrite it (see the write guards).
+ * A non-object carries no version claim, so it is never "future".
+ */
+function isFutureVersioned(versioned: unknown): boolean {
+  if (typeof versioned !== 'object' || versioned === null) return false;
+  return !needsMigration(versioned) && dslVersionOf(versioned) !== DSL_VERSION;
+}
+
+/**
+ * Migrate a document forward to the current DSL version, leaving the opaque,
+ * app-owned `outline` untouched. The outline is not DSL-shaped, so migrations
+ * must never see it — splitting it out here makes the "outline is not migrated"
+ * contract literally true and stops a future migration transform from silently
+ * dropping the snapshot while rebuilding the aggregate. Throws (via `migrate`)
+ * if the document's version has no path up the ladder.
+ *
+ * Scenes (including an app-widened union) *do* stay inside the migrated core:
+ * the DSL owns the scene contract, so its migrations are the authority on scene
+ * shape and are expected to key on `scene.type` and pass app kinds through
+ * untouched. This is the deliberate asymmetry with `outline`, which the DSL owns
+ * no contract for at all.
+ */
+function migrateDocument<TScene extends SceneLike>(
+  doc: MaicDocument<TScene>,
+): MaicDocument<TScene> {
+  const { outline, ...core } = doc;
+  const migrated = migrate(core) as MaicDocument<TScene>;
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
+export class BrowserDocumentStore<
+  TScene extends SceneLike = Scene,
+> implements DocumentStore<TScene> {
+  private readonly idb: IDBFactory;
+  private readonly dbName: string;
+  private readonly validateScene: SceneValidator;
+  private dbPromise?: Promise<IDBDatabase>;
+
+  constructor(options: BrowserDocumentStoreOptions = {}) {
+    this.idb = options.indexedDB ?? globalThis.indexedDB;
+    this.dbName = options.dbName ?? 'maic-documents';
+    this.validateScene = options.validateScene ?? validateScene;
+  }
+
+  private openDb(): Promise<IDBDatabase> {
+    // Do NOT cache a rejected open: a transient failure (private-mode IDB, a
+    // one-off VersionError) would otherwise brick the store for the session.
+    this.dbPromise ??= new Promise<IDBDatabase>((resolve, reject) => {
+      const req = this.idb.open(this.dbName, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STAGES)) {
+          db.createObjectStore(STAGES, { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains(SCENES)) {
+          // Compound key so scene ids need only be unique WITHIN a stage —
+          // documents stay isolated even if two courses reuse a scene id.
+          const scenes = db.createObjectStore(SCENES, { keyPath: ['stageId', 'id'] });
+          scenes.createIndex(SCENES_BY_STAGE, 'stageId', { unique: false });
+        }
+        if (!db.objectStoreNames.contains(OUTLINES)) {
+          db.createObjectStore(OUTLINES, { keyPath: 'stageId' });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    }).catch((err) => {
+      this.dbPromise = undefined;
+      throw err;
+    });
+    return this.dbPromise;
+  }
+
+  /**
+   * Run `body` inside one transaction, resolving with its return value on
+   * commit. A throw from `body` aborts the transaction and rejects with that
+   * error, so a failed multi-write leaves the stores untouched (atomicity).
+   */
+  private async txRun<T>(
+    stores: string[],
+    mode: IDBTransactionMode,
+    body: (tx: IDBTransaction) => Promise<T> | T,
+  ): Promise<T> {
+    const db = await this.openDb();
+    return new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(stores, mode);
+      let result: T;
+      let failure: unknown;
+      tx.oncomplete = () => resolve(result);
+      tx.onerror = () => reject(failure ?? tx.error);
+      tx.onabort = () => reject(failure ?? tx.error);
+      void (async () => {
+        try {
+          result = await body(tx);
+        } catch (err) {
+          failure = err;
+          // The transaction may already be finishing; ignore a late abort throw.
+          try {
+            tx.abort();
+          } catch {
+            /* already inactive */
+          }
+        }
+      })();
+    });
+  }
+
+  async saveDocument(doc: MaicDocument<TScene>): Promise<void> {
+    // Forward-compatibility: refuse to persist (and thereby downgrade) a document
+    // written by a newer client. `loadDocument` returns such documents untouched;
+    // saving one back would relabel its newer-shaped rows as this older version.
+    if (isFutureVersioned(doc)) {
+      throw new Error(
+        `@openmaic/storage: refusing to save document ${JSON.stringify(doc.stage.id)} — it was ` +
+          `written at DSL version ${JSON.stringify(dslVersionOf(doc))}, newer than this ` +
+          `client's ${DSL_VERSION}`,
+      );
+    }
+    // Normalize stale input forward to the current version — the same migration
+    // `loadDocument` runs on read. An explicit older stamp (e.g. an import at a
+    // prior version) is migrated up rather than blindly stamped current, and a
+    // stamp with no path up the ladder fails loud, so a document is never
+    // persisted mislabeled as a version it was not actually migrated to.
+    const normalized = migrateDocument(doc);
+
+    // Validate the (normalized) aggregate BEFORE opening a transaction, so an
+    // invalid stage or scene fails loud without any partial write.
+    assertValid(validateStage(normalized.stage), `stage ${normalized.stage.id}`);
+    const stageId = normalized.stage.id;
+    const seen = new Set<string>();
+    for (const scene of normalized.scenes) {
+      assertValid(this.validateScene(scene), `scene ${scene.id}`);
+      // The scene's own stageId is the compound-key partition it lands in; a
+      // scene whose stageId disagrees with its document would be written to a
+      // partition no read path for this document sees. Fail loud rather than
+      // silently lose it (validateScene checks stageId is a string, not that it
+      // matches the parent).
+      assertStorableScene(scene, stageId);
+      // Two scenes sharing an id collapse to one compound key on write — the
+      // second would silently overwrite the first. Reject the aggregate instead.
+      if (seen.has(scene.id)) {
+        throw new Error(
+          `@openmaic/storage: duplicate scene id ${JSON.stringify(scene.id)} in document ${JSON.stringify(stageId)}`,
+        );
+      }
+      seen.add(scene.id);
+    }
+
+    const { stageRow, sceneRows, outlineRow } = splitDocument(normalized);
+
+    await this.txRun([STAGES, SCENES, OUTLINES], 'readwrite', async (tx) => {
+      const stages = tx.objectStore(STAGES);
+      // Read the stored stage row inside the write transaction (no TOCTOU) and
+      // refuse to overwrite a document written by a newer client — the incoming
+      // document may itself be current/unversioned, so the incoming-version
+      // guard above does not catch a blind overwrite of newer stored data.
+      const existingStage = await reqP<StageRow | undefined>(stages.get(stageId));
+      if (existingStage && isFutureVersioned(existingStage)) {
+        throw new Error(
+          `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
+            `stored copy is at DSL version ${JSON.stringify(dslVersionOf(existingStage))}, newer ` +
+            `than this client's ${DSL_VERSION}`,
+        );
+      }
+      stages.put(stageRow);
+
+      // Diff scenes: write only new/changed rows, delete removed ones. Bias to
+      // write when equality is uncertain — a spurious identical write is
+      // harmless (idempotent); a missed write would lose an edit.
+      const scenes = tx.objectStore(SCENES);
+      const existing = await reqP<TScene[]>(scenes.index(SCENES_BY_STAGE).getAll(stageId));
+      const existingById = new Map(existing.map((s) => [s.id, s]));
+      const incomingIds = new Set(sceneRows.map((s) => s.id));
+      for (const scene of sceneRows) {
+        const prev = existingById.get(scene.id);
+        if (!prev || JSON.stringify(prev) !== JSON.stringify(scene)) scenes.put(scene);
+      }
+      for (const prev of existing) {
+        if (!incomingIds.has(prev.id)) scenes.delete([stageId, prev.id]);
+      }
+
+      // A full-aggregate save with no outline means "no outline" — clear any.
+      const outlines = tx.objectStore(OUTLINES);
+      if (outlineRow) outlines.put(outlineRow);
+      else outlines.delete(stageId);
+    });
+  }
+
+  async loadDocument(stageId: string): Promise<MaicDocument<TScene> | null> {
+    const rows = await this.txRun([STAGES, SCENES, OUTLINES], 'readonly', async (tx) => {
+      const stageRow = await reqP<StageRow | undefined>(tx.objectStore(STAGES).get(stageId));
+      if (!stageRow) return null;
+      const sceneRows = await reqP<TScene[]>(
+        tx.objectStore(SCENES).index(SCENES_BY_STAGE).getAll(stageId),
+      );
+      const outlineRow = await reqP<OutlineRow | undefined>(tx.objectStore(OUTLINES).get(stageId));
+      return { stageRow, sceneRows, outlineRow };
+    });
+    if (!rows) return null;
+
+    const document = reassembleDocument(rows.stageRow, rows.sceneRows, rows.outlineRow);
+    // Migrate the aggregate forward (outline excluded); forward-versioned
+    // documents pass through untouched (never downgraded).
+    return migrateDocument(document);
+  }
+
+  async listDocuments(): Promise<DocumentSummary[]> {
+    return this.txRun([STAGES, SCENES], 'readonly', async (tx) => {
+      const stageRows = await reqP<StageRow[]>(tx.objectStore(STAGES).getAll());
+      const index = tx.objectStore(SCENES).index(SCENES_BY_STAGE);
+      const summaries: DocumentSummary[] = [];
+      for (const stage of stageRows) {
+        const sceneCount = await reqP<number>(index.count(stage.id));
+        summaries.push({
+          id: stage.id,
+          name: stage.name,
+          createdAt: stage.createdAt,
+          updatedAt: stage.updatedAt,
+          sceneCount,
+        });
+      }
+      return summaries;
+    });
+  }
+
+  async deleteDocument(stageId: string): Promise<void> {
+    // Whole-document removal is a deliberate, coarse user action, so it is
+    // intentionally NOT version-guarded (unlike the incremental put/deleteScene
+    // mutations): the caller means to discard the entire document regardless of
+    // the DSL version it was written at.
+    await this.txRun([STAGES, SCENES, OUTLINES], 'readwrite', async (tx) => {
+      tx.objectStore(STAGES).delete(stageId);
+      tx.objectStore(OUTLINES).delete(stageId);
+      const scenes = tx.objectStore(SCENES);
+      const keys = await reqP<IDBValidKey[]>(scenes.index(SCENES_BY_STAGE).getAllKeys(stageId));
+      for (const key of keys) scenes.delete(key);
+    });
+  }
+
+  async putScene(stageId: string, scene: TScene): Promise<void> {
+    assertValid(this.validateScene(scene), `scene ${scene.id}`);
+    assertStorableScene(scene, stageId);
+    await this.txRun([STAGES, SCENES], 'readwrite', async (tx) => {
+      const stages = tx.objectStore(STAGES);
+      const stageRow = await reqP<StageRow | undefined>(stages.get(stageId));
+      if (!stageRow) {
+        throw new Error(
+          `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
+        );
+      }
+      // An incremental scene write must land in an already-current document. If
+      // the stored document is stale, its other scenes have not been migrated,
+      // so marking the whole document current off one write would strand them
+      // below the migrate-on-read line; if it is newer, this client must not
+      // downgrade it. Either way, require a full load + save to normalize first.
+      if (dslVersionOf(stageRow) !== DSL_VERSION) {
+        throw new Error(
+          `@openmaic/storage: cannot putScene into document ${JSON.stringify(stageId)} at DSL ` +
+            `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
+            `to ${DSL_VERSION} first`,
+        );
+      }
+      tx.objectStore(SCENES).put(scene);
+    });
+  }
+
+  async getScene(stageId: string, sceneId: string): Promise<TScene | null> {
+    const stageRow = await this.txRun([STAGES], 'readonly', (tx) =>
+      reqP<StageRow | undefined>(tx.objectStore(STAGES).get(stageId)),
+    );
+    if (!stageRow) return null;
+
+    // Fast path when the document needs no migration (current OR ahead of us):
+    // read the one row. A stale (older) document routes through the whole-
+    // document migrate path below, so a lone scene is never returned
+    // un-migrated (per the whole-document migration granularity).
+    if (!needsMigration(stageRow)) {
+      const scene = await this.txRun([SCENES], 'readonly', (tx) =>
+        reqP<TScene | undefined>(tx.objectStore(SCENES).get([stageId, sceneId])),
+      );
+      return scene ?? null;
+    }
+    const document = await this.loadDocument(stageId);
+    return document?.scenes.find((s) => s.id === sceneId) ?? null;
+  }
+
+  async deleteScene(stageId: string, sceneId: string): Promise<void> {
+    await this.txRun([STAGES, SCENES], 'readwrite', async (tx) => {
+      const stageRow = await reqP<StageRow | undefined>(tx.objectStore(STAGES).get(stageId));
+      // Idempotent: nothing to delete if the document is already gone.
+      if (!stageRow) return;
+      // Deleting a scene is an incremental mutation, so it takes the same guard
+      // as putScene: the stored document must be current. This client must not
+      // partially edit a newer-versioned document (which loadDocument otherwise
+      // preserves untouched), nor mutate a stale one before it is normalized.
+      // A whole-document removal (deleteDocument) is a deliberate coarse action
+      // and is intentionally NOT version-guarded.
+      if (dslVersionOf(stageRow) !== DSL_VERSION) {
+        throw new Error(
+          `@openmaic/storage: cannot deleteScene from document ${JSON.stringify(stageId)} at DSL ` +
+            `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
+            `to ${DSL_VERSION} first`,
+        );
+      }
+      tx.objectStore(SCENES).delete([stageId, sceneId]);
+    });
+  }
+}

--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -2,8 +2,8 @@
  * Browser {@link DocumentStore} backend: `document` aggregates normalized across
  * three IndexedDB object stores (`stages` / `scenes` / `outlines`). Writes
  * validate against the scene gate (the DSL `validateScene` by default, or an
- * injected validator for app-widened scene kinds) and diff scene rows (touching
- * only what changed); reads reassemble and migrate the document forward. Matches
+ * injected validator for app-widened scene kinds) and write scene rows (deleting
+ * ones no longer present); reads reassemble and migrate the document forward. Matches
  * the Part 1 asset backend's idiom — an injectable `IDBFactory`, a memoized open
  * that clears on failure, and transactions that resolve on commit (not on the
  * request) so a write claims durability only once the store actually kept it.
@@ -93,74 +93,6 @@ function assertStorableScene(scene: SceneLike, stageId: string): void {
         `${JSON.stringify(s.order)}`,
     );
   }
-}
-
-function isPlainObject(v: object): boolean {
-  const proto = Object.getPrototypeOf(v) as unknown;
-  return proto === Object.prototype || proto === null;
-}
-
-/**
- * Structural deep-equality used *only* to decide whether the write-diff may skip
- * re-writing an unchanged scene. It must never report two different values as
- * equal — a false positive would silently drop an edit — so anything it does not
- * confidently recognize (a class instance, a Blob, a typed array) is treated as
- * NOT equal, biasing the diff toward a harmless spurious write.
- *
- * A plain `JSON.stringify` compare is unsafe here because the store is generic
- * over opaque app scene content, and IndexedDB persists structured-clone values
- * (`Map` / `Set` / `Date`, `NaN`, `undefined` members, …) that JSON flattens or
- * drops — so two genuinely different scenes could stringify identically. This
- * recognizes the common cases (primitives incl. `NaN`, plain objects, arrays,
- * `Map`, `Set`, `Date`) and declines to prove equality for anything else.
- */
-function structuralEquals(a: unknown, b: unknown, depth = 0): boolean {
-  if (Object.is(a, b)) return true;
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
-  // Bound recursion: cyclic or pathologically deep content is treated as "not
-  // provably equal" (→ write) rather than risking a stack overflow. Safe, since a
-  // spurious write never loses data; ordinary scene content is shallow.
-  if (depth > 100) return false;
-
-  if (a instanceof Date || b instanceof Date) {
-    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
-  }
-
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) if (!structuralEquals(a[i], b[i], depth + 1)) return false;
-    return true;
-  }
-
-  if (a instanceof Map || b instanceof Map) {
-    if (!(a instanceof Map) || !(b instanceof Map) || a.size !== b.size) return false;
-    // Object keys from two separate structured-clone copies are distinct refs, so
-    // `b.has(k)` fails for them → NOT equal → write (a safe spurious write, never
-    // a false positive). Primitive keys compare correctly.
-    for (const [k, v] of a)
-      if (!b.has(k) || !structuralEquals(v, b.get(k), depth + 1)) return false;
-    return true;
-  }
-
-  if (a instanceof Set || b instanceof Set) {
-    if (!(a instanceof Set) || !(b instanceof Set) || a.size !== b.size) return false;
-    for (const v of a) if (!b.has(v)) return false;
-    return true;
-  }
-
-  // Plain objects only. A non-plain object (class instance, typed array, Blob)
-  // may carry state not visible through own-enumerable keys, so decline to prove
-  // equality and let the diff write.
-  if (!isPlainObject(a) || !isPlainObject(b)) return false;
-  const ra = a as Record<string, unknown>;
-  const rb = b as Record<string, unknown>;
-  const keys = Object.keys(ra);
-  if (keys.length !== Object.keys(rb).length) return false;
-  for (const k of keys) {
-    if (!Object.prototype.hasOwnProperty.call(rb, k) || !structuralEquals(ra[k], rb[k], depth + 1))
-      return false;
-  }
-  return true;
 }
 
 /**
@@ -333,21 +265,23 @@ export class BrowserDocumentStore<
       }
       stages.put(stageRow);
 
-      // Diff scenes: write only new/changed rows, delete removed ones. Equality
-      // is decided by `structuralEquals`, which is safe for opaque app scene
-      // content (unlike a JSON compare) and biases to write when uncertain — a
-      // spurious identical write is harmless (idempotent); a missed write would
-      // lose an edit.
+      // Write every incoming scene, then delete the ones no longer present. We do
+      // NOT diff-skip "unchanged" scenes: deciding a scene is unchanged means
+      // reliably comparing opaque app content, which would require faithfully
+      // reproducing IndexedDB's structured-clone equality (iteration order, sparse
+      // arrays, expando properties, prototype, shared-reference topology) — a
+      // false-positive minefield where a wrong "equal" silently drops an edit. A
+      // redundant write is harmless; cheap per-scene incremental writes go through
+      // `putScene`.
       const scenes = tx.objectStore(SCENES);
-      const existing = await reqP<TScene[]>(scenes.index(SCENES_BY_STAGE).getAll(stageId));
-      const existingById = new Map(existing.map((s) => [s.id, s]));
       const incomingIds = new Set(sceneRows.map((s) => s.id));
-      for (const scene of sceneRows) {
-        const prev = existingById.get(scene.id);
-        if (!prev || !structuralEquals(prev, scene)) scenes.put(scene);
-      }
-      for (const prev of existing) {
-        if (!incomingIds.has(prev.id)) scenes.delete([stageId, prev.id]);
+      for (const scene of sceneRows) scenes.put(scene);
+      const existingKeys = await reqP<IDBValidKey[]>(
+        scenes.index(SCENES_BY_STAGE).getAllKeys(stageId),
+      );
+      for (const key of existingKeys) {
+        const id = Array.isArray(key) ? (key[1] as string) : (key as string);
+        if (!incomingIds.has(id)) scenes.delete(key);
       }
 
       // A full-aggregate save with no outline means "no outline" — clear any.

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -81,8 +81,10 @@ export interface DocumentSummary {
 export interface DocumentStore<TScene extends SceneLike = Scene> {
   /**
    * Validate the aggregate, stamp it at the current DSL version, split it into
-   * rows, and write only the children that changed (deleting removed scenes).
-   * Atomic: an invalid stage or scene throws before anything is written.
+   * rows, write every scene, and delete scenes no longer present. Atomic: an
+   * invalid stage or scene throws before anything is written. (Reliably diffing
+   * opaque scene content is not attempted; cheap per-scene writes use
+   * {@link putScene}.)
    */
   saveDocument(doc: MaicDocument<TScene>): Promise<void>;
 

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -1,0 +1,128 @@
+/**
+ * DocumentStore — persist the DSL `document` aggregate (a course: stage metadata
+ * + scenes + embedded agents / quiz / actions + an app-owned outline snapshot).
+ *
+ * The DSL owns the *entities* (`Stage`, `Scene`) and the *what* of persistence
+ * (shape + validation + migration); this store owns the *where/how*: it
+ * normalizes the embedded aggregate into per-entity rows on write (diffing so it
+ * touches only changed children) and reassembles them on read, migrating the
+ * whole document forward via the DSL migration ladder. The pluggable seam is the
+ * backend, not the database driver — every backend satisfies one contract test.
+ */
+import type { Stage, Scene } from '@openmaic/dsl';
+
+/**
+ * The minimal scene shape the store itself depends on — the fields it uses to
+ * normalize (`stageId` + `id` are the compound row key), order (`order`), and
+ * integrity-check scenes. The DSL `Scene` satisfies it. The store is generic
+ * over the concrete scene type so an app can persist its own widened scene union
+ * (interactive / pbl / …) — content the DSL does not own — by supplying a
+ * matching {@link SceneValidator}. Everything below `SceneLike` is opaque to the
+ * store and rides along verbatim.
+ */
+export interface SceneLike {
+  id: string;
+  stageId: string;
+  order: number;
+}
+
+/**
+ * Validate a scene at the write boundary. Defaults to the DSL `validateScene`
+ * (which owns the universal `slide` / `quiz` kinds); an app that widens `Scene`
+ * with its own content kinds injects a validator that also accepts those, so the
+ * gate stays fail-loud for the app's shapes rather than silently rejecting them.
+ */
+export type SceneValidator = (
+  scene: unknown,
+) => { valid: true } | { valid: false; errors: { path: string; message: string }[] };
+
+/**
+ * The portable, embedded form of a persisted course. Storage normalizes it into
+ * per-entity rows on write and reassembles it on read.
+ *
+ * `scenes` defaults to the DSL `Scene` (bare = `Scene<Action, SlideContent |
+ * QuizContent>`, a discriminated union). Apps widen `TScene` with their own
+ * scene union — the store treats scene content opaquely and only touches the
+ * {@link SceneLike} fields.
+ *
+ * `outline` is an opaque, app-owned snapshot (the DSL owns no outline type). The
+ * store persists it verbatim and never inspects it — it is not validated and not
+ * migrated. Snapshot semantics: it captures original generation intent and is
+ * not kept in sync as scenes are edited.
+ *
+ * `dslVersion` is the migrate() envelope stamp ({@link DSL_VERSION_KEY}); absent
+ * on legacy data written before the version field existed.
+ */
+export interface MaicDocument<TScene extends SceneLike = Scene> {
+  stage: Stage;
+  scenes: TScene[];
+  outline?: unknown;
+  dslVersion?: string;
+}
+
+/**
+ * A lightweight per-document row for a course picker — enough to render a list
+ * without loading whole documents.
+ */
+export interface DocumentSummary {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  sceneCount: number;
+}
+
+/**
+ * Persist DSL `document` aggregates. `saveDocument` validates and writes the
+ * whole aggregate (diffing scene rows); `loadDocument` reassembles and
+ * migrate-on-reads. The `*Scene` methods are incremental conveniences over the
+ * normalized rows for scene-level editing.
+ */
+export interface DocumentStore<TScene extends SceneLike = Scene> {
+  /**
+   * Validate the aggregate, stamp it at the current DSL version, split it into
+   * rows, and write only the children that changed (deleting removed scenes).
+   * Atomic: an invalid stage or scene throws before anything is written.
+   */
+  saveDocument(doc: MaicDocument<TScene>): Promise<void>;
+
+  /**
+   * Reassemble the document for `stageId` (scenes sorted by `order`, outline
+   * attached), migrated forward to the current DSL version. `null` if absent.
+   */
+  loadDocument(stageId: string): Promise<MaicDocument<TScene> | null>;
+
+  /** A summary per stored document. */
+  listDocuments(): Promise<DocumentSummary[]>;
+
+  /**
+   * Cascade-delete the stage, its scenes, and its outline. Idempotent. Unlike
+   * the incremental scene mutations, a whole-document removal is a deliberate
+   * coarse action and is intentionally not version-guarded.
+   */
+  deleteDocument(stageId: string): Promise<void>;
+
+  /**
+   * Validate and upsert a single scene into an existing, already-current
+   * document. The stored document must be at the current DSL version: a stale
+   * document would leave its unmigrated sibling scenes stranded above the
+   * migrate-on-read line, and a newer one must not be downgraded — so an
+   * incremental write into a non-current document is rejected (normalize it with
+   * a `loadDocument` + `saveDocument` first). Throws if the parent document is
+   * absent or not current, or the scene does not belong to `stageId`.
+   */
+  putScene(stageId: string, scene: TScene): Promise<void>;
+
+  /**
+   * Read a single scene, migrated forward via its parent document's version.
+   * `null` if the scene or its document is absent.
+   */
+  getScene(stageId: string, sceneId: string): Promise<TScene | null>;
+
+  /**
+   * Delete a single scene. Idempotent (a no-op if the document or scene is
+   * absent). Like `putScene`, this incremental mutation requires the stored
+   * document to be current, so it throws on a stale or newer-versioned document.
+   */
+  deleteScene(stageId: string, sceneId: string): Promise<void>;
+}

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -92,7 +92,13 @@ export interface DocumentStore<TScene extends SceneLike = Scene> {
    */
   loadDocument(stageId: string): Promise<MaicDocument<TScene> | null>;
 
-  /** A summary per stored document. */
+  /**
+   * A summary per stored document. Returns only version-independent fields
+   * (id / name / timestamps / sceneCount) and never migrates or reads content,
+   * so — unlike the content APIs — it intentionally tolerates a corrupt or
+   * unrecognized `dslVersion` stamp rather than failing the whole listing on one
+   * bad row (a broken document still surfaces fail-loud when actually opened).
+   */
   listDocuments(): Promise<DocumentSummary[]>;
 
   /**

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -7,9 +7,11 @@
  * persists — the KV / asset primitives and their swappable backends. The
  * pluggable seam is the backend, not the database driver.
  *
- * Part 1 ships the browser backends (zero server) and the primitive contracts;
- * the HTTP backend + reference server and the DocumentStore / RuntimeStore
- * follow in later parts (see the tracking issue).
+ * The KV / asset primitives ship with browser backends (zero server) and their
+ * primitive contracts; the `DocumentStore` adds the normalized document
+ * aggregate (browser backend, migrate-on-read, validation gate). The HTTP
+ * backend + reference server and the `RuntimeStore` follow in later parts (see
+ * the tracking issue).
  */
 export type { KVScope, KVStore } from './kv/types.js';
 export { DEFAULT_KV_SCOPE } from './kv/types.js';
@@ -21,6 +23,15 @@ export {
   type PersistedValue,
   type PersistStorageLike,
 } from './zustand/persist.js';
+
+export type {
+  DocumentStore,
+  MaicDocument,
+  DocumentSummary,
+  SceneLike,
+  SceneValidator,
+} from './document/types.js';
+export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
 
 // Re-export the DSL-owned asset contract for convenience, so consumers can get
 // the interface and a backend from one import without reaching into the DSL.

--- a/packages/@openmaic/storage/test/document-adapter.test.ts
+++ b/packages/@openmaic/storage/test/document-adapter.test.ts
@@ -1,0 +1,52 @@
+// Unit tests for the pure aggregate <-> normalized adapter, independent of any
+// backend. The backend contract exercises these too, but pinning them here locks
+// the split/reassemble semantics a future HTTP backend must also honour.
+import { describe, expect, test } from 'vitest';
+import { DSL_VERSION, DSL_VERSION_KEY } from '@openmaic/dsl';
+import { reassembleDocument, splitDocument } from '../src/document/adapter.js';
+import { makeDocument, slideScene } from './document-contract.js';
+
+describe('splitDocument', () => {
+  test('stamps the current DSL version on the stage row', () => {
+    const { stageRow } = splitDocument(makeDocument());
+    expect(stageRow[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+  });
+
+  test('emits an outline row only when the document carries an outline', () => {
+    const withOutline = splitDocument(makeDocument());
+    expect(withOutline.outlineRow).toEqual({
+      stageId: 'stage-1',
+      outline: { entries: [{ id: 'o1', title: 'Intro' }], generationComplete: true },
+    });
+
+    const bare = makeDocument();
+    delete bare.outline;
+    expect(splitDocument(bare).outlineRow).toBeUndefined();
+  });
+});
+
+describe('reassembleDocument', () => {
+  test('sorts scenes by order and lifts the version to the document root', () => {
+    const rows = splitDocument({
+      stage: { id: 'stage-1', name: 'C', createdAt: 1, updatedAt: 2 },
+      scenes: [slideScene('stage-1', 'b', 1), slideScene('stage-1', 'a', 0)],
+    });
+    const doc = reassembleDocument(rows.stageRow, rows.sceneRows, rows.outlineRow);
+
+    expect(doc.scenes.map((s) => s.id)).toEqual(['a', 'b']);
+    expect(doc.dslVersion).toBe(DSL_VERSION);
+    // the version stamp does not leak back onto the stage
+    expect(DSL_VERSION_KEY in doc.stage).toBe(false);
+    expect(doc.outline).toBeUndefined();
+  });
+
+  test('round-trips a document through split then reassemble', () => {
+    const original = makeDocument();
+    const rows = splitDocument(original);
+    const doc = reassembleDocument(rows.stageRow, rows.sceneRows, rows.outlineRow);
+
+    expect(doc.stage).toEqual(original.stage);
+    expect(doc.scenes).toEqual(original.scenes);
+    expect(doc.outline).toEqual(original.outline);
+  });
+});

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -324,4 +324,90 @@ describe('BrowserDocumentStore with an app-widened scene union', () => {
     const got = await store.getScene('stage-1', 'm1');
     expect(got!.content.data.get('k')).toBe(2);
   });
+
+  test('re-saves a scene whose Map/Set was only reordered', async () => {
+    // Map/Set iteration order is observable and IndexedDB preserves it, so an
+    // order-only edit (same entries, reordered) is a real change and must not be
+    // skipped by the write-diff.
+    interface OrderScene {
+      id: string;
+      stageId: string;
+      title: string;
+      order: number;
+      type: 'interactive';
+      content: { type: 'interactive'; m: Map<string, number>; s: Set<string> };
+    }
+    const store = new BrowserDocumentStore<OrderScene>({
+      indexedDB: new IDBFactory(),
+      validateScene: () => ({ valid: true }),
+    });
+    const base: OrderScene = {
+      id: 'o1',
+      stageId: 'stage-1',
+      title: 'W',
+      order: 0,
+      type: 'interactive',
+      content: {
+        type: 'interactive',
+        m: new Map([
+          ['a', 1],
+          ['b', 2],
+        ]),
+        s: new Set(['x', 'y']),
+      },
+    };
+    const stage = { id: 'stage-1', name: 'C', createdAt: 1, updatedAt: 2 };
+    await store.saveDocument({ stage, scenes: [base] });
+
+    // Same entries, reversed order — no membership/value change.
+    const reordered: OrderScene = {
+      ...base,
+      content: {
+        type: 'interactive',
+        m: new Map([
+          ['b', 2],
+          ['a', 1],
+        ]),
+        s: new Set(['y', 'x']),
+      },
+    };
+    await store.saveDocument({ stage: { ...stage, updatedAt: 3 }, scenes: [reordered] });
+
+    const got = await store.getScene('stage-1', 'o1');
+    expect([...got!.content.m.keys()]).toEqual(['b', 'a']);
+    expect([...got!.content.s]).toEqual(['y', 'x']);
+  });
+
+  test('re-saves a scene whose plain-object key order changed', async () => {
+    // Own string-key insertion order is observable and IndexedDB preserves it, so
+    // a key-order-only change is a real edit (same treatment as Map/Set).
+    interface ObjScene {
+      id: string;
+      stageId: string;
+      title: string;
+      order: number;
+      type: 'interactive';
+      content: { type: 'interactive'; cfg: Record<string, number> };
+    }
+    const store = new BrowserDocumentStore<ObjScene>({
+      indexedDB: new IDBFactory(),
+      validateScene: () => ({ valid: true }),
+    });
+    const base: ObjScene = {
+      id: 'p1',
+      stageId: 'stage-1',
+      title: 'W',
+      order: 0,
+      type: 'interactive',
+      content: { type: 'interactive', cfg: { a: 1, b: 2 } },
+    };
+    const stage = { id: 'stage-1', name: 'C', createdAt: 1, updatedAt: 2 };
+    await store.saveDocument({ stage, scenes: [base] });
+
+    const reordered: ObjScene = { ...base, content: { type: 'interactive', cfg: { b: 2, a: 1 } } };
+    await store.saveDocument({ stage: { ...stage, updatedAt: 3 }, scenes: [reordered] });
+
+    const got = await store.getScene('stage-1', 'p1');
+    expect(Object.keys(got!.content.cfg)).toEqual(['b', 'a']);
+  });
 });

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import { DSL_VERSION, DSL_VERSION_KEY, validateScene } from '@openmaic/dsl';
+import { BrowserDocumentStore, type MaicDocument } from '../src/index.js';
+import { runDocumentStoreContract, makeDocument, slideScene } from './document-contract.js';
+
+// Each store gets its own in-memory IndexedDB factory so contract cases stay
+// isolated without leaning on an ambient global.
+function makeStore(): BrowserDocumentStore {
+  return new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+}
+
+runDocumentStoreContract('BrowserDocumentStore', makeStore);
+
+// --- backend-specific: migrate-on-read needs to seed a raw row at an old
+// version, which the public API (which always stamps the current version) can't
+// express. ---
+describe('BrowserDocumentStore migrate-on-read', () => {
+  // Open the raw DB the store uses and overwrite the stage row's version stamp,
+  // simulating a document written by an older client.
+  async function reStampStage(
+    idb: IDBFactory,
+    dbName: string,
+    stageId: string,
+    version: string | undefined,
+  ): Promise<void> {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = idb.open(dbName);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction('stages', 'readwrite');
+      const store = tx.objectStore('stages');
+      const get = store.get(stageId);
+      get.onsuccess = () => {
+        const row = get.result as Record<string, unknown>;
+        if (version === undefined) delete row[DSL_VERSION_KEY];
+        else row[DSL_VERSION_KEY] = version;
+        store.put(row);
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  }
+
+  test('stamps a legacy (unversioned) document forward on load', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-legacy';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+    await reStampStage(idb, dbName, 'stage-1', undefined);
+
+    const loaded = await store.loadDocument('stage-1');
+    expect(loaded!.dslVersion).toBe(DSL_VERSION);
+  });
+
+  test('returns a future-versioned document untouched (no downgrade)', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-future';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
+
+    const loaded = await store.loadDocument('stage-1');
+    expect(loaded!.dslVersion).toBe('99.0.0');
+  });
+
+  test('getScene reads a future-versioned document without downgrade', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-future-scene';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
+
+    // A document at/above the current version needs no migration, so getScene
+    // returns the row directly (never downgraded).
+    const scene = await store.getScene('stage-1', 'scene-a');
+    expect(scene!.id).toBe('scene-a');
+  });
+
+  test('getScene migrates a stale (legacy) document on read', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-stale-scene';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+    await reStampStage(idb, dbName, 'stage-1', undefined); // legacy
+
+    // A stale document routes getScene through the whole-document migrate path.
+    const scene = await store.getScene('stage-1', 'scene-a');
+    expect(scene!.id).toBe('scene-a');
+  });
+
+  test('putScene rejects when the stored document is not current', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-putscene-noncurrent';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+
+    // Legacy stored document: the other scenes have not been migrated, so
+    // stamping the whole document current off one incremental write would
+    // corrupt them — reject and require a full load + save first.
+    await reStampStage(idb, dbName, 'stage-1', undefined);
+    await expect(store.putScene('stage-1', slideScene('stage-1', 'new', 2))).rejects.toThrow();
+    // rejected write left nothing behind (a legacy doc still migrates on read)
+    expect(await store.getScene('stage-1', 'new')).toBeNull();
+
+    // Future stored document: an old client must not downgrade it.
+    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
+    await expect(store.putScene('stage-1', slideScene('stage-1', 'new2', 3))).rejects.toThrow();
+    expect(await store.getScene('stage-1', 'new2')).toBeNull();
+  });
+
+  test('refuses to overwrite a stored document written by a newer client', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-overwrite-future';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument()); // current
+    await reStampStage(idb, dbName, 'stage-1', '99.0.0'); // stored as future
+
+    // A fresh/current document for the same id (its own dslVersion is not future,
+    // so the incoming-version guard passes) must still not clobber the newer
+    // stored document — the store checks the stored row inside the write tx.
+    const fresh = makeDocument();
+    fresh.stage.name = 'Old Client Overwrite';
+    await expect(store.saveDocument(fresh)).rejects.toThrow();
+
+    const loaded = await store.loadDocument('stage-1');
+    expect(loaded!.dslVersion).toBe('99.0.0');
+    expect(loaded!.stage.name).toBe('Intro Course');
+  });
+
+  test('deleteScene rejects when the stored document is not current', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-deletescene-noncurrent';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+
+    // Future stored document: an old client must not mutate newer-versioned data
+    // (mirrors the putScene guard — deleting a scene is an incremental mutation).
+    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow();
+    expect((await store.loadDocument('stage-1'))!.scenes.map((s) => s.id)).toEqual([
+      'scene-a',
+      'scene-b',
+    ]);
+
+    // Stale stored document must be normalized (load + save) before incremental ops.
+    await reStampStage(idb, dbName, 'stage-1', undefined);
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow();
+  });
+
+  test('fails loud on a malformed stored version stamp', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-malformed';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+    // A present-but-corrupt stamp makes a false version claim; reads must throw
+    // rather than silently comparing it as some arbitrary version.
+    await reStampStage(idb, dbName, 'stage-1', 'not-a-version');
+    await expect(store.loadDocument('stage-1')).rejects.toThrow();
+    await expect(store.getScene('stage-1', 'scene-a')).rejects.toThrow();
+    // saveDocument reads the stored stamp inside its future-overwrite guard, so a
+    // corrupt stored stamp also fails loud (recoverable via deleteDocument).
+    await expect(store.saveDocument(makeDocument())).rejects.toThrow();
+  });
+});
+
+// The store is generic over the scene type: an app can persist its own widened
+// scene union (kinds the DSL does not own, e.g. `interactive`) by injecting a
+// matching validator. The store treats scene content opaquely.
+describe('BrowserDocumentStore with an app-widened scene union', () => {
+  interface InteractiveScene {
+    id: string;
+    stageId: string;
+    title: string;
+    order: number;
+    type: 'interactive';
+    content: { type: 'interactive'; html: string };
+  }
+
+  // Accept the app's own kind, else fall back to the DSL validator (slide/quiz).
+  const validateAppScene = (scene: unknown) => {
+    const s = scene as { type?: unknown; id?: unknown };
+    if (s.type === 'interactive') {
+      return typeof s.id === 'string'
+        ? { valid: true as const }
+        : { valid: false as const, errors: [{ path: '/id', message: 'expected string id' }] };
+    }
+    return validateScene(scene);
+  };
+
+  const interactiveDoc: MaicDocument<InteractiveScene> = {
+    stage: { id: 'stage-1', name: 'Interactive Course', createdAt: 1, updatedAt: 2 },
+    scenes: [
+      {
+        id: 'i1',
+        stageId: 'stage-1',
+        title: 'Widget',
+        order: 0,
+        type: 'interactive',
+        content: { type: 'interactive', html: '<div/>' },
+      },
+    ],
+  };
+
+  test('persists an app-only interactive scene via an injected validator', async () => {
+    const store = new BrowserDocumentStore<InteractiveScene>({
+      indexedDB: new IDBFactory(),
+      validateScene: validateAppScene,
+    });
+    await store.saveDocument(interactiveDoc);
+
+    const loaded = await store.loadDocument('stage-1');
+    expect(loaded!.scenes[0]).toMatchObject({
+      type: 'interactive',
+      content: { type: 'interactive', html: '<div/>' },
+    });
+  });
+
+  test('the default store (DSL validator) rejects an app-only scene kind', async () => {
+    const store = new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+    await expect(store.saveDocument(interactiveDoc as unknown as MaicDocument)).rejects.toThrow();
+  });
+
+  test('supports incremental scene ops for an app scene union', async () => {
+    const store = new BrowserDocumentStore<InteractiveScene>({
+      indexedDB: new IDBFactory(),
+      validateScene: validateAppScene,
+    });
+    await store.saveDocument(interactiveDoc);
+
+    const added: InteractiveScene = {
+      id: 'i2',
+      stageId: 'stage-1',
+      title: 'Widget 2',
+      order: 1,
+      type: 'interactive',
+      content: { type: 'interactive', html: '<span/>' },
+    };
+    await store.putScene('stage-1', added);
+    expect((await store.getScene('stage-1', 'i2'))!.content.html).toBe('<span/>');
+
+    await store.deleteScene('stage-1', 'i1');
+    expect((await store.loadDocument('stage-1'))!.scenes.map((s) => s.id)).toEqual(['i2']);
+  });
+
+  test('enforces the phantom-partition guard even under a permissive validator', async () => {
+    // A validator that accepts everything must NOT be able to weaken the store's
+    // own key invariant: a scene whose stageId disagrees with its document is
+    // still rejected (assertStorableScene runs independently of the validator).
+    const store = new BrowserDocumentStore<InteractiveScene>({
+      indexedDB: new IDBFactory(),
+      validateScene: () => ({ valid: true }),
+    });
+    const mismatched: MaicDocument<InteractiveScene> = {
+      stage: { id: 'stage-1', name: 'C', createdAt: 1, updatedAt: 2 },
+      scenes: [
+        {
+          id: 'x',
+          stageId: 'other-stage',
+          title: 'W',
+          order: 0,
+          type: 'interactive',
+          content: { type: 'interactive', html: '' },
+        },
+      ],
+    };
+    await expect(store.saveDocument(mismatched)).rejects.toThrow();
+    expect(await store.loadDocument('stage-1')).toBeNull();
+  });
+});

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -165,6 +165,22 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // corrupt stored stamp also fails loud (recoverable via deleteDocument).
     await expect(store.saveDocument(makeDocument())).rejects.toThrow();
   });
+
+  test('listDocuments tolerates a malformed version stamp', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-list-malformed';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    await store.saveDocument(makeDocument());
+    await reStampStage(idb, dbName, 'stage-1', 'not-a-version');
+
+    // listDocuments returns only version-independent summary fields and never
+    // migrates or reads content, so a corrupt stamp does not break the whole list
+    // (one bad row must not make the picker unusable) — content reads still fail loud.
+    const list = await store.listDocuments();
+    expect(list.map((d) => d.id)).toEqual(['stage-1']);
+    expect(list[0]).toMatchObject({ name: 'Intro Course', sceneCount: 2 });
+    await expect(store.loadDocument('stage-1')).rejects.toThrow();
+  });
 });
 
 // The store is generic over the scene type: an app can persist its own widened
@@ -269,5 +285,43 @@ describe('BrowserDocumentStore with an app-widened scene union', () => {
     };
     await expect(store.saveDocument(mismatched)).rejects.toThrow();
     expect(await store.loadDocument('stage-1')).toBeNull();
+  });
+
+  test('re-saves a scene whose opaque structured-clone content changed', async () => {
+    // IndexedDB persists Map/Set/Date/… that JSON.stringify flattens to `{}`, so the
+    // write-diff must not compare opaque app content via JSON — a real edit to a
+    // Map value would otherwise stringify identically and be silently skipped.
+    interface MapScene {
+      id: string;
+      stageId: string;
+      title: string;
+      order: number;
+      type: 'interactive';
+      content: { type: 'interactive'; data: Map<string, number> };
+    }
+    const store = new BrowserDocumentStore<MapScene>({
+      indexedDB: new IDBFactory(),
+      validateScene: () => ({ valid: true }),
+    });
+    const base: MapScene = {
+      id: 'm1',
+      stageId: 'stage-1',
+      title: 'W',
+      order: 0,
+      type: 'interactive',
+      content: { type: 'interactive', data: new Map([['k', 1]]) },
+    };
+    const stage = { id: 'stage-1', name: 'C', createdAt: 1, updatedAt: 2 };
+    await store.saveDocument({ stage, scenes: [base] });
+
+    // Only the Map value changes; JSON.stringify(base) === JSON.stringify(edited).
+    const edited: MapScene = {
+      ...base,
+      content: { type: 'interactive', data: new Map([['k', 2]]) },
+    };
+    await store.saveDocument({ stage: { ...stage, updatedAt: 3 }, scenes: [edited] });
+
+    const got = await store.getScene('stage-1', 'm1');
+    expect(got!.content.data.get('k')).toBe(2);
   });
 });

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -168,6 +168,15 @@ export function runDocumentStoreContract(name: string, makeStore: () => Document
       expect(await store.getScene('other-stage', 'stray')).toBeNull();
     });
 
+    test('rejects a scene with a non-finite order', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      // NaN/Infinity are `typeof number` but break the read-time `order` sort.
+      (doc.scenes[0] as { order: number }).order = NaN;
+      await expect(store.saveDocument(doc)).rejects.toThrow();
+      expect(await store.loadDocument('stage-1')).toBeNull();
+    });
+
     test('rejects duplicate scene ids within a document', async () => {
       const store = makeStore();
       const doc = makeDocument('stage-1');

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -1,0 +1,329 @@
+// Implementation-agnostic contract for `DocumentStore`. Every backend (browser
+// today, HTTP later) is proven equivalent by running this same suite against it,
+// so a new backend cannot silently diverge from the store's semantics.
+//
+// Backend-specific behaviours that need to seed raw rows (migrate-on-read,
+// forward-compat) live in the backend's own test file, not here.
+import { describe, expect, test } from 'vitest';
+import { DSL_VERSION } from '@openmaic/dsl';
+import type { Scene } from '@openmaic/dsl';
+import type { DocumentStore, MaicDocument } from '../src/index.js';
+
+// --- fixtures ---------------------------------------------------------------
+
+// Fixtures are cast through `unknown`: `validateScene` only requires `content.canvas`
+// to be an object, so these minimal shapes are valid at the boundary without
+// spelling out a full `Slide` (viewportSize / theme / …) the store never inspects.
+
+/** A valid slide scene (passes `validateScene`: id/stageId/title/order + slide content). */
+export function slideScene(stageId: string, id: string, order: number, title = id): Scene {
+  return {
+    id,
+    stageId,
+    title,
+    order,
+    type: 'slide',
+    content: { type: 'slide', canvas: { id: `canvas-${id}`, elements: [] } },
+  } as unknown as Scene;
+}
+
+/** A valid quiz scene. */
+export function quizScene(stageId: string, id: string, order: number, title = id): Scene {
+  return {
+    id,
+    stageId,
+    title,
+    order,
+    type: 'quiz',
+    content: {
+      type: 'quiz',
+      questions: [{ id: `q-${id}`, type: 'single', question: 'Q?' }],
+    },
+  } as unknown as Scene;
+}
+
+/** A valid document: stage metadata + two scenes + an outline snapshot. */
+export function makeDocument(stageId = 'stage-1'): MaicDocument {
+  return {
+    stage: { id: stageId, name: 'Intro Course', createdAt: 1000, updatedAt: 2000 },
+    scenes: [slideScene(stageId, 'scene-a', 0), quizScene(stageId, 'scene-b', 1)],
+    outline: { entries: [{ id: 'o1', title: 'Intro' }], generationComplete: true },
+  };
+}
+
+// --- contract ---------------------------------------------------------------
+
+export function runDocumentStoreContract(name: string, makeStore: () => DocumentStore): void {
+  describe(`DocumentStore contract: ${name}`, () => {
+    test('round-trips a full document (stage + scenes + outline)', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded).not.toBeNull();
+      expect(loaded!.stage).toMatchObject(doc.stage);
+      expect(loaded!.scenes.map((s) => s.id)).toEqual(['scene-a', 'scene-b']);
+      expect(loaded!.outline).toEqual(doc.outline);
+    });
+
+    test('loadDocument returns null for an unknown stage', async () => {
+      const store = makeStore();
+      expect(await store.loadDocument('nope')).toBeNull();
+    });
+
+    test('scenes come back sorted by order regardless of input order', async () => {
+      const store = makeStore();
+      const doc = makeDocument('stage-x');
+      doc.scenes = [
+        slideScene('stage-x', 'third', 2),
+        slideScene('stage-x', 'first', 0),
+        slideScene('stage-x', 'second', 1),
+      ];
+      await store.saveDocument(doc);
+
+      const loaded = await store.loadDocument('stage-x');
+      expect(loaded!.scenes.map((s) => s.id)).toEqual(['first', 'second', 'third']);
+    });
+
+    test('stamps the current DSL version on load', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.dslVersion).toBe(DSL_VERSION);
+    });
+
+    test('listDocuments returns one summary per stage with a scene count', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument('stage-1'));
+      await store.saveDocument(makeDocument('stage-2'));
+
+      const list = await store.listDocuments();
+      expect(list.map((d) => d.id).sort()).toEqual(['stage-1', 'stage-2']);
+      const one = list.find((d) => d.id === 'stage-1')!;
+      expect(one).toMatchObject({ name: 'Intro Course', createdAt: 1000, sceneCount: 2 });
+    });
+
+    test('deleteDocument removes the stage, its scenes, and its outline', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      await store.deleteDocument('stage-1');
+
+      expect(await store.loadDocument('stage-1')).toBeNull();
+      expect(await store.getScene('stage-1', 'scene-a')).toBeNull();
+      expect(await store.listDocuments()).toEqual([]);
+    });
+
+    test('deleteDocument is idempotent', async () => {
+      const store = makeStore();
+      await store.deleteDocument('never-existed');
+      await store.saveDocument(makeDocument());
+      await store.deleteDocument('stage-1');
+      await expect(store.deleteDocument('stage-1')).resolves.toBeUndefined();
+    });
+
+    // --- validation gate ---
+
+    test('rejects a document whose stage is missing required fields', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      // drop the required `name`
+      delete (doc.stage as { name?: string }).name;
+      await expect(store.saveDocument(doc)).rejects.toThrow();
+    });
+
+    test('rejects a document with an invalid scene', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      // a slide scene whose content type disagrees with the scene type
+      (doc.scenes[0] as { content: unknown }).content = { type: 'quiz', questions: [] };
+      await expect(store.saveDocument(doc)).rejects.toThrow();
+    });
+
+    test('a rejected save leaves the store untouched (atomic)', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+
+      const bad = makeDocument();
+      bad.stage.name = 'Renamed';
+      bad.scenes.push({ id: 'broken', stageId: 'stage-1' } as unknown as Scene); // invalid scene
+      await expect(store.saveDocument(bad)).rejects.toThrow();
+
+      // original persists; nothing from the bad save landed
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.stage.name).toBe('Intro Course');
+      expect(loaded!.scenes.map((s) => s.id)).toEqual(['scene-a', 'scene-b']);
+      expect(await store.getScene('stage-1', 'broken')).toBeNull();
+    });
+
+    test('rejects a scene whose stageId does not match the document', async () => {
+      const store = makeStore();
+      const doc = makeDocument('stage-1');
+      // a scene mis-assigned to a different stage would otherwise be written to a
+      // phantom partition no read path can see — fail loud instead of losing it.
+      doc.scenes = [slideScene('stage-1', 'ok', 0), slideScene('other-stage', 'stray', 1)];
+      await expect(store.saveDocument(doc)).rejects.toThrow();
+      // nothing landed: the whole save is rejected before any write
+      expect(await store.loadDocument('stage-1')).toBeNull();
+      expect(await store.getScene('other-stage', 'stray')).toBeNull();
+    });
+
+    test('rejects duplicate scene ids within a document', async () => {
+      const store = makeStore();
+      const doc = makeDocument('stage-1');
+      doc.scenes = [slideScene('stage-1', 'dup', 0), slideScene('stage-1', 'dup', 1)];
+      await expect(store.saveDocument(doc)).rejects.toThrow();
+      // rejected before any write — nothing landed
+      expect(await store.loadDocument('stage-1')).toBeNull();
+    });
+
+    test('rejects saving a document stamped at an unknown/unreachable DSL version', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      // A stale stamp with no path up the DSL migration ladder is corrupt input —
+      // fail loud rather than persist it mislabeled as current.
+      doc.dslVersion = '0.0.1';
+      await expect(store.saveDocument(doc)).rejects.toThrow();
+      expect(await store.loadDocument('stage-1')).toBeNull();
+    });
+
+    test('normalizes a legacy-stamped document to the current version on save', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      // A pre-versioning stamp is lifted forward by the ladder, then persisted at
+      // the current version (never mislabeled without running migrate()).
+      doc.dslVersion = '0.0.0';
+      await store.saveDocument(doc);
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.dslVersion).toBe(DSL_VERSION);
+      // the opaque outline survives migration verbatim (it is not DSL-shaped, so
+      // migrations never see it)
+      expect(loaded!.outline).toEqual(doc.outline);
+    });
+
+    test('rejects saving a document written by a newer client', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument()); // current
+
+      const future = makeDocument();
+      future.dslVersion = '99.0.0';
+      future.stage.name = 'Should Not Persist';
+      // an old client must not overwrite (and downgrade) a newer-versioned document
+      await expect(store.saveDocument(future)).rejects.toThrow();
+
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.stage.name).toBe('Intro Course');
+    });
+
+    // --- incremental scene ops ---
+
+    test('putScene inserts a new scene into an existing document', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      await store.putScene('stage-1', slideScene('stage-1', 'scene-c', 2));
+
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.scenes.map((s) => s.id)).toEqual(['scene-a', 'scene-b', 'scene-c']);
+    });
+
+    test('putScene overwrites an existing scene', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      await store.putScene('stage-1', slideScene('stage-1', 'scene-a', 0, 'Renamed Title'));
+
+      const scene = await store.getScene('stage-1', 'scene-a');
+      expect(scene!.title).toBe('Renamed Title');
+    });
+
+    test('putScene rejects a scene whose stageId does not match the argument', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument('stage-1'));
+      await expect(
+        store.putScene('stage-1', slideScene('other-stage', 'stray', 2)),
+      ).rejects.toThrow();
+      // the mismatched scene is not reachable under either stage
+      expect(await store.getScene('stage-1', 'stray')).toBeNull();
+      expect(await store.getScene('other-stage', 'stray')).toBeNull();
+    });
+
+    test('putScene rejects when the parent document is absent', async () => {
+      const store = makeStore();
+      await expect(
+        store.putScene('ghost-stage', slideScene('ghost-stage', 's', 0)),
+      ).rejects.toThrow();
+    });
+
+    test('putScene validates the scene', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      await expect(
+        store.putScene('stage-1', { id: 'x', stageId: 'stage-1' } as unknown as Scene),
+      ).rejects.toThrow();
+    });
+
+    test('getScene returns null for a missing scene', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      expect(await store.getScene('stage-1', 'no-such-scene')).toBeNull();
+    });
+
+    test('deleteScene removes one scene and leaves the others', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument());
+      await store.deleteScene('stage-1', 'scene-a');
+
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.scenes.map((s) => s.id)).toEqual(['scene-b']);
+      await expect(store.deleteScene('stage-1', 'scene-a')).resolves.toBeUndefined();
+    });
+
+    test('deleteScene on an absent document is a no-op', async () => {
+      const store = makeStore();
+      await expect(store.deleteScene('ghost-stage', 'x')).resolves.toBeUndefined();
+    });
+
+    // --- diff-on-write (observable behaviour) ---
+
+    test('re-saving reconciles added / edited / removed scenes', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument()); // scene-a, scene-b
+
+      const next = makeDocument();
+      next.scenes = [
+        slideScene('stage-1', 'scene-a', 0, 'Edited A'), // edited
+        slideScene('stage-1', 'scene-c', 1), // added; scene-b removed
+      ];
+      await store.saveDocument(next);
+
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.scenes.map((s) => s.id)).toEqual(['scene-a', 'scene-c']);
+      expect(loaded!.scenes.find((s) => s.id === 'scene-a')!.title).toBe('Edited A');
+      expect(await store.getScene('stage-1', 'scene-b')).toBeNull();
+    });
+
+    // --- outline snapshot ---
+
+    test('persists the outline verbatim and can clear it', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+      expect((await store.loadDocument('stage-1'))!.outline).toEqual(doc.outline);
+
+      const withoutOutline = makeDocument();
+      delete withoutOutline.outline;
+      await store.saveDocument(withoutOutline);
+      expect((await store.loadDocument('stage-1'))!.outline).toBeUndefined();
+    });
+
+    test('documents are isolated from one another', async () => {
+      const store = makeStore();
+      await store.saveDocument(makeDocument('stage-1'));
+      await store.saveDocument(makeDocument('stage-2'));
+      await store.deleteScene('stage-1', 'scene-a');
+
+      // stage-2 untouched by a stage-1 scene delete
+      const two = await store.loadDocument('stage-2');
+      expect(two!.scenes.map((s) => s.id)).toEqual(['scene-a', 'scene-b']);
+    });
+  });
+}


### PR DESCRIPTION
Part 2 of the `@openmaic/storage` rollout (RFC #779, part breakdown #857), following the KV / asset primitives in #858.

## What

Adds `DocumentStore` — persistence for the `document` aggregate (a course: stage metadata + scenes + embedded agents / quiz / actions + an opaque outline snapshot) — with a browser (IndexedDB) backend. Depends only on `@openmaic/dsl`; no Dexie dependency (raw injected `IDBFactory`, matching the Part 1 asset backend).

Implements the three mechanisms from #779:

1. **Aggregate ↔ normalized adapter.** The portable embedded document splits into per-entity rows on write (diffing so only changed scenes are written; removed scenes deleted) and reassembles on read. Scenes key by `[stageId, id]` so documents stay isolated even if two courses reuse a scene id.
2. **Migrate-on-read/write.** Each document is root-stamped with `dslVersion`. Reads run the DSL migration ladder forward — a newer-versioned document passes through untouched (never downgraded). `saveDocument` normalizes stale input forward (or fails loud on a version with no ladder path) and refuses to overwrite a newer stored document; the incremental `putScene` / `deleteScene` require an already-current document so they can never strand unmigrated sibling scenes above the read line. The opaque outline rides alongside — persisted verbatim, never validated or migrated.
3. **Validation gate.** Writes run `validateStage` / `validateScene` and fail loud before any row is written (atomic). The store additionally enforces its own key/sort invariants — a scene belongs to its stage, `id` is a string, `order` is a number, no duplicate ids — independently of the content validator.

## Public API (DSL-typed repositories)

`saveDocument` / `loadDocument` / `listDocuments` / `deleteDocument`, plus incremental `putScene` / `getScene` / `deleteScene`.

The store is **generic over the scene type**: `DocumentStore<TScene>` defaults to the DSL `Scene` (universal `slide` / `quiz`). An app that widens `Scene` with its own kinds (`interactive` / `pbl`, content the DSL does not own) parameterizes the store over its scene union and injects a matching `validateScene`, so those scenes persist and the gate stays fail-loud for the app's shapes.

## Open questions from #779, resolved

- **Public API shape (#779 Q1):** DSL-typed repositories (not a generic `collection<T>`).
- **Outline update policy (#779 Q2):** original-intent snapshot — persisted verbatim, opaque to the store.

## Tests

- One **backend-agnostic contract suite** (`test/document-contract.ts`), run against the browser backend, so a future HTTP backend is proven equivalent by the same suite.
- Backend-seeded cases for migrate-on-read, forward-compat (no downgrade), version-guard rejections, and the app-widened scene union.
- Pure adapter unit tests for split / reassemble.

## Scope / non-goals (this part)

HTTP backend + reference server, `RuntimeStore`, asset-manifest wiring, and routing the app's existing storage through this store are later parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)