### PR TITLE
feat(choreography): scaffold @openmaic/choreography — shared orchestration spec (#863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Unit Tests (importer)
         run: pnpm --filter @openmaic/importer test
 
+      - name: Unit Tests (choreography)
+        run: pnpm --filter @openmaic/choreography test
+
+      - name: Typecheck (choreography)
+        run: pnpm --filter @openmaic/choreography typecheck
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,32 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // Package boundary (machine-enforced): @openmaic/choreography is a standalone,
+  // app-agnostic orchestration spec (timing + action timeline + animation
+  // descriptors). Same policy as the boundaries above — it must contain NO
+  // `@/…` host-app path-alias string, so a deadline can't punch a "temporary"
+  // host dependency through the spec. It depends only on @openmaic/dsl and
+  // carries no React/DOM/render-backend concept, so the exporter can interpret
+  // it in a pure Node environment; both the app runtime and the exporter import
+  // the package, never the reverse.
+  {
+    files: ['packages/@openmaic/choreography/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/^@\\//]',
+          message:
+            '@openmaic/choreography must not reference a host-app path (@/…). This package authors no `@/…` strings — depend only on @openmaic/dsl. The app and exporter interpret the spec; neither is imported by it.',
+        },
+        {
+          selector: 'TemplateElement[value.cooked=/^@\\//]',
+          message:
+            '@openmaic/choreography must not reference a host-app path (@/…) in a template literal. Depend only on @openmaic/dsl.',
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/lib/action/engine.ts
+++ b/lib/action/engine.ts
@@ -36,6 +36,18 @@ import type {
   WidgetRevealAction,
 } from '@/lib/types/action';
 import type { CodeLine } from '@openmaic/dsl';
+import {
+  EFFECT_AUTO_CLEAR_MS,
+  MAX_VIDEO_WAIT_MS,
+  WB_OPEN_MS,
+  WB_DRAW_MS,
+  WB_EDIT_MS,
+  WB_DELETE_MS,
+  WB_CLOSE_MS,
+  WIDGET_MS,
+  wbDrawCodeMs,
+  wbClearMs,
+} from '@openmaic/choreography';
 import katex from 'katex';
 import { createLogger } from '@/lib/logger';
 
@@ -70,9 +82,6 @@ function generateLineIds(count: number): string[] {
 }
 
 // ==================== ActionEngine ====================
-
-/** Default duration (ms) before fire-and-forget effects auto-clear */
-const EFFECT_AUTO_CLEAR_MS = 5000;
 
 /** Callback for sending messages to widget iframe */
 export type WidgetMessageCallback = (type: string, payload: Record<string, unknown>) => void;
@@ -266,7 +275,6 @@ export class ActionEngine {
     // the playback engine from hanging indefinitely if the video element is
     // invalid or the state change is missed.
     return new Promise<void>((resolve) => {
-      const MAX_VIDEO_WAIT_MS = 5 * 60 * 1000; // 5 minutes
       const timeout = setTimeout(() => {
         unsubscribe();
         log.warn(`[playVideo] Timeout waiting for video ${action.elementId} to finish`);
@@ -337,7 +345,7 @@ export class ActionEngine {
     this.stageAPI.whiteboard.get();
     useCanvasStore.getState().setWhiteboardOpen(true);
     // Wait for open animation to complete (slow spring: stiffness 120, damping 18, mass 1.2)
-    await delay(2000);
+    await delay(WB_OPEN_MS);
   }
 
   private async executeWbDrawText(action: WbDrawTextAction): Promise<void> {
@@ -369,7 +377,7 @@ export class ActionEngine {
     );
 
     // Wait for element fade-in animation
-    await delay(800);
+    await delay(WB_DRAW_MS);
   }
 
   private async executeWbDrawShape(action: WbDrawShapeAction): Promise<void> {
@@ -395,7 +403,7 @@ export class ActionEngine {
     );
 
     // Wait for element fade-in animation
-    await delay(800);
+    await delay(WB_DRAW_MS);
   }
 
   private async executeWbDrawChart(action: WbDrawChartAction): Promise<void> {
@@ -419,7 +427,7 @@ export class ActionEngine {
       wb.data.id,
     );
 
-    await delay(800);
+    await delay(WB_DRAW_MS);
   }
 
   private async executeWbDrawLatex(action: WbDrawLatexAction): Promise<void> {
@@ -455,7 +463,7 @@ export class ActionEngine {
       return;
     }
 
-    await delay(800);
+    await delay(WB_DRAW_MS);
   }
 
   private async executeWbDrawTable(action: WbDrawTableAction): Promise<void> {
@@ -511,7 +519,7 @@ export class ActionEngine {
       wb.data.id,
     );
 
-    await delay(800);
+    await delay(WB_DRAW_MS);
   }
 
   private async executeWbDrawLine(action: WbDrawLineAction): Promise<void> {
@@ -544,7 +552,7 @@ export class ActionEngine {
     );
 
     // Wait for element fade-in animation
-    await delay(800);
+    await delay(WB_DRAW_MS);
   }
 
   private async executeWbDrawCode(action: WbDrawCodeAction): Promise<void> {
@@ -573,7 +581,7 @@ export class ActionEngine {
     );
 
     // Wait for typing animation: base 800ms + 50ms per line, capped at 3s
-    const animMs = Math.min(800 + lines.length * 50, 3000);
+    const animMs = wbDrawCodeMs(lines.length);
     await delay(animMs);
   }
 
@@ -636,7 +644,7 @@ export class ActionEngine {
     );
 
     // Wait for edit animation
-    await delay(600);
+    await delay(WB_EDIT_MS);
   }
 
   private async executeWbDelete(action: WbDeleteAction): Promise<void> {
@@ -644,7 +652,7 @@ export class ActionEngine {
     if (!wb.success || !wb.data) return;
 
     this.stageAPI.whiteboard.deleteElement(action.elementId, wb.data.id);
-    await delay(300);
+    await delay(WB_DELETE_MS);
   }
 
   private async executeWbClear(): Promise<void> {
@@ -661,7 +669,7 @@ export class ActionEngine {
     useCanvasStore.getState().setWhiteboardClearing(true);
 
     // Wait for cascade: base 380ms + 55ms per element, capped at 1400ms
-    const animMs = Math.min(380 + elementCount * 55, 1400);
+    const animMs = wbClearMs(elementCount);
     await delay(animMs);
 
     // Actually remove elements
@@ -672,7 +680,7 @@ export class ActionEngine {
   private async executeWbClose(): Promise<void> {
     useCanvasStore.getState().setWhiteboardOpen(false);
     // Wait for close animation (500ms ease-out tween)
-    await delay(700);
+    await delay(WB_CLOSE_MS);
   }
 
   // ==================== Widget Actions ====================
@@ -693,14 +701,14 @@ export class ActionEngine {
       content: action.content,
     });
     // Quick delay for visual effect
-    await delay(300);
+    await delay(WIDGET_MS);
   }
 
   /** Execute widget setState action */
   private async executeWidgetSetState(action: WidgetSetStateAction): Promise<void> {
     this.sendWidgetMessage('SET_WIDGET_STATE', { state: action.state, content: action.content });
     // Quick delay for state change to propagate
-    await delay(300);
+    await delay(WIDGET_MS);
   }
 
   /** Execute widget annotation action */
@@ -709,12 +717,12 @@ export class ActionEngine {
       target: action.target,
       content: action.content,
     });
-    await delay(300);
+    await delay(WIDGET_MS);
   }
 
   /** Execute widget reveal action */
   private async executeWidgetReveal(action: WidgetRevealAction): Promise<void> {
     this.sendWidgetMessage('REVEAL_ELEMENT', { target: action.target, content: action.content });
-    await delay(300);
+    await delay(WIDGET_MS);
   }
 }

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -35,7 +35,11 @@ import type {
 } from './types';
 import type { AudioPlayer } from '@/lib/utils/audio-player';
 import { ActionEngine } from '@/lib/action/engine';
-import { resolvePlaybackCursor } from './engine-cursor';
+import {
+  resolvePlaybackCursor,
+  estimateSpeechDurationMs,
+  DISCUSSION_TRIGGER_DELAY_MS,
+} from '@openmaic/choreography';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useSettingsStore } from '@/lib/store/settings';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
@@ -462,20 +466,12 @@ export class PlaybackEngine {
         });
 
         // Estimated reading time when no pre-generated audio (TTS disabled).
-        // CJK text: ~150ms/char (one char ≈ one word).
-        // Non-CJK text: ~240ms/word (≈250 WPM).
-        // Min 2s. Cancelled on pause; resume() calls processNext directly.
+        // The estimate (CJK vs word-based pace, 2s floor, speed-adjusted) lives
+        // in @openmaic/choreography so the video exporter dwells identically.
+        // Cancelled on pause; resume() calls processNext directly.
         const scheduleReadingTimer = () => {
-          const text = speechAction.text;
-          const cjkCount = (
-            text.match(/[\u4e00-\u9fff\u3400-\u4dbf\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || []
-          ).length;
-          const isCJK = cjkCount > text.length * 0.3;
           const speed = this.callbacks.getPlaybackSpeed?.() ?? 1;
-          const rawMs = isCJK
-            ? Math.max(2000, text.length * 150)
-            : Math.max(2000, text.split(/\s+/).filter(Boolean).length * 240);
-          const readingMs = rawMs / speed;
+          const readingMs = estimateSpeechDurationMs(speechAction.text, { speed });
           this.speechTimerStart = Date.now();
           this.speechTimerRemaining = readingMs;
           this.speechTimer = setTimeout(() => {
@@ -574,7 +570,7 @@ export class PlaybackEngine {
           this.currentTrigger = trigger;
           this.callbacks.onProactiveShow?.(trigger);
           // Engine pauses here — user calls confirmDiscussion() or skipDiscussion()
-        }, 3000);
+        }, DISCUSSION_TRIGGER_DELAY_MS);
         break;
       }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.9.0"
   },
   "scripts": {
-    "postinstall": "cd packages/mathml2omml && npm run build && cd ../pptxgenjs && npm run build && cd ../@openmaic/dsl && pnpm run build && cd ../storage && pnpm run build && cd ../importer && pnpm run build && cd ../renderer && pnpm run build && cd ../../.. && node scripts/sync-maic-importer.mjs",
+    "postinstall": "cd packages/mathml2omml && npm run build && cd ../pptxgenjs && npm run build && cd ../@openmaic/dsl && pnpm run build && cd ../choreography && pnpm run build && cd ../storage && pnpm run build && cd ../importer && pnpm run build && cd ../renderer && pnpm run build && cd ../../.. && node scripts/sync-maic-importer.mjs",
     "sync:maic-importer": "node scripts/sync-maic-importer.mjs",
     "dev": "next dev",
     "build": "node scripts/assert-vendor-maic-importer.mjs && next build",
@@ -94,6 +94,7 @@
     "partial-json": "^0.1.7",
     "pptxgenjs": "workspace:*",
     "pptxtojson": "^1.11.0",
+    "@openmaic/choreography": "workspace:*",
     "@openmaic/dsl": "workspace:*",
     "@openmaic/importer": "workspace:*",
     "@openmaic/renderer": "workspace:*",

--- a/packages/@openmaic/choreography/.gitignore
+++ b/packages/@openmaic/choreography/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+*.tsbuildinfo

--- a/packages/@openmaic/choreography/LICENSE
+++ b/packages/@openmaic/choreography/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 THU-MAIC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@openmaic/choreography/README.md
+++ b/packages/@openmaic/choreography/README.md
@@ -1,0 +1,34 @@
+# @openmaic/choreography
+
+The MAIC **orchestration spec** — the single source of truth for the semantics a
+faithful classroom-video exporter needs from playback, so the app runtime and
+the exporter interpret the same spec instead of each re-implementing (and
+silently drifting from) the other.
+
+Pure TypeScript. Depends only on [`@openmaic/dsl`](../dsl); no React, DOM, GSAP,
+framer-motion, or any render backend — the exporter runs in a pure Node
+environment, verifiable on the dependency graph.
+
+## Contents
+
+- **Timing** (`timing.ts`) — playback timing constants (`EFFECT_AUTO_CLEAR_MS`,
+  `DISCUSSION_TRIGGER_DELAY_MS`, the whiteboard/widget action durations, …) and
+  the deterministic no-audio narration estimate `estimateSpeechDurationMs`.
+- **Cursor** (`cursor.ts`) — `resolvePlaybackCursor`, the scene/action walk
+  (with the empty-scene dwell beat).
+- **Timeline** (`timeline.ts`) — `resolveActionTimeline`, the index-domain →
+  time-domain expansion: blocking actions advance the cursor, fire-and-forget
+  visual effects do not. Accepts an optional audio-duration resolver and falls
+  back to the estimate.
+- **Descriptors** (`descriptors/`) — versioned, declarative animation
+  descriptors (`spotlight.v1`, `laser.v1`) describing *what property, from what
+  value to what value, over how long, with what easing* — no implementation.
+  Schema-validated against a build-time-generated JSON Schema.
+
+## Scripts
+
+```bash
+pnpm build       # tsc + JSON Schema codegen → dist/
+pnpm test        # vitest (standalone; resolves src, no build needed)
+pnpm typecheck   # tsc --noEmit
+```

--- a/packages/@openmaic/choreography/package.json
+++ b/packages/@openmaic/choreography/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@openmaic/choreography",
+  "version": "0.0.1",
+  "description": "The MAIC orchestration spec: the pure, single source of truth for playback timing, the index→time action timeline, and versioned animation descriptors. Depends only on @openmaic/dsl; both the app runtime and the video exporter interpret it, so neither owns the semantics.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./schema/*": "./dist/schema/*"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist && tsc -p tsconfig.json && node scripts/gen-schema.mjs",
+    "build:schema": "node scripts/gen-schema.mjs",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "pnpm run build"
+  },
+  "keywords": [
+    "maic",
+    "choreography",
+    "orchestration",
+    "timing",
+    "animation",
+    "spec"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/THU-MAIC/OpenMAIC",
+    "directory": "packages/@openmaic/choreography"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "dependencies": {
+    "@openmaic/dsl": "workspace:*"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "ts-json-schema-generator": "~2.4.0",
+    "typescript": "^5",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/@openmaic/choreography/scripts/gen-schema.mjs
+++ b/packages/@openmaic/choreography/scripts/gen-schema.mjs
@@ -1,0 +1,60 @@
+// Build-time JSON Schema codegen for @openmaic/choreography.
+//
+// Runs ts-json-schema-generator (a devDependency) over the animation-descriptor
+// TS types and emits static dist/schema/*.json, so descriptors are
+// schema-validated (see test/descriptors.test.ts) and non-TS consumers can
+// validate their own. The generator is BUILD-ONLY — the package keeps a single
+// runtime dependency (@openmaic/dsl).
+import { createGenerator } from 'ts-json-schema-generator';
+import { mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+
+/** Schema root type -> emitted filename. */
+export const ROOTS = {
+  AnimationDescriptor: 'animation-descriptor.schema.json',
+};
+
+// One generator over the whole tsconfig program, built lazily and reused for
+// every root — parses/type-builds the program once instead of per type.
+let generator;
+function getGenerator() {
+  generator ??= createGenerator({
+    tsconfig: resolve(pkgRoot, 'tsconfig.json'),
+    skipTypeCheck: true,
+    topRef: true,
+    jsDoc: 'extended',
+  });
+  return generator;
+}
+
+/** Generate the JSON Schema object for one root type (in-memory). */
+export function generateSchema(typeName) {
+  if (!(typeName in ROOTS)) throw new Error(`unknown schema root: ${typeName}`);
+  return getGenerator().createSchema(typeName);
+}
+
+function main() {
+  const outDir = resolve(pkgRoot, 'dist/schema');
+  mkdirSync(outDir, { recursive: true });
+  for (const [typeName, out] of Object.entries(ROOTS)) {
+    writeFileSync(resolve(outDir, out), JSON.stringify(generateSchema(typeName), null, 2) + '\n');
+    console.log(`wrote dist/schema/${out}`);
+  }
+}
+
+// Run only when invoked directly (`node scripts/gen-schema.mjs`). Compare real
+// paths so a symlinked invocation (bin shim, pnpm link) still matches.
+function invokedDirectly() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) main();

--- a/packages/@openmaic/choreography/src/cursor.ts
+++ b/packages/@openmaic/choreography/src/cursor.ts
@@ -1,5 +1,12 @@
-import type { Action } from '@/lib/types/action';
-import type { Scene } from '@/lib/types/stage';
+/**
+ * Playback cursor — resolve the current action from a `(sceneIndex, actionIndex)`
+ * cursor over a scene list.
+ *
+ * Moved verbatim from the app's `lib/playback/engine-cursor.ts` so the app
+ * runtime and the video exporter walk scenes identically. Pure — types come
+ * from `@openmaic/dsl`, no runtime dependencies.
+ */
+import type { Action, SceneCore } from '@openmaic/dsl';
 
 /**
  * Synthetic dwell beat yielded for a scene that carries no actions. It is an
@@ -30,10 +37,12 @@ export interface CursorResult {
  * yields one {@link EMPTY_SCENE_DWELL} beat (when its action cursor is still 0)
  * rather than being skipped. Returns `null` once every scene is consumed.
  *
- * Pure: it does not mutate inputs; the caller adopts the returned cursor.
+ * Pure: it does not mutate inputs; the caller adopts the returned cursor. Typed
+ * against {@link SceneCore} (only `id` + `actions` are read), so an app-widened
+ * `Scene` (extra content kinds) is accepted without casting.
  */
 export function resolvePlaybackCursor(
-  scenes: Scene[],
+  scenes: SceneCore[],
   sceneIndex: number,
   actionIndex: number,
 ): CursorResult | null {

--- a/packages/@openmaic/choreography/src/descriptors/index.ts
+++ b/packages/@openmaic/choreography/src/descriptors/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Animation descriptor registry — the versioned, declarative animations both
+ * the app effect components and the video exporter interpret.
+ */
+import type { AnimationDescriptor } from './types.js';
+import { spotlightV1 } from './spotlight.js';
+import { laserV1 } from './laser.js';
+
+export * from './types.js';
+export { spotlightV1 } from './spotlight.js';
+export { laserV1 } from './laser.js';
+
+/** All shipped descriptors, keyed by their versioned id. */
+export const DESCRIPTORS: Record<string, AnimationDescriptor> = {
+  'spotlight.v1': spotlightV1,
+  'laser.v1': laserV1,
+};
+
+/** Look up a descriptor by its versioned id (e.g. 'spotlight.v1'). */
+export function getDescriptor(id: string): AnimationDescriptor | undefined {
+  return DESCRIPTORS[id];
+}

--- a/packages/@openmaic/choreography/src/descriptors/laser.ts
+++ b/packages/@openmaic/choreography/src/descriptors/laser.ts
@@ -1,0 +1,113 @@
+import type { AnimationDescriptor } from './types.js';
+
+/**
+ * laser.v1 — a laser dot flies in from the nearest off-screen corner to the
+ * element center, with a pulsing ring and a glowing core.
+ *
+ * Values captured verbatim from the `LaserOverlay` effect component
+ * (`motion/react`):
+ * - dot fly-in: left/top 500ms expo-out `[0.22,1,0.36,1]`; opacity 150ms;
+ *   start corner is `center > 50 ? 105 : -5` (percent) per axis.
+ * - exit: 250ms ease-in `[0.4,0,1,1]` back to the start corner.
+ * - ring: infinite pulse, scale 1→2.8, opacity 0.6→0, 1500ms easeOut, 300ms
+ *   repeat delay.
+ * - core: 10px square, glow `0 0 8px 2px {color}60`.
+ *
+ * Color default `#ff0000` (the app store default; the component's own default is
+ * `#ff3b30`, but the store value wins at runtime).
+ */
+export const laserV1: AnimationDescriptor = {
+  id: 'laser.v1',
+  version: 1,
+  effect: 'laser',
+  params: { color: '#ff0000' },
+  zIndex: 101,
+  layers: [
+    {
+      id: 'dot',
+      tracks: [
+        {
+          property: 'left',
+          from: { axis: 'centerX', threshold: 50, whenAbove: 105, whenBelow: -5 },
+          to: { ref: 'centerX' },
+          durationMs: 500,
+          easing: { type: 'cubicBezier', points: [0.22, 1, 0.36, 1] },
+          phase: 'enter',
+        },
+        {
+          property: 'top',
+          from: { axis: 'centerY', threshold: 50, whenAbove: 105, whenBelow: -5 },
+          to: { ref: 'centerY' },
+          durationMs: 500,
+          easing: { type: 'cubicBezier', points: [0.22, 1, 0.36, 1] },
+          phase: 'enter',
+        },
+        {
+          property: 'opacity',
+          from: 0,
+          to: 1,
+          durationMs: 150,
+          phase: 'enter',
+        },
+        {
+          property: 'left',
+          from: { ref: 'centerX' },
+          to: { axis: 'centerX', threshold: 50, whenAbove: 105, whenBelow: -5 },
+          durationMs: 250,
+          easing: { type: 'cubicBezier', points: [0.4, 0, 1, 1] },
+          phase: 'exit',
+        },
+        {
+          property: 'top',
+          from: { ref: 'centerY' },
+          to: { axis: 'centerY', threshold: 50, whenAbove: 105, whenBelow: -5 },
+          durationMs: 250,
+          easing: { type: 'cubicBezier', points: [0.4, 0, 1, 1] },
+          phase: 'exit',
+        },
+        {
+          property: 'opacity',
+          from: 1,
+          to: 0,
+          durationMs: 250,
+          easing: { type: 'cubicBezier', points: [0.4, 0, 1, 1] },
+          phase: 'exit',
+        },
+      ],
+    },
+    {
+      id: 'ring',
+      staticProps: { border: '1.5px solid {color}' },
+      tracks: [
+        {
+          property: 'scale',
+          from: 1,
+          to: 2.8,
+          durationMs: 1500,
+          easing: { type: 'named', name: 'easeOut' },
+          repeat: 'infinite',
+          repeatDelayMs: 300,
+        },
+        {
+          property: 'opacity',
+          from: 0.6,
+          to: 0,
+          durationMs: 1500,
+          easing: { type: 'named', name: 'easeOut' },
+          repeat: 'infinite',
+          repeatDelayMs: 300,
+        },
+      ],
+    },
+    {
+      id: 'core',
+      staticProps: {
+        width: 10,
+        height: 10,
+        backgroundColor: '{color}',
+        boxShadow: '0 0 8px 2px {color}60',
+      },
+      tracks: [],
+    },
+  ],
+};

--- a/packages/@openmaic/choreography/src/descriptors/spotlight.ts
+++ b/packages/@openmaic/choreography/src/descriptors/spotlight.ts
@@ -1,0 +1,130 @@
+import type { AnimationDescriptor } from './types.js';
+
+/**
+ * spotlight.v1 — focus a single element, dimming the rest.
+ *
+ * An SVG mask (0-100 viewBox) punches a rounded cutout over a dimmed full-screen
+ * rect; a white border traces the cutout. Values captured verbatim from the
+ * `SpotlightOverlay` effect component (`motion/react`):
+ * - cutout: 600ms expo-out, insets from ±8/rx4 to the tight ±~0.5/rx1 frame.
+ * - border: 500ms expo-out, delayed 50ms, fading in as it settles.
+ * - dim: static `rgba(0,0,0,{dimness})`, dimness default 0.7.
+ *
+ * Shared easing `[0.16, 1, 0.3, 1]` (the spotlight expo-out).
+ */
+export const spotlightV1: AnimationDescriptor = {
+  id: 'spotlight.v1',
+  version: 1,
+  effect: 'spotlight',
+  params: { dimness: 0.7 },
+  zIndex: 100,
+  layers: [
+    {
+      id: 'cutout',
+      staticProps: { fill: '#000000' },
+      tracks: [
+        {
+          property: 'x',
+          from: { ref: 'x', offset: -8 },
+          to: { ref: 'x', offset: -0.4 },
+          durationMs: 600,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'y',
+          from: { ref: 'y', offset: -8 },
+          to: { ref: 'y', offset: -0.6 },
+          durationMs: 600,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'width',
+          from: { ref: 'w', offset: 16 },
+          to: { ref: 'w', offset: 0.8 },
+          durationMs: 600,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'height',
+          from: { ref: 'h', offset: 16 },
+          to: { ref: 'h', offset: 1.2 },
+          durationMs: 600,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'rx',
+          from: 4,
+          to: 1,
+          durationMs: 600,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+      ],
+    },
+    {
+      id: 'border',
+      staticProps: {
+        stroke: 'rgba(255,255,255,0.7)',
+        strokeWidth: 1.2,
+        fill: 'none',
+        vectorEffect: 'non-scaling-stroke',
+      },
+      tracks: [
+        {
+          property: 'x',
+          from: { ref: 'x', offset: -4 },
+          to: { ref: 'x', offset: -0.4 },
+          durationMs: 500,
+          delayMs: 50,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'y',
+          from: { ref: 'y', offset: -4 },
+          to: { ref: 'y', offset: -0.6 },
+          durationMs: 500,
+          delayMs: 50,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'width',
+          from: { ref: 'w', offset: 8 },
+          to: { ref: 'w', offset: 0.8 },
+          durationMs: 500,
+          delayMs: 50,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'height',
+          from: { ref: 'h', offset: 8 },
+          to: { ref: 'h', offset: 1.2 },
+          durationMs: 500,
+          delayMs: 50,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'opacity',
+          from: 0,
+          to: 1,
+          durationMs: 500,
+          delayMs: 50,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+        {
+          property: 'rx',
+          from: 2,
+          to: 1,
+          durationMs: 500,
+          delayMs: 50,
+          easing: { type: 'cubicBezier', points: [0.16, 1, 0.3, 1] },
+        },
+      ],
+    },
+    {
+      id: 'dim',
+      // Full-screen dim behind the cutout. The container's opacity fade-in has
+      // no explicit duration in the source (engine default), so no track here.
+      staticProps: { fill: 'rgba(0,0,0,{dimness})' },
+      tracks: [],
+    },
+  ],
+};

--- a/packages/@openmaic/choreography/src/descriptors/types.ts
+++ b/packages/@openmaic/choreography/src/descriptors/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Animation descriptor model — a declarative, render-backend-agnostic
+ * description of an effect animation: *what property, from what value to what
+ * value, over how long, with what easing*. No implementation, no `motion`, no
+ * DOM. The app's effect components and the video exporter both interpret these,
+ * so the animation values live in exactly one place.
+ *
+ * Descriptors are versioned (`spotlight.v1`) and schema-validated — the JSON
+ * Schema is generated from these types at build time (see scripts/gen-schema.mjs)
+ * and every shipped descriptor is checked against it in tests.
+ *
+ * Pure types, no runtime dependencies.
+ */
+
+/** A field of the target element's percentage geometry (0-100 space). */
+export type GeometryRef = 'x' | 'y' | 'w' | 'h' | 'centerX' | 'centerY';
+
+/**
+ * A value derived linearly from the target element's geometry:
+ * `value = geometry[ref] * scale + offset`. Used for effect positions that
+ * track the highlighted element (e.g. a spotlight cutout inset by a few units).
+ */
+export interface GeometryValue {
+  ref: GeometryRef;
+  /** Multiplier on the geometry field. Default 1. */
+  scale?: number;
+  /** Added after scaling. Default 0. */
+  offset?: number;
+}
+
+/**
+ * A corner/edge fly-in start value: pick one of two off-screen positions based
+ * on which half of the viewport the element center sits in. Models the laser's
+ * `center > 50 ? 105 : -5` start rule.
+ */
+export interface CornerValue {
+  /** Which center axis to test. */
+  axis: 'centerX' | 'centerY';
+  /** Comparison threshold (percent). */
+  threshold: number;
+  /** Value used when the center is strictly above the threshold. */
+  whenAbove: number;
+  /** Value used otherwise. */
+  whenBelow: number;
+}
+
+/**
+ * An animatable endpoint: a literal number, a literal string (colors; may carry
+ * a `{param}` placeholder), or a geometry-/corner-derived value.
+ */
+export type AnimatableValue = number | string | GeometryValue | CornerValue;
+
+/** Easing curve. Omit on a track to use the consumer's engine default. */
+export type Easing =
+  | { type: 'cubicBezier'; points: [number, number, number, number] }
+  | { type: 'named'; name: string }
+  | { type: 'spring'; stiffness: number; damping: number; mass?: number };
+
+/** Which phase of the effect lifecycle a track belongs to. Default 'enter'. */
+export type TrackPhase = 'enter' | 'exit';
+
+/** A single animated property from `from` to `to` over `durationMs`. */
+export interface Track {
+  /** The property name (e.g. 'x', 'width', 'opacity', 'scale', 'left', 'top'). */
+  property: string;
+  from: AnimatableValue;
+  to: AnimatableValue;
+  durationMs: number;
+  delayMs?: number;
+  /** Omitted when the source specifies no explicit easing. */
+  easing?: Easing;
+  phase?: TrackPhase;
+  /** Number of repeats, or 'infinite'. Omit for no repeat. */
+  repeat?: number | 'infinite';
+  repeatDelayMs?: number;
+}
+
+/**
+ * A visual layer of the effect (e.g. the spotlight cutout, its border, the
+ * laser ring). Groups animated `tracks` with non-animated `staticProps`; string
+ * static values may contain `{param}` placeholders resolved from `params`.
+ */
+export interface Layer {
+  id: string;
+  tracks: Track[];
+  staticProps?: Record<string, number | string>;
+}
+
+/** A versioned, declarative animation for one effect. */
+export interface AnimationDescriptor {
+  /** Stable id including version, e.g. 'spotlight.v1'. */
+  id: string;
+  /** Numeric version, bumped on any behavioral change. */
+  version: number;
+  effect: 'spotlight' | 'laser';
+  /** Default parameter values; consumers may override (e.g. dimness, color). */
+  params?: Record<string, number | string>;
+  /** Stacking order the effect renders at. */
+  zIndex: number;
+  layers: Layer[];
+}

--- a/packages/@openmaic/choreography/src/index.ts
+++ b/packages/@openmaic/choreography/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @openmaic/choreography — the shared orchestration/spec package.
+ *
+ * The single source of truth for the semantics a faithful video exporter needs
+ * from playback, so neither the app runtime nor the exporter re-implements (and
+ * silently drifts from) the other:
+ *
+ * - **Timing** — playback timing constants + the deterministic no-audio speech
+ *   estimate ({@link estimateSpeechDurationMs}).
+ * - **Cursor** — {@link resolvePlaybackCursor}, the scene/action walk.
+ * - **Timeline** — {@link resolveActionTimeline}, the index→time expansion.
+ * - **Descriptors** — versioned, declarative animation descriptors
+ *   ({@link DESCRIPTORS}, e.g. `spotlight.v1`).
+ *
+ * Dependency arrow (kept acyclic): @openmaic/choreography -> @openmaic/dsl.
+ * This package must never gain a runtime dependency on React, DOM, GSAP,
+ * framer-motion, or any render backend — the exporter runs in pure Node.
+ */
+export * from './timing.js';
+export * from './cursor.js';
+export * from './timeline.js';
+export * from './descriptors/index.js';

--- a/packages/@openmaic/choreography/src/timeline.ts
+++ b/packages/@openmaic/choreography/src/timeline.ts
@@ -1,0 +1,195 @@
+/**
+ * `resolveActionTimeline` — the index-domain → time-domain expansion.
+ *
+ * Playback drives actions by a `(sceneIndex, actionIndex)` cursor; a faithful
+ * video exporter needs the same sequence laid out on a wall-clock. This pure
+ * function formalizes the semantics the app's `PlaybackEngine.processNext`
+ * switch expresses as control flow:
+ *
+ * - **Blocking** actions (speech, whiteboard, widget, video, discussion) hold
+ *   the cursor until they complete — the next action starts after them.
+ * - **Fire-and-forget** actions (spotlight, laser) do not block: playback
+ *   continues immediately, and the effect persists visually for
+ *   {@link EFFECT_AUTO_CLEAR_MS} before auto-clearing.
+ *
+ * The blocking/non-blocking partition is read from the DSL's
+ * {@link FIRE_AND_FORGET_ACTIONS} rather than hardcoded here, so the two stay
+ * in lockstep. Durations come from the shared {@link timing} spec.
+ *
+ * Pure, no runtime dependencies.
+ */
+import type {
+  Action,
+  SceneCore,
+  SpeechAction,
+  PlayVideoAction,
+  WbDrawCodeAction,
+  WbClearAction,
+} from '@openmaic/dsl';
+import { FIRE_AND_FORGET_ACTIONS } from '@openmaic/dsl';
+import { EMPTY_SCENE_DWELL } from './cursor.js';
+import {
+  EFFECT_AUTO_CLEAR_MS,
+  DISCUSSION_TRIGGER_DELAY_MS,
+  MAX_VIDEO_WAIT_MS,
+  WB_OPEN_MS,
+  WB_DRAW_MS,
+  WB_EDIT_MS,
+  WB_DELETE_MS,
+  WB_CLOSE_MS,
+  WIDGET_MS,
+  wbDrawCodeMs,
+  wbClearMs,
+  estimateSpeechDurationMs,
+} from './timing.js';
+
+const FIRE_AND_FORGET = new Set<string>(FIRE_AND_FORGET_ACTIONS);
+
+export interface ResolveTimelineOptions {
+  /** Playback speed multiplier applied to the no-audio speech estimate. Default 1. */
+  playbackSpeed?: number;
+  /**
+   * Real narration duration (ms) for a speech action when pre-generated audio
+   * exists. Return `null`/`undefined` to fall back to the deterministic
+   * {@link estimateSpeechDurationMs}. The exporter, which knows each clip's
+   * stored audio duration (issue #861), supplies this.
+   */
+  getAudioDurationMs?: (action: SpeechAction) => number | null | undefined;
+  /**
+   * Real video duration (ms) for a play_video action. Return `null`/`undefined`
+   * when unknown (treated as 0, i.e. no dwell). Capped at {@link MAX_VIDEO_WAIT_MS}.
+   */
+  getVideoDurationMs?: (action: PlayVideoAction) => number | null | undefined;
+  /**
+   * Live whiteboard element count when a wb_clear runs (the clear animation
+   * scales with it). Defaults to 0 (the animation floor) when not supplied; the
+   * exporter, which replays whiteboard state, can provide the true count.
+   */
+  getClearElementCount?: (action: WbClearAction) => number;
+}
+
+export interface TimelineSegment {
+  action: Action;
+  sceneId: string;
+  sceneIndex: number;
+  actionIndex: number;
+  /** Wall-clock start (ms) relative to the start of playback. */
+  startMs: number;
+  /** How long the action is visually present (ms). */
+  durationMs: number;
+  /**
+   * How much the playback cursor advances (ms) before the next action starts.
+   * Equal to `durationMs` for blocking actions, `0` for fire-and-forget.
+   */
+  advancesCursorMs: number;
+  /** Whether the action blocks the cursor (false only for fire-and-forget). */
+  blocking: boolean;
+}
+
+/** Line count of a code block, matching the app's `code.split('\n')` typing anim. */
+function codeLineCount(code: string): number {
+  return code.split('\n').length;
+}
+
+/**
+ * The visual duration (ms) of a single action — how long it is present on
+ * screen. For blocking actions this is also how long the cursor waits.
+ */
+function actionDurationMs(action: Action, opts: ResolveTimelineOptions): number {
+  switch (action.type) {
+    case 'speech': {
+      const audio = opts.getAudioDurationMs?.(action);
+      if (audio != null) return audio;
+      return estimateSpeechDurationMs(action.text, { speed: opts.playbackSpeed ?? 1 });
+    }
+    case 'spotlight':
+    case 'laser':
+      return EFFECT_AUTO_CLEAR_MS;
+    case 'discussion':
+      // Deterministic dwell before the ProactiveCard shows. The subsequent
+      // interactive wait (user answers/skips) is not part of the deterministic
+      // timeline and is out of scope here.
+      return DISCUSSION_TRIGGER_DELAY_MS;
+    case 'play_video': {
+      const video = opts.getVideoDurationMs?.(action) ?? 0;
+      return Math.min(video, MAX_VIDEO_WAIT_MS);
+    }
+    case 'wb_open':
+      return WB_OPEN_MS;
+    case 'wb_draw_text':
+    case 'wb_draw_shape':
+    case 'wb_draw_chart':
+    case 'wb_draw_latex':
+    case 'wb_draw_table':
+    case 'wb_draw_line':
+      return WB_DRAW_MS;
+    case 'wb_draw_code':
+      return wbDrawCodeMs(codeLineCount((action as WbDrawCodeAction).code));
+    case 'wb_edit_code':
+      return WB_EDIT_MS;
+    case 'wb_clear':
+      return wbClearMs(opts.getClearElementCount?.(action as WbClearAction) ?? 0);
+    case 'wb_delete':
+      return WB_DELETE_MS;
+    case 'wb_close':
+      return WB_CLOSE_MS;
+    case 'widget_highlight':
+    case 'widget_setState':
+    case 'widget_annotation':
+    case 'widget_reveal':
+      return WIDGET_MS;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Expand a scene list into an ordered wall-clock timeline. Scenes and their
+ * actions are visited in order; a scene with no actions yields one
+ * {@link EMPTY_SCENE_DWELL} beat (a blank speech clip's dwell) so it still
+ * shows, mirroring {@link resolvePlaybackCursor}.
+ *
+ * @returns segments in play order, each stamped with `startMs`, its visual
+ *          `durationMs`, and how far it `advancesCursorMs`.
+ *
+ * Typed against {@link SceneCore} (only `id` + `actions` are read), so an
+ * app-widened `Scene` (extra content kinds) is accepted without casting.
+ */
+export function resolveActionTimeline(
+  scenes: SceneCore[],
+  opts: ResolveTimelineOptions = {},
+): TimelineSegment[] {
+  const segments: TimelineSegment[] = [];
+  let clockMs = 0;
+
+  const push = (action: Action, sceneId: string, sceneIndex: number, actionIndex: number) => {
+    const durationMs = actionDurationMs(action, opts);
+    const blocking = !FIRE_AND_FORGET.has(action.type);
+    const advancesCursorMs = blocking ? durationMs : 0;
+    segments.push({
+      action,
+      sceneId,
+      sceneIndex,
+      actionIndex,
+      startMs: clockMs,
+      durationMs,
+      advancesCursorMs,
+      blocking,
+    });
+    clockMs += advancesCursorMs;
+  };
+
+  scenes.forEach((scene, sceneIndex) => {
+    const actions = scene.actions ?? [];
+    if (actions.length === 0) {
+      // Empty scene → one synthetic dwell beat, exactly as the cursor yields.
+      push(EMPTY_SCENE_DWELL, scene.id, sceneIndex, 0);
+      return;
+    }
+    actions.forEach((action, actionIndex) => {
+      push(action, scene.id, sceneIndex, actionIndex);
+    });
+  });
+
+  return segments;
+}

--- a/packages/@openmaic/choreography/src/timing.ts
+++ b/packages/@openmaic/choreography/src/timing.ts
@@ -1,0 +1,110 @@
+/**
+ * Timing spec — the single source of truth for playback timing.
+ *
+ * These constants and the no-audio narration estimate were previously inlined
+ * in the app engines (`lib/action/engine.ts`, `lib/playback/engine.ts`). They
+ * are moved here verbatim so the app runtime and the video exporter interpret
+ * the same numbers: if either side re-implemented them, the exported video
+ * would silently drift whenever the app is tuned. The literals below are the
+ * behavior-defining values — change them here and both consumers follow.
+ *
+ * Pure, no runtime dependencies.
+ */
+
+// ==================== Effect / scene timing ====================
+
+/** Duration (ms) a fire-and-forget effect (spotlight/laser) stays before auto-clearing. */
+export const EFFECT_AUTO_CLEAR_MS = 5000;
+
+/** Delay (ms) before a discussion trigger shows its ProactiveCard (lets prior speech finish). */
+export const DISCUSSION_TRIGGER_DELAY_MS = 3000;
+
+/** Safety cap (ms) on how long playback waits for a video to finish. */
+export const MAX_VIDEO_WAIT_MS = 5 * 60 * 1000;
+
+// ==================== Whiteboard / widget action durations ====================
+//
+// The blocking "visual duration" of each synchronous action — how long the
+// engine awaits before advancing to the next action. Lifted verbatim from the
+// `delay(...)` call sites in `lib/action/engine.ts`.
+
+/** wb_open — open animation (slow spring). */
+export const WB_OPEN_MS = 2000;
+
+/** wb_draw_* (text/shape/chart/latex/table/line) — element fade-in. */
+export const WB_DRAW_MS = 800;
+
+/** wb_edit_code — line-level edit animation. */
+export const WB_EDIT_MS = 600;
+
+/** wb_delete — element removal. */
+export const WB_DELETE_MS = 300;
+
+/** wb_close — close animation (ease-out tween). */
+export const WB_CLOSE_MS = 700;
+
+/** widget_* interactions (highlight/setState/annotation/reveal). */
+export const WIDGET_MS = 300;
+
+/**
+ * wb_draw_code — typing animation: base 800ms + 50ms/line, capped at 3000ms.
+ * Verbatim from `lib/action/engine.ts` (`Math.min(800 + lines.length * 50, 3000)`).
+ */
+export function wbDrawCodeMs(lineCount: number): number {
+  return Math.min(800 + lineCount * 50, 3000);
+}
+
+/**
+ * wb_clear — clear animation: base 380ms + 55ms/element, capped at 1400ms.
+ * Verbatim from `lib/action/engine.ts` (`Math.min(380 + elementCount * 55, 1400)`).
+ */
+export function wbClearMs(elementCount: number): number {
+  return Math.min(380 + elementCount * 55, 1400);
+}
+
+// ==================== No-audio narration estimate ====================
+
+/**
+ * Characters counted as CJK for the reading-timer heuristic: CJK Unified
+ * Ideographs (+ Ext-A), Hiragana, Katakana, Hangul Syllables. Verbatim from the
+ * regex in `lib/playback/engine.ts`'s `scheduleReadingTimer`.
+ */
+const CJK_REGEX = /[一-鿿㐀-䶿぀-ゟ゠-ヿ가-힯]/g;
+
+/** Text is treated as CJK when this fraction of its characters are CJK. */
+const CJK_RATIO_THRESHOLD = 0.3;
+
+/** Minimum estimated reading time (ms), regardless of length. */
+const MIN_READING_MS = 2000;
+
+/** CJK narration pace: ms per character (one char ≈ one word). */
+const CJK_MS_PER_CHAR = 150;
+
+/** Non-CJK narration pace: ms per word (≈250 WPM). */
+const NON_CJK_MS_PER_WORD = 240;
+
+export interface SpeechEstimateOptions {
+  /** Playback speed multiplier; the estimate is divided by it. Default 1. */
+  speed?: number;
+}
+
+/**
+ * Estimate how long narration takes to "speak" when no pre-generated audio is
+ * available (TTS disabled). Deterministic — the exporter and the app's
+ * reading-timer must agree on the dwell of an audio-less speech clip.
+ *
+ * - CJK text (>30% CJK chars): ~150ms/char.
+ * - Non-CJK text: ~240ms/word (≈250 WPM).
+ * - Floored at 2000ms, then divided by playback speed.
+ *
+ * Moved verbatim from `lib/playback/engine.ts`'s `scheduleReadingTimer`.
+ */
+export function estimateSpeechDurationMs(text: string, opts?: SpeechEstimateOptions): number {
+  const speed = opts?.speed ?? 1;
+  const cjkCount = (text.match(CJK_REGEX) || []).length;
+  const isCJK = cjkCount > text.length * CJK_RATIO_THRESHOLD;
+  const rawMs = isCJK
+    ? Math.max(MIN_READING_MS, text.length * CJK_MS_PER_CHAR)
+    : Math.max(MIN_READING_MS, text.split(/\s+/).filter(Boolean).length * NON_CJK_MS_PER_WORD);
+  return rawMs / speed;
+}

--- a/packages/@openmaic/choreography/test/cursor.test.ts
+++ b/packages/@openmaic/choreography/test/cursor.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { resolvePlaybackCursor, EMPTY_SCENE_DWELL } from '@/lib/playback/engine-cursor';
-import type { Action } from '@/lib/types/action';
-import type { Scene } from '@/lib/types/stage';
+import { resolvePlaybackCursor, EMPTY_SCENE_DWELL } from '@openmaic/choreography';
+import type { Action, Scene } from '@openmaic/dsl';
 
 const a = (id: string): Action => ({ id, type: 'speech', text: id }) as Action;
 const sc = (id: string, actions: Action[]): Scene =>

--- a/packages/@openmaic/choreography/test/descriptors.test.ts
+++ b/packages/@openmaic/choreography/test/descriptors.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { DESCRIPTORS, spotlightV1, laserV1, getDescriptor } from '@openmaic/choreography';
+// JS codegen helper (the build-only generator); vitest/esbuild resolves it at
+// runtime and tsc infers its exports via allowJs.
+import { generateSchema } from '../scripts/gen-schema.mjs';
+
+// Generate the descriptor schema once, then compile it.
+const schema = generateSchema('AnimationDescriptor');
+const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+
+describe('animation descriptor registry', () => {
+  it('registers spotlight.v1 and laser.v1 under their versioned ids', () => {
+    expect(Object.keys(DESCRIPTORS).sort()).toEqual(['laser.v1', 'spotlight.v1']);
+    expect(getDescriptor('spotlight.v1')).toBe(spotlightV1);
+    expect(getDescriptor('laser.v1')).toBe(laserV1);
+    expect(getDescriptor('nope.v1')).toBeUndefined();
+  });
+
+  it('ids and versions are consistent', () => {
+    for (const [key, d] of Object.entries(DESCRIPTORS)) {
+      expect(d.id).toBe(key);
+      expect(d.version).toBe(1);
+      expect(key.endsWith(`.v${d.version}`)).toBe(true);
+    }
+  });
+});
+
+describe('every shipped descriptor conforms to the generated JSON Schema', () => {
+  for (const [key, d] of Object.entries(DESCRIPTORS)) {
+    it(`${key} validates`, () => {
+      const ok = validate(d);
+      if (!ok) console.error(validate.errors);
+      expect(ok).toBe(true);
+    });
+  }
+
+  it('rejects a descriptor missing required fields', () => {
+    expect(validate({ id: 'x.v1', version: 1 })).toBe(false);
+  });
+});
+
+describe('spotlight.v1 pins the source animation values', () => {
+  it('has the dim/cutout/border layers and z-index 100', () => {
+    expect(spotlightV1.zIndex).toBe(100);
+    expect(spotlightV1.params).toMatchObject({ dimness: 0.7 });
+    expect(spotlightV1.layers.map((l) => l.id).sort()).toEqual(['border', 'cutout', 'dim']);
+  });
+
+  it('cutout uses the 600ms expo-out curve', () => {
+    const cutout = spotlightV1.layers.find((l) => l.id === 'cutout')!;
+    for (const t of cutout.tracks) {
+      expect(t.durationMs).toBe(600);
+      expect(t.easing).toEqual({ type: 'cubicBezier', points: [0.16, 1, 0.3, 1] });
+    }
+  });
+
+  it('border is 500ms, delayed 50ms', () => {
+    const border = spotlightV1.layers.find((l) => l.id === 'border')!;
+    for (const t of border.tracks) {
+      expect(t.durationMs).toBe(500);
+      expect(t.delayMs).toBe(50);
+    }
+  });
+});
+
+describe('laser.v1 pins the source animation values', () => {
+  it('has the dot/ring/core layers, z-index 101, red default', () => {
+    expect(laserV1.zIndex).toBe(101);
+    expect(laserV1.params).toMatchObject({ color: '#ff0000' });
+    expect(laserV1.layers.map((l) => l.id).sort()).toEqual(['core', 'dot', 'ring']);
+  });
+
+  it('the ring pulses infinitely, scale 1→2.8, 1500ms, 300ms repeat delay', () => {
+    const ring = laserV1.layers.find((l) => l.id === 'ring')!;
+    const scale = ring.tracks.find((t) => t.property === 'scale')!;
+    expect(scale).toMatchObject({
+      from: 1,
+      to: 2.8,
+      durationMs: 1500,
+      repeat: 'infinite',
+      repeatDelayMs: 300,
+    });
+  });
+
+  it('the dot fly-in is 500ms enter and 250ms exit', () => {
+    const dot = laserV1.layers.find((l) => l.id === 'dot')!;
+    const enterLeft = dot.tracks.find((t) => t.property === 'left' && t.phase === 'enter')!;
+    const exitLeft = dot.tracks.find((t) => t.property === 'left' && t.phase === 'exit')!;
+    expect(enterLeft.durationMs).toBe(500);
+    expect(exitLeft.durationMs).toBe(250);
+  });
+});

--- a/packages/@openmaic/choreography/test/timeline.test.ts
+++ b/packages/@openmaic/choreography/test/timeline.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'vitest';
+import {
+  resolveActionTimeline,
+  estimateSpeechDurationMs,
+  EFFECT_AUTO_CLEAR_MS,
+  DISCUSSION_TRIGGER_DELAY_MS,
+  WB_OPEN_MS,
+  WB_DRAW_MS,
+} from '@openmaic/choreography';
+import type { Action, Scene } from '@openmaic/dsl';
+
+const sc = (id: string, actions: Action[]): Scene =>
+  ({
+    id,
+    stageId: 's',
+    type: 'slide',
+    title: id,
+    order: 1,
+    content: { type: 'slide', canvas: {} },
+    actions,
+  }) as unknown as Scene;
+
+const speech = (id: string, text: string): Action => ({ id, type: 'speech', text }) as Action;
+const spotlight = (id: string): Action => ({ id, type: 'spotlight', elementId: 'e' }) as Action;
+const laser = (id: string): Action => ({ id, type: 'laser', elementId: 'e' }) as Action;
+const wbOpen = (id: string): Action => ({ id, type: 'wb_open' }) as Action;
+const wbText = (id: string): Action =>
+  ({ id, type: 'wb_draw_text', content: 'c', x: 0, y: 0 }) as Action;
+
+describe('resolveActionTimeline — index → time expansion', () => {
+  test('blocking speech advances the cursor by its estimated duration', () => {
+    const scenes = [sc('S0', [speech('a0', 'one two three four five six seven eight nine ten')])];
+    const [seg] = resolveActionTimeline(scenes);
+    const expected = estimateSpeechDurationMs('one two three four five six seven eight nine ten');
+    expect(seg).toMatchObject({
+      sceneId: 'S0',
+      sceneIndex: 0,
+      actionIndex: 0,
+      startMs: 0,
+      durationMs: expected,
+      advancesCursorMs: expected,
+      blocking: true,
+    });
+  });
+
+  test('speech uses the audio-duration resolver when it returns a value', () => {
+    const scenes = [sc('S0', [speech('a0', 'whatever')])];
+    const segs = resolveActionTimeline(scenes, { getAudioDurationMs: () => 4321 });
+    expect(segs[0]).toMatchObject({ durationMs: 4321, advancesCursorMs: 4321 });
+  });
+
+  test('speech falls back to the estimate when the resolver returns null', () => {
+    const scenes = [sc('S0', [speech('a0', 'a b c')])];
+    const segs = resolveActionTimeline(scenes, { getAudioDurationMs: () => null });
+    expect(segs[0].durationMs).toBe(estimateSpeechDurationMs('a b c'));
+  });
+
+  test('playback speed flows into the speech estimate', () => {
+    const text = 'one two three four five six seven eight nine ten';
+    const scenes = [sc('S0', [speech('a0', text)])];
+    const segs = resolveActionTimeline(scenes, { playbackSpeed: 2 });
+    expect(segs[0].durationMs).toBe(estimateSpeechDurationMs(text, { speed: 2 }));
+  });
+
+  test('fire-and-forget effects do NOT advance the cursor (visual duration only)', () => {
+    const scenes = [sc('S0', [spotlight('a0'), laser('a1'), speech('a2', 'hi there friend')])];
+    const [sp, la, sp2] = resolveActionTimeline(scenes);
+    // spotlight: visual EFFECT_AUTO_CLEAR_MS, but cursor does not advance
+    expect(sp).toMatchObject({
+      startMs: 0,
+      durationMs: EFFECT_AUTO_CLEAR_MS,
+      advancesCursorMs: 0,
+      blocking: false,
+    });
+    // laser: same, and it starts at 0 too since the spotlight didn't advance the clock
+    expect(la).toMatchObject({
+      startMs: 0,
+      durationMs: EFFECT_AUTO_CLEAR_MS,
+      advancesCursorMs: 0,
+      blocking: false,
+    });
+    // the following speech also starts at 0 (nothing before it advanced the cursor)
+    expect(sp2.startMs).toBe(0);
+    expect(sp2.blocking).toBe(true);
+  });
+
+  test('startMs accumulates across blocking actions and scenes', () => {
+    const scenes = [sc('S0', [wbOpen('a0'), wbText('a1')]), sc('S1', [wbText('b0')])];
+    const segs = resolveActionTimeline(scenes);
+    expect(segs.map((s) => s.startMs)).toEqual([0, WB_OPEN_MS, WB_OPEN_MS + WB_DRAW_MS]);
+    expect(segs.map((s) => s.durationMs)).toEqual([WB_OPEN_MS, WB_DRAW_MS, WB_DRAW_MS]);
+  });
+
+  test('an empty scene yields one dwell beat (empty-text speech = 2000ms floor)', () => {
+    const scenes = [sc('S0', [])];
+    const segs = resolveActionTimeline(scenes);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toMatchObject({
+      sceneId: 'S0',
+      startMs: 0,
+      durationMs: 2000,
+      advancesCursorMs: 2000,
+      blocking: true,
+    });
+    expect(segs[0].action).toMatchObject({ type: 'speech', text: '' });
+  });
+
+  test('a mid-list empty scene still dwells and shifts later scenes', () => {
+    const scenes = [
+      sc('S0', [speech('a0', 'a b c')]),
+      sc('S1', []),
+      sc('S2', [speech('c0', 'x y z')]),
+    ];
+    const segs = resolveActionTimeline(scenes);
+    const d = estimateSpeechDurationMs('a b c'); // = 2000
+    expect(segs.map((s) => s.sceneId)).toEqual(['S0', 'S1', 'S2']);
+    expect(segs.map((s) => s.startMs)).toEqual([0, d, d + 2000]);
+  });
+
+  test('discussion contributes a deterministic trigger-delay dwell', () => {
+    const scenes = [sc('S0', [{ id: 'd0', type: 'discussion', topic: 't' } as Action])];
+    const [seg] = resolveActionTimeline(scenes);
+    expect(seg).toMatchObject({
+      durationMs: DISCUSSION_TRIGGER_DELAY_MS,
+      advancesCursorMs: DISCUSSION_TRIGGER_DELAY_MS,
+      blocking: true,
+    });
+  });
+
+  test('play_video uses the video-duration resolver, capped, and defaults to 0', () => {
+    const scenes = [sc('S0', [{ id: 'v0', type: 'play_video', elementId: 'e' } as Action])];
+    expect(resolveActionTimeline(scenes)[0].durationMs).toBe(0);
+    expect(resolveActionTimeline(scenes, { getVideoDurationMs: () => 12_000 })[0].durationMs).toBe(
+      12_000,
+    );
+    expect(
+      resolveActionTimeline(scenes, { getVideoDurationMs: () => 10 * 60 * 1000 })[0].durationMs,
+    ).toBe(5 * 60 * 1000); // capped at MAX_VIDEO_WAIT_MS
+  });
+
+  test('wb_draw_code duration scales with line count', () => {
+    const code = 'l1\nl2\nl3\nl4\nl5'; // 5 lines
+    const scenes = [
+      sc('S0', [{ id: 'c0', type: 'wb_draw_code', language: 'ts', code, x: 0, y: 0 } as Action]),
+    ];
+    expect(resolveActionTimeline(scenes)[0].durationMs).toBe(800 + 5 * 50);
+  });
+
+  test('wb_clear duration scales with the injected element count', () => {
+    const scenes = [sc('S0', [{ id: 'cl', type: 'wb_clear' } as Action])];
+    expect(resolveActionTimeline(scenes)[0].durationMs).toBe(380); // default 0 elements
+    expect(resolveActionTimeline(scenes, { getClearElementCount: () => 4 })[0].durationMs).toBe(
+      380 + 4 * 55,
+    );
+  });
+
+  test('empty scene list yields an empty timeline', () => {
+    expect(resolveActionTimeline([])).toEqual([]);
+  });
+});

--- a/packages/@openmaic/choreography/test/timing.test.ts
+++ b/packages/@openmaic/choreography/test/timing.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+import {
+  estimateSpeechDurationMs,
+  EFFECT_AUTO_CLEAR_MS,
+  DISCUSSION_TRIGGER_DELAY_MS,
+  MAX_VIDEO_WAIT_MS,
+  WB_OPEN_MS,
+  WB_DRAW_MS,
+  WB_EDIT_MS,
+  WB_DELETE_MS,
+  WB_CLOSE_MS,
+  WIDGET_MS,
+  wbDrawCodeMs,
+  wbClearMs,
+} from '@openmaic/choreography';
+
+describe('timing constants (verbatim from the app engines)', () => {
+  test('pin the effect / scene timing values', () => {
+    expect(EFFECT_AUTO_CLEAR_MS).toBe(5000);
+    expect(DISCUSSION_TRIGGER_DELAY_MS).toBe(3000);
+    expect(MAX_VIDEO_WAIT_MS).toBe(5 * 60 * 1000);
+  });
+
+  test('pin the whiteboard / widget action durations', () => {
+    expect(WB_OPEN_MS).toBe(2000);
+    expect(WB_DRAW_MS).toBe(800);
+    expect(WB_EDIT_MS).toBe(600);
+    expect(WB_DELETE_MS).toBe(300);
+    expect(WB_CLOSE_MS).toBe(700);
+    expect(WIDGET_MS).toBe(300);
+  });
+});
+
+describe('wbDrawCodeMs — base 800 + 50/line, capped 3000', () => {
+  test('base with no/one line', () => {
+    expect(wbDrawCodeMs(0)).toBe(800);
+    expect(wbDrawCodeMs(1)).toBe(850);
+  });
+  test('scales per line', () => {
+    expect(wbDrawCodeMs(10)).toBe(1300);
+  });
+  test('caps at 3000', () => {
+    expect(wbDrawCodeMs(44)).toBe(3000); // 800 + 44*50 = 3000 exactly
+    expect(wbDrawCodeMs(100)).toBe(3000);
+  });
+});
+
+describe('wbClearMs — base 380 + 55/element, capped 1400', () => {
+  test('base with no elements', () => {
+    expect(wbClearMs(0)).toBe(380);
+  });
+  test('scales per element', () => {
+    expect(wbClearMs(4)).toBe(600);
+  });
+  test('caps at 1400', () => {
+    expect(wbClearMs(19)).toBe(1400); // 380 + 19*55 = 1425 → capped
+    expect(wbClearMs(200)).toBe(1400);
+  });
+});
+
+describe('estimateSpeechDurationMs — no-audio narration estimate', () => {
+  test('empty text floors at 2000ms', () => {
+    expect(estimateSpeechDurationMs('')).toBe(2000);
+  });
+
+  test('non-CJK uses 240ms/word above the floor', () => {
+    // 10 words * 240 = 2400 (above the 2000 floor)
+    const text = 'one two three four five six seven eight nine ten';
+    expect(estimateSpeechDurationMs(text)).toBe(2400);
+  });
+
+  test('non-CJK short text floors at 2000ms', () => {
+    // 3 words * 240 = 720 → floored to 2000
+    expect(estimateSpeechDurationMs('a b c')).toBe(2000);
+  });
+
+  test('non-CJK collapses whitespace when counting words', () => {
+    // Leading/trailing/multiple spaces must not inflate the word count.
+    const a = estimateSpeechDurationMs('  one   two  three  ');
+    const b = estimateSpeechDurationMs('one two three');
+    expect(a).toBe(b);
+  });
+
+  test('CJK uses 150ms/char above the floor', () => {
+    // 20 CJK chars * 150 = 3000 (all chars are CJK → ratio 1 > 0.3)
+    const text = '一二三四五六七八九十一二三四五六七八九十';
+    expect(text.length).toBe(20);
+    expect(estimateSpeechDurationMs(text)).toBe(3000);
+  });
+
+  test('the 0.3 CJK ratio threshold selects the CJK branch', () => {
+    // 40 chars, 16 CJK → ratio 0.4 > 0.3 → CJK branch → 40 * 150 = 6000.
+    const cjk = '一二三四五六七八九十一二三四五六';
+    const latin = 'abcdefghijklmnopqrstuvwx'; // 24 chars
+    const text = cjk + latin;
+    expect(text.length).toBe(40);
+    expect(estimateSpeechDurationMs(text)).toBe(text.length * 150);
+  });
+
+  test('below the 0.3 ratio uses the word branch', () => {
+    // Mostly Latin with a few CJK chars → ratio ≤ 0.3 → word branch.
+    const text = 'hello world this is a test 一 二'; // 8 "words", 2 CJK of ~30 chars
+    const words = text.split(/\s+/).filter(Boolean).length;
+    expect(estimateSpeechDurationMs(text)).toBe(Math.max(2000, words * 240));
+  });
+
+  test('divides by playback speed', () => {
+    const text = 'one two three four five six seven eight nine ten'; // 2400ms @ 1x
+    expect(estimateSpeechDurationMs(text, { speed: 2 })).toBe(1200);
+    expect(estimateSpeechDurationMs(text, { speed: 0.5 })).toBe(4800);
+  });
+
+  test('speed applies after the floor', () => {
+    // Floored to 2000, then /2 = 1000.
+    expect(estimateSpeechDurationMs('a b c', { speed: 2 })).toBe(1000);
+  });
+});

--- a/packages/@openmaic/choreography/tsconfig.json
+++ b/packages/@openmaic/choreography/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "preserveConstEnums": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/@openmaic/choreography/vitest.config.ts
+++ b/packages/@openmaic/choreography/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Resolve `@openmaic/choreography` self-imports and the `@openmaic/dsl` dependency
+// to their package sources, so `pnpm test` is standalone on a clean checkout (no
+// `dist` build required). Consumers still resolve via each package's `exports`
+// map → `dist` as before.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@openmaic/choreography': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+      '@openmaic/dsl': fileURLToPath(new URL('../dsl/src/index.ts', import.meta.url)),
+    },
+  },
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@napi-rs/canvas':
         specifier: ^0.1.88
         version: 0.1.96
+      '@openmaic/choreography':
+        specifier: workspace:*
+        version: link:packages/@openmaic/choreography
       '@openmaic/dsl':
         specifier: workspace:*
         version: link:packages/@openmaic/dsl
@@ -387,6 +390,25 @@ importers:
       vue-to-react:
         specifier: ^1.0.0
         version: 1.0.0
+
+  packages/@openmaic/choreography:
+    dependencies:
+      '@openmaic/dsl':
+        specifier: workspace:*
+        version: link:../dsl
+    devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.18.0
+      ts-json-schema-generator:
+        specifier: ~2.4.0
+        version: 2.4.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@9.12.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@openmaic/dsl:
     devDependencies:


### PR DESCRIPTION
## Summary

Introduces `@openmaic/choreography`, a small **pure-TS spec package** that both app playback and the (future) classroom video exporter consume, so orchestration semantics — timing, the index→time action timeline, and animation descriptors — have exactly **one home**. Neither side owns the semantics; both interpret the same spec, so the exported video cannot silently drift from real playback when the app is tuned.

The first step is a **behavior-neutral refactor**: the timing constants/formulas that lived in the app engines are moved into the package, the app imports them, and the local literals are deleted. Removing the duplicated literals is what makes drift structurally impossible.

## Related Issues

Closes #863
Sub-issue of #854 (Hyperframes-based classroom video export). Independent of #861/#862 — see note under Changes.

## Changes

- **New package `packages/@openmaic/choreography`** (mirrors `@openmaic/dsl`): pure TS, single runtime dep `@openmaic/dsl`. No React / DOM / GSAP / framer-motion — enforced by a DOM-free `tsconfig` `lib`, an eslint `@/` import-boundary block, and isolated build, so "runs in a pure Node environment" is verifiable on the dependency graph.
- **`timing.ts`** — timing constants (`EFFECT_AUTO_CLEAR_MS`, `DISCUSSION_TRIGGER_DELAY_MS`, the `WB_*`/widget durations, `MAX_VIDEO_WAIT_MS`, `wbDrawCodeMs`/`wbClearMs`) + the deterministic no-audio `estimateSpeechDurationMs`, moved **verbatim** from the app engines.
- **`cursor.ts`** — `resolvePlaybackCursor` + `EMPTY_SCENE_DWELL`, moved from `lib/playback/engine-cursor.ts` (typed on `SceneCore` so an app-widened `Scene` assigns without casting).
- **`timeline.ts`** — new pure `resolveActionTimeline`, the index-domain → time-domain expansion (blocking cursor-advance vs fire-and-forget visual duration), keyed off the DSL action categories. Takes an **optional** audio-duration resolver and falls back to the estimate, so it does **not** depend on the #861/#862 audio-duration work.
- **`descriptors/`** — versioned, schema-validated animation descriptors `spotlight.v1` + `laser.v1` (declarative: property / from / to / duration / easing — no implementation); JSON Schema generated at build time.
- **Behavior-neutral engine refactor** — `lib/action/engine.ts` and `lib/playback/engine.ts` now import from the package; the local literals are deleted.
- **Wiring** — root `package.json` dep + `postinstall` (built after `dsl`), eslint boundary block, CI `test`/`typecheck` steps.

Overlay components migrate to reading the descriptors incrementally (not a blocker; the exporter implements from the descriptors directly). The IR/compiler and any Hyperframes/render-backend concepts are explicitly out of scope.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. `pnpm install` (postinstall builds the package after `@openmaic/dsl`).
2. `pnpm --filter @openmaic/choreography test` — 48 tests pass.
3. `pnpm --filter @openmaic/choreography build` / `typecheck` — tsc + JSON-Schema codegen succeed under the DOM-free lib.
4. `npx tsc --noEmit` and `pnpm lint` at root — app compiles against the package; the new import boundary passes.

### What you personally verified

- Ran the app dev server and confirmed playback behaves identically after the engines were switched to import the moved constants/estimate/cursor (speech dwell, whiteboard/widget timings, spotlight/laser auto-clear).
- `resolveActionTimeline` golden cases: blocking speech (audio vs estimate fallback, playback-speed scaling), fire-and-forget effects with `advancesCursorMs = 0`, effect auto-clear, `wb_*` durations, discussion trigger-delay dwell, empty-scene dwell, and `startMs` accumulation across scenes.
- Descriptors are ajv-validated against the generated schema; `spotlight.v1`/`laser.v1` values pinned to the current component behavior.
- Confirmed the diff only swaps literals for imports (no logic change) and that no moved literals remain in the app engines.
- **Not** covered here: migrating overlay components to read descriptors, and `highlight`/`zoom` descriptors — deferred by design.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes) — N/A, no UI change

Note: the only failing tests in the full `pnpm test` run are `tests/server/{provider-config,classroom-generation-retry}`, which fail identically on base `main` (verified via stash) and import none of the changed code — pre-existing/flaky, unrelated to this PR.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (package README)
- [x] My changes do not introduce new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)