### PR TITLE
fix(prompts): add postMessage listener contract to diagram/game/code widgets

### DIFF
--- a/lib/prompts/templates/code-content/system.md
+++ b/lib/prompts/templates/code-content/system.md
@@ -139,7 +139,10 @@ window.addEventListener('message', function(event) {
     case 'SET_WIDGET_STATE':
       // e.g. { code: "...", run: true } — set editor contents, optionally run.
       if (state && typeof state.code === 'string') {
-        if (typeof editor?.setValue === 'function') editor.setValue(state.code);
+        // Guard the identifier itself: `editor?.setValue` still throws
+        // ReferenceError when no `editor` variable is declared (e.g. a
+        // textarea-only widget). `typeof editor` is safe for that case.
+        if (typeof editor !== 'undefined' && typeof editor.setValue === 'function') editor.setValue(state.code);
         else { const ta = document.getElementById('code-input'); if (ta) ta.value = state.code; }
       }
       if (state && state.run && typeof runCode === 'function') runCode();

--- a/lib/prompts/templates/code-content/system.md
+++ b/lib/prompts/templates/code-content/system.md
@@ -123,6 +123,76 @@ async function runCode() {
 - Ensure editor has minimum height of 200px on mobile
 - Test cases should be collapsible on small screens
 
+## CRITICAL: postMessage Listener for Widget Actions (REQUIRED)
+
+The platform drives this widget by posting messages into the iframe
+(`SET_WIDGET_STATE`, `HIGHLIGHT_ELEMENT`, `ANNOTATE_ELEMENT`, `REVEAL_ELEMENT`).
+Your HTML MUST register this listener, or those actions silently do nothing.
+For a code playground, `SET_WIDGET_STATE` typically loads code into the editor and
+optionally runs it:
+
+```javascript
+window.addEventListener('message', function(event) {
+  const { type, target, state, content } = event.data;
+
+  switch (type) {
+    case 'SET_WIDGET_STATE':
+      // e.g. { code: "...", run: true } — set editor contents, optionally run.
+      if (state && typeof state.code === 'string') {
+        if (typeof editor?.setValue === 'function') editor.setValue(state.code);
+        else { const ta = document.getElementById('code-input'); if (ta) ta.value = state.code; }
+      }
+      if (state && state.run && typeof runCode === 'function') runCode();
+      break;
+
+    case 'HIGHLIGHT_ELEMENT':
+      const highlightEl = document.querySelector(target);
+      if (highlightEl) {
+        highlightEl.style.outline = '3px solid rgba(139, 92, 246, 0.8)';
+        highlightEl.style.outlineOffset = '4px';
+        highlightEl.style.animation = 'pulse-highlight 2s infinite';
+        setTimeout(() => {
+          highlightEl.style.outline = '';
+          highlightEl.style.animation = '';
+        }, 3000);
+      }
+      break;
+
+    case 'ANNOTATE_ELEMENT':
+      const annotateEl = document.querySelector(target);
+      if (annotateEl && content) {
+        const rect = annotateEl.getBoundingClientRect();
+        const tooltip = document.createElement('div');
+        tooltip.className = 'teacher-annotation';
+        tooltip.style.cssText = 'position:fixed; top:' + (rect.top - 40) + 'px; left:' + rect.left + 'px; background:rgba(139,92,246,0.95); color:white; padding:8px 12px; border-radius:8px; font-size:14px; z-index:1000; animation:fadeIn 0.3s;';
+        tooltip.textContent = content;
+        document.body.appendChild(tooltip);
+        setTimeout(() => tooltip.remove(), 4000);
+      }
+      break;
+
+    case 'REVEAL_ELEMENT':
+      // Reveal a hidden element (e.g. the solution or a hint panel)
+      const revealEl = document.querySelector(target);
+      if (revealEl) {
+        revealEl.style.display = '';
+        revealEl.style.opacity = '1';
+      }
+      break;
+  }
+});
+
+const style = document.createElement('style');
+style.textContent = '@keyframes pulse-highlight { 0%, 100% { outline-color: rgba(139, 92, 246, 0.8); } 50% { outline-color: rgba(139, 92, 246, 0.4); } } @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }';
+document.head.appendChild(style);
+```
+
+### Element Naming Convention
+
+So highlight/annotate/reveal can target UI, use consistent ids:
+- Run button: `id="run-btn"`, output panel: `id="output"`, editor host: `id="code-input"`.
+- Solution/hint panels: `id="solution"`, `id="hint-{n}"`.
+
 ## Output Format
 
 Return ONLY the HTML document, no markdown fences or explanations.

--- a/lib/prompts/templates/diagram-content/system.md
+++ b/lib/prompts/templates/diagram-content/system.md
@@ -50,6 +50,83 @@ function getEdgePoints(from, to) {
 }
 ```
 
+## CRITICAL: postMessage Listener for Widget Actions (REQUIRED)
+
+The platform drives this widget by posting messages into the iframe
+(`SET_WIDGET_STATE`, `HIGHLIGHT_ELEMENT`, `ANNOTATE_ELEMENT`, `REVEAL_ELEMENT`).
+Your HTML MUST register this listener, or those actions silently do nothing:
+
+```javascript
+// Add this script at the end of your HTML
+window.addEventListener('message', function(event) {
+  const { type, target, state, content } = event.data;
+
+  switch (type) {
+    case 'SET_WIDGET_STATE':
+      // Apply state keyed by node id. Use the same convention as REVEAL_ELEMENT:
+      // each diagram node is `id="node-{id}"` (matching the JSON node ids).
+      if (state) {
+        Object.entries(state).forEach(([key, value]) => {
+          const node = document.getElementById('node-' + key) || document.querySelector('[data-node="' + key + '"]');
+          if (node) {
+            node.style.opacity = value ? '1' : '0.35';
+            node.classList.toggle('active', !!value);
+          }
+        });
+      }
+      break;
+
+    case 'HIGHLIGHT_ELEMENT':
+      // Highlight the target element with a pulsing border
+      const highlightEl = document.querySelector(target);
+      if (highlightEl) {
+        highlightEl.style.outline = '3px solid rgba(139, 92, 246, 0.8)';
+        highlightEl.style.outlineOffset = '4px';
+        highlightEl.style.animation = 'pulse-highlight 2s infinite';
+        setTimeout(() => {
+          highlightEl.style.outline = '';
+          highlightEl.style.animation = '';
+        }, 3000);
+      }
+      break;
+
+    case 'ANNOTATE_ELEMENT':
+      // Show an annotation tooltip near the target element
+      const annotateEl = document.querySelector(target);
+      if (annotateEl && content) {
+        const rect = annotateEl.getBoundingClientRect();
+        const tooltip = document.createElement('div');
+        tooltip.className = 'teacher-annotation';
+        tooltip.style.cssText = 'position:fixed; top:' + (rect.top - 40) + 'px; left:' + rect.left + 'px; background:rgba(139,92,246,0.95); color:white; padding:8px 12px; border-radius:8px; font-size:14px; z-index:1000; animation:fadeIn 0.3s;';
+        tooltip.textContent = content;
+        document.body.appendChild(tooltip);
+        setTimeout(() => tooltip.remove(), 4000);
+      }
+      break;
+
+    case 'REVEAL_ELEMENT':
+      // Reveal a hidden node/element
+      const revealEl = document.querySelector(target);
+      if (revealEl) {
+        revealEl.style.display = '';
+        revealEl.style.opacity = '1';
+      }
+      break;
+  }
+});
+
+// Add this CSS for animations
+const style = document.createElement('style');
+style.textContent = '@keyframes pulse-highlight { 0%, 100% { outline-color: rgba(139, 92, 246, 0.8); } 50% { outline-color: rgba(139, 92, 246, 0.4); } } @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }';
+document.head.appendChild(style);
+```
+
+### Element Naming Convention
+
+So highlight/annotate/reveal can target nodes, give each node a stable id:
+- Node groups: `id="node-{id}"` (e.g., `id="node-n1"`), matching the JSON `id`.
+- Edge labels: `id="edge-{from}-{to}"` if they need to be targeted.
+
 ## Output
 
 Return exactly ONE complete HTML document. No markdown fences, no duplication.

--- a/lib/prompts/templates/game-content/system.md
+++ b/lib/prompts/templates/game-content/system.md
@@ -175,6 +175,83 @@ const objectY = groundY - BOTTOM_MARGIN - (altitude / maxHeight) * playableHeigh
 - Use padding or margins to create "safe zones" for game objects
 - Position game objects within the visible canvas area, not under overlays
 
+## CRITICAL: postMessage Listener for Widget Actions (REQUIRED)
+
+The platform drives this widget by posting messages into the iframe
+(`SET_WIDGET_STATE`, `HIGHLIGHT_ELEMENT`, `ANNOTATE_ELEMENT`, `REVEAL_ELEMENT`).
+Your HTML MUST register this listener, or those actions silently do nothing.
+Register it at the end of the body (or inside your DOMContentLoaded setup) so the
+game can be driven the same way a player would drive it:
+
+```javascript
+window.addEventListener('message', function(event) {
+  const { type, target, state, content } = event.data;
+
+  switch (type) {
+    case 'SET_WIDGET_STATE':
+      // Apply state to controls / game params. Keys map to controls by id;
+      // route to the game via a global setter when one exists.
+      if (state) {
+        Object.entries(state).forEach(([key, value]) => {
+          const control = document.getElementById(key + '-slider') || document.getElementById(key) || document.querySelector('[data-var="' + key + '"]');
+          if (control) {
+            control.value = value;
+            control.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+          if (typeof window.setGameParam === 'function') window.setGameParam(key, value);
+        });
+      }
+      break;
+
+    case 'HIGHLIGHT_ELEMENT':
+      const highlightEl = document.querySelector(target);
+      if (highlightEl) {
+        highlightEl.style.outline = '3px solid rgba(139, 92, 246, 0.8)';
+        highlightEl.style.outlineOffset = '4px';
+        highlightEl.style.animation = 'pulse-highlight 2s infinite';
+        setTimeout(() => {
+          highlightEl.style.outline = '';
+          highlightEl.style.animation = '';
+        }, 3000);
+      }
+      break;
+
+    case 'ANNOTATE_ELEMENT':
+      const annotateEl = document.querySelector(target);
+      if (annotateEl && content) {
+        const rect = annotateEl.getBoundingClientRect();
+        const tooltip = document.createElement('div');
+        tooltip.className = 'teacher-annotation';
+        tooltip.style.cssText = 'position:fixed; top:' + (rect.top - 40) + 'px; left:' + rect.left + 'px; background:rgba(139,92,246,0.95); color:white; padding:8px 12px; border-radius:8px; font-size:14px; z-index:1000; animation:fadeIn 0.3s;';
+        tooltip.textContent = content;
+        document.body.appendChild(tooltip);
+        setTimeout(() => tooltip.remove(), 4000);
+      }
+      break;
+
+    case 'REVEAL_ELEMENT':
+      const revealEl = document.querySelector(target);
+      if (revealEl) {
+        revealEl.style.display = '';
+        revealEl.style.opacity = '1';
+      }
+      break;
+  }
+});
+
+const style = document.createElement('style');
+style.textContent = '@keyframes pulse-highlight { 0%, 100% { outline-color: rgba(139, 92, 246, 0.8); } 50% { outline-color: rgba(139, 92, 246, 0.4); } } @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }';
+document.head.appendChild(style);
+```
+
+### Element Naming Convention
+
+So highlight/annotate/reveal can target controls, use consistent ids:
+- Sliders: `id="{param}-slider"` (e.g., `id="thrust-slider"`)
+- Buttons: `id="{action}-btn"` (e.g., `id="start-btn"`, `id="reset-btn"`)
+- If game parameters live only in JS state, expose `window.setGameParam(key, value)`
+  so `SET_WIDGET_STATE` can drive them.
+
 ## Output Format (CRITICAL)
 
 **Return EXACTLY ONE HTML document.** Do NOT:


### PR DESCRIPTION
## Summary

Widget actions are delivered to the iframe via `postMessage` (`lib/action/engine.ts:691-717`), so a widget must register a `message` listener to be driven by scene actions. The `simulation`, `visualization3d`, and `procedural-skill` content prompts document this contract; `diagram`, `game`, and `code` did not — so widgets of those types never emit the handler and every scene action targeting them silently no-ops.

This adds the `## CRITICAL: postMessage Listener for Widget Actions` section (handling `SET_WIDGET_STATE` / `HIGHLIGHT_ELEMENT` / `ANNOTATE_ELEMENT` / `REVEAL_ELEMENT`) to the three prompts, adapting the `SET_WIDGET_STATE` handler to each widget type's DOM and mirroring the existing simulation prompt for the highlight/annotate/reveal handlers. Each prompt also gets an Element Naming Convention note so those actions have stable targets.

The message shape (`{ type, target, state, content }`) matches what the iframe host posts (`components/scene-renderers/InteractiveIframeHost.tsx:109` sends `{ type, ...payload }`) and what the existing simulation handler already consumes.

Addresses point 1 of #871. The simulation select-variable issue (point 2) is left for separate discussion.

## Test plan

- Generate one widget of each affected type (`diagram`, `game`, `code`) and confirm the output HTML registers a `window` `message` listener handling the four action types.
- Replay each action against a generated widget and confirm it responds (highlight appears, state applies, annotation shows, element reveals) instead of no-op.
