### PR TITLE
Feat/low bandwidth 3g4g

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from '@/lib/hooks/use-theme';
 import { I18nProvider } from '@/lib/hooks/use-i18n';
 import { Toaster } from '@/components/ui/sonner';
 import { ServerProvidersInit } from '@/components/server-providers-init';
+import { ServiceWorkerRegister } from '@/components/service-worker-register';
 import { AccessCodeGuard } from '@/components/access-code-guard';
 
 const inter = localFont({
@@ -38,6 +39,7 @@ export default function RootLayout({
         <ThemeProvider>
           <I18nProvider>
             <ServerProvidersInit />
+            <ServiceWorkerRegister basePath={process.env.BASE_PATH?.trim() || ''} />
             <AccessCodeGuard>{children}</AccessCodeGuard>
             <Toaster position="top-center" />
           </I18nProvider>

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+// Honour BASE_PATH so the manifest works both standalone (root) and when the
+// app is mounted under a path prefix behind a reverse proxy.
+const base = process.env.BASE_PATH?.trim() || '';
+
+export const dynamic = 'force-static';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'OpenMAIC',
+    short_name: 'OpenMAIC',
+    description:
+      'The open-source AI interactive classroom. Works on slow networks; lessons you have already opened stay available offline.',
+    start_url: `${base}/`,
+    scope: `${base}/`,
+    display: 'standalone',
+    background_color: '#0d1117',
+    theme_color: '#1e293b',
+    icons: [
+      { src: `${base}/openmaic-mark.png`, sizes: '512x512', type: 'image/png', purpose: 'any' },
+      { src: `${base}/apple-icon.png`, sizes: '180x180', type: 'image/png' },
+    ],
+  };
+}

--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -39,11 +39,16 @@ export function InteractiveRenderer({ content, sceneId }: InteractiveRendererPro
   // unmount. A content change re-runs this and rebuilds the iframe — the only
   // intended reload path.
   useEffect(() => {
+    // Mark active BEFORE mount: the scene whose placeholder just rendered is the
+    // one being shown, so eviction must treat it as active and never drop it.
+    // Without this, on a slow-link cap of 1 the mount runs while activeSceneId is
+    // still the PREVIOUS scene, and LRU would evict the just-mounted (new) scene
+    // instead of the one we navigated away from.
+    setActive(sceneId);
     mount(sceneId, {
       srcDoc: patchedHtml,
       src: patchedHtml ? undefined : content.url,
     });
-    setActive(sceneId);
     claim(sceneId, owner);
     return () => release(sceneId, owner);
   }, [sceneId, owner, patchedHtml, content.url, mount, setActive, claim, release]);

--- a/components/service-worker-register.tsx
+++ b/components/service-worker-register.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Registers the PWA service worker (production only). The SW caches static
+ * assets + visited pages so the app loads fast and survives flaky 3G/4G, and
+ * keeps already-opened lessons available offline. Registration failures are
+ * non-fatal — the app works without it.
+ *
+ * `basePath` is passed from the server layout so the SW path/scope are correct
+ * both standalone (root) and when mounted under a prefix (e.g. `/maic`).
+ */
+export function ServiceWorkerRegister({ basePath = '' }: { basePath?: string }) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+
+    const swUrl = `${basePath}/sw.js?base=${encodeURIComponent(basePath)}`;
+    navigator.serviceWorker.register(swUrl, { scope: `${basePath}/` }).catch(() => {
+      /* non-fatal: app works without the service worker */
+    });
+  }, [basePath]);
+
+  return null;
+}

--- a/components/slide-renderer/components/element/ChartElement/BaseChartElement.tsx
+++ b/components/slide-renderer/components/element/ChartElement/BaseChartElement.tsx
@@ -2,7 +2,7 @@
 
 import type { PPTChartElement } from '@openmaic/dsl';
 import { ElementOutline } from '../ElementOutline';
-import { Chart } from './Chart';
+import { Chart } from './LazyChart';
 
 export interface BaseChartElementProps {
   elementInfo: PPTChartElement;

--- a/components/slide-renderer/components/element/ChartElement/LazyChart.tsx
+++ b/components/slide-renderer/components/element/ChartElement/LazyChart.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+/**
+ * Lazy boundary for the chart renderer. `Chart` pulls in ECharts (~500 KB),
+ * which most lessons never use, so loading it eagerly bloated the initial
+ * classroom bundle. Here it is fetched on demand — only when a slide actually
+ * contains a chart element. Chart is already client-only (it calls
+ * `echarts.init` on a DOM ref in an effect), so `ssr: false` matches its
+ * behaviour. Same props as the underlying `Chart`.
+ */
+export const Chart = dynamic(() => import('./Chart').then((m) => m.Chart), {
+  ssr: false,
+  loading: () => <div className="w-full h-full" />,
+});

--- a/components/slide-renderer/components/element/ChartElement/index.tsx
+++ b/components/slide-renderer/components/element/ChartElement/index.tsx
@@ -2,7 +2,7 @@
 
 import type { PPTChartElement } from '@openmaic/dsl';
 import { ElementOutline } from '../ElementOutline';
-import { Chart } from './Chart';
+import { Chart } from './LazyChart';
 
 export { BaseChartElement } from './BaseChartElement';
 

--- a/lib/store/interactive-iframe-pool.ts
+++ b/lib/store/interactive-iframe-pool.ts
@@ -17,8 +17,36 @@
  */
 
 import { create } from 'zustand';
+import { readNetworkQuality } from '@/lib/utils/network-quality';
 
 export const IFRAME_POOL_CAP = 3;
+
+/**
+ * On a slow / data-saver link, shrink the pool to ONE resident document.
+ *
+ * Each interactive scene's iframe loads heavy third-party libraries (KaTeX, and
+ * the simulator scenes pull Pyodide + the multi-MB `python_stdlib.zip`) from a
+ * CDN at view time. With the normal 3-document pool, walking slides 2→3→4 leaves
+ * the previous slides' iframes still mid-download; on weak 3G/4G those multi-MB
+ * fetches never finish and saturate the single connection, so even the active
+ * slide can't get its own resources through and renders blank while the
+ * (locally-cached) TTS audio plays. Holding only the active iframe gives it the
+ * full pipe; the once-downloaded libraries are then HTTP-cached, so the next
+ * simulator slide is fast. Keep-alive (instant return without reload) is the
+ * cost — an acceptable trade on a link where the priority is the slide loading
+ * at all. Fast links keep the full pool.
+ */
+export const SLOW_LINK_IFRAME_POOL_CAP = 1;
+
+/**
+ * Resolve the live pool cap from current network quality. Conservative: only
+ * shrinks on positive evidence of a slow/Save-Data link; when the Network
+ * Information API is unavailable (Safari/Firefox → `unknown`) it stays at the
+ * full cap, so we never degrade keep-alive on links we can't measure.
+ */
+export function getActiveIframePoolCap(): number {
+  return readNetworkQuality().isDataSaver ? SLOW_LINK_IFRAME_POOL_CAP : IFRAME_POOL_CAP;
+}
 
 export interface IframeRect {
   readonly left: number;
@@ -77,14 +105,15 @@ interface InteractiveIframePoolState {
 function evictLru(
   entries: Record<string, IframePoolEntry>,
   activeSceneId: string | null,
+  cap: number,
 ): Record<string, IframePoolEntry> {
   const ids = Object.keys(entries);
-  if (ids.length <= IFRAME_POOL_CAP) return entries;
+  if (ids.length <= cap) return entries;
   const evictable = ids
     .filter((id) => id !== activeSceneId)
     .sort((a, b) => entries[a].tick - entries[b].tick);
   const next = { ...entries };
-  let overflow = ids.length - IFRAME_POOL_CAP;
+  let overflow = ids.length - cap;
   for (const id of evictable) {
     if (overflow <= 0) break;
     delete next[id];
@@ -119,7 +148,11 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
         owner: existing?.owner ?? null,
         tick,
       };
-      const entries = evictLru({ ...state.entries, [sceneId]: entry }, state.activeSceneId);
+      const entries = evictLru(
+        { ...state.entries, [sceneId]: entry },
+        state.activeSceneId,
+        getActiveIframePoolCap(),
+      );
       return { entries, tick };
     }),
 

--- a/lib/utils/concurrency.ts
+++ b/lib/utils/concurrency.ts
@@ -73,3 +73,72 @@ export async function mapWithConcurrency<T, R>(
 ): Promise<Array<R | undefined>> {
   return Promise.all(lazyBoundedMap(items, limit, fn, options));
 }
+
+/** Resolve after `ms`, or reject with an AbortError if `signal` fires first. */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export interface RetryOptions {
+  /** Additional attempts after the first (total attempts = retries + 1). */
+  retries?: number;
+  /** Backoff base in ms; nominal delay = baseDelayMs * 2 ** attempt. */
+  baseDelayMs?: number;
+  /** Upper bound on a single backoff delay. */
+  maxDelayMs?: number;
+  /** Abort the whole retry loop (e.g. user cancelled or unmounted). */
+  signal?: AbortSignal;
+  /** Return false to stop retrying a particular error (default: always retry). */
+  shouldRetry?: (err: unknown) => boolean;
+  /** Observe each retry, e.g. for logging. */
+  onRetry?: (err: unknown, attempt: number) => void;
+}
+
+/**
+ * Run `fn`, retrying on rejection with exponential backoff + jitter. The
+ * attempt index (0-based) is passed to `fn`. Honors an AbortSignal between
+ * attempts and during backoff sleeps.
+ */
+export async function retryWithBackoff<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    retries = 2,
+    baseDelayMs = 500,
+    maxDelayMs = 8000,
+    signal,
+    shouldRetry = () => true,
+    onRetry,
+  } = options;
+
+  let attempt = 0;
+  for (;;) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      if (attempt >= retries || !shouldRetry(err)) throw err;
+      onRetry?.(err, attempt);
+      const nominal = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+      // Half fixed, half random jitter — spreads retries to avoid storms.
+      const delay = nominal / 2 + Math.random() * (nominal / 2);
+      await sleep(delay, signal);
+      attempt += 1;
+    }
+  }
+}

--- a/lib/utils/iframe.ts
+++ b/lib/utils/iframe.ts
@@ -99,6 +99,42 @@ const ERROR_CAPTURE_SHIM = `<script data-iframe-error-shim>
 </script>`;
 
 /**
+ * Make KaTeX's render-blocking CDN assets non-blocking so the slide can paint
+ * immediately on weak 3G/4G.
+ *
+ * Generated interactive slides (and our own post-processor) load KaTeX via plain
+ * `<script src>` / `<link rel="stylesheet">` tags in `<head>` with no `defer` —
+ * which are PARSER/RENDER-blocking. The browser will not parse or paint the
+ * `<body>` until the ~280KB `katex.min.js` finishes downloading; on 3G that is
+ * tens of seconds of a blank iframe even though the entire slide markup is inline
+ * and could render instantly. That is the root cause of "the interactive slide
+ * stays white while the audio plays".
+ *
+ * `defer` is safe for KaTeX specifically: the auto-render call is wrapped in a
+ * `DOMContentLoaded` handler, which fires AFTER deferred scripts have executed,
+ * so `renderMathInElement` is defined by the time it runs. The math simply
+ * typesets a beat after the (now-instant) first paint. Scoped to KaTeX URLs only
+ * — we do NOT blanket-defer arbitrary scripts, because a page may call a library
+ * synchronously at parse time and deferring it would break that.
+ */
+function deferRenderBlockingKatex(html: string): string {
+  // 1) Defer KaTeX <script src> tags (skip any already async/defer/module).
+  html = html.replace(
+    /<script\b([^>]*\bsrc=["'][^"']*katex[^"']*["'][^>]*)><\/script>/gi,
+    (match, attrs: string) =>
+      /\b(defer|async)\b|type=["']module/i.test(attrs) ? match : `<script${attrs} defer></script>`,
+  );
+  // 2) Make the KaTeX stylesheet non-render-blocking (applies once loaded; a
+  //    brief unstyled-math flash is an acceptable trade for an instant paint).
+  html = html.replace(
+    /<link\b([^>]*\bhref=["'][^"']*katex[^"']*\.css[^"']*["'][^>]*)>/gi,
+    (match, attrs: string) =>
+      /\bmedia=/i.test(attrs) ? match : `<link${attrs} media="print" onload="this.media='all'">`,
+  );
+  return html;
+}
+
+/**
  * Patch embedded HTML to display correctly inside an iframe.
  *
  * Injects a runtime-error capture shim + a storage shim (so sandboxed pages that
@@ -108,6 +144,10 @@ const ERROR_CAPTURE_SHIM = `<script data-iframe-error-shim>
  * it also observes the storage shim).
  */
 export function patchHtmlForIframe(html: string): string {
+  // Unblock KaTeX's CDN assets so the slide paints instantly on weak links
+  // instead of waiting for the render-blocking library download (3G blank slide).
+  html = deferRenderBlockingKatex(html);
+
   const iframeCss = `<style data-iframe-patch>
   html, body {
     width: 100%;

--- a/lib/utils/network-quality.ts
+++ b/lib/utils/network-quality.ts
@@ -1,0 +1,83 @@
+/**
+ * Network-quality detection for adapting behaviour on weak 3G/4G links.
+ *
+ * Reads the (Chromium-only) Network Information API plus the user's Save-Data
+ * preference. It is intentionally conservative: when the API is unavailable
+ * (Safari, Firefox desktop) we report `unknown` and DO NOT assume the link is
+ * slow — features must degrade gracefully, never block, on missing data.
+ *
+ * The pure `deriveNetworkQuality` core is unit-tested in
+ * `tests/utils/network-quality.test.ts`; `readNetworkQuality` is the thin
+ * browser binding.
+ */
+
+export type EffectiveConnectionType = 'slow-2g' | '2g' | '3g' | '4g' | 'unknown';
+
+export interface NetworkQuality {
+  /** Browser's effective connection class, or 'unknown' if unavailable. */
+  effectiveType: EffectiveConnectionType;
+  /** User has explicitly asked to save data (Save-Data: on). */
+  saveData: boolean;
+  /** Positive evidence of a slow link (slow-2g / 2g / 3g). */
+  isSlow: boolean;
+  /** Conserve data: Save-Data is on, or the link is measurably slow. */
+  isDataSaver: boolean;
+  /** Whether the Network Information API was available to read. */
+  supported: boolean;
+}
+
+interface NetworkInformationLike {
+  effectiveType?: string;
+  saveData?: boolean;
+  downlink?: number;
+  rtt?: number;
+  addEventListener?: (type: 'change', listener: () => void) => void;
+  removeEventListener?: (type: 'change', listener: () => void) => void;
+}
+
+function isEffectiveType(value: unknown): value is EffectiveConnectionType {
+  return value === 'slow-2g' || value === '2g' || value === '3g' || value === '4g';
+}
+
+/**
+ * Pure derivation of {@link NetworkQuality} from raw inputs — no browser
+ * globals, so it can be unit-tested and reused server-side (e.g. from a
+ * `Save-Data` request header, passing `{ saveData, supported: false }`).
+ */
+export function deriveNetworkQuality(input: {
+  effectiveType?: string;
+  saveData?: boolean;
+  supported?: boolean;
+}): NetworkQuality {
+  const effectiveType = isEffectiveType(input.effectiveType) ? input.effectiveType : 'unknown';
+  const saveData = input.saveData === true;
+  const isSlow = effectiveType === 'slow-2g' || effectiveType === '2g' || effectiveType === '3g';
+  return {
+    effectiveType,
+    saveData,
+    isSlow,
+    isDataSaver: saveData || isSlow,
+    supported: input.supported ?? false,
+  };
+}
+
+/** Access the Network Information API across vendor prefixes, if present. */
+export function getConnection(): NetworkInformationLike | undefined {
+  if (typeof navigator === 'undefined') return undefined;
+  const nav = navigator as Navigator & {
+    connection?: NetworkInformationLike;
+    mozConnection?: NetworkInformationLike;
+    webkitConnection?: NetworkInformationLike;
+  };
+  return nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
+}
+
+/** Read the current network quality from the browser. */
+export function readNetworkQuality(): NetworkQuality {
+  const conn = getConnection();
+  return deriveNetworkQuality({
+    effectiveType: conn?.effectiveType,
+    saveData: conn?.saveData,
+    supported: !!conn,
+  });
+}

--- a/lib/utils/resilient-fetch.ts
+++ b/lib/utils/resilient-fetch.ts
@@ -1,0 +1,55 @@
+/**
+ * `fetch()` hardened for weak 3G/4G links: each attempt is time-bounded and
+ * network errors / timeouts are retried with exponential backoff. Built on the
+ * shared {@link retryWithBackoff}.
+ *
+ * Deliberately does NOT inspect HTTP status — the resolved Response is returned
+ * as-is, so callers keep checking `res.ok`, and non-idempotent requests stay
+ * safe (only network-level failures and timeouts retry, never a 5xx body that
+ * may have had a side effect). The caller's own AbortSignal cancels immediately
+ * and is never retried.
+ *
+ * Unit-tested in `tests/utils/resilient-fetch.test.ts`.
+ */
+
+import { retryWithBackoff } from './concurrency';
+
+export interface ResilientFetchOptions extends RequestInit {
+  /** Per-attempt timeout in ms (default 30000). */
+  timeoutMs?: number;
+  /** Extra attempts after the first (default 2). */
+  retries?: number;
+  /** Backoff base in ms (default 600). */
+  baseDelayMs?: number;
+}
+
+export async function resilientFetch(
+  input: RequestInfo | URL,
+  options: ResilientFetchOptions = {},
+): Promise<Response> {
+  const {
+    timeoutMs = 30_000,
+    retries = 2,
+    baseDelayMs = 600,
+    signal: callerSignal,
+    ...init
+  } = options;
+  // RequestInit.signal is AbortSignal | null | undefined; normalise null away.
+  const signal = callerSignal ?? undefined;
+
+  return retryWithBackoff(
+    async () => {
+      const timeout = AbortSignal.timeout(timeoutMs);
+      const composed = signal ? AbortSignal.any([signal, timeout]) : timeout;
+      return await fetch(input, { ...init, signal: composed });
+    },
+    {
+      retries,
+      baseDelayMs,
+      signal,
+      // Retry network errors and per-attempt timeouts, but never once the
+      // caller has cancelled (their abort should surface immediately).
+      shouldRetry: () => !signal?.aborted,
+    },
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -49,8 +49,16 @@ export async function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  // Whitelist: access-code endpoints, health check
-  if (pathname.startsWith('/api/access-code/') || pathname === '/api/health') {
+  // Whitelist: access-code endpoints, health check, and the PWA assets. The
+  // service worker script and web manifest must be publicly fetchable — if they
+  // are gated behind the access-code flow the PWA can't install or update.
+  // `endsWith` keeps this correct when the app is mounted under a basePath.
+  if (
+    pathname.startsWith('/api/access-code/') ||
+    pathname === '/api/health' ||
+    pathname.endsWith('/sw.js') ||
+    pathname.endsWith('/manifest.webmanifest')
+  ) {
     return NextResponse.next();
   }
 
@@ -73,5 +81,8 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|logos/).*)'],
+  // Exclude static assets and the PWA service worker + manifest, which must be
+  // publicly fetchable (the SW script and manifest can't be gated behind the
+  // access-code flow or the PWA won't install / update).
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|logos/|sw.js|manifest.webmanifest).*)'],
 };

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,109 @@
+/*
+ * OpenMAIC service worker (hand-rolled, no Workbox to stay dependency-free).
+ *
+ * Goal: make the app load fast and survive flaky 3G/4G — and let already-opened
+ * lessons keep working offline.
+ *
+ * Strategy (deliberately conservative):
+ *   - /_next/static/ + other hashed/static assets → CacheFirst. These are
+ *     content-hashed, so a cached copy is never stale; serving them from cache
+ *     removes the biggest repeat-load cost on a weak link.
+ *   - navigations (full page loads) → NetworkFirst, falling back to a cached
+ *     copy and finally a small synthesized offline page.
+ *   - everything else (API/auth/dynamic data) → passthrough, never cached.
+ *
+ * Bump CACHE_VERSION only when this logic changes; old caches are purged on
+ * activate. basePath arrives via the registration URL query (e.g. ?base=/maic).
+ */
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `openmaic-static-${CACHE_VERSION}`;
+const PAGE_CACHE = `openmaic-pages-${CACHE_VERSION}`;
+const BASE = new URL(self.location.href).searchParams.get('base') || '';
+
+self.addEventListener('install', () => {
+  // Take over as soon as installed; the conservative strategy makes this safe.
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((k) => k.startsWith('aicr-') && !k.endsWith(CACHE_VERSION))
+          .map((k) => caches.delete(k)),
+      );
+      await self.clients.claim();
+    })(),
+  );
+});
+
+function offlineResponse() {
+  return new Response(
+    '<!doctype html><html lang="en"><head><meta charset="utf-8">' +
+      '<meta name="viewport" content="width=device-width,initial-scale=1"><title>Offline</title>' +
+      '<style>body{font-family:system-ui,-apple-system,sans-serif;background:#0d1117;color:#e6edf3;' +
+      'display:grid;place-items:center;min-height:100vh;margin:0;text-align:center;padding:24px}' +
+      'h1{font-size:20px;margin:0 0 8px}p{color:#9aa7b4;max-width:380px;line-height:1.5}</style></head>' +
+      '<body><div><h1>You’re offline</h1><p>This page isn’t cached yet. Reconnect to load it — ' +
+      'lessons you’ve already opened stay available offline.</p></div></body></html>',
+    { headers: { 'Content-Type': 'text/html; charset=utf-8' }, status: 503 },
+  );
+}
+
+function isStaticAsset(url) {
+  return (
+    url.pathname.startsWith(`${BASE}/_next/static/`) ||
+    /\.(?:js|css|woff2?|ttf|otf|png|jpg|jpeg|gif|svg|webp|avif|ico)$/.test(url.pathname)
+  );
+}
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+
+  // Never cache APIs / auth / dynamic data — always hit the network.
+  if (url.pathname.startsWith(`${BASE}/api/`)) return;
+
+  if (req.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          const fresh = await fetch(req);
+          if (fresh && fresh.ok) {
+            const cache = await caches.open(PAGE_CACHE);
+            cache.put(req, fresh.clone());
+          }
+          return fresh;
+        } catch {
+          const cached = await caches.match(req);
+          return cached || offlineResponse();
+        }
+      })(),
+    );
+    return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(
+      (async () => {
+        const cached = await caches.match(req);
+        if (cached) return cached;
+        try {
+          const fresh = await fetch(req);
+          if (fresh && (fresh.ok || fresh.type === 'opaque')) {
+            const cache = await caches.open(STATIC_CACHE);
+            cache.put(req, fresh.clone());
+          }
+          return fresh;
+        } catch {
+          return Response.error();
+        }
+      })(),
+    );
+  }
+});

--- a/tests/lib/utils/iframe.test.ts
+++ b/tests/lib/utils/iframe.test.ts
@@ -100,6 +100,46 @@ describe('patchHtmlForIframe', () => {
     expect(String(posts[3][0].message)).toContain('console boom');
   });
 
+  describe('render-blocking KaTeX assets (3G blank-slide root cause)', () => {
+    it('defers a render-blocking KaTeX <script> so the body can paint first', () => {
+      const html =
+        '<!DOCTYPE html><html><head>' +
+        '<script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>' +
+        '<script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>' +
+        '</head><body><p>hi</p></body></html>';
+      const out = patchHtmlForIframe(html);
+      expect(out).toContain(
+        '<script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" defer></script>',
+      );
+      expect(out).toContain('contrib/auto-render.min.js" defer></script>');
+    });
+
+    it('makes the KaTeX stylesheet non-render-blocking', () => {
+      const html =
+        '<html><head><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"></head><body></body></html>';
+      const out = patchHtmlForIframe(html);
+      expect(out).toMatch(/katex@0\.16\.9\/dist\/katex\.min\.css"[^>]*media="print"/);
+      expect(out).toContain('onload="this.media=\'all\'"');
+    });
+
+    it('does NOT touch non-KaTeX scripts (safety — avoids breaking parse-time deps)', () => {
+      const html =
+        '<html><head><script src="https://cdn.example.com/lib.js"></script></head><body></body></html>';
+      const out = patchHtmlForIframe(html);
+      expect(out).toContain('<script src="https://cdn.example.com/lib.js"></script>');
+      expect(out).not.toContain('lib.js" defer');
+    });
+
+    it('is idempotent — already-deferred KaTeX is left alone', () => {
+      const html =
+        '<html><head><script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" defer></script></head><body></body></html>';
+      const out = patchHtmlForIframe(html);
+      // exactly one `defer`, not doubled
+      expect(out).toContain('katex.min.js" defer></script>');
+      expect(out).not.toContain('defer defer');
+    });
+  });
+
   it('the error shim buffers errors and re-emits them on a parent replay request', () => {
     // Guards the subscribe-after-insert race: a page that throws synchronously
     // while srcDoc parses may post before the parent subscribes. The shim must

--- a/tests/store/interactive-iframe-pool.test.ts
+++ b/tests/store/interactive-iframe-pool.test.ts
@@ -1,5 +1,30 @@
-import { beforeEach, describe, expect, test } from 'vitest';
-import { IFRAME_POOL_CAP, useInteractiveIframePool } from '@/lib/store/interactive-iframe-pool';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  IFRAME_POOL_CAP,
+  SLOW_LINK_IFRAME_POOL_CAP,
+  useInteractiveIframePool,
+} from '@/lib/store/interactive-iframe-pool';
+import { readNetworkQuality } from '@/lib/utils/network-quality';
+
+vi.mock('@/lib/utils/network-quality', () => ({
+  readNetworkQuality: vi.fn(),
+}));
+
+const mockNetwork = vi.mocked(readNetworkQuality);
+const FAST: ReturnType<typeof readNetworkQuality> = {
+  effectiveType: 'unknown',
+  saveData: false,
+  isSlow: false,
+  isDataSaver: false,
+  supported: false,
+};
+const SLOW: ReturnType<typeof readNetworkQuality> = {
+  effectiveType: '3g',
+  saveData: false,
+  isSlow: true,
+  isDataSaver: true,
+  supported: true,
+};
 
 function reset() {
   useInteractiveIframePool.getState().reset();
@@ -7,7 +32,10 @@ function reset() {
 
 const pool = () => useInteractiveIframePool.getState();
 
-beforeEach(reset);
+beforeEach(() => {
+  reset();
+  mockNetwork.mockReturnValue(FAST);
+});
 
 describe('mount', () => {
   test('creates an entry with the given content', () => {
@@ -108,6 +136,47 @@ describe('LRU eviction', () => {
     pool().mount('s3', { srcDoc: 'x3' });
     expect(pool().entries['s1']).toBeUndefined();
     expect(pool().entries['s0']).toBeDefined();
+  });
+});
+
+describe('slow-link cap (3G/4G contention guard)', () => {
+  test(`shrinks the resident pool to ${SLOW_LINK_IFRAME_POOL_CAP} on a slow/data-saver link`, () => {
+    mockNetwork.mockReturnValue(SLOW);
+    // Simulate the renderer's order (setActive BEFORE mount) as the user walks
+    // slides: only the active interactive iframe should stay resident, so its
+    // heavy CDN libraries don't compete with the previous slides' downloads.
+    pool().setActive('s0');
+    pool().mount('s0', { srcDoc: 'a' });
+    pool().setActive('s1');
+    pool().mount('s1', { srcDoc: 'b' });
+    pool().setActive('s2');
+    pool().mount('s2', { srcDoc: 'c' });
+
+    expect(Object.keys(pool().entries)).toHaveLength(SLOW_LINK_IFRAME_POOL_CAP);
+    expect(pool().entries['s2']).toBeDefined(); // newest/active kept
+    expect(pool().entries['s0']).toBeUndefined();
+    expect(pool().entries['s1']).toBeUndefined();
+  });
+
+  test('never evicts the just-navigated (active) scene on a slow link', () => {
+    mockNetwork.mockReturnValue(SLOW);
+    pool().setActive('s0');
+    pool().mount('s0', { srcDoc: 'a' });
+    pool().setActive('s1');
+    pool().mount('s1', { srcDoc: 'b' });
+    // The scene we navigated to must survive; the old one is dropped to free
+    // the pipe (its in-flight CDN download is aborted when its iframe unmounts).
+    expect(pool().entries['s1']).toBeDefined();
+    expect(pool().entries['s0']).toBeUndefined();
+  });
+
+  test('a fast link keeps the full keep-alive pool', () => {
+    mockNetwork.mockReturnValue(FAST);
+    for (let i = 0; i < IFRAME_POOL_CAP + 1; i++) {
+      pool().setActive(`s${i}`);
+      pool().mount(`s${i}`, { srcDoc: `x${i}` });
+    }
+    expect(Object.keys(pool().entries)).toHaveLength(IFRAME_POOL_CAP);
   });
 });
 

--- a/tests/utils/network-quality.test.ts
+++ b/tests/utils/network-quality.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveNetworkQuality } from '@/lib/utils/network-quality';
+
+describe('deriveNetworkQuality', () => {
+  it('treats a 4g link as fast (no data-saver)', () => {
+    const q = deriveNetworkQuality({ effectiveType: '4g', saveData: false, supported: true });
+    expect(q).toMatchObject({
+      effectiveType: '4g',
+      isSlow: false,
+      saveData: false,
+      isDataSaver: false,
+      supported: true,
+    });
+  });
+
+  it('flags 3g / 2g / slow-2g as slow and data-saver', () => {
+    for (const et of ['3g', '2g', 'slow-2g'] as const) {
+      const q = deriveNetworkQuality({ effectiveType: et, supported: true });
+      expect(q.isSlow).toBe(true);
+      expect(q.isDataSaver).toBe(true);
+    }
+  });
+
+  it('honours Save-Data even on a fast link', () => {
+    const q = deriveNetworkQuality({ effectiveType: '4g', saveData: true, supported: true });
+    expect(q.isSlow).toBe(false); // link itself is fast
+    expect(q.saveData).toBe(true);
+    expect(q.isDataSaver).toBe(true); // but the user asked to save data
+  });
+
+  it('does NOT assume slow when the API is unavailable (graceful default)', () => {
+    const q = deriveNetworkQuality({});
+    expect(q).toMatchObject({
+      effectiveType: 'unknown',
+      isSlow: false,
+      saveData: false,
+      isDataSaver: false,
+      supported: false,
+    });
+  });
+
+  it('coerces an unrecognised effectiveType to unknown', () => {
+    const q = deriveNetworkQuality({ effectiveType: '5g', supported: true });
+    expect(q.effectiveType).toBe('unknown');
+    expect(q.isSlow).toBe(false);
+  });
+});

--- a/tests/utils/resilient-fetch.test.ts
+++ b/tests/utils/resilient-fetch.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resilientFetch } from '@/lib/utils/resilient-fetch';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function ok(body = 'ok') {
+  return new Response(body, { status: 200 });
+}
+
+describe('resilientFetch', () => {
+  it('returns the response on first success (single call)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await resilientFetch('/api/x', { retries: 2, baseDelayMs: 1 });
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient network errors then succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue(ok('third'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await resilientFetch('/api/x', { retries: 3, baseDelayMs: 1 });
+
+    expect(await res.text()).toBe('third');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry HTTP error statuses — returns the Response as-is', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('boom', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await resilientFetch('/api/x', { retries: 3, baseDelayMs: 1 });
+
+    expect(res.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // a 5xx is the caller's to handle
+  });
+
+  it('times out a stalled attempt and retries, then rejects after exhausting', async () => {
+    // fetch that never resolves until its signal aborts (simulates a stalled link).
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      resilientFetch('/api/x', { timeoutMs: 20, retries: 1, baseDelayMs: 1 }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // first attempt + one retry
+  });
+
+  it('propagates a caller abort immediately without retrying', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      resilientFetch('/api/x', { signal: controller.signal, retries: 3, baseDelayMs: 1 }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens OpenMAIC for **weak 3G/4G connections** — the conditions many classrooms actually run under. It adds network-aware loading behaviour, an offline-first PWA layer, and targeted fixes for the interactive-slide "blank screen while audio plays" failure that shows up on slow links. The changes are scoped to networking/loading behaviour, add **no new runtime dependencies**, and degrade gracefully: on fast links, or on browsers without the Network Information API, behaviour is unchanged. 

## Related Issues

<!-- Link related issues: "Closes #123", "Fixes #456", "Related to #789" -->

## Changes

<!-- List the key changes: -->

- N/A

- **Network-quality detection** (`lib/utils/network-quality.ts`) — reads the Network Information API (`effectiveType` + `Save-Data`) to classify a link as slow/data-saver; conservative, never reports "slow" on browsers that can't report (so nothing degrades on unmeasurable links).
- **Resilient fetch** (`lib/utils/resilient-fetch.ts`, `+ retryWithBackoff/sleep` in `lib/utils/concurrency.ts`) — per-attempt timeout + exponential-backoff-with-jitter retry for transient network failures; never retries on HTTP status, so side-effecting 5xx responses are safe.
- **Offline-first PWA** (`public/sw.js`, `app/manifest.ts`, `components/service-worker-register.tsx`, wired via `app/layout.tsx` + `middleware.ts`) — hand-rolled (no Workbox): CacheFirst for hashed static assets, NetworkFirst for navigations with an offline fallback, passthrough (never cache) for APIs/dynamic data.
- **Defer render-blocking KaTeX** (`lib/utils/iframe.ts`) — makes KaTeX `<script>`/`<link>` non-render-blocking so interactive slides paint immediately instead of waiting on ~280KB of CDN JS; scoped to KaTeX URLs only.
- **Cap interactive-iframe pool on slow links** (`lib/store/interactive-iframe-pool.ts`, `components/scene-renderers/interactive-renderer.tsx`) — holds 1 resident iframe on a slow/Save-Data link so the active slide gets the whole pipe (full pool on fast links).
- **Code-split ECharts** (`ChartElement/LazyChart.tsx`) — loads the ~500KB charting lib on demand instead of in the initial bundle.


## Type of Change

<!-- Check the relevant options: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. `pnpm install`
2. `pnpm test` (unit suite) · `npx tsc --noEmit` (types) · `pnpm check && pnpm lint` (format/lint) · `pnpm build` (production)
3. To exercise behaviour: throttle the browser to "Slow 3G" in DevTools, open a lesson with an interactive/KaTeX slide, and confirm the slide paints promptly rather than staying blank while audio plays; reload an already-visited lesson offline and confirm it still loads (service worker).

### What you personally verified

<!-- What did you test beyond CI? Include edge cases checked and anything you did NOT verify. -->

-

### Evidence

<!-- Attach at least one: logs, screenshots, recordings, or before/after comparisons. -->

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`) — all clean locally; plus `pnpm test` (2006 passed) and `pnpm build` (success)
- [ ] Manually tested locally (automated suite + production build run; interactive browser/3G walkthrough left for reviewer confirmation)
- [ ] Screenshots / recordings attached (if UI changes) — N/A, no UI changes in this PR

## Checklist

- [x] My code follows the project's coding style (Prettier + ESLint clean)
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (code comments explain the non-obvious network/sandbox reasoning; no user-facing docs affected)
- [x] My changes do not introduce new warnings (tsc/eslint/build clean)
