### PR TITLE
feat(storage): RuntimeStore — sessions + append-only records, browser backend (#869 Part B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Unit Tests (dsl)
         run: pnpm --filter @openmaic/dsl test
 
+      - name: Unit Tests (storage)
+        run: pnpm --filter @openmaic/storage test
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -52,8 +52,10 @@ a browser.
   store over its scene union and injects a matching `validateScene`, so those
   scenes persist and the gate stays fail-loud for the app's shapes.
 - **Runtime layer.** `RuntimeStore` is partitioned by `(stageId, learnerKey)`:
-  a stage has many sessions — one or more per learner — so every query is
-  partition-scoped, never global. Sessions are **born stamped**: the store
+  a stage has many sessions — one or more per learner — so every listing is
+  partition-scoped (there is deliberately no global listing; single-session
+  operations are id-keyed, and `mergeLearner` is the one deliberate
+  cross-stage sweep). Sessions are **born stamped**: the store
   writes `runtimeDslVersion` itself at `createSession`, and the runtime line
   has no unversioned epoch, so an unstamped row fails loud instead of being
   lifted like a legacy document. Records are **append-only** ordered facts

--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -28,6 +28,7 @@ a browser.
 | `StorageProvider` (from `@openmaic/dsl`) | the asset seam: `put(blob) → ref`, `resolve(ref) → url`, `remove(ref)` | `BrowserAssetProvider` over IndexedDB + object URLs |
 | `kvPersistStorage` | adapt a `KVStore` into a zustand `persist` storage | — |
 | `DocumentStore` | persist the DSL `document` aggregate (stage + scenes + embedded agents / quiz / actions + an outline snapshot) | `BrowserDocumentStore` over IndexedDB (normalized `stages` / `scenes` / `outlines`) |
+| `RuntimeStore` | persist what a learner produces while taking a course — sessions + append-only records (chat, quiz attempts, playback facts) | `BrowserRuntimeStore` over IndexedDB (`sessions` / `records`) |
 
 - **Scopes.** `account` values are user data a server-backed deployment syncs
   across devices; `device` values (theme, locale, layout) never leave the
@@ -50,11 +51,27 @@ a browser.
   kinds (`interactive` / `pbl`, content the DSL does not own) parameterizes the
   store over its scene union and injects a matching `validateScene`, so those
   scenes persist and the gate stays fail-loud for the app's shapes.
+- **Runtime layer.** `RuntimeStore` is partitioned by `(stageId, learnerKey)`:
+  a stage has many sessions — one or more per learner — so every query is
+  partition-scoped, never global. Sessions are **born stamped**: the store
+  writes `runtimeDslVersion` itself at `createSession`, and the runtime line
+  has no unversioned epoch, so an unstamped row fails loud instead of being
+  lifted like a legacy document. Records are **append-only** ordered facts
+  under an **active** session; the store assigns the per-session monotonic
+  `seq` on append — the sole replay ordering key, never timestamps. Record
+  payloads are gated per kind by injectable validators, defaulting to the DSL
+  skeleton guards for `chat` / `quizAttempt` (`playback` and app-defined kinds
+  carry app-owned payloads). `mergeLearner` re-keys an anonymous learner's
+  sessions to a signed-in key across all stages; `deleteLearnerRuntime`
+  cascades one learner's sessions + records on one stage, and
+  `deleteStageRuntime` clears a whole stage — the hook a document deletion
+  cascades through.
 
 ## Backend equivalence
 
 Each primitive has one implementation-agnostic contract suite
-(`test/kv-contract.ts`, `test/asset-contract.ts`, `test/document-contract.ts`).
+(`test/kv-contract.ts`, `test/asset-contract.ts`, `test/document-contract.ts`,
+`test/runtime-contract.ts`).
 Every backend is proven by running the same suite against it, so a new backend
 (the coming HTTP one) cannot silently diverge from the primitive's semantics.
 
@@ -65,8 +82,9 @@ Every backend is proven by running the same suite against it, so a new backend
 - [x] implementation-agnostic contract suites
 - [x] `DocumentStore` (aggregate ↔ normalized adapter, migrate-on-read via the
       DSL migration registry, validation gate) + browser backend
+- [x] `RuntimeStore` (sessions + append-only records, runtime version line,
+      per-kind payload gate) + browser backend
 - [ ] wire the app's zustand stores + ad-hoc `localStorage` through `KVStore`
-- [ ] `RuntimeStore`
 - [ ] HTTP backend + reference server + one HTTP contract
 
 ## License

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -33,6 +33,8 @@ export type {
 } from './document/types.js';
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
 
+export type { RuntimeStore, RuntimeSessionInit, RuntimePayloadValidator } from './runtime/types.js';
+
 // Re-export the DSL-owned asset contract for convenience, so consumers can get
 // the interface and a backend from one import without reaching into the DSL.
 export type { AssetRef, AssetMeta, BinaryBlob, StorageProvider } from '@openmaic/dsl';

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -34,6 +34,7 @@ export type {
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
 
 export type { RuntimeStore, RuntimeSessionInit, RuntimePayloadValidator } from './runtime/types.js';
+export { BrowserRuntimeStore, type BrowserRuntimeStoreOptions } from './runtime/browser.js';
 
 // Re-export the DSL-owned asset contract for convenience, so consumers can get
 // the interface and a backend from one import without reaching into the DSL.

--- a/packages/@openmaic/storage/src/runtime/browser.ts
+++ b/packages/@openmaic/storage/src/runtime/browser.ts
@@ -410,7 +410,10 @@ export class BrowserRuntimeStore implements RuntimeStore {
         // malformed / sibling-stamped) throws the runtime line's own error
         // from inside the guard and aborts the merge the same way.
         if (isFutureRuntimeVersioned(row)) throw futureSessionError(row.id, row);
-        const updated: RuntimeSession = { ...row, learnerKey: toLearnerKey };
+        // Migrate a stale row in place before mutating it — the same
+        // migrate-in-place semantics as setSessionStatus/appendRecord — so a
+        // merge never writes an old stamp into the target partition.
+        const updated: RuntimeSession = { ...migrateSession(row), learnerKey: toLearnerKey };
         assertValid(validateRuntimeSession(updated), `runtime session ${JSON.stringify(row.id)}`);
         sessions.put(updated);
       }

--- a/packages/@openmaic/storage/src/runtime/browser.ts
+++ b/packages/@openmaic/storage/src/runtime/browser.ts
@@ -242,7 +242,17 @@ export class BrowserRuntimeStore implements RuntimeStore {
     const row = await this.txRun([SESSIONS], 'readonly', (tx) =>
       reqP<RuntimeSession | undefined>(tx.objectStore(SESSIONS).get(sessionId)),
     );
-    return row === undefined ? undefined : migrateSession(row);
+    if (row === undefined) return undefined;
+    const session = migrateSession(row);
+    // A read gates the stored row through the same envelope validation as the
+    // writes: a row whose stamp resolves but whose other fields are corrupt is
+    // a stored-row integrity failure, and a direct read fails loud rather than
+    // hand the caller a session the store itself would refuse to write.
+    assertValid(
+      validateRuntimeSession(session),
+      `stored runtime session ${JSON.stringify(sessionId)}`,
+    );
+    return session;
   }
 
   async listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]> {
@@ -251,16 +261,21 @@ export class BrowserRuntimeStore implements RuntimeStore {
         tx.objectStore(SESSIONS).index(SESSIONS_BY_STAGE_LEARNER).getAll([stageId, learnerKey]),
       ),
     );
-    // Listings tolerate corrupt rows by omission (the `listDocuments`
-    // precedent): one poison row must not make the whole partition
-    // unenumerable. A direct `getSession` on such an id stays fail-loud, and
-    // the delete paths remain the cleanup tool.
+    // Listings tolerate corrupt rows — version OR envelope corruption — by
+    // omission (the `listDocuments` precedent): one poison row must not make
+    // the whole partition unenumerable. A direct `getSession` on such an id
+    // stays fail-loud, and the delete paths remain the cleanup tool.
     const sessions: RuntimeSession[] = [];
     for (const row of rows) {
       try {
-        sessions.push(migrateSession(row));
+        const session = migrateSession(row);
+        assertValid(
+          validateRuntimeSession(session),
+          `stored runtime session ${JSON.stringify(session.id)}`,
+        );
+        sessions.push(session);
       } catch {
-        // omitted: this row's version resolution failed
+        // omitted: this row's version resolution or envelope validation failed
       }
     }
     // Order by the instant each timestamp denotes, not by the string: ISO-8601

--- a/packages/@openmaic/storage/src/runtime/browser.ts
+++ b/packages/@openmaic/storage/src/runtime/browser.ts
@@ -1,0 +1,393 @@
+/**
+ * Browser {@link RuntimeStore} backend: runtime sessions + append-only records
+ * across two IndexedDB object stores (`sessions` / `records`). Writes stamp the
+ * runtime version, validate the full envelope, and gate record payloads through
+ * the per-kind validators (the DSL skeleton guards by default, or an injected
+ * map for app-defined kinds); reads migrate sessions forward on the runtime
+ * line. Matches the document backend's idiom — an injectable `IDBFactory`, a
+ * memoized open that clears on failure, and transactions that resolve on commit
+ * (not on the request) so a write claims durability only once the store
+ * actually kept it.
+ */
+import {
+  RUNTIME_DSL_VERSION,
+  isChatMessageSkeleton,
+  isQuizAttemptSkeleton,
+  migrateRuntime,
+  needsRuntimeMigration,
+  runtimeDslVersionOf,
+  validateRuntimeRecord,
+  validateRuntimeSession,
+} from '@openmaic/dsl';
+import type {
+  RuntimePayload,
+  RuntimeRecord,
+  RuntimeRecordInit,
+  RuntimeSession,
+  RuntimeSessionStatus,
+} from '@openmaic/dsl';
+import type { RuntimePayloadValidator, RuntimeSessionInit, RuntimeStore } from './types.js';
+
+const SESSIONS = 'sessions';
+const RECORDS = 'records';
+const SESSIONS_BY_STAGE_LEARNER = 'by-stage-learner';
+const SESSIONS_BY_LEARNER = 'by-learner';
+const SESSIONS_BY_STAGE = 'by-stage';
+
+/**
+ * Default per-kind payload gate: the DSL skeletons for the skeleton kinds.
+ * Kinds without an entry (`playback`, app-defined kinds) take app-owned
+ * payloads the store does not inspect.
+ */
+const DEFAULT_PAYLOAD_VALIDATORS: Record<string, RuntimePayloadValidator> = {
+  chat: (p) =>
+    isChatMessageSkeleton(p)
+      ? { valid: true }
+      : {
+          valid: false,
+          errors: [
+            {
+              path: '/payload',
+              message: 'chat payload must match ChatMessageSkeleton (role + content)',
+            },
+          ],
+        },
+  quizAttempt: (p) =>
+    isQuizAttemptSkeleton(p)
+      ? { valid: true }
+      : {
+          valid: false,
+          errors: [
+            {
+              path: '/payload',
+              message: 'quizAttempt payload must match QuizAttemptSkeleton (phase + answers)',
+            },
+          ],
+        },
+};
+
+export interface BrowserRuntimeStoreOptions {
+  /** IndexedDB factory. Defaults to the ambient `indexedDB`. Injectable for tests. */
+  indexedDB?: IDBFactory;
+  /** Database name. Defaults to `maic-runtime`. */
+  dbName?: string;
+  /**
+   * Per-kind payload validators run at the append boundary, keyed by
+   * `RuntimeSession.kind`. REPLACES the default map (the DSL skeleton guards
+   * for `chat` / `quizAttempt`), so an app that widens a skeleton kind's
+   * payload — or wants no gate at all — takes full ownership of the mapping
+   * rather than fighting a merged default.
+   */
+  payloadValidators?: Record<string, RuntimePayloadValidator>;
+}
+
+/** Promisify a single IndexedDB request. */
+function reqP<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Throw a fail-loud error listing every validation issue, or pass. */
+function assertValid(result: ReturnType<typeof validateRuntimeSession>, label: string): void {
+  if (result.valid) return;
+  const detail = result.errors.map((e) => `${e.path || '/'}: ${e.message}`).join('; ');
+  throw new Error(`@openmaic/storage: invalid ${label}: ${detail}`);
+}
+
+/**
+ * True when a stored session row is stamped *ahead* of this client's
+ * `RUNTIME_DSL_VERSION` (`needsRuntimeMigration` false means version >=
+ * current; a version that is also not equal to current is strictly greater).
+ * Such data was written by a newer client; an older client must not mutate it
+ * (see the write guards). A non-object carries no version claim, so it is
+ * never "future". Only ever called on rows read from the store — which this
+ * backend always stamps — so the runtime-line readers' fail-loud throw on an
+ * unstamped or sibling-stamped object propagates as a corruption error rather
+ * than being swallowed.
+ */
+function isFutureRuntimeVersioned(row: unknown): boolean {
+  if (typeof row !== 'object' || row === null) return false;
+  return !needsRuntimeMigration(row) && runtimeDslVersionOf(row) !== RUNTIME_DSL_VERSION;
+}
+
+/** The shared write-guard error for a session written by a newer client. */
+function futureSessionError(sessionId: string, row: RuntimeSession): Error {
+  return new Error(
+    `@openmaic/storage: session ${JSON.stringify(sessionId)} was written at runtime DSL ` +
+      `version ${JSON.stringify(runtimeDslVersionOf(row))}, newer than this client's ` +
+      `${RUNTIME_DSL_VERSION}`,
+  );
+}
+
+/**
+ * Migrate a session row forward on the runtime line. Future-stamped rows pass
+ * through unchanged — a read never downgrades, mirroring `loadDocument`.
+ */
+function migrateSession(row: RuntimeSession): RuntimeSession {
+  return needsRuntimeMigration(row) ? (migrateRuntime(row) as RuntimeSession) : row;
+}
+
+/** Every record of one session: `seq` spans `[0, Infinity)` under its id. */
+function sessionRecordRange(sessionId: string): IDBKeyRange {
+  return IDBKeyRange.bound([sessionId, 0], [sessionId, Infinity]);
+}
+
+export class BrowserRuntimeStore implements RuntimeStore {
+  private readonly idb: IDBFactory;
+  private readonly dbName: string;
+  private readonly payloadValidators: Record<string, RuntimePayloadValidator>;
+  private dbPromise?: Promise<IDBDatabase>;
+
+  constructor(options: BrowserRuntimeStoreOptions = {}) {
+    this.idb = options.indexedDB ?? globalThis.indexedDB;
+    this.dbName = options.dbName ?? 'maic-runtime';
+    this.payloadValidators = options.payloadValidators ?? DEFAULT_PAYLOAD_VALIDATORS;
+  }
+
+  private openDb(): Promise<IDBDatabase> {
+    // Do NOT cache a rejected open: a transient failure (private-mode IDB, a
+    // one-off VersionError) would otherwise brick the store for the session.
+    this.dbPromise ??= new Promise<IDBDatabase>((resolve, reject) => {
+      const req = this.idb.open(this.dbName, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(SESSIONS)) {
+          const sessions = db.createObjectStore(SESSIONS, { keyPath: 'id' });
+          // The partition key of the runtime layer: every list/delete query is
+          // scoped to one learner on one stage (or one whole dimension of it).
+          sessions.createIndex(SESSIONS_BY_STAGE_LEARNER, ['stageId', 'learnerKey'], {
+            unique: false,
+          });
+          sessions.createIndex(SESSIONS_BY_LEARNER, 'learnerKey', { unique: false });
+          sessions.createIndex(SESSIONS_BY_STAGE, 'stageId', { unique: false });
+        }
+        if (!db.objectStoreNames.contains(RECORDS)) {
+          // Compound key so record ordering IS the primary-key ordering: a
+          // ranged read over one session comes back sorted by `seq` for free.
+          db.createObjectStore(RECORDS, { keyPath: ['sessionId', 'seq'] });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    }).catch((err) => {
+      this.dbPromise = undefined;
+      throw err;
+    });
+    return this.dbPromise;
+  }
+
+  /**
+   * Run `body` inside one transaction, resolving with its return value on
+   * commit. A throw from `body` aborts the transaction and rejects with that
+   * error, so a failed multi-write leaves the stores untouched (atomicity).
+   */
+  private async txRun<T>(
+    stores: string[],
+    mode: IDBTransactionMode,
+    body: (tx: IDBTransaction) => Promise<T> | T,
+  ): Promise<T> {
+    const db = await this.openDb();
+    return new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(stores, mode);
+      let result: T;
+      let failure: unknown;
+      tx.oncomplete = () => resolve(result);
+      tx.onerror = () => reject(failure ?? tx.error);
+      tx.onabort = () => reject(failure ?? tx.error);
+      void (async () => {
+        try {
+          result = await body(tx);
+        } catch (err) {
+          failure = err;
+          // The transaction may already be finishing; ignore a late abort throw.
+          try {
+            tx.abort();
+          } catch {
+            /* already inactive */
+          }
+        }
+      })();
+    });
+  }
+
+  /** The payload gate for `kind`, if one is configured (own keys only). */
+  private validatorFor(kind: string): RuntimePayloadValidator | undefined {
+    return Object.hasOwn(this.payloadValidators, kind) ? this.payloadValidators[kind] : undefined;
+  }
+
+  async createSession(init: RuntimeSessionInit): Promise<RuntimeSession> {
+    // The store owns the version stamp: sessions are born stamped, and the
+    // completed envelope is validated BEFORE the transaction opens, so an
+    // invalid session fails loud without any write.
+    const stamped: RuntimeSession = { ...init, runtimeDslVersion: RUNTIME_DSL_VERSION };
+    assertValid(validateRuntimeSession(stamped), `runtime session ${JSON.stringify(stamped.id)}`);
+
+    await this.txRun([SESSIONS], 'readwrite', async (tx) => {
+      const sessions = tx.objectStore(SESSIONS);
+      // Creating twice is a caller bug, not an upsert. Check inside the write
+      // transaction (no TOCTOU) for a deterministic error; `add` (not `put`)
+      // stays as the safety net so a race can never silently overwrite.
+      const existing = await reqP<RuntimeSession | undefined>(sessions.get(stamped.id));
+      if (existing !== undefined) {
+        throw new Error(`@openmaic/storage: session ${JSON.stringify(stamped.id)} already exists`);
+      }
+      sessions.add(stamped);
+    });
+    return stamped;
+  }
+
+  async getSession(sessionId: string): Promise<RuntimeSession | undefined> {
+    const row = await this.txRun([SESSIONS], 'readonly', (tx) =>
+      reqP<RuntimeSession | undefined>(tx.objectStore(SESSIONS).get(sessionId)),
+    );
+    return row === undefined ? undefined : migrateSession(row);
+  }
+
+  async listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]> {
+    const rows = await this.txRun([SESSIONS], 'readonly', (tx) =>
+      reqP<RuntimeSession[]>(
+        tx.objectStore(SESSIONS).index(SESSIONS_BY_STAGE_LEARNER).getAll([stageId, learnerKey]),
+      ),
+    );
+    // ISO-8601 timestamps in one zone compare correctly as plain strings (the
+    // contract requires the zone designator), so `createdAt` string order is
+    // chronological order; tie-break on `id` for a deterministic listing.
+    return rows
+      .map(migrateSession)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+  }
+
+  async setSessionStatus(
+    sessionId: string,
+    status: RuntimeSessionStatus,
+    updatedAt: string,
+  ): Promise<void> {
+    await this.txRun([SESSIONS], 'readwrite', async (tx) => {
+      const sessions = tx.objectStore(SESSIONS);
+      const row = await reqP<RuntimeSession | undefined>(sessions.get(sessionId));
+      if (!row) {
+        throw new Error(`@openmaic/storage: no session ${JSON.stringify(sessionId)}`);
+      }
+      // Forward-compatibility: never mutate (and thereby downgrade) a session
+      // written by a newer client.
+      if (isFutureRuntimeVersioned(row)) throw futureSessionError(sessionId, row);
+      // A stale row is migrated in place before the write. Unlike `putScene`
+      // there is nothing to strand: records carry no version of their own, and
+      // this interface has no full-session save for a caller-side remedy.
+      const updated: RuntimeSession = { ...migrateSession(row), status, updatedAt };
+      assertValid(validateRuntimeSession(updated), `runtime session ${JSON.stringify(sessionId)}`);
+      sessions.put(updated);
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    // Idempotent and deliberately version-agnostic: removal is a coarse,
+    // deliberate action regardless of the version the data was written at.
+    await this.txRun([SESSIONS, RECORDS], 'readwrite', (tx) => {
+      tx.objectStore(SESSIONS).delete(sessionId);
+      tx.objectStore(RECORDS).delete(sessionRecordRange(sessionId));
+    });
+  }
+
+  async appendRecord<TPayload extends RuntimePayload>(
+    init: RuntimeRecordInit<TPayload>,
+  ): Promise<RuntimeRecord<TPayload>> {
+    // Pre-flight the envelope BEFORE opening the write transaction. `seq` is
+    // store-assigned, so validate with a placeholder the in-tx value replaces —
+    // every other field is exactly what will be persisted.
+    assertValid(
+      validateRuntimeRecord({ ...init, seq: 0 }),
+      `runtime record ${JSON.stringify(init.id)}`,
+    );
+
+    return this.txRun([SESSIONS, RECORDS], 'readwrite', async (tx) => {
+      const sessions = tx.objectStore(SESSIONS);
+      const row = await reqP<RuntimeSession | undefined>(sessions.get(init.sessionId));
+      if (!row) {
+        throw new Error(`@openmaic/storage: no session ${JSON.stringify(init.sessionId)}`);
+      }
+      if (isFutureRuntimeVersioned(row)) throw futureSessionError(init.sessionId, row);
+      // Migrate a stale parent in place inside the same transaction, so the
+      // stored session and the record appended under it land together.
+      let session = row;
+      if (needsRuntimeMigration(row)) {
+        session = migrateSession(row);
+        sessions.put(session);
+      }
+      if (session.status !== 'active') {
+        throw new Error(
+          `@openmaic/storage: cannot append to session ${JSON.stringify(init.sessionId)} with ` +
+            `status '${session.status}' — records may only be appended to an active session`,
+        );
+      }
+      // The payload gate keys on the parent's kind (after migration).
+      const validator = this.validatorFor(session.kind);
+      if (validator) {
+        assertValid(validator(init.payload), `runtime record ${JSON.stringify(init.id)}`);
+      }
+
+      // Assign the per-session monotonic `seq` inside the same transaction that
+      // inserts: the highest existing key in the session's range, plus one.
+      const records = tx.objectStore(RECORDS);
+      const last = await reqP(records.openCursor(sessionRecordRange(init.sessionId), 'prev'));
+      const seq = last ? (last.value as RuntimeRecord).seq + 1 : 0;
+      const record: RuntimeRecord<TPayload> = { ...init, seq };
+      records.add(record);
+      return record;
+    });
+  }
+
+  async listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]> {
+    // The compound primary key ['sessionId', 'seq'] makes a ranged read come
+    // back already ordered by `seq`. An absent session simply owns no range.
+    const rows = await this.txRun([RECORDS], 'readonly', (tx) =>
+      reqP<RuntimeRecord[]>(tx.objectStore(RECORDS).getAll(sessionRecordRange(sessionId))),
+    );
+    const sceneId = opts?.sceneId;
+    // Anchors are best-effort: the filter narrows to records anchored to that
+    // scene, excluding un-anchored ones.
+    return sceneId === undefined ? rows : rows.filter((r) => r.sceneId === sceneId);
+  }
+
+  async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {
+    // Global re-key (across ALL stages) — the anonymous-learner-signs-in
+    // migration. Sessions are keyed by their own id, so the move is
+    // non-clobbering by construction; records reference sessions by id and are
+    // untouched. Version-agnostic: rows keep their own stamps.
+    return this.txRun([SESSIONS], 'readwrite', async (tx) => {
+      const sessions = tx.objectStore(SESSIONS);
+      const rows = await reqP<RuntimeSession[]>(
+        sessions.index(SESSIONS_BY_LEARNER).getAll(fromLearnerKey),
+      );
+      for (const row of rows) sessions.put({ ...row, learnerKey: toLearnerKey });
+      return rows.length;
+    });
+  }
+
+  async deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void> {
+    await this.deleteSessionsByIndex(SESSIONS_BY_STAGE_LEARNER, [stageId, learnerKey]);
+  }
+
+  async deleteStageRuntime(stageId: string): Promise<void> {
+    await this.deleteSessionsByIndex(SESSIONS_BY_STAGE, stageId);
+  }
+
+  /**
+   * Cascade-delete every session matched by an index query, plus each
+   * session's record range. Idempotent (nothing matched, nothing deleted) and
+   * deliberately version-agnostic, like `deleteDocument`.
+   */
+  private async deleteSessionsByIndex(indexName: string, query: IDBValidKey): Promise<void> {
+    await this.txRun([SESSIONS, RECORDS], 'readwrite', async (tx) => {
+      const sessions = tx.objectStore(SESSIONS);
+      const records = tx.objectStore(RECORDS);
+      const ids = await reqP<IDBValidKey[]>(sessions.index(indexName).getAllKeys(query));
+      for (const id of ids) {
+        sessions.delete(id);
+        records.delete(sessionRecordRange(id as string));
+      }
+    });
+  }
+}

--- a/packages/@openmaic/storage/src/runtime/browser.ts
+++ b/packages/@openmaic/storage/src/runtime/browser.ts
@@ -251,12 +251,26 @@ export class BrowserRuntimeStore implements RuntimeStore {
         tx.objectStore(SESSIONS).index(SESSIONS_BY_STAGE_LEARNER).getAll([stageId, learnerKey]),
       ),
     );
-    // ISO-8601 timestamps in one zone compare correctly as plain strings (the
-    // contract requires the zone designator), so `createdAt` string order is
-    // chronological order; tie-break on `id` for a deterministic listing.
-    return rows
-      .map(migrateSession)
-      .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+    // Listings tolerate corrupt rows by omission (the `listDocuments`
+    // precedent): one poison row must not make the whole partition
+    // unenumerable. A direct `getSession` on such an id stays fail-loud, and
+    // the delete paths remain the cleanup tool.
+    const sessions: RuntimeSession[] = [];
+    for (const row of rows) {
+      try {
+        sessions.push(migrateSession(row));
+      } catch {
+        // omitted: this row's version resolution failed
+      }
+    }
+    // Order by the instant each timestamp denotes, not by the string: ISO-8601
+    // permits numeric zone offsets, and string order disagrees with instant
+    // order across offsets. `Date.parse` is safe here — both strings already
+    // passed `isIsoTimestamp` at write time. Tie-break on `id` for a
+    // deterministic listing.
+    return sessions.sort(
+      (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt) || a.id.localeCompare(b.id),
+    );
   }
 
   async setSessionStatus(
@@ -329,11 +343,20 @@ export class BrowserRuntimeStore implements RuntimeStore {
       }
 
       // Assign the per-session monotonic `seq` inside the same transaction that
-      // inserts: the highest existing key in the session's range, plus one.
+      // inserts: the highest existing key in the session's range, plus one. A
+      // key cursor reads only the compound primary key — deserializing the
+      // whole previous record (payload included) to read one integer would be
+      // O(payload) for no benefit.
       const records = tx.objectStore(RECORDS);
-      const last = await reqP(records.openCursor(sessionRecordRange(init.sessionId), 'prev'));
-      const seq = last ? (last.value as RuntimeRecord).seq + 1 : 0;
+      const last = await reqP(records.openKeyCursor(sessionRecordRange(init.sessionId), 'prev'));
+      const seq = last ? (last.primaryKey as [string, number])[1] + 1 : 0;
       const record: RuntimeRecord<TPayload> = { ...init, seq };
+      // The pre-flight above fails before the transaction opens (no write
+      // started); this assert on the REAL record — with the store-assigned
+      // `seq` — makes the "validates the completed envelope" contract
+      // literally true. validateRuntimeRecord is pure and synchronous, so the
+      // transaction cannot idle out here.
+      assertValid(validateRuntimeRecord(record), `runtime record ${JSON.stringify(init.id)}`);
       records.add(record);
       return record;
     });
@@ -353,15 +376,44 @@ export class BrowserRuntimeStore implements RuntimeStore {
 
   async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {
     // Global re-key (across ALL stages) — the anonymous-learner-signs-in
-    // migration. Sessions are keyed by their own id, so the move is
-    // non-clobbering by construction; records reference sessions by id and are
-    // untouched. Version-agnostic: rows keep their own stamps.
+    // migration, and the one deliberate cross-stage sweep in the interface.
+    // Sessions are keyed by their own id, so the move is non-clobbering by
+    // construction; records reference sessions by id and are untouched.
+    //
+    // A merge is a write, so it takes the same gates as every other write: a
+    // learner key `createSession` would reject must not be written here, a
+    // newer client's session must not be mutated, and every re-keyed envelope
+    // is validated before it is put. Any throw aborts the WHOLE merge
+    // atomically (txRun) — loud and clean beats silently contaminating the
+    // target partition with poison rows; `deleteSession` on the offending id
+    // is the unblock.
+    if (
+      typeof fromLearnerKey !== 'string' ||
+      fromLearnerKey === '' ||
+      typeof toLearnerKey !== 'string' ||
+      toLearnerKey === ''
+    ) {
+      throw new Error('@openmaic/storage: learner keys must be non-empty strings');
+    }
+    // Self-merge: nothing to move — return without opening a transaction, so
+    // "a second run moves 0" holds for the degenerate case too (re-keying
+    // x → x would otherwise count every row, every time).
+    if (fromLearnerKey === toLearnerKey) return 0;
     return this.txRun([SESSIONS], 'readwrite', async (tx) => {
       const sessions = tx.objectStore(SESSIONS);
       const rows = await reqP<RuntimeSession[]>(
         sessions.index(SESSIONS_BY_LEARNER).getAll(fromLearnerKey),
       );
-      for (const row of rows) sessions.put({ ...row, learnerKey: toLearnerKey });
+      for (const row of rows) {
+        // Re-keying is a mutation; a future-stamped session was written by a
+        // newer client and must not be touched. A corrupt stamp (absent /
+        // malformed / sibling-stamped) throws the runtime line's own error
+        // from inside the guard and aborts the merge the same way.
+        if (isFutureRuntimeVersioned(row)) throw futureSessionError(row.id, row);
+        const updated: RuntimeSession = { ...row, learnerKey: toLearnerKey };
+        assertValid(validateRuntimeSession(updated), `runtime session ${JSON.stringify(row.id)}`);
+        sessions.put(updated);
+      }
       return rows.length;
     });
   }

--- a/packages/@openmaic/storage/src/runtime/types.ts
+++ b/packages/@openmaic/storage/src/runtime/types.ts
@@ -1,0 +1,132 @@
+/**
+ * RuntimeStore — the persistence contract for the learner-runtime layer
+ * (#869): `RuntimeSession`s (identity + lifecycle, partitioned by
+ * `(stageId, learnerKey)`) and their append-only `RuntimeRecord`s.
+ *
+ * The mirror of {@link DocumentStore} for the runtime quadrant of the storage
+ * RFC, with the differences the envelope forces:
+ *
+ * - **Multi-tenant**: a document has ONE stored aggregate; a stage has MANY
+ *   runtime sessions — one or more per `(learnerKey, kind)`. Every query is
+ *   therefore partition-scoped, never global.
+ * - **The store owns the version stamp.** The runtime line has no unversioned
+ *   epoch, so `createSession` takes {@link RuntimeSessionInit} (no stamp) and
+ *   the store stamps `RUNTIME_DSL_VERSION` itself. No code path persists an
+ *   unstamped session.
+ * - **Records are not independently versioned** — the version rides the parent
+ *   session; records are ordered facts under it, `seq` assigned by the store.
+ *
+ * Payload internals are app-owned: per-kind validators are injected like
+ * scene-content validators on DocumentStore, defaulting to the DSL skeleton
+ * guards for the skeleton kinds (`chat`, `quizAttempt`).
+ */
+import type {
+  RuntimePayload,
+  RuntimeRecord,
+  RuntimeRecordInit,
+  RuntimeSession,
+  RuntimeSessionStatus,
+} from '@openmaic/dsl';
+
+/**
+ * The shape a caller hands to {@link RuntimeStore.createSession}: a full
+ * session minus its version stamp. The store stamps `runtimeDslVersion`
+ * itself — sessions are born stamped, and the stamp is the store's write
+ * duty, never the caller's.
+ */
+export type RuntimeSessionInit = Omit<RuntimeSession, 'runtimeDslVersion'>;
+
+/**
+ * Validates one kind's record payload at the store's write boundary — the
+ * runtime counterpart of `SceneValidator` (#860). Same result shape as the
+ * DSL validators so implementations can return them directly.
+ */
+export type RuntimePayloadValidator = (
+  payload: unknown,
+) => { valid: true } | { valid: false; errors: { path: string; message: string }[] };
+
+/**
+ * Persistence contract for runtime sessions + records. All reads migrate on
+ * read (`migrateRuntime`); all writes validate the full envelope and stamp /
+ * guard the runtime version line. Implementations MUST be safe against
+ * version skew from other clients sharing the same storage:
+ *
+ * - a FUTURE-stamped stored session (written by a newer client) rejects
+ *   `appendRecord` / `setSessionStatus` rather than downgrade or corrupt;
+ * - an older-stamped stored session is migrated in place before the write
+ *   (a documented divergence from `putScene`: records carry no version, so
+ *   there are no unmigrated siblings to strand, and this interface has no
+ *   full-session save for a caller-side "load and save" remedy).
+ */
+export interface RuntimeStore {
+  /**
+   * Persist a new session. Stamps `runtimeDslVersion: RUNTIME_DSL_VERSION`,
+   * validates the completed envelope (`validateRuntimeSession`), and fails
+   * loud if a session with the same `id` already exists — creating twice is
+   * a caller bug, not an upsert.
+   */
+  createSession(init: RuntimeSessionInit): Promise<RuntimeSession>;
+
+  /** Load one session, migrated to the current runtime version. `undefined` if absent. */
+  getSession(sessionId: string): Promise<RuntimeSession | undefined>;
+
+  /**
+   * All sessions of one learner on one stage (any status, any kind), migrated,
+   * ordered by `createdAt` ascending. The `(stageId, learnerKey)` pair is the
+   * partition key of the runtime layer — there is deliberately no global
+   * listing.
+   */
+  listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]>;
+
+  /**
+   * Update one session's lifecycle status. `updatedAt` is caller-supplied
+   * (the store is clock-free). Throws if the session is absent, if the stored
+   * copy is future-stamped, or if the envelope would become invalid.
+   */
+  setSessionStatus(
+    sessionId: string,
+    status: RuntimeSessionStatus,
+    updatedAt: string,
+  ): Promise<void>;
+
+  /** Delete one session and all its records. Idempotent. */
+  deleteSession(sessionId: string): Promise<void>;
+
+  /**
+   * Append one record to an ACTIVE session. The store assigns the
+   * per-session monotonic `seq` (starting at 0) inside the same transaction
+   * that inserts, validates the completed envelope
+   * (`validateRuntimeRecord`), and runs the parent session's kind payload
+   * validator if one is configured. Throws if the parent session is absent,
+   * not `active`, or future-stamped.
+   */
+  appendRecord<TPayload extends RuntimePayload>(
+    init: RuntimeRecordInit<TPayload>,
+  ): Promise<RuntimeRecord<TPayload>>;
+
+  /**
+   * A session's records ordered by `seq` (the sole replay ordering key).
+   * `sceneId` narrows to records anchored to that scene (best-effort anchors;
+   * records without a `sceneId` are excluded when the filter is present).
+   */
+  listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]>;
+
+  /**
+   * Re-key every session of `fromLearnerKey` (across ALL stages) to
+   * `toLearnerKey` — the anonymous-learner-signs-in migration. Returns the
+   * number of sessions moved. Idempotent (a second run moves 0) and
+   * non-clobbering by construction (sessions are keyed by their own `id`).
+   * Collapsing duplicate same-kind sessions after a merge (e.g. keeping one
+   * playback session) is app read-policy, not store behavior.
+   */
+  mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number>;
+
+  /** Delete one learner's sessions + records on one stage. Idempotent. */
+  deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void>;
+
+  /**
+   * Delete ALL learners' runtime for a stage — the hook a document deletion
+   * cascades through. Idempotent, deliberately version-agnostic.
+   */
+  deleteStageRuntime(stageId: string): Promise<void>;
+}

--- a/packages/@openmaic/storage/src/runtime/types.ts
+++ b/packages/@openmaic/storage/src/runtime/types.ts
@@ -7,8 +7,10 @@
  * RFC, with the differences the envelope forces:
  *
  * - **Multi-tenant**: a document has ONE stored aggregate; a stage has MANY
- *   runtime sessions — one or more per `(learnerKey, kind)`. Every query is
- *   therefore partition-scoped, never global.
+ *   runtime sessions — one or more per `(learnerKey, kind)`. Every LISTING is
+ *   therefore partition-scoped — there is deliberately no global listing;
+ *   single-session operations are id-keyed, and {@link RuntimeStore.mergeLearner}
+ *   is the one deliberate cross-stage sweep (the sign-in migration).
  * - **The store owns the version stamp.** The runtime line has no unversioned
  *   epoch, so `createSession` takes {@link RuntimeSessionInit} (no stamp) and
  *   the store stamps `RUNTIME_DSL_VERSION` itself. No code path persists an
@@ -72,16 +74,22 @@ export interface RuntimeStore {
 
   /**
    * All sessions of one learner on one stage (any status, any kind), migrated,
-   * ordered by `createdAt` ascending. The `(stageId, learnerKey)` pair is the
-   * partition key of the runtime layer — there is deliberately no global
-   * listing.
+   * ordered by `createdAt` ascending — by the instant each timestamp denotes,
+   * not by string order (ISO-8601 permits numeric zone offsets). The
+   * `(stageId, learnerKey)` pair is the partition key of the runtime layer —
+   * there is deliberately no global listing. Listings tolerate corrupt rows
+   * by omission (one poison row must not make the whole partition
+   * unenumerable — the `listDocuments` precedent); a direct {@link getSession}
+   * on such an id stays fail-loud, and the delete paths are the cleanup tool.
    */
   listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]>;
 
   /**
    * Update one session's lifecycle status. `updatedAt` is caller-supplied
    * (the store is clock-free). Throws if the session is absent, if the stored
-   * copy is future-stamped, or if the envelope would become invalid.
+   * copy is future-stamped, or if the envelope would become invalid — or
+   * throws the runtime version line's own error when the stored row's stamp
+   * is corrupt (absent / malformed / sibling-stamped).
    */
   setSessionStatus(
     sessionId: string,
@@ -98,7 +106,9 @@ export interface RuntimeStore {
    * that inserts, validates the completed envelope
    * (`validateRuntimeRecord`), and runs the parent session's kind payload
    * validator if one is configured. Throws if the parent session is absent,
-   * not `active`, or future-stamped.
+   * not `active`, or future-stamped — or throws the runtime version line's
+   * own error when the stored row's stamp is corrupt (absent / malformed /
+   * sibling-stamped).
    */
   appendRecord<TPayload extends RuntimePayload>(
     init: RuntimeRecordInit<TPayload>,
@@ -113,9 +123,19 @@ export interface RuntimeStore {
 
   /**
    * Re-key every session of `fromLearnerKey` (across ALL stages) to
-   * `toLearnerKey` — the anonymous-learner-signs-in migration. Returns the
-   * number of sessions moved. Idempotent (a second run moves 0) and
+   * `toLearnerKey` — the anonymous-learner-signs-in migration, and the one
+   * deliberate cross-stage sweep in the interface. Returns the number of
+   * sessions moved. Idempotent (a second run — or a self-merge — moves 0) and
    * non-clobbering by construction (sessions are keyed by their own `id`).
+   *
+   * A merge is a write, so it takes the write gates: throws on an empty
+   * learner key, on a future-stamped session (a newer client's data must not
+   * be mutated), or with the runtime version line's own error when a stored
+   * row's stamp is corrupt (absent / malformed / sibling-stamped); every
+   * re-keyed envelope is validated before it is written. Any throw aborts the
+   * WHOLE merge atomically — no partial move ever lands; delete the offending
+   * session to unblock.
+   *
    * Collapsing duplicate same-kind sessions after a merge (e.g. keeping one
    * playback session) is app read-policy, not store behavior.
    */

--- a/packages/@openmaic/storage/src/runtime/types.ts
+++ b/packages/@openmaic/storage/src/runtime/types.ts
@@ -69,7 +69,12 @@ export interface RuntimeStore {
    */
   createSession(init: RuntimeSessionInit): Promise<RuntimeSession>;
 
-  /** Load one session, migrated to the current runtime version. `undefined` if absent. */
+  /**
+   * Load one session, migrated to the current runtime version. `undefined` if
+   * absent. Fail-loud on a corrupt stored row — whether the corruption is the
+   * version stamp (absent / malformed / sibling-stamped) or the rest of the
+   * envelope (a session the store itself would refuse to write).
+   */
   getSession(sessionId: string): Promise<RuntimeSession | undefined>;
 
   /**
@@ -77,10 +82,11 @@ export interface RuntimeStore {
    * ordered by `createdAt` ascending — by the instant each timestamp denotes,
    * not by string order (ISO-8601 permits numeric zone offsets). The
    * `(stageId, learnerKey)` pair is the partition key of the runtime layer —
-   * there is deliberately no global listing. Listings tolerate corrupt rows
-   * by omission (one poison row must not make the whole partition
-   * unenumerable — the `listDocuments` precedent); a direct {@link getSession}
-   * on such an id stays fail-loud, and the delete paths are the cleanup tool.
+   * there is deliberately no global listing. Listings tolerate corrupt rows —
+   * version or envelope corruption alike — by omission (one poison row must
+   * not make the whole partition unenumerable — the `listDocuments`
+   * precedent); a direct {@link getSession} on such an id stays fail-loud, and
+   * the delete paths are the cleanup tool.
    */
   listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]>;
 

--- a/packages/@openmaic/storage/test/runtime-browser.test.ts
+++ b/packages/@openmaic/storage/test/runtime-browser.test.ts
@@ -1,15 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { IDBFactory } from 'fake-indexeddb';
 import { RUNTIME_DSL_VERSION_KEY } from '@openmaic/dsl';
 import { BrowserRuntimeStore } from '../src/index.js';
 import { makeRecordInit, makeSession, runRuntimeStoreContract } from './runtime-contract.js';
-
-// The runtime backend builds its ranged record reads with the ambient
-// `IDBKeyRange` — in a real browser it is always provided alongside
-// `indexedDB`. Tests inject a fake factory, so supply the matching fake range
-// class as the ambient global (what `fake-indexeddb/auto` would do, minus the
-// ambient factory the store deliberately takes by injection instead).
-globalThis.IDBKeyRange = IDBKeyRange;
 
 // Each store gets its own in-memory IndexedDB factory so contract cases stay
 // isolated without leaning on an ambient global.
@@ -22,14 +15,13 @@ runRuntimeStoreContract(
 // at a foreign version, which the public API (the store always stamps the
 // current version) can't express. Mirrors the document backend's reStampStage. ---
 
-// Open the raw DB the store uses and overwrite the session row's version stamp,
-// simulating a session written by another (older / newer / broken) client.
-// `version: undefined` DELETES the stamp — a corrupt row no producer can write.
-async function reStampSession(
+// Open the raw DB the store uses and rewrite one stored session row in place,
+// simulating a row written by another (older / newer / broken) client.
+async function rewriteSessionRow(
   idb: IDBFactory,
   dbName: string,
   sessionId: string,
-  version: string | undefined,
+  rewrite: (row: Record<string, unknown>) => void,
 ): Promise<void> {
   const db = await new Promise<IDBDatabase>((resolve, reject) => {
     const req = idb.open(dbName);
@@ -42,8 +34,7 @@ async function reStampSession(
     const get = store.get(sessionId);
     get.onsuccess = () => {
       const row = get.result as Record<string, unknown>;
-      if (version === undefined) delete row[RUNTIME_DSL_VERSION_KEY];
-      else row[RUNTIME_DSL_VERSION_KEY] = version;
+      rewrite(row);
       store.put(row);
     };
     tx.oncomplete = () => resolve();
@@ -52,19 +43,35 @@ async function reStampSession(
   db.close();
 }
 
+// Overwrite the session row's version stamp. `version: undefined` DELETES the
+// stamp — a corrupt row no producer can write.
+async function reStampSession(
+  idb: IDBFactory,
+  dbName: string,
+  sessionId: string,
+  version: string | undefined,
+): Promise<void> {
+  await rewriteSessionRow(idb, dbName, sessionId, (row) => {
+    if (version === undefined) delete row[RUNTIME_DSL_VERSION_KEY];
+    else row[RUNTIME_DSL_VERSION_KEY] = version;
+  });
+}
+
 describe('BrowserRuntimeStore migrate-on-read', () => {
-  test('a stale-stamped session fails loud on read (no ladder path yet)', async () => {
+  test('a below-epoch stamp fails loud on read (no ladder path)', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-runtime-stale';
     const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
     await store.createSession(makeSession());
     await reStampSession(idb, dbName, 'sess-1', '0.0.9');
 
-    // The runtime ladder is EMPTY today (the initial runtime version IS the
-    // current one), so a past stamp has no migration path and the ladder fails
-    // loud rather than guessing. When the first real runtime migration lands,
-    // this test flips to asserting the lift — a stale session migrated forward
-    // on read, mirroring the document backend's legacy-stamp test.
+    // '0.0.9' predates the runtime line's pinned initial version, so no ladder
+    // will EVER have a path from it — the runtime line has no unversioned
+    // epoch, and its migrations start at the pinned first shipped version.
+    // This below-epoch fail-loud case therefore stays valid forever. When the
+    // first real runtime migration lands, ADD a new test seeding the pinned
+    // initial version and asserting the lift (mirroring the document backend's
+    // legacy-stamp test) — do not repurpose this one.
     await expect(store.getSession('sess-1')).rejects.toThrow(/no migration path/);
   });
 });
@@ -142,5 +149,89 @@ describe('BrowserRuntimeStore corrupt rows', () => {
     // aggregate), never legacy data — it fails loud instead of resurrecting
     // silently at some guessed version.
     await expect(store.getSession('sess-1')).rejects.toThrow(/no unversioned epoch/);
+  });
+
+  test('writes against a stamp-stripped row fail loud too', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-unstamped-writes';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession());
+    await reStampSession(idb, dbName, 'sess-1', undefined);
+
+    // The write guards read the stored row's version first, so a corrupt stamp
+    // surfaces the runtime line's own error rather than being written through.
+    await expect(
+      store.setSessionStatus('sess-1', 'completed', '2026-01-01T00:01:00.000Z'),
+    ).rejects.toThrow(/no unversioned epoch/);
+    await expect(store.appendRecord(makeRecordInit('sess-1'))).rejects.toThrow(
+      /no unversioned epoch/,
+    );
+  });
+
+  test('a corrupt row is omitted from listings but stays loud on direct read', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-tolerant-listing';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession({ id: 'h1' }));
+    await store.createSession(makeSession({ id: 'h2' }));
+    await store.createSession(makeSession({ id: 'corrupt' }));
+    await reStampSession(idb, dbName, 'corrupt', undefined);
+
+    // One poison row must not make the whole partition unenumerable: listings
+    // tolerate corrupt rows by omission (the listDocuments precedent), while a
+    // direct read stays fail-loud and the delete paths remain the cleanup tool.
+    expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+      'h1',
+      'h2',
+    ]);
+    await expect(store.getSession('corrupt')).rejects.toThrow(/no unversioned epoch/);
+  });
+});
+
+describe('BrowserRuntimeStore mergeLearner guards', () => {
+  test('a sibling-stamped row aborts the whole merge atomically', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-merge-poison';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    // 'a-healthy' sorts before 'z-poison' in the index walk, so its re-key is
+    // written first and the poison row's throw must roll it back.
+    await store.createSession(makeSession({ id: 'a-healthy' }));
+    await store.createSession(makeSession({ id: 'z-poison' }));
+    await store.createSession(makeSession({ id: 'existing', learnerKey: 'user:42' }));
+    // Sibling-stamped: the document line's stamp present, the runtime line's
+    // absent — the undecidable cross-line state the version readers reject.
+    await rewriteSessionRow(idb, dbName, 'z-poison', (row) => {
+      delete row[RUNTIME_DSL_VERSION_KEY];
+      row.dslVersion = '0.1.0';
+    });
+
+    await expect(store.mergeLearner('anon:device-1', 'user:42')).rejects.toThrow(/misrouted/);
+    // Atomic abort: NOTHING moved — the target partition is unchanged and the
+    // healthy row is still under the source key (its in-tx re-key rolled back).
+    expect((await store.listSessions('stage-1', 'user:42')).map((s) => s.id)).toEqual(['existing']);
+    expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+      'a-healthy',
+    ]);
+  });
+
+  test('a future-stamped row aborts the merge with nothing moved', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-merge-future';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession({ id: 'a-healthy' }));
+    await store.createSession(makeSession({ id: 'z-future' }));
+    await store.createSession(makeSession({ id: 'existing', learnerKey: 'user:42' }));
+    await reStampSession(idb, dbName, 'z-future', '9.9.9');
+
+    // Re-keying is a mutation; a newer client's session must not be mutated.
+    await expect(store.mergeLearner('anon:device-1', 'user:42')).rejects.toThrow(
+      /newer than this client/,
+    );
+    expect((await store.listSessions('stage-1', 'user:42')).map((s) => s.id)).toEqual(['existing']);
+    // future rows pass through listings unchanged, so both remain visible here
+    expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+      'a-healthy',
+      'z-future',
+    ]);
   });
 });

--- a/packages/@openmaic/storage/test/runtime-browser.test.ts
+++ b/packages/@openmaic/storage/test/runtime-browser.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from 'vitest';
 import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { RUNTIME_DSL_VERSION_KEY } from '@openmaic/dsl';
 import { BrowserRuntimeStore } from '../src/index.js';
-import { runRuntimeStoreContract } from './runtime-contract.js';
+import { makeRecordInit, makeSession, runRuntimeStoreContract } from './runtime-contract.js';
 
 // The runtime backend builds its ranged record reads with the ambient
 // `IDBKeyRange` — in a real browser it is always provided alongside
@@ -15,3 +17,130 @@ runRuntimeStoreContract(
   'BrowserRuntimeStore',
   () => new BrowserRuntimeStore({ indexedDB: new IDBFactory() }),
 );
+
+// --- backend-specific: version-skew behaviours need to seed a raw session row
+// at a foreign version, which the public API (the store always stamps the
+// current version) can't express. Mirrors the document backend's reStampStage. ---
+
+// Open the raw DB the store uses and overwrite the session row's version stamp,
+// simulating a session written by another (older / newer / broken) client.
+// `version: undefined` DELETES the stamp — a corrupt row no producer can write.
+async function reStampSession(
+  idb: IDBFactory,
+  dbName: string,
+  sessionId: string,
+  version: string | undefined,
+): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = idb.open(dbName);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('sessions', 'readwrite');
+    const store = tx.objectStore('sessions');
+    const get = store.get(sessionId);
+    get.onsuccess = () => {
+      const row = get.result as Record<string, unknown>;
+      if (version === undefined) delete row[RUNTIME_DSL_VERSION_KEY];
+      else row[RUNTIME_DSL_VERSION_KEY] = version;
+      store.put(row);
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+}
+
+describe('BrowserRuntimeStore migrate-on-read', () => {
+  test('a stale-stamped session fails loud on read (no ladder path yet)', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-stale';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession());
+    await reStampSession(idb, dbName, 'sess-1', '0.0.9');
+
+    // The runtime ladder is EMPTY today (the initial runtime version IS the
+    // current one), so a past stamp has no migration path and the ladder fails
+    // loud rather than guessing. When the first real runtime migration lands,
+    // this test flips to asserting the lift — a stale session migrated forward
+    // on read, mirroring the document backend's legacy-stamp test.
+    await expect(store.getSession('sess-1')).rejects.toThrow(/no migration path/);
+  });
+});
+
+describe('BrowserRuntimeStore forward-compatibility', () => {
+  test('a future-stamped session reads through unchanged but rejects writes', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-future';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession());
+    await reStampSession(idb, dbName, 'sess-1', '9.9.9');
+
+    // Read never downgrades: the newer-shaped row survives for the next
+    // compatible reader.
+    const loaded = await store.getSession('sess-1');
+    expect(loaded!.runtimeDslVersion).toBe('9.9.9');
+
+    // ...but an older client must not mutate newer-versioned data.
+    await expect(store.appendRecord(makeRecordInit('sess-1'))).rejects.toThrow(
+      /newer than this client/,
+    );
+    await expect(
+      store.setSessionStatus('sess-1', 'completed', '2026-01-01T00:01:00.000Z'),
+    ).rejects.toThrow(/newer than this client/);
+  });
+});
+
+describe('BrowserRuntimeStore injected payload validators', () => {
+  test('payloadValidators: {} replaces (not merges) the default skeleton gate', async () => {
+    const store = new BrowserRuntimeStore({
+      indexedDB: new IDBFactory(),
+      payloadValidators: {},
+    });
+    await store.createSession(makeSession()); // kind: 'chat'
+    // A non-skeleton chat payload — rejected by the default map (see the
+    // contract suite), accepted once the app owns the whole mapping.
+    await expect(
+      store.appendRecord(makeRecordInit('sess-1', { payload: { phase: 'draft' } })),
+    ).resolves.toMatchObject({ seq: 0 });
+  });
+
+  test('a custom validator gates its kind with its own message', async () => {
+    const store = new BrowserRuntimeStore({
+      indexedDB: new IDBFactory(),
+      payloadValidators: {
+        playback: (p) =>
+          typeof p === 'object' && p !== null && 'position' in p
+            ? { valid: true }
+            : {
+                valid: false,
+                errors: [{ path: '/payload', message: 'playback payload requires a position' }],
+              },
+      },
+    });
+    await store.createSession(makeSession({ kind: 'playback' }));
+    await expect(
+      store.appendRecord(makeRecordInit('sess-1', { payload: { position: 1 } })),
+    ).resolves.toMatchObject({ seq: 0 });
+    await expect(
+      store.appendRecord(makeRecordInit('sess-1', { payload: { note: 'x' } })),
+    ).rejects.toThrow(/playback payload requires a position/);
+  });
+});
+
+describe('BrowserRuntimeStore corrupt rows', () => {
+  test('a raw row missing its runtime stamp fails loud on read', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-unstamped';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession());
+    await reStampSession(idb, dbName, 'sess-1', undefined); // strip the stamp
+
+    // The runtime line has no unversioned epoch: sessions are born stamped, so
+    // an unstamped stored row is corruption (or a misrouted document-line
+    // aggregate), never legacy data — it fails loud instead of resurrecting
+    // silently at some guessed version.
+    await expect(store.getSession('sess-1')).rejects.toThrow(/no unversioned epoch/);
+  });
+});

--- a/packages/@openmaic/storage/test/runtime-browser.test.ts
+++ b/packages/@openmaic/storage/test/runtime-browser.test.ts
@@ -168,6 +168,42 @@ describe('BrowserRuntimeStore corrupt rows', () => {
     );
   });
 
+  test('a version-valid row with a corrupt envelope fails loud on direct read', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-corrupt-envelope';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession());
+    // The stamp stays valid; another field is corrupted — version resolution
+    // alone would wave this row through.
+    await rewriteSessionRow(idb, dbName, 'sess-1', (row) => {
+      row.createdAt = 'not-iso';
+    });
+
+    await expect(store.getSession('sess-1')).rejects.toThrow(/createdAt/);
+  });
+
+  test('envelope-corrupt rows are omitted from listings like version-corrupt ones', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-corrupt-envelope-listing';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession({ id: 'h1' }));
+    await store.createSession(makeSession({ id: 'h2' }));
+    await store.createSession(makeSession({ id: 'bad-created' }));
+    await store.createSession(makeSession({ id: 'bad-status' }));
+    await rewriteSessionRow(idb, dbName, 'bad-created', (row) => {
+      row.createdAt = 'not-iso';
+    });
+    await rewriteSessionRow(idb, dbName, 'bad-status', (row) => {
+      row.status = 'paused';
+    });
+
+    // Corrupt-row tolerance covers the whole envelope, not just the stamp.
+    expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+      'h1',
+      'h2',
+    ]);
+  });
+
   test('a corrupt row is omitted from listings but stays loud on direct read', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-runtime-tolerant-listing';

--- a/packages/@openmaic/storage/test/runtime-browser.test.ts
+++ b/packages/@openmaic/storage/test/runtime-browser.test.ts
@@ -1,0 +1,17 @@
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { BrowserRuntimeStore } from '../src/index.js';
+import { runRuntimeStoreContract } from './runtime-contract.js';
+
+// The runtime backend builds its ranged record reads with the ambient
+// `IDBKeyRange` — in a real browser it is always provided alongside
+// `indexedDB`. Tests inject a fake factory, so supply the matching fake range
+// class as the ambient global (what `fake-indexeddb/auto` would do, minus the
+// ambient factory the store deliberately takes by injection instead).
+globalThis.IDBKeyRange = IDBKeyRange;
+
+// Each store gets its own in-memory IndexedDB factory so contract cases stay
+// isolated without leaning on an ambient global.
+runRuntimeStoreContract(
+  'BrowserRuntimeStore',
+  () => new BrowserRuntimeStore({ indexedDB: new IDBFactory() }),
+);

--- a/packages/@openmaic/storage/test/runtime-browser.test.ts
+++ b/packages/@openmaic/storage/test/runtime-browser.test.ts
@@ -214,6 +214,28 @@ describe('BrowserRuntimeStore mergeLearner guards', () => {
     ]);
   });
 
+  test('a below-epoch stale row aborts the merge with nothing moved', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-runtime-merge-stale';
+    const store = new BrowserRuntimeStore({ indexedDB: idb, dbName });
+    await store.createSession(makeSession({ id: 'a-healthy' }));
+    await store.createSession(makeSession({ id: 'z-stale' }));
+    await store.createSession(makeSession({ id: 'existing', learnerKey: 'user:42' }));
+    await reStampSession(idb, dbName, 'z-stale', '0.0.9');
+
+    // The merge migrates each stale row in place before re-keying it (the same
+    // migrate-in-place semantics as setSessionStatus/appendRecord), so a
+    // below-epoch stamp hits the ladder's fail-loud — the same error every
+    // path gives it until a real runtime migration lands.
+    await expect(store.mergeLearner('anon:device-1', 'user:42')).rejects.toThrow(
+      /no migration path/,
+    );
+    expect((await store.listSessions('stage-1', 'user:42')).map((s) => s.id)).toEqual(['existing']);
+    expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+      'a-healthy',
+    ]);
+  });
+
   test('a future-stamped row aborts the merge with nothing moved', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-runtime-merge-future';

--- a/packages/@openmaic/storage/test/runtime-contract.ts
+++ b/packages/@openmaic/storage/test/runtime-contract.ts
@@ -1,0 +1,288 @@
+// Implementation-agnostic contract for `RuntimeStore`. Every backend is proven
+// equivalent by running this same suite against it, so a new backend cannot
+// silently diverge from the store's semantics.
+//
+// Backend-specific behaviours live in the backend's own test file, not here:
+// seeding raw rows (migrate-on-read, future-stamp skew) and — mirroring how
+// document-contract handles injected scene validators — building a store with
+// non-default options (`payloadValidators` overrides).
+import { describe, expect, test } from 'vitest';
+import { RUNTIME_DSL_VERSION } from '@openmaic/dsl';
+import type { RuntimeRecordInit } from '@openmaic/dsl';
+import type { RuntimeStore, RuntimeSessionInit } from '../src/index.js';
+
+// --- fixtures ---------------------------------------------------------------
+
+const T0 = '2026-01-01T00:00:00.000Z';
+const T1 = '2026-01-01T00:01:00.000Z';
+
+/** A valid session init (the pre-stamp shape `createSession` takes). */
+export function makeSession(overrides: Partial<RuntimeSessionInit> = {}): RuntimeSessionInit {
+  return {
+    id: 'sess-1',
+    kind: 'chat',
+    stageId: 'stage-1',
+    learnerKey: 'anon:device-1',
+    status: 'active',
+    createdAt: T0,
+    updatedAt: T0,
+    ...overrides,
+  };
+}
+
+// Deterministic id counter: fixture ids must be unique per call (records are
+// append-only under one session) but stable across runs — no randomness.
+let recordCounter = 0;
+
+/** A valid record init (the pre-`seq` shape `appendRecord` takes). */
+export function makeRecordInit(
+  sessionId: string,
+  overrides: Record<string, unknown> = {},
+): RuntimeRecordInit {
+  recordCounter += 1;
+  return {
+    id: `rec-${recordCounter}`,
+    sessionId,
+    createdAt: T1,
+    payload: { role: 'user', content: 'hello' },
+    ...overrides,
+  } as RuntimeRecordInit;
+}
+
+// --- contract ---------------------------------------------------------------
+
+export function runRuntimeStoreContract(name: string, makeStore: () => RuntimeStore): void {
+  describe(`RuntimeStore contract: ${name}`, () => {
+    describe('sessions', () => {
+      test('createSession stamps the runtime version; getSession round-trips it', async () => {
+        const store = makeStore();
+        const created = await store.createSession(makeSession());
+        expect(created.runtimeDslVersion).toBe(RUNTIME_DSL_VERSION);
+        expect(created).toMatchObject(makeSession());
+
+        const loaded = await store.getSession('sess-1');
+        expect(loaded).toEqual(created);
+      });
+
+      test('createSession rejects a duplicate id — creating twice is a caller bug', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession());
+        await expect(store.createSession(makeSession())).rejects.toThrow(/already exists/);
+      });
+
+      test('createSession rejects an invalid envelope and stores nothing', async () => {
+        const store = makeStore();
+        await expect(store.createSession(makeSession({ learnerKey: '' }))).rejects.toThrow(
+          /learnerKey/,
+        );
+        expect(await store.getSession('sess-1')).toBeUndefined();
+      });
+
+      test('getSession resolves undefined for an absent id', async () => {
+        const store = makeStore();
+        expect(await store.getSession('nope')).toBeUndefined();
+      });
+
+      test('listSessions returns only the (stageId, learnerKey) partition, ordered by createdAt', async () => {
+        const store = makeStore();
+        // Insert the later-created session first: order must come from
+        // `createdAt`, not insertion order.
+        await store.createSession(makeSession({ id: 'a2', createdAt: T1, updatedAt: T1 }));
+        await store.createSession(makeSession({ id: 'a1' }));
+        await store.createSession(makeSession({ id: 'b1', learnerKey: 'anon:device-2' }));
+        await store.createSession(makeSession({ id: 'c1', stageId: 'stage-2' }));
+
+        const partition = await store.listSessions('stage-1', 'anon:device-1');
+        expect(partition.map((s) => s.id)).toEqual(['a1', 'a2']);
+        // isolation both ways: other learner, other stage
+        expect((await store.listSessions('stage-1', 'anon:device-2')).map((s) => s.id)).toEqual([
+          'b1',
+        ]);
+        expect((await store.listSessions('stage-2', 'anon:device-1')).map((s) => s.id)).toEqual([
+          'c1',
+        ]);
+      });
+
+      test('setSessionStatus transitions active → completed with the supplied updatedAt', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession());
+        await store.setSessionStatus('sess-1', 'completed', T1);
+
+        const loaded = await store.getSession('sess-1');
+        expect(loaded!.status).toBe('completed');
+        expect(loaded!.updatedAt).toBe(T1);
+      });
+
+      test('setSessionStatus rejects an absent session', async () => {
+        const store = makeStore();
+        await expect(store.setSessionStatus('ghost', 'completed', T1)).rejects.toThrow(
+          /no session/i,
+        );
+      });
+
+      test('deleteSession removes the session and its records; idempotent', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession());
+        await store.appendRecord(makeRecordInit('sess-1'));
+        await store.deleteSession('sess-1');
+
+        expect(await store.getSession('sess-1')).toBeUndefined();
+        expect(await store.listRecords('sess-1')).toEqual([]);
+        await expect(store.deleteSession('sess-1')).resolves.toBeUndefined();
+      });
+    });
+
+    describe('records', () => {
+      test('appendRecord assigns monotonic seq from 0 and stamps nothing on the record', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession());
+        const r0 = await store.appendRecord(makeRecordInit('sess-1'));
+        const r1 = await store.appendRecord(makeRecordInit('sess-1'));
+        const r2 = await store.appendRecord(makeRecordInit('sess-1'));
+
+        expect([r0.seq, r1.seq, r2.seq]).toEqual([0, 1, 2]);
+        // records ride the parent session's version — no stamp of their own
+        expect('runtimeDslVersion' in r0).toBe(false);
+      });
+
+      test('appendRecord round-trips a null payload and rejects an undefined one', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession({ kind: 'playback' }));
+        const stored = await store.appendRecord(makeRecordInit('sess-1', { payload: null }));
+        expect(stored.payload).toBeNull();
+        expect((await store.listRecords('sess-1'))[0]!.payload).toBeNull();
+
+        await expect(
+          store.appendRecord(makeRecordInit('sess-1', { payload: undefined })),
+        ).rejects.toThrow(/payload/);
+      });
+
+      test('appendRecord rejects an absent parent and a non-active parent', async () => {
+        const store = makeStore();
+        await expect(store.appendRecord(makeRecordInit('ghost'))).rejects.toThrow(/no session/i);
+
+        await store.createSession(makeSession());
+        await store.setSessionStatus('sess-1', 'completed', T1);
+        await expect(store.appendRecord(makeRecordInit('sess-1'))).rejects.toThrow(/active/);
+      });
+
+      test('appendRecord validates skeleton payloads for skeleton kinds by default', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession()); // kind: 'chat'
+        await expect(
+          store.appendRecord(makeRecordInit('sess-1', { payload: { role: 'user', content: 'x' } })),
+        ).resolves.toMatchObject({ seq: 0 });
+        // a quiz-shaped payload on a chat session fails the chat skeleton guard
+        await expect(
+          store.appendRecord(makeRecordInit('sess-1', { payload: { phase: 'draft' } })),
+        ).rejects.toThrow(/payload/);
+
+        // `playback` has no DSL skeleton: an arbitrary object payload is accepted
+        await store.createSession(makeSession({ id: 'sess-2', kind: 'playback' }));
+        await expect(
+          store.appendRecord(makeRecordInit('sess-2', { payload: { position: 42 } })),
+        ).resolves.toMatchObject({ seq: 0 });
+      });
+
+      // Injected `payloadValidators` overrides need a store built with
+      // non-default options, which this factory cannot express — they are
+      // covered in the backend's own test file (as document-contract does for
+      // injected scene validators).
+
+      test('listRecords orders by seq and narrows to anchored records with { sceneId }', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession({ kind: 'playback' }));
+        const a = await store.appendRecord(
+          makeRecordInit('sess-1', { sceneId: 'scene-1', payload: { n: 0 } }),
+        );
+        const b = await store.appendRecord(
+          makeRecordInit('sess-1', { sceneId: 'scene-2', payload: { n: 1 } }),
+        );
+        const c = await store.appendRecord(
+          makeRecordInit('sess-1', { sceneId: 'scene-1', payload: { n: 2 } }),
+        );
+        const unanchored = await store.appendRecord(
+          makeRecordInit('sess-1', { payload: { n: 3 } }),
+        );
+
+        const all = await store.listRecords('sess-1');
+        expect(all.map((r) => r.id)).toEqual([a.id, b.id, c.id, unanchored.id]);
+
+        const anchored = await store.listRecords('sess-1', { sceneId: 'scene-1' });
+        // only records anchored to scene-1; the un-anchored record is excluded
+        expect(anchored.map((r) => r.id)).toEqual([a.id, c.id]);
+      });
+    });
+
+    describe('learner ops', () => {
+      test('mergeLearner re-keys every session of the source learner across all stages', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession({ id: 'from-1' }));
+        await store.createSession(makeSession({ id: 'from-2', stageId: 'stage-2' }));
+        await store.createSession(makeSession({ id: 'kept', learnerKey: 'user:42' }));
+
+        const moved = await store.mergeLearner('anon:device-1', 'user:42');
+        expect(moved).toBe(2);
+
+        // the target learner now owns both partitions, existing sessions untouched
+        expect((await store.listSessions('stage-1', 'user:42')).map((s) => s.id).sort()).toEqual([
+          'from-1',
+          'kept',
+        ]);
+        expect((await store.listSessions('stage-2', 'user:42')).map((s) => s.id)).toEqual([
+          'from-2',
+        ]);
+        expect(await store.listSessions('stage-1', 'anon:device-1')).toEqual([]);
+
+        // idempotent: a second run finds nothing to move
+        expect(await store.mergeLearner('anon:device-1', 'user:42')).toBe(0);
+      });
+
+      test('deleteLearnerRuntime removes exactly one learner on one stage; idempotent', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession({ id: 'target' }));
+        await store.appendRecord(makeRecordInit('target'));
+        await store.createSession(makeSession({ id: 'other-learner', learnerKey: 'user:42' }));
+        await store.createSession(makeSession({ id: 'other-stage', stageId: 'stage-2' }));
+
+        await store.deleteLearnerRuntime('stage-1', 'anon:device-1');
+        expect(await store.getSession('target')).toBeUndefined();
+        expect(await store.listRecords('target')).toEqual([]);
+        // other learner and other stage survive
+        expect(await store.getSession('other-learner')).toBeDefined();
+        expect(await store.getSession('other-stage')).toBeDefined();
+
+        await expect(
+          store.deleteLearnerRuntime('stage-1', 'anon:device-1'),
+        ).resolves.toBeUndefined();
+      });
+
+      test('deleteStageRuntime removes every learner on the stage; other stages survive', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession({ id: 's1' }));
+        await store.appendRecord(makeRecordInit('s1'));
+        await store.createSession(makeSession({ id: 's2', learnerKey: 'user:42' }));
+        await store.createSession(makeSession({ id: 's3', stageId: 'stage-2' }));
+
+        await store.deleteStageRuntime('stage-1');
+        expect(await store.getSession('s1')).toBeUndefined();
+        expect(await store.getSession('s2')).toBeUndefined();
+        expect(await store.listRecords('s1')).toEqual([]);
+        expect(await store.getSession('s3')).toBeDefined();
+
+        await expect(store.deleteStageRuntime('stage-1')).resolves.toBeUndefined();
+      });
+    });
+
+    describe('version line', () => {
+      test('a stored session carries the runtime stamp only — never a dslVersion key', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession());
+        const stored = await store.getSession('sess-1');
+        expect(stored!.runtimeDslVersion).toBe(RUNTIME_DSL_VERSION);
+        // the document line's stamp must not leak onto the runtime line
+        expect('dslVersion' in stored!).toBe(false);
+      });
+    });
+  });
+}

--- a/packages/@openmaic/storage/test/runtime-contract.ts
+++ b/packages/@openmaic/storage/test/runtime-contract.ts
@@ -103,6 +103,30 @@ export function runRuntimeStoreContract(name: string, makeStore: () => RuntimeSt
         ]);
       });
 
+      test('listSessions orders by the instant a timestamp denotes, not by the string', async () => {
+        const store = makeStore();
+        // As strings the Z form sorts first ('2025-…' < '2026-…'); as instants
+        // the offset form is earlier (2026-01-01T00:30+02:00 = 2025-12-31T22:30Z).
+        await store.createSession(
+          makeSession({
+            id: 'zulu',
+            createdAt: '2025-12-31T23:00:00Z',
+            updatedAt: '2025-12-31T23:00:00Z',
+          }),
+        );
+        await store.createSession(
+          makeSession({
+            id: 'offset',
+            createdAt: '2026-01-01T00:30:00+02:00',
+            updatedAt: '2026-01-01T00:30:00+02:00',
+          }),
+        );
+        expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+          'offset',
+          'zulu',
+        ]);
+      });
+
       test('setSessionStatus transitions active → completed with the supplied updatedAt', async () => {
         const store = makeStore();
         await store.createSession(makeSession());
@@ -236,6 +260,25 @@ export function runRuntimeStoreContract(name: string, makeStore: () => RuntimeSt
 
         // idempotent: a second run finds nothing to move
         expect(await store.mergeLearner('anon:device-1', 'user:42')).toBe(0);
+      });
+
+      test('mergeLearner rejects empty learner keys', async () => {
+        const store = makeStore();
+        // a merge is a write: keys createSession would reject must not be
+        // written by the merge either
+        await expect(store.mergeLearner('', 'user:42')).rejects.toThrow(/non-empty/);
+        await expect(store.mergeLearner('anon:device-1', '')).rejects.toThrow(/non-empty/);
+      });
+
+      test('a self-merge moves nothing and returns 0, repeatably', async () => {
+        const store = makeStore();
+        await store.createSession(makeSession());
+        expect(await store.mergeLearner('anon:device-1', 'anon:device-1')).toBe(0);
+        expect(await store.mergeLearner('anon:device-1', 'anon:device-1')).toBe(0);
+        // the session is untouched under its original key
+        expect((await store.listSessions('stage-1', 'anon:device-1')).map((s) => s.id)).toEqual([
+          'sess-1',
+        ]);
       });
 
       test('deleteLearnerRuntime removes exactly one learner on one stage; idempotent', async () => {

--- a/packages/@openmaic/storage/test/setup.ts
+++ b/packages/@openmaic/storage/test/setup.ts
@@ -1,15 +1,23 @@
 // Test shims for the handful of browser globals the backends touch that Node
 // does not provide natively. The backends themselves take their `Storage` /
 // `IDBFactory` by injection, so tests pass fresh isolated instances; these
-// shims only cover the ambient APIs (object URLs, IndexedDB factory type,
+// shims only cover the ambient APIs (object URLs, IndexedDB key ranges,
 // crypto) a real browser supplies.
 import { webcrypto } from 'node:crypto';
+import { IDBKeyRange } from 'fake-indexeddb';
 import { beforeEach } from 'vitest';
 
 // Node ≥20 exposes `globalThis.crypto`, but guard for older/edge runners so
 // content-hashing (crypto.subtle.digest) works the same as in a browser.
 if (!globalThis.crypto?.subtle) {
   Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+}
+
+// The runtime backend builds its ranged record reads with the ambient
+// `IDBKeyRange`, which real browsers always pair with `indexedDB` but Node
+// lacks — supply the fake-indexeddb one that matches the injected factories.
+if (!('IDBKeyRange' in globalThis)) {
+  globalThis.IDBKeyRange = IDBKeyRange;
 }
 
 // object-URL registry: `createObjectURL(blob)` mints a unique `blob:` URL and


### PR DESCRIPTION
Part B of #869: the `RuntimeStore` persistence contract for the learner-runtime layer — interface + browser (IndexedDB) backend + backend-agnostic contract suite in `@openmaic/storage`, mirroring the DocumentStore delivery (#860). Builds directly on the Part A envelope (#870).

## What

- **`RuntimeStore`** (`src/runtime/types.ts`) — sessions are multi-tenant by `(stageId, learnerKey)`; records are append-only ordered facts under an **active** session, with the store-assigned per-session monotonic `seq` as the sole replay ordering key. Operations: session create/get/list/status/delete, `appendRecord`/`listRecords` (with best-effort `sceneId` narrowing), `mergeLearner` (the anonymous-learner-signs-in re-key, global by design), and the two deletion cascades (`deleteLearnerRuntime`, `deleteStageRuntime` — the document-deletion hook).
- **`BrowserRuntimeStore`** (`src/runtime/browser.ts`) — raw IndexedDB via an injected `IDBFactory` (no Dexie), the document backend's exact idioms: memoized open, transactions resolving on commit, fail-loud validation before the write transaction opens.
- **Version-line duty**: sessions are **born stamped** — the store writes `runtimeDslVersion: RUNTIME_DSL_VERSION` at `createSession`; there is no code path that persists an unstamped session (the runtime line has no unversioned epoch, per the Part A review). Reads migrate via `migrateRuntime`; writes reject future-stamped rows and migrate stale rows in place (a documented divergence from `putScene`: records carry no version of their own, and the interface has no full-session save for a caller-side remedy).
- **Per-kind payload validators** injected like `SceneValidator` (#860), defaulting to the DSL skeleton guards for `chat`/`quizAttempt`; `playback` and app-defined kinds carry app-owned payloads.
- **Contract suite** `runRuntimeStoreContract(name, makeStore)` + backend-specific version-skew tests (stale / future / corrupt / sibling-stamped seeded rows).
- **CI**: adds `pnpm --filter @openmaic/storage test` — the package's suite (including the pre-existing DocumentStore/KV/asset contracts) previously never ran in CI.

## Behavior decisions worth reviewer attention

- **Listings tolerate corrupt rows by omission** (the `listDocuments` precedent): one poison row must not make a whole partition unenumerable. Direct `getSession` on such an id stays fail-loud, and the delete paths are the cleanup tool.
- **`mergeLearner` takes every write gate**: key validation, per-row future-guard, migrate-before-re-key, envelope validation — any throw aborts the whole merge atomically. Self-merge is a no-op returning 0.
- **The contract pins gapless `seq` from 0** — intentional strictness: a backend that cannot serialize appends (e.g. a future HTTP backend without server-side sequencing) should fail the suite, not silently diverge.

## Deliberately out of scope (noted for the record)

- Replay-asset export (#779 open question 3) — follow-up once the export shape is settled.
- Bulk-import / seq-backfill primitives for migrating the app's existing Dexie/localStorage data — they belong to the app-side strangler migration, which will also need a permissive `payloadValidators` override for legacy shapes.
- Read paths do not persist migrations (only writes do) — re-reads re-run the ladder; acceptable while migrations are cheap, revisit if a heavy migration ever lands.

## Tests

103 passing (`pnpm --filter @openmaic/storage test`); typecheck, build, prettier, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)