### PR TITLE
feat(audio): persist audio duration when storing TTS (#861)

### DIFF
--- a/lib/audio/audio-duration.ts
+++ b/lib/audio/audio-duration.ts
@@ -1,0 +1,200 @@
+/**
+ * Dependency-free audio duration measurement.
+ *
+ * Video export (#854) maps each narration/TTS clip onto a timeline segment,
+ * which needs the clip's duration. Rather than decode audio at render time
+ * (slow, and impossible to validate in a pure-manifest test without
+ * FFmpeg/Chrome), we measure duration once when the client persists TTS audio
+ * and store it on the `AudioFileRecord` alongside the blob.
+ *
+ * This module parses the container headers directly (no DOM / native audio
+ * API), so it's unit-testable in plain Node and stays usable from either the
+ * browser or a server context. It covers the two formats OpenMAIC's TTS
+ * providers actually emit — WAV and MP3 — and returns `null` for anything it
+ * cannot parse so callers degrade gracefully (store the audio, leave duration
+ * undefined) instead of failing.
+ */
+
+/** Coerce common inputs into a Uint8Array view without copying when possible. */
+function toBytes(input: Uint8Array | ArrayBuffer): Uint8Array {
+  return input instanceof Uint8Array ? input : new Uint8Array(input);
+}
+
+function readAscii(bytes: Uint8Array, offset: number, length: number): string {
+  let out = '';
+  for (let i = 0; i < length; i++) out += String.fromCharCode(bytes[offset + i] ?? 0);
+  return out;
+}
+
+function readUint32LE(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24)) >>>
+    0
+  );
+}
+
+function readUint32BE(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3]) >>>
+    0
+  );
+}
+
+/**
+ * WAV: walk the RIFF chunk list to find `fmt ` (byte rate) and `data` (size).
+ * duration = dataSize / byteRate. Walking chunks — rather than assuming fixed
+ * offsets — tolerates optional chunks (LIST, fact, …) some encoders insert
+ * before `data`.
+ */
+export function measureWavDuration(input: Uint8Array | ArrayBuffer): number | null {
+  const bytes = toBytes(input);
+  if (bytes.length < 12) return null;
+  if (readAscii(bytes, 0, 4) !== 'RIFF' || readAscii(bytes, 8, 4) !== 'WAVE') return null;
+
+  let byteRate = 0;
+  let dataSize = 0;
+  let offset = 12;
+  while (offset + 8 <= bytes.length) {
+    const chunkId = readAscii(bytes, offset, 4);
+    const chunkSize = readUint32LE(bytes, offset + 4);
+    const bodyOffset = offset + 8;
+    if (chunkId === 'fmt ' && bodyOffset + 16 <= bytes.length) {
+      byteRate = readUint32LE(bytes, bodyOffset + 8);
+    } else if (chunkId === 'data') {
+      // Some streams write 0 / 0xFFFFFFFF for an unknown-length data chunk;
+      // fall back to the actual remaining bytes in that case.
+      const declared = chunkSize;
+      const remaining = bytes.length - bodyOffset;
+      dataSize = declared > 0 && declared <= remaining ? declared : remaining;
+      break;
+    }
+    // Chunks are word-aligned: an odd size is padded with one byte.
+    offset = bodyOffset + chunkSize + (chunkSize % 2);
+  }
+
+  if (byteRate <= 0 || dataSize <= 0) return null;
+  return dataSize / byteRate;
+}
+
+// MPEG audio version → layer → bitrate table (kbps). Index by version bits then
+// layer bits, then the 4-bit bitrate index from the frame header.
+const MP3_BITRATES: Record<string, number[]> = {
+  // MPEG 1
+  '1-1': [0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448],
+  '1-2': [0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384],
+  '1-3': [0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320],
+  // MPEG 2 / 2.5
+  '2-1': [0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256],
+  '2-2': [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160],
+  '2-3': [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160],
+};
+
+const MP3_SAMPLE_RATES: Record<string, number[]> = {
+  '1': [44100, 48000, 32000],
+  '2': [22050, 24000, 16000],
+  '2.5': [11025, 12000, 8000],
+};
+
+/** Skip an ID3v2 tag if present; returns the offset of the first audio byte. */
+function skipId3v2(bytes: Uint8Array): number {
+  if (bytes.length < 10 || readAscii(bytes, 0, 3) !== 'ID3') return 0;
+  // Tag size is a 28-bit syncsafe integer in bytes 6..9.
+  const size =
+    ((bytes[6] & 0x7f) << 21) |
+    ((bytes[7] & 0x7f) << 14) |
+    ((bytes[8] & 0x7f) << 7) |
+    (bytes[9] & 0x7f);
+  return 10 + size;
+}
+
+/**
+ * MP3: parse the first frame header for version/layer/bitrate/sample-rate, then
+ * prefer a Xing/Info (or VBRI) frame count for a VBR-accurate duration. Falls
+ * back to a CBR estimate (audio bytes × 8 / bitrate) when no VBR header exists.
+ */
+export function measureMp3Duration(input: Uint8Array | ArrayBuffer): number | null {
+  const bytes = toBytes(input);
+  const audioStart = skipId3v2(bytes);
+
+  // Find the first frame sync (11 set bits: 0xFF followed by 0xE0-mask top 3).
+  let frame = -1;
+  for (let i = audioStart; i + 4 <= bytes.length; i++) {
+    if (bytes[i] === 0xff && (bytes[i + 1] & 0xe0) === 0xe0) {
+      frame = i;
+      break;
+    }
+  }
+  if (frame < 0) return null;
+
+  const b1 = bytes[frame + 1];
+  const b2 = bytes[frame + 2];
+  const versionBits = (b1 >> 3) & 0x03; // 0=2.5, 2=2, 3=1
+  const layerBits = (b1 >> 1) & 0x03; // 3=Layer1, 2=Layer2, 1=Layer3
+  const bitrateIdx = (b2 >> 4) & 0x0f;
+  const sampleRateIdx = (b2 >> 2) & 0x03;
+
+  if (versionBits === 1 || layerBits === 0) return null; // reserved
+  if (bitrateIdx === 0 || bitrateIdx === 15) return null; // free/bad
+  if (sampleRateIdx === 3) return null; // reserved
+
+  const version = versionBits === 3 ? '1' : versionBits === 2 ? '2' : '2.5';
+  const layer = layerBits === 3 ? 1 : layerBits === 2 ? 2 : 3;
+  const bitrateGroup = version === '1' ? '1' : '2';
+  const bitrateKbps = MP3_BITRATES[`${bitrateGroup}-${layer}`]?.[bitrateIdx];
+  const sampleRate = MP3_SAMPLE_RATES[version]?.[sampleRateIdx];
+  if (!bitrateKbps || !sampleRate) return null;
+
+  // Samples per frame: Layer1 = 384; Layer2 = 1152; Layer3 = 1152 (MPEG1) or 576 (MPEG2/2.5).
+  const samplesPerFrame = layer === 1 ? 384 : layer === 2 ? 1152 : version === '1' ? 1152 : 576;
+
+  // Xing/Info header sits at a fixed offset after the frame header, depending on
+  // MPEG version and channel mode.
+  const channelMode = (bytes[frame + 3] >> 6) & 0x03; // 3 = mono
+  const xingOffset =
+    frame + 4 + (version === '1' ? (channelMode === 3 ? 17 : 32) : channelMode === 3 ? 9 : 17);
+  if (xingOffset + 12 <= bytes.length) {
+    const tag = readAscii(bytes, xingOffset, 4);
+    if (tag === 'Xing' || tag === 'Info') {
+      const flags = readUint32BE(bytes, xingOffset + 4);
+      if (flags & 0x01) {
+        const frameCount = readUint32BE(bytes, xingOffset + 8);
+        if (frameCount > 0) return (frameCount * samplesPerFrame) / sampleRate;
+      }
+    }
+  }
+
+  // CBR estimate from the audio payload size: bytes × 8 bits / bitrate.
+  const audioBytes = bytes.length - frame;
+  return (audioBytes * 8) / (bitrateKbps * 1000);
+}
+
+/**
+ * Measure audio duration (seconds) from raw bytes, dispatching on `format`
+ * (falls back to content sniffing). Returns `null` when the format is
+ * unsupported or the bytes cannot be parsed — callers should treat `null` as
+ * "unknown duration" and still persist the audio.
+ */
+export function measureAudioDuration(
+  input: Uint8Array | ArrayBuffer,
+  format?: string,
+): number | null {
+  const bytes = toBytes(input);
+  if (bytes.length === 0) return null;
+
+  const fmt = format?.toLowerCase();
+  if (fmt === 'wav' || fmt === 'x-wav' || fmt === 'wave') return measureWavDuration(bytes);
+  if (fmt === 'mp3' || fmt === 'mpeg' || fmt === 'mpga') return measureMp3Duration(bytes);
+
+  // No usable format hint: sniff by magic bytes.
+  if (readAscii(bytes, 0, 4) === 'RIFF') return measureWavDuration(bytes);
+  if (readAscii(bytes, 0, 3) === 'ID3' || (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0)) {
+    return measureMp3Duration(bytes);
+  }
+  return null;
+}

--- a/lib/audio/audio-duration.ts
+++ b/lib/audio/audio-duration.ts
@@ -169,16 +169,43 @@ export function measureMp3Duration(input: Uint8Array | ArrayBuffer): number | nu
     }
   }
 
-  // CBR estimate from the audio payload size: bytes × 8 bits / bitrate.
-  const audioBytes = bytes.length - frame;
+  // VBRI (Fraunhofer) header sits at a fixed 32-byte offset after the frame
+  // header, independent of channel mode, with the frame count at byte 14.
+  const vbriOffset = frame + 4 + 32;
+  if (vbriOffset + 18 <= bytes.length && readAscii(bytes, vbriOffset, 4) === 'VBRI') {
+    const frameCount = readUint32BE(bytes, vbriOffset + 14);
+    if (frameCount > 0) return (frameCount * samplesPerFrame) / sampleRate;
+  }
+
+  // CBR estimate from the audio payload size: bytes × 8 bits / bitrate. Exclude
+  // a trailing ID3v1 tag (last 128 bytes, 'TAG' magic) so it doesn't inflate
+  // the byte count.
+  let end = bytes.length;
+  if (end - frame >= 128 && readAscii(bytes, end - 128, 3) === 'TAG') end -= 128;
+  const audioBytes = end - frame;
   return (audioBytes * 8) / (bitrateKbps * 1000);
 }
 
+/** Recognize the container from magic bytes, ignoring any reported format. */
+function sniffFormat(bytes: Uint8Array): 'wav' | 'mp3' | null {
+  if (readAscii(bytes, 0, 4) === 'RIFF' && readAscii(bytes, 8, 4) === 'WAVE') return 'wav';
+  if (readAscii(bytes, 0, 3) === 'ID3' || (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0)) {
+    return 'mp3';
+  }
+  return null;
+}
+
 /**
- * Measure audio duration (seconds) from raw bytes, dispatching on `format`
- * (falls back to content sniffing). Returns `null` when the format is
- * unsupported or the bytes cannot be parsed — callers should treat `null` as
- * "unknown duration" and still persist the audio.
+ * Measure audio duration (seconds) from raw bytes. Returns `null` when the
+ * format is unsupported or the bytes cannot be parsed — callers should treat
+ * `null` as "unknown duration" and still persist the audio.
+ *
+ * The `format` hint is derived upstream from a `Content-Type` header and can be
+ * wrong (e.g. `getAudioResponseFormat` falls back to `mp3` when the type is
+ * missing, while the provider actually returned WAV). So we sniff the magic
+ * bytes first and only trust the hint when the content is unrecognizable — a
+ * mismatched hint never sends WAV bytes through the MP3 parser (which could
+ * false-sync into a wrong duration) or vice versa.
  */
 export function measureAudioDuration(
   input: Uint8Array | ArrayBuffer,
@@ -187,14 +214,14 @@ export function measureAudioDuration(
   const bytes = toBytes(input);
   if (bytes.length === 0) return null;
 
+  // Content wins over the reported format when the magic bytes are recognized.
+  const sniffed = sniffFormat(bytes);
+  if (sniffed === 'wav') return measureWavDuration(bytes);
+  if (sniffed === 'mp3') return measureMp3Duration(bytes);
+
+  // Unrecognizable content: fall back to the reported format hint.
   const fmt = format?.toLowerCase();
   if (fmt === 'wav' || fmt === 'x-wav' || fmt === 'wave') return measureWavDuration(bytes);
   if (fmt === 'mp3' || fmt === 'mpeg' || fmt === 'mpga') return measureMp3Duration(bytes);
-
-  // No usable format hint: sniff by magic bytes.
-  if (readAscii(bytes, 0, 4) === 'RIFF') return measureWavDuration(bytes);
-  if (readAscii(bytes, 0, 3) === 'ID3' || (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0)) {
-    return measureMp3Duration(bytes);
-  }
   return null;
 }

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -16,6 +16,7 @@ import type { AgentInfo } from '@/lib/generation/generation-pipeline';
 import type { Scene } from '@/lib/types/stage';
 import type { SpeechAction } from '@/lib/types/action';
 import { splitLongSpeechActions } from '@/lib/audio/tts-utils';
+import { measureAudioDuration } from '@/lib/audio/audio-duration';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
 import { resolveAgentVoiceOptions, pickNarratorAgent } from '@/lib/audio/agent-voice';
 import { useAgentRegistry } from '@/lib/orchestration/registry/store';
@@ -289,9 +290,14 @@ export async function generateAndStoreTTS(
     bytes[i] = binary.charCodeAt(i);
   }
   const blob = new Blob([bytes], { type: `audio/${data.format}` });
+  // Measure duration once at store time so video export (#854) can map this
+  // clip onto a timeline without re-decoding. null → leave undefined; the audio
+  // still persists and plays.
+  const duration = measureAudioDuration(bytes, data.format) ?? undefined;
   await db.audioFiles.put({
     id: audioId,
     blob,
+    duration,
     format: data.format,
     createdAt: Date.now(),
   });

--- a/tests/audio/audio-duration.test.ts
+++ b/tests/audio/audio-duration.test.ts
@@ -58,6 +58,40 @@ function buildCbrMp3(seconds: number): Uint8Array {
   return bytes;
 }
 
+/**
+ * Build a single MPEG-1 Layer III mono frame carrying a Xing/Info header with a
+ * known frame count. The header sits at frame + 4 + 17 for MPEG-1 mono.
+ */
+function buildXingMp3(frameCount: number, tag: 'Xing' | 'Info' = 'Xing'): Uint8Array {
+  const bytes = new Uint8Array(512);
+  bytes[0] = 0xff; // sync
+  bytes[1] = 0xfb; // MPEG1, Layer III, no CRC
+  bytes[2] = 0x90; // 128 kbps, 44100 Hz, no padding
+  bytes[3] = 0xc0; // mono
+  const off = 4 + 17;
+  tag.split('').forEach((c, i) => (bytes[off + i] = c.charCodeAt(0)));
+  const dv = new DataView(bytes.buffer);
+  dv.setUint32(off + 4, 0x01, false); // flags: frame-count present
+  dv.setUint32(off + 8, frameCount, false);
+  return bytes;
+}
+
+/**
+ * Build a single MPEG-1 mono frame carrying a VBRI header with a known frame
+ * count. VBRI sits at a fixed frame + 4 + 32 offset, frame count at byte 14.
+ */
+function buildVbriMp3(frameCount: number): Uint8Array {
+  const bytes = new Uint8Array(512);
+  bytes[0] = 0xff;
+  bytes[1] = 0xfb;
+  bytes[2] = 0x90;
+  bytes[3] = 0xc0;
+  const off = 4 + 32;
+  'VBRI'.split('').forEach((c, i) => (bytes[off + i] = c.charCodeAt(0)));
+  new DataView(bytes.buffer).setUint32(off + 14, frameCount, false);
+  return bytes;
+}
+
 describe('measureWavDuration', () => {
   it('measures duration from a PCM WAV header', () => {
     const wav = buildWav(2.5);
@@ -115,6 +149,33 @@ describe('measureMp3Duration', () => {
   it('returns null when no frame sync is found', () => {
     expect(measureMp3Duration(new Uint8Array(64))).toBeNull();
   });
+
+  it('uses the Xing frame count for VBR-accurate duration', () => {
+    // 153 frames × 1152 samples / 44100 Hz ≈ 3.997 s.
+    const d = measureMp3Duration(buildXingMp3(153));
+    expect(d).not.toBeNull();
+    expect(d!).toBeCloseTo((153 * 1152) / 44100, 3);
+  });
+
+  it('uses an Info (CBR) header frame count too', () => {
+    const d = measureMp3Duration(buildXingMp3(100, 'Info'));
+    expect(d!).toBeCloseTo((100 * 1152) / 44100, 3);
+  });
+
+  it('uses the VBRI frame count when no Xing/Info header is present', () => {
+    const d = measureMp3Duration(buildVbriMp3(200));
+    expect(d).not.toBeNull();
+    expect(d!).toBeCloseTo((200 * 1152) / 44100, 3);
+  });
+
+  it('excludes a trailing ID3v1 tag from the CBR estimate', () => {
+    const mp3 = buildCbrMp3(2);
+    const withTag = new Uint8Array(mp3.length + 128);
+    withTag.set(mp3, 0);
+    'TAG'.split('').forEach((c, i) => (withTag[mp3.length + i] = c.charCodeAt(0)));
+    // The 128-byte tag must not inflate the estimate: same duration as without.
+    expect(measureMp3Duration(withTag)).toBeCloseTo(measureMp3Duration(mp3)!, 3);
+  });
 });
 
 describe('measureAudioDuration', () => {
@@ -130,6 +191,19 @@ describe('measureAudioDuration', () => {
   it('sniffs format when no hint is given', () => {
     expect(measureAudioDuration(buildWav(1))).toBeCloseTo(1, 3);
     expect(measureAudioDuration(buildCbrMp3(1))).not.toBeNull();
+  });
+
+  it('trusts content over a wrong format hint (mp3 hint, WAV bytes)', () => {
+    // getAudioResponseFormat falls back to 'mp3' when Content-Type is missing,
+    // but the provider may actually return WAV. Content must win.
+    expect(measureAudioDuration(buildWav(2.5), 'mp3')).toBeCloseTo(2.5, 3);
+  });
+
+  it('trusts content over a wrong format hint (wav hint, MP3 bytes)', () => {
+    const d = measureAudioDuration(buildCbrMp3(2), 'wav');
+    expect(d).not.toBeNull();
+    expect(d!).toBeGreaterThan(1.5);
+    expect(d!).toBeLessThan(2.5);
   });
 
   it('degrades to null on empty or unsupported input (caller still persists)', () => {

--- a/tests/audio/audio-duration.test.ts
+++ b/tests/audio/audio-duration.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  measureAudioDuration,
+  measureMp3Duration,
+  measureWavDuration,
+} from '@/lib/audio/audio-duration';
+
+/** Build a minimal 44-byte-header PCM WAV for a given duration. */
+function buildWav(
+  seconds: number,
+  sampleRate = 8000,
+  channels = 1,
+  bitsPerSample = 16,
+): Uint8Array {
+  const bytesPerSample = bitsPerSample / 8;
+  const byteRate = sampleRate * channels * bytesPerSample;
+  const dataSize = Math.round(byteRate * seconds);
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+  const ascii = (offset: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+  };
+  ascii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  ascii(8, 'WAVE');
+  ascii(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, channels * bytesPerSample, true);
+  view.setUint16(34, bitsPerSample, true);
+  ascii(36, 'data');
+  view.setUint32(40, dataSize, true);
+  return new Uint8Array(buffer);
+}
+
+/**
+ * Build a CBR MP3 (MPEG-1 Layer III, 128 kbps, 44100 Hz, mono) of roughly the
+ * requested duration by repeating a valid frame header + padding. Duration is
+ * estimated from total audio bytes, so exact frame content doesn't matter.
+ */
+function buildCbrMp3(seconds: number): Uint8Array {
+  const bitrateKbps = 128;
+  const sampleRate = 44100;
+  const samplesPerFrame = 1152;
+  const frameLength = Math.floor((samplesPerFrame / 8) * ((bitrateKbps * 1000) / sampleRate));
+  const frameCount = Math.round((seconds * sampleRate) / samplesPerFrame);
+  const bytes = new Uint8Array(frameLength * frameCount);
+  for (let f = 0; f < frameCount; f++) {
+    const off = f * frameLength;
+    bytes[off] = 0xff; // sync
+    bytes[off + 1] = 0xfb; // MPEG1, Layer III, no CRC
+    bytes[off + 2] = 0x90; // 128 kbps (0x9), 44100 Hz (0x0), no padding
+    bytes[off + 3] = 0xc0; // mono
+  }
+  return bytes;
+}
+
+describe('measureWavDuration', () => {
+  it('measures duration from a PCM WAV header', () => {
+    const wav = buildWav(2.5);
+    expect(measureWavDuration(wav)).toBeCloseTo(2.5, 3);
+  });
+
+  it('tolerates an odd-length preceding chunk (word alignment)', () => {
+    // Prepend a LIST chunk of odd size before data; parser must skip its pad byte.
+    const base = buildWav(1);
+    const list = new Uint8Array(8 + 3 + 1); // header + 3-byte body + 1 pad
+    const dv = new DataView(list.buffer);
+    'LIST'.split('').forEach((c, i) => dv.setUint8(i, c.charCodeAt(0)));
+    dv.setUint32(4, 3, true);
+    // Splice the LIST chunk in right after the WAVE tag (offset 12).
+    const out = new Uint8Array(base.length + list.length);
+    out.set(base.subarray(0, 12), 0);
+    out.set(list, 12);
+    out.set(base.subarray(12), 12 + list.length);
+    // Fix RIFF size.
+    new DataView(out.buffer).setUint32(4, out.length - 8, true);
+    expect(measureWavDuration(out)).toBeCloseTo(1, 3);
+  });
+
+  it('returns null for non-RIFF bytes', () => {
+    expect(measureWavDuration(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))).toBeNull();
+  });
+});
+
+describe('measureMp3Duration', () => {
+  it('estimates duration of a CBR MP3', () => {
+    const mp3 = buildCbrMp3(3);
+    const d = measureMp3Duration(mp3);
+    expect(d).not.toBeNull();
+    expect(d!).toBeGreaterThan(2.5);
+    expect(d!).toBeLessThan(3.5);
+  });
+
+  it('skips a leading ID3v2 tag', () => {
+    const mp3 = buildCbrMp3(2);
+    const id3 = new Uint8Array(10 + 20);
+    'ID3'.split('').forEach((c, i) => (id3[i] = c.charCodeAt(0)));
+    id3[6] = 0;
+    id3[7] = 0;
+    id3[8] = 0;
+    id3[9] = 20; // syncsafe size = 20
+    const out = new Uint8Array(id3.length + mp3.length);
+    out.set(id3, 0);
+    out.set(mp3, id3.length);
+    const d = measureMp3Duration(out);
+    expect(d).not.toBeNull();
+    expect(d!).toBeGreaterThan(1.5);
+    expect(d!).toBeLessThan(2.5);
+  });
+
+  it('returns null when no frame sync is found', () => {
+    expect(measureMp3Duration(new Uint8Array(64))).toBeNull();
+  });
+});
+
+describe('measureAudioDuration', () => {
+  it('dispatches on the wav format hint', () => {
+    expect(measureAudioDuration(buildWav(1.5), 'wav')).toBeCloseTo(1.5, 3);
+  });
+
+  it('dispatches on the mp3 format hint', () => {
+    const d = measureAudioDuration(buildCbrMp3(1), 'mp3');
+    expect(d).not.toBeNull();
+  });
+
+  it('sniffs format when no hint is given', () => {
+    expect(measureAudioDuration(buildWav(1))).toBeCloseTo(1, 3);
+    expect(measureAudioDuration(buildCbrMp3(1))).not.toBeNull();
+  });
+
+  it('degrades to null on empty or unsupported input (caller still persists)', () => {
+    expect(measureAudioDuration(new Uint8Array(0))).toBeNull();
+    expect(measureAudioDuration(new Uint8Array([0x00, 0x01, 0x02, 0x03]), 'flac')).toBeNull();
+  });
+
+  it('accepts an ArrayBuffer as well as a Uint8Array', () => {
+    const wav = buildWav(2);
+    const copy = wav.slice().buffer as ArrayBuffer;
+    expect(measureAudioDuration(copy, 'wav')).toBeCloseTo(2, 3);
+  });
+});


### PR DESCRIPTION
## Summary

Persist audio duration when the client stores TTS audio, as a prerequisite for #854 (Hyperframes-based classroom video export). Closes #861.

The video-export compiler needs each narration clip's duration to map it onto a timeline segment. `AudioFileRecord.duration` already exists in the IndexedDB schema but the TTS store path never populated it — so export/import (which round-trip duration through the media manifest) had nothing to carry, and the compiler would have to re-decode every clip at render time (slow, and impossible to validate in a pure-manifest test without FFmpeg/Chrome).

## Design: duration is an asset property

Duration belongs to the audio **file**, not the speech **action** — re-generating a line (new voice/speed) keeps the text but changes the duration, and it travels with the blob. This matches the existing export/import convention:

- Export reads `af.record.duration` into `mediaIndex[].duration` (`use-export-classroom.ts:160`).
- Import writes `meta.duration` back into `AudioFileRecord.duration` (`use-import-classroom.ts:129`).

So this PR populates `AudioFileRecord.duration` and does **not** add a field to the `@openmaic/dsl` `SpeechAction` contract.

## Scope

Client persistence path only. The server generation path serializes scenes to JSON with no `AudioFileRecord` and no media index, so it has no asset-side home for duration; that's left to a later slice (e.g. when the server emits a media manifest, or at #854's compiler stage).

## Changes

- **`lib/audio/audio-duration.ts`** (new): dependency-free `measureAudioDuration` — a RIFF chunk walk for WAV and a Xing/Info-or-CBR estimate for MP3 (the two formats OpenMAIC's TTS providers emit). Pure byte parsing, no DOM, returns `null` for anything it can't parse so callers degrade gracefully.
- **`lib/hooks/use-scene-generator.ts`** (`generateAndStoreTTS`): populate `AudioFileRecord.duration` when storing to IndexedDB.
- **`tests/audio/audio-duration.test.ts`**: WAV/MP3 parsing, word-alignment/ID3 edge cases, format dispatch + sniffing, graceful degradation on empty/unsupported input.

## Degradation

Decode failure never blocks persistence: `measureAudioDuration` returns `null`, `duration` is left undefined, and the audio is still stored and playable.

## Testing

- `pnpm vitest run tests/audio/audio-duration.test.ts` — 11 passing.
- `pnpm exec tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
