### PR TITLE
feat(renderer/editing): 8-point resize + rotate operate handles (#851 Part A)

### DIFF
--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -437,8 +437,12 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
               absolute SCREEN coordinates (baking in `viewportStyles`) and are
               gated on EDITABILITY (`onElementsChange`), not generic
               `interactive`: without a mutation channel the gestures no-op, so
-              a select-only mount shows no draggable handles. */}
+              a select-only mount shows no draggable handles. Shown only for a
+              SINGLE-element selection: these gestures transform one element,
+              and per-element handles on a multi-selection would misread as
+              group scaling (which is a later slice). */}
           {Boolean(onElementsChange) &&
+            activeSelection.elementIds.length === 1 &&
             elements.map((el) => {
               if (el.type === 'line') return null;
               if (!activeSelection.elementIds.includes(el.id) || el.lock) return null;

--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -1,14 +1,21 @@
 'use client';
 
-import { useRef } from 'react';
+import { Fragment, useRef } from 'react';
+import type { PPTElement } from '@openmaic/dsl';
 
 import { SlideCanvas } from '../SlideCanvas';
 import { getLineElementPath } from '../utils/element';
 import { useViewportSize } from '../hooks/useViewportSize';
 import { SelectionOverlay } from './handles/SelectionOverlay';
 import { LineHandles } from './handles/LineHandles';
+import { ResizeHandles } from './handles/ResizeHandles';
+import { RotateHandle } from './handles/RotateHandle';
 import { useEditGesture } from './useEditGesture';
 import { useLineHandleGesture } from './useLineHandleGesture';
+import { useResizeGesture } from './useResizeGesture';
+import { useRotateGesture } from './useRotateGesture';
+import { getResizeHandles } from './core/resize';
+import { canRotate } from './core/rotate';
 import { EMPTY_SELECTION, type EditableSlideCanvasProps } from './types';
 
 /**
@@ -83,14 +90,52 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
     onElementsChange,
   });
 
+  // Resize gesture (8-point handles on selected box elements). Like the line
+  // gesture, it owns its own working copy (the resized box props), layered on
+  // the box gesture's `workingSlide` below.
+  const { resizeDrag, onResizeHandlePointerDown } = useResizeGesture({
+    slide,
+    scale: canvasScale,
+    snapping,
+    onElementsChange,
+  });
+
+  // Rotate gesture (the handle floating above a box's top edge). It converts
+  // absolute pointer positions to canvas coordinates, so it needs the overlay
+  // origin (`overlayRef` + `viewportStyles`) rather than just a scale.
+  const { rotateDrag, onRotateHandlePointerDown } = useRotateGesture({
+    overlayRef,
+    viewportStyles,
+    scale: canvasScale,
+    onElementsChange,
+  });
+
   // The elements to render/hit-test: the box gesture's working copy, with the
-  // active line-handle drag's props merged in so the v1 canvas, the line's
-  // stroke blocker, and its handles all preview off the SAME working element
-  // and move together during a reshape.
-  const displayElements = lineDrag
-    ? workingSlide.elements.map((el) => (el.id === lineDrag.id ? { ...el, ...lineDrag.props } : el))
-    : workingSlide.elements;
-  const displaySlide = lineDrag ? { ...workingSlide, elements: displayElements } : workingSlide;
+  // active handle drag's props (line reshape / resize box / rotate angle)
+  // merged in so the v1 canvas, the hit layers, and the handles all preview
+  // off the SAME working element and move together during a gesture. At most
+  // one handle gesture is ever in flight (single-pointer hooks), so the merges
+  // never compete.
+  let displayElements = workingSlide.elements;
+  if (lineDrag) {
+    displayElements = displayElements.map((el) =>
+      el.id === lineDrag.id ? ({ ...el, ...lineDrag.props } as PPTElement) : el,
+    );
+  }
+  if (resizeDrag) {
+    displayElements = displayElements.map((el) =>
+      el.id === resizeDrag.id ? ({ ...el, ...resizeDrag.props } as PPTElement) : el,
+    );
+  }
+  if (rotateDrag) {
+    displayElements = displayElements.map((el) =>
+      el.id === rotateDrag.id ? ({ ...el, rotate: rotateDrag.rotate } as PPTElement) : el,
+    );
+  }
+  const displaySlide =
+    displayElements === workingSlide.elements
+      ? workingSlide
+      : { ...workingSlide, elements: displayElements };
 
   const elements = displayElements;
 
@@ -378,6 +423,48 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                   canvasScale={canvasScale}
                   onHandlePointerDown={(handle, e) => onHandlePointerDown(el, handle, e)}
                 />
+              );
+            })}
+
+          {/* Box operate handles: a selected, unlocked box element gets its
+              8-point resize handles and, where the kind supports it, a rotate
+              handle above the top edge. Per-kind gates live in the cores:
+              `getResizeHandles` (text → width axis only, by `vertical`; code →
+              none) and `canRotate` (chart/video/audio excluded). Lines are
+              excluded entirely — their chrome is `LineHandles` above. Handles
+              read the WORKING element (`elements`), so they track the live
+              preview during a resize/rotate. Like the line handles they use
+              absolute SCREEN coordinates (baking in `viewportStyles`) and are
+              gated on EDITABILITY (`onElementsChange`), not generic
+              `interactive`: without a mutation channel the gestures no-op, so
+              a select-only mount shows no draggable handles. */}
+          {Boolean(onElementsChange) &&
+            elements.map((el) => {
+              if (el.type === 'line') return null;
+              if (!activeSelection.elementIds.includes(el.id) || el.lock) return null;
+              const handles = getResizeHandles(el);
+              const rotatable = canRotate(el);
+              if (handles.length === 0 && !rotatable) return null;
+              return (
+                <Fragment key={`operate-${el.id}`}>
+                  {handles.length > 0 && (
+                    <ResizeHandles
+                      element={el}
+                      handles={handles}
+                      viewportStyles={viewportStyles}
+                      canvasScale={canvasScale}
+                      onHandlePointerDown={(handle, e) => onResizeHandlePointerDown(el, handle, e)}
+                    />
+                  )}
+                  {rotatable && (
+                    <RotateHandle
+                      element={el}
+                      viewportStyles={viewportStyles}
+                      canvasScale={canvasScale}
+                      onPointerDown={(e) => onRotateHandlePointerDown(el, e)}
+                    />
+                  )}
+                </Fragment>
               );
             })}
 

--- a/packages/@openmaic/renderer/src/editing/core/drag.ts
+++ b/packages/@openmaic/renderer/src/editing/core/drag.ts
@@ -31,8 +31,10 @@ const DEFAULT_SNAP_RANGE = 5;
  * snap `range`: `true` enables both element- and canvas-snapping at the
  * default range; `false`/absent disables snapping entirely (`null`); an
  * explicit `SnappingOptions` object is used as-is, with `range` defaulted.
+ * Shared by the drag and resize cores so both gestures interpret the
+ * `snapping` prop identically.
  */
-function resolveSnapping(
+export function resolveSnapping(
   snapping: boolean | SnappingOptions | undefined,
 ): { opts: SnappingOptions; range: number } | null {
   if (snapping === true) {

--- a/packages/@openmaic/renderer/src/editing/core/intent.ts
+++ b/packages/@openmaic/renderer/src/editing/core/intent.ts
@@ -8,3 +8,22 @@ import type { EditIntent } from '../types';
 export function moveIntent(id: string, props: { left: number; top: number }): EditIntent {
   return { type: 'element.update', id, props };
 }
+
+/**
+ * Build the `element.update` intent for a completed resize gesture: the box
+ * props only (`left`/`top`/`width`/`height`). Kind-specific content that must
+ * track the box (a shape's path/viewBox, a table's `cellMinHeight`, an image's
+ * clip mode) is intentionally NOT recomputed here — the host can post-process
+ * in response to the intent, or a later slice moves that math into the package.
+ */
+export function resizeIntent(
+  id: string,
+  props: { left: number; top: number; width: number; height: number },
+): EditIntent {
+  return { type: 'element.update', id, props };
+}
+
+/** Build the `element.update` intent for a completed rotate gesture. */
+export function rotateIntent(id: string, rotate: number): EditIntent {
+  return { type: 'element.update', id, props: { rotate } };
+}

--- a/packages/@openmaic/renderer/src/editing/core/resize.ts
+++ b/packages/@openmaic/renderer/src/editing/core/resize.ts
@@ -1,0 +1,488 @@
+import type { PPTElement, PPTLineElement } from '@openmaic/dsl';
+import type { SnappingOptions } from '../types';
+import { resolveSnapping } from './drag';
+import { buildAlignLines, snapRange, type Guide } from './snapping';
+
+/**
+ * Pure, store-free core for the 8-point box resize gesture. Ported from the
+ * app's scale-element gesture, but with no React/store/DOM: the caller feeds
+ * the ORIGINAL element plus a pointer delta already converted to canvas units,
+ * and gets back the new `left/top/width/height` box plus any alignment guides.
+ * No `@/` imports — this module only consumes the DSL element shape, the
+ * sibling snapping/drag cores, and plain numbers.
+ *
+ * Scope note: `computeResize` emits ONLY the box props. Kind-specific content
+ * recomputation that must track the box (a shape's `pathFormula`/`viewBox`
+ * path, a table's `cellMinHeight`, an image's clip mode) is a host/app concern
+ * or a later slice — the host can post-process in response to the intent.
+ */
+
+/** A selectable element that carries a box model (`width`/`height`/`rotate`). */
+export type PPTBoxElement = Exclude<PPTElement, PPTLineElement>;
+
+/** The eight resize points on a box element's selection frame. */
+export type ResizeHandle =
+  | 'left-top'
+  | 'top'
+  | 'right-top'
+  | 'left'
+  | 'right'
+  | 'left-bottom'
+  | 'bottom'
+  | 'right-bottom';
+
+/** All eight handles, in the app's render order (row-major, top to bottom). */
+export const RESIZE_HANDLES: readonly ResizeHandle[] = [
+  'left-top',
+  'top',
+  'right-top',
+  'left',
+  'right',
+  'left-bottom',
+  'bottom',
+  'right-bottom',
+];
+
+/** The diagonally/axially opposite handle — the visually fixed point of a resize. */
+export const OPPOSITE_HANDLE: Record<ResizeHandle, ResizeHandle> = {
+  'left-top': 'right-bottom',
+  top: 'bottom',
+  'right-top': 'left-bottom',
+  left: 'right',
+  right: 'left',
+  'left-bottom': 'right-top',
+  bottom: 'top',
+  'right-bottom': 'left-top',
+};
+
+/**
+ * Minimum size (canvas units) an element may be resized down to, per type.
+ * Mirrors the app's element config so the package clamps identically.
+ */
+export const ELEMENT_MIN_SIZE: Record<string, number> = {
+  text: 40,
+  image: 20,
+  shape: 20,
+  chart: 200,
+  table: 30,
+  video: 250,
+  audio: 20,
+  latex: 20,
+};
+
+/** Fallback minimum size for element types missing from {@link ELEMENT_MIN_SIZE}. */
+const DEFAULT_MIN_SIZE = 20;
+
+interface Box {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface Point {
+  left: number;
+  top: number;
+}
+
+/**
+ * Positions (canvas units) of the eight resize points of a ROTATED box: each
+ * un-rotated frame point rotated about the box center by `angle` (degrees,
+ * CSS-clockwise). At `angle === 0` this degenerates to the plain frame points
+ * (e.g. `left-top` = `(left, top)`), so it also serves as the single source of
+ * truth for handle placement at any rotation.
+ */
+export function getRotateElementPoints(element: Box, angle: number): Record<ResizeHandle, Point> {
+  const { left, top, width, height } = element;
+
+  const radius = Math.sqrt(Math.pow(width, 2) + Math.pow(height, 2)) / 2;
+  const auxiliaryAngle = (Math.atan(height / width) * 180) / Math.PI;
+
+  const tlbraRadian = ((180 - angle - auxiliaryAngle) * Math.PI) / 180;
+  const trblaRadian = ((auxiliaryAngle - angle) * Math.PI) / 180;
+  const taRadian = ((90 - angle) * Math.PI) / 180;
+  const raRadian = (angle * Math.PI) / 180;
+
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  const middleLeft = left + halfWidth;
+  const middleTop = top + halfHeight;
+
+  return {
+    'left-top': {
+      left: middleLeft + radius * Math.cos(tlbraRadian),
+      top: middleTop - radius * Math.sin(tlbraRadian),
+    },
+    top: {
+      left: middleLeft + halfHeight * Math.cos(taRadian),
+      top: middleTop - halfHeight * Math.sin(taRadian),
+    },
+    'right-top': {
+      left: middleLeft + radius * Math.cos(trblaRadian),
+      top: middleTop - radius * Math.sin(trblaRadian),
+    },
+    right: {
+      left: middleLeft + halfWidth * Math.cos(raRadian),
+      top: middleTop + halfWidth * Math.sin(raRadian),
+    },
+    'right-bottom': {
+      left: middleLeft - radius * Math.cos(tlbraRadian),
+      top: middleTop + radius * Math.sin(tlbraRadian),
+    },
+    bottom: {
+      left: middleLeft - halfHeight * Math.sin(raRadian),
+      top: middleTop + halfHeight * Math.cos(raRadian),
+    },
+    'left-bottom': {
+      left: middleLeft - radius * Math.cos(trblaRadian),
+      top: middleTop + radius * Math.sin(trblaRadian),
+    },
+    left: {
+      left: middleLeft - halfWidth * Math.cos(raRadian),
+      top: middleTop - halfWidth * Math.sin(raRadian),
+    },
+  };
+}
+
+/**
+ * The point opposite the operated handle on a rotated box — the base point
+ * that must stay visually fixed while the box resizes (e.g. dragging
+ * `right-bottom` keeps the rotated `left-top` corner in place).
+ */
+function getOppositePoint(handle: ResizeHandle, points: Record<ResizeHandle, Point>): Point {
+  return points[OPPOSITE_HANDLE[handle]];
+}
+
+export type ResizeCursor = 'nwse-resize' | 'ns-resize' | 'nesw-resize' | 'ew-resize';
+
+/**
+ * The visual cursor cycle a handle's cursor advances through as the element
+ * rotates: every +45deg of rotation shifts a handle's on-screen direction one
+ * step clockwise (nwse -> ns -> nesw -> ew -> nwse ...).
+ */
+const CURSOR_CYCLE: readonly ResizeCursor[] = [
+  'nwse-resize',
+  'ns-resize',
+  'nesw-resize',
+  'ew-resize',
+];
+
+/** Each handle's cursor at rotation 0 as an index into {@link CURSOR_CYCLE}. */
+const CURSOR_BASE_INDEX: Record<ResizeHandle, number> = {
+  'left-top': 0,
+  'right-bottom': 0,
+  top: 1,
+  bottom: 1,
+  'right-top': 2,
+  'left-bottom': 2,
+  left: 3,
+  right: 3,
+};
+
+/**
+ * Rotation-aware resize cursor for a handle: bucket `rotate` to the nearest of
+ * 0/45/90/135 (mod 180, +-22.5deg thresholds, negatives wrap the same way),
+ * then advance the handle's rotation-0 cursor one {@link CURSOR_CYCLE} step per
+ * 45deg bucket. Reproduces the app's full handle x bucket cursor table.
+ */
+export function getResizeCursor(handle: ResizeHandle, rotate: number): ResizeCursor {
+  let bucket: 0 | 45 | 90 | 135;
+  if (rotate > -22.5 && rotate <= 22.5) bucket = 0;
+  else if (rotate > 22.5 && rotate <= 67.5) bucket = 45;
+  else if (rotate > 67.5 && rotate <= 112.5) bucket = 90;
+  else if (rotate > 112.5 && rotate <= 157.5) bucket = 135;
+  else if (rotate > 157.5 || rotate <= -157.5) bucket = 0;
+  else if (rotate > -157.5 && rotate <= -112.5) bucket = 45;
+  else if (rotate > -112.5 && rotate <= -67.5) bucket = 90;
+  else bucket = 135; // (-67.5, -22.5]
+
+  return CURSOR_CYCLE[(CURSOR_BASE_INDEX[handle] + bucket / 45) % 4];
+}
+
+/**
+ * Which resize handles a box element exposes, by kind (app parity):
+ * - `code`: none — the app renders no resize points for code blocks.
+ * - `text`: only the width axis, since text height follows content — `left`/
+ *   `right`, or `top`/`bottom` when the text is vertical.
+ * - everything else: all eight points.
+ * Line elements never reach here (they have endpoint handles, not a box).
+ */
+export function getResizeHandles(element: PPTBoxElement): readonly ResizeHandle[] {
+  if (element.type === 'code') return [];
+  if (element.type === 'text') {
+    return element.vertical ? ['top', 'bottom'] : ['left', 'right'];
+  }
+  return RESIZE_HANDLES;
+}
+
+/**
+ * Single-element resize input for one gesture tick: the ORIGINAL element (as
+ * captured at pointer-down — deltas always apply to the origin, never to a
+ * previous tick's output), the operated handle, its siblings (`others`, snap
+ * candidates), the viewport (canvas bounds for `toCanvas` snapping), the
+ * pointer delta already converted to canvas units, whether the aspect-lock
+ * modifier (Ctrl/Shift/Meta) is held at THIS tick, and the snapping config.
+ */
+export interface ResizeInput {
+  element: PPTBoxElement;
+  handle: ResizeHandle;
+  others: PPTElement[];
+  viewport: { width: number; height: number };
+  deltaCanvas: { x: number; y: number };
+  aspectModifier?: boolean;
+  snapping?: boolean | SnappingOptions;
+}
+
+/** The resized element's new box plus the guides to render, if any. */
+export interface ResizeResult {
+  props: { left: number; top: number; width: number; height: number };
+  guides: Guide[];
+}
+
+/**
+ * Apply a resize delta to a single box element. Composition, per the app:
+ *
+ * - **Un-rotated**: the moving edge(s) follow the pointer delta directly; the
+ *   moving corner/edge position is snapped against `others`/the canvas BEFORE
+ *   min-size clamping (aspect lock recomputes the other axis from whichever
+ *   axis snapped); resizing from a left/top edge shifts `left`/`top` so the
+ *   opposite edge stays put. Rotated siblings and lines are excluded from the
+ *   snap candidates (their axis-aligned bboxes are not meaningful snap edges).
+ * - **Rotated**: the pointer delta is first rotated into the element's local
+ *   axes; the same per-handle size math applies; then the position is
+ *   corrected so the point OPPOSITE the operated handle stays visually fixed
+ *   (resizing changes where the rotated opposite corner lands, so `left`/`top`
+ *   must compensate). No snapping for rotated elements (app parity).
+ *
+ * Aspect lock (`aspectModifier` held, or the element's own `fixedRatio`) only
+ * affects the four CORNER handles: the vertical delta is recomputed from the
+ * horizontal one at the origin's aspect ratio. Edge handles ignore it.
+ *
+ * Min-size clamping uses the per-type {@link ELEMENT_MIN_SIZE}; under aspect
+ * lock the limit is scaled so both axes reach their minimum together.
+ */
+export function computeResize(input: ResizeInput): ResizeResult {
+  const { element, handle, others, viewport, deltaCanvas, aspectModifier, snapping } = input;
+
+  const originLeft = element.left;
+  const originTop = element.top;
+  const originWidth = element.width;
+  const originHeight = element.height;
+
+  const rotate = element.rotate || 0;
+  const rotateRadian = (Math.PI * rotate) / 180;
+
+  const fixedRatio =
+    Boolean(aspectModifier) || ('fixedRatio' in element && Boolean(element.fixedRatio));
+  const aspectRatio = originWidth / originHeight;
+
+  const minSize = ELEMENT_MIN_SIZE[element.type] ?? DEFAULT_MIN_SIZE;
+  // Clamp a candidate size to the per-type minimum. Under aspect lock the
+  // shorter axis governs: scale the limits so width and height hit their
+  // minimums at the same aspect-locked step (app parity).
+  const getSizeWithinRange = (size: number, axis: 'width' | 'height'): number => {
+    if (!fixedRatio) return size < minSize ? minSize : size;
+
+    let minWidth = minSize;
+    let minHeight = minSize;
+    const ratio = originWidth / originHeight;
+    if (ratio < 1) minHeight = minSize / ratio;
+    if (ratio > 1) minWidth = minSize * ratio;
+
+    if (axis === 'width') return size < minWidth ? minWidth : size;
+    return size < minHeight ? minHeight : size;
+  };
+
+  let left = originLeft;
+  let top = originTop;
+  let width = originWidth;
+  let height = originHeight;
+  let guides: Guide[] = [];
+
+  // ROTATED path: rotate the pointer delta into element-local axes, apply the
+  // per-handle size math, then correct the position so the opposite point
+  // stays fixed. No alignment snapping for rotated elements (app parity —
+  // axis-aligned snap lines are meaningless against a rotated frame).
+  if (rotate) {
+    const revisedX =
+      Math.cos(rotateRadian) * deltaCanvas.x + Math.sin(rotateRadian) * deltaCanvas.y;
+    let revisedY = Math.cos(rotateRadian) * deltaCanvas.y - Math.sin(rotateRadian) * deltaCanvas.x;
+
+    // Aspect lock (corners only): derive the local vertical delta from the
+    // horizontal one so the box scales at the origin's ratio.
+    if (fixedRatio) {
+      if (handle === 'right-bottom' || handle === 'left-top') revisedY = revisedX / aspectRatio;
+      if (handle === 'left-bottom' || handle === 'right-top') revisedY = -revisedX / aspectRatio;
+    }
+
+    // Per-handle size/position math in the local frame. The position computed
+    // here still needs the opposite-point correction below: resizing a rotated
+    // box moves where its rotated opposite point lands, and only a `left`/`top`
+    // shift keeps it visually fixed. The SIZE needs no correction — the delta
+    // was already rotated into local axes above.
+    if (handle === 'right-bottom') {
+      width = getSizeWithinRange(originWidth + revisedX, 'width');
+      height = getSizeWithinRange(originHeight + revisedY, 'height');
+    } else if (handle === 'left-bottom') {
+      width = getSizeWithinRange(originWidth - revisedX, 'width');
+      height = getSizeWithinRange(originHeight + revisedY, 'height');
+      left = originLeft - (width - originWidth);
+    } else if (handle === 'left-top') {
+      width = getSizeWithinRange(originWidth - revisedX, 'width');
+      height = getSizeWithinRange(originHeight - revisedY, 'height');
+      left = originLeft - (width - originWidth);
+      top = originTop - (height - originHeight);
+    } else if (handle === 'right-top') {
+      width = getSizeWithinRange(originWidth + revisedX, 'width');
+      height = getSizeWithinRange(originHeight - revisedY, 'height');
+      top = originTop - (height - originHeight);
+    } else if (handle === 'top') {
+      height = getSizeWithinRange(originHeight - revisedY, 'height');
+      top = originTop - (height - originHeight);
+    } else if (handle === 'bottom') {
+      height = getSizeWithinRange(originHeight + revisedY, 'height');
+    } else if (handle === 'left') {
+      width = getSizeWithinRange(originWidth - revisedX, 'width');
+      left = originLeft - (width - originWidth);
+    } else if (handle === 'right') {
+      width = getSizeWithinRange(originWidth + revisedX, 'width');
+    }
+
+    // Opposite-point correction: capture where the opposite point sat on the
+    // ORIGINAL box, recompute it on the resized box, and shift `left`/`top`
+    // back by the drift so the opposite handle stays visually fixed.
+    const basePoint = getOppositePoint(
+      handle,
+      getRotateElementPoints(
+        { left: originLeft, top: originTop, width: originWidth, height: originHeight },
+        rotate,
+      ),
+    );
+    const currentPoint = getOppositePoint(
+      handle,
+      getRotateElementPoints({ left, top, width, height }, rotate),
+    );
+
+    left -= currentPoint.left - basePoint.left;
+    top -= currentPoint.top - basePoint.top;
+
+    return { props: { left, top, width, height }, guides };
+  }
+
+  // UN-ROTATED path: the pointer delta applies directly, with alignment
+  // snapping of the moving corner/edge and simple left/top shifts.
+  let moveX = deltaCanvas.x;
+  let moveY = deltaCanvas.y;
+
+  // Aspect lock (corners only), pre-snap: same derivation as the rotated path.
+  if (fixedRatio) {
+    if (handle === 'right-bottom' || handle === 'left-top') moveY = moveX / aspectRatio;
+    if (handle === 'left-bottom' || handle === 'right-top') moveY = -moveX / aspectRatio;
+  }
+
+  const resolved = resolveSnapping(snapping);
+  const lines = resolved
+    ? buildAlignLines(
+        // Rotated siblings and lines are excluded from resize snap candidates
+        // (app parity): a rotated element's axis-aligned bbox edges are not
+        // where anything visually aligns, and a line has no box to align to.
+        others.filter((o) => o.type !== 'line' && !(o.rotate ?? 0)),
+        viewport,
+        resolved.opts,
+      )
+    : null;
+
+  // Snap the MOVING point (the operated corner, or the moving edge on one
+  // axis) against the candidate lines, BEFORE clamping. A degenerate
+  // single-point range makes `snapRange` probe exactly that point; edge
+  // handles suppress the non-moving axis by passing it no candidate lines.
+  const snapPoint = (
+    probeX: number,
+    probeY: number,
+    axes: 'both' | 'x' | 'y',
+  ): { dx: number; dy: number } => {
+    if (!lines || !resolved) return { dx: 0, dy: 0 };
+    const {
+      dx,
+      dy,
+      guides: g,
+    } = snapRange(
+      { minX: probeX, maxX: probeX, minY: probeY, maxY: probeY },
+      {
+        vertical: axes === 'y' ? [] : lines.vertical,
+        horizontal: axes === 'x' ? [] : lines.horizontal,
+      },
+      resolved.range,
+    );
+    guides = g;
+    return { dx, dy };
+  };
+
+  // Post-snap aspect re-lock (corners): if the vertical axis snapped, it wins
+  // and the horizontal delta is recomputed from it; otherwise the horizontal
+  // delta drives, exactly as in the pre-snap derivation.
+  const relockAspect = (dy: number, sign: 1 | -1) => {
+    if (!fixedRatio) return;
+    if (dy !== 0) moveX = sign * moveY * aspectRatio;
+    else moveY = (sign * moveX) / aspectRatio;
+  };
+
+  if (handle === 'right-bottom') {
+    const { dx, dy } = snapPoint(
+      originLeft + originWidth + moveX,
+      originTop + originHeight + moveY,
+      'both',
+    );
+    moveX += dx;
+    moveY += dy;
+    relockAspect(dy, 1);
+    width = getSizeWithinRange(originWidth + moveX, 'width');
+    height = getSizeWithinRange(originHeight + moveY, 'height');
+  } else if (handle === 'left-bottom') {
+    const { dx, dy } = snapPoint(originLeft + moveX, originTop + originHeight + moveY, 'both');
+    moveX += dx;
+    moveY += dy;
+    relockAspect(dy, -1);
+    width = getSizeWithinRange(originWidth - moveX, 'width');
+    height = getSizeWithinRange(originHeight + moveY, 'height');
+    left = originLeft - (width - originWidth);
+  } else if (handle === 'left-top') {
+    const { dx, dy } = snapPoint(originLeft + moveX, originTop + moveY, 'both');
+    moveX += dx;
+    moveY += dy;
+    relockAspect(dy, 1);
+    width = getSizeWithinRange(originWidth - moveX, 'width');
+    height = getSizeWithinRange(originHeight - moveY, 'height');
+    left = originLeft - (width - originWidth);
+    top = originTop - (height - originHeight);
+  } else if (handle === 'right-top') {
+    const { dx, dy } = snapPoint(originLeft + originWidth + moveX, originTop + moveY, 'both');
+    moveX += dx;
+    moveY += dy;
+    relockAspect(dy, -1);
+    width = getSizeWithinRange(originWidth + moveX, 'width');
+    height = getSizeWithinRange(originHeight - moveY, 'height');
+    top = originTop - (height - originHeight);
+  } else if (handle === 'left') {
+    const { dx } = snapPoint(originLeft + moveX, originTop, 'x');
+    moveX += dx;
+    width = getSizeWithinRange(originWidth - moveX, 'width');
+    left = originLeft - (width - originWidth);
+  } else if (handle === 'right') {
+    const { dx } = snapPoint(originLeft + originWidth + moveX, originTop, 'x');
+    moveX += dx;
+    width = getSizeWithinRange(originWidth + moveX, 'width');
+  } else if (handle === 'top') {
+    const { dy } = snapPoint(originLeft, originTop + moveY, 'y');
+    moveY += dy;
+    height = getSizeWithinRange(originHeight - moveY, 'height');
+    top = originTop - (height - originHeight);
+  } else if (handle === 'bottom') {
+    const { dy } = snapPoint(originLeft, originTop + originHeight + moveY, 'y');
+    moveY += dy;
+    height = getSizeWithinRange(originHeight + moveY, 'height');
+  }
+
+  return { props: { left, top, width, height }, guides };
+}

--- a/packages/@openmaic/renderer/src/editing/core/rotate.ts
+++ b/packages/@openmaic/renderer/src/editing/core/rotate.ts
@@ -1,0 +1,84 @@
+import type { PPTElement } from '@openmaic/dsl';
+
+/**
+ * Pure, store-free core for the rotate gesture. Ported from the app's
+ * rotate-element gesture, but with no React/store/DOM: the caller feeds the
+ * ORIGINAL element's box plus the pointer position already converted to canvas
+ * units, and gets back the new signed rotation angle. No `@/` imports — this
+ * module only consumes the DSL element shape and plain numbers.
+ */
+
+/** Snap threshold (degrees) around the 45deg multiples. Mirrors the app. */
+export const ROTATE_SNAP_RANGE = 5;
+
+/**
+ * Element kinds that expose a rotate handle (app parity): the app's operate
+ * layer renders no rotate handle for charts, video, or audio (and lines have
+ * no `rotate` at all; code blocks render no operate handles whatsoever).
+ */
+const ROTATABLE_TYPES: ReadonlySet<PPTElement['type']> = new Set([
+  'text',
+  'image',
+  'shape',
+  'table',
+  'latex',
+]);
+
+/** Whether an element kind supports the rotate gesture. */
+export function canRotate(element: PPTElement): boolean {
+  return ROTATABLE_TYPES.has(element.type);
+}
+
+/**
+ * Angle (degrees) of the ray from the origin to `(x, y)`, measured CLOCKWISE
+ * from straight up — matching CSS `rotate()` — via `atan2(x, y)` (note the
+ * argument order: x first). Range `(-180, 180]`.
+ */
+function getAngleFromCoordinate(x: number, y: number): number {
+  const radian = Math.atan2(x, y);
+  return (180 / Math.PI) * radian;
+}
+
+/**
+ * Rotate input for one gesture tick: the ORIGINAL element's box (the rotation
+ * center is its center and never moves during the gesture) and the pointer
+ * position in canvas units.
+ */
+export interface RotateInput {
+  element: { left: number; top: number; width: number; height: number };
+  pointerCanvas: { x: number; y: number };
+}
+
+/**
+ * The new rotation for a box whose rotate handle is dragged to `pointerCanvas`:
+ * the CSS-clockwise angle of center->pointer measured from straight up, snapped
+ * to the nearest multiple of 45deg when within {@link ROTATE_SNAP_RANGE}. The
+ * result is SIGNED in `(-180, 180]` (never normalized to `[0, 360)`), matching
+ * how the app stores `rotate`.
+ */
+export function computeRotate(input: RotateInput): number {
+  const { element, pointerCanvas } = input;
+
+  const centerX = element.left + element.width / 2;
+  const centerY = element.top + element.height / 2;
+
+  // Screen-y grows downward, so invert the vertical component to measure the
+  // angle in the y-up frame `getAngleFromCoordinate` expects.
+  const x = pointerCanvas.x - centerX;
+  const y = centerY - pointerCanvas.y;
+
+  let angle = getAngleFromCoordinate(x, y);
+
+  // Snap to multiples of 45deg when close (0, +-45, +-90, +-135, +-180).
+  if (Math.abs(angle) <= ROTATE_SNAP_RANGE) angle = 0;
+  else if (angle > 0 && Math.abs(angle - 45) <= ROTATE_SNAP_RANGE) angle = 45;
+  else if (angle < 0 && Math.abs(angle + 45) <= ROTATE_SNAP_RANGE) angle = -45;
+  else if (angle > 0 && Math.abs(angle - 90) <= ROTATE_SNAP_RANGE) angle = 90;
+  else if (angle < 0 && Math.abs(angle + 90) <= ROTATE_SNAP_RANGE) angle = -90;
+  else if (angle > 0 && Math.abs(angle - 135) <= ROTATE_SNAP_RANGE) angle = 135;
+  else if (angle < 0 && Math.abs(angle + 135) <= ROTATE_SNAP_RANGE) angle = -135;
+  else if (angle > 0 && Math.abs(angle - 180) <= ROTATE_SNAP_RANGE) angle = 180;
+  else if (angle < 0 && Math.abs(angle + 180) <= ROTATE_SNAP_RANGE) angle = -180;
+
+  return angle;
+}

--- a/packages/@openmaic/renderer/src/editing/handles/ResizeHandles.tsx
+++ b/packages/@openmaic/renderer/src/editing/handles/ResizeHandles.tsx
@@ -1,0 +1,83 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+import type { ViewportStyles } from '../../hooks/useViewportSize';
+import {
+  getRotateElementPoints,
+  getResizeCursor,
+  type PPTBoxElement,
+  type ResizeHandle,
+} from '../core/resize';
+
+export interface ResizeHandlesProps {
+  /** The box element whose resize points are drawn. */
+  element: PPTBoxElement;
+  /** Which of the eight points to draw (per-kind gate, e.g. text gets two). */
+  handles: readonly ResizeHandle[];
+  /** SlideCanvas centering offset — handles share the element container's origin. */
+  viewportStyles: ViewportStyles;
+  /** Canvas → screen scale (`props.scale ?? fitScale`). */
+  canvasScale: number;
+  /** Arm a resize gesture from a pointer-down on a handle box. */
+  onHandlePointerDown: (handle: ResizeHandle, e: ReactPointerEvent) => void;
+}
+
+/** Half the handle box size, so `translate(-HALF, -HALF)` centers it on its point. */
+const HANDLE_HALF = 5;
+
+/**
+ * Presentational 8-point resize handles for a selected box element.
+ * Props-driven only: draws a small draggable box centered on each requested
+ * point, with a rotation-aware directional cursor.
+ *
+ * Positions are computed ANALYTICALLY in canvas space via
+ * {@link getRotateElementPoints} — the exact rotated location of each frame
+ * point — rather than nesting the handles inside a rotated CSS frame. That
+ * keeps every handle in plain overlay screen coordinates (like `LineHandles`),
+ * so hit-testing, the drag math, and the un-rotated 10px handle boxes all
+ * agree: `left = viewportStyles.left + point.left * canvasScale` (same for
+ * `top`), matching the element container's origin even when letterboxed.
+ * Each box carries `data-resize-handle={handle}` and arms the resize gesture
+ * via `onHandlePointerDown`. No `@/` imports.
+ */
+export function ResizeHandles({
+  element,
+  handles,
+  viewportStyles,
+  canvasScale,
+  onHandlePointerDown,
+}: ResizeHandlesProps) {
+  const rotate = element.rotate || 0;
+  const points = getRotateElementPoints(
+    { left: element.left, top: element.top, width: element.width, height: element.height },
+    rotate,
+  );
+
+  return (
+    <>
+      {handles.map((handle) => {
+        const point = points[handle];
+        return (
+          <div
+            key={handle}
+            data-resize-handle={handle}
+            onPointerDown={(e) => onHandlePointerDown(handle, e)}
+            style={{
+              position: 'absolute',
+              left: `${viewportStyles.left + point.left * canvasScale}px`,
+              top: `${viewportStyles.top + point.top * canvasScale}px`,
+              width: '10px',
+              height: '10px',
+              transform: `translate(-${HANDLE_HALF}px, -${HANDLE_HALF}px)`,
+              border: '1px solid #3b82f6',
+              backgroundColor: '#fff',
+              boxSizing: 'border-box',
+              pointerEvents: 'auto',
+              cursor: getResizeCursor(handle, rotate),
+              touchAction: 'none',
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/packages/@openmaic/renderer/src/editing/handles/RotateHandle.tsx
+++ b/packages/@openmaic/renderer/src/editing/handles/RotateHandle.tsx
@@ -1,0 +1,83 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+import type { ViewportStyles } from '../../hooks/useViewportSize';
+import { getRotateElementPoints, type PPTBoxElement } from '../core/resize';
+
+export interface RotateHandleProps {
+  /** The box element whose rotate handle is drawn. */
+  element: PPTBoxElement;
+  /** SlideCanvas centering offset — the handle shares the element container's origin. */
+  viewportStyles: ViewportStyles;
+  /** Canvas → screen scale (`props.scale ?? fitScale`). */
+  canvasScale: number;
+  /** Arm a rotate gesture from a pointer-down on the handle box. */
+  onPointerDown: (e: ReactPointerEvent) => void;
+}
+
+/** Half the handle box size, so `translate(-HALF, -HALF)` centers it on its point. */
+const HANDLE_HALF = 5;
+
+/**
+ * Screen-pixel gap between the element's rotated top edge and the rotate
+ * handle, along the element's rotated "up" direction (app parity: the app
+ * offsets the handle 25 un-scaled px above the frame inside its rotated
+ * operate layer, so the gap is constant on screen at any zoom).
+ */
+const ROTATE_HANDLE_OFFSET_PX = 25;
+
+/**
+ * Presentational rotate handle for a selected box element: a small grab-cursor
+ * box floating above the element's rotated top-center point.
+ *
+ * Position is computed ANALYTICALLY (like `ResizeHandles`): the rotated
+ * top-center point comes from {@link getRotateElementPoints}, then the handle
+ * is pushed {@link ROTATE_HANDLE_OFFSET_PX} screen px further along the rotated
+ * up vector `(sin θ, -cos θ)` — the un-rotated `(0, -1)` turned by the
+ * element's angle — so the handle orbits the element as it rotates. The box
+ * carries `data-rotate-handle` and arms the rotate gesture via
+ * `onPointerDown`. No `@/` imports.
+ */
+export function RotateHandle({
+  element,
+  viewportStyles,
+  canvasScale,
+  onPointerDown,
+}: RotateHandleProps) {
+  const rotate = element.rotate || 0;
+  const rotateRadian = (Math.PI * rotate) / 180;
+
+  const topPoint = getRotateElementPoints(
+    { left: element.left, top: element.top, width: element.width, height: element.height },
+    rotate,
+  ).top;
+
+  const left =
+    viewportStyles.left +
+    topPoint.left * canvasScale +
+    ROTATE_HANDLE_OFFSET_PX * Math.sin(rotateRadian);
+  const top =
+    viewportStyles.top +
+    topPoint.top * canvasScale -
+    ROTATE_HANDLE_OFFSET_PX * Math.cos(rotateRadian);
+
+  return (
+    <div
+      data-rotate-handle=""
+      onPointerDown={onPointerDown}
+      style={{
+        position: 'absolute',
+        left: `${left}px`,
+        top: `${top}px`,
+        width: '10px',
+        height: '10px',
+        transform: `translate(-${HANDLE_HALF}px, -${HANDLE_HALF}px)`,
+        border: '1px solid #3b82f6',
+        backgroundColor: '#fff',
+        boxSizing: 'border-box',
+        pointerEvents: 'auto',
+        cursor: 'grab',
+        touchAction: 'none',
+      }}
+    />
+  );
+}

--- a/packages/@openmaic/renderer/src/editing/useResizeGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useResizeGesture.ts
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState, useEffect, useRef, type PointerEvent as ReactPointerEvent } from 'react';
+import type { Slide } from '@openmaic/dsl';
+
+import {
+  computeResize,
+  type PPTBoxElement,
+  type ResizeHandle,
+  type ResizeResult,
+} from './core/resize';
+import { resizeIntent } from './core/intent';
+import type { Guide } from './core/snapping';
+import type { EditIntent, SnappingOptions } from './types';
+
+/**
+ * Distance (screen px) a handle must travel between pointer-down and pointer-up
+ * before the gesture commits a resize. Below this a handle click is inert (no
+ * `element.update`), mirroring the box drag/click threshold in useEditGesture.
+ */
+const DRAG_THRESHOLD_PX = 2;
+
+export interface UseResizeGestureArgs {
+  /** The controlled slide — supplies snap candidates and the canvas bounds. */
+  slide: Slide;
+  /** Canvas → screen scale; the inverse converts the pointer delta to canvas units. */
+  scale: number;
+  snapping?: boolean | SnappingOptions;
+  onElementsChange?: (intents: EditIntent[]) => void;
+}
+
+/** The in-flight resize drag: which element, the working box, and its guides. */
+export interface ResizeDrag {
+  id: string;
+  props: ResizeResult['props'];
+  /** Alignment guides for the active resize (computed; drawn by a later PR). */
+  guides: Guide[];
+}
+
+export interface UseResizeGestureResult {
+  /** The active resize drag's working box (for live preview), else `null`. */
+  resizeDrag: ResizeDrag | null;
+  /** Arm a resize gesture from a pointer-down on `element`'s `handle`. */
+  onResizeHandlePointerDown: (
+    element: PPTBoxElement,
+    handle: ResizeHandle,
+    e: ReactPointerEvent,
+  ) => void;
+}
+
+/**
+ * Owns one 8-point resize gesture, mirroring {@link useEditGesture} but for a
+ * dragged resize handle. Pointer-down records the pointer start + the ORIGINAL
+ * element + the handle; window pointer-move converts the screen delta to canvas
+ * units (`/scale`), reads the aspect-lock modifier (Ctrl/Shift/Meta) off the
+ * MOVE event (so holding/releasing it mid-drag re-locks live, app parity), runs
+ * the store-free {@link computeResize} against the sibling elements, and
+ * republishes the resulting box as a working copy for 60fps preview; pointer-up
+ * commits exactly one `element.update` intent when the pointer moved past
+ * {@link DRAG_THRESHOLD_PX} and a mutation channel exists, then clears the
+ * working copy. `pointercancel` reverts without emitting.
+ *
+ * Single-pointer by design: a second pointer-down while a gesture is in flight
+ * is ignored, and window move/up from any other pointerId is dropped. Pure
+ * gesture glue: no store, no `@/` imports.
+ */
+export function useResizeGesture(args: UseResizeGestureArgs): UseResizeGestureResult {
+  const { slide, scale, snapping, onElementsChange } = args;
+
+  const [resizeDrag, setResizeDrag] = useState<ResizeDrag | null>(null);
+
+  // Teardown for the currently-armed gesture's window listeners; the unmount
+  // effect removes any listeners still live so a late move/up can't setState on
+  // an unmounted host.
+  const teardownRef = useRef<(() => void) | null>(null);
+  // The pointerId owning the in-flight gesture (single-pointer guard).
+  const activePointerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      teardownRef.current?.();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+    },
+    [],
+  );
+
+  const onResizeHandlePointerDown = (
+    element: PPTBoxElement,
+    handle: ResizeHandle,
+    e: ReactPointerEvent,
+  ) => {
+    // Defense-in-depth: never arm on a locked element (the primary guard skips
+    // rendering handles for a locked element in EditableSlideCanvas).
+    if (element.lock) return;
+    if (activePointerRef.current !== null) return;
+    activePointerRef.current = e.pointerId;
+
+    // A handle drag resizes the element — it must never fall through to the
+    // box hit layer beneath (which would start a move or change selection).
+    e.stopPropagation();
+
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const effectiveScale = scale || 1;
+
+    const others = slide.elements.filter((o) => o.id !== element.id);
+    const viewport = {
+      width: slide.viewportSize,
+      height: slide.viewportSize * slide.viewportRatio,
+    };
+
+    try {
+      (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+    } catch {
+      // jsdom / unsupported: pointer capture is a best-effort nicety.
+    }
+
+    const compute = (clientX: number, clientY: number, aspectModifier: boolean) =>
+      computeResize({
+        element,
+        handle,
+        others,
+        viewport,
+        deltaCanvas: {
+          x: (clientX - startX) / effectiveScale,
+          y: (clientY - startY) / effectiveScale,
+        },
+        aspectModifier,
+        snapping,
+      });
+
+    // The aspect-lock modifier is re-read from EVERY pointer event, so the
+    // lock engages/disengages live as the user presses/releases the key
+    // mid-drag (deltas always re-apply to the ORIGINAL element, so toggling
+    // never accumulates error).
+    const modifierOf = (ev: PointerEvent) => ev.ctrlKey || ev.shiftKey || ev.metaKey;
+
+    const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      // No mutation channel: a live preview would just follow the pointer and
+      // snap back on pointer-up. Skip live movement when nothing can commit.
+      if (!onElementsChange) return;
+      const { props, guides } = compute(ev.clientX, ev.clientY, modifierOf(ev));
+      setResizeDrag({ id: element.id, props, guides });
+    };
+
+    const removeListeners = () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleCancel);
+    };
+
+    const handleUp = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      removeListeners();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+
+      const movedPast = Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD_PX;
+      if (movedPast && onElementsChange) {
+        const { props } = compute(ev.clientX, ev.clientY, modifierOf(ev));
+        onElementsChange([resizeIntent(element.id, props)]);
+      }
+
+      setResizeDrag(null);
+    };
+
+    const handleCancel = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      removeListeners();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+      setResizeDrag(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleCancel);
+    teardownRef.current = removeListeners;
+  };
+
+  return { resizeDrag, onResizeHandlePointerDown };
+}

--- a/packages/@openmaic/renderer/src/editing/useResizeGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useResizeGesture.ts
@@ -160,7 +160,15 @@ export function useResizeGesture(args: UseResizeGestureArgs): UseResizeGestureRe
       const movedPast = Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD_PX;
       if (movedPast && onElementsChange) {
         const { props } = compute(ev.clientX, ev.clientY, modifierOf(ev));
-        onElementsChange([resizeIntent(element.id, props)]);
+        // Snapping can pull the box back to exactly its original geometry; a
+        // no-op update would still cost the host an undo entry, so skip it
+        // (same guard as the rotate gesture's unchanged-angle case).
+        const unchanged =
+          props.left === element.left &&
+          props.top === element.top &&
+          props.width === element.width &&
+          props.height === element.height;
+        if (!unchanged) onElementsChange([resizeIntent(element.id, props)]);
       }
 
       setResizeDrag(null);

--- a/packages/@openmaic/renderer/src/editing/useRotateGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useRotateGesture.ts
@@ -1,0 +1,180 @@
+'use client';
+
+import {
+  useState,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from 'react';
+
+import { computeRotate } from './core/rotate';
+import { rotateIntent } from './core/intent';
+import type { PPTBoxElement } from './core/resize';
+import type { ViewportStyles } from '../hooks/useViewportSize';
+import type { EditIntent } from './types';
+
+/**
+ * Distance (screen px) the pointer must travel between pointer-down and
+ * pointer-up before the gesture commits a rotation. Below this a handle click
+ * is inert (no `element.update`), mirroring the other gesture hooks.
+ */
+const DRAG_THRESHOLD_PX = 2;
+
+export interface UseRotateGestureArgs {
+  /**
+   * The interaction overlay element. Its bounding rect (captured once per
+   * gesture, at pointer-down) plus `viewportStyles.left/top` locate the canvas
+   * origin on screen, which is what converts absolute pointer positions to
+   * canvas coordinates — rotation is computed from the ABSOLUTE pointer
+   * position relative to the element center, not from a pointer delta.
+   */
+  overlayRef: RefObject<HTMLElement | null>;
+  /** SlideCanvas centering offset (screen px) inside the overlay. */
+  viewportStyles: ViewportStyles;
+  /** Canvas → screen scale; the inverse converts pointer positions to canvas units. */
+  scale: number;
+  onElementsChange?: (intents: EditIntent[]) => void;
+}
+
+/** The in-flight rotate drag: which element and the working angle to preview. */
+export interface RotateDrag {
+  id: string;
+  rotate: number;
+}
+
+export interface UseRotateGestureResult {
+  /** The active rotate drag's working angle (for live preview), else `null`. */
+  rotateDrag: RotateDrag | null;
+  /** Arm a rotate gesture from a pointer-down on `element`'s rotate handle. */
+  onRotateHandlePointerDown: (element: PPTBoxElement, e: ReactPointerEvent) => void;
+}
+
+/**
+ * Owns one rotate-handle gesture, mirroring {@link useEditGesture} but for the
+ * rotate handle above a box's top edge. Pointer-down records the ORIGINAL
+ * element (whose center is the rotation pivot for the whole gesture) and the
+ * canvas origin's screen position; window pointer-move converts the pointer's
+ * absolute position to canvas coordinates, runs the store-free
+ * {@link computeRotate} (signed angle, 45° snap), and republishes the angle as
+ * a working copy for 60fps preview; pointer-up commits exactly one
+ * `element.update` intent when the pointer moved past {@link DRAG_THRESHOLD_PX},
+ * a mutation channel exists, and the angle actually changed, then clears the
+ * working copy. `pointercancel` reverts without emitting.
+ *
+ * Single-pointer by design: a second pointer-down while a gesture is in flight
+ * is ignored, and window move/up from any other pointerId is dropped. Pure
+ * gesture glue: no store, no `@/` imports.
+ */
+export function useRotateGesture(args: UseRotateGestureArgs): UseRotateGestureResult {
+  const { overlayRef, viewportStyles, scale, onElementsChange } = args;
+
+  const [rotateDrag, setRotateDrag] = useState<RotateDrag | null>(null);
+
+  // Teardown for the currently-armed gesture's window listeners; the unmount
+  // effect removes any listeners still live so a late move/up can't setState on
+  // an unmounted host.
+  const teardownRef = useRef<(() => void) | null>(null);
+  // The pointerId owning the in-flight gesture (single-pointer guard).
+  const activePointerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      teardownRef.current?.();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+    },
+    [],
+  );
+
+  const onRotateHandlePointerDown = (element: PPTBoxElement, e: ReactPointerEvent) => {
+    // Defense-in-depth: never arm on a locked element (the primary guard skips
+    // rendering handles for a locked element in EditableSlideCanvas).
+    if (element.lock) return;
+    if (activePointerRef.current !== null) return;
+    // Rotation needs the canvas origin; without a mounted overlay the pointer
+    // position cannot be mapped to canvas coordinates, so don't arm at all.
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+    activePointerRef.current = e.pointerId;
+
+    // A handle drag rotates the element — it must never fall through to the
+    // box hit layer beneath (which would start a move or change selection).
+    e.stopPropagation();
+
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const effectiveScale = scale || 1;
+
+    // Canvas origin in client coordinates, captured once per gesture (the
+    // canvas doesn't scroll/zoom mid-gesture; app parity).
+    const overlayRect = overlay.getBoundingClientRect();
+    const originX = overlayRect.left + viewportStyles.left;
+    const originY = overlayRect.top + viewportStyles.top;
+
+    const originRotate = element.rotate || 0;
+
+    try {
+      (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+    } catch {
+      // jsdom / unsupported: pointer capture is a best-effort nicety.
+    }
+
+    const compute = (clientX: number, clientY: number) =>
+      computeRotate({
+        element,
+        pointerCanvas: {
+          x: (clientX - originX) / effectiveScale,
+          y: (clientY - originY) / effectiveScale,
+        },
+      });
+
+    const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      // No mutation channel: a live preview would just follow the pointer and
+      // snap back on pointer-up. Skip live movement when nothing can commit.
+      if (!onElementsChange) return;
+      setRotateDrag({ id: element.id, rotate: compute(ev.clientX, ev.clientY) });
+    };
+
+    const removeListeners = () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleCancel);
+    };
+
+    const handleUp = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      removeListeners();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+
+      const movedPast = Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD_PX;
+      if (movedPast && onElementsChange) {
+        const rotate = compute(ev.clientX, ev.clientY);
+        // Snapping can land the pointer back on the original angle; a no-op
+        // update would still cost the host an undo entry, so skip it.
+        if (rotate !== originRotate) {
+          onElementsChange([rotateIntent(element.id, rotate)]);
+        }
+      }
+
+      setRotateDrag(null);
+    };
+
+    const handleCancel = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      removeListeners();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+      setRotateDrag(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleCancel);
+    teardownRef.current = removeListeners;
+  };
+
+  return { rotateDrag, onRotateHandlePointerDown };
+}

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.operate.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.operate.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import type { Slide } from '@openmaic/dsl';
+import { EditableSlideCanvas } from '../../src/editing/EditableSlideCanvas';
+import { useViewportSize } from '../../src/hooks/useViewportSize';
+
+// Mock the shared viewport-fit hook (jsdom reports container size 0) so the
+// overlay uses a known scale/offset, exactly like the base canvas tests.
+vi.mock('../../src/hooks/useViewportSize', () => ({
+  useViewportSize: vi.fn(),
+}));
+
+const textEl = {
+  id: 'txt',
+  type: 'text',
+  left: 100,
+  top: 100,
+  width: 200,
+  height: 80,
+  rotate: 0,
+  content: 'x',
+  defaultFontName: 'a',
+  defaultColor: '#000',
+  lineHeight: 1,
+};
+
+const imageEl = {
+  id: 'img',
+  type: 'image',
+  left: 100,
+  top: 100,
+  width: 200,
+  height: 80,
+  rotate: 0,
+  fixedRatio: false,
+  src: 'x.png',
+};
+
+const videoEl = {
+  id: 'vid',
+  type: 'video',
+  left: 400,
+  top: 100,
+  width: 320,
+  height: 180,
+  rotate: 0,
+  src: 'v.mp4',
+};
+
+const lineEl = {
+  id: 'lin',
+  type: 'line',
+  left: 100,
+  top: 400,
+  start: [0, 0],
+  end: [100, 0],
+  width: 2,
+  style: 'solid',
+  color: '#333',
+  points: ['', ''],
+};
+
+function makeSlide(elements: unknown[]): Slide {
+  return {
+    id: 's',
+    viewportSize: 1000,
+    viewportRatio: 0.5625,
+    elements,
+  } as unknown as Slide;
+}
+
+function renderCanvas(elements: unknown[], selectedId: string) {
+  const onElementsChange = vi.fn();
+  const utils = render(
+    <EditableSlideCanvas
+      slide={makeSlide(elements)}
+      scale={1}
+      selection={{ elementIds: [selectedId], primaryId: selectedId }}
+      onSelectionChange={vi.fn()}
+      onElementsChange={onElementsChange}
+    />,
+  );
+  return { ...utils, onElementsChange };
+}
+
+const resizeHandlesIn = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('[data-resize-handle]')).map((n) =>
+    n.getAttribute('data-resize-handle'),
+  );
+
+describe('EditableSlideCanvas — operate handle gates', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('a selected horizontal text element gets left/right handles plus a rotate handle', () => {
+    const { container } = renderCanvas([textEl], 'txt');
+    expect(resizeHandlesIn(container)).toEqual(['left', 'right']);
+    expect(container.querySelector('[data-rotate-handle]')).not.toBeNull();
+  });
+
+  it('a selected vertical text element gets top/bottom handles instead', () => {
+    const { container } = renderCanvas([{ ...textEl, vertical: true }], 'txt');
+    expect(resizeHandlesIn(container)).toEqual(['top', 'bottom']);
+  });
+
+  it('a selected image gets all eight handles plus a rotate handle', () => {
+    const { container } = renderCanvas([imageEl], 'img');
+    expect(resizeHandlesIn(container)).toHaveLength(8);
+    expect(container.querySelector('[data-rotate-handle]')).not.toBeNull();
+  });
+
+  it('a selected video gets eight resize handles but NO rotate handle', () => {
+    const { container } = renderCanvas([videoEl], 'vid');
+    expect(resizeHandlesIn(container)).toHaveLength(8);
+    expect(container.querySelector('[data-rotate-handle]')).toBeNull();
+  });
+
+  it('a selected line gets neither resize nor rotate handles (its chrome is LineHandles)', () => {
+    const { container } = renderCanvas([lineEl], 'lin');
+    expect(container.querySelector('[data-resize-handle]')).toBeNull();
+    expect(container.querySelector('[data-rotate-handle]')).toBeNull();
+    expect(container.querySelectorAll('[data-line-handle]').length).toBeGreaterThan(0);
+  });
+
+  it('a locked element gets no operate handles at all', () => {
+    const { container } = renderCanvas([{ ...imageEl, lock: true }], 'img');
+    expect(container.querySelector('[data-resize-handle]')).toBeNull();
+    expect(container.querySelector('[data-rotate-handle]')).toBeNull();
+  });
+
+  it('an unselected element gets no operate handles', () => {
+    const { container } = renderCanvas([imageEl, textEl], 'txt');
+    // Only the selected text's two handles — none from the unselected image.
+    expect(resizeHandlesIn(container)).toEqual(['left', 'right']);
+  });
+
+  it('a select-only mount (no onElementsChange) shows no operate handles', () => {
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([imageEl])}
+        scale={1}
+        selection={{ elementIds: ['img'], primaryId: 'img' }}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('[data-resize-handle]')).toBeNull();
+    expect(container.querySelector('[data-rotate-handle]')).toBeNull();
+  });
+});
+
+describe('EditableSlideCanvas — operate gestures end-to-end', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('dragging a resize handle emits ONE resize intent (and never a move — no fall-through)', () => {
+    const { container, onElementsChange } = renderCanvas([imageEl], 'img');
+    const handle = container.querySelector('[data-resize-handle="right-bottom"]') as HTMLElement;
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 300, clientY: 180 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 330, clientY: 200 });
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 330, clientY: 200 });
+
+    expect(onElementsChange).toHaveBeenCalledTimes(1);
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.update',
+        id: 'img',
+        props: { left: 100, top: 100, width: 230, height: 100 },
+      },
+    ]);
+  });
+
+  it('dragging the rotate handle emits ONE rotate intent', () => {
+    const { container, onElementsChange } = renderCanvas([imageEl], 'img');
+    const handle = container.querySelector('[data-rotate-handle]') as HTMLElement;
+
+    // Element center (200, 140); the mocked overlay rect is all-zero in jsdom,
+    // so client coordinates are canvas coordinates. End right of center: +90°.
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 200, clientY: 75 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 300, clientY: 140 });
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 300, clientY: 140 });
+
+    expect(onElementsChange).toHaveBeenCalledTimes(1);
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'img', props: { rotate: 90 } },
+    ]);
+  });
+
+  it('previews the resize on the working copy during the drag (handles track live)', () => {
+    const { container } = renderCanvas([imageEl], 'img');
+    const handle = container.querySelector('[data-resize-handle="right-bottom"]') as HTMLElement;
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 300, clientY: 180 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 330, clientY: 200 });
+
+    // Mid-drag, the handle re-renders at the working box's corner (330, 200).
+    const live = container.querySelector('[data-resize-handle="right-bottom"]') as HTMLElement;
+    expect(parseFloat(live.style.left)).toBeCloseTo(330, 5);
+    expect(parseFloat(live.style.top)).toBeCloseTo(200, 5);
+
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 330, clientY: 200 });
+    // After commit the working copy clears; the controlled slide (unchanged
+    // here — the host didn't apply the intent) snaps the handle back.
+    const settled = container.querySelector('[data-resize-handle="right-bottom"]') as HTMLElement;
+    expect(parseFloat(settled.style.left)).toBeCloseTo(300, 5);
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.operate.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.operate.test.tsx
@@ -152,6 +152,22 @@ describe('EditableSlideCanvas — operate handle gates', () => {
     expect(container.querySelector('[data-resize-handle]')).toBeNull();
     expect(container.querySelector('[data-rotate-handle]')).toBeNull();
   });
+
+  it('a multi-element selection shows no operate handles (single-element gestures only)', () => {
+    // The resize/rotate gestures transform one element; per-element handles on
+    // a multi-selection would misread as group scaling, which is a later slice.
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([textEl, imageEl])}
+        scale={1}
+        selection={{ elementIds: ['txt', 'img'], primaryId: 'txt' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('[data-resize-handle]')).toBeNull();
+    expect(container.querySelector('[data-rotate-handle]')).toBeNull();
+  });
 });
 
 describe('EditableSlideCanvas — operate gestures end-to-end', () => {

--- a/packages/@openmaic/renderer/test/editing/core/resize.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/resize.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect } from 'vitest';
+import type { PPTElement, PPTTextElement, PPTImageElement, PPTShapeElement } from '@openmaic/dsl';
+import {
+  computeResize,
+  getResizeHandles,
+  getResizeCursor,
+  getRotateElementPoints,
+  RESIZE_HANDLES,
+} from '../../../src/editing/core/resize';
+
+const text = (o: Partial<PPTTextElement> = {}): PPTTextElement =>
+  ({
+    id: 'a',
+    type: 'text',
+    left: 100,
+    top: 100,
+    width: 200,
+    height: 80,
+    rotate: 0,
+    content: 'x',
+    defaultFontName: 'a',
+    defaultColor: '#000',
+    lineHeight: 1,
+    ...o,
+  }) as PPTTextElement;
+
+const image = (o: Partial<PPTImageElement> = {}): PPTImageElement =>
+  ({
+    id: 'i',
+    type: 'image',
+    left: 100,
+    top: 100,
+    width: 200,
+    height: 80,
+    rotate: 0,
+    fixedRatio: false,
+    src: 'x.png',
+    ...o,
+  }) as PPTImageElement;
+
+const shape = (o: Partial<PPTShapeElement> = {}): PPTShapeElement =>
+  ({
+    id: 's',
+    type: 'shape',
+    left: 400,
+    top: 300,
+    width: 100,
+    height: 50,
+    rotate: 0,
+    fixedRatio: false,
+    viewBox: [100, 50],
+    path: 'M 0 0 L 100 0 L 100 50 L 0 50 Z',
+    fill: '#ccc',
+    ...o,
+  }) as PPTShapeElement;
+
+const viewport = { width: 1000, height: 562.5 };
+const noOthers: PPTElement[] = [];
+
+describe('computeResize — un-rotated', () => {
+  it('grows width/height from the right-bottom corner without moving left/top', () => {
+    const r = computeResize({
+      element: text(),
+      handle: 'right-bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 30, y: 20 },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 230, height: 100 });
+    expect(r.guides).toEqual([]);
+  });
+
+  it('shrinks from the left-top corner and shifts left/top so the opposite corner stays put', () => {
+    const r = computeResize({
+      element: text(),
+      handle: 'left-top',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 10, y: 5 },
+    });
+    // width 200-10=190, height 80-5=75; left/top shift by the size change.
+    expect(r.props).toEqual({ left: 110, top: 105, width: 190, height: 75 });
+  });
+
+  it('an edge handle only affects its own axis (left edge ignores the y delta)', () => {
+    const r = computeResize({
+      element: text(),
+      handle: 'left',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 30, y: 999 },
+    });
+    expect(r.props).toEqual({ left: 130, top: 100, width: 170, height: 80 });
+  });
+
+  it('clamps to the per-type minimum size (text: 40) and keeps the anchored edge fixed', () => {
+    // Dragging the LEFT edge far right: width clamps at 40, and left shifts by
+    // the (clamped) size change so the RIGHT edge stays at 300.
+    const r = computeResize({
+      element: text(),
+      handle: 'left',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 300, y: 0 },
+    });
+    expect(r.props).toEqual({ left: 260, top: 100, width: 40, height: 80 });
+  });
+
+  it("locks the aspect ratio from the element's own fixedRatio on a corner", () => {
+    // aspectRatio 200/80 = 2.5; moveY = moveX / 2.5 = 40.
+    const r = computeResize({
+      element: image({ fixedRatio: true }),
+      handle: 'right-bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 100, y: 0 },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 300, height: 120 });
+  });
+
+  it('locks the aspect ratio from the modifier on a corner (left-bottom sign flip)', () => {
+    // lb: moveY = -moveX / ratio = -(-50)/2.5 = 20.
+    const r = computeResize({
+      element: text(),
+      handle: 'left-bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: -50, y: 0 },
+      aspectModifier: true,
+    });
+    expect(r.props).toEqual({ left: 50, top: 100, width: 250, height: 100 });
+  });
+
+  it('edge handles ignore the aspect lock entirely', () => {
+    const r = computeResize({
+      element: image({ fixedRatio: true }),
+      handle: 'right',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 50, y: 0 },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 250, height: 80 });
+  });
+
+  it('scales the min-size limits under aspect lock so both axes bottom out together', () => {
+    // image min 20, ratio 2.5 > 1 → minWidth = 50, minHeight = 20.
+    const r = computeResize({
+      element: image({ fixedRatio: true }),
+      handle: 'right-bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: -400, y: 0 },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 50, height: 20 });
+  });
+
+  it('snaps the moving edge to a sibling edge before clamping', () => {
+    // Element right edge starts at 300; delta 97 puts it at 397, within range
+    // 5 of the sibling's left edge (400) → snapped to exactly 400.
+    const r = computeResize({
+      element: text(),
+      handle: 'right-bottom',
+      others: [shape()],
+      viewport,
+      deltaCanvas: { x: 97, y: 0 },
+      snapping: { toElements: true },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 300, height: 80 });
+    expect(r.guides).toHaveLength(1);
+    expect(r.guides[0].type).toBe('vertical');
+  });
+
+  it('recomputes the aspect-locked axis from the snapped axis (y snap drives x)', () => {
+    // rb, aspect locked (ratio 2.5): delta x=10 → moveY = 4 → moving corner y
+    // probe = 184, within 5 of the sibling's top edge (183) → dy = -1 →
+    // moveY = 3, then moveX re-derived = 3 * 2.5 = 7.5.
+    const r = computeResize({
+      element: image({ fixedRatio: true }),
+      handle: 'right-bottom',
+      others: [shape({ top: 183, height: 40 })],
+      viewport,
+      deltaCanvas: { x: 10, y: 0 },
+      snapping: { toElements: true },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 207.5, height: 83 });
+    expect(r.guides).toHaveLength(1);
+    expect(r.guides[0].type).toBe('horizontal');
+  });
+
+  it('excludes rotated siblings and lines from the snap candidates', () => {
+    // Same setup as the sibling-edge snap above, but the sibling is rotated —
+    // its axis-aligned bbox must NOT act as a snap line, so no snap occurs.
+    const r = computeResize({
+      element: text(),
+      handle: 'right-bottom',
+      others: [shape({ rotate: 30 })],
+      viewport,
+      deltaCanvas: { x: 97, y: 0 },
+      snapping: { toElements: true },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 297, height: 80 });
+    expect(r.guides).toEqual([]);
+  });
+
+  it('snaps to the canvas edges/centers when toCanvas is enabled', () => {
+    // Right edge probe = 300 + 197 = 497, within 5 of the canvas centerX (500).
+    const r = computeResize({
+      element: text(),
+      handle: 'right',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 197, y: 0 },
+      snapping: { toCanvas: true },
+    });
+    expect(r.props).toEqual({ left: 100, top: 100, width: 400, height: 80 });
+  });
+});
+
+describe('computeResize — rotated', () => {
+  it('rotates the pointer delta into local axes and keeps the opposite corner fixed', () => {
+    // rotate 90: revisedX = sin(90)*dy = 30, revisedY = 0 → width 130.
+    // Opposite-point correction: the rotated left-top of the origin box sits at
+    // (175, 75); after the naive resize it lands at (190, 60), so left/top
+    // shift back by (15, -15).
+    const r = computeResize({
+      element: text({ left: 100, top: 100, width: 100, height: 50, rotate: 90 }),
+      handle: 'right-bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 0, y: 30 },
+    });
+    expect(r.props.left).toBeCloseTo(85, 5);
+    expect(r.props.top).toBeCloseTo(115, 5);
+    expect(r.props.width).toBeCloseTo(130, 5);
+    expect(r.props.height).toBeCloseTo(50, 5);
+  });
+
+  it('resizes an edge of a 180-rotated element (bottom handle tracks the on-screen top)', () => {
+    // rotate 180: revisedY = -dy = 20 → height 100; the opposite (top) point
+    // correction shifts top from 100 to 80 so the rotated top point stays put.
+    const r = computeResize({
+      element: text({ rotate: 180 }),
+      handle: 'bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 0, y: -20 },
+    });
+    expect(r.props.left).toBeCloseTo(100, 5);
+    expect(r.props.top).toBeCloseTo(80, 5);
+    expect(r.props.width).toBeCloseTo(200, 5);
+    expect(r.props.height).toBeCloseTo(100, 5);
+  });
+
+  it('never snaps a rotated element, even when snapping is enabled', () => {
+    const r = computeResize({
+      element: text({ left: 100, top: 100, width: 100, height: 50, rotate: 90 }),
+      handle: 'right-bottom',
+      others: [shape()],
+      viewport,
+      deltaCanvas: { x: 0, y: 30 },
+      snapping: true,
+    });
+    expect(r.props.width).toBeCloseTo(130, 5);
+    expect(r.guides).toEqual([]);
+  });
+
+  it('applies the aspect lock in local axes on a rotated corner', () => {
+    // rotate 90, rb, delta (0, 25): revisedX = 25, locked revisedY = 25 / 2
+    // (ratio 100/50) = 12.5 → width 125, height 62.5.
+    const r = computeResize({
+      element: text({ left: 100, top: 100, width: 100, height: 50, rotate: 90 }),
+      handle: 'right-bottom',
+      others: noOthers,
+      viewport,
+      deltaCanvas: { x: 0, y: 25 },
+      aspectModifier: true,
+    });
+    expect(r.props.width).toBeCloseTo(125, 5);
+    expect(r.props.height).toBeCloseTo(62.5, 5);
+  });
+});
+
+describe('getRotateElementPoints', () => {
+  it('degenerates to the plain frame points at rotation 0', () => {
+    const p = getRotateElementPoints({ left: 100, top: 100, width: 200, height: 80 }, 0);
+    expect(p['left-top'].left).toBeCloseTo(100, 5);
+    expect(p['left-top'].top).toBeCloseTo(100, 5);
+    expect(p.top.left).toBeCloseTo(200, 5);
+    expect(p.top.top).toBeCloseTo(100, 5);
+    expect(p.right.left).toBeCloseTo(300, 5);
+    expect(p.right.top).toBeCloseTo(140, 5);
+    expect(p['right-bottom'].left).toBeCloseTo(300, 5);
+    expect(p['right-bottom'].top).toBeCloseTo(180, 5);
+    expect(p.bottom.left).toBeCloseTo(200, 5);
+    expect(p.bottom.top).toBeCloseTo(180, 5);
+  });
+
+  it('rotates every point about the center (90-degree check)', () => {
+    // Center (150, 125); left-top (100, 100) → rel (-50, -25) → rotated 90°
+    // clockwise → (25, -50) → (175, 75).
+    const p = getRotateElementPoints({ left: 100, top: 100, width: 100, height: 50 }, 90);
+    expect(p['left-top'].left).toBeCloseTo(175, 5);
+    expect(p['left-top'].top).toBeCloseTo(75, 5);
+    expect(p['right-bottom'].left).toBeCloseTo(125, 5);
+    expect(p['right-bottom'].top).toBeCloseTo(175, 5);
+    expect(p.top.left).toBeCloseTo(175, 5);
+    expect(p.top.top).toBeCloseTo(125, 5);
+  });
+});
+
+describe('getResizeHandles — per-kind gates', () => {
+  it('code elements expose no handles', () => {
+    expect(
+      getResizeHandles({
+        id: 'c',
+        type: 'code',
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        rotate: 0,
+      } as never),
+    ).toEqual([]);
+  });
+
+  it('horizontal text exposes only left/right', () => {
+    expect(getResizeHandles(text())).toEqual(['left', 'right']);
+  });
+
+  it('vertical text exposes only top/bottom', () => {
+    expect(getResizeHandles(text({ vertical: true }))).toEqual(['top', 'bottom']);
+  });
+
+  it('other box kinds expose all eight handles', () => {
+    expect(getResizeHandles(image())).toEqual(RESIZE_HANDLES);
+    expect(getResizeHandles(shape())).toEqual(RESIZE_HANDLES);
+  });
+});
+
+describe('getResizeCursor — rotation-aware buckets', () => {
+  it('matches the directional table at rotation 0', () => {
+    expect(getResizeCursor('left-top', 0)).toBe('nwse-resize');
+    expect(getResizeCursor('right-bottom', 0)).toBe('nwse-resize');
+    expect(getResizeCursor('top', 0)).toBe('ns-resize');
+    expect(getResizeCursor('left-bottom', 0)).toBe('nesw-resize');
+    expect(getResizeCursor('right', 0)).toBe('ew-resize');
+  });
+
+  it('advances one direction per 45-degree bucket', () => {
+    expect(getResizeCursor('left-top', 45)).toBe('ns-resize');
+    expect(getResizeCursor('left', 45)).toBe('nwse-resize');
+    expect(getResizeCursor('top', 90)).toBe('ew-resize');
+    expect(getResizeCursor('right-bottom', 135)).toBe('ew-resize');
+  });
+
+  it('wraps negative rotations and the ±180 seam back onto the same buckets', () => {
+    expect(getResizeCursor('right-bottom', -100)).toBe('nesw-resize'); // bucket 90
+    expect(getResizeCursor('left', -30)).toBe('nesw-resize'); // bucket 135
+    expect(getResizeCursor('bottom', 170)).toBe('ns-resize'); // bucket 0
+    expect(getResizeCursor('bottom', -170)).toBe('ns-resize'); // bucket 0
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/core/rotate.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/rotate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { PPTElement } from '@openmaic/dsl';
+import { computeRotate, canRotate } from '../../../src/editing/core/rotate';
+
+// Box 200x80 at (100, 100): center (200, 140). All pointer positions below are
+// canvas coordinates around that center.
+const box = { left: 100, top: 100, width: 200, height: 80 };
+
+const rotate = (x: number, y: number) => computeRotate({ element: box, pointerCanvas: { x, y } });
+
+describe('computeRotate', () => {
+  it('is 0 when the pointer sits straight above the center', () => {
+    expect(rotate(200, 40)).toBe(0);
+  });
+
+  it('measures clockwise-positive: pointer to the right of the center is +90', () => {
+    expect(rotate(300, 140)).toBe(90);
+  });
+
+  it('stays SIGNED: pointer to the left of the center is -90, not 270', () => {
+    expect(rotate(100, 140)).toBe(-90);
+  });
+
+  it('pointer straight below the center is 180 (atan2 upper seam)', () => {
+    expect(rotate(200, 240)).toBe(180);
+  });
+
+  it('leaves angles outside the snap range untouched', () => {
+    // 30° ray: center + 100 * (sin 30, -cos 30).
+    const a = rotate(200 + 100 * Math.sin(Math.PI / 6), 140 - 100 * Math.cos(Math.PI / 6));
+    expect(a).toBeCloseTo(30, 5);
+  });
+
+  it('snaps to 45 within the 5-degree range', () => {
+    // 43° ray → within 5° of 45 → snapped.
+    const rad = (43 * Math.PI) / 180;
+    expect(rotate(200 + 100 * Math.sin(rad), 140 - 100 * Math.cos(rad))).toBe(45);
+  });
+
+  it('snaps negative angles to the negative multiples (-48 → -45)', () => {
+    const rad = (-48 * Math.PI) / 180;
+    expect(rotate(200 + 100 * Math.sin(rad), 140 - 100 * Math.cos(rad))).toBe(-45);
+  });
+
+  it('snaps small angles to 0', () => {
+    const rad = (3 * Math.PI) / 180;
+    expect(rotate(200 + 100 * Math.sin(rad), 140 - 100 * Math.cos(rad))).toBe(0);
+  });
+
+  it('snaps near the ±180 seam', () => {
+    const rad = (177 * Math.PI) / 180;
+    expect(rotate(200 + 100 * Math.sin(rad), 140 - 100 * Math.cos(rad))).toBe(180);
+    const negRad = (-176 * Math.PI) / 180;
+    expect(rotate(200 + 100 * Math.sin(negRad), 140 - 100 * Math.cos(negRad))).toBe(-180);
+  });
+});
+
+describe('canRotate — per-kind gate', () => {
+  const el = (type: string) => ({ type }) as unknown as PPTElement;
+
+  it('allows text, image, shape, table, latex', () => {
+    for (const type of ['text', 'image', 'shape', 'table', 'latex']) {
+      expect(canRotate(el(type))).toBe(true);
+    }
+  });
+
+  it('blocks chart, video, audio, code, line', () => {
+    for (const type of ['chart', 'video', 'audio', 'code', 'line']) {
+      expect(canRotate(el(type))).toBe(false);
+    }
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/handles/ResizeHandles.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/handles/ResizeHandles.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import { ResizeHandles } from '../../../src/editing/handles/ResizeHandles';
+import { RotateHandle } from '../../../src/editing/handles/RotateHandle';
+import { RESIZE_HANDLES, type PPTBoxElement } from '../../../src/editing/core/resize';
+
+const element = {
+  id: 'a',
+  type: 'image',
+  left: 100,
+  top: 100,
+  width: 200,
+  height: 80,
+  rotate: 0,
+  fixedRatio: false,
+  src: 'x.png',
+} as unknown as PPTBoxElement;
+
+const viewportStyles = { left: 0, top: 0, width: 1000, height: 562.5 };
+
+describe('ResizeHandles', () => {
+  it('renders one box per requested handle at the un-rotated frame points', () => {
+    const { container } = render(
+      <ResizeHandles
+        element={element}
+        handles={RESIZE_HANDLES}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onHandlePointerDown={vi.fn()}
+      />,
+    );
+    const boxes = container.querySelectorAll('[data-resize-handle]');
+    expect(boxes).toHaveLength(8);
+
+    const at = (h: string) => container.querySelector(`[data-resize-handle="${h}"]`) as HTMLElement;
+    expect(at('left-top').style.left).toBe('100px');
+    expect(at('left-top').style.top).toBe('100px');
+    expect(at('top').style.left).toBe('200px');
+    expect(at('top').style.top).toBe('100px');
+    expect(at('right').style.left).toBe('300px');
+    expect(at('right').style.top).toBe('140px');
+    expect(at('right-bottom').style.left).toBe('300px');
+    expect(at('right-bottom').style.top).toBe('180px');
+  });
+
+  it('renders only the requested subset (text-style two handles)', () => {
+    const { container } = render(
+      <ResizeHandles
+        element={element}
+        handles={['left', 'right']}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onHandlePointerDown={vi.fn()}
+      />,
+    );
+    const boxes = container.querySelectorAll('[data-resize-handle]');
+    expect(boxes).toHaveLength(2);
+  });
+
+  it('positions handles at the ROTATED frame points (not the axis-aligned box)', () => {
+    // 100x50 box at (100, 100) rotated 90°: center (150, 125), the rotated
+    // top-center point sits at (175, 125).
+    const rotated = { ...element, left: 100, top: 100, width: 100, height: 50, rotate: 90 };
+    const { container } = render(
+      <ResizeHandles
+        element={rotated as PPTBoxElement}
+        handles={RESIZE_HANDLES}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onHandlePointerDown={vi.fn()}
+      />,
+    );
+    const top = container.querySelector('[data-resize-handle="top"]') as HTMLElement;
+    expect(parseFloat(top.style.left)).toBeCloseTo(175, 5);
+    expect(parseFloat(top.style.top)).toBeCloseTo(125, 5);
+    const leftTop = container.querySelector('[data-resize-handle="left-top"]') as HTMLElement;
+    expect(parseFloat(leftTop.style.left)).toBeCloseTo(175, 5);
+    expect(parseFloat(leftTop.style.top)).toBeCloseTo(75, 5);
+  });
+
+  it('applies the centering offset and canvas scale like the other overlays', () => {
+    const { container } = render(
+      <ResizeHandles
+        element={element}
+        handles={['left-top']}
+        viewportStyles={{ ...viewportStyles, left: 160 }}
+        canvasScale={0.5}
+        onHandlePointerDown={vi.fn()}
+      />,
+    );
+    const lt = container.querySelector('[data-resize-handle="left-top"]') as HTMLElement;
+    expect(lt.style.left).toBe('210px'); // 160 + 100 * 0.5
+    expect(lt.style.top).toBe('50px'); // 0 + 100 * 0.5
+  });
+
+  it('carries a rotation-aware directional cursor', () => {
+    const { container: c0 } = render(
+      <ResizeHandles
+        element={element}
+        handles={['left-top']}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onHandlePointerDown={vi.fn()}
+      />,
+    );
+    expect((c0.querySelector('[data-resize-handle="left-top"]') as HTMLElement).style.cursor).toBe(
+      'nwse-resize',
+    );
+
+    const { container: c45 } = render(
+      <ResizeHandles
+        element={{ ...element, rotate: 45 } as PPTBoxElement}
+        handles={['left-top']}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onHandlePointerDown={vi.fn()}
+      />,
+    );
+    expect((c45.querySelector('[data-resize-handle="left-top"]') as HTMLElement).style.cursor).toBe(
+      'ns-resize',
+    );
+  });
+
+  it('reports the pressed handle through onHandlePointerDown', () => {
+    const onDown = vi.fn();
+    const { container } = render(
+      <ResizeHandles
+        element={element}
+        handles={RESIZE_HANDLES}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onHandlePointerDown={onDown}
+      />,
+    );
+    fireEvent.pointerDown(
+      container.querySelector('[data-resize-handle="left-bottom"]') as HTMLElement,
+      { pointerId: 1 },
+    );
+    expect(onDown).toHaveBeenCalledTimes(1);
+    expect(onDown.mock.calls[0][0]).toBe('left-bottom');
+  });
+});
+
+describe('RotateHandle', () => {
+  it('floats 25 screen px above the top-center point at rotation 0', () => {
+    const { container } = render(
+      <RotateHandle
+        element={element}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onPointerDown={vi.fn()}
+      />,
+    );
+    const handle = container.querySelector('[data-rotate-handle]') as HTMLElement;
+    // Top-center (200, 100), pushed 25px along (0, -1).
+    expect(parseFloat(handle.style.left)).toBeCloseTo(200, 5);
+    expect(parseFloat(handle.style.top)).toBeCloseTo(75, 5);
+    expect(handle.style.cursor).toBe('grab');
+  });
+
+  it('orbits with the element: at 90° it sits 25px to the right of the rotated top point', () => {
+    const rotated = { ...element, left: 100, top: 100, width: 100, height: 50, rotate: 90 };
+    const { container } = render(
+      <RotateHandle
+        element={rotated as PPTBoxElement}
+        viewportStyles={viewportStyles}
+        canvasScale={1}
+        onPointerDown={vi.fn()}
+      />,
+    );
+    const handle = container.querySelector('[data-rotate-handle]') as HTMLElement;
+    // Rotated top point (175, 125), up vector (sin 90, -cos 90) = (1, 0).
+    expect(parseFloat(handle.style.left)).toBeCloseTo(200, 5);
+    expect(parseFloat(handle.style.top)).toBeCloseTo(125, 5);
+  });
+
+  it('keeps the 25px gap constant on screen regardless of canvas scale', () => {
+    const { container } = render(
+      <RotateHandle
+        element={element}
+        viewportStyles={viewportStyles}
+        canvasScale={0.5}
+        onPointerDown={vi.fn()}
+      />,
+    );
+    const handle = container.querySelector('[data-rotate-handle]') as HTMLElement;
+    // Top-center (200, 100) * 0.5 = (100, 50), minus the un-scaled 25px gap.
+    expect(parseFloat(handle.style.left)).toBeCloseTo(100, 5);
+    expect(parseFloat(handle.style.top)).toBeCloseTo(25, 5);
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/useResizeGesture.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/useResizeGesture.test.tsx
@@ -81,6 +81,37 @@ describe('useResizeGesture', () => {
     ]);
   });
 
+  it('a drag whose snap returns the box to its origin emits nothing (no no-op undo entry)', () => {
+    // Sibling left edge sits exactly at the target's original right edge
+    // (100 + 200 = 300). A +3px drag on the `right` handle moves past the 2px
+    // threshold, but snapping (range 5) pulls the moving edge back to 300 —
+    // the computed box equals the origin, so no intent may be emitted.
+    const sibling = { ...baseElement, id: 'b', left: 300, top: 300 };
+    const slide = {
+      id: 's',
+      viewportSize: 1000,
+      viewportRatio: 0.5625,
+      elements: [baseElement, sibling],
+    } as unknown as Slide;
+    const el = slide.elements[0] as PPTBoxElement;
+    const onElementsChange = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={slide}
+        scale={1}
+        snapping={true}
+        onElementsChange={onElementsChange}
+        targetEl={el}
+        handle="right"
+      />,
+    );
+    const hit = container.querySelector('[data-testid="hit"]') as HTMLElement;
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 3, clientY: 0 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 3, clientY: 0 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+
   it('converts the screen delta to canvas units through scale', () => {
     const slide = makeSlide();
     const el = slide.elements[0] as PPTBoxElement;

--- a/packages/@openmaic/renderer/test/editing/useResizeGesture.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/useResizeGesture.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import type { Slide } from '@openmaic/dsl';
+import { useResizeGesture, type UseResizeGestureArgs } from '../../src/editing/useResizeGesture';
+import type { PPTBoxElement, ResizeHandle } from '../../src/editing/core/resize';
+
+const baseElement = {
+  id: 'a',
+  type: 'text',
+  left: 100,
+  top: 100,
+  width: 200,
+  height: 80,
+  rotate: 0,
+  content: 'x',
+  defaultFontName: 'a',
+  defaultColor: '#000',
+  lineHeight: 1,
+};
+
+function makeSlide(overrides: Record<string, unknown> = {}): Slide {
+  return {
+    id: 's',
+    viewportSize: 1000,
+    viewportRatio: 0.5625,
+    elements: [{ ...baseElement, ...overrides }],
+  } as unknown as Slide;
+}
+
+/**
+ * Minimal harness: wires a single handle's `onResizeHandlePointerDown` to a
+ * real DOM node so `fireEvent.pointer*` (real PointerEvents bubbling to
+ * `window`, exactly like the production handle div) exercises
+ * `useResizeGesture` exactly as `EditableSlideCanvas` does — but directly, so
+ * a pointer-down can be armed on a locked element even without a rendered
+ * handle (defense-in-depth: the hook must refuse on its own).
+ */
+function Harness(props: UseResizeGestureArgs & { targetEl: PPTBoxElement; handle: ResizeHandle }) {
+  const { targetEl, handle, ...args } = props;
+  const { onResizeHandlePointerDown } = useResizeGesture(args);
+  return (
+    <div data-testid="hit" onPointerDown={(e) => onResizeHandlePointerDown(targetEl, handle, e)} />
+  );
+}
+
+function setup(handle: ResizeHandle, elementOverrides: Record<string, unknown> = {}) {
+  const slide = makeSlide(elementOverrides);
+  const el = slide.elements[0] as PPTBoxElement;
+  const onElementsChange = vi.fn();
+  const { container } = render(
+    <Harness
+      slide={slide}
+      scale={1}
+      onElementsChange={onElementsChange}
+      targetEl={el}
+      handle={handle}
+    />,
+  );
+  const hit = container.querySelector('[data-testid="hit"]') as HTMLElement;
+  return { hit, onElementsChange };
+}
+
+describe('useResizeGesture', () => {
+  it('commits exactly one element.update with the resized box on pointer-up', () => {
+    const { hit, onElementsChange } = setup('right-bottom');
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 10, clientY: 5 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 30, clientY: 20 });
+
+    // Two moves, ONE intent: per completed gesture, never per frame.
+    expect(onElementsChange).toHaveBeenCalledTimes(1);
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.update',
+        id: 'a',
+        props: { left: 100, top: 100, width: 230, height: 100 },
+      },
+    ]);
+  });
+
+  it('converts the screen delta to canvas units through scale', () => {
+    const slide = makeSlide();
+    const el = slide.elements[0] as PPTBoxElement;
+    const onElementsChange = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={slide}
+        scale={0.5}
+        onElementsChange={onElementsChange}
+        targetEl={el}
+        handle="right"
+      />,
+    );
+    const hit = container.querySelector('[data-testid="hit"]') as HTMLElement;
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 25, clientY: 0 });
+
+    // 25 screen px at scale 0.5 → 50 canvas units → width 250.
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { left: 100, top: 100, width: 250, height: 80 } },
+    ]);
+  });
+
+  it('reads the aspect-lock modifier off the pointer event at commit time', () => {
+    const { hit, onElementsChange } = setup('right-bottom');
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 50, clientY: 0, shiftKey: true });
+
+    // ratio 2.5: moveY = 50 / 2.5 = 20 → height 100.
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { left: 100, top: 100, width: 250, height: 100 } },
+    ]);
+  });
+
+  it('a handle click below the drag threshold emits nothing', () => {
+    const { hit, onElementsChange } = setup('right-bottom');
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 1, clientY: 1 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+
+  it('pointercancel reverts without emitting, and a fresh gesture can re-arm', () => {
+    const { hit, onElementsChange } = setup('right-bottom');
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerCancel(hit, { pointerId: 1 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+
+    // The hook must be ready for the next gesture after a cancel.
+    fireEvent.pointerDown(hit, { pointerId: 2, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(hit, { pointerId: 2, clientX: 10, clientY: 0 });
+    expect(onElementsChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to arm on a locked element (defense-in-depth)', () => {
+    const { hit, onElementsChange } = setup('right-bottom', { lock: true });
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 30, clientY: 20 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores window move/up from a different pointerId (single-pointer guard)', () => {
+    const { hit, onElementsChange } = setup('right-bottom');
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 0, clientY: 0 });
+    // A second pointer's up must not commit the first pointer's gesture.
+    fireEvent.pointerUp(hit, { pointerId: 2, clientX: 100, clientY: 100 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+    // The owning pointer still completes normally.
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 30, clientY: 20 });
+    expect(onElementsChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/useRotateGesture.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/useRotateGesture.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useRef } from 'react';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import { useRotateGesture, type UseRotateGestureArgs } from '../../src/editing/useRotateGesture';
+import type { PPTBoxElement } from '../../src/editing/core/resize';
+
+// Box 200x80 at (100, 100): center (200, 140). In jsdom the overlay's
+// getBoundingClientRect() is all-zero, so with viewportStyles offset 0 and
+// scale 1 the client coordinates fired below ARE canvas coordinates.
+const element = {
+  id: 'a',
+  type: 'text',
+  left: 100,
+  top: 100,
+  width: 200,
+  height: 80,
+  rotate: 0,
+  content: 'x',
+  defaultFontName: 'a',
+  defaultColor: '#000',
+  lineHeight: 1,
+} as unknown as PPTBoxElement;
+
+const viewportStyles = { left: 0, top: 0, width: 1000, height: 562.5 };
+
+/**
+ * Minimal harness: mounts a real overlay node (the rect source) and wires the
+ * rotate handle's pointer-down to a hit node, exercising `useRotateGesture`
+ * exactly as `EditableSlideCanvas` does.
+ */
+function Harness(props: Omit<UseRotateGestureArgs, 'overlayRef'> & { targetEl: PPTBoxElement }) {
+  const { targetEl, ...args } = props;
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const { onRotateHandlePointerDown } = useRotateGesture({ ...args, overlayRef });
+  return (
+    <div ref={overlayRef}>
+      <div data-testid="hit" onPointerDown={(e) => onRotateHandlePointerDown(targetEl, e)} />
+    </div>
+  );
+}
+
+function setup(targetEl: PPTBoxElement = element) {
+  const onElementsChange = vi.fn();
+  const { container } = render(
+    <Harness
+      viewportStyles={viewportStyles}
+      scale={1}
+      onElementsChange={onElementsChange}
+      targetEl={targetEl}
+    />,
+  );
+  const hit = container.querySelector('[data-testid="hit"]') as HTMLElement;
+  return { hit, onElementsChange };
+}
+
+describe('useRotateGesture', () => {
+  it('commits exactly one element.update with the signed angle on pointer-up', () => {
+    const { hit, onElementsChange } = setup();
+    // Start above the center, drag to the right of it: +90°.
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 260, clientY: 70 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 300, clientY: 140 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 300, clientY: 140 });
+
+    expect(onElementsChange).toHaveBeenCalledTimes(1);
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { rotate: 90 } },
+    ]);
+  });
+
+  it('keeps the angle signed for counter-clockwise drags (-90, not 270)', () => {
+    const { hit, onElementsChange } = setup();
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 100, clientY: 140 });
+
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { rotate: -90 } },
+    ]);
+  });
+
+  it('snaps to 45-degree multiples within the snap range', () => {
+    const { hit, onElementsChange } = setup();
+    const rad = (43 * Math.PI) / 180;
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerUp(hit, {
+      pointerId: 1,
+      clientX: 200 + 100 * Math.sin(rad),
+      clientY: 140 - 100 * Math.cos(rad),
+    });
+
+    expect(onElementsChange.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { rotate: 45 } },
+    ]);
+  });
+
+  it('a handle click below the drag threshold emits nothing', () => {
+    const { hit, onElementsChange } = setup();
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 201, clientY: 40 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+
+  it('skips the emit when the drag lands back on the original angle', () => {
+    // Element already at 90; dragging (past the threshold) to a point that
+    // computes 90 again must not emit a no-op update.
+    const rotated = { ...element, rotate: 90 } as PPTBoxElement;
+    const { hit, onElementsChange } = setup(rotated);
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 300, clientY: 140 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+
+  it('pointercancel reverts without emitting', () => {
+    const { hit, onElementsChange } = setup();
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerMove(hit, { pointerId: 1, clientX: 300, clientY: 140 });
+    fireEvent.pointerCancel(hit, { pointerId: 1 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+
+  it('refuses to arm on a locked element (defense-in-depth)', () => {
+    const locked = { ...element, lock: true } as PPTBoxElement;
+    const { hit, onElementsChange } = setup(locked);
+    fireEvent.pointerDown(hit, { pointerId: 1, clientX: 200, clientY: 40 });
+    fireEvent.pointerUp(hit, { pointerId: 1, clientX: 300, clientY: 140 });
+    expect(onElementsChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Continues #851 Part A after the selection + drag-to-move slice (#859): the next two deferred capabilities of the `@openmaic/renderer` editing surface. Nothing in the app imports these yet, so this merges inert — no runtime behavior change.

## What

- **`core/resize.ts`** — `computeResize`: the unrotated path snaps the moving edge (before min-size clamping, with the aspect re-lock applied after a snap), the rotated path rotates the pointer delta into element-local axes and applies the opposite-point correction so the handle diagonally opposite the drag stays visually fixed. Per-type minimum sizes; aspect lock from a held modifier (Ctrl/Shift/Meta) or the element's `fixedRatio`, corners only; rotation-bucketed resize cursors; per-kind handle gates (text exposes only its width axis — left/right, or top/bottom when `vertical`; code gets none; line is excluded — its chrome is the landed `LineHandles`).
- **`core/rotate.ts`** — `computeRotate`: signed `(-180, 180]` angle from the pointer around the element center, snapped to 45° multiples within range 5; `canRotate` gate (chart/video/audio excluded, per the app's operate dispatch).
- **`useResizeGesture` / `useRotateGesture`** + **`ResizeHandles` / `RotateHandle`**, wired into `EditableSlideCanvas` behind the existing editability gates. Handle positions are computed analytically in screen space from the same rotated-points math as the resize correction (not nested in a rotated CSS frame). All the landed gesture invariants hold: one `element.update` intent per completed gesture, pointercancel reverts, single-pointer guard, 2px threshold, working-copy live preview.
- Operate handles render only for a **single-element** selection — group scaling is a later slice, and per-element handles on a multi-selection would misread as it.

## Deferred (stated in code comments)

Content-space recomputation stays host-side or comes in later slices: shape `pathFormula`/`viewBox` refresh, table row-height redistribution, image clip mode, group (multi-element) scaling, and guide-line rendering (guides are computed, matching the landed move gesture, but not yet drawn).

## Review

Cross-model review before pushing (Codex `exec review` high effort + an independent red-team pass over the geometry against the in-repo reference implementation, the kind × handle × rotate × lock state matrix, and the gesture protocol): no P1/P2. The two accepted P3s are fixed in the second commit (no-op resize intents after a snap-back no longer emitted; handles gated to single selection). Known accepted deviations: the aspect modifier also accepts Meta (Cmd on macOS); resize snap candidates include sibling center lines (the shared `buildAlignLines`), which the in-app resize did not use.

## Tests & boundary

134 tests across the editing subpath (≈70 new: pure geometry with hand-computed expectations incl. the rotated opposite-point invariant, both gesture hooks, handle components, canvas wiring); package build emits `dist/editing`; `tsc` clean; respects the #853 import boundary (no host `@/…` imports).

Part of #851 (Part A) / #720 Phase 3.
