### PR TITLE
feat(dsl): runtime envelope — RuntimeSession + RuntimeRecord + core-kind skeletons (#869 Part A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Unit Tests (importer)
         run: pnpm --filter @openmaic/importer test
 
+      - name: Unit Tests (dsl)
+        run: pnpm --filter @openmaic/dsl test
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -165,9 +165,14 @@ stage/learner/kind) and `RuntimeRecord<TPayload>` (ordered facts; the
 store-assigned `seq` is the replay ordering key). Core-kind payload skeletons
 (`chat`, `quizAttempt`) live here; payload internals are app-owned, validated at
 the store boundary via injected validators (`runtime.ts` guards + `validate.ts`).
-A `RuntimeSession` carries the same `dslVersion` stamp as a document and rides the
-same `migrate`-on-read ladder above, so runtime state migrates forward alongside
-the slide contract.
+A `RuntimeSession` carries the same `dslVersion` envelope *field* as a document,
+but rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
+`RUNTIME_DSL_MIGRATIONS` ladder, walked by `migrateRuntime` (not `migrate`). The
+document and runtime serialized shapes evolve independently, so a future
+`Stage`/`Scene` document migration never runs over — or accidentally consumes — a
+runtime envelope, and vice versa. The runner mechanism (contiguous ladder,
+idempotent, forward-compatible, fail-loud) is shared; only the ladder and target
+version differ.
 
 ## Status
 

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -170,10 +170,29 @@ A `RuntimeSession` carries its **own** version envelope field,
 rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
 `RUNTIME_DSL_MIGRATIONS` ladder, walked by `migrateRuntime` (not `migrate`), with
 `runtimeDslVersionOf` / `needsRuntimeMigration` as the runtime-line counterparts
-of `dslVersionOf` / `needsMigration`. The two lines stamp **different fields**,
-so neither ladder reads the other's version — but disjoint fields alone are not
-enough: a session lacking `dslVersion` would still read as *unversioned* to the
-document runner and be lifted onto the wrong line. The **cross-line guard** —
+of `dslVersionOf` / `needsMigration`.
+
+Unlike the document line, the runtime line has **no unversioned epoch**. Real
+pre-versioning documents exist, so `migrate` lifts an unstamped document from
+`UNVERSIONED_DSL_VERSION` via its first ladder entry. Nothing legitimately
+predates the runtime envelope, though — it is a brand-new contract, and the
+future `RuntimeStore` stamps `RUNTIME_DSL_VERSION` at write time. So a
+`RuntimeSession` is **born stamped** (`runtimeDslVersion` is a **required** field,
+not optional), `RUNTIME_DSL_MIGRATIONS` ships **empty** (no legacy-lift entry;
+the first real runtime shape change appends a step from the pinned
+`INITIAL_RUNTIME_DSL_VERSION` and bumps `RUNTIME_DSL_VERSION`), and an unstamped
+object reaching any runtime-line function (`migrateRuntime`,
+`needsRuntimeMigration`, `runtimeDslVersionOf`) **throws** — it is a misrouted
+legacy document or an unstamped producer write, not legacy data to lift.
+(Non-objects stay exempt: they are not migratable aggregates and read as
+unversioned on every line.) An empty ladder is still fully functional — a
+stamped-current session early-returns as already current, and a session stamped
+at an unknown older version hits the "no migration path" fail-loud.
+
+The two lines stamp **different fields**, so neither ladder reads the other's
+version — but disjoint fields alone are not enough: a session lacking
+`dslVersion` would still read as *unversioned* to the document runner and be
+lifted onto the wrong line. The **cross-line guard** —
 enforced in the shared envelope reader, so the plain `dslVersionOf` /
 `runtimeDslVersionOf` reads, the `needs*Migration` predicates, and the runners
 all give one answer per envelope — closes this with three-case semantics: (1) own line's stamp present → migrate normally
@@ -184,7 +203,8 @@ other line's aggregate misrouted here is byte-identical to this line's data
 carrying a stray foreign stamp; migrating would mangle the former, returning it
 unchanged would permanently orphan the latter from its own line — so it is
 treated like a malformed stamp and fails loud. `validateRuntimeSession`
-likewise rejects a stray `dslVersion` on a session at the door. The runner
+likewise rejects a session **missing** its `runtimeDslVersion` (born stamped, no
+legacy epoch) and a **stray** `dslVersion` on a session at the door. The runner
 mechanism (contiguous ladder, idempotent, forward-compatible, fail-loud) is
 shared; only the ladder, target version, own stamp field, and the sibling field
 the guard checks differ.

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -165,14 +165,19 @@ stage/learner/kind) and `RuntimeRecord<TPayload>` (ordered facts; the
 store-assigned `seq` is the replay ordering key). Core-kind payload skeletons
 (`chat`, `quizAttempt`) live here; payload internals are app-owned, validated at
 the store boundary via injected validators (`runtime.ts` guards + `validate.ts`).
-A `RuntimeSession` carries the same `dslVersion` envelope *field* as a document,
-but rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
-`RUNTIME_DSL_MIGRATIONS` ladder, walked by `migrateRuntime` (not `migrate`). The
-document and runtime serialized shapes evolve independently, so a future
-`Stage`/`Scene` document migration never runs over — or accidentally consumes — a
-runtime envelope, and vice versa. The runner mechanism (contiguous ladder,
-idempotent, forward-compatible, fail-loud) is shared; only the ladder and target
-version differ.
+A `RuntimeSession` carries its **own** version envelope field,
+`runtimeDslVersion` — mechanically disjoint from a document's `dslVersion` — and
+rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
+`RUNTIME_DSL_MIGRATIONS` ladder, walked by `migrateRuntime` (not `migrate`), with
+`runtimeDslVersionOf` / `needsRuntimeMigration` as the runtime-line counterparts
+of `dslVersionOf` / `needsMigration`. Because the two lines stamp **different
+fields**, their separation is mechanical rather than a call-site convention: a
+future `Stage`/`Scene` document migration walked over a session finds no
+`dslVersion` stamp and, at worst, adds a foreign field it owns, never consuming
+or corrupting the runtime line's `runtimeDslVersion` — and vice versa. Misrouted
+data is inert, not silently reinterpreted. The runner mechanism (contiguous
+ladder, idempotent, forward-compatible, fail-loud) is shared; only the ladder,
+target version, and stamped field differ.
 
 ## Status
 

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -156,6 +156,19 @@ Which aggregate carries the `dslVersion` field — a whole `Stage`, a single Sce
 row, or a bundle — is left to the store that first consumes this pipeline; the
 runner only needs the envelope field.
 
+## Runtime envelope (#869)
+
+Learner-produced runtime data (chat, quiz attempts, playback facts) is persisted
+outside the document, per learner, through a `RuntimeStore` (`@openmaic/storage`).
+This package owns the envelope: `RuntimeSession` (identity + lifecycle, keyed by
+stage/learner/kind) and `RuntimeRecord<TPayload>` (ordered facts; the
+store-assigned `seq` is the replay ordering key). Core-kind payload skeletons
+(`chat`, `quizAttempt`) live here; payload internals are app-owned, validated at
+the store boundary via injected validators (`runtime.ts` guards + `validate.ts`).
+A `RuntimeSession` carries the same `dslVersion` stamp as a document and rides the
+same `migrate`-on-read ladder above, so runtime state migrates forward alongside
+the slide contract.
+
 ## Status
 
 Both consumers are now wired to `@openmaic/dsl` and no longer vendor their own copy

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -170,14 +170,20 @@ A `RuntimeSession` carries its **own** version envelope field,
 rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
 `RUNTIME_DSL_MIGRATIONS` ladder, walked by `migrateRuntime` (not `migrate`), with
 `runtimeDslVersionOf` / `needsRuntimeMigration` as the runtime-line counterparts
-of `dslVersionOf` / `needsMigration`. Because the two lines stamp **different
-fields**, their separation is mechanical rather than a call-site convention: a
-future `Stage`/`Scene` document migration walked over a session finds no
-`dslVersion` stamp and, at worst, adds a foreign field it owns, never consuming
-or corrupting the runtime line's `runtimeDslVersion` — and vice versa. Misrouted
-data is inert, not silently reinterpreted. The runner mechanism (contiguous
-ladder, idempotent, forward-compatible, fail-loud) is shared; only the ladder,
-target version, and stamped field differ.
+of `dslVersionOf` / `needsMigration`. The two lines stamp **different fields**,
+so neither ladder reads the other's version — but disjoint fields alone are not
+enough: a session lacking `dslVersion` would still read as *unversioned* to the
+document runner and be lifted onto the wrong line. Inertness is delivered by the
+**cross-line guard** in the shared `runLadder`, which follows three-case
+semantics: (1) own line's stamp present → migrate normally on the own line,
+regardless of the other key; (2) both stamps absent → genuine legacy data, walk
+the own ladder; (3) own stamp absent but the sibling line's stamp present → the
+aggregate belongs to the other line, so return it unchanged (never lifted, never
+stamped with a foreign field). So a future `Stage`/`Scene` document migration
+walked over a session is a no-op, and vice versa: misrouted data is inert, not
+silently reinterpreted. The runner mechanism (contiguous ladder, idempotent,
+forward-compatible, fail-loud) is shared; only the ladder, target version, own
+stamp field, and the sibling field the guard checks differ.
 
 ## Status
 

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -173,17 +173,20 @@ rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
 of `dslVersionOf` / `needsMigration`. The two lines stamp **different fields**,
 so neither ladder reads the other's version — but disjoint fields alone are not
 enough: a session lacking `dslVersion` would still read as *unversioned* to the
-document runner and be lifted onto the wrong line. Inertness is delivered by the
-**cross-line guard** in the shared `runLadder`, which follows three-case
-semantics: (1) own line's stamp present → migrate normally on the own line,
-regardless of the other key; (2) both stamps absent → genuine legacy data, walk
-the own ladder; (3) own stamp absent but the sibling line's stamp present → the
-aggregate belongs to the other line, so return it unchanged (never lifted, never
-stamped with a foreign field). So a future `Stage`/`Scene` document migration
-walked over a session is a no-op, and vice versa: misrouted data is inert, not
-silently reinterpreted. The runner mechanism (contiguous ladder, idempotent,
-forward-compatible, fail-loud) is shared; only the ladder, target version, own
-stamp field, and the sibling field the guard checks differ.
+document runner and be lifted onto the wrong line. The **cross-line guard** in
+the shared `runLadder` (mirrored by the `needs*Migration` predicates) closes
+this with three-case semantics: (1) own line's stamp present → migrate normally
+on the own line, regardless of the other key; (2) both stamps absent → genuine
+legacy data, walk the own ladder; (3) own stamp absent but the sibling line's
+stamp present → **throw**. Case (3) is undecidable from the envelope — the
+other line's aggregate misrouted here is byte-identical to this line's data
+carrying a stray foreign stamp; migrating would mangle the former, returning it
+unchanged would permanently orphan the latter from its own line — so it is
+treated like a malformed stamp and fails loud. `validateRuntimeSession`
+likewise rejects a stray `dslVersion` on a session at the door. The runner
+mechanism (contiguous ladder, idempotent, forward-compatible, fail-loud) is
+shared; only the ladder, target version, own stamp field, and the sibling field
+the guard checks differ.
 
 ## Status
 

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -173,9 +173,10 @@ rides its **own** version line: `RUNTIME_DSL_VERSION` and a dedicated
 of `dslVersionOf` / `needsMigration`. The two lines stamp **different fields**,
 so neither ladder reads the other's version — but disjoint fields alone are not
 enough: a session lacking `dslVersion` would still read as *unversioned* to the
-document runner and be lifted onto the wrong line. The **cross-line guard** in
-the shared `runLadder` (mirrored by the `needs*Migration` predicates) closes
-this with three-case semantics: (1) own line's stamp present → migrate normally
+document runner and be lifted onto the wrong line. The **cross-line guard** —
+enforced in the shared envelope reader, so the plain `dslVersionOf` /
+`runtimeDslVersionOf` reads, the `needs*Migration` predicates, and the runners
+all give one answer per envelope — closes this with three-case semantics: (1) own line's stamp present → migrate normally
 on the own line, regardless of the other key; (2) both stamps absent → genuine
 legacy data, walk the own ladder; (3) own stamp absent but the sibling line's
 stamp present → **throw**. Case (3) is undecidable from the envelope — the

--- a/packages/@openmaic/dsl/src/index.ts
+++ b/packages/@openmaic/dsl/src/index.ts
@@ -31,3 +31,4 @@ export * from './validate.js';
 export * from './normalize.js';
 export * from './version.js';
 export * from './storage.js';
+export * from './runtime.js';

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -30,12 +30,18 @@
  * Versioning: a session carries its OWN version field, `runtimeDslVersion`
  * (distinct from a document's `dslVersion`), and rides its OWN version line —
  * `RUNTIME_DSL_VERSION` + `migrateRuntime`, not the document's `DSL_VERSION` +
- * `migrate`. The two lines stamp different envelope fields, so neither ladder
- * reads the other's version — but disjoint fields alone would still let a
- * misrouted session be lifted (as unversioned) on the document line. The
- * cross-line guard in `runLadder` closes this: a runner throws on any
- * aggregate that carries the sibling line's stamp but not its own, surfacing
- * the misroute instead of guessing — and vice versa (see `version.ts`).
+ * `migrate`. The stamp is **required** on a session: sessions are born stamped
+ * at write time and the runtime line has **no unversioned epoch** (nothing
+ * legitimately predates this brand-new envelope, unlike real pre-versioning
+ * documents). So an unstamped object reaching the runtime line is a bug — a
+ * misrouted legacy document or an unstamped producer write — and fails loud
+ * (`noRuntimeEpochError`) rather than being lifted like a legacy document. The
+ * two lines stamp different envelope fields, so neither ladder reads the other's
+ * version — but disjoint fields alone would still let a misrouted session be
+ * lifted (as unversioned) on the document line. The cross-line guard in
+ * `runLadder` closes this: a runner throws on any aggregate that carries the
+ * sibling line's stamp but not its own, surfacing the misroute instead of
+ * guessing — and vice versa (see `version.ts`).
  *
  * No runtime dependencies. Pure types + plain data constants only.
  */
@@ -177,20 +183,31 @@ export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
  * `(stageId, learnerKey)` plus a `kind`; a learner may hold several sessions
  * of the same kind on one stage (e.g. repeated quiz attempts).
  *
- * Extends {@link RuntimeVersioned}, so a session carries an optional
- * `runtimeDslVersion` serialized-contract stamp (absent on legacy data) — a
- * DIFFERENT envelope field from a document's `dslVersion`. Stamping +
- * migrate-on-read run on the runtime line only: a session is stamped with
- * `RUNTIME_DSL_VERSION` and migrated by `migrateRuntime`, independent of the
- * document's `DSL_VERSION` / `migrate`. The two stamps live on distinct fields
- * so neither ladder reads the other's; the cross-line guard in `runLadder`
- * turns a misrouted migration into a loud error rather than corruption — a
- * runner throws on any aggregate stamped on the sibling line but not its own,
- * and `validateRuntimeSession` rejects a stray `dslVersion` at the door
+ * Extends {@link RuntimeVersioned} but **overrides its stamp to required**: a
+ * session carries a `runtimeDslVersion` serialized-contract stamp — a DIFFERENT
+ * envelope field from a document's `dslVersion`. Sessions are **born stamped**:
+ * producers write `RUNTIME_DSL_VERSION` at creation and there is no unversioned
+ * epoch on the runtime line (nothing legitimately predates the envelope), so a
+ * stored session always carries the stamp; an absent one is a transient
+ * in-memory state at most, never valid stored data. Stamping + migrate-on-read
+ * run on the runtime line only: a session is migrated by `migrateRuntime`,
+ * independent of the document's `DSL_VERSION` / `migrate`. The two stamps live on
+ * distinct fields so neither ladder reads the other's; the cross-line guard in
+ * `runLadder` turns a misrouted migration into a loud error rather than
+ * corruption — a runner throws on any aggregate stamped on the sibling line but
+ * not its own — while a wholly-unstamped object hitting the runtime line throws
+ * `noRuntimeEpochError` (no legacy lift), and `validateRuntimeSession` rejects
+ * both a missing `runtimeDslVersion` and a stray `dslVersion` at the door
  * (see `version.ts`).
  */
 export interface RuntimeSession extends RuntimeVersioned {
   id: string;
+  /**
+   * Runtime-contract version this session was written at. Required: sessions are
+   * born stamped with `RUNTIME_DSL_VERSION`; the runtime line has no unversioned
+   * epoch, so this narrows {@link RuntimeVersioned}'s optional field to mandatory.
+   */
+  runtimeDslVersion: string;
   /** {@link CoreRuntimeKind} or an app-defined kind. */
   kind: string;
   stageId: string;

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -79,8 +79,20 @@ export function isRuntimeSessionStatus(value: unknown): value is RuntimeSessionS
  * zone designator (`Z` or `±hh:mm`). Runtime timestamps are display metadata
  * whose only cross-tab guarantee is a comparable, unambiguous instant, so the
  * zone is not optional here — a zoneless string names no instant.
+ *
+ * Capture groups feed the component-level range check in {@link isIsoTimestamp}:
+ * 1 year, 2 month, 3 day, 4 hour, 5 minute, 6 second, 7 optional offset hours,
+ * 8 optional offset minutes (groups 7/8 are undefined for the `Z` form).
  */
-const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+const ISO_TIMESTAMP_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2}))$/;
+
+/** Days in a Gregorian month, applying the full leap-year rule for February. */
+function daysInMonth(year: number, month: number): number {
+  const isLeap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const lengths = [31, isLeap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return lengths[month - 1];
+}
 
 /**
  * True when `value` is a well-formed ISO-8601 timestamp per the runtime
@@ -88,31 +100,45 @@ const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{
  * (unlike stage/scene/action), so this pure check is where the documented
  * "ISO 8601" promise on `createdAt` / `updatedAt` is actually enforced.
  *
- * Three layers, none of which alone suffices:
- * - the regex pins the *format* (`Date.parse` alone accepts many non-ISO forms
- *   — bare dates, `'2026/01/01'`, even some free text — so it cannot stand in
- *   for a format check), and pins the mandatory zone designator;
- * - `!Number.isNaN(Date.parse(value))` rejects field-range violations the regex
- *   lets through (month `13`, hour `25`, minute / second `60`), which only a
- *   real date parse catches; but
- * - `Date.parse` does NOT reliably reject day-of-month overflow: on V8 (the CI
- *   Node 22 engine) `'2026-02-30'`, `'2026-02-29'` (2026 is not a leap year),
- *   and `'2026-04-31'` all *normalize* (roll into the next month) instead of
- *   yielding `NaN`, and the verdict is engine-dependent. So the final layer
- *   re-parses the calendar date and requires it to round-trip unchanged, which
- *   rejects the overflow AND makes the verdict engine-independent.
+ * The regex pins the *format* (a lone `Date.parse` accepts many non-ISO forms —
+ * bare dates, `'2026/01/01'`, even some free text — so it cannot stand in for a
+ * format check) and the mandatory zone designator; its capture groups then feed
+ * a purely arithmetic component-range check. We deliberately do NOT touch
+ * `Date` at all:
  *
- * Pure, no runtime dependencies.
+ * - `Date.parse` cannot be used to pin calendar validity, because V8 (the CI
+ *   Node engine) does not reject calendar-impossible full datetimes — it
+ *   NORMALIZES them to a neighbouring real instant. `'2026-02-30T00:00:00.000Z'`
+ *   silently becomes March 2 and `'2026-01-01T24:00:00.000Z'` becomes the next
+ *   day, both parsing to a finite number rather than `NaN`, so a `Date.parse`
+ *   gate would wave calendar-impossible values through. Its verdicts are also
+ *   engine-dependent.
+ *
+ * The component check therefore validates each field directly: month `1..12`;
+ * day `1..daysInMonth` under the full Gregorian leap rule (÷4, except centuries
+ * unless ÷400); hour `≤ 23`; minute and second `≤ 59` — leap-second `:60` is
+ * deliberately rejected; and for a numeric `±hh:mm` zone, offset hours `≤ 23`
+ * and offset minutes `≤ 59`.
+ *
+ * Pure, no runtime dependencies, no `Date` usage.
  */
 export function isIsoTimestamp(value: string): boolean {
-  if (!ISO_TIMESTAMP_RE.test(value) || Number.isNaN(Date.parse(value))) return false;
-  // Day-of-month round-trip: reject a day that `Date.UTC` normalized into the
-  // next month (e.g. Feb 30 -> Mar 2) rather than accepting it as valid.
-  const y = Number(value.slice(0, 4));
-  const m = Number(value.slice(5, 7));
-  const day = Number(value.slice(8, 10));
-  const d = new Date(Date.UTC(y, m - 1, day));
-  return d.getUTCFullYear() === y && d.getUTCMonth() === m - 1 && d.getUTCDate() === day;
+  const m = ISO_TIMESTAMP_RE.exec(value);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  const hour = Number(m[4]);
+  const minute = Number(m[5]);
+  const second = Number(m[6]);
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > daysInMonth(year, month)) return false;
+  if (hour > 23 || minute > 59 || second > 59) return false;
+  // Numeric zone offset (`Z` leaves groups 7/8 undefined and is always in range).
+  if (m[7] !== undefined) {
+    if (Number(m[7]) > 23 || Number(m[8]) > 59) return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -32,10 +32,10 @@
  * `RUNTIME_DSL_VERSION` + `migrateRuntime`, not the document's `DSL_VERSION` +
  * `migrate`. The two lines stamp different envelope fields, so neither ladder
  * reads the other's version — but disjoint fields alone would still let a
- * misrouted session be lifted (as unversioned) on the document line. Inertness
- * is delivered by the cross-line guard in `runLadder`: a runner returns any
- * aggregate that carries the sibling line's stamp but not its own untouched,
- * never stamping a foreign field — and vice versa (see `version.ts`).
+ * misrouted session be lifted (as unversioned) on the document line. The
+ * cross-line guard in `runLadder` closes this: a runner throws on any
+ * aggregate that carries the sibling line's stamp but not its own, surfacing
+ * the misroute instead of guessing — and vice versa (see `version.ts`).
  *
  * No runtime dependencies. Pure types + plain data constants only.
  */
@@ -183,9 +183,10 @@ export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
  * migrate-on-read run on the runtime line only: a session is stamped with
  * `RUNTIME_DSL_VERSION` and migrated by `migrateRuntime`, independent of the
  * document's `DSL_VERSION` / `migrate`. The two stamps live on distinct fields
- * so neither ladder reads the other's; the cross-line guard in `runLadder` is
- * what makes misrouting a migration inert rather than corrupting — a runner
- * leaves any aggregate stamped on the sibling line but not its own untouched
+ * so neither ladder reads the other's; the cross-line guard in `runLadder`
+ * turns a misrouted migration into a loud error rather than corruption — a
+ * runner throws on any aggregate stamped on the sibling line but not its own,
+ * and `validateRuntimeSession` rejects a stray `dslVersion` at the door
  * (see `version.ts`).
  */
 export interface RuntimeSession extends RuntimeVersioned {

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -27,6 +27,12 @@
  * runtime feed with document data: convert at the boundary, never compare a
  * runtime `createdAt` string against a document's numeric timestamp directly.
  *
+ * Versioning: a session carries the shared `dslVersion` envelope field but rides
+ * its OWN version line — `RUNTIME_DSL_VERSION` + `migrateRuntime`, not the
+ * document's `DSL_VERSION` + `migrate`. The two serialized shapes evolve
+ * independently, so a document migration can never run over runtime data (see
+ * `version.ts`).
+ *
  * No runtime dependencies. Pure types + plain data constants only.
  */
 import type { DslVersioned } from './version.js';
@@ -65,6 +71,35 @@ export function isRuntimeSessionStatus(value: unknown): value is RuntimeSessionS
 }
 
 /**
+ * ISO-8601 shape a runtime timestamp string is required to match:
+ * `YYYY-MM-DDTHH:mm:ss`, an optional fractional-second part, and a mandatory
+ * zone designator (`Z` or `±hh:mm`). Runtime timestamps are display metadata
+ * whose only cross-tab guarantee is a comparable, unambiguous instant, so the
+ * zone is not optional here — a zoneless string names no instant.
+ */
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * True when `value` is a well-formed ISO-8601 timestamp per the runtime
+ * contract. The runtime envelope has no generated schema artifact backing it
+ * (unlike stage/scene/action), so this pure check is where the documented
+ * "ISO 8601" promise on `createdAt` / `updatedAt` is actually enforced.
+ *
+ * Both halves are required and neither alone suffices:
+ * - the regex pins the *format* (`Date.parse` alone accepts many non-ISO forms
+ *   — bare dates, `'2026/01/01'`, even some free text — so it cannot stand in
+ *   for a format check), while
+ * - `!Number.isNaN(Date.parse(value))` pins *calendar validity* (the regex
+ *   happily matches an impossible `2026-13-01` or `2026-02-30`, which only a
+ *   real date parse rejects).
+ *
+ * Pure, no runtime dependencies.
+ */
+export function isIsoTimestamp(value: string): boolean {
+  return ISO_TIMESTAMP_RE.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+/**
  * The core runtime kind *names* the contract recognizes — the ones Part B
  * migrates first. `RuntimeSession.kind` is an open `string`, so apps define
  * their own kinds without touching the contract; these are just the recognized
@@ -100,9 +135,11 @@ export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
  * of the same kind on one stage (e.g. repeated quiz attempts).
  *
  * Extends {@link DslVersioned}, so a session carries the same optional
- * `dslVersion` serialized-contract stamp (absent on legacy data) and rides the
- * same stamping + migrate-on-read ladder as the document aggregate — sharing
- * one envelope definition instead of re-declaring the field here.
+ * `dslVersion` serialized-contract stamp (absent on legacy data) — sharing one
+ * envelope *field* definition instead of re-declaring it here. The stamping +
+ * migrate-on-read *ladder* is NOT shared: a session is stamped with
+ * `RUNTIME_DSL_VERSION` and migrated by `migrateRuntime`, on a version line
+ * independent of the document's `DSL_VERSION` / `migrate` (see `version.ts`).
  */
 export interface RuntimeSession extends DslVersioned {
   id: string;
@@ -123,11 +160,24 @@ export interface RuntimeSession extends DslVersioned {
 }
 
 /**
+ * The set of values a {@link RuntimeRecord.payload} may hold: any value EXCEPT
+ * `undefined`. `null` is deliberately included — it is a legal stored payload an
+ * app may deliberately persist, and {@link validateRuntimeRecord} accepts it.
+ *
+ * `NonNullable<unknown>` is `{}` (every non-nullish value) without the banned
+ * bare-`{}` literal; unioning `null` back in yields "anything but `undefined`".
+ * This aligns the static type with the runtime validator, which rejects
+ * `payload: undefined` but accepts `null` — a plain `unknown` payload would let
+ * `payload: undefined` type-check yet fail at append time.
+ */
+export type RuntimePayload = NonNullable<unknown> | null;
+
+/**
  * One ordered fact inside a session. Identity, learner and lifecycle live on
  * the parent {@link RuntimeSession}; the record carries only ordering,
  * anchoring, and the app-owned payload.
  */
-export interface RuntimeRecord<TPayload = unknown> {
+export interface RuntimeRecord<TPayload extends RuntimePayload = RuntimePayload> {
   id: string;
   /** Parent {@link RuntimeSession.id}. */
   sessionId: string;
@@ -158,7 +208,10 @@ export interface RuntimeRecord<TPayload = unknown> {
  * creation type omits it structurally rather than trusting producers to leave
  * it out (and to leave it consistent across concurrent appenders).
  */
-export type RuntimeRecordInit<TPayload = unknown> = Omit<RuntimeRecord<TPayload>, 'seq'>;
+export type RuntimeRecordInit<TPayload extends RuntimePayload = RuntimePayload> = Omit<
+  RuntimeRecord<TPayload>,
+  'seq'
+>;
 
 /** Speaker roles the replay renderer can rely on for `chat` records. */
 export type ChatRuntimeRole = 'user' | 'assistant' | 'system';

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -30,11 +30,12 @@
  * Versioning: a session carries its OWN version field, `runtimeDslVersion`
  * (distinct from a document's `dslVersion`), and rides its OWN version line —
  * `RUNTIME_DSL_VERSION` + `migrateRuntime`, not the document's `DSL_VERSION` +
- * `migrate`. Because the two lines stamp different envelope fields, the
- * separation is mechanical, not merely a call-site convention: a document
- * migration walked over a session finds no `dslVersion` stamp and, at worst,
- * adds a foreign field it owns, never consuming or corrupting the runtime line's
- * `runtimeDslVersion` stamp — and vice versa (see `version.ts`).
+ * `migrate`. The two lines stamp different envelope fields, so neither ladder
+ * reads the other's version — but disjoint fields alone would still let a
+ * misrouted session be lifted (as unversioned) on the document line. Inertness
+ * is delivered by the cross-line guard in `runLadder`: a runner returns any
+ * aggregate that carries the sibling line's stamp but not its own untouched,
+ * never stamping a foreign field — and vice versa (see `version.ts`).
  *
  * No runtime dependencies. Pure types + plain data constants only.
  */
@@ -181,9 +182,11 @@ export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
  * DIFFERENT envelope field from a document's `dslVersion`. Stamping +
  * migrate-on-read run on the runtime line only: a session is stamped with
  * `RUNTIME_DSL_VERSION` and migrated by `migrateRuntime`, independent of the
- * document's `DSL_VERSION` / `migrate`. Because the two stamps live on distinct
- * fields, misrouting a migration is inert rather than corrupting (see
- * `version.ts`).
+ * document's `DSL_VERSION` / `migrate`. The two stamps live on distinct fields
+ * so neither ladder reads the other's; the cross-line guard in `runLadder` is
+ * what makes misrouting a migration inert rather than corrupting — a runner
+ * leaves any aggregate stamped on the sibling line but not its own untouched
+ * (see `version.ts`).
  */
 export interface RuntimeSession extends RuntimeVersioned {
   id: string;

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -1,0 +1,162 @@
+/**
+ * Runtime layer contract (#869): what a learner produces while taking a
+ * course — conversations, quiz attempts, playback facts. Runtime data does
+ * not travel with the document; it is persisted per learner by a
+ * `RuntimeStore` (`@openmaic/storage`, Part B of #869) and is exportable as
+ * a replay. This module owns only the *envelope* and the skeletons of the
+ * core kinds; payload internals are app-owned and injected via generics,
+ * exactly like widened scene content on `DocumentStore<TScene>` (#860).
+ *
+ * Two-level model, deliberately:
+ *
+ * - A {@link RuntimeSession} is the unit of identity and lifecycle. It owns
+ *   the `(stageId, learnerKey, kind)` dimensions and the status ladder. A
+ *   document has many sessions — one or more per learner.
+ * - A {@link RuntimeRecord} is an ordered fact inside one session. Ordering
+ *   is the store-assigned monotonic {@link RuntimeRecord.seq}, never client
+ *   timestamps (multiple tabs and clock skew make wall clocks unreliable
+ *   for replay). Timestamps are display metadata.
+ *
+ * Anchors are best-effort: documents are editable, so a `sceneId` /
+ * `actionIndex` written yesterday may dangle after today's edit. Consumers
+ * (replay, summaries) MUST tolerate missing or stale anchors.
+ *
+ * No runtime dependencies. Pure types + plain data constants only.
+ */
+
+/**
+ * Lifecycle of a session. Records carry no lifecycle of their own — a chat
+ * message or an answered question is a fact, not a state machine.
+ *
+ * - `active`: the learner may still append records.
+ * - `completed`: closed normally; eligible for replay export.
+ * - `archived`: kept for history but hidden from default listings.
+ */
+export type RuntimeSessionStatus = 'active' | 'completed' | 'archived';
+
+/** All session statuses, in lifecycle order. */
+export const RUNTIME_SESSION_STATUSES = ['active', 'completed', 'archived'] as const;
+
+/** Narrow an unknown value to a valid {@link RuntimeSessionStatus}. */
+export function isRuntimeSessionStatus(value: unknown): value is RuntimeSessionStatus {
+  return (RUNTIME_SESSION_STATUSES as readonly unknown[]).includes(value);
+}
+
+/**
+ * Runtime kinds whose payload skeletons the DSL owns. `RuntimeSession.kind`
+ * is an open `string` — apps define their own kinds without touching the
+ * contract; these are only the ones with a DSL-owned skeleton.
+ */
+export type CoreRuntimeKind = 'chat' | 'quizAttempt' | 'playback';
+
+/** All core runtime kinds. */
+export const CORE_RUNTIME_KINDS = ['chat', 'quizAttempt', 'playback'] as const;
+
+/** Narrow an unknown value to a valid {@link CoreRuntimeKind}. */
+export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
+  return (CORE_RUNTIME_KINDS as readonly unknown[]).includes(value);
+}
+
+/**
+ * The unit of learner-runtime identity and lifecycle. Sessions are keyed by
+ * `(stageId, learnerKey)` plus a `kind`; a learner may hold several sessions
+ * of the same kind on one stage (e.g. repeated quiz attempts).
+ */
+export interface RuntimeSession {
+  id: string;
+  /** {@link CoreRuntimeKind} or an app-defined kind. */
+  kind: string;
+  stageId: string;
+  /**
+   * Opaque principal string — the DSL does not own auth. Deployments choose
+   * the shape (an anonymous device key, an account id, …); stores treat it
+   * as an exact-match partition key.
+   */
+  learnerKey: string;
+  status: RuntimeSessionStatus;
+  /** ISO 8601. */
+  createdAt: string;
+  /** ISO 8601. */
+  updatedAt: string;
+  /**
+   * Serialized-contract version stamp (see `DSL_VERSION_KEY`), same
+   * stamping + migrate-on-read ladder as the document aggregate. Absent on
+   * legacy data.
+   */
+  dslVersion?: string;
+}
+
+/**
+ * One ordered fact inside a session. Identity, learner and lifecycle live on
+ * the parent {@link RuntimeSession}; the record carries only ordering,
+ * anchoring, and the app-owned payload.
+ */
+export interface RuntimeRecord<TPayload = unknown> {
+  id: string;
+  /** Parent {@link RuntimeSession.id}. */
+  sessionId: string;
+  /**
+   * Per-session monotonic sequence, assigned by the store on append. The
+   * sole replay ordering key — never order by timestamp.
+   */
+  seq: number;
+  /** Best-effort anchor into the document timeline; may dangle after edits. */
+  sceneId?: string;
+  /** Best-effort anchor; index into the anchored scene's actions. */
+  actionIndex?: number;
+  /**
+   * App-defined sub-anchor below the scene/action granularity (e.g. a quiz
+   * question id or a PBL microtask id). Opaque to the DSL.
+   */
+  subAnchor?: string;
+  /** ISO 8601. Display metadata only — see {@link RuntimeRecord.seq}. */
+  createdAt: string;
+  /** App-owned payload; validation is injected per kind, like scene content. */
+  payload: TPayload;
+}
+
+/** Speaker roles the replay renderer can rely on for `chat` records. */
+export type ChatRuntimeRole = 'user' | 'assistant' | 'system';
+
+/** All chat roles. */
+export const CHAT_RUNTIME_ROLES = ['user', 'assistant', 'system'] as const;
+
+/** Narrow an unknown value to a valid {@link ChatRuntimeRole}. */
+export function isChatRuntimeRole(value: unknown): value is ChatRuntimeRole {
+  return (CHAT_RUNTIME_ROLES as readonly unknown[]).includes(value);
+}
+
+/**
+ * Minimal payload skeleton for `chat` records — just enough structure for a
+ * replay renderer (who spoke, what text). Apps extend with their own fields
+ * (attachments, tool traces, …) by intersection.
+ */
+export interface ChatMessageSkeleton {
+  role: ChatRuntimeRole;
+  content: string;
+}
+
+/**
+ * Phases of a quiz attempt. Mirrors the lifecycle the browser app expresses
+ * today by creating/deleting storage keys (draft → submitted → reviewed),
+ * made explicit so downstream consumers can reason about *when* and *in
+ * which attempt* an answer was given.
+ */
+export type QuizAttemptPhase = 'draft' | 'submitted' | 'reviewed';
+
+/** All quiz attempt phases, in lifecycle order. */
+export const QUIZ_ATTEMPT_PHASES = ['draft', 'submitted', 'reviewed'] as const;
+
+/** Narrow an unknown value to a valid {@link QuizAttemptPhase}. */
+export function isQuizAttemptPhase(value: unknown): value is QuizAttemptPhase {
+  return (QUIZ_ATTEMPT_PHASES as readonly unknown[]).includes(value);
+}
+
+/**
+ * Minimal payload skeleton for `quizAttempt` records. Answers are keyed by
+ * question id; grading detail and scoring algorithms are app-owned.
+ */
+export interface QuizAttemptSkeleton {
+  phase: QuizAttemptPhase;
+  answers: Record<string, unknown>;
+}

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -257,6 +257,10 @@ export function isQuizAttemptSkeleton(value: unknown): value is QuizAttemptSkele
     isQuizAttemptPhase(v.phase) &&
     typeof v.answers === 'object' &&
     v.answers !== null &&
-    !Array.isArray(v.answers)
+    !Array.isArray(v.answers) &&
+    // Require a plain id→answer record: a Map/Date/class instance would pass the
+    // object check but hide its entries from `answers[questionId]` consumers.
+    (Object.getPrototypeOf(v.answers) === Object.prototype ||
+      Object.getPrototypeOf(v.answers) === null)
   );
 }

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -27,15 +27,18 @@
  * runtime feed with document data: convert at the boundary, never compare a
  * runtime `createdAt` string against a document's numeric timestamp directly.
  *
- * Versioning: a session carries the shared `dslVersion` envelope field but rides
- * its OWN version line — `RUNTIME_DSL_VERSION` + `migrateRuntime`, not the
- * document's `DSL_VERSION` + `migrate`. The two serialized shapes evolve
- * independently, so a document migration can never run over runtime data (see
- * `version.ts`).
+ * Versioning: a session carries its OWN version field, `runtimeDslVersion`
+ * (distinct from a document's `dslVersion`), and rides its OWN version line —
+ * `RUNTIME_DSL_VERSION` + `migrateRuntime`, not the document's `DSL_VERSION` +
+ * `migrate`. Because the two lines stamp different envelope fields, the
+ * separation is mechanical, not merely a call-site convention: a document
+ * migration walked over a session finds no `dslVersion` stamp and, at worst,
+ * adds a foreign field it owns, never consuming or corrupting the runtime line's
+ * `runtimeDslVersion` stamp — and vice versa (see `version.ts`).
  *
  * No runtime dependencies. Pure types + plain data constants only.
  */
-import type { DslVersioned } from './version.js';
+import type { RuntimeVersioned } from './version.js';
 
 /**
  * Lifecycle of a session. Records carry no lifecycle of their own — a chat
@@ -85,18 +88,31 @@ const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{
  * (unlike stage/scene/action), so this pure check is where the documented
  * "ISO 8601" promise on `createdAt` / `updatedAt` is actually enforced.
  *
- * Both halves are required and neither alone suffices:
+ * Three layers, none of which alone suffices:
  * - the regex pins the *format* (`Date.parse` alone accepts many non-ISO forms
  *   — bare dates, `'2026/01/01'`, even some free text — so it cannot stand in
- *   for a format check), while
- * - `!Number.isNaN(Date.parse(value))` pins *calendar validity* (the regex
- *   happily matches an impossible `2026-13-01` or `2026-02-30`, which only a
- *   real date parse rejects).
+ *   for a format check), and pins the mandatory zone designator;
+ * - `!Number.isNaN(Date.parse(value))` rejects field-range violations the regex
+ *   lets through (month `13`, hour `25`, minute / second `60`), which only a
+ *   real date parse catches; but
+ * - `Date.parse` does NOT reliably reject day-of-month overflow: on V8 (the CI
+ *   Node 22 engine) `'2026-02-30'`, `'2026-02-29'` (2026 is not a leap year),
+ *   and `'2026-04-31'` all *normalize* (roll into the next month) instead of
+ *   yielding `NaN`, and the verdict is engine-dependent. So the final layer
+ *   re-parses the calendar date and requires it to round-trip unchanged, which
+ *   rejects the overflow AND makes the verdict engine-independent.
  *
  * Pure, no runtime dependencies.
  */
 export function isIsoTimestamp(value: string): boolean {
-  return ISO_TIMESTAMP_RE.test(value) && !Number.isNaN(Date.parse(value));
+  if (!ISO_TIMESTAMP_RE.test(value) || Number.isNaN(Date.parse(value))) return false;
+  // Day-of-month round-trip: reject a day that `Date.UTC` normalized into the
+  // next month (e.g. Feb 30 -> Mar 2) rather than accepting it as valid.
+  const y = Number(value.slice(0, 4));
+  const m = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const d = new Date(Date.UTC(y, m - 1, day));
+  return d.getUTCFullYear() === y && d.getUTCMonth() === m - 1 && d.getUTCDate() === day;
 }
 
 /**
@@ -134,14 +150,16 @@ export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
  * `(stageId, learnerKey)` plus a `kind`; a learner may hold several sessions
  * of the same kind on one stage (e.g. repeated quiz attempts).
  *
- * Extends {@link DslVersioned}, so a session carries the same optional
- * `dslVersion` serialized-contract stamp (absent on legacy data) — sharing one
- * envelope *field* definition instead of re-declaring it here. The stamping +
- * migrate-on-read *ladder* is NOT shared: a session is stamped with
- * `RUNTIME_DSL_VERSION` and migrated by `migrateRuntime`, on a version line
- * independent of the document's `DSL_VERSION` / `migrate` (see `version.ts`).
+ * Extends {@link RuntimeVersioned}, so a session carries an optional
+ * `runtimeDslVersion` serialized-contract stamp (absent on legacy data) — a
+ * DIFFERENT envelope field from a document's `dslVersion`. Stamping +
+ * migrate-on-read run on the runtime line only: a session is stamped with
+ * `RUNTIME_DSL_VERSION` and migrated by `migrateRuntime`, independent of the
+ * document's `DSL_VERSION` / `migrate`. Because the two stamps live on distinct
+ * fields, misrouting a migration is inert rather than corrupting (see
+ * `version.ts`).
  */
-export interface RuntimeSession extends DslVersioned {
+export interface RuntimeSession extends RuntimeVersioned {
   id: string;
   /** {@link CoreRuntimeKind} or an app-defined kind. */
   kind: string;

--- a/packages/@openmaic/dsl/src/runtime.ts
+++ b/packages/@openmaic/dsl/src/runtime.ts
@@ -21,8 +21,15 @@
  * `actionIndex` written yesterday may dangle after today's edit. Consumers
  * (replay, summaries) MUST tolerate missing or stale anchors.
  *
+ * Timestamps here are ISO 8601 strings — a deliberate divergence from the
+ * document aggregate's epoch-millisecond numbers. The runtime contract
+ * standardizes on ISO (#869), so do NOT mix the two encodings when merging a
+ * runtime feed with document data: convert at the boundary, never compare a
+ * runtime `createdAt` string against a document's numeric timestamp directly.
+ *
  * No runtime dependencies. Pure types + plain data constants only.
  */
+import type { DslVersioned } from './version.js';
 
 /**
  * Lifecycle of a session. Records carry no lifecycle of their own — a chat
@@ -35,7 +42,22 @@
 export type RuntimeSessionStatus = 'active' | 'completed' | 'archived';
 
 /** All session statuses, in lifecycle order. */
-export const RUNTIME_SESSION_STATUSES = ['active', 'completed', 'archived'] as const;
+export const RUNTIME_SESSION_STATUSES = [
+  'active',
+  'completed',
+  'archived',
+] as const satisfies readonly RuntimeSessionStatus[];
+
+// Compile-time exhaustiveness: every RuntimeSessionStatus must appear above.
+// `satisfies` proves each entry is a valid status; this proves the converse, so
+// adding a union member without extending the tuple fails the build.
+type _RuntimeSessionStatusesExhaustive = [RuntimeSessionStatus] extends [
+  (typeof RUNTIME_SESSION_STATUSES)[number],
+]
+  ? true
+  : never;
+const _runtimeSessionStatusesExhaustive: _RuntimeSessionStatusesExhaustive = true;
+void _runtimeSessionStatusesExhaustive;
 
 /** Narrow an unknown value to a valid {@link RuntimeSessionStatus}. */
 export function isRuntimeSessionStatus(value: unknown): value is RuntimeSessionStatus {
@@ -43,14 +65,29 @@ export function isRuntimeSessionStatus(value: unknown): value is RuntimeSessionS
 }
 
 /**
- * Runtime kinds whose payload skeletons the DSL owns. `RuntimeSession.kind`
- * is an open `string` — apps define their own kinds without touching the
- * contract; these are only the ones with a DSL-owned skeleton.
+ * The core runtime kind *names* the contract recognizes — the ones Part B
+ * migrates first. `RuntimeSession.kind` is an open `string`, so apps define
+ * their own kinds without touching the contract; these are just the recognized
+ * ones. Note this is about kind *names*, not skeletons: the DSL ships payload
+ * skeletons for `chat` and `quizAttempt` only. `playback` has NO skeleton by
+ * design — its payload is app-owned; only the kind name is contract-recognized.
  */
 export type CoreRuntimeKind = 'chat' | 'quizAttempt' | 'playback';
 
 /** All core runtime kinds. */
-export const CORE_RUNTIME_KINDS = ['chat', 'quizAttempt', 'playback'] as const;
+export const CORE_RUNTIME_KINDS = [
+  'chat',
+  'quizAttempt',
+  'playback',
+] as const satisfies readonly CoreRuntimeKind[];
+
+// Compile-time exhaustiveness: every CoreRuntimeKind must appear above (see the
+// RUNTIME_SESSION_STATUSES check for the pattern).
+type _CoreRuntimeKindsExhaustive = [CoreRuntimeKind] extends [(typeof CORE_RUNTIME_KINDS)[number]]
+  ? true
+  : never;
+const _coreRuntimeKindsExhaustive: _CoreRuntimeKindsExhaustive = true;
+void _coreRuntimeKindsExhaustive;
 
 /** Narrow an unknown value to a valid {@link CoreRuntimeKind}. */
 export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
@@ -61,8 +98,13 @@ export function isCoreRuntimeKind(value: unknown): value is CoreRuntimeKind {
  * The unit of learner-runtime identity and lifecycle. Sessions are keyed by
  * `(stageId, learnerKey)` plus a `kind`; a learner may hold several sessions
  * of the same kind on one stage (e.g. repeated quiz attempts).
+ *
+ * Extends {@link DslVersioned}, so a session carries the same optional
+ * `dslVersion` serialized-contract stamp (absent on legacy data) and rides the
+ * same stamping + migrate-on-read ladder as the document aggregate — sharing
+ * one envelope definition instead of re-declaring the field here.
  */
-export interface RuntimeSession {
+export interface RuntimeSession extends DslVersioned {
   id: string;
   /** {@link CoreRuntimeKind} or an app-defined kind. */
   kind: string;
@@ -78,12 +120,6 @@ export interface RuntimeSession {
   createdAt: string;
   /** ISO 8601. */
   updatedAt: string;
-  /**
-   * Serialized-contract version stamp (see `DSL_VERSION_KEY`), same
-   * stamping + migrate-on-read ladder as the document aggregate. Absent on
-   * legacy data.
-   */
-  dslVersion?: string;
 }
 
 /**
@@ -115,11 +151,32 @@ export interface RuntimeRecord<TPayload = unknown> {
   payload: TPayload;
 }
 
+/**
+ * The shape a producer hands to a store's `append`: a {@link RuntimeRecord}
+ * minus its `seq`. Ordering is store-owned — `seq` is the per-session monotonic
+ * key the store assigns on append and cannot be supplied by the caller — so the
+ * creation type omits it structurally rather than trusting producers to leave
+ * it out (and to leave it consistent across concurrent appenders).
+ */
+export type RuntimeRecordInit<TPayload = unknown> = Omit<RuntimeRecord<TPayload>, 'seq'>;
+
 /** Speaker roles the replay renderer can rely on for `chat` records. */
 export type ChatRuntimeRole = 'user' | 'assistant' | 'system';
 
 /** All chat roles. */
-export const CHAT_RUNTIME_ROLES = ['user', 'assistant', 'system'] as const;
+export const CHAT_RUNTIME_ROLES = [
+  'user',
+  'assistant',
+  'system',
+] as const satisfies readonly ChatRuntimeRole[];
+
+// Compile-time exhaustiveness: every ChatRuntimeRole must appear above (see the
+// RUNTIME_SESSION_STATUSES check for the pattern).
+type _ChatRuntimeRolesExhaustive = [ChatRuntimeRole] extends [(typeof CHAT_RUNTIME_ROLES)[number]]
+  ? true
+  : never;
+const _chatRuntimeRolesExhaustive: _ChatRuntimeRolesExhaustive = true;
+void _chatRuntimeRolesExhaustive;
 
 /** Narrow an unknown value to a valid {@link ChatRuntimeRole}. */
 export function isChatRuntimeRole(value: unknown): value is ChatRuntimeRole {
@@ -137,6 +194,18 @@ export interface ChatMessageSkeleton {
 }
 
 /**
+ * Narrow an unknown value to a {@link ChatMessageSkeleton}: an object whose
+ * `role` is a recognized {@link ChatRuntimeRole} and whose `content` is a
+ * string. Structural subset only — app-added fields are ignored, matching how
+ * apps extend the skeleton by intersection. Pure, no runtime deps.
+ */
+export function isChatMessageSkeleton(value: unknown): value is ChatMessageSkeleton {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { role?: unknown; content?: unknown };
+  return isChatRuntimeRole(v.role) && typeof v.content === 'string';
+}
+
+/**
  * Phases of a quiz attempt. Mirrors the lifecycle the browser app expresses
  * today by creating/deleting storage keys (draft → submitted → reviewed),
  * made explicit so downstream consumers can reason about *when* and *in
@@ -145,7 +214,21 @@ export interface ChatMessageSkeleton {
 export type QuizAttemptPhase = 'draft' | 'submitted' | 'reviewed';
 
 /** All quiz attempt phases, in lifecycle order. */
-export const QUIZ_ATTEMPT_PHASES = ['draft', 'submitted', 'reviewed'] as const;
+export const QUIZ_ATTEMPT_PHASES = [
+  'draft',
+  'submitted',
+  'reviewed',
+] as const satisfies readonly QuizAttemptPhase[];
+
+// Compile-time exhaustiveness: every QuizAttemptPhase must appear above (see the
+// RUNTIME_SESSION_STATUSES check for the pattern).
+type _QuizAttemptPhasesExhaustive = [QuizAttemptPhase] extends [
+  (typeof QUIZ_ATTEMPT_PHASES)[number],
+]
+  ? true
+  : never;
+const _quizAttemptPhasesExhaustive: _QuizAttemptPhasesExhaustive = true;
+void _quizAttemptPhasesExhaustive;
 
 /** Narrow an unknown value to a valid {@link QuizAttemptPhase}. */
 export function isQuizAttemptPhase(value: unknown): value is QuizAttemptPhase {
@@ -159,4 +242,21 @@ export function isQuizAttemptPhase(value: unknown): value is QuizAttemptPhase {
 export interface QuizAttemptSkeleton {
   phase: QuizAttemptPhase;
   answers: Record<string, unknown>;
+}
+
+/**
+ * Narrow an unknown value to a {@link QuizAttemptSkeleton}: an object whose
+ * `phase` is a recognized {@link QuizAttemptPhase} and whose `answers` is a
+ * plain object (the id→answer map — not an array or null). Structural subset
+ * only; the answer values themselves stay app-owned. Pure, no runtime deps.
+ */
+export function isQuizAttemptSkeleton(value: unknown): value is QuizAttemptSkeleton {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { phase?: unknown; answers?: unknown };
+  return (
+    isQuizAttemptPhase(v.phase) &&
+    typeof v.answers === 'object' &&
+    v.answers !== null &&
+    !Array.isArray(v.answers)
+  );
 }

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -17,6 +17,7 @@
  */
 import { isActionType } from './action.js';
 import type { ActionType } from './action.js';
+import { isRuntimeSessionStatus } from './runtime.js';
 
 export interface ValidationIssue {
   /** JSON-pointer-ish path to the offending value, e.g. `/actions/0/elementId`. */
@@ -204,5 +205,83 @@ export function validateScene(doc: unknown): ValidationResult {
 export function validateAction(doc: unknown): ValidationResult {
   const errors: ValidationIssue[] = [];
   checkAction(doc, '', errors);
+  return done(errors);
+}
+
+/** Required envelope fields of a runtime session, with their runtime kinds. */
+const RUNTIME_SESSION_REQUIRED_FIELDS: Readonly<Record<string, FieldKind>> = {
+  id: 'string',
+  kind: 'string',
+  stageId: 'string',
+  learnerKey: 'string',
+  status: 'string',
+  createdAt: 'string',
+  updatedAt: 'string',
+};
+
+/**
+ * Validate a runtime session envelope (#869). Payloads live on records, so
+ * this is a pure envelope check; `kind` is an open string by design.
+ */
+export function validateRuntimeSession(doc: unknown): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  if (!isObject(doc)) {
+    return { valid: false, errors: [{ path: '/', message: 'runtime session must be an object' }] };
+  }
+  for (const [field, kind] of Object.entries(RUNTIME_SESSION_REQUIRED_FIELDS)) {
+    if (!matchesKind(doc[field], kind)) {
+      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
+    }
+  }
+  if (typeof doc.status === 'string' && !isRuntimeSessionStatus(doc.status)) {
+    errors.push({
+      path: '/status',
+      message: `unknown session status: ${JSON.stringify(doc.status)}`,
+    });
+  }
+  if (doc.dslVersion !== undefined && typeof doc.dslVersion !== 'string') {
+    errors.push({ path: '/dslVersion', message: 'expected string `dslVersion`' });
+  }
+  return done(errors);
+}
+
+/** Required envelope fields of a runtime record, with their runtime kinds. */
+const RUNTIME_RECORD_REQUIRED_FIELDS: Readonly<Record<string, FieldKind>> = {
+  id: 'string',
+  sessionId: 'string',
+  seq: 'number',
+  createdAt: 'string',
+};
+
+/** Optional anchor fields of a runtime record, with their runtime kinds. */
+const RUNTIME_RECORD_OPTIONAL_FIELDS: Readonly<Record<string, FieldKind>> = {
+  sceneId: 'string',
+  actionIndex: 'number',
+  subAnchor: 'string',
+};
+
+/**
+ * Validate a runtime record envelope (#869). The payload is app-owned and
+ * checked only for presence — per-kind payload validators are injected at
+ * the store boundary, exactly like scene-content validators (#860).
+ */
+export function validateRuntimeRecord(doc: unknown): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  if (!isObject(doc)) {
+    return { valid: false, errors: [{ path: '/', message: 'runtime record must be an object' }] };
+  }
+  for (const [field, kind] of Object.entries(RUNTIME_RECORD_REQUIRED_FIELDS)) {
+    if (!matchesKind(doc[field], kind)) {
+      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
+    }
+  }
+  for (const [field, kind] of Object.entries(RUNTIME_RECORD_OPTIONAL_FIELDS)) {
+    if (doc[field] !== undefined && !matchesKind(doc[field], kind)) {
+      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
+    }
+  }
+  if (!('payload' in doc)) {
+    errors.push({ path: '/payload', message: 'expected `payload`' });
+  }
   return done(errors);
 }

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -17,7 +17,7 @@
  */
 import { isActionType } from './action.js';
 import type { ActionType } from './action.js';
-import { isRuntimeSessionStatus } from './runtime.js';
+import { isIsoTimestamp, isRuntimeSessionStatus } from './runtime.js';
 import { isWellFormedDslVersion } from './version.js';
 
 export interface ValidationIssue {
@@ -279,6 +279,16 @@ export function validateRuntimeSession(doc: unknown): ValidationResult {
       message: `unknown session status: ${JSON.stringify(doc.status)}`,
     });
   }
+  // `createdAt` / `updatedAt` are documented ISO-8601 strings. The table check
+  // above only proves they are strings; refine the present ones to the ISO
+  // format (same "only refine an already-string field" guard as `seq` below, so
+  // a wrong-typed value is reported once, by the table, not twice).
+  if (typeof doc.createdAt === 'string' && !isIsoTimestamp(doc.createdAt)) {
+    errors.push({ path: '/createdAt', message: 'expected ISO 8601 `createdAt`' });
+  }
+  if (typeof doc.updatedAt === 'string' && !isIsoTimestamp(doc.updatedAt)) {
+    errors.push({ path: '/updatedAt', message: 'expected ISO 8601 `updatedAt`' });
+  }
   // `dslVersion` is optional, but a present stamp must be a well-formed `x.y.z`
   // string: `migrate`/`dslVersionOf` throw on a malformed stamp, so accepting a
   // string like `'legacy'` here would only defer the failure to read time.
@@ -335,6 +345,12 @@ export function validateRuntimeRecord(doc: unknown): ValidationResult {
     !(Number.isInteger(doc.actionIndex) && doc.actionIndex >= 0)
   ) {
     errors.push({ path: '/actionIndex', message: 'expected non-negative integer `actionIndex`' });
+  }
+
+  // `createdAt` is a documented ISO-8601 string (display metadata; ordering is
+  // `seq`). Refine the present string to the ISO format, same guard as above.
+  if (typeof doc.createdAt === 'string' && !isIsoTimestamp(doc.createdAt)) {
+    errors.push({ path: '/createdAt', message: 'expected ISO 8601 `createdAt`' });
   }
 
   // Require a real payload value, not merely the key. `'payload' in doc` would

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -293,9 +293,7 @@ export function validateRuntimeSession(doc: unknown): ValidationResult {
   // `runtimeDslVersion` is optional, but a present stamp must be a well-formed
   // `x.y.z` string: `migrateRuntime`/`runtimeDslVersionOf` throw on a malformed
   // stamp, so accepting a string like `'legacy'` here would only defer the
-  // failure to read time. A session versions on `runtimeDslVersion`, NOT the
-  // document line's `dslVersion`; a stray `dslVersion` on a session is an
-  // unknown field this structural-subset validator ignores.
+  // failure to read time.
   if (doc.runtimeDslVersion !== undefined) {
     if (typeof doc.runtimeDslVersion !== 'string') {
       errors.push({ path: '/runtimeDslVersion', message: 'expected string `runtimeDslVersion`' });
@@ -305,6 +303,19 @@ export function validateRuntimeSession(doc: unknown): ValidationResult {
         message: 'malformed `runtimeDslVersion`: expected x.y.z',
       });
     }
+  }
+  // A session versions on `runtimeDslVersion`; the document line's `dslVersion`
+  // is never part of a session's shape. This is the one deliberate exception to
+  // the structural-subset rule (unknown fields ignored): a stray sibling stamp
+  // is evidence of a misrouted migration, and once stored it makes the envelope
+  // ambiguous to the cross-line guard (`migrate`/`migrateRuntime` fail loud on
+  // own-stamp-absent + sibling-stamp-present), so reject it at the door.
+  if (doc.dslVersion !== undefined) {
+    errors.push({
+      path: '/dslVersion',
+      message:
+        'unexpected document-line `dslVersion` on a runtime session; sessions version on `runtimeDslVersion`',
+    });
   }
   return done(errors);
 }

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -280,23 +280,30 @@ export function validateRuntimeSession(doc: unknown): ValidationResult {
     });
   }
   // `createdAt` / `updatedAt` are documented ISO-8601 strings. The table check
-  // above only proves they are strings; refine the present ones to the ISO
-  // format (same "only refine an already-string field" guard as `seq` below, so
-  // a wrong-typed value is reported once, by the table, not twice).
-  if (typeof doc.createdAt === 'string' && !isIsoTimestamp(doc.createdAt)) {
+  // above only proves they are strings and, being required, already reports an
+  // empty string as non-empty. Refine only a present NON-EMPTY string to the ISO
+  // format, so an empty (or wrong-typed) value is reported once — by the table —
+  // not twice at the same path.
+  if (typeof doc.createdAt === 'string' && doc.createdAt !== '' && !isIsoTimestamp(doc.createdAt)) {
     errors.push({ path: '/createdAt', message: 'expected ISO 8601 `createdAt`' });
   }
-  if (typeof doc.updatedAt === 'string' && !isIsoTimestamp(doc.updatedAt)) {
+  if (typeof doc.updatedAt === 'string' && doc.updatedAt !== '' && !isIsoTimestamp(doc.updatedAt)) {
     errors.push({ path: '/updatedAt', message: 'expected ISO 8601 `updatedAt`' });
   }
-  // `dslVersion` is optional, but a present stamp must be a well-formed `x.y.z`
-  // string: `migrate`/`dslVersionOf` throw on a malformed stamp, so accepting a
-  // string like `'legacy'` here would only defer the failure to read time.
-  if (doc.dslVersion !== undefined) {
-    if (typeof doc.dslVersion !== 'string') {
-      errors.push({ path: '/dslVersion', message: 'expected string `dslVersion`' });
-    } else if (!isWellFormedDslVersion(doc.dslVersion)) {
-      errors.push({ path: '/dslVersion', message: 'malformed `dslVersion`: expected x.y.z' });
+  // `runtimeDslVersion` is optional, but a present stamp must be a well-formed
+  // `x.y.z` string: `migrateRuntime`/`runtimeDslVersionOf` throw on a malformed
+  // stamp, so accepting a string like `'legacy'` here would only defer the
+  // failure to read time. A session versions on `runtimeDslVersion`, NOT the
+  // document line's `dslVersion`; a stray `dslVersion` on a session is an
+  // unknown field this structural-subset validator ignores.
+  if (doc.runtimeDslVersion !== undefined) {
+    if (typeof doc.runtimeDslVersion !== 'string') {
+      errors.push({ path: '/runtimeDslVersion', message: 'expected string `runtimeDslVersion`' });
+    } else if (!isWellFormedDslVersion(doc.runtimeDslVersion)) {
+      errors.push({
+        path: '/runtimeDslVersion',
+        message: 'malformed `runtimeDslVersion`: expected x.y.z',
+      });
     }
   }
   return done(errors);
@@ -348,8 +355,9 @@ export function validateRuntimeRecord(doc: unknown): ValidationResult {
   }
 
   // `createdAt` is a documented ISO-8601 string (display metadata; ordering is
-  // `seq`). Refine the present string to the ISO format, same guard as above.
-  if (typeof doc.createdAt === 'string' && !isIsoTimestamp(doc.createdAt)) {
+  // `seq`). Refine only a present non-empty string to the ISO format; an empty
+  // string is already reported once by the required-field table above.
+  if (typeof doc.createdAt === 'string' && doc.createdAt !== '' && !isIsoTimestamp(doc.createdAt)) {
     errors.push({ path: '/createdAt', message: 'expected ISO 8601 `createdAt`' });
   }
 

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -290,19 +290,28 @@ export function validateRuntimeSession(doc: unknown): ValidationResult {
   if (typeof doc.updatedAt === 'string' && doc.updatedAt !== '' && !isIsoTimestamp(doc.updatedAt)) {
     errors.push({ path: '/updatedAt', message: 'expected ISO 8601 `updatedAt`' });
   }
-  // `runtimeDslVersion` is optional, but a present stamp must be a well-formed
-  // `x.y.z` string: `migrateRuntime`/`runtimeDslVersionOf` throw on a malformed
-  // stamp, so accepting a string like `'legacy'` here would only defer the
-  // failure to read time.
-  if (doc.runtimeDslVersion !== undefined) {
-    if (typeof doc.runtimeDslVersion !== 'string') {
-      errors.push({ path: '/runtimeDslVersion', message: 'expected string `runtimeDslVersion`' });
-    } else if (!isWellFormedDslVersion(doc.runtimeDslVersion)) {
-      errors.push({
-        path: '/runtimeDslVersion',
-        message: 'malformed `runtimeDslVersion`: expected x.y.z',
-      });
-    }
+  // `runtimeDslVersion` is REQUIRED on a session: sessions are stamped at write
+  // time and the runtime line has no unversioned epoch (nothing legitimately
+  // predates the runtime envelope), so an absent stamp is a bug — a misrouted
+  // legacy document or an unstamped producer write — not legacy data to lift.
+  // Kept as its own block (not folded into the required-field table) so an
+  // absent stamp gets a specific message and is reported exactly once at
+  // `/runtimeDslVersion`. A present stamp must be a well-formed `x.y.z` string:
+  // `migrateRuntime`/`runtimeDslVersionOf` throw on a malformed stamp, so
+  // accepting a string like `'legacy'` here would only defer the failure to
+  // read time.
+  if (doc.runtimeDslVersion === undefined) {
+    errors.push({
+      path: '/runtimeDslVersion',
+      message: 'missing `runtimeDslVersion`; runtime sessions are stamped at write time',
+    });
+  } else if (typeof doc.runtimeDslVersion !== 'string') {
+    errors.push({ path: '/runtimeDslVersion', message: 'expected string `runtimeDslVersion`' });
+  } else if (!isWellFormedDslVersion(doc.runtimeDslVersion)) {
+    errors.push({
+      path: '/runtimeDslVersion',
+      message: 'malformed `runtimeDslVersion`: expected x.y.z',
+    });
   }
   // A session versions on `runtimeDslVersion`; the document line's `dslVersion`
   // is never part of a session's shape. This is the one deliberate exception to

--- a/packages/@openmaic/dsl/src/validate.ts
+++ b/packages/@openmaic/dsl/src/validate.ts
@@ -18,6 +18,7 @@
 import { isActionType } from './action.js';
 import type { ActionType } from './action.js';
 import { isRuntimeSessionStatus } from './runtime.js';
+import { isWellFormedDslVersion } from './version.js';
 
 export interface ValidationIssue {
   /** JSON-pointer-ish path to the offending value, e.g. `/actions/0/elementId`. */
@@ -99,6 +100,49 @@ function reqNumber(
 
 function done(errors: ValidationIssue[]): ValidationResult {
   return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+/**
+ * Check a table of root-level envelope fields against their declared runtime
+ * kinds, pushing one {@link ValidationIssue} per violation at path `/<field>`.
+ *
+ * One helper for all three runtime-envelope tables (session-required,
+ * record-required, record-optional) so the presence / kind / emptiness rules
+ * cannot drift between the copies. Two modes:
+ *
+ * - required (`opts.optional` falsy): the field must be present with its kind,
+ *   and a required `'string'` must additionally be **non-empty** — an empty
+ *   `id` / `learnerKey` passes `typeof` yet is useless as an identity/partition
+ *   key, so it is a contract violation, not valid data.
+ * - optional (`opts.optional` true): the field is only checked *when present*,
+ *   and only for its `typeof` kind. Optional anchors (`sceneId`, `subAnchor`)
+ *   stay lax on emptiness — an empty best-effort anchor is the app's business.
+ *
+ * `checkAction`'s variant-field loop is deliberately NOT routed through here:
+ * it uses nested paths and a different "requires"/"must be" message shape.
+ */
+function checkFields(
+  doc: Record<string, unknown>,
+  fields: Readonly<Record<string, FieldKind>>,
+  opts: { optional?: boolean },
+  errors: ValidationIssue[],
+): void {
+  for (const [field, kind] of Object.entries(fields)) {
+    const value = doc[field];
+    if (opts.optional) {
+      if (value !== undefined && !matchesKind(value, kind)) {
+        errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
+      }
+      continue;
+    }
+    if (!matchesKind(value, kind)) {
+      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
+      continue;
+    }
+    if (kind === 'string' && value === '') {
+      errors.push({ path: `/${field}`, message: `expected non-empty string \`${field}\`` });
+    }
+  }
 }
 
 function checkAction(doc: unknown, path: string, errors: ValidationIssue[]): void {
@@ -228,19 +272,22 @@ export function validateRuntimeSession(doc: unknown): ValidationResult {
   if (!isObject(doc)) {
     return { valid: false, errors: [{ path: '/', message: 'runtime session must be an object' }] };
   }
-  for (const [field, kind] of Object.entries(RUNTIME_SESSION_REQUIRED_FIELDS)) {
-    if (!matchesKind(doc[field], kind)) {
-      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
-    }
-  }
+  checkFields(doc, RUNTIME_SESSION_REQUIRED_FIELDS, {}, errors);
   if (typeof doc.status === 'string' && !isRuntimeSessionStatus(doc.status)) {
     errors.push({
       path: '/status',
       message: `unknown session status: ${JSON.stringify(doc.status)}`,
     });
   }
-  if (doc.dslVersion !== undefined && typeof doc.dslVersion !== 'string') {
-    errors.push({ path: '/dslVersion', message: 'expected string `dslVersion`' });
+  // `dslVersion` is optional, but a present stamp must be a well-formed `x.y.z`
+  // string: `migrate`/`dslVersionOf` throw on a malformed stamp, so accepting a
+  // string like `'legacy'` here would only defer the failure to read time.
+  if (doc.dslVersion !== undefined) {
+    if (typeof doc.dslVersion !== 'string') {
+      errors.push({ path: '/dslVersion', message: 'expected string `dslVersion`' });
+    } else if (!isWellFormedDslVersion(doc.dslVersion)) {
+      errors.push({ path: '/dslVersion', message: 'malformed `dslVersion`: expected x.y.z' });
+    }
   }
   return done(errors);
 }
@@ -270,17 +317,30 @@ export function validateRuntimeRecord(doc: unknown): ValidationResult {
   if (!isObject(doc)) {
     return { valid: false, errors: [{ path: '/', message: 'runtime record must be an object' }] };
   }
-  for (const [field, kind] of Object.entries(RUNTIME_RECORD_REQUIRED_FIELDS)) {
-    if (!matchesKind(doc[field], kind)) {
-      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
-    }
+  checkFields(doc, RUNTIME_RECORD_REQUIRED_FIELDS, {}, errors);
+  checkFields(doc, RUNTIME_RECORD_OPTIONAL_FIELDS, { optional: true }, errors);
+
+  // `seq` is the sole replay ordering key, so it must be a real array-like
+  // index. `matchesKind(_, 'number')` above already accepts NaN / Infinity /
+  // negative / fractional (all `typeof === 'number'`); narrow to a non-negative
+  // integer here so a malformed value can't silently corrupt replay order.
+  if (typeof doc.seq === 'number' && !(Number.isInteger(doc.seq) && doc.seq >= 0)) {
+    errors.push({ path: '/seq', message: 'expected non-negative integer `seq`' });
   }
-  for (const [field, kind] of Object.entries(RUNTIME_RECORD_OPTIONAL_FIELDS)) {
-    if (doc[field] !== undefined && !matchesKind(doc[field], kind)) {
-      errors.push({ path: `/${field}`, message: `expected ${kind} \`${field}\`` });
-    }
+  // `actionIndex` is an index into a scene's actions when present: same
+  // non-negative-integer rule as `seq` (a wrong-typed value was already flagged
+  // by the optional-field check above, so only refine a present number here).
+  if (
+    typeof doc.actionIndex === 'number' &&
+    !(Number.isInteger(doc.actionIndex) && doc.actionIndex >= 0)
+  ) {
+    errors.push({ path: '/actionIndex', message: 'expected non-negative integer `actionIndex`' });
   }
-  if (!('payload' in doc)) {
+
+  // Require a real payload value, not merely the key. `'payload' in doc` would
+  // pass an explicit `{ payload: undefined }`; reject that. `null` stays legal —
+  // it is a value an app may have deliberately stored.
+  if (doc.payload === undefined) {
     errors.push({ path: '/payload', message: 'expected `payload`' });
   }
   return done(errors);

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -94,6 +94,48 @@ export const DSL_MIGRATIONS: readonly DslMigration[] = [
   { from: UNVERSIONED_DSL_VERSION, to: INITIAL_DSL_VERSION, migrate: (doc) => doc },
 ];
 
+/**
+ * Current version of the serialized *runtime* contract (#869) — the on-disk
+ * shape of a {@link RuntimeSession} / runtime record, NOT the slide document.
+ *
+ * This is a **deliberately separate version line** from {@link DSL_VERSION}.
+ * A {@link RuntimeSession} shares the `dslVersion` envelope *field* (it extends
+ * `DslVersioned`), but the two ladders version independent serialized shapes:
+ * a change to the document (Stage/Scene) shape must never force — or, worse,
+ * accidentally *consume* — a runtime step, and vice versa. A `DslMigration`
+ * body is an arbitrary whole-document transform; if runtime sessions rode
+ * `DSL_MIGRATIONS`, a future real Stage/Scene migration authored against the
+ * document shape would run over a `RuntimeSession` and could corrupt or throw.
+ */
+export const RUNTIME_DSL_VERSION = '0.1.0' as const;
+
+export type RuntimeDslVersion = typeof RUNTIME_DSL_VERSION;
+
+/**
+ * The first shipped runtime-contract version — a **pinned literal**, not the
+ * moving {@link RUNTIME_DSL_VERSION} (see {@link INITIAL_DSL_VERSION} for why
+ * migration endpoints must be immutable). Equal to `RUNTIME_DSL_VERSION` today;
+ * the two diverge the moment the runtime shape first changes.
+ */
+export const INITIAL_RUNTIME_DSL_VERSION = '0.1.0' as const;
+
+/**
+ * Ordered migration ladder for the runtime contract, wholly independent of
+ * {@link DSL_MIGRATIONS}. Same invariants (contiguous chain, last `to` ===
+ * {@link RUNTIME_DSL_VERSION}, every endpoint a **pinned literal**), same
+ * legacy-lift shape: the first entry stamps pre-`dslVersion` runtime data up to
+ * {@link INITIAL_RUNTIME_DSL_VERSION} as a no-op transform (the runtime shape is
+ * brand new, so nothing predates 0.1.0 to reshape — the entry just wires the
+ * pipeline and gives real runtime data a version to migrate forward from).
+ *
+ * It shares {@link UNVERSIONED_DSL_VERSION} as its legacy origin because that
+ * constant names "wrote no `dslVersion` stamp", a property of the shared
+ * envelope field, not of either aggregate's shape.
+ */
+export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [
+  { from: UNVERSIONED_DSL_VERSION, to: INITIAL_RUNTIME_DSL_VERSION, migrate: (doc) => doc },
+];
+
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
@@ -183,31 +225,59 @@ function stampVersion(doc: unknown, version: string): unknown {
  * Pure: never mutates the input; each step returns a fresh object stamped with
  * its target version.
  */
-export function migrate(doc: unknown): unknown {
+/**
+ * Shared ladder runner behind {@link migrate} and {@link migrateRuntime}. The
+ * walk / stamp / fail-loud mechanism is identical for both version lines; only
+ * the `ladder` and its `targetVersion` differ, so they are parameters rather
+ * than duplicated. This is what keeps the two ladders *independent* — each
+ * caller passes its own steps and endpoint, so a document migration can never
+ * be walked over runtime data (or vice versa). Behavior is byte-identical to
+ * the previous inline `migrate` body.
+ */
+function runLadder(doc: unknown, ladder: readonly DslMigration[], targetVersion: string): unknown {
   if (!isObject(doc)) return doc;
 
   let version = dslVersionOf(doc);
 
   // Already current, or written ahead of us — leave the document as-is.
-  if (compareVersions(version, DSL_VERSION) >= 0) return doc;
+  if (compareVersions(version, targetVersion) >= 0) return doc;
 
   let current: unknown = doc;
   // Walk the ladder one step at a time. Guard against a malformed (cyclic /
   // non-advancing) registry so a bad entry can't spin forever.
-  for (let step = 0; step < DSL_MIGRATIONS.length + 1; step++) {
-    if (version === DSL_VERSION) return current;
-    const next = DSL_MIGRATIONS.find((m) => m.from === version);
+  for (let step = 0; step < ladder.length + 1; step++) {
+    if (version === targetVersion) return current;
+    const next = ladder.find((m) => m.from === version);
     if (!next) {
-      throw new Error(`@openmaic/dsl: no migration path from "${version}" to "${DSL_VERSION}"`);
+      throw new Error(`@openmaic/dsl: no migration path from "${version}" to "${targetVersion}"`);
     }
     current = stampVersion(next.migrate(current), next.to);
     version = next.to;
   }
 
-  if (version !== DSL_VERSION) {
+  if (version !== targetVersion) {
     throw new Error(
-      `@openmaic/dsl: migration ladder did not reach "${DSL_VERSION}" (stuck at "${version}")`,
+      `@openmaic/dsl: migration ladder did not reach "${targetVersion}" (stuck at "${version}")`,
     );
   }
   return current;
+}
+
+export function migrate(doc: unknown): unknown {
+  return runLadder(doc, DSL_MIGRATIONS, DSL_VERSION);
+}
+
+/**
+ * Migrate a runtime document ({@link RuntimeSession} / runtime record) forward
+ * to {@link RUNTIME_DSL_VERSION}, walking {@link RUNTIME_DSL_MIGRATIONS}.
+ *
+ * The exact counterpart of {@link migrate} on the runtime version line —
+ * idempotent, forward-compatible, fail-loud, pure, non-objects returned as-is —
+ * but pinned to the runtime ladder + target version. Runtime state is stamped
+ * and migrated on read through *this* function, never {@link migrate}, so the
+ * document and runtime shapes evolve without either ladder consuming the other's
+ * data.
+ */
+export function migrateRuntime(doc: unknown): unknown {
+  return runLadder(doc, RUNTIME_DSL_MIGRATIONS, RUNTIME_DSL_VERSION);
 }

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -50,6 +50,17 @@ export const INITIAL_DSL_VERSION = '0.1.0' as const;
 export const DSL_VERSION_KEY = 'dslVersion' as const;
 
 /**
+ * Envelope property that carries the serialized-contract version on a runtime
+ * session. Mechanically **disjoint** from {@link DSL_VERSION_KEY}: the two
+ * version lines stamp different fields, so a document migration walked over a
+ * session finds no {@link DSL_VERSION_KEY} stamp to read (and, at worst, adds a
+ * foreign field it owns) and the runtime ladder finds no {@link DSL_VERSION_KEY}
+ * either — neither line can read, consume, or corrupt the other's stamp, and
+ * misrouted data is inert rather than silently reinterpreted.
+ */
+export const RUNTIME_DSL_VERSION_KEY = 'runtimeDslVersion' as const;
+
+/**
  * A document that may carry a DSL contract-version stamp. `@openmaic/dsl` does
  * not bind this to a specific aggregate (see the module note) — it is the
  * minimal envelope the {@link migrate} runner reads and writes.
@@ -57,6 +68,17 @@ export const DSL_VERSION_KEY = 'dslVersion' as const;
 export interface DslVersioned {
   /** Serialized-contract version this document was written at. Absent on legacy data. */
   dslVersion?: string;
+}
+
+/**
+ * A runtime session that may carry a runtime-contract version stamp. The
+ * runtime counterpart of {@link DslVersioned}, stamped by {@link migrateRuntime}
+ * on a **different** envelope field ({@link RUNTIME_DSL_VERSION_KEY}) so the two
+ * version lines are byte-distinguishable, not convention-separated.
+ */
+export interface RuntimeVersioned {
+  /** Runtime-contract version this session was written at. Absent on legacy data. */
+  runtimeDslVersion?: string;
 }
 
 /**
@@ -96,16 +118,21 @@ export const DSL_MIGRATIONS: readonly DslMigration[] = [
 
 /**
  * Current version of the serialized *runtime* contract (#869) — the on-disk
- * shape of a {@link RuntimeSession} / runtime record, NOT the slide document.
+ * shape of a {@link RuntimeSession}, NOT the slide document.
  *
- * This is a **deliberately separate version line** from {@link DSL_VERSION}.
- * A {@link RuntimeSession} shares the `dslVersion` envelope *field* (it extends
- * `DslVersioned`), but the two ladders version independent serialized shapes:
- * a change to the document (Stage/Scene) shape must never force — or, worse,
- * accidentally *consume* — a runtime step, and vice versa. A `DslMigration`
- * body is an arbitrary whole-document transform; if runtime sessions rode
- * `DSL_MIGRATIONS`, a future real Stage/Scene migration authored against the
- * document shape would run over a `RuntimeSession` and could corrupt or throw.
+ * This is a **deliberately separate version line** from {@link DSL_VERSION},
+ * and the separation is mechanical, not by convention: a {@link RuntimeSession}
+ * stamps its version on {@link RUNTIME_DSL_VERSION_KEY}, a distinct envelope
+ * field from the document's {@link DSL_VERSION_KEY}. The two ladders version
+ * independent serialized shapes, so a change to the document (Stage/Scene) shape
+ * must never force — or, worse, accidentally *consume* — a runtime step, and
+ * vice versa. A `DslMigration` body is an arbitrary whole-document transform;
+ * if runtime sessions rode `DSL_MIGRATIONS`, a future real Stage/Scene migration
+ * authored against the document shape would run over a `RuntimeSession` and
+ * could corrupt or throw. Because the stamps live on different fields, even a
+ * misrouted document migration cannot find or overwrite the runtime stamp: it
+ * would at worst add its own foreign `dslVersion` field, never mutate
+ * `runtimeDslVersion`.
  */
 export const RUNTIME_DSL_VERSION = '0.1.0' as const;
 
@@ -123,14 +150,16 @@ export const INITIAL_RUNTIME_DSL_VERSION = '0.1.0' as const;
  * Ordered migration ladder for the runtime contract, wholly independent of
  * {@link DSL_MIGRATIONS}. Same invariants (contiguous chain, last `to` ===
  * {@link RUNTIME_DSL_VERSION}, every endpoint a **pinned literal**), same
- * legacy-lift shape: the first entry stamps pre-`dslVersion` runtime data up to
- * {@link INITIAL_RUNTIME_DSL_VERSION} as a no-op transform (the runtime shape is
- * brand new, so nothing predates 0.1.0 to reshape — the entry just wires the
- * pipeline and gives real runtime data a version to migrate forward from).
+ * legacy-lift shape: the first entry stamps pre-`runtimeDslVersion` runtime data
+ * up to {@link INITIAL_RUNTIME_DSL_VERSION} as a no-op transform (the runtime
+ * shape is brand new, so nothing predates 0.1.0 to reshape — the entry just
+ * wires the pipeline and gives real runtime data a version to migrate forward
+ * from).
  *
  * It shares {@link UNVERSIONED_DSL_VERSION} as its legacy origin because that
- * constant names "wrote no `dslVersion` stamp", a property of the shared
- * envelope field, not of either aggregate's shape.
+ * constant names "wrote no version stamp" — the absence of a stamp, not a shape.
+ * Each ladder reads its own envelope field, so the shared origin value never
+ * conflates the two lines.
  */
 export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [
   { from: UNVERSIONED_DSL_VERSION, to: INITIAL_RUNTIME_DSL_VERSION, migrate: (doc) => doc },
@@ -143,10 +172,12 @@ function isObject(v: unknown): v is Record<string, unknown> {
 /**
  * A well-formed `x.y.z` version: exactly three non-negative integer parts.
  *
- * Exported so the runtime-envelope validators can reject a present-but-malformed
- * `dslVersion` stamp at their boundary — the same well-formedness rule that
- * {@link dslVersionOf} / {@link migrate} enforce by throwing — rather than
- * letting a bad stamp pass a mere `typeof` check and blow up downstream.
+ * Exported so the envelope validators can reject a present-but-malformed version
+ * stamp (either line's — `dslVersion` or `runtimeDslVersion`) at their boundary
+ * — the same well-formedness rule that {@link dslVersionOf} /
+ * {@link runtimeDslVersionOf} / {@link migrate} / {@link migrateRuntime} enforce
+ * by throwing — rather than letting a bad stamp pass a mere `typeof` check and
+ * blow up downstream.
  */
 export function isWellFormedDslVersion(v: string): boolean {
   return /^\d+\.\d+\.\d+$/.test(v);
@@ -169,42 +200,95 @@ function compareVersions(a: string, b: string): number {
 }
 
 /**
- * Read the serialized-contract version a document was written at.
+ * Read the version an aggregate was written at from an arbitrary envelope
+ * `key`. The shared engine behind {@link dslVersionOf} (document line) and
+ * {@link runtimeDslVersionOf} (runtime line) — each passes its own key, so the
+ * two lines read disjoint fields and never conflate.
  *
- * - A non-object, or an object with no {@link DSL_VERSION_KEY} field, is treated
- *   as {@link UNVERSIONED_DSL_VERSION} (legacy / pre-versioning data).
+ * - A non-object, or an object with no `key` field, is treated as
+ *   {@link UNVERSIONED_DSL_VERSION} (legacy / pre-versioning data).
  * - A **present but malformed** stamp (not a well-formed `x.y.z` string) is
  *   corrupt data making a false version claim, so this **throws** rather than
  *   letting a bad stamp silently compare as some arbitrary version and bypass
  *   migration.
  */
-export function dslVersionOf(doc: unknown): string {
+function versionOf(doc: unknown, key: string): string {
   if (!isObject(doc)) return UNVERSIONED_DSL_VERSION;
-  const raw = doc[DSL_VERSION_KEY];
+  const raw = doc[key];
   if (raw === undefined) return UNVERSIONED_DSL_VERSION;
   if (typeof raw !== 'string' || !isWellFormedDslVersion(raw)) {
     throw new Error(
-      `@openmaic/dsl: invalid ${DSL_VERSION_KEY} stamp ${JSON.stringify(raw)} (expected "x.y.z")`,
+      `@openmaic/dsl: invalid ${key} stamp ${JSON.stringify(raw)} (expected "x.y.z")`,
     );
   }
   return raw;
 }
 
 /**
- * True when `doc` is a migratable document written at an older version than
- * {@link DSL_VERSION}. A non-object is not a migratable document, so this is
- * `false` for it — mirroring {@link migrate}'s no-op, so the two never disagree
- * (a caller looping `while (needsMigration(x)) x = migrate(x)` always terminates).
- * Throws on an object carrying a malformed stamp (see {@link dslVersionOf}).
+ * Read the serialized *document* contract version a document was written at,
+ * from its {@link DSL_VERSION_KEY} envelope field. See {@link versionOf} for the
+ * unstamped / malformed-stamp rules.
  */
-export function needsMigration(doc: unknown): boolean {
-  if (!isObject(doc)) return false;
-  return compareVersions(dslVersionOf(doc), DSL_VERSION) < 0;
+export function dslVersionOf(doc: unknown): string {
+  return versionOf(doc, DSL_VERSION_KEY);
 }
 
-/** Purely stamp a document's version, returning a new object (never mutating). */
-function stampVersion(doc: unknown, version: string): unknown {
-  return isObject(doc) ? { ...doc, [DSL_VERSION_KEY]: version } : doc;
+/**
+ * Read the serialized *runtime* contract version a session was written at, from
+ * its {@link RUNTIME_DSL_VERSION_KEY} envelope field — the runtime-line
+ * counterpart of {@link dslVersionOf}, reading a disjoint field. Same
+ * unstamped / malformed-stamp rules (see {@link versionOf}).
+ */
+export function runtimeDslVersionOf(doc: unknown): string {
+  return versionOf(doc, RUNTIME_DSL_VERSION_KEY);
+}
+
+/**
+ * Shared predicate behind {@link needsMigration} and
+ * {@link needsRuntimeMigration}: true when `doc` is an object stamped (on
+ * envelope `key`) older than `targetVersion`. A non-object is not a migratable
+ * aggregate, so this is `false` for it — mirroring the runners' no-op, so the
+ * predicate and its runner never disagree (a `while (needs…(x)) x = migrate…(x)`
+ * loop always terminates). Throws on a malformed stamp (see {@link versionOf}).
+ */
+function needsLadder(doc: unknown, key: string, targetVersion: string): boolean {
+  if (!isObject(doc)) return false;
+  return compareVersions(versionOf(doc, key), targetVersion) < 0;
+}
+
+/**
+ * True when `doc` is a migratable document written at an older version than
+ * {@link DSL_VERSION}. The document-line predicate (counterpart:
+ * {@link needsRuntimeMigration}, which reads the runtime envelope field). A
+ * non-object is not a migratable document, so this is `false` for it — mirroring
+ * {@link migrate}'s no-op, so the two never disagree (a caller looping
+ * `while (needsMigration(x)) x = migrate(x)` always terminates). Throws on an
+ * object carrying a malformed stamp (see {@link dslVersionOf}).
+ */
+export function needsMigration(doc: unknown): boolean {
+  return needsLadder(doc, DSL_VERSION_KEY, DSL_VERSION);
+}
+
+/**
+ * True when `doc` is a runtime session written at an older version than
+ * {@link RUNTIME_DSL_VERSION}. The runtime-line counterpart of
+ * {@link needsMigration}: it reads {@link RUNTIME_DSL_VERSION_KEY} and pairs with
+ * {@link migrateRuntime}, so a `while (needsRuntimeMigration(x)) x = migrateRuntime(x)`
+ * loop always terminates. Pairing {@link needsMigration} with
+ * {@link migrateRuntime} (or vice versa) once the lines diverge would spin or
+ * silently skip — always pair a predicate with its own line's runner. Throws on
+ * a malformed stamp (see {@link runtimeDslVersionOf}).
+ */
+export function needsRuntimeMigration(doc: unknown): boolean {
+  return needsLadder(doc, RUNTIME_DSL_VERSION_KEY, RUNTIME_DSL_VERSION);
+}
+
+/**
+ * Purely stamp an aggregate's version onto envelope `key`, returning a new
+ * object (never mutating). Keyed so each ladder writes its own line's field.
+ */
+function stampVersion(doc: unknown, version: string, key: string): unknown {
+  return isObject(doc) ? { ...doc, [key]: version } : doc;
 }
 
 /**
@@ -228,16 +312,22 @@ function stampVersion(doc: unknown, version: string): unknown {
 /**
  * Shared ladder runner behind {@link migrate} and {@link migrateRuntime}. The
  * walk / stamp / fail-loud mechanism is identical for both version lines; only
- * the `ladder` and its `targetVersion` differ, so they are parameters rather
- * than duplicated. This is what keeps the two ladders *independent* — each
- * caller passes its own steps and endpoint, so a document migration can never
- * be walked over runtime data (or vice versa). Behavior is byte-identical to
- * the previous inline `migrate` body.
+ * the `ladder`, its `targetVersion`, and the envelope `key` differ, so they are
+ * parameters rather than duplicated. This is what keeps the two ladders
+ * *independent* — each caller passes its own steps, endpoint, and stamp field,
+ * so a document migration reads and writes only `dslVersion` while the runtime
+ * ladder reads and writes only `runtimeDslVersion`; neither can be walked over
+ * the other's stamp.
  */
-function runLadder(doc: unknown, ladder: readonly DslMigration[], targetVersion: string): unknown {
+function runLadder(
+  doc: unknown,
+  ladder: readonly DslMigration[],
+  targetVersion: string,
+  key: string,
+): unknown {
   if (!isObject(doc)) return doc;
 
-  let version = dslVersionOf(doc);
+  let version = versionOf(doc, key);
 
   // Already current, or written ahead of us — leave the document as-is.
   if (compareVersions(version, targetVersion) >= 0) return doc;
@@ -251,7 +341,7 @@ function runLadder(doc: unknown, ladder: readonly DslMigration[], targetVersion:
     if (!next) {
       throw new Error(`@openmaic/dsl: no migration path from "${version}" to "${targetVersion}"`);
     }
-    current = stampVersion(next.migrate(current), next.to);
+    current = stampVersion(next.migrate(current), next.to, key);
     version = next.to;
   }
 
@@ -264,20 +354,21 @@ function runLadder(doc: unknown, ladder: readonly DslMigration[], targetVersion:
 }
 
 export function migrate(doc: unknown): unknown {
-  return runLadder(doc, DSL_MIGRATIONS, DSL_VERSION);
+  return runLadder(doc, DSL_MIGRATIONS, DSL_VERSION, DSL_VERSION_KEY);
 }
 
 /**
- * Migrate a runtime document ({@link RuntimeSession} / runtime record) forward
- * to {@link RUNTIME_DSL_VERSION}, walking {@link RUNTIME_DSL_MIGRATIONS}.
+ * Migrate a {@link RuntimeSession} forward to {@link RUNTIME_DSL_VERSION},
+ * walking {@link RUNTIME_DSL_MIGRATIONS} and stamping
+ * {@link RUNTIME_DSL_VERSION_KEY}.
  *
  * The exact counterpart of {@link migrate} on the runtime version line —
  * idempotent, forward-compatible, fail-loud, pure, non-objects returned as-is —
- * but pinned to the runtime ladder + target version. Runtime state is stamped
- * and migrated on read through *this* function, never {@link migrate}, so the
- * document and runtime shapes evolve without either ladder consuming the other's
- * data.
+ * but pinned to the runtime ladder, target version, and envelope field. Runtime
+ * state is stamped and migrated on read through *this* function, never
+ * {@link migrate}, so the document and runtime shapes evolve without either
+ * ladder consuming the other's data.
  */
 export function migrateRuntime(doc: unknown): unknown {
-  return runLadder(doc, RUNTIME_DSL_MIGRATIONS, RUNTIME_DSL_VERSION);
+  return runLadder(doc, RUNTIME_DSL_MIGRATIONS, RUNTIME_DSL_VERSION, RUNTIME_DSL_VERSION_KEY);
 }

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -214,10 +214,7 @@ export const INITIAL_RUNTIME_DSL_VERSION = '0.1.0' as const;
  * as current, and a session stamped at some unknown older version hits the
  * "no migration path" fail-loud.
  */
-// FAULT INJECTION (local only, never committed): mistaken legacy origin 0.0.0
-export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [
-  { from: '0.0.0', to: '0.1.0', migrate: (doc) => doc },
-];
+export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [];
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -214,19 +214,28 @@ function compareVersions(a: string, b: string): number {
  * Read the version an aggregate was written at from an arbitrary envelope
  * `key`. The shared engine behind {@link dslVersionOf} (document line) and
  * {@link runtimeDslVersionOf} (runtime line) — each passes its own key, so the
- * two lines read disjoint fields and never conflate.
+ * two lines read disjoint fields and never conflate. This is where every
+ * envelope rule is enforced, so the plain readers, the `needs*Migration`
+ * predicates, and the migration runners all give one answer for one envelope:
  *
- * - A non-object, or an object with no `key` field, is treated as
+ * - A non-object, or an object with neither line's stamp, is treated as
  *   {@link UNVERSIONED_DSL_VERSION} (legacy / pre-versioning data).
  * - A **present but malformed** stamp (not a well-formed `x.y.z` string) is
  *   corrupt data making a false version claim, so this **throws** rather than
  *   letting a bad stamp silently compare as some arbitrary version and bypass
  *   migration.
+ * - An **ambiguous cross-line envelope** — own `key` absent, sibling `otherKey`
+ *   present — also **throws** (see {@link crossLineError}). Reading it as
+ *   unversioned would let a version report claim `0.0.0` for data the runner
+ *   refuses to migrate.
  */
-function versionOf(doc: unknown, key: string): string {
+function versionOf(doc: unknown, key: string, otherKey: string): string {
   if (!isObject(doc)) return UNVERSIONED_DSL_VERSION;
   const raw = doc[key];
-  if (raw === undefined) return UNVERSIONED_DSL_VERSION;
+  if (raw === undefined) {
+    if (doc[otherKey] !== undefined) throw crossLineError(key, otherKey);
+    return UNVERSIONED_DSL_VERSION;
+  }
   if (typeof raw !== 'string' || !isWellFormedDslVersion(raw)) {
     throw new Error(
       `@openmaic/dsl: invalid ${key} stamp ${JSON.stringify(raw)} (expected "x.y.z")`,
@@ -237,21 +246,24 @@ function versionOf(doc: unknown, key: string): string {
 
 /**
  * Read the serialized *document* contract version a document was written at,
- * from its {@link DSL_VERSION_KEY} envelope field. See {@link versionOf} for the
- * unstamped / malformed-stamp rules.
+ * from its {@link DSL_VERSION_KEY} envelope field. An authoritative read: it
+ * applies every envelope rule — unstamped, malformed-stamp, and the cross-line
+ * throw on an ambiguous envelope — so callers reporting a version never claim
+ * one for data {@link migrate} refuses to touch (see {@link versionOf}).
  */
 export function dslVersionOf(doc: unknown): string {
-  return versionOf(doc, DSL_VERSION_KEY);
+  return versionOf(doc, DSL_VERSION_KEY, RUNTIME_DSL_VERSION_KEY);
 }
 
 /**
  * Read the serialized *runtime* contract version a session was written at, from
  * its {@link RUNTIME_DSL_VERSION_KEY} envelope field — the runtime-line
- * counterpart of {@link dslVersionOf}, reading a disjoint field. Same
- * unstamped / malformed-stamp rules (see {@link versionOf}).
+ * counterpart of {@link dslVersionOf}, reading a disjoint field. Same rules,
+ * including the cross-line throw on an ambiguous envelope (see
+ * {@link versionOf}).
  */
 export function runtimeDslVersionOf(doc: unknown): string {
-  return versionOf(doc, RUNTIME_DSL_VERSION_KEY);
+  return versionOf(doc, RUNTIME_DSL_VERSION_KEY, DSL_VERSION_KEY);
 }
 
 /**
@@ -267,14 +279,21 @@ export function runtimeDslVersionOf(doc: unknown): string {
  */
 function needsLadder(doc: unknown, key: string, targetVersion: string, otherKey: string): boolean {
   if (!isObject(doc)) return false;
-  if (doc[key] === undefined && doc[otherKey] !== undefined) throw crossLineError(key, otherKey);
-  return compareVersions(versionOf(doc, key), targetVersion) < 0;
+  // The cross-line throw on an ambiguous envelope comes from `versionOf`
+  // itself, so the predicate, its runner, and the plain readers cannot drift.
+  return compareVersions(versionOf(doc, key, otherKey), targetVersion) < 0;
 }
 
 /**
- * The error thrown by the cross-line guard in {@link runLadder} and
- * {@link needsLadder} — one constructor so the runner and its predicate can
- * never drift apart on what the ambiguous state means.
+ * The error thrown on an ambiguous cross-line envelope — own `key` absent,
+ * sibling `otherKey` present. That state is undecidable: the other line's
+ * aggregate misrouted here is byte-identical to this line's data carrying a
+ * stray foreign stamp, and each silent answer locks in one failure mode
+ * (walking the ladder mangles the former; treating it as current/unversioned
+ * orphans the latter from its own line). Thrown from {@link versionOf}, the
+ * single reader behind the runners, the `needs*Migration` predicates, and the
+ * plain `*VersionOf` readers, so none of them can drift apart on what the
+ * ambiguous state means.
  */
 function crossLineError(key: string, otherKey: string): Error {
   return new Error(
@@ -378,18 +397,12 @@ function runLadder(
 ): unknown {
   if (!isObject(doc)) return doc;
 
-  // Cross-line guard, case (3): this line's stamp absent but the other line's
-  // stamp present. The envelope cannot distinguish "the other line's aggregate,
-  // misrouted here" from "this line's data carrying a stray foreign stamp" —
-  // the two are byte-identical. Silently walking the ladder would mangle the
-  // former; silently returning unchanged would orphan the latter (valid data
-  // that never becomes eligible for its own line). Neither guess is safe, so
-  // fail loud, like a malformed stamp. (Cases (1) own stamp present and (2)
-  // both absent fall through to the normal walk below, where a
-  // present-but-malformed own stamp still throws via `versionOf`.)
-  if (doc[key] === undefined && doc[otherKey] !== undefined) throw crossLineError(key, otherKey);
-
-  let version = versionOf(doc, key);
+  // Case (3) of the cross-line guard — own stamp absent, sibling stamp present
+  // — throws inside `versionOf` (see `crossLineError` for why neither silent
+  // answer is safe), as does a present-but-malformed own stamp. Enforcing both
+  // in the shared reader keeps the runner, its predicate, and the plain
+  // `*VersionOf` readers in agreement on every envelope.
+  let version = versionOf(doc, key, otherKey);
 
   // Already current, or written ahead of us — leave the document as-is.
   if (compareVersions(version, targetVersion) >= 0) return doc;

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -214,7 +214,10 @@ export const INITIAL_RUNTIME_DSL_VERSION = '0.1.0' as const;
  * as current, and a session stamped at some unknown older version hits the
  * "no migration path" fail-loud.
  */
-export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [];
+// FAULT INJECTION (local only, never committed): mistaken legacy origin 0.0.0
+export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [
+  { from: '0.0.0', to: '0.1.0', migrate: (doc) => doc },
+];
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -257,27 +257,33 @@ export function runtimeDslVersionOf(doc: unknown): string {
 /**
  * Shared predicate behind {@link needsMigration} and
  * {@link needsRuntimeMigration}: true when `doc` is an object stamped (on
- * envelope `key`) older than `targetVersion`. A non-object is not a migratable
- * aggregate, so this is `false` for it — mirroring the runners' no-op, so the
- * predicate and its runner never disagree (a `while (needs…(x)) x = migrate…(x)`
- * loop always terminates). Throws on a malformed stamp (see {@link versionOf}).
+ * envelope `key`) older than `targetVersion`. It must return `false` for every
+ * input its runner leaves untouched, so the predicate and its runner never
+ * disagree and a `while (needs…(x)) x = migrate…(x)` loop always terminates.
+ * Two such mirrors: a non-object (not a migratable aggregate — the runners
+ * return it as-is), and a misrouted aggregate under {@link runLadder}'s
+ * cross-line guard (own stamp absent, `otherKey` stamp present — the runner
+ * returns it unchanged, so reporting it as needing migration would spin
+ * forever). Throws on a malformed own-line stamp (see {@link versionOf}).
  */
-function needsLadder(doc: unknown, key: string, targetVersion: string): boolean {
+function needsLadder(doc: unknown, key: string, targetVersion: string, otherKey: string): boolean {
   if (!isObject(doc)) return false;
+  if (doc[key] === undefined && doc[otherKey] !== undefined) return false;
   return compareVersions(versionOf(doc, key), targetVersion) < 0;
 }
 
 /**
  * True when `doc` is a migratable document written at an older version than
  * {@link DSL_VERSION}. The document-line predicate (counterpart:
- * {@link needsRuntimeMigration}, which reads the runtime envelope field). A
- * non-object is not a migratable document, so this is `false` for it — mirroring
- * {@link migrate}'s no-op, so the two never disagree (a caller looping
- * `while (needsMigration(x)) x = migrate(x)` always terminates). Throws on an
- * object carrying a malformed stamp (see {@link dslVersionOf}).
+ * {@link needsRuntimeMigration}, which reads the runtime envelope field). It is
+ * `false` for every input {@link migrate} leaves untouched — a non-object, and a
+ * runtime-line aggregate under the cross-line guard — so the two never disagree
+ * (a caller looping `while (needsMigration(x)) x = migrate(x)` always
+ * terminates). Throws on an object carrying a malformed stamp (see
+ * {@link dslVersionOf}).
  */
 export function needsMigration(doc: unknown): boolean {
-  return needsLadder(doc, DSL_VERSION_KEY, DSL_VERSION);
+  return needsLadder(doc, DSL_VERSION_KEY, DSL_VERSION, RUNTIME_DSL_VERSION_KEY);
 }
 
 /**
@@ -285,13 +291,15 @@ export function needsMigration(doc: unknown): boolean {
  * {@link RUNTIME_DSL_VERSION}. The runtime-line counterpart of
  * {@link needsMigration}: it reads {@link RUNTIME_DSL_VERSION_KEY} and pairs with
  * {@link migrateRuntime}, so a `while (needsRuntimeMigration(x)) x = migrateRuntime(x)`
- * loop always terminates. Pairing {@link needsMigration} with
- * {@link migrateRuntime} (or vice versa) once the lines diverge would spin or
- * silently skip — always pair a predicate with its own line's runner. Throws on
- * a malformed stamp (see {@link runtimeDslVersionOf}).
+ * loop always terminates — including on a misrouted document-line aggregate,
+ * which the cross-line guard makes both the predicate and the runner ignore.
+ * Pairing {@link needsMigration} with {@link migrateRuntime} (or vice versa)
+ * once the lines diverge would spin or silently skip — always pair a predicate
+ * with its own line's runner. Throws on a malformed stamp (see
+ * {@link runtimeDslVersionOf}).
  */
 export function needsRuntimeMigration(doc: unknown): boolean {
-  return needsLadder(doc, RUNTIME_DSL_VERSION_KEY, RUNTIME_DSL_VERSION);
+  return needsLadder(doc, RUNTIME_DSL_VERSION_KEY, RUNTIME_DSL_VERSION, DSL_VERSION_KEY);
 }
 
 /**

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -55,14 +55,14 @@ export const DSL_VERSION_KEY = 'dslVersion' as const;
  * version lines stamp different fields, so neither ladder can read, consume, or
  * corrupt the other's stamp.
  *
- * Disjoint keys are necessary but **not sufficient** for inertness: an object
- * carrying only this key still *lacks* {@link DSL_VERSION_KEY}, so the document
- * runner would read it as {@link UNVERSIONED_DSL_VERSION} and walk its legacy
- * ladder over the session — stamping a foreign field and, once a real transform
- * lands, mangling the payload. What actually makes misrouted data inert is the
- * cross-line guard in {@link runLadder}: a runner whose own stamp is absent but
- * whose sibling's stamp is present returns the object untouched. See that
- * function for the three-case semantics.
+ * Disjoint keys are necessary but **not sufficient** to protect misrouted
+ * data: an object carrying only this key still *lacks* {@link DSL_VERSION_KEY},
+ * so the document runner would read it as {@link UNVERSIONED_DSL_VERSION} and
+ * walk its legacy ladder over the session — stamping a foreign field and, once
+ * a real transform lands, mangling the payload. The cross-line guard in
+ * {@link runLadder} closes this: a runner whose own stamp is absent but whose
+ * sibling's stamp is present **throws** rather than guessing. See that function
+ * for the three-case semantics.
  */
 export const RUNTIME_DSL_VERSION_KEY = 'runtimeDslVersion' as const;
 
@@ -140,10 +140,10 @@ export const DSL_MIGRATIONS: readonly DslMigration[] = [
  * The disjoint stamp fields keep each ladder from reading the other's version,
  * but they do not by themselves stop a misrouted aggregate from being lifted on
  * the wrong line (it simply reads as unversioned there). The cross-line guard in
- * {@link runLadder} is what delivers inertness: a runner returns any aggregate
- * that carries the *sibling* line's stamp but not its own untouched, so a
- * misrouted document migration never even stamps its foreign `dslVersion` onto a
- * runtime session.
+ * {@link runLadder} closes this: a runner **throws** on any aggregate that
+ * carries the *sibling* line's stamp but not its own, so a misrouted document
+ * migration surfaces as an error instead of stamping a foreign `dslVersion`
+ * onto a runtime session.
  */
 export const RUNTIME_DSL_VERSION = '0.1.0' as const;
 
@@ -257,30 +257,42 @@ export function runtimeDslVersionOf(doc: unknown): string {
 /**
  * Shared predicate behind {@link needsMigration} and
  * {@link needsRuntimeMigration}: true when `doc` is an object stamped (on
- * envelope `key`) older than `targetVersion`. It must return `false` for every
- * input its runner leaves untouched, so the predicate and its runner never
- * disagree and a `while (needs…(x)) x = migrate…(x)` loop always terminates.
- * Two such mirrors: a non-object (not a migratable aggregate — the runners
- * return it as-is), and a misrouted aggregate under {@link runLadder}'s
- * cross-line guard (own stamp absent, `otherKey` stamp present — the runner
- * returns it unchanged, so reporting it as needing migration would spin
- * forever). Throws on a malformed own-line stamp (see {@link versionOf}).
+ * envelope `key`) older than `targetVersion`. It mirrors its runner on every
+ * input, so the two never disagree and a `while (needs…(x)) x = migrate…(x)`
+ * loop always terminates: `false` for a non-object (the runners return those
+ * as-is), and the same **throw** as {@link runLadder}'s cross-line guard for an
+ * ambiguous envelope (own stamp absent, `otherKey` stamp present) — quietly
+ * answering either way there would misreport data the runner refuses to touch.
+ * Also throws on a malformed own-line stamp (see {@link versionOf}).
  */
 function needsLadder(doc: unknown, key: string, targetVersion: string, otherKey: string): boolean {
   if (!isObject(doc)) return false;
-  if (doc[key] === undefined && doc[otherKey] !== undefined) return false;
+  if (doc[key] === undefined && doc[otherKey] !== undefined) throw crossLineError(key, otherKey);
   return compareVersions(versionOf(doc, key), targetVersion) < 0;
+}
+
+/**
+ * The error thrown by the cross-line guard in {@link runLadder} and
+ * {@link needsLadder} — one constructor so the runner and its predicate can
+ * never drift apart on what the ambiguous state means.
+ */
+function crossLineError(key: string, otherKey: string): Error {
+  return new Error(
+    `@openmaic/dsl: object carries "${otherKey}" but no "${key}" — a misrouted ` +
+      `aggregate from the other version line, or a stray foreign stamp; route it ` +
+      `to the correct runner or repair the envelope before migrating`,
+  );
 }
 
 /**
  * True when `doc` is a migratable document written at an older version than
  * {@link DSL_VERSION}. The document-line predicate (counterpart:
- * {@link needsRuntimeMigration}, which reads the runtime envelope field). It is
- * `false` for every input {@link migrate} leaves untouched — a non-object, and a
- * runtime-line aggregate under the cross-line guard — so the two never disagree
+ * {@link needsRuntimeMigration}, which reads the runtime envelope field). It
+ * mirrors {@link migrate} on every input — `false` for a non-object, the same
+ * cross-line-guard throw for an ambiguous envelope — so the two never disagree
  * (a caller looping `while (needsMigration(x)) x = migrate(x)` always
- * terminates). Throws on an object carrying a malformed stamp (see
- * {@link dslVersionOf}).
+ * terminates or fails loud on the same input). Throws on an object carrying a
+ * malformed stamp (see {@link dslVersionOf}).
  */
 export function needsMigration(doc: unknown): boolean {
   return needsLadder(doc, DSL_VERSION_KEY, DSL_VERSION, RUNTIME_DSL_VERSION_KEY);
@@ -291,12 +303,12 @@ export function needsMigration(doc: unknown): boolean {
  * {@link RUNTIME_DSL_VERSION}. The runtime-line counterpart of
  * {@link needsMigration}: it reads {@link RUNTIME_DSL_VERSION_KEY} and pairs with
  * {@link migrateRuntime}, so a `while (needsRuntimeMigration(x)) x = migrateRuntime(x)`
- * loop always terminates — including on a misrouted document-line aggregate,
- * which the cross-line guard makes both the predicate and the runner ignore.
- * Pairing {@link needsMigration} with {@link migrateRuntime} (or vice versa)
- * once the lines diverge would spin or silently skip — always pair a predicate
- * with its own line's runner. Throws on a malformed stamp (see
- * {@link runtimeDslVersionOf}).
+ * loop always terminates or fails loud on the same input — on a misrouted
+ * document-line aggregate both the predicate and the runner throw the same
+ * cross-line-guard error. Pairing {@link needsMigration} with
+ * {@link migrateRuntime} (or vice versa) once the lines diverge would spin or
+ * silently skip — always pair a predicate with its own line's runner. Throws on
+ * a malformed stamp (see {@link runtimeDslVersionOf}).
  */
 export function needsRuntimeMigration(doc: unknown): boolean {
   return needsLadder(doc, RUNTIME_DSL_VERSION_KEY, RUNTIME_DSL_VERSION, DSL_VERSION_KEY);
@@ -338,20 +350,24 @@ function stampVersion(doc: unknown, version: string, key: string): unknown {
  * only `dslVersion` while the runtime ladder reads and writes only
  * `runtimeDslVersion`; neither can be walked over the other's stamp.
  *
- * **Cross-line guard.** Disjoint stamp keys alone do NOT make misrouted data
- * inert: an aggregate carrying the *other* line's stamp still lacks this line's
+ * **Cross-line guard.** Disjoint stamp keys alone do NOT protect misrouted
+ * data: an aggregate carrying the *other* line's stamp still lacks this line's
  * key, so `versionOf` reads it as {@link UNVERSIONED_DSL_VERSION} and the runner
  * would walk its own legacy ladder over it — stamping a foreign key and, once a
  * real transform lands on either ladder, mangling or throwing on the other
- * line's payload. The inertness comes from this guard, keyed on the presence of
- * the two stamps:
+ * line's payload. The guard is keyed on the presence of the two stamps:
  *
  * 1. Own line's stamp present → migrate normally on this line, regardless of the
  *    other key (a doubly-stamped envelope is each runner's own line's data).
  * 2. Both stamps absent → genuine legacy data → walk this line's ladder as before.
- * 3. Own stamp ABSENT + other line's stamp PRESENT → this is the *other* line's
- *    aggregate, misrouted here. Return it unchanged: never lift it, never stamp
- *    this line's key onto it.
+ * 3. Own stamp ABSENT + other line's stamp PRESENT → **throw**. The envelope
+ *    cannot say whether this is the other line's aggregate misrouted here or
+ *    this line's data carrying a stray foreign stamp — walking the ladder would
+ *    mangle the former, while silently returning it unchanged would permanently
+ *    orphan the latter from its own line (its predicate would report "current"
+ *    forever). An ambiguous envelope is corrupt data, handled like a malformed
+ *    stamp: fail loud. `validateRuntimeSession` rejects a stray `dslVersion` at
+ *    the door for the same reason.
  */
 function runLadder(
   doc: unknown,
@@ -363,11 +379,15 @@ function runLadder(
   if (!isObject(doc)) return doc;
 
   // Cross-line guard, case (3): this line's stamp absent but the other line's
-  // stamp present → the object belongs to the other version line. It is inert
-  // here — returned byte-identical, never lifted or stamped. (Cases (1) own
-  // stamp present and (2) both absent fall through to the normal walk below,
-  // where a present-but-malformed own stamp still throws via `versionOf`.)
-  if (doc[key] === undefined && doc[otherKey] !== undefined) return doc;
+  // stamp present. The envelope cannot distinguish "the other line's aggregate,
+  // misrouted here" from "this line's data carrying a stray foreign stamp" —
+  // the two are byte-identical. Silently walking the ladder would mangle the
+  // former; silently returning unchanged would orphan the latter (valid data
+  // that never becomes eligible for its own line). Neither guess is safe, so
+  // fail loud, like a malformed stamp. (Cases (1) own stamp present and (2)
+  // both absent fall through to the normal walk below, where a
+  // present-but-malformed own stamp still throws via `versionOf`.)
+  if (doc[key] === undefined && doc[otherKey] !== undefined) throw crossLineError(key, otherKey);
 
   let version = versionOf(doc, key);
 

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -98,8 +98,15 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-/** A well-formed `x.y.z` version: exactly three non-negative integer parts. */
-function isValidVersion(v: string): boolean {
+/**
+ * A well-formed `x.y.z` version: exactly three non-negative integer parts.
+ *
+ * Exported so the runtime-envelope validators can reject a present-but-malformed
+ * `dslVersion` stamp at their boundary — the same well-formedness rule that
+ * {@link dslVersionOf} / {@link migrate} enforce by throwing — rather than
+ * letting a bad stamp pass a mere `typeof` check and blow up downstream.
+ */
+export function isWellFormedDslVersion(v: string): boolean {
   return /^\d+\.\d+\.\d+$/.test(v);
 }
 
@@ -133,7 +140,7 @@ export function dslVersionOf(doc: unknown): string {
   if (!isObject(doc)) return UNVERSIONED_DSL_VERSION;
   const raw = doc[DSL_VERSION_KEY];
   if (raw === undefined) return UNVERSIONED_DSL_VERSION;
-  if (typeof raw !== 'string' || !isValidVersion(raw)) {
+  if (typeof raw !== 'string' || !isWellFormedDslVersion(raw)) {
     throw new Error(
       `@openmaic/dsl: invalid ${DSL_VERSION_KEY} stamp ${JSON.stringify(raw)} (expected "x.y.z")`,
     );

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -29,7 +29,13 @@ export type DslVersion = typeof DSL_VERSION;
 /**
  * The version a document is treated as when it carries no {@link DSL_VERSION_KEY}
  * stamp: everything written before the version field existed. The first
- * migration lifts these legacy documents forward.
+ * {@link DSL_MIGRATIONS} entry lifts these legacy documents forward.
+ *
+ * A **document-line-only** concept. The runtime line has no unversioned epoch —
+ * its envelope is brand new and stamped at write time, so it lifts nothing (see
+ * {@link RUNTIME_DSL_MIGRATIONS} / {@link noRuntimeEpochError}). This constant
+ * therefore names the document line's legacy origin; the runtime runner passes
+ * `null` for its legacy version instead of reusing it.
  */
 export const UNVERSIONED_DSL_VERSION = '0.0.0' as const;
 
@@ -77,13 +83,29 @@ export interface DslVersioned {
 }
 
 /**
- * A runtime session that may carry a runtime-contract version stamp. The
- * runtime counterpart of {@link DslVersioned}, stamped by {@link migrateRuntime}
- * on a **different** envelope field ({@link RUNTIME_DSL_VERSION_KEY}) so the two
- * version lines are byte-distinguishable, not convention-separated.
+ * A runtime aggregate that **may** carry a runtime-contract version stamp — the
+ * envelope-layer type the readers ({@link runtimeDslVersionOf}), predicate
+ * ({@link needsRuntimeMigration}), and runner ({@link migrateRuntime}) operate
+ * over, all of which accept `unknown` and tolerate an absent stamp at the type
+ * level. The runtime counterpart of {@link DslVersioned}, stamped by
+ * {@link migrateRuntime} on a **different** envelope field
+ * ({@link RUNTIME_DSL_VERSION_KEY}) so the two version lines are
+ * byte-distinguishable, not convention-separated.
+ *
+ * The field is optional *here* because this is the "may carry" envelope view.
+ * For a {@link RuntimeSession} the stamp is **required** — sessions are born
+ * stamped, there is no unversioned epoch (see {@link RUNTIME_DSL_VERSION}), so an
+ * absent `runtimeDslVersion` is only a transient in-memory state before the
+ * producer stamps it, never a stored one; a stored session without it is a bug
+ * the runtime-line functions and {@link RuntimeSession}'s required override both
+ * reject.
  */
 export interface RuntimeVersioned {
-  /** Runtime-contract version this session was written at. Absent on legacy data. */
+  /**
+   * Runtime-contract version this aggregate was written at. Optional on this
+   * envelope view; {@link RuntimeSession} overrides it to required (born stamped,
+   * no legacy epoch).
+   */
   runtimeDslVersion?: string;
 }
 
@@ -144,6 +166,15 @@ export const DSL_MIGRATIONS: readonly DslMigration[] = [
  * carries the *sibling* line's stamp but not its own, so a misrouted document
  * migration surfaces as an error instead of stamping a foreign `dslVersion`
  * onto a runtime session.
+ *
+ * Unlike {@link DSL_VERSION}, this line has **no unversioned epoch**. Real
+ * pre-versioning *documents* exist, so the document line lifts an unstamped
+ * document from {@link UNVERSIONED_DSL_VERSION}; nothing legitimately predates
+ * the runtime envelope, and the future `RuntimeStore` stamps this version at
+ * write time. So an object reaching a runtime-line function *without* a stamp is
+ * not legacy data — it is a misrouted legacy document or an unstamped producer
+ * write, and fails loud (see {@link noRuntimeEpochError}) rather than being
+ * lifted. {@link RUNTIME_DSL_MIGRATIONS} accordingly ships empty.
  */
 export const RUNTIME_DSL_VERSION = '0.1.0' as const;
 
@@ -154,27 +185,36 @@ export type RuntimeDslVersion = typeof RUNTIME_DSL_VERSION;
  * moving {@link RUNTIME_DSL_VERSION} (see {@link INITIAL_DSL_VERSION} for why
  * migration endpoints must be immutable). Equal to `RUNTIME_DSL_VERSION` today;
  * the two diverge the moment the runtime shape first changes.
+ *
+ * The runtime line **starts here**, not at an unversioned epoch: there is no
+ * pre-versioning runtime data to lift, so {@link RUNTIME_DSL_MIGRATIONS} ships
+ * empty and this pinned version is the `from` of the first real step appended
+ * when the runtime shape first changes.
  */
 export const INITIAL_RUNTIME_DSL_VERSION = '0.1.0' as const;
 
 /**
  * Ordered migration ladder for the runtime contract, wholly independent of
- * {@link DSL_MIGRATIONS}. Same invariants (contiguous chain, last `to` ===
- * {@link RUNTIME_DSL_VERSION}, every endpoint a **pinned literal**), same
- * legacy-lift shape: the first entry stamps pre-`runtimeDslVersion` runtime data
- * up to {@link INITIAL_RUNTIME_DSL_VERSION} as a no-op transform (the runtime
- * shape is brand new, so nothing predates 0.1.0 to reshape — the entry just
- * wires the pipeline and gives real runtime data a version to migrate forward
- * from).
+ * {@link DSL_MIGRATIONS}. Same invariants when non-empty (contiguous chain, last
+ * `to` === {@link RUNTIME_DSL_VERSION}, every endpoint a **pinned literal**), but
+ * — unlike the document ladder — it starts **empty**, with NO legacy-lift entry.
  *
- * It shares {@link UNVERSIONED_DSL_VERSION} as its legacy origin because that
- * constant names "wrote no version stamp" — the absence of a stamp, not a shape.
- * Each ladder reads its own envelope field, so the shared origin value never
- * conflates the two lines.
+ * The runtime line has **no unversioned epoch**. Its envelope is a brand-new
+ * contract: the future `RuntimeStore` stamps {@link RUNTIME_DSL_VERSION} at write
+ * time, so nothing legitimately predates {@link INITIAL_RUNTIME_DSL_VERSION} and
+ * there is no pre-versioning runtime data to lift. An unstamped object reaching
+ * {@link migrateRuntime} is therefore a bug, not legacy data, and fails loud (see
+ * {@link noRuntimeEpochError}) rather than being lifted by a no-op first entry.
+ *
+ * The first real runtime shape change bumps {@link RUNTIME_DSL_VERSION} and
+ * appends a step from the pinned {@link INITIAL_RUNTIME_DSL_VERSION} to the new
+ * version — the same append discipline as {@link DSL_MIGRATIONS}, just without a
+ * pre-seeded legacy row. An empty ladder is fully functional: a session already
+ * stamped at {@link RUNTIME_DSL_VERSION} early-returns from {@link migrateRuntime}
+ * as current, and a session stamped at some unknown older version hits the
+ * "no migration path" fail-loud.
  */
-export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [
-  { from: UNVERSIONED_DSL_VERSION, to: INITIAL_RUNTIME_DSL_VERSION, migrate: (doc) => doc },
-];
+export const RUNTIME_DSL_MIGRATIONS: readonly DslMigration[] = [];
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -218,8 +258,18 @@ function compareVersions(a: string, b: string): number {
  * envelope rule is enforced, so the plain readers, the `needs*Migration`
  * predicates, and the migration runners all give one answer for one envelope:
  *
- * - A non-object, or an object with neither line's stamp, is treated as
- *   {@link UNVERSIONED_DSL_VERSION} (legacy / pre-versioning data).
+ * - A non-object is not a migratable aggregate: it is treated as
+ *   {@link UNVERSIONED_DSL_VERSION} on every line, an established convention the
+ *   runners (return input) and predicates (false) mirror. `legacyVersion` does
+ *   NOT govern non-objects — only the "object present but wholly unstamped" case.
+ * - An object with neither line's stamp is legacy / pre-versioning data. What
+ *   that means depends on the line: the caller passes `legacyVersion` = the
+ *   version an unstamped aggregate is lifted from ({@link UNVERSIONED_DSL_VERSION}
+ *   for the document line, whose real pre-versioning documents exist), or `null`
+ *   for a line with **no unversioned epoch** (the runtime line — its envelope is
+ *   brand new, nothing legitimately predates it), in which case this **throws**
+ *   {@link noRuntimeEpochError} rather than inventing a version for a misrouted
+ *   legacy document or an unstamped producer write.
  * - A **present but malformed** stamp (not a well-formed `x.y.z` string) is
  *   corrupt data making a false version claim, so this **throws** rather than
  *   letting a bad stamp silently compare as some arbitrary version and bypass
@@ -229,12 +279,18 @@ function compareVersions(a: string, b: string): number {
  *   unversioned would let a version report claim `0.0.0` for data the runner
  *   refuses to migrate.
  */
-function versionOf(doc: unknown, key: string, otherKey: string): string {
+function versionOf(
+  doc: unknown,
+  key: string,
+  otherKey: string,
+  legacyVersion: string | null,
+): string {
   if (!isObject(doc)) return UNVERSIONED_DSL_VERSION;
   const raw = doc[key];
   if (raw === undefined) {
     if (doc[otherKey] !== undefined) throw crossLineError(key, otherKey);
-    return UNVERSIONED_DSL_VERSION;
+    if (legacyVersion === null) throw noRuntimeEpochError();
+    return legacyVersion;
   }
   if (typeof raw !== 'string' || !isWellFormedDslVersion(raw)) {
     throw new Error(
@@ -252,7 +308,7 @@ function versionOf(doc: unknown, key: string, otherKey: string): string {
  * one for data {@link migrate} refuses to touch (see {@link versionOf}).
  */
 export function dslVersionOf(doc: unknown): string {
-  return versionOf(doc, DSL_VERSION_KEY, RUNTIME_DSL_VERSION_KEY);
+  return versionOf(doc, DSL_VERSION_KEY, RUNTIME_DSL_VERSION_KEY, UNVERSIONED_DSL_VERSION);
 }
 
 /**
@@ -260,10 +316,15 @@ export function dslVersionOf(doc: unknown): string {
  * its {@link RUNTIME_DSL_VERSION_KEY} envelope field — the runtime-line
  * counterpart of {@link dslVersionOf}, reading a disjoint field. Same rules,
  * including the cross-line throw on an ambiguous envelope (see
- * {@link versionOf}).
+ * {@link versionOf}), with **one difference**: the runtime line has no
+ * unversioned epoch, so an unstamped object (not a non-object — those still read
+ * as {@link UNVERSIONED_DSL_VERSION}) **throws** {@link noRuntimeEpochError}
+ * rather than reading as `0.0.0`. Sessions are stamped with
+ * {@link RUNTIME_DSL_VERSION} at write time; an unstamped one here is a misrouted
+ * legacy document or an unstamped producer write, both bugs.
  */
 export function runtimeDslVersionOf(doc: unknown): string {
-  return versionOf(doc, RUNTIME_DSL_VERSION_KEY, DSL_VERSION_KEY);
+  return versionOf(doc, RUNTIME_DSL_VERSION_KEY, DSL_VERSION_KEY, null);
 }
 
 /**
@@ -275,13 +336,22 @@ export function runtimeDslVersionOf(doc: unknown): string {
  * as-is), and the same **throw** as {@link runLadder}'s cross-line guard for an
  * ambiguous envelope (own stamp absent, `otherKey` stamp present) — quietly
  * answering either way there would misreport data the runner refuses to touch.
- * Also throws on a malformed own-line stamp (see {@link versionOf}).
+ * Also throws on a malformed own-line stamp, and — when this line has no
+ * unversioned epoch (`legacyVersion === null`) — on an object with no stamp at
+ * all (see {@link versionOf}).
  */
-function needsLadder(doc: unknown, key: string, targetVersion: string, otherKey: string): boolean {
+function needsLadder(
+  doc: unknown,
+  key: string,
+  targetVersion: string,
+  otherKey: string,
+  legacyVersion: string | null,
+): boolean {
   if (!isObject(doc)) return false;
-  // The cross-line throw on an ambiguous envelope comes from `versionOf`
-  // itself, so the predicate, its runner, and the plain readers cannot drift.
-  return compareVersions(versionOf(doc, key, otherKey), targetVersion) < 0;
+  // The cross-line throw on an ambiguous envelope, and the no-epoch throw on a
+  // wholly-unstamped object, both come from `versionOf` itself, so the
+  // predicate, its runner, and the plain readers cannot drift.
+  return compareVersions(versionOf(doc, key, otherKey, legacyVersion), targetVersion) < 0;
 }
 
 /**
@@ -304,6 +374,30 @@ function crossLineError(key: string, otherKey: string): Error {
 }
 
 /**
+ * The error thrown when a runtime-line function is handed an object carrying no
+ * version stamp at all. Unlike the document line — where real pre-versioning
+ * documents exist and are lifted from {@link UNVERSIONED_DSL_VERSION} — the
+ * runtime line has **no unversioned epoch**: its envelope is a brand-new
+ * contract, the future `RuntimeStore` stamps {@link RUNTIME_DSL_VERSION} at write
+ * time, so nothing legitimately predates it. An unstamped object reaching a
+ * runtime-line reader / predicate / runner is therefore a bug — a misrouted
+ * legacy document or an unstamped producer write — and fails loud rather than
+ * being invented a version and lifted. Thrown from {@link versionOf} (the single
+ * reader behind the runners, predicates, and plain readers) when its
+ * `legacyVersion` argument is `null`, so none of them can drift on what an
+ * unstamped runtime object means. Non-objects are exempt: they are not
+ * migratable aggregates and read as {@link UNVERSIONED_DSL_VERSION} on every line.
+ */
+function noRuntimeEpochError(): Error {
+  return new Error(
+    `@openmaic/dsl: object carries no version stamp; the runtime line has no ` +
+      `unversioned epoch — runtime sessions are stamped with "runtimeDslVersion" ` +
+      `at write time, so an unstamped object here is a misrouted legacy document ` +
+      `or an unstamped producer write`,
+  );
+}
+
+/**
  * True when `doc` is a migratable document written at an older version than
  * {@link DSL_VERSION}. The document-line predicate (counterpart:
  * {@link needsRuntimeMigration}, which reads the runtime envelope field). It
@@ -314,7 +408,13 @@ function crossLineError(key: string, otherKey: string): Error {
  * malformed stamp (see {@link dslVersionOf}).
  */
 export function needsMigration(doc: unknown): boolean {
-  return needsLadder(doc, DSL_VERSION_KEY, DSL_VERSION, RUNTIME_DSL_VERSION_KEY);
+  return needsLadder(
+    doc,
+    DSL_VERSION_KEY,
+    DSL_VERSION,
+    RUNTIME_DSL_VERSION_KEY,
+    UNVERSIONED_DSL_VERSION,
+  );
 }
 
 /**
@@ -327,10 +427,13 @@ export function needsMigration(doc: unknown): boolean {
  * cross-line-guard error. Pairing {@link needsMigration} with
  * {@link migrateRuntime} (or vice versa) once the lines diverge would spin or
  * silently skip — always pair a predicate with its own line's runner. Throws on
- * a malformed stamp (see {@link runtimeDslVersionOf}).
+ * a malformed stamp, and — because the runtime line has **no unversioned
+ * epoch** — on a wholly-unstamped object (a misrouted legacy document or an
+ * unstamped producer write; see {@link noRuntimeEpochError}). Non-objects still
+ * answer `false`, as on the document line.
  */
 export function needsRuntimeMigration(doc: unknown): boolean {
-  return needsLadder(doc, RUNTIME_DSL_VERSION_KEY, RUNTIME_DSL_VERSION, DSL_VERSION_KEY);
+  return needsLadder(doc, RUNTIME_DSL_VERSION_KEY, RUNTIME_DSL_VERSION, DSL_VERSION_KEY, null);
 }
 
 /**
@@ -378,7 +481,13 @@ function stampVersion(doc: unknown, version: string, key: string): unknown {
  *
  * 1. Own line's stamp present → migrate normally on this line, regardless of the
  *    other key (a doubly-stamped envelope is each runner's own line's data).
- * 2. Both stamps absent → genuine legacy data → walk this line's ladder as before.
+ * 2. Both stamps absent → depends on the line. A line WITH an unversioned epoch
+ *    (`legacyVersion` non-null, the document line) treats it as genuine legacy
+ *    data and walks its ladder from `legacyVersion`. A line with NO unversioned
+ *    epoch (`legacyVersion === null`, the runtime line) **throws**
+ *    {@link noRuntimeEpochError}: its envelope is brand new and stamped at write
+ *    time, so an unstamped object is a misrouted legacy document or an unstamped
+ *    producer write, not migratable legacy data.
  * 3. Own stamp ABSENT + other line's stamp PRESENT → **throw**. The envelope
  *    cannot say whether this is the other line's aggregate misrouted here or
  *    this line's data carrying a stray foreign stamp — walking the ladder would
@@ -394,15 +503,18 @@ function runLadder(
   targetVersion: string,
   key: string,
   otherKey: string,
+  legacyVersion: string | null,
 ): unknown {
   if (!isObject(doc)) return doc;
 
   // Case (3) of the cross-line guard — own stamp absent, sibling stamp present
   // — throws inside `versionOf` (see `crossLineError` for why neither silent
-  // answer is safe), as does a present-but-malformed own stamp. Enforcing both
-  // in the shared reader keeps the runner, its predicate, and the plain
-  // `*VersionOf` readers in agreement on every envelope.
-  let version = versionOf(doc, key, otherKey);
+  // answer is safe), as does a present-but-malformed own stamp, and — on a line
+  // with no unversioned epoch (`legacyVersion === null`) — a wholly-unstamped
+  // object (see `noRuntimeEpochError`). Enforcing all three in the shared reader
+  // keeps the runner, its predicate, and the plain `*VersionOf` readers in
+  // agreement on every envelope.
+  let version = versionOf(doc, key, otherKey, legacyVersion);
 
   // Already current, or written ahead of us — leave the document as-is.
   if (compareVersions(version, targetVersion) >= 0) return doc;
@@ -429,7 +541,14 @@ function runLadder(
 }
 
 export function migrate(doc: unknown): unknown {
-  return runLadder(doc, DSL_MIGRATIONS, DSL_VERSION, DSL_VERSION_KEY, RUNTIME_DSL_VERSION_KEY);
+  return runLadder(
+    doc,
+    DSL_MIGRATIONS,
+    DSL_VERSION,
+    DSL_VERSION_KEY,
+    RUNTIME_DSL_VERSION_KEY,
+    UNVERSIONED_DSL_VERSION,
+  );
 }
 
 /**
@@ -443,6 +562,13 @@ export function migrate(doc: unknown): unknown {
  * state is stamped and migrated on read through *this* function, never
  * {@link migrate}, so the document and runtime shapes evolve without either
  * ladder consuming the other's data.
+ *
+ * **No unversioned epoch.** Unlike {@link migrate}, this line does not lift an
+ * unstamped object: sessions are born stamped with {@link RUNTIME_DSL_VERSION}
+ * at write time, so a wholly-unstamped object here is a misrouted legacy
+ * document or an unstamped producer write and **throws** {@link noRuntimeEpochError}
+ * (passed `legacyVersion = null`). Non-objects are still returned unchanged, as
+ * on the document line — they are not migratable aggregates.
  */
 export function migrateRuntime(doc: unknown): unknown {
   return runLadder(
@@ -451,5 +577,6 @@ export function migrateRuntime(doc: unknown): unknown {
     RUNTIME_DSL_VERSION,
     RUNTIME_DSL_VERSION_KEY,
     DSL_VERSION_KEY,
+    null,
   );
 }

--- a/packages/@openmaic/dsl/src/version.ts
+++ b/packages/@openmaic/dsl/src/version.ts
@@ -52,11 +52,17 @@ export const DSL_VERSION_KEY = 'dslVersion' as const;
 /**
  * Envelope property that carries the serialized-contract version on a runtime
  * session. Mechanically **disjoint** from {@link DSL_VERSION_KEY}: the two
- * version lines stamp different fields, so a document migration walked over a
- * session finds no {@link DSL_VERSION_KEY} stamp to read (and, at worst, adds a
- * foreign field it owns) and the runtime ladder finds no {@link DSL_VERSION_KEY}
- * either — neither line can read, consume, or corrupt the other's stamp, and
- * misrouted data is inert rather than silently reinterpreted.
+ * version lines stamp different fields, so neither ladder can read, consume, or
+ * corrupt the other's stamp.
+ *
+ * Disjoint keys are necessary but **not sufficient** for inertness: an object
+ * carrying only this key still *lacks* {@link DSL_VERSION_KEY}, so the document
+ * runner would read it as {@link UNVERSIONED_DSL_VERSION} and walk its legacy
+ * ladder over the session — stamping a foreign field and, once a real transform
+ * lands, mangling the payload. What actually makes misrouted data inert is the
+ * cross-line guard in {@link runLadder}: a runner whose own stamp is absent but
+ * whose sibling's stamp is present returns the object untouched. See that
+ * function for the three-case semantics.
  */
 export const RUNTIME_DSL_VERSION_KEY = 'runtimeDslVersion' as const;
 
@@ -129,10 +135,15 @@ export const DSL_MIGRATIONS: readonly DslMigration[] = [
  * vice versa. A `DslMigration` body is an arbitrary whole-document transform;
  * if runtime sessions rode `DSL_MIGRATIONS`, a future real Stage/Scene migration
  * authored against the document shape would run over a `RuntimeSession` and
- * could corrupt or throw. Because the stamps live on different fields, even a
- * misrouted document migration cannot find or overwrite the runtime stamp: it
- * would at worst add its own foreign `dslVersion` field, never mutate
- * `runtimeDslVersion`.
+ * could corrupt or throw.
+ *
+ * The disjoint stamp fields keep each ladder from reading the other's version,
+ * but they do not by themselves stop a misrouted aggregate from being lifted on
+ * the wrong line (it simply reads as unversioned there). The cross-line guard in
+ * {@link runLadder} is what delivers inertness: a runner returns any aggregate
+ * that carries the *sibling* line's stamp but not its own untouched, so a
+ * misrouted document migration never even stamps its foreign `dslVersion` onto a
+ * runtime session.
  */
 export const RUNTIME_DSL_VERSION = '0.1.0' as const;
 
@@ -312,20 +323,43 @@ function stampVersion(doc: unknown, version: string, key: string): unknown {
 /**
  * Shared ladder runner behind {@link migrate} and {@link migrateRuntime}. The
  * walk / stamp / fail-loud mechanism is identical for both version lines; only
- * the `ladder`, its `targetVersion`, and the envelope `key` differ, so they are
- * parameters rather than duplicated. This is what keeps the two ladders
- * *independent* — each caller passes its own steps, endpoint, and stamp field,
- * so a document migration reads and writes only `dslVersion` while the runtime
- * ladder reads and writes only `runtimeDslVersion`; neither can be walked over
- * the other's stamp.
+ * the `ladder`, its `targetVersion`, the own envelope `key`, and the *other*
+ * line's `otherKey` differ, so they are parameters rather than duplicated. This
+ * is what keeps the two ladders *independent* — each caller passes its own
+ * steps, endpoint, and stamp field, so a document migration reads and writes
+ * only `dslVersion` while the runtime ladder reads and writes only
+ * `runtimeDslVersion`; neither can be walked over the other's stamp.
+ *
+ * **Cross-line guard.** Disjoint stamp keys alone do NOT make misrouted data
+ * inert: an aggregate carrying the *other* line's stamp still lacks this line's
+ * key, so `versionOf` reads it as {@link UNVERSIONED_DSL_VERSION} and the runner
+ * would walk its own legacy ladder over it — stamping a foreign key and, once a
+ * real transform lands on either ladder, mangling or throwing on the other
+ * line's payload. The inertness comes from this guard, keyed on the presence of
+ * the two stamps:
+ *
+ * 1. Own line's stamp present → migrate normally on this line, regardless of the
+ *    other key (a doubly-stamped envelope is each runner's own line's data).
+ * 2. Both stamps absent → genuine legacy data → walk this line's ladder as before.
+ * 3. Own stamp ABSENT + other line's stamp PRESENT → this is the *other* line's
+ *    aggregate, misrouted here. Return it unchanged: never lift it, never stamp
+ *    this line's key onto it.
  */
 function runLadder(
   doc: unknown,
   ladder: readonly DslMigration[],
   targetVersion: string,
   key: string,
+  otherKey: string,
 ): unknown {
   if (!isObject(doc)) return doc;
+
+  // Cross-line guard, case (3): this line's stamp absent but the other line's
+  // stamp present → the object belongs to the other version line. It is inert
+  // here — returned byte-identical, never lifted or stamped. (Cases (1) own
+  // stamp present and (2) both absent fall through to the normal walk below,
+  // where a present-but-malformed own stamp still throws via `versionOf`.)
+  if (doc[key] === undefined && doc[otherKey] !== undefined) return doc;
 
   let version = versionOf(doc, key);
 
@@ -354,7 +388,7 @@ function runLadder(
 }
 
 export function migrate(doc: unknown): unknown {
-  return runLadder(doc, DSL_MIGRATIONS, DSL_VERSION, DSL_VERSION_KEY);
+  return runLadder(doc, DSL_MIGRATIONS, DSL_VERSION, DSL_VERSION_KEY, RUNTIME_DSL_VERSION_KEY);
 }
 
 /**
@@ -370,5 +404,11 @@ export function migrate(doc: unknown): unknown {
  * ladder consuming the other's data.
  */
 export function migrateRuntime(doc: unknown): unknown {
-  return runLadder(doc, RUNTIME_DSL_MIGRATIONS, RUNTIME_DSL_VERSION, RUNTIME_DSL_VERSION_KEY);
+  return runLadder(
+    doc,
+    RUNTIME_DSL_MIGRATIONS,
+    RUNTIME_DSL_VERSION,
+    RUNTIME_DSL_VERSION_KEY,
+    DSL_VERSION_KEY,
+  );
 }

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -155,19 +155,29 @@ describe('isIsoTimestamp', () => {
     expect(isIsoTimestamp('2024-02-29T00:00:00Z')).toBe(true); // real leap day
   });
 
-  it('rejects day-of-month overflow that Date.parse normalizes instead of failing', () => {
-    // V8 rolls these into the next month rather than returning NaN; the explicit
-    // day round-trip is what rejects them, engine-independently.
+  it('rejects calendar-impossible day-of-month, incl. leap-year rules', () => {
+    // V8 NORMALIZES full ISO datetimes like Feb 30 into the next month (a real
+    // instant, not NaN), so Date.parse cannot reject these; the component-level
+    // day-in-month check is what rejects them, engine-independently.
     expect(isIsoTimestamp('2026-02-30T00:00:00.000Z')).toBe(false);
-    expect(isIsoTimestamp('2026-02-29T00:00:00Z')).toBe(false); // 2026 is not a leap year
-    expect(isIsoTimestamp('2026-04-31T00:00:00Z')).toBe(false); // April has 30 days
+    expect(isIsoTimestamp('2026-02-29T00:00:00.000Z')).toBe(false); // 2026 is not a leap year
+    expect(isIsoTimestamp('2024-02-29T00:00:00.000Z')).toBe(true); // divisible by 4 -> leap
+    expect(isIsoTimestamp('2026-04-31T00:00:00.000Z')).toBe(false); // April has 30 days
+    expect(isIsoTimestamp('2100-02-29T00:00:00.000Z')).toBe(false); // century, not /400 -> not leap
+    expect(isIsoTimestamp('2000-02-29T00:00:00.000Z')).toBe(true); // divisible by 400 -> leap
   });
 
-  it('rejects field-range violations (Date.parse yields NaN)', () => {
+  it('rejects field-range violations', () => {
     expect(isIsoTimestamp('2026-13-01T00:00:00Z')).toBe(false); // month 13
     expect(isIsoTimestamp('2026-01-01T25:00:00Z')).toBe(false); // hour 25
+    expect(isIsoTimestamp('2026-01-01T24:00:00.000Z')).toBe(false); // hour 24 (no end-of-day form)
     expect(isIsoTimestamp('2026-01-01T00:60:00Z')).toBe(false); // minute 60
-    expect(isIsoTimestamp('2026-01-01T00:00:60Z')).toBe(false); // second 60
+    expect(isIsoTimestamp('2026-01-01T00:00:60Z')).toBe(false); // second 60 (leap second not accepted)
+  });
+
+  it('rejects out-of-range numeric zone offsets', () => {
+    expect(isIsoTimestamp('2026-01-01T00:00:00+25:00')).toBe(false); // offset hours 25
+    expect(isIsoTimestamp('2026-01-01T00:00:00+00:60')).toBe(false); // offset minutes 60
   });
 
   it('rejects zoneless and date-only forms (the regex requires a zone + time)', () => {

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -106,6 +106,9 @@ describe('runtime payload skeleton guards', () => {
     expect(isQuizAttemptSkeleton({ phase: 'graded', answers: {} })).toBe(false); // bad phase
     expect(isQuizAttemptSkeleton({ phase: 'draft', answers: [] })).toBe(false); // array, not object
     expect(isQuizAttemptSkeleton({ phase: 'draft', answers: null })).toBe(false); // null answers
+    expect(isQuizAttemptSkeleton({ phase: 'draft', answers: new Map() })).toBe(false); // Map, not a plain record
+    expect(isQuizAttemptSkeleton({ phase: 'draft', answers: new Date() })).toBe(false); // class instance, not a plain record
+    expect(isQuizAttemptSkeleton({ phase: 'draft', answers: Object.create(null) })).toBe(true); // null-prototype plain record
     expect(isQuizAttemptSkeleton({ phase: 'draft' })).toBe(false); // missing answers
     expect(isQuizAttemptSkeleton(null)).toBe(false);
   });

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -5,14 +5,17 @@ import {
   DSL_VERSION,
   QUIZ_ATTEMPT_PHASES,
   RUNTIME_SESSION_STATUSES,
+  isChatMessageSkeleton,
   isChatRuntimeRole,
   isCoreRuntimeKind,
   isQuizAttemptPhase,
+  isQuizAttemptSkeleton,
   isRuntimeSessionStatus,
   migrate,
   type ChatMessageSkeleton,
   type QuizAttemptSkeleton,
   type RuntimeRecord,
+  type RuntimeRecordInit,
   type RuntimeSession,
 } from '@openmaic/dsl';
 
@@ -71,6 +74,40 @@ describe('runtime envelope shapes (compile-time contract)', () => {
       payload: { phase: 'submitted', answers: { q1: 'A' } },
     };
     expect(quiz.payload.phase).toBe('submitted');
+  });
+
+  it('lets a producer construct a RuntimeRecordInit without a store-assigned seq', () => {
+    // Compile-time contract: `seq` is store-owned, so the creation shape omits
+    // it. Supplying `seq` here would be a type error; leaving it out type-checks.
+    const init: RuntimeRecordInit<ChatMessageSkeleton> = {
+      id: 'r1',
+      sessionId: 's1',
+      createdAt: '2026-01-01T00:00:01.000Z',
+      payload: { role: 'assistant', content: 'hi' },
+    };
+    expect(init.id).toBe('r1');
+  });
+});
+
+describe('runtime payload skeleton guards', () => {
+  it('narrows chat message skeletons and rejects malformed ones', () => {
+    expect(isChatMessageSkeleton({ role: 'user', content: 'hi' })).toBe(true);
+    expect(isChatMessageSkeleton({ role: 'assistant', content: '' })).toBe(true);
+    expect(isChatMessageSkeleton({ role: 'tool', content: 'hi' })).toBe(false); // bad role
+    expect(isChatMessageSkeleton({ role: 'user', content: 42 })).toBe(false); // non-string
+    expect(isChatMessageSkeleton({ role: 'user' })).toBe(false); // missing content
+    expect(isChatMessageSkeleton(null)).toBe(false);
+    expect(isChatMessageSkeleton('user')).toBe(false);
+  });
+
+  it('narrows quiz attempt skeletons and rejects malformed ones', () => {
+    expect(isQuizAttemptSkeleton({ phase: 'draft', answers: {} })).toBe(true);
+    expect(isQuizAttemptSkeleton({ phase: 'submitted', answers: { q1: 'A' } })).toBe(true);
+    expect(isQuizAttemptSkeleton({ phase: 'graded', answers: {} })).toBe(false); // bad phase
+    expect(isQuizAttemptSkeleton({ phase: 'draft', answers: [] })).toBe(false); // array, not object
+    expect(isQuizAttemptSkeleton({ phase: 'draft', answers: null })).toBe(false); // null answers
+    expect(isQuizAttemptSkeleton({ phase: 'draft' })).toBe(false); // missing answers
+    expect(isQuizAttemptSkeleton(null)).toBe(false);
   });
 });
 

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -169,6 +169,8 @@ describe('isIsoTimestamp', () => {
 
   it('rejects field-range violations', () => {
     expect(isIsoTimestamp('2026-13-01T00:00:00Z')).toBe(false); // month 13
+    expect(isIsoTimestamp('2026-00-15T00:00:00Z')).toBe(false); // month 00
+    expect(isIsoTimestamp('2026-01-00T00:00:00Z')).toBe(false); // day 00
     expect(isIsoTimestamp('2026-01-01T25:00:00Z')).toBe(false); // hour 25
     expect(isIsoTimestamp('2026-01-01T24:00:00.000Z')).toBe(false); // hour 24 (no end-of-day form)
     expect(isIsoTimestamp('2026-01-01T00:60:00Z')).toBe(false); // minute 60

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it } from 'vitest';
 import {
   CHAT_RUNTIME_ROLES,
   CORE_RUNTIME_KINDS,
+  DSL_VERSION,
   QUIZ_ATTEMPT_PHASES,
   RUNTIME_SESSION_STATUSES,
   isChatRuntimeRole,
   isCoreRuntimeKind,
   isQuizAttemptPhase,
   isRuntimeSessionStatus,
+  migrate,
   type ChatMessageSkeleton,
   type QuizAttemptSkeleton,
   type RuntimeRecord,
   type RuntimeSession,
-} from '../src/index.js';
+} from '@openmaic/dsl';
 
 describe('runtime envelope guards', () => {
   it('accepts every declared session status and rejects others', () => {
@@ -69,5 +71,41 @@ describe('runtime envelope shapes (compile-time contract)', () => {
       payload: { phase: 'submitted', answers: { q1: 'A' } },
     };
     expect(quiz.payload.phase).toBe('submitted');
+  });
+});
+
+describe('runtime envelope rides the DSL version ladder', () => {
+  it('lifts an unversioned session to the current DSL_VERSION', () => {
+    // A RuntimeSession persisted before the `dslVersion` stamp existed: no
+    // envelope field, so `migrate` treats it as legacy/unversioned and walks it
+    // up the ladder, stamping the result — the session rides the same
+    // migrate-on-read path as a document.
+    const legacy: Omit<RuntimeSession, 'dslVersion'> = {
+      id: 's1',
+      kind: 'chat',
+      stageId: 'stage1',
+      learnerKey: 'anon:device-1',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const lifted = migrate(legacy) as RuntimeSession;
+    expect(lifted.dslVersion).toBe(DSL_VERSION);
+    // Migration is pure: the payload is carried through untouched, only stamped.
+    expect(lifted).toEqual({ ...legacy, dslVersion: DSL_VERSION });
+  });
+
+  it('leaves a current-version session untouched', () => {
+    const current: RuntimeSession = {
+      id: 's1',
+      kind: 'chat',
+      stageId: 'stage1',
+      learnerKey: 'anon:device-1',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      dslVersion: DSL_VERSION,
+    };
+    expect(migrate(current)).toEqual(current);
   });
 });

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -77,6 +77,35 @@ describe('runtime envelope shapes (compile-time contract)', () => {
     expect(quiz.payload.phase).toBe('submitted');
   });
 
+  it('requires runtimeDslVersion on a session at the type level (born stamped)', () => {
+    // The stamp is required: a session is born stamped and the runtime line has
+    // no unversioned epoch, so a directly-constructed session omitting it is a
+    // type error. (Envelope-view code operates over `RuntimeVersioned`, whose
+    // field stays optional; this required-ness is specific to `RuntimeSession`.)
+    // @ts-expect-error runtimeDslVersion is required on a RuntimeSession
+    const bad: RuntimeSession = {
+      id: 's1',
+      kind: 'chat',
+      stageId: 'stage1',
+      learnerKey: 'anon:device-1',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    void bad;
+    const good: RuntimeSession = {
+      id: 's1',
+      kind: 'chat',
+      stageId: 'stage1',
+      learnerKey: 'anon:device-1',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      runtimeDslVersion: RUNTIME_DSL_VERSION,
+    };
+    expect(good.runtimeDslVersion).toBe(RUNTIME_DSL_VERSION);
+  });
+
   it('excludes undefined from payload at the type level (aligns with the validator)', () => {
     // The validator rejects `payload: undefined`; the static type must agree, so
     // `undefined` is not assignable to the payload — this is a type error.
@@ -191,12 +220,13 @@ describe('isIsoTimestamp', () => {
 });
 
 describe('runtime envelope rides the dedicated runtime version ladder', () => {
-  it('lifts an unversioned session to the current RUNTIME_DSL_VERSION', () => {
-    // A RuntimeSession persisted before the `runtimeDslVersion` stamp existed:
-    // no envelope field, so `migrateRuntime` treats it as legacy/unversioned and
-    // walks it up the *runtime* ladder, stamping the result. Runtime state
-    // migrates on its own version line, not the document ladder.
-    const legacy: Omit<RuntimeSession, 'runtimeDslVersion'> = {
+  it('throws on an unstamped session — the runtime line has no unversioned epoch', () => {
+    // A session is born stamped (`runtimeDslVersion` is required, written at
+    // creation), so an object arriving WITHOUT the stamp is not legacy data to
+    // lift — it is a misrouted legacy document or an unstamped producer write.
+    // `migrateRuntime` fails loud rather than inventing a version, because the
+    // runtime line has no unversioned epoch (unlike the document line).
+    const unstamped: Omit<RuntimeSession, 'runtimeDslVersion'> = {
       id: 's1',
       kind: 'chat',
       stageId: 'stage1',
@@ -205,10 +235,7 @@ describe('runtime envelope rides the dedicated runtime version ladder', () => {
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
     };
-    const lifted = migrateRuntime(legacy) as RuntimeSession;
-    expect(lifted.runtimeDslVersion).toBe(RUNTIME_DSL_VERSION);
-    // Migration is pure: the payload is carried through untouched, only stamped.
-    expect(lifted).toEqual({ ...legacy, runtimeDslVersion: RUNTIME_DSL_VERSION });
+    expect(() => migrateRuntime(unstamped)).toThrow(/no unversioned epoch/);
   });
 
   it('leaves a current-version session untouched', () => {

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_RUNTIME_ROLES,
+  CORE_RUNTIME_KINDS,
+  QUIZ_ATTEMPT_PHASES,
+  RUNTIME_SESSION_STATUSES,
+  isChatRuntimeRole,
+  isCoreRuntimeKind,
+  isQuizAttemptPhase,
+  isRuntimeSessionStatus,
+  type ChatMessageSkeleton,
+  type QuizAttemptSkeleton,
+  type RuntimeRecord,
+  type RuntimeSession,
+} from '../src/index.js';
+
+describe('runtime envelope guards', () => {
+  it('accepts every declared session status and rejects others', () => {
+    for (const s of RUNTIME_SESSION_STATUSES) expect(isRuntimeSessionStatus(s)).toBe(true);
+    expect(isRuntimeSessionStatus('paused')).toBe(false);
+    expect(isRuntimeSessionStatus(undefined)).toBe(false);
+    expect(isRuntimeSessionStatus(1)).toBe(false);
+  });
+
+  it('accepts every core kind and rejects app-defined kinds', () => {
+    expect(CORE_RUNTIME_KINDS).toEqual(['chat', 'quizAttempt', 'playback']);
+    for (const k of CORE_RUNTIME_KINDS) expect(isCoreRuntimeKind(k)).toBe(true);
+    expect(isCoreRuntimeKind('myWidget')).toBe(false);
+  });
+
+  it('accepts every chat role and quiz phase', () => {
+    for (const r of CHAT_RUNTIME_ROLES) expect(isChatRuntimeRole(r)).toBe(true);
+    expect(isChatRuntimeRole('tool')).toBe(false);
+    for (const p of QUIZ_ATTEMPT_PHASES) expect(isQuizAttemptPhase(p)).toBe(true);
+    expect(isQuizAttemptPhase('graded')).toBe(false);
+  });
+});
+
+describe('runtime envelope shapes (compile-time contract)', () => {
+  it('a session owns identity/lifecycle; a record owns ordering/anchoring/payload', () => {
+    const session: RuntimeSession = {
+      id: 's1',
+      kind: 'chat',
+      stageId: 'stage1',
+      learnerKey: 'anon:device-1',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      dslVersion: '0.1.0',
+    };
+    const record: RuntimeRecord<ChatMessageSkeleton> = {
+      id: 'r1',
+      sessionId: session.id,
+      seq: 0,
+      sceneId: 'scene1',
+      actionIndex: 3,
+      createdAt: '2026-01-01T00:00:01.000Z',
+      payload: { role: 'user', content: 'hello' },
+    };
+    expect(record.sessionId).toBe(session.id);
+    expect(record.payload.role).toBe('user');
+    const quiz: RuntimeRecord<QuizAttemptSkeleton> = {
+      id: 'r2',
+      sessionId: 's2',
+      seq: 0,
+      sceneId: 'scene2',
+      subAnchor: 'question-3',
+      createdAt: '2026-01-01T00:00:02.000Z',
+      payload: { phase: 'submitted', answers: { q1: 'A' } },
+    };
+    expect(quiz.payload.phase).toBe('submitted');
+  });
+});

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   CHAT_RUNTIME_ROLES,
   CORE_RUNTIME_KINDS,
-  DSL_VERSION,
   QUIZ_ATTEMPT_PHASES,
+  RUNTIME_DSL_VERSION,
   RUNTIME_SESSION_STATUSES,
   isChatMessageSkeleton,
   isChatRuntimeRole,
@@ -11,7 +11,7 @@ import {
   isQuizAttemptPhase,
   isQuizAttemptSkeleton,
   isRuntimeSessionStatus,
-  migrate,
+  migrateRuntime,
   type ChatMessageSkeleton,
   type QuizAttemptSkeleton,
   type RuntimeRecord,
@@ -76,6 +76,38 @@ describe('runtime envelope shapes (compile-time contract)', () => {
     expect(quiz.payload.phase).toBe('submitted');
   });
 
+  it('excludes undefined from payload at the type level (aligns with the validator)', () => {
+    // The validator rejects `payload: undefined`; the static type must agree, so
+    // `undefined` is not assignable to the payload — this is a type error.
+    const bad: RuntimeRecord = {
+      id: 'r1',
+      sessionId: 's1',
+      seq: 0,
+      createdAt: '2026-01-01T00:00:01.000Z',
+      // @ts-expect-error payload cannot be undefined (RuntimePayload excludes it)
+      payload: undefined,
+    };
+    void bad;
+    // `null` stays a legal stored payload (the validator accepts it too).
+    const withNull: RuntimeRecord = {
+      id: 'r2',
+      sessionId: 's1',
+      seq: 0,
+      createdAt: '2026-01-01T00:00:01.000Z',
+      payload: null,
+    };
+    expect(withNull.payload).toBe(null);
+    // The init shape inherits the same constraint via Omit.
+    const initBad: RuntimeRecordInit = {
+      id: 'r3',
+      sessionId: 's1',
+      createdAt: '2026-01-01T00:00:01.000Z',
+      // @ts-expect-error payload cannot be undefined on the init shape either
+      payload: undefined,
+    };
+    void initBad;
+  });
+
   it('lets a producer construct a RuntimeRecordInit without a store-assigned seq', () => {
     // Compile-time contract: `seq` is store-owned, so the creation shape omits
     // it. Supplying `seq` here would be a type error; leaving it out type-checks.
@@ -114,12 +146,12 @@ describe('runtime payload skeleton guards', () => {
   });
 });
 
-describe('runtime envelope rides the DSL version ladder', () => {
-  it('lifts an unversioned session to the current DSL_VERSION', () => {
+describe('runtime envelope rides the dedicated runtime version ladder', () => {
+  it('lifts an unversioned session to the current RUNTIME_DSL_VERSION', () => {
     // A RuntimeSession persisted before the `dslVersion` stamp existed: no
-    // envelope field, so `migrate` treats it as legacy/unversioned and walks it
-    // up the ladder, stamping the result — the session rides the same
-    // migrate-on-read path as a document.
+    // envelope field, so `migrateRuntime` treats it as legacy/unversioned and
+    // walks it up the *runtime* ladder, stamping the result. Runtime state
+    // migrates on its own version line, not the document ladder.
     const legacy: Omit<RuntimeSession, 'dslVersion'> = {
       id: 's1',
       kind: 'chat',
@@ -129,10 +161,10 @@ describe('runtime envelope rides the DSL version ladder', () => {
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
     };
-    const lifted = migrate(legacy) as RuntimeSession;
-    expect(lifted.dslVersion).toBe(DSL_VERSION);
+    const lifted = migrateRuntime(legacy) as RuntimeSession;
+    expect(lifted.dslVersion).toBe(RUNTIME_DSL_VERSION);
     // Migration is pure: the payload is carried through untouched, only stamped.
-    expect(lifted).toEqual({ ...legacy, dslVersion: DSL_VERSION });
+    expect(lifted).toEqual({ ...legacy, dslVersion: RUNTIME_DSL_VERSION });
   });
 
   it('leaves a current-version session untouched', () => {
@@ -144,8 +176,8 @@ describe('runtime envelope rides the DSL version ladder', () => {
       status: 'active',
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
-      dslVersion: DSL_VERSION,
+      dslVersion: RUNTIME_DSL_VERSION,
     };
-    expect(migrate(current)).toEqual(current);
+    expect(migrateRuntime(current)).toEqual(current);
   });
 });

--- a/packages/@openmaic/dsl/test/runtime.test.ts
+++ b/packages/@openmaic/dsl/test/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   isChatMessageSkeleton,
   isChatRuntimeRole,
   isCoreRuntimeKind,
+  isIsoTimestamp,
   isQuizAttemptPhase,
   isQuizAttemptSkeleton,
   isRuntimeSessionStatus,
@@ -51,7 +52,7 @@ describe('runtime envelope shapes (compile-time contract)', () => {
       status: 'active',
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
-      dslVersion: '0.1.0',
+      runtimeDslVersion: '0.1.0',
     };
     const record: RuntimeRecord<ChatMessageSkeleton> = {
       id: 'r1',
@@ -146,13 +147,44 @@ describe('runtime payload skeleton guards', () => {
   });
 });
 
+describe('isIsoTimestamp', () => {
+  it('accepts well-formed zoned timestamps', () => {
+    expect(isIsoTimestamp('2026-01-01T00:00:00Z')).toBe(true);
+    expect(isIsoTimestamp('2026-01-01T00:00:00.000Z')).toBe(true); // fractional seconds
+    expect(isIsoTimestamp('2026-01-01T08:00:00+08:00')).toBe(true); // offset form
+    expect(isIsoTimestamp('2024-02-29T00:00:00Z')).toBe(true); // real leap day
+  });
+
+  it('rejects day-of-month overflow that Date.parse normalizes instead of failing', () => {
+    // V8 rolls these into the next month rather than returning NaN; the explicit
+    // day round-trip is what rejects them, engine-independently.
+    expect(isIsoTimestamp('2026-02-30T00:00:00.000Z')).toBe(false);
+    expect(isIsoTimestamp('2026-02-29T00:00:00Z')).toBe(false); // 2026 is not a leap year
+    expect(isIsoTimestamp('2026-04-31T00:00:00Z')).toBe(false); // April has 30 days
+  });
+
+  it('rejects field-range violations (Date.parse yields NaN)', () => {
+    expect(isIsoTimestamp('2026-13-01T00:00:00Z')).toBe(false); // month 13
+    expect(isIsoTimestamp('2026-01-01T25:00:00Z')).toBe(false); // hour 25
+    expect(isIsoTimestamp('2026-01-01T00:60:00Z')).toBe(false); // minute 60
+    expect(isIsoTimestamp('2026-01-01T00:00:60Z')).toBe(false); // second 60
+  });
+
+  it('rejects zoneless and date-only forms (the regex requires a zone + time)', () => {
+    expect(isIsoTimestamp('2026-01-01T00:00:00')).toBe(false); // no zone designator
+    expect(isIsoTimestamp('2026-01-01')).toBe(false); // date only
+    expect(isIsoTimestamp('2026/01/01T00:00:00Z')).toBe(false); // wrong separators
+    expect(isIsoTimestamp('not-a-date')).toBe(false);
+  });
+});
+
 describe('runtime envelope rides the dedicated runtime version ladder', () => {
   it('lifts an unversioned session to the current RUNTIME_DSL_VERSION', () => {
-    // A RuntimeSession persisted before the `dslVersion` stamp existed: no
-    // envelope field, so `migrateRuntime` treats it as legacy/unversioned and
+    // A RuntimeSession persisted before the `runtimeDslVersion` stamp existed:
+    // no envelope field, so `migrateRuntime` treats it as legacy/unversioned and
     // walks it up the *runtime* ladder, stamping the result. Runtime state
     // migrates on its own version line, not the document ladder.
-    const legacy: Omit<RuntimeSession, 'dslVersion'> = {
+    const legacy: Omit<RuntimeSession, 'runtimeDslVersion'> = {
       id: 's1',
       kind: 'chat',
       stageId: 'stage1',
@@ -162,9 +194,9 @@ describe('runtime envelope rides the dedicated runtime version ladder', () => {
       updatedAt: '2026-01-01T00:00:00.000Z',
     };
     const lifted = migrateRuntime(legacy) as RuntimeSession;
-    expect(lifted.dslVersion).toBe(RUNTIME_DSL_VERSION);
+    expect(lifted.runtimeDslVersion).toBe(RUNTIME_DSL_VERSION);
     // Migration is pure: the payload is carried through untouched, only stamped.
-    expect(lifted).toEqual({ ...legacy, dslVersion: RUNTIME_DSL_VERSION });
+    expect(lifted).toEqual({ ...legacy, runtimeDslVersion: RUNTIME_DSL_VERSION });
   });
 
   it('leaves a current-version session untouched', () => {
@@ -176,7 +208,7 @@ describe('runtime envelope rides the dedicated runtime version ladder', () => {
       status: 'active',
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
-      dslVersion: RUNTIME_DSL_VERSION,
+      runtimeDslVersion: RUNTIME_DSL_VERSION,
     };
     expect(migrateRuntime(current)).toEqual(current);
   });

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -83,7 +83,7 @@ describe('validateAction', () => {
     expect(errors(r)).toContain('/type');
   });
   it('flags a known action type missing a variant-required field', () => {
-    // cosarah's example: a spotlight with no elementId is unusable at runtime.
+    // A spotlight with no elementId is unusable at runtime.
     const r = validateAction({ id: 'a', type: 'spotlight' });
     expect(errors(r)).toContain('/elementId');
     const d = validateAction({ id: 'a', type: 'discussion' });
@@ -176,6 +176,36 @@ describe('validateRuntimeSession', () => {
     if (result.valid) throw new Error('unreachable');
     expect(result.errors.map((e) => e.path)).toContain('/learnerKey');
   });
+
+  it('rejects a non-ISO-8601 createdAt / updatedAt (contract says ISO 8601)', () => {
+    // These pass the `typeof === 'string'` table check but are not timestamps;
+    // the contract docs call them ISO 8601, so a bare string is not enough.
+    const bad = validateRuntimeSession({
+      ...good,
+      createdAt: 'not-a-date',
+      updatedAt: 'still-bad',
+    });
+    expect(bad.valid).toBe(false);
+    if (bad.valid) throw new Error('unreachable');
+    const paths = bad.errors.map((e) => e.path);
+    expect(paths).toContain('/createdAt');
+    expect(paths).toContain('/updatedAt');
+  });
+
+  it('rejects a calendar-impossible ISO date (month 13)', () => {
+    // Well-formed shape but not a real date: the regex alone would accept it,
+    // so `Date.parse` calendar validity is what rejects it.
+    const r = validateRuntimeSession({ ...good, createdAt: '2026-13-01T00:00:00.000Z' });
+    expect(r.valid).toBe(false);
+    if (r.valid) throw new Error('unreachable');
+    expect(r.errors.map((e) => e.path)).toContain('/createdAt');
+  });
+
+  it('accepts an ISO-8601 offset timestamp form', () => {
+    expect(validateRuntimeSession({ ...good, createdAt: '2026-01-01T08:00:00+08:00' })).toEqual({
+      valid: true,
+    });
+  });
 });
 
 describe('validateRuntimeRecord', () => {
@@ -255,5 +285,20 @@ describe('validateRuntimeRecord', () => {
     for (const p of ['/id', '/sessionId', '/seq', '/createdAt', '/payload']) {
       expect(paths).toContain(p);
     }
+  });
+
+  it('rejects a non-ISO-8601 createdAt (contract says ISO 8601)', () => {
+    const r = validateRuntimeRecord({ ...good, createdAt: 'not-a-date' });
+    expect(r.valid).toBe(false);
+    if (r.valid) throw new Error('unreachable');
+    expect(r.errors.map((e) => e.path)).toContain('/createdAt');
+    // A calendar-impossible but well-formed date is rejected too (Date.parse).
+    expect(validateRuntimeRecord({ ...good, createdAt: '2026-13-01T00:00:00.000Z' }).valid).toBe(
+      false,
+    );
+    // An offset form is accepted.
+    expect(validateRuntimeRecord({ ...good, createdAt: '2026-01-01T08:00:00+08:00' })).toEqual({
+      valid: true,
+    });
   });
 });

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { validateStage, validateScene, validateAction, type ValidationResult } from '@openmaic/dsl';
+import {
+  validateStage,
+  validateScene,
+  validateAction,
+  validateRuntimeSession,
+  validateRuntimeRecord,
+  type ValidationResult,
+} from '@openmaic/dsl';
 
 function errors(r: ValidationResult): string[] {
   return r.valid ? [] : r.errors.map((e) => e.path);
@@ -90,5 +97,106 @@ describe('validateAction', () => {
   it('requires a string id', () => {
     const r = validateAction({ type: 'laser', elementId: 'e' });
     expect(errors(r)).toContain('/id');
+  });
+});
+
+describe('validateRuntimeSession', () => {
+  const good = {
+    id: 's1',
+    kind: 'chat',
+    stageId: 'stage1',
+    learnerKey: 'anon:device-1',
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('accepts a minimal valid session', () => {
+    expect(validateRuntimeSession(good)).toEqual({ valid: true });
+  });
+
+  it('accepts an app-defined kind and an optional dslVersion', () => {
+    expect(validateRuntimeSession({ ...good, kind: 'myWidget', dslVersion: '0.1.0' })).toEqual({
+      valid: true,
+    });
+  });
+
+  it('rejects non-objects', () => {
+    const result = validateRuntimeSession(null);
+    expect(result.valid).toBe(false);
+  });
+
+  it('reports every missing required field with a path', () => {
+    const result = validateRuntimeSession({});
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    const paths = result.errors.map((e) => e.path);
+    for (const p of [
+      '/id',
+      '/kind',
+      '/stageId',
+      '/learnerKey',
+      '/status',
+      '/createdAt',
+      '/updatedAt',
+    ]) {
+      expect(paths).toContain(p);
+    }
+  });
+
+  it('rejects an unknown status value', () => {
+    const result = validateRuntimeSession({ ...good, status: 'paused' });
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    expect(result.errors[0].path).toBe('/status');
+  });
+
+  it('rejects a non-string dslVersion', () => {
+    const result = validateRuntimeSession({ ...good, dslVersion: 1 });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateRuntimeRecord', () => {
+  const good = {
+    id: 'r1',
+    sessionId: 's1',
+    seq: 0,
+    createdAt: '2026-01-01T00:00:01.000Z',
+    payload: { role: 'user', content: 'hi' },
+  };
+
+  it('accepts a minimal valid record (payload is opaque)', () => {
+    expect(validateRuntimeRecord(good)).toEqual({ valid: true });
+  });
+
+  it('accepts optional anchors of the right shape', () => {
+    expect(
+      validateRuntimeRecord({ ...good, sceneId: 'sc1', actionIndex: 2, subAnchor: 'q3' }),
+    ).toEqual({ valid: true });
+  });
+
+  it('rejects a record with no payload key', () => {
+    const { payload: _payload, ...rest } = good;
+    const result = validateRuntimeRecord(rest);
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    expect(result.errors.map((e) => e.path)).toContain('/payload');
+  });
+
+  it('rejects wrongly-typed optional anchors', () => {
+    expect(validateRuntimeRecord({ ...good, actionIndex: 'x' }).valid).toBe(false);
+    expect(validateRuntimeRecord({ ...good, sceneId: 5 }).valid).toBe(false);
+    expect(validateRuntimeRecord({ ...good, subAnchor: 5 }).valid).toBe(false);
+  });
+
+  it('rejects missing required fields with paths', () => {
+    const result = validateRuntimeRecord({});
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    const paths = result.errors.map((e) => e.path);
+    for (const p of ['/id', '/sessionId', '/seq', '/createdAt', '/payload']) {
+      expect(paths).toContain(p);
+    }
   });
 });

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -115,8 +115,10 @@ describe('validateRuntimeSession', () => {
     expect(validateRuntimeSession(good)).toEqual({ valid: true });
   });
 
-  it('accepts an app-defined kind and an optional dslVersion', () => {
-    expect(validateRuntimeSession({ ...good, kind: 'myWidget', dslVersion: '0.1.0' })).toEqual({
+  it('accepts an app-defined kind and an optional runtimeDslVersion', () => {
+    expect(
+      validateRuntimeSession({ ...good, kind: 'myWidget', runtimeDslVersion: '0.1.0' }),
+    ).toEqual({
       valid: true,
     });
   });
@@ -151,22 +153,42 @@ describe('validateRuntimeSession', () => {
     expect(result.errors[0].path).toBe('/status');
   });
 
-  it('rejects a non-string dslVersion', () => {
-    const result = validateRuntimeSession({ ...good, dslVersion: 1 });
+  it('rejects a non-string runtimeDslVersion', () => {
+    const result = validateRuntimeSession({ ...good, runtimeDslVersion: 1 });
     expect(result.valid).toBe(false);
   });
 
-  it('rejects a present-but-malformed dslVersion stamp', () => {
+  it('rejects a present-but-malformed runtimeDslVersion stamp', () => {
     // A well-formed string that is not `x.y.z` would pass the typeof check yet
-    // make `migrate`/`dslVersionOf` throw downstream — reject it at the door.
-    const result = validateRuntimeSession({ ...good, dslVersion: 'legacy' });
+    // make `migrateRuntime`/`runtimeDslVersionOf` throw downstream — reject it
+    // at the door.
+    const result = validateRuntimeSession({ ...good, runtimeDslVersion: 'legacy' });
     expect(result.valid).toBe(false);
     if (result.valid) throw new Error('unreachable');
-    expect(result.errors.map((e) => e.path)).toContain('/dslVersion');
+    expect(result.errors.map((e) => e.path)).toContain('/runtimeDslVersion');
   });
 
-  it('accepts a well-formed dslVersion stamp', () => {
-    expect(validateRuntimeSession({ ...good, dslVersion: '0.1.0' })).toEqual({ valid: true });
+  it('accepts a well-formed runtimeDslVersion stamp', () => {
+    expect(validateRuntimeSession({ ...good, runtimeDslVersion: '0.1.0' })).toEqual({
+      valid: true,
+    });
+  });
+
+  it('ignores a stray document-line dslVersion on a session (unknown field)', () => {
+    // A session versions on `runtimeDslVersion`; `dslVersion` is not part of its
+    // contract, so this structural-subset validator neither reads nor rejects
+    // it — even a value that would be malformed as a version stamp is ignored.
+    expect(validateRuntimeSession({ ...good, dslVersion: 'legacy' })).toEqual({ valid: true });
+  });
+
+  it('reports an empty-string createdAt exactly once, at /createdAt', () => {
+    // The required-field table already flags an empty string as non-empty; the
+    // ISO refinement must not fire a second error at the same path.
+    const result = validateRuntimeSession({ ...good, createdAt: '' });
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    const createdAtErrors = result.errors.filter((e) => e.path === '/createdAt');
+    expect(createdAtErrors).toHaveLength(1);
   });
 
   it('rejects an empty required string (learnerKey)', () => {

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -174,11 +174,27 @@ describe('validateRuntimeSession', () => {
     });
   });
 
-  it('ignores a stray document-line dslVersion on a session (unknown field)', () => {
-    // A session versions on `runtimeDslVersion`; `dslVersion` is not part of its
-    // contract, so this structural-subset validator neither reads nor rejects
-    // it — even a value that would be malformed as a version stamp is ignored.
-    expect(validateRuntimeSession({ ...good, dslVersion: 'legacy' })).toEqual({ valid: true });
+  it('rejects a stray document-line dslVersion on a session', () => {
+    // A session versions on `runtimeDslVersion`; `dslVersion` never belongs on
+    // its shape. This is the deliberate exception to the structural-subset rule:
+    // a stray sibling stamp is evidence of a misrouted migration, and once
+    // stored it makes the envelope ambiguous to the cross-line guard (which
+    // fails loud on own-stamp-absent + sibling-stamp-present) — so reject it at
+    // the door, whatever its value.
+    for (const stray of ['legacy', '0.1.0']) {
+      const result = validateRuntimeSession({ ...good, dslVersion: stray });
+      expect(result.valid).toBe(false);
+      if (result.valid) throw new Error('unreachable');
+      expect(result.errors.map((e) => e.path)).toContain('/dslVersion');
+    }
+    // Rejected even alongside a well-formed own-line stamp: a doubly-stamped
+    // session is equally the product of a misroute.
+    const doubly = validateRuntimeSession({
+      ...good,
+      runtimeDslVersion: '0.1.0',
+      dslVersion: '0.1.0',
+    });
+    expect(doubly.valid).toBe(false);
   });
 
   it('reports an empty-string createdAt exactly once, at /createdAt', () => {

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -109,18 +109,33 @@ describe('validateRuntimeSession', () => {
     status: 'active',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
+    // Required: sessions are born stamped, the runtime line has no unversioned epoch.
+    runtimeDslVersion: '0.1.0',
   };
 
   it('accepts a minimal valid session', () => {
     expect(validateRuntimeSession(good)).toEqual({ valid: true });
   });
 
-  it('accepts an app-defined kind and an optional runtimeDslVersion', () => {
+  it('accepts an app-defined kind alongside the required runtimeDslVersion', () => {
     expect(
       validateRuntimeSession({ ...good, kind: 'myWidget', runtimeDslVersion: '0.1.0' }),
     ).toEqual({
       valid: true,
     });
+  });
+
+  it('rejects a session missing runtimeDslVersion, reported once at /runtimeDslVersion', () => {
+    // The stamp is required now: an absent one is a bug (a misrouted legacy
+    // document or an unstamped producer write), not legacy data to lift, since
+    // the runtime line has no unversioned epoch. Reported exactly once.
+    const { runtimeDslVersion: _v, ...noStamp } = good;
+    const result = validateRuntimeSession(noStamp);
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    const stampErrors = result.errors.filter((e) => e.path === '/runtimeDslVersion');
+    expect(stampErrors).toHaveLength(1);
+    expect(stampErrors[0].message).toMatch(/missing/);
   });
 
   it('rejects non-objects', () => {
@@ -141,6 +156,8 @@ describe('validateRuntimeSession', () => {
       '/status',
       '/createdAt',
       '/updatedAt',
+      // Required now: an empty session is missing the runtime stamp too.
+      '/runtimeDslVersion',
     ]) {
       expect(paths).toContain(p);
     }

--- a/packages/@openmaic/dsl/test/validate.test.ts
+++ b/packages/@openmaic/dsl/test/validate.test.ts
@@ -155,6 +155,27 @@ describe('validateRuntimeSession', () => {
     const result = validateRuntimeSession({ ...good, dslVersion: 1 });
     expect(result.valid).toBe(false);
   });
+
+  it('rejects a present-but-malformed dslVersion stamp', () => {
+    // A well-formed string that is not `x.y.z` would pass the typeof check yet
+    // make `migrate`/`dslVersionOf` throw downstream — reject it at the door.
+    const result = validateRuntimeSession({ ...good, dslVersion: 'legacy' });
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    expect(result.errors.map((e) => e.path)).toContain('/dslVersion');
+  });
+
+  it('accepts a well-formed dslVersion stamp', () => {
+    expect(validateRuntimeSession({ ...good, dslVersion: '0.1.0' })).toEqual({ valid: true });
+  });
+
+  it('rejects an empty required string (learnerKey)', () => {
+    // `''` passes typeof but is useless as a partition key.
+    const result = validateRuntimeSession({ ...good, learnerKey: '' });
+    expect(result.valid).toBe(false);
+    if (result.valid) throw new Error('unreachable');
+    expect(result.errors.map((e) => e.path)).toContain('/learnerKey');
+  });
 });
 
 describe('validateRuntimeRecord', () => {
@@ -182,6 +203,42 @@ describe('validateRuntimeRecord', () => {
     expect(result.valid).toBe(false);
     if (result.valid) throw new Error('unreachable');
     expect(result.errors.map((e) => e.path)).toContain('/payload');
+  });
+
+  it('rejects an explicit `payload: undefined` but accepts a null payload', () => {
+    // `'payload' in doc` would pass an explicit-undefined; require a real value.
+    // `null` stays legal — it is a value the app may have deliberately stored.
+    const undef = validateRuntimeRecord({ ...good, payload: undefined });
+    expect(undef.valid).toBe(false);
+    if (undef.valid) throw new Error('unreachable');
+    expect(undef.errors.map((e) => e.path)).toContain('/payload');
+    expect(validateRuntimeRecord({ ...good, payload: null })).toEqual({ valid: true });
+  });
+
+  it('rejects a seq that is not a non-negative integer', () => {
+    // `seq` is the sole replay ordering key; NaN/Infinity/negative/fractional
+    // all pass `typeof === "number"` but would corrupt ordering.
+    for (const seq of [Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5]) {
+      const r = validateRuntimeRecord({ ...good, seq });
+      expect(r.valid).toBe(false);
+      if (r.valid) throw new Error('unreachable');
+      expect(r.errors.map((e) => e.path)).toContain('/seq');
+    }
+    expect(validateRuntimeRecord({ ...good, seq: 0 })).toEqual({ valid: true });
+  });
+
+  it('rejects a negative optional actionIndex', () => {
+    const r = validateRuntimeRecord({ ...good, actionIndex: -1 });
+    expect(r.valid).toBe(false);
+    if (r.valid) throw new Error('unreachable');
+    expect(r.errors.map((e) => e.path)).toContain('/actionIndex');
+  });
+
+  it('rejects an empty required string (id)', () => {
+    const r = validateRuntimeRecord({ ...good, id: '' });
+    expect(r.valid).toBe(false);
+    if (r.valid) throw new Error('unreachable');
+    expect(r.errors.map((e) => e.path)).toContain('/id');
   });
 
   it('rejects wrongly-typed optional anchors', () => {

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -169,14 +169,26 @@ describe('needsRuntimeMigration', () => {
     expect(needsRuntimeMigration({ id: 'legacy' })).toBe(true);
     expect(needsRuntimeMigration({ [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION })).toBe(false);
     expect(needsRuntimeMigration({ [RUNTIME_DSL_VERSION_KEY]: '99.0.0' })).toBe(false);
-    // A document-line stamp does not satisfy the runtime predicate.
-    expect(needsRuntimeMigration({ [DSL_VERSION_KEY]: RUNTIME_DSL_VERSION })).toBe(true);
   });
   it('agrees with migrateRuntime on non-objects (loop terminates)', () => {
     for (const v of [42, null, undefined, 'x', []]) {
       expect(needsRuntimeMigration(v)).toBe(false);
       expect(needsRuntimeMigration(migrateRuntime(v))).toBe(false);
     }
+  });
+  it('is false for a misrouted document-line aggregate (mirrors the runner guard)', () => {
+    // migrateRuntime returns a document-stamped object untouched (cross-line
+    // guard), so the predicate must not report it as needing migration — a
+    // `while (needsRuntimeMigration(x)) x = migrateRuntime(x)` loop would
+    // otherwise never terminate.
+    const doc = { [DSL_VERSION_KEY]: DSL_VERSION, id: 'doc' };
+    expect(needsRuntimeMigration(doc)).toBe(false);
+    expect(migrateRuntime(doc)).toBe(doc);
+    // Doubly-stamped data is the runtime line's own: predicate and runner both
+    // act on the runtime stamp as usual.
+    expect(
+      needsRuntimeMigration({ [DSL_VERSION_KEY]: DSL_VERSION, [RUNTIME_DSL_VERSION_KEY]: '0.0.0' }),
+    ).toBe(true);
   });
 });
 
@@ -214,6 +226,15 @@ describe('needsMigration', () => {
   });
   it('throws on a malformed stamp rather than silently reporting no migration', () => {
     expect(() => needsMigration({ [DSL_VERSION_KEY]: '0.1.0-beta' })).toThrow(/invalid dslVersion/);
+  });
+  it('is false for a misrouted runtime-line aggregate (mirrors the runner guard)', () => {
+    // migrate returns a runtime-stamped session untouched (cross-line guard),
+    // so the predicate must not report it as needing migration — a
+    // `while (needsMigration(x)) x = migrate(x)` loop would otherwise never
+    // terminate.
+    const session = { [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION, id: 's' };
+    expect(needsMigration(session)).toBe(false);
+    expect(migrate(session)).toBe(session);
   });
 });
 

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -37,35 +37,59 @@ describe('DSL_MIGRATIONS ladder invariants', () => {
 });
 
 describe('RUNTIME_DSL_MIGRATIONS ladder invariants', () => {
-  it('is a contiguous chain ending at RUNTIME_DSL_VERSION', () => {
-    // The runtime ladder is a *separate* version line from the document ladder
-    // (they version independent serialized shapes), but obeys the same
-    // contiguity + terminal-endpoint invariants.
-    expect(RUNTIME_DSL_MIGRATIONS.length).toBeGreaterThan(0);
+  it('is empty today — the runtime line has no unversioned epoch to lift from', () => {
+    // Unlike the document ladder, the runtime ladder ships EMPTY: the runtime
+    // envelope is brand new (nothing legitimately predates it), so there is no
+    // legacy-lift first entry. It stays a valid, fully-functional ladder — an
+    // empty ladder just means every stamped-current session is already at the
+    // target and no walk is needed.
+    expect(RUNTIME_DSL_MIGRATIONS.length).toBe(0);
+  });
+
+  it('IF non-empty (future), is a contiguous chain ending at RUNTIME_DSL_VERSION', () => {
+    // Guards the invariant the *first real* runtime shape change must satisfy:
+    // a contiguous chain whose last `to` reaches RUNTIME_DSL_VERSION. Vacuously
+    // true while empty; becomes a real check the moment a step is appended.
     for (let i = 1; i < RUNTIME_DSL_MIGRATIONS.length; i++) {
       expect(RUNTIME_DSL_MIGRATIONS[i].from).toBe(RUNTIME_DSL_MIGRATIONS[i - 1].to);
     }
-    expect(RUNTIME_DSL_MIGRATIONS[RUNTIME_DSL_MIGRATIONS.length - 1].to).toBe(RUNTIME_DSL_VERSION);
-  });
-
-  it('begins by lifting legacy (unversioned) runtime data', () => {
-    expect(RUNTIME_DSL_MIGRATIONS[0].from).toBe(UNVERSIONED_DSL_VERSION);
+    if (RUNTIME_DSL_MIGRATIONS.length > 0) {
+      expect(RUNTIME_DSL_MIGRATIONS[RUNTIME_DSL_MIGRATIONS.length - 1].to).toBe(
+        RUNTIME_DSL_VERSION,
+      );
+    }
   });
 });
 
 describe('migrateRuntime', () => {
-  it('stamps legacy runtime data onto runtimeDslVersion, not the document key', () => {
-    const out = migrateRuntime({ id: 'sess' }) as Record<string, unknown>;
-    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
-    // The runtime line never touches the document envelope field.
-    expect(out[DSL_VERSION_KEY]).toBeUndefined();
+  it('throws on an unstamped object — the runtime line has no unversioned epoch', () => {
+    // Unlike the document line, an unstamped object is NOT legacy data to lift:
+    // sessions are born stamped, so this is a misrouted legacy document or an
+    // unstamped producer write — fail loud instead of inventing a version.
+    expect(() => migrateRuntime({ id: 'sess' })).toThrow(/no unversioned epoch/);
   });
 
-  it('is idempotent and returns non-objects unchanged', () => {
-    const once = migrateRuntime({ id: 's' });
+  it('is idempotent on a stamped-current session and returns non-objects unchanged', () => {
+    // An already-current (stamped) session early-returns by reference — the
+    // empty ladder needs no walk once the object is at the target version.
+    const once = { id: 's', [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION };
     expect(migrateRuntime(once)).toBe(once);
+    expect(migrateRuntime(migrateRuntime(once))).toBe(once);
+    // Non-objects are not migratable aggregates: returned as-is on every line,
+    // never subject to the no-epoch throw.
     expect(migrateRuntime(42)).toBe(42);
     expect(migrateRuntime(null)).toBe(null);
+  });
+
+  it('stamps only the runtime envelope field, never the document key', () => {
+    // A doubly-stamped-free session at the current version keeps the runtime
+    // stamp and never grows a `dslVersion`.
+    const out = migrateRuntime({
+      id: 'sess',
+      [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION,
+    }) as Record<string, unknown>;
+    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    expect(out[DSL_VERSION_KEY]).toBeUndefined();
   });
 
   it('leaves a forward-versioned runtime document untouched', () => {
@@ -75,7 +99,8 @@ describe('migrateRuntime', () => {
 
   it('fails loud when the ladder has no path from the runtime version', () => {
     // A runtime version older than RUNTIME_DSL_VERSION with no matching `from`
-    // entry — mirrors the document ladder's unbridgeable-stamp case.
+    // entry — with an empty ladder, ANY stamped-older version hits this. Mirrors
+    // the document ladder's unbridgeable-stamp case.
     expect(() => migrateRuntime({ id: 's', [RUNTIME_DSL_VERSION_KEY]: '0.0.5' })).toThrow(
       /no migration path/,
     );
@@ -127,26 +152,35 @@ describe('cross-line guard (ambiguous envelopes fail loud, not reinterpreted)', 
     expect(migratedRuntime[DSL_VERSION_KEY]).toBe(DSL_VERSION);
   });
 
-  it('an object with NEITHER stamp still gets the legacy lift on both runners', () => {
-    // Case (2): both stamps absent → genuine legacy data, walk the own ladder
-    // as before. The guard must NOT intercept this: each runner lifts it onto
-    // its own line.
+  it('an object with NEITHER stamp: document line lifts it, runtime line throws (no epoch)', () => {
+    // Case (2), but the two lines diverge here. The document line HAS an
+    // unversioned epoch → genuine legacy data, lifted onto its own ladder. The
+    // runtime line has NO unversioned epoch → an unstamped object is a misrouted
+    // legacy document or an unstamped producer write, so it fails loud instead.
     const legacy = { id: 'z', name: 'course' };
     const lifted = migrate(legacy) as Record<string, unknown>;
     expect(lifted[DSL_VERSION_KEY]).toBe(DSL_VERSION);
     expect(lifted[RUNTIME_DSL_VERSION_KEY]).toBeUndefined();
     expect(lifted.name).toBe('course');
 
-    const liftedRuntime = migrateRuntime(legacy) as Record<string, unknown>;
-    expect(liftedRuntime[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
-    expect(liftedRuntime[DSL_VERSION_KEY]).toBeUndefined();
-    expect(liftedRuntime.name).toBe('course');
+    expect(() => migrateRuntime(legacy)).toThrow(/no unversioned epoch/);
   });
 });
 
 describe('runtimeDslVersionOf', () => {
   it('reads a stamped runtime version', () => {
     expect(runtimeDslVersionOf({ [RUNTIME_DSL_VERSION_KEY]: '9.9.9' })).toBe('9.9.9');
+  });
+  it('throws on an unstamped object (no unversioned epoch)', () => {
+    // The runtime line has no legacy epoch, so an unstamped object does not read
+    // as `0.0.0` here — it throws, matching migrateRuntime / needsRuntimeMigration.
+    expect(() => runtimeDslVersionOf({ id: 'x' })).toThrow(/no unversioned epoch/);
+  });
+  it('reads non-objects as unversioned (not migratable aggregates)', () => {
+    // Non-objects are exempt from the no-epoch throw on every line — they are not
+    // migratable aggregates and read as the unversioned sentinel.
+    expect(runtimeDslVersionOf(null)).toBe(UNVERSIONED_DSL_VERSION);
+    expect(runtimeDslVersionOf('nope')).toBe(UNVERSIONED_DSL_VERSION);
   });
   it('throws on an ambiguous document-stamped envelope (authoritative read)', () => {
     // Reading this as unversioned would report `0.0.0` for data migrateRuntime
@@ -163,8 +197,12 @@ describe('runtimeDslVersionOf', () => {
 });
 
 describe('needsRuntimeMigration', () => {
-  it('is true for unstamped sessions and false at/ahead of the current version', () => {
-    expect(needsRuntimeMigration({ id: 'legacy' })).toBe(true);
+  it('throws on an unstamped session (no epoch) and is false at/ahead of the current version', () => {
+    // No unversioned epoch: an unstamped object is a bug, not legacy data, so the
+    // predicate throws — matching migrateRuntime, so a
+    // `while (needsRuntimeMigration(x)) x = migrateRuntime(x)` loop fails loud on
+    // the same input rather than spinning.
+    expect(() => needsRuntimeMigration({ id: 'legacy' })).toThrow(/no unversioned epoch/);
     expect(needsRuntimeMigration({ [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION })).toBe(false);
     expect(needsRuntimeMigration({ [RUNTIME_DSL_VERSION_KEY]: '99.0.0' })).toBe(false);
   });

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -145,10 +145,15 @@ describe('cross-line guard (ambiguous envelopes fail loud, not reinterpreted)', 
 });
 
 describe('runtimeDslVersionOf', () => {
-  it('reads a stamped runtime version and ignores the document key', () => {
+  it('reads a stamped runtime version', () => {
     expect(runtimeDslVersionOf({ [RUNTIME_DSL_VERSION_KEY]: '9.9.9' })).toBe('9.9.9');
-    // A document-line stamp is invisible to the runtime reader.
-    expect(runtimeDslVersionOf({ [DSL_VERSION_KEY]: '9.9.9' })).toBe(UNVERSIONED_DSL_VERSION);
+  });
+  it('throws on an ambiguous document-stamped envelope (authoritative read)', () => {
+    // Reading this as unversioned would report `0.0.0` for data migrateRuntime
+    // refuses to touch — the reader applies the same cross-line rule.
+    expect(() => runtimeDslVersionOf({ [DSL_VERSION_KEY]: '9.9.9' })).toThrow(
+      /carries "dslVersion" but no "runtimeDslVersion"/,
+    );
   });
   it('throws on a present-but-malformed runtime stamp', () => {
     expect(() => runtimeDslVersionOf({ [RUNTIME_DSL_VERSION_KEY]: '0.1' })).toThrow(
@@ -194,6 +199,14 @@ describe('dslVersionOf', () => {
     expect(dslVersionOf({ id: 'x' })).toBe(UNVERSIONED_DSL_VERSION);
     expect(dslVersionOf(null)).toBe(UNVERSIONED_DSL_VERSION);
     expect(dslVersionOf('nope')).toBe(UNVERSIONED_DSL_VERSION);
+  });
+  it('throws on an ambiguous runtime-stamped envelope (authoritative read)', () => {
+    // The reader, the predicate, and the runner give one answer per envelope:
+    // this state throws everywhere instead of reading as `0.0.0` here while
+    // `migrate` refuses to touch it.
+    expect(() => dslVersionOf({ [RUNTIME_DSL_VERSION_KEY]: '9.9.9' })).toThrow(
+      /carries "runtimeDslVersion" but no "dslVersion"/,
+    );
   });
   it('throws on a present-but-malformed stamp (no silent bypass)', () => {
     // "1", "0.1", "0.1.0-beta" would otherwise parse into a comparable version

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -88,30 +88,23 @@ describe('migrateRuntime', () => {
   });
 });
 
-describe('cross-line guard (misrouted data is inert, not reinterpreted)', () => {
-  it('migrate() returns a runtime session UNCHANGED — no document lift, no dslVersion added', () => {
+describe('cross-line guard (ambiguous envelopes fail loud, not reinterpreted)', () => {
+  it('migrate() throws on a runtime-stamped object — no document lift, no silent skip', () => {
     // Case (3): own stamp (dslVersion) ABSENT + other line's stamp
-    // (runtimeDslVersion) PRESENT. This object is the runtime line's data,
-    // misrouted into the document runner. The guard — not the disjoint keys —
-    // is what makes it inert: migrate must return it byte-identical, NOT walk
-    // the document ladder over it and stamp a foreign `dslVersion`.
+    // (runtimeDslVersion) PRESENT. Byte-identical to "runtime session misrouted
+    // into the document runner" AND to "document carrying a stray runtime
+    // stamp" — walking the ladder would mangle the former, returning it
+    // unchanged would orphan the latter, so the only safe answer is to throw.
     const session = { id: 's', [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION };
-    const out = migrate(session);
-    expect(out).toEqual(session);
-    expect(out).not.toHaveProperty(DSL_VERSION_KEY);
-    // Same object back (guard short-circuits before any copy).
-    expect(out).toBe(session);
+    expect(() => migrate(session)).toThrow(/carries "runtimeDslVersion" but no "dslVersion"/);
   });
 
-  it('migrateRuntime() returns a document UNCHANGED — no runtime lift, no runtimeDslVersion added', () => {
+  it('migrateRuntime() throws on a document-stamped object — no runtime lift, no orphaning', () => {
     // Symmetric case (3): own stamp (runtimeDslVersion) ABSENT + document
-    // line's stamp (dslVersion) PRESENT. The document is inert to the runtime
-    // runner: returned untouched, never stamped with `runtimeDslVersion`.
+    // line's stamp (dslVersion) PRESENT. Same undecidable state, mirrored:
+    // fail loud instead of guessing.
     const doc = { id: 'd', [DSL_VERSION_KEY]: DSL_VERSION };
-    const out = migrateRuntime(doc);
-    expect(out).toEqual(doc);
-    expect(out).not.toHaveProperty(RUNTIME_DSL_VERSION_KEY);
-    expect(out).toBe(doc);
+    expect(() => migrateRuntime(doc)).toThrow(/carries "dslVersion" but no "runtimeDslVersion"/);
   });
 
   it('an object carrying BOTH stamps migrates normally on each runner’s own line', () => {
@@ -176,14 +169,15 @@ describe('needsRuntimeMigration', () => {
       expect(needsRuntimeMigration(migrateRuntime(v))).toBe(false);
     }
   });
-  it('is false for a misrouted document-line aggregate (mirrors the runner guard)', () => {
-    // migrateRuntime returns a document-stamped object untouched (cross-line
-    // guard), so the predicate must not report it as needing migration — a
-    // `while (needsRuntimeMigration(x)) x = migrateRuntime(x)` loop would
-    // otherwise never terminate.
+  it('throws on an ambiguous document-stamped envelope (mirrors the runner guard)', () => {
+    // migrateRuntime throws on a document-stamped object (cross-line guard), so
+    // the predicate must throw the same error — quietly answering true would
+    // spin a `while (needsRuntimeMigration(x)) x = migrateRuntime(x)` loop,
+    // quietly answering false would misreport data the runner refuses to touch.
     const doc = { [DSL_VERSION_KEY]: DSL_VERSION, id: 'doc' };
-    expect(needsRuntimeMigration(doc)).toBe(false);
-    expect(migrateRuntime(doc)).toBe(doc);
+    expect(() => needsRuntimeMigration(doc)).toThrow(
+      /carries "dslVersion" but no "runtimeDslVersion"/,
+    );
     // Doubly-stamped data is the runtime line's own: predicate and runner both
     // act on the runtime stamp as usual.
     expect(
@@ -227,14 +221,15 @@ describe('needsMigration', () => {
   it('throws on a malformed stamp rather than silently reporting no migration', () => {
     expect(() => needsMigration({ [DSL_VERSION_KEY]: '0.1.0-beta' })).toThrow(/invalid dslVersion/);
   });
-  it('is false for a misrouted runtime-line aggregate (mirrors the runner guard)', () => {
-    // migrate returns a runtime-stamped session untouched (cross-line guard),
-    // so the predicate must not report it as needing migration — a
-    // `while (needsMigration(x)) x = migrate(x)` loop would otherwise never
-    // terminate.
+  it('throws on an ambiguous runtime-stamped envelope (mirrors the runner guard)', () => {
+    // migrate throws on a runtime-stamped object (cross-line guard), so the
+    // predicate must throw the same error rather than quietly answer either
+    // way — see the needsRuntimeMigration counterpart for the two failure
+    // modes a quiet answer would pick between.
     const session = { [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION, id: 's' };
-    expect(needsMigration(session)).toBe(false);
-    expect(migrate(session)).toBe(session);
+    expect(() => needsMigration(session)).toThrow(
+      /carries "runtimeDslVersion" but no "dslVersion"/,
+    );
   });
 });
 

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -88,25 +88,66 @@ describe('migrateRuntime', () => {
   });
 });
 
-describe('ladder independence (mechanical, disjoint envelope fields)', () => {
-  it('document migrate() leaves a runtimeDslVersion stamp untouched', () => {
-    // A session stamped on the runtime line, walked by the document runner:
-    // migrate reads `dslVersion` (absent), so it lifts the object on the
-    // document line and never consumes or mutates `runtimeDslVersion`.
+describe('cross-line guard (misrouted data is inert, not reinterpreted)', () => {
+  it('migrate() returns a runtime session UNCHANGED — no document lift, no dslVersion added', () => {
+    // Case (3): own stamp (dslVersion) ABSENT + other line's stamp
+    // (runtimeDslVersion) PRESENT. This object is the runtime line's data,
+    // misrouted into the document runner. The guard — not the disjoint keys —
+    // is what makes it inert: migrate must return it byte-identical, NOT walk
+    // the document ladder over it and stamp a foreign `dslVersion`.
     const session = { id: 's', [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION };
-    const out = migrate(session) as Record<string, unknown>;
-    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
-    expect(out[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+    const out = migrate(session);
+    expect(out).toEqual(session);
+    expect(out).not.toHaveProperty(DSL_VERSION_KEY);
+    // Same object back (guard short-circuits before any copy).
+    expect(out).toBe(session);
   });
 
-  it('migrateRuntime() leaves a dslVersion stamp untouched', () => {
-    // A document stamped on the document line, walked by the runtime runner:
-    // migrateRuntime reads `runtimeDslVersion` (absent) and never mutates
-    // `dslVersion`.
+  it('migrateRuntime() returns a document UNCHANGED — no runtime lift, no runtimeDslVersion added', () => {
+    // Symmetric case (3): own stamp (runtimeDslVersion) ABSENT + document
+    // line's stamp (dslVersion) PRESENT. The document is inert to the runtime
+    // runner: returned untouched, never stamped with `runtimeDslVersion`.
     const doc = { id: 'd', [DSL_VERSION_KEY]: DSL_VERSION };
-    const out = migrateRuntime(doc) as Record<string, unknown>;
-    expect(out[DSL_VERSION_KEY]).toBe(DSL_VERSION);
-    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    const out = migrateRuntime(doc);
+    expect(out).toEqual(doc);
+    expect(out).not.toHaveProperty(RUNTIME_DSL_VERSION_KEY);
+    expect(out).toBe(doc);
+  });
+
+  it('an object carrying BOTH stamps migrates normally on each runner’s own line', () => {
+    // Case (1): own line's stamp present → migrate normally on own line,
+    // regardless of the other key. The guard only fires when the OWN stamp is
+    // absent, so a doubly-stamped envelope is handled by each runner exactly as
+    // if the other stamp were not there.
+    const both = {
+      id: 'x',
+      [DSL_VERSION_KEY]: DSL_VERSION,
+      [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION,
+    };
+    // Each runner sees its own line already current → idempotent no-op, and
+    // leaves the other line's stamp intact.
+    const migrated = migrate(both) as Record<string, unknown>;
+    expect(migrated[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+    expect(migrated[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    const migratedRuntime = migrateRuntime(both) as Record<string, unknown>;
+    expect(migratedRuntime[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    expect(migratedRuntime[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+  });
+
+  it('an object with NEITHER stamp still gets the legacy lift on both runners', () => {
+    // Case (2): both stamps absent → genuine legacy data, walk the own ladder
+    // as before. The guard must NOT intercept this: each runner lifts it onto
+    // its own line.
+    const legacy = { id: 'z', name: 'course' };
+    const lifted = migrate(legacy) as Record<string, unknown>;
+    expect(lifted[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+    expect(lifted[RUNTIME_DSL_VERSION_KEY]).toBeUndefined();
+    expect(lifted.name).toBe('course');
+
+    const liftedRuntime = migrateRuntime(legacy) as Record<string, unknown>;
+    expect(liftedRuntime[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    expect(liftedRuntime[DSL_VERSION_KEY]).toBeUndefined();
+    expect(liftedRuntime.name).toBe('course');
   });
 });
 

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -5,9 +5,12 @@ import {
   INITIAL_DSL_VERSION,
   DSL_VERSION_KEY,
   DSL_MIGRATIONS,
+  RUNTIME_DSL_VERSION,
+  RUNTIME_DSL_MIGRATIONS,
   dslVersionOf,
   needsMigration,
   migrate,
+  migrateRuntime,
 } from '@openmaic/dsl';
 
 describe('DSL_MIGRATIONS ladder invariants', () => {
@@ -27,6 +30,48 @@ describe('DSL_MIGRATIONS ladder invariants', () => {
     // DSL_VERSION moves past it. (They're equal today; the assertion guards the
     // intent, not the current value.)
     expect(DSL_MIGRATIONS[0].to).toBe(INITIAL_DSL_VERSION);
+  });
+});
+
+describe('RUNTIME_DSL_MIGRATIONS ladder invariants', () => {
+  it('is a contiguous chain ending at RUNTIME_DSL_VERSION', () => {
+    // The runtime ladder is a *separate* version line from the document ladder
+    // (they version independent serialized shapes), but obeys the same
+    // contiguity + terminal-endpoint invariants.
+    expect(RUNTIME_DSL_MIGRATIONS.length).toBeGreaterThan(0);
+    for (let i = 1; i < RUNTIME_DSL_MIGRATIONS.length; i++) {
+      expect(RUNTIME_DSL_MIGRATIONS[i].from).toBe(RUNTIME_DSL_MIGRATIONS[i - 1].to);
+    }
+    expect(RUNTIME_DSL_MIGRATIONS[RUNTIME_DSL_MIGRATIONS.length - 1].to).toBe(RUNTIME_DSL_VERSION);
+  });
+
+  it('begins by lifting legacy (unversioned) runtime data', () => {
+    expect(RUNTIME_DSL_MIGRATIONS[0].from).toBe(UNVERSIONED_DSL_VERSION);
+  });
+});
+
+describe('migrateRuntime', () => {
+  it('stamps legacy runtime data up to RUNTIME_DSL_VERSION, independent of DSL_VERSION', () => {
+    const out = migrateRuntime({ id: 'sess' }) as Record<string, unknown>;
+    expect(out[DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+  });
+
+  it('is idempotent and returns non-objects unchanged', () => {
+    const once = migrateRuntime({ id: 's' });
+    expect(migrateRuntime(once)).toBe(once);
+    expect(migrateRuntime(42)).toBe(42);
+    expect(migrateRuntime(null)).toBe(null);
+  });
+
+  it('leaves a forward-versioned runtime document untouched', () => {
+    const future = { id: 's', [DSL_VERSION_KEY]: '99.0.0' };
+    expect(migrateRuntime(future)).toBe(future);
+  });
+
+  it('fails loud on a malformed stamp', () => {
+    expect(() => migrateRuntime({ id: 's', [DSL_VERSION_KEY]: '0.1' })).toThrow(
+      /invalid dslVersion/,
+    );
   });
 });
 

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -6,9 +6,12 @@ import {
   DSL_VERSION_KEY,
   DSL_MIGRATIONS,
   RUNTIME_DSL_VERSION,
+  RUNTIME_DSL_VERSION_KEY,
   RUNTIME_DSL_MIGRATIONS,
   dslVersionOf,
+  runtimeDslVersionOf,
   needsMigration,
+  needsRuntimeMigration,
   migrate,
   migrateRuntime,
 } from '@openmaic/dsl';
@@ -51,9 +54,11 @@ describe('RUNTIME_DSL_MIGRATIONS ladder invariants', () => {
 });
 
 describe('migrateRuntime', () => {
-  it('stamps legacy runtime data up to RUNTIME_DSL_VERSION, independent of DSL_VERSION', () => {
+  it('stamps legacy runtime data onto runtimeDslVersion, not the document key', () => {
     const out = migrateRuntime({ id: 'sess' }) as Record<string, unknown>;
-    expect(out[DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    // The runtime line never touches the document envelope field.
+    expect(out[DSL_VERSION_KEY]).toBeUndefined();
   });
 
   it('is idempotent and returns non-objects unchanged', () => {
@@ -64,14 +69,73 @@ describe('migrateRuntime', () => {
   });
 
   it('leaves a forward-versioned runtime document untouched', () => {
-    const future = { id: 's', [DSL_VERSION_KEY]: '99.0.0' };
+    const future = { id: 's', [RUNTIME_DSL_VERSION_KEY]: '99.0.0' };
     expect(migrateRuntime(future)).toBe(future);
   });
 
-  it('fails loud on a malformed stamp', () => {
-    expect(() => migrateRuntime({ id: 's', [DSL_VERSION_KEY]: '0.1' })).toThrow(
-      /invalid dslVersion/,
+  it('fails loud when the ladder has no path from the runtime version', () => {
+    // A runtime version older than RUNTIME_DSL_VERSION with no matching `from`
+    // entry — mirrors the document ladder's unbridgeable-stamp case.
+    expect(() => migrateRuntime({ id: 's', [RUNTIME_DSL_VERSION_KEY]: '0.0.5' })).toThrow(
+      /no migration path/,
     );
+  });
+
+  it('fails loud on a malformed stamp', () => {
+    expect(() => migrateRuntime({ id: 's', [RUNTIME_DSL_VERSION_KEY]: '0.1' })).toThrow(
+      /invalid runtimeDslVersion/,
+    );
+  });
+});
+
+describe('ladder independence (mechanical, disjoint envelope fields)', () => {
+  it('document migrate() leaves a runtimeDslVersion stamp untouched', () => {
+    // A session stamped on the runtime line, walked by the document runner:
+    // migrate reads `dslVersion` (absent), so it lifts the object on the
+    // document line and never consumes or mutates `runtimeDslVersion`.
+    const session = { id: 's', [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION };
+    const out = migrate(session) as Record<string, unknown>;
+    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+    expect(out[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+  });
+
+  it('migrateRuntime() leaves a dslVersion stamp untouched', () => {
+    // A document stamped on the document line, walked by the runtime runner:
+    // migrateRuntime reads `runtimeDslVersion` (absent) and never mutates
+    // `dslVersion`.
+    const doc = { id: 'd', [DSL_VERSION_KEY]: DSL_VERSION };
+    const out = migrateRuntime(doc) as Record<string, unknown>;
+    expect(out[DSL_VERSION_KEY]).toBe(DSL_VERSION);
+    expect(out[RUNTIME_DSL_VERSION_KEY]).toBe(RUNTIME_DSL_VERSION);
+  });
+});
+
+describe('runtimeDslVersionOf', () => {
+  it('reads a stamped runtime version and ignores the document key', () => {
+    expect(runtimeDslVersionOf({ [RUNTIME_DSL_VERSION_KEY]: '9.9.9' })).toBe('9.9.9');
+    // A document-line stamp is invisible to the runtime reader.
+    expect(runtimeDslVersionOf({ [DSL_VERSION_KEY]: '9.9.9' })).toBe(UNVERSIONED_DSL_VERSION);
+  });
+  it('throws on a present-but-malformed runtime stamp', () => {
+    expect(() => runtimeDslVersionOf({ [RUNTIME_DSL_VERSION_KEY]: '0.1' })).toThrow(
+      /invalid runtimeDslVersion/,
+    );
+  });
+});
+
+describe('needsRuntimeMigration', () => {
+  it('is true for unstamped sessions and false at/ahead of the current version', () => {
+    expect(needsRuntimeMigration({ id: 'legacy' })).toBe(true);
+    expect(needsRuntimeMigration({ [RUNTIME_DSL_VERSION_KEY]: RUNTIME_DSL_VERSION })).toBe(false);
+    expect(needsRuntimeMigration({ [RUNTIME_DSL_VERSION_KEY]: '99.0.0' })).toBe(false);
+    // A document-line stamp does not satisfy the runtime predicate.
+    expect(needsRuntimeMigration({ [DSL_VERSION_KEY]: RUNTIME_DSL_VERSION })).toBe(true);
+  });
+  it('agrees with migrateRuntime on non-objects (loop terminates)', () => {
+    for (const v of [42, null, undefined, 'x', []]) {
+      expect(needsRuntimeMigration(v)).toBe(false);
+      expect(needsRuntimeMigration(migrateRuntime(v))).toBe(false);
+    }
   });
 });
 

--- a/packages/@openmaic/dsl/test/version.test.ts
+++ b/packages/@openmaic/dsl/test/version.test.ts
@@ -3,6 +3,7 @@ import {
   DSL_VERSION,
   UNVERSIONED_DSL_VERSION,
   INITIAL_DSL_VERSION,
+  INITIAL_RUNTIME_DSL_VERSION,
   DSL_VERSION_KEY,
   DSL_MIGRATIONS,
   RUNTIME_DSL_VERSION,
@@ -46,17 +47,21 @@ describe('RUNTIME_DSL_MIGRATIONS ladder invariants', () => {
     expect(RUNTIME_DSL_MIGRATIONS.length).toBe(0);
   });
 
-  it('IF non-empty (future), is a contiguous chain ending at RUNTIME_DSL_VERSION', () => {
-    // Guards the invariant the *first real* runtime shape change must satisfy:
-    // a contiguous chain whose last `to` reaches RUNTIME_DSL_VERSION. Vacuously
-    // true while empty; becomes a real check the moment a step is appended.
-    for (let i = 1; i < RUNTIME_DSL_MIGRATIONS.length; i++) {
-      expect(RUNTIME_DSL_MIGRATIONS[i].from).toBe(RUNTIME_DSL_MIGRATIONS[i - 1].to);
-    }
+  it('IF non-empty (future), starts at the pinned initial version and chains to RUNTIME_DSL_VERSION', () => {
+    // Guards the invariants the *first real* runtime shape change must satisfy.
+    // Vacuously true while empty; becomes a real check the moment a step is
+    // appended. The first `from` is pinned to INITIAL_RUNTIME_DSL_VERSION — the
+    // runtime line has no unversioned epoch, so a ladder starting anywhere
+    // earlier (e.g. a copy-pasted 0.0.0 legacy lift) would reintroduce the
+    // lift-arbitrary-unstamped-data hole this model removed.
     if (RUNTIME_DSL_MIGRATIONS.length > 0) {
+      expect(RUNTIME_DSL_MIGRATIONS[0].from).toBe(INITIAL_RUNTIME_DSL_VERSION);
       expect(RUNTIME_DSL_MIGRATIONS[RUNTIME_DSL_MIGRATIONS.length - 1].to).toBe(
         RUNTIME_DSL_VERSION,
       );
+    }
+    for (let i = 1; i < RUNTIME_DSL_MIGRATIONS.length; i++) {
+      expect(RUNTIME_DSL_MIGRATIONS[i].from).toBe(RUNTIME_DSL_MIGRATIONS[i - 1].to);
     }
   });
 });


### PR DESCRIPTION
Part A of #869: the DSL-native runtime layer contract — pure types, guards, and validators in `@openmaic/dsl`, no storage code (the `RuntimeStore` browser backend + contract suite is Part B). Mirrors how #858/#860 delivered the document side.

## What

- **`RuntimeSession`** — the unit of learner-runtime identity and lifecycle: owns `(stageId, learnerKey, kind)` and the `active → completed → archived` status ladder. Extends `RuntimeVersioned`: sessions stamp their own `runtimeDslVersion` envelope field and ride a dedicated runtime version line (`RUNTIME_DSL_VERSION` + `RUNTIME_DSL_MIGRATIONS` + `migrateRuntime`), mechanically disjoint from the document ladder (proved by test).
- **`RuntimeRecord<TPayload>`** — one ordered fact inside a session. The store-assigned monotonic `seq` is the sole replay ordering key (never client timestamps); `sceneId`/`actionIndex`/`subAnchor` are documented best-effort anchors into the editable document timeline. Payload internals are app-owned via the generic, exactly like `DocumentStore<TScene>` (#860).
- **`RuntimeRecordInit`** — the creation shape a producer hands to `append`: structurally omits `seq`, since only the store may assign it.
- **Core-kind skeletons** for `chat` (roles + content) and `quizAttempt` (phase + answers map), with guards. `playback` is a recognized kind name with a deliberately app-owned payload.
- **Envelope validators** `validateRuntimeSession` / `validateRuntimeRecord` — the store write gate: well-formed `x.y.z` version stamps, ISO-8601 timestamps validated by pure calendar arithmetic (same rule `migrate` enforces, via the newly exported `isWellFormedDslVersion`), non-negative-integer `seq`/`actionIndex`, non-empty required identity strings, payload presence.

## Design decisions refining the RFC text

- Sessions are first-class and records reference them by `sessionId` — identity/lifecycle lives once on the session instead of being duplicated per record, resolving the session/record granularity #869 left open.
- Replay ordering moved from timestamps to store-assigned `seq` (multi-tab and clock-skew safe); timestamps remain display metadata, ISO 8601 by design (divergence from the document aggregate's epoch-ms is called out in the module docs).
- Compile-time exhaustiveness links between each union type and its `as const` array, following the `SCENE_TYPES` house pattern.

## Tests

153 passing (`pnpm --filter @openmaic/dsl test`); typecheck, build, prettier, eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> [!NOTE]
> Scope grew slightly during review: a dedicated runtime version line with its own `runtimeDslVersion` envelope field (review thread on migration-ladder coupling), pure component-level ISO-8601 calendar validation (review thread on `Date.parse` normalization), and the `@openmaic/dsl` test suite now runs in PR CI.
