### PR TITLE
feat(renderer/editing): marquee multi-select + multi-element drag (#851 Part A)

### DIFF
--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -11,6 +11,7 @@ import { LineHandles } from './handles/LineHandles';
 import { ResizeHandles } from './handles/ResizeHandles';
 import { RotateHandle } from './handles/RotateHandle';
 import { MarqueeBox } from './handles/MarqueeBox';
+import { isSelectionModifier, resolveClickSelection } from './core/selection';
 import { useEditGesture } from './useEditGesture';
 import { useLineHandleGesture } from './useLineHandleGesture';
 import { useMarqueeGesture } from './useMarqueeGesture';
@@ -115,8 +116,9 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
   // Marquee (rubber-band) gesture. It arms from a blank-canvas pointer-down on
   // the capture surface below the element hit targets, tracks a live rectangle,
   // and on release REPLACES the selection with whatever it covers (or clears it
-  // on a sub-threshold blank click). Selection-only, so it is gated on
-  // `onSelectionChange`.
+  // on a sub-threshold blank click). The capture surface only mounts on
+  // editable hosts (`onElementsChange` — see the surface comment below), and
+  // the hook itself additionally requires `onSelectionChange` to publish.
   const { marqueeRect, onCanvasPointerDown } = useMarqueeGesture({
     slide,
     scale: canvasScale,
@@ -189,9 +191,13 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
               while a pointer-down on empty canvas falls to this full-bleed layer
               and arms a rubber-band select. It is a sibling of the element hit
               divs (not an ancestor), so an element pointer-down never bubbles
-              into it. Selection-only, so it is gated on `onSelectionChange`;
-              without it the surface is absent and blank clicks do nothing. */}
-          {Boolean(onSelectionChange) && (
+              into it. Gated on EDITABILITY (`onElementsChange`), not on
+              `onSelectionChange`: this full-bleed `touchAction: 'none'` layer
+              would swallow native touch panning across the whole canvas, which
+              is only acceptable in a real editor. A select-only/viewer-ish
+              mount renders no surface — element tap-select still works via the
+              per-element hit targets; blank taps neither marquee nor clear. */}
+          {Boolean(onElementsChange) && (
             <div
               data-marquee-surface=""
               onPointerDown={onCanvasPointerDown}
@@ -313,34 +319,41 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                         // bypasses the `activePointerRef` multi-pointer guard.
                         // A second pointer-down on a line during an in-flight
                         // box drag can therefore change the selection mid-
-                        // gesture. This is deferred together with multi-touch/
-                        // multi-select support; single-pointer/mouse use (only
-                        // one active pointer at a time) is unaffected.
+                        // gesture. More generally, the single-pointer guarantee
+                        // is PER-HOOK: each gesture hook (move/marquee/line-
+                        // handle/resize/rotate) guards only its own active
+                        // pointer, so a second pointer can still arm a
+                        // DIFFERENT hook's gesture concurrently. Cross-hook
+                        // arbitration is deferred together with multi-touch
+                        // support; single-pointer/mouse use (only one active
+                        // pointer at a time) is unaffected.
                         //
                         // Always consume the pointer to block fall-through to
                         // an overlapped box beneath (even with no selection
                         // callback, and even when the line is locked). When a
-                        // selection callback is provided, also select the line
-                        // — on pointer-down, for parity with box elements
-                        // (which select via onElementPointerDown). A line is
-                        // selectable but NOT draggable here: no working copy is
-                        // armed and no move intent is ever emitted (line
-                        // editing deferred).
+                        // selection callback is provided, resolve the click
+                        // through the SAME modifier/selection table as box
+                        // elements ({@link resolveClickSelection}) so a
+                        // modifier click adds/removes a line from a multi-
+                        // selection too. A line is selectable but NOT draggable
+                        // here: `armDrag` is ignored, no working copy is armed,
+                        // and no move intent is ever emitted (line editing
+                        // deferred).
                         e.stopPropagation();
                         // A locked line is inert like a locked box: it blocks
                         // fall-through (stopPropagation above) but must not be
                         // selected.
                         if (el.lock) return;
-                        // Idempotent re-selection: skip the emit when this line
-                        // is already the sole primary selection, mirroring the
-                        // box `alreadySolePrimary` guard in useEditGesture — a
-                        // re-click on an already-selected line must not re-emit.
-                        const alreadySolePrimary =
-                          activeSelection.primaryId === el.id &&
-                          activeSelection.elementIds.length === 1 &&
-                          activeSelection.elementIds[0] === el.id;
-                        if (alreadySolePrimary) return;
-                        onSelectionChange?.({ elementIds: [el.id], primaryId: el.id });
+                        const { next } = resolveClickSelection({
+                          element: el,
+                          elements: slide.elements,
+                          selection: activeSelection,
+                          modifier: isSelectionModifier(e),
+                        });
+                        // `next` is null when nothing changes (e.g. a re-click
+                        // on the current primary, or a subtractive click that
+                        // would empty the selection) — no redundant re-emit.
+                        if (next) onSelectionChange?.(next);
                       }}
                       style={{ cursor: 'default', touchAction: 'none' }}
                     />

--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -116,9 +116,9 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
   // Marquee (rubber-band) gesture. It arms from a blank-canvas pointer-down on
   // the capture surface below the element hit targets, tracks a live rectangle,
   // and on release REPLACES the selection with whatever it covers (or clears it
-  // on a sub-threshold blank click). The capture surface only mounts on
-  // editable hosts (`onElementsChange` — see the surface comment below), and
-  // the hook itself additionally requires `onSelectionChange` to publish.
+  // on a sub-threshold blank click). The capture surface mounts for selection
+  // hosts (`onSelectionChange` — see the surface comment below); the hook itself
+  // also requires `onSelectionChange` to publish.
   const { marqueeRect, onCanvasPointerDown } = useMarqueeGesture({
     slide,
     scale: canvasScale,
@@ -191,17 +191,21 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
               while a pointer-down on empty canvas falls to this full-bleed layer
               and arms a rubber-band select. It is a sibling of the element hit
               divs (not an ancestor), so an element pointer-down never bubbles
-              into it. Gated on EDITABILITY (`onElementsChange`), not on
-              `onSelectionChange`: this full-bleed `touchAction: 'none'` layer
-              would swallow native touch panning across the whole canvas, which
-              is only acceptable in a real editor. A select-only/viewer-ish
-              mount renders no surface — element tap-select still works via the
-              per-element hit targets; blank taps neither marquee nor clear. */}
-          {Boolean(onElementsChange) && (
+              into it. Gated on SELECTION (`onSelectionChange`) so select-only
+              mounts still get mouse/pen marquee and sub-threshold blank-clear.
+              Touch suppression is gated separately on EDITABILITY
+              (`onElementsChange`): select-only mounts preserve native touch
+              panning, while touch-driven marquee requires an editable mount. */}
+          {Boolean(onSelectionChange) && (
             <div
               data-marquee-surface=""
               onPointerDown={onCanvasPointerDown}
-              style={{ position: 'absolute', inset: 0, pointerEvents: 'auto', touchAction: 'none' }}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                pointerEvents: 'auto',
+                touchAction: onElementsChange ? 'none' : undefined,
+              }}
             />
           )}
           {elements.map((el) => {

--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -156,6 +156,9 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
       : { ...workingSlide, elements: displayElements };
 
   const elements = displayElements;
+  // Touch suppression belongs to mutation gestures: select-only hosts keep
+  // native touch panning, while tap-select still receives pointer events.
+  const editingTouchAction = onElementsChange ? 'none' : undefined;
 
   return (
     // Outer wrapper carries the documented `className`/`style` pass-through
@@ -204,7 +207,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                 position: 'absolute',
                 inset: 0,
                 pointerEvents: 'auto',
-                touchAction: onElementsChange ? 'none' : undefined,
+                touchAction: editingTouchAction,
               }}
             />
           )}
@@ -359,7 +362,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                         // would empty the selection) — no redundant re-emit.
                         if (next) onSelectionChange?.(next);
                       }}
-                      style={{ cursor: 'default', touchAction: 'none' }}
+                      style={{ cursor: 'default', touchAction: editingTouchAction }}
                     />
                     {/* Highlight path — selection chrome only, rendered when the
                         line is selected. Purely visual (`pointer-events: none`),
@@ -421,7 +424,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                   transformOrigin: 'center',
                   pointerEvents: 'auto',
                   cursor: 'default',
-                  touchAction: 'none',
+                  touchAction: editingTouchAction,
                 }}
               />
             ) : (
@@ -439,7 +442,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                   transformOrigin: 'center',
                   pointerEvents: 'auto',
                   cursor: 'move',
-                  touchAction: 'none',
+                  touchAction: editingTouchAction,
                 }}
               />
             );

--- a/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/renderer/src/editing/EditableSlideCanvas.tsx
@@ -10,8 +10,10 @@ import { SelectionOverlay } from './handles/SelectionOverlay';
 import { LineHandles } from './handles/LineHandles';
 import { ResizeHandles } from './handles/ResizeHandles';
 import { RotateHandle } from './handles/RotateHandle';
+import { MarqueeBox } from './handles/MarqueeBox';
 import { useEditGesture } from './useEditGesture';
 import { useLineHandleGesture } from './useLineHandleGesture';
+import { useMarqueeGesture } from './useMarqueeGesture';
 import { useResizeGesture } from './useResizeGesture';
 import { useRotateGesture } from './useRotateGesture';
 import { getResizeHandles } from './core/resize';
@@ -110,6 +112,20 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
     onElementsChange,
   });
 
+  // Marquee (rubber-band) gesture. It arms from a blank-canvas pointer-down on
+  // the capture surface below the element hit targets, tracks a live rectangle,
+  // and on release REPLACES the selection with whatever it covers (or clears it
+  // on a sub-threshold blank click). Selection-only, so it is gated on
+  // `onSelectionChange`.
+  const { marqueeRect, onCanvasPointerDown } = useMarqueeGesture({
+    slide,
+    scale: canvasScale,
+    overlayRef,
+    viewportStyles,
+    selection: activeSelection,
+    onSelectionChange,
+  });
+
   // The elements to render/hit-test: the box gesture's working copy, with the
   // active handle drag's props (line reshape / resize box / rotate angle)
   // merged in so the v1 canvas, the hit layers, and the handles all preview
@@ -167,6 +183,21 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
             line up with the rendered elements even when the container is
             letterboxed (aspect ratio != slide's). */}
         <div ref={overlayRef} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+          {/* Blank-canvas marquee capture surface. Rendered FIRST so it sits
+              beneath the per-element hit targets in stacking order: a pointer-
+              down on an element hits that element's div (painted later, on top),
+              while a pointer-down on empty canvas falls to this full-bleed layer
+              and arms a rubber-band select. It is a sibling of the element hit
+              divs (not an ancestor), so an element pointer-down never bubbles
+              into it. Selection-only, so it is gated on `onSelectionChange`;
+              without it the surface is absent and blank clicks do nothing. */}
+          {Boolean(onSelectionChange) && (
+            <div
+              data-marquee-surface=""
+              onPointerDown={onCanvasPointerDown}
+              style={{ position: 'absolute', inset: 0, pointerEvents: 'auto', touchAction: 'none' }}
+            />
+          )}
           {elements.map((el) => {
             // Line elements: a line's real hit area is its (often bent) stroke,
             // not its rectangular bounding box. A rectangular bbox blocker
@@ -471,6 +502,17 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                 </Fragment>
               );
             })}
+
+          {/* Live marquee rectangle, drawn while a blank-canvas rubber-band
+              select is in flight. Purely visual (`pointerEvents: none`); it
+              shares the element container's origin via `viewportStyles`. */}
+          {marqueeRect && (
+            <MarqueeBox
+              rect={marqueeRect}
+              viewportStyles={viewportStyles}
+              canvasScale={canvasScale}
+            />
+          )}
 
           {/* SelectionOverlay is left untouched; wrap it in a positioning
               container matching SlideCanvas's element container so its

--- a/packages/@openmaic/renderer/src/editing/core/drag.ts
+++ b/packages/@openmaic/renderer/src/editing/core/drag.ts
@@ -1,6 +1,6 @@
 import type { PPTElement } from '@openmaic/dsl';
 import type { SnappingOptions } from '../types';
-import { getElementRange } from './geometry';
+import { getElementRange, getElementListRange } from './geometry';
 import { buildAlignLines, snapRange, type Guide } from './snapping';
 
 /**
@@ -98,4 +98,82 @@ export function computeDragMove(input: DragInput): DragResult {
     props: { left: shiftedLeft + dx, top: shiftedTop + dy },
     guides,
   };
+}
+
+/**
+ * Multi-element drag input for one gesture-commit tick: the pointer's grab
+ * element (`handleElement`, always a member of `selected`), the whole selected
+ * set to translate rigidly (`selected`, INCLUDING the handle), the snap
+ * candidates (`others` — the caller has already excluded every selected
+ * element), the viewport, the pointer delta already converted to canvas units,
+ * an optional single-axis lock, and the snapping config.
+ */
+export interface MultiDragInput {
+  handleElement: PPTElement;
+  selected: PPTElement[];
+  others: PPTElement[];
+  viewport: { width: number; height: number };
+  deltaCanvas: { x: number; y: number };
+  axisLock?: 'x' | 'y';
+  snapping?: boolean | SnappingOptions;
+}
+
+/** Every selected element's new position plus the guides to render, if any. */
+export interface MultiDragResult {
+  updates: Array<{ id: string; props: { left: number; top: number } }>;
+  guides: Guide[];
+}
+
+/**
+ * Apply a drag delta to a MULTI-element selection as one rigid translation.
+ * Composition mirrors {@link computeDragMove} but snaps the whole set together:
+ * shift every selected element by `deltaCanvas` → take the UNION bounding box of
+ * the shifted set (`getElementListRange`) → snap that union against
+ * `others`/the canvas → apply the SAME corrected delta to every selected
+ * element's origin. The snap is computed once on the union (not per element), so
+ * the set never deforms — spacing between selected elements is preserved.
+ *
+ * `handleElement` is declared for the caller's clarity (it identifies the
+ * pointer's grab element within `selected`); the correction is identical for
+ * every member, so it is applied uniformly rather than relative to the handle.
+ * Lines carried inside the selection are translated too (they own `left`/`top`),
+ * unlike the single-element {@link computeDragMove} which leaves a lone line put.
+ *
+ * With a single selected element this reduces EXACTLY to {@link computeDragMove}'s
+ * position math (same union == that element's range, same snap correction), so
+ * the hook can route N == 1 through either and get identical results.
+ * No React, no store, no `@/` imports.
+ */
+export function computeMultiDragMove(input: MultiDragInput): MultiDragResult {
+  const { selected, others, viewport, deltaCanvas, axisLock, snapping } = input;
+
+  const dx0 = axisLock === 'y' ? 0 : deltaCanvas.x;
+  const dy0 = axisLock === 'x' ? 0 : deltaCanvas.y;
+
+  let dx = 0;
+  let dy = 0;
+  let guides: Guide[] = [];
+
+  const resolved = resolveSnapping(snapping);
+  if (resolved) {
+    const shifted = selected.map(
+      (el) => ({ ...el, left: el.left + dx0, top: el.top + dy0 }) as PPTElement,
+    );
+    const targetRange = getElementListRange(shifted);
+    const lines = buildAlignLines(others, viewport, resolved.opts);
+    const snapped = snapRange(targetRange, lines, resolved.range);
+    dx = snapped.dx;
+    dy = snapped.dy;
+    guides = snapped.guides;
+  }
+
+  const totalX = dx0 + dx;
+  const totalY = dy0 + dy;
+
+  const updates = selected.map((el) => ({
+    id: el.id,
+    props: { left: el.left + totalX, top: el.top + totalY },
+  }));
+
+  return { updates, guides };
 }

--- a/packages/@openmaic/renderer/src/editing/core/drag.ts
+++ b/packages/@openmaic/renderer/src/editing/core/drag.ts
@@ -147,6 +147,10 @@ export interface MultiDragResult {
 export function computeMultiDragMove(input: MultiDragInput): MultiDragResult {
   const { selected, others, viewport, deltaCanvas, axisLock, snapping } = input;
 
+  // Exported-API hardening: an empty set has no union bbox (a min/max over
+  // nothing degenerates to ±Infinity), so there is nothing to move or snap.
+  if (selected.length === 0) return { updates: [], guides: [] };
+
   const dx0 = axisLock === 'y' ? 0 : deltaCanvas.x;
   const dy0 = axisLock === 'x' ? 0 : deltaCanvas.y;
 

--- a/packages/@openmaic/renderer/src/editing/core/drag.ts
+++ b/packages/@openmaic/renderer/src/editing/core/drag.ts
@@ -1,6 +1,6 @@
 import type { PPTElement } from '@openmaic/dsl';
 import type { SnappingOptions } from '../types';
-import { getElementRange, getElementListRange } from './geometry';
+import { getElementRange, getEditingElementListRange } from './geometry';
 import { buildAlignLines, snapRange, type Guide } from './snapping';
 
 /**
@@ -127,8 +127,8 @@ export interface MultiDragResult {
 /**
  * Apply a drag delta to a MULTI-element selection as one rigid translation.
  * Composition mirrors {@link computeDragMove} but snaps the whole set together:
- * shift every selected element by `deltaCanvas` → take the UNION bounding box of
- * the shifted set (`getElementListRange`) → snap that union against
+ * shift every selected element by `deltaCanvas` → take the editing UNION
+ * bounding box of the shifted set (`getEditingElementListRange`) → snap that union against
  * `others`/the canvas → apply the SAME corrected delta to every selected
  * element's origin. The snap is computed once on the union (not per element), so
  * the set never deforms — spacing between selected elements is preserved.
@@ -163,7 +163,7 @@ export function computeMultiDragMove(input: MultiDragInput): MultiDragResult {
     const shifted = selected.map(
       (el) => ({ ...el, left: el.left + dx0, top: el.top + dy0 }) as PPTElement,
     );
-    const targetRange = getElementListRange(shifted);
+    const targetRange = getEditingElementListRange(shifted);
     const lines = buildAlignLines(others, viewport, resolved.opts);
     const snapped = snapRange(targetRange, lines, resolved.range);
     dx = snapped.dx;

--- a/packages/@openmaic/renderer/src/editing/core/geometry.ts
+++ b/packages/@openmaic/renderer/src/editing/core/geometry.ts
@@ -150,8 +150,19 @@ export function getVisualElementRange(el: PPTElement): ElementRange {
     xs.push(el.broken[0]);
     ys.push(el.broken[1]);
   } else if (el.broken2) {
-    xs.push(el.broken2[0]);
-    ys.push(el.broken2[1]);
+    /**
+     * Mirrors `getLineElementPath`: `broken2` selects two orthogonal elbows,
+     * not a drawn vertex. Keep this in lockstep so visual snap bounds follow
+     * the rendered stroke instead of the control handle.
+     */
+    const { minX, maxX, minY, maxY } = getElementRange(el);
+    if (maxX - minX >= maxY - minY) {
+      xs.push(el.broken2[0], el.broken2[0]);
+      ys.push(start[1], end[1]);
+    } else {
+      xs.push(start[0], end[0]);
+      ys.push(el.broken2[1], el.broken2[1]);
+    }
   } else if (el.curve) {
     pushQuadraticExtrema(xs, start[0], el.curve[0], end[0]);
     pushQuadraticExtrema(ys, start[1], el.curve[1], end[1]);

--- a/packages/@openmaic/renderer/src/editing/core/geometry.ts
+++ b/packages/@openmaic/renderer/src/editing/core/geometry.ts
@@ -31,6 +31,57 @@ export interface ElementRange {
   maxY: number;
 }
 
+type Point = [number, number];
+
+function quadraticAt(p0: number, c: number, p2: number, t: number): number {
+  const mt = 1 - t;
+  return mt * mt * p0 + 2 * mt * t * c + t * t * p2;
+}
+
+function cubicAt(p0: number, c1: number, c2: number, p3: number, t: number): number {
+  const mt = 1 - t;
+  return mt * mt * mt * p0 + 3 * mt * mt * t * c1 + 3 * mt * t * t * c2 + t * t * t * p3;
+}
+
+function pushQuadraticExtrema(values: number[], p0: number, c: number, p2: number): void {
+  const denominator = p0 - 2 * c + p2;
+  if (denominator === 0) return;
+  const t = (p0 - c) / denominator;
+  if (t > 0 && t < 1) values.push(quadraticAt(p0, c, p2, t));
+}
+
+function pushCubicRoot(
+  values: number[],
+  p0: number,
+  c1: number,
+  c2: number,
+  p3: number,
+  t: number,
+): void {
+  if (t > 0 && t < 1) values.push(cubicAt(p0, c1, c2, p3, t));
+}
+
+function pushCubicExtrema(values: number[], p0: number, c1: number, c2: number, p3: number): void {
+  const a = -p0 + 3 * c1 - 3 * c2 + p3;
+  const b = 3 * p0 - 6 * c1 + 3 * c2;
+  const c = -3 * p0 + 3 * c1;
+  const derivativeA = 3 * a;
+  const derivativeB = 2 * b;
+  const derivativeC = c;
+
+  if (derivativeA === 0) {
+    if (derivativeB !== 0) pushCubicRoot(values, p0, c1, c2, p3, -derivativeC / derivativeB);
+    return;
+  }
+
+  const discriminant = derivativeB * derivativeB - 4 * derivativeA * derivativeC;
+  if (discriminant < 0) return;
+
+  const root = Math.sqrt(discriminant);
+  pushCubicRoot(values, p0, c1, c2, p3, (-derivativeB - root) / (2 * derivativeA));
+  if (root !== 0) pushCubicRoot(values, p0, c1, c2, p3, (-derivativeB + root) / (2 * derivativeA));
+}
+
 /**
  * Conservative editing AABB for a line element's rendered path, in canvas
  * units: the box over `start`, `end`, and every present path control point
@@ -74,11 +125,48 @@ function getLineEditingRange(el: PPTLineElement): ElementRange {
 /**
  * Editing-side element range. Non-line elements delegate to the renderer's
  * shared range helper; line elements use the control-point-aware path AABB so
- * marquee hit-testing, multi-drag union snapping, and snap candidate lines all
- * reason about the same bent-line geometry.
+ * marquee hit-testing and multi-drag union snapping answer "could this be
+ * here?" without false misses.
  */
 export function getEditingElementRange(el: PPTElement): ElementRange {
   return el.type === 'line' ? getLineEditingRange(el) : getElementRange(el);
+}
+
+/**
+ * Visual element range for alignment guides. Non-line elements share their
+ * normal range; line elements use the exact rendered path bounds so guides
+ * answer "what does the user see aligned?" and never point at invisible
+ * Bezier control-hull geometry.
+ */
+export function getVisualElementRange(el: PPTElement): ElementRange {
+  if (el.type !== 'line') return getElementRange(el);
+
+  const xs = [el.start[0], el.end[0]];
+  const ys = [el.start[1], el.end[1]];
+  const start: Point = el.start;
+  const end: Point = el.end;
+
+  if (el.broken) {
+    xs.push(el.broken[0]);
+    ys.push(el.broken[1]);
+  } else if (el.broken2) {
+    xs.push(el.broken2[0]);
+    ys.push(el.broken2[1]);
+  } else if (el.curve) {
+    pushQuadraticExtrema(xs, start[0], el.curve[0], end[0]);
+    pushQuadraticExtrema(ys, start[1], el.curve[1], end[1]);
+  } else if (el.cubic) {
+    const [c1, c2] = el.cubic;
+    pushCubicExtrema(xs, start[0], c1[0], c2[0], end[0]);
+    pushCubicExtrema(ys, start[1], c1[1], c2[1], end[1]);
+  }
+
+  return {
+    minX: el.left + Math.min(...xs),
+    maxX: el.left + Math.max(...xs),
+    minY: el.top + Math.min(...ys),
+    maxY: el.top + Math.max(...ys),
+  };
 }
 
 /** Union bbox of a list of elements, in canvas units. */

--- a/packages/@openmaic/renderer/src/editing/core/geometry.ts
+++ b/packages/@openmaic/renderer/src/editing/core/geometry.ts
@@ -1,4 +1,4 @@
-import type { PPTElement } from '@openmaic/dsl';
+import type { PPTElement, PPTLineElement } from '@openmaic/dsl';
 
 // Reuse the renderer's single source of truth for element bounds instead of a
 // local re-implementation. `getElementRange` there is line-aware (derives
@@ -31,6 +31,56 @@ export interface ElementRange {
   maxY: number;
 }
 
+/**
+ * Conservative editing AABB for a line element's rendered path, in canvas
+ * units: the box over `start`, `end`, and every present path control point
+ * (`broken`, `broken2`, `curve`, `cubic`), offset by the element origin.
+ *
+ * Straight/broken/broken2 polylines draw through these vertices directly, and
+ * quadratic/cubic Beziers stay inside the convex hull of their control points,
+ * so this range never misses a visible bend. It is intentionally conservative:
+ * a Bezier rarely reaches the control point itself, but editing hit-testing and
+ * snap math prefer extra coverage over a false miss.
+ */
+function getLineEditingRange(el: PPTLineElement): ElementRange {
+  const xs = [el.start[0], el.end[0]];
+  const ys = [el.start[1], el.end[1]];
+  if (el.broken) {
+    xs.push(el.broken[0]);
+    ys.push(el.broken[1]);
+  }
+  if (el.broken2) {
+    xs.push(el.broken2[0]);
+    ys.push(el.broken2[1]);
+  }
+  if (el.curve) {
+    xs.push(el.curve[0]);
+    ys.push(el.curve[1]);
+  }
+  if (el.cubic) {
+    for (const [cx, cy] of el.cubic) {
+      xs.push(cx);
+      ys.push(cy);
+    }
+  }
+  return {
+    minX: el.left + Math.min(...xs),
+    maxX: el.left + Math.max(...xs),
+    minY: el.top + Math.min(...ys),
+    maxY: el.top + Math.max(...ys),
+  };
+}
+
+/**
+ * Editing-side element range. Non-line elements delegate to the renderer's
+ * shared range helper; line elements use the control-point-aware path AABB so
+ * marquee hit-testing, multi-drag union snapping, and snap candidate lines all
+ * reason about the same bent-line geometry.
+ */
+export function getEditingElementRange(el: PPTElement): ElementRange {
+  return el.type === 'line' ? getLineEditingRange(el) : getElementRange(el);
+}
+
 /** Union bbox of a list of elements, in canvas units. */
 export function getElementListRange(els: PPTElement[]): ElementRange {
   const leftValues: number[] = [];
@@ -40,6 +90,29 @@ export function getElementListRange(els: PPTElement[]): ElementRange {
 
   for (const el of els) {
     const { minX, maxX, minY, maxY } = getElementRange(el);
+    leftValues.push(minX);
+    topValues.push(minY);
+    rightValues.push(maxX);
+    bottomValues.push(maxY);
+  }
+
+  return {
+    minX: Math.min(...leftValues),
+    maxX: Math.max(...rightValues),
+    minY: Math.min(...topValues),
+    maxY: Math.max(...bottomValues),
+  };
+}
+
+/** Union bbox of a list of elements using editing-side ranges. */
+export function getEditingElementListRange(els: PPTElement[]): ElementRange {
+  const leftValues: number[] = [];
+  const topValues: number[] = [];
+  const rightValues: number[] = [];
+  const bottomValues: number[] = [];
+
+  for (const el of els) {
+    const { minX, maxX, minY, maxY } = getEditingElementRange(el);
     leftValues.push(minX);
     topValues.push(minY);
     rightValues.push(maxX);

--- a/packages/@openmaic/renderer/src/editing/core/intent.ts
+++ b/packages/@openmaic/renderer/src/editing/core/intent.ts
@@ -27,3 +27,16 @@ export function resizeIntent(
 export function rotateIntent(id: string, rotate: number): EditIntent {
   return { type: 'element.update', id, props: { rotate } };
 }
+
+/**
+ * Build the single `element.updateMany` intent for a completed MULTI-element
+ * move gesture: every selected element's new `left`/`top` in one intent, so the
+ * whole rigid translation lands as ONE host undo entry (never one intent per
+ * element). Single-element drags keep emitting `element.update` (backward compat
+ * with hosts); this is only for N > 1.
+ */
+export function moveManyIntent(
+  updates: Array<{ id: string; props: { left: number; top: number } }>,
+): EditIntent {
+  return { type: 'element.updateMany', updates };
+}

--- a/packages/@openmaic/renderer/src/editing/core/marquee.ts
+++ b/packages/@openmaic/renderer/src/editing/core/marquee.ts
@@ -1,5 +1,5 @@
-import type { PPTElement, PPTLineElement } from '@openmaic/dsl';
-import { getElementRange, type ElementRange } from './geometry';
+import type { PPTElement } from '@openmaic/dsl';
+import { getEditingElementRange, type ElementRange } from './geometry';
 
 /**
  * Pure marquee (rubber-band / drag-select) math for the editing surface. Ported
@@ -53,49 +53,6 @@ export function marqueeRect(start: MarqueePoint, current: MarqueePoint): Marquee
 }
 
 /**
- * Conservative AABB for a line element's rendered path, in canvas units: the
- * box over `start`, `end`, and every present path control point (`broken`,
- * `broken2`, `curve`, `cubic`), offset by the element origin. `getElementRange`
- * only spans start/end, so a bent line's visible path can bow outside that
- * chord and a marquee over the bend would miss it.
- *
- * Correct-by-construction for every path shape: a straight/broken/broken2
- * polyline's vertices are all drawn from these coordinates, and a quadratic/
- * cubic Bézier lies within the convex hull of its control points — so this box
- * NEVER misses the rendered path. It is conservative, not tight (a Bézier
- * rarely reaches its control points), so `contain` mode may demand slightly
- * more room around the bend than the rendered stroke strictly needs.
- */
-function getLineMarqueeRange(el: PPTLineElement): ElementRange {
-  const xs = [el.start[0], el.end[0]];
-  const ys = [el.start[1], el.end[1]];
-  if (el.broken) {
-    xs.push(el.broken[0]);
-    ys.push(el.broken[1]);
-  }
-  if (el.broken2) {
-    xs.push(el.broken2[0]);
-    ys.push(el.broken2[1]);
-  }
-  if (el.curve) {
-    xs.push(el.curve[0]);
-    ys.push(el.curve[1]);
-  }
-  if (el.cubic) {
-    for (const [cx, cy] of el.cubic) {
-      xs.push(cx);
-      ys.push(cy);
-    }
-  }
-  return {
-    minX: el.left + Math.min(...xs),
-    maxX: el.left + Math.max(...xs),
-    minY: el.top + Math.min(...ys),
-    maxY: el.top + Math.max(...ys),
-  };
-}
-
-/**
  * Whether an element's bounding range hits the marquee per `mode`. `contain` is
  * inclusive of a boundary-touching edge (`>=`/`<=`); `intersect` requires a
  * strictly-positive overlap (`>`/`<`) so edge-to-edge touching does not count.
@@ -122,9 +79,9 @@ function hitsMarquee(range: ElementRange, rect: MarqueeRect, mode: MarqueeMode):
  *
  * Rules, ported from the app:
  * - Non-line elements are tested by their rotation-aware AABB
- *   ({@link getElementRange}), so a rotated element uses its enclosing box.
+ *   ({@link getEditingElementRange}), so a rotated element uses its enclosing box.
  * - Line elements are tested by a control-point-aware conservative AABB
- *   ({@link getLineMarqueeRange}), so a bent line's bow is still hit-testable.
+ *   ({@link getEditingElementRange}), so a bent line's bow is still hit-testable.
  * - Locked elements (and any `excludeIds`) are never selected.
  * - Group cohesion is all-or-nothing: a matched element that carries a
  *   `groupId` survives only if EVERY member of that group also matched — so a
@@ -144,7 +101,7 @@ export function computeMarqueeSelection(
   for (const el of elements) {
     if (el.lock) continue;
     if (excluded?.has(el.id)) continue;
-    const range = el.type === 'line' ? getLineMarqueeRange(el) : getElementRange(el);
+    const range = getEditingElementRange(el);
     if (hitsMarquee(range, rect, mode)) matched.push(el);
   }
 

--- a/packages/@openmaic/renderer/src/editing/core/marquee.ts
+++ b/packages/@openmaic/renderer/src/editing/core/marquee.ts
@@ -1,0 +1,115 @@
+import type { PPTElement } from '@openmaic/dsl';
+import { getElementRange, type ElementRange } from './geometry';
+
+/**
+ * Pure marquee (rubber-band / drag-select) math for the editing surface. Ported
+ * from the app's `useMouseSelection`, but store-free and normalized: the caller
+ * feeds a rectangle already in canvas units plus the slide elements, and gets
+ * back the ids the marquee selects. No React, no store, no `@/` imports — this
+ * module only consumes the DSL element shape and plain numbers, so it can be
+ * exercised with plain unit tests and reused by any host.
+ *
+ * The app stores the marquee as start + |magnitude| + quadrant and branches the
+ * containment test four ways (one per drag direction). Here the rectangle is
+ * NORMALIZED to `{minX,minY,maxX,maxY}` at the source ({@link marqueeRect}), so
+ * containment/intersection each collapse to a single predicate regardless of
+ * drag direction — which also sidesteps the app's stale-closure quadrant bug.
+ */
+
+/** A pointer position in canvas units (viewportSize space). */
+export interface MarqueePoint {
+  x: number;
+  y: number;
+}
+
+/** A normalized marquee rectangle in canvas units (min/max on each axis). */
+export type MarqueeRect = ElementRange;
+
+/**
+ * How an element's bounds must relate to the marquee rectangle to be selected:
+ * - `contain`: the element's AABB is wholly inside the rectangle (no modifier).
+ * - `intersect`: the element's AABB overlaps the rectangle at all (Ctrl/Shift).
+ */
+export type MarqueeMode = 'contain' | 'intersect';
+
+export interface MarqueeSelectionOptions {
+  mode: MarqueeMode;
+  /** Ids the marquee must never select (e.g. host-hidden elements). */
+  excludeIds?: readonly string[];
+}
+
+/**
+ * Normalize a start + current pointer pair (canvas units) into a rectangle with
+ * min/max on each axis, so the four drag directions all produce the same
+ * `{minX,minY,maxX,maxY}` and containment is a single predicate.
+ */
+export function marqueeRect(start: MarqueePoint, current: MarqueePoint): MarqueeRect {
+  return {
+    minX: Math.min(start.x, current.x),
+    minY: Math.min(start.y, current.y),
+    maxX: Math.max(start.x, current.x),
+    maxY: Math.max(start.y, current.y),
+  };
+}
+
+/**
+ * Whether an element's bounding range hits the marquee per `mode`. `contain` is
+ * inclusive of a boundary-touching edge (`>=`/`<=`); `intersect` requires a
+ * strictly-positive overlap (`>`/`<`) so edge-to-edge touching does not count.
+ */
+function hitsMarquee(range: ElementRange, rect: MarqueeRect, mode: MarqueeMode): boolean {
+  if (mode === 'contain') {
+    return (
+      range.minX >= rect.minX &&
+      range.maxX <= rect.maxX &&
+      range.minY >= rect.minY &&
+      range.maxY <= rect.maxY
+    );
+  }
+  return (
+    range.minX < rect.maxX &&
+    range.maxX > rect.minX &&
+    range.minY < rect.maxY &&
+    range.maxY > rect.minY
+  );
+}
+
+/**
+ * The ids the marquee `rect` selects from `elements`, in element (z-)order.
+ *
+ * Rules, ported from the app:
+ * - Each element is tested by its rotation- and line-aware AABB
+ *   ({@link getElementRange}), so a rotated element uses its enclosing box.
+ * - Locked elements (and any `excludeIds`) are never selected.
+ * - Group cohesion is all-or-nothing: a matched element that carries a
+ *   `groupId` survives only if EVERY member of that group also matched — so a
+ *   partial box over a group never splits it.
+ *
+ * The result REPLACES the selection (the caller decides how to publish it).
+ */
+export function computeMarqueeSelection(
+  rect: MarqueeRect,
+  elements: readonly PPTElement[],
+  options: MarqueeSelectionOptions,
+): string[] {
+  const { mode, excludeIds } = options;
+  const excluded = excludeIds && excludeIds.length ? new Set(excludeIds) : null;
+
+  const matched: PPTElement[] = [];
+  for (const el of elements) {
+    if (el.lock) continue;
+    if (excluded?.has(el.id)) continue;
+    if (hitsMarquee(getElementRange(el), rect, mode)) matched.push(el);
+  }
+
+  const matchedIds = new Set(matched.map((el) => el.id));
+  const cohesive = matched.filter((el) => {
+    if (!el.groupId) return true;
+    // A grouped element stays only if every sibling in its group also matched.
+    return elements
+      .filter((o) => o.groupId === el.groupId)
+      .every((member) => matchedIds.has(member.id));
+  });
+
+  return cohesive.map((el) => el.id);
+}

--- a/packages/@openmaic/renderer/src/editing/core/marquee.ts
+++ b/packages/@openmaic/renderer/src/editing/core/marquee.ts
@@ -1,4 +1,4 @@
-import type { PPTElement } from '@openmaic/dsl';
+import type { PPTElement, PPTLineElement } from '@openmaic/dsl';
 import { getElementRange, type ElementRange } from './geometry';
 
 /**
@@ -53,6 +53,49 @@ export function marqueeRect(start: MarqueePoint, current: MarqueePoint): Marquee
 }
 
 /**
+ * Conservative AABB for a line element's rendered path, in canvas units: the
+ * box over `start`, `end`, and every present path control point (`broken`,
+ * `broken2`, `curve`, `cubic`), offset by the element origin. `getElementRange`
+ * only spans start/end, so a bent line's visible path can bow outside that
+ * chord and a marquee over the bend would miss it.
+ *
+ * Correct-by-construction for every path shape: a straight/broken/broken2
+ * polyline's vertices are all drawn from these coordinates, and a quadratic/
+ * cubic Bézier lies within the convex hull of its control points — so this box
+ * NEVER misses the rendered path. It is conservative, not tight (a Bézier
+ * rarely reaches its control points), so `contain` mode may demand slightly
+ * more room around the bend than the rendered stroke strictly needs.
+ */
+function getLineMarqueeRange(el: PPTLineElement): ElementRange {
+  const xs = [el.start[0], el.end[0]];
+  const ys = [el.start[1], el.end[1]];
+  if (el.broken) {
+    xs.push(el.broken[0]);
+    ys.push(el.broken[1]);
+  }
+  if (el.broken2) {
+    xs.push(el.broken2[0]);
+    ys.push(el.broken2[1]);
+  }
+  if (el.curve) {
+    xs.push(el.curve[0]);
+    ys.push(el.curve[1]);
+  }
+  if (el.cubic) {
+    for (const [cx, cy] of el.cubic) {
+      xs.push(cx);
+      ys.push(cy);
+    }
+  }
+  return {
+    minX: el.left + Math.min(...xs),
+    maxX: el.left + Math.max(...xs),
+    minY: el.top + Math.min(...ys),
+    maxY: el.top + Math.max(...ys),
+  };
+}
+
+/**
  * Whether an element's bounding range hits the marquee per `mode`. `contain` is
  * inclusive of a boundary-touching edge (`>=`/`<=`); `intersect` requires a
  * strictly-positive overlap (`>`/`<`) so edge-to-edge touching does not count.
@@ -78,8 +121,10 @@ function hitsMarquee(range: ElementRange, rect: MarqueeRect, mode: MarqueeMode):
  * The ids the marquee `rect` selects from `elements`, in element (z-)order.
  *
  * Rules, ported from the app:
- * - Each element is tested by its rotation- and line-aware AABB
+ * - Non-line elements are tested by their rotation-aware AABB
  *   ({@link getElementRange}), so a rotated element uses its enclosing box.
+ * - Line elements are tested by a control-point-aware conservative AABB
+ *   ({@link getLineMarqueeRange}), so a bent line's bow is still hit-testable.
  * - Locked elements (and any `excludeIds`) are never selected.
  * - Group cohesion is all-or-nothing: a matched element that carries a
  *   `groupId` survives only if EVERY member of that group also matched — so a
@@ -99,7 +144,8 @@ export function computeMarqueeSelection(
   for (const el of elements) {
     if (el.lock) continue;
     if (excluded?.has(el.id)) continue;
-    if (hitsMarquee(getElementRange(el), rect, mode)) matched.push(el);
+    const range = el.type === 'line' ? getLineMarqueeRange(el) : getElementRange(el);
+    if (hitsMarquee(range, rect, mode)) matched.push(el);
   }
 
   const matchedIds = new Set(matched.map((el) => el.id));

--- a/packages/@openmaic/renderer/src/editing/core/selection.ts
+++ b/packages/@openmaic/renderer/src/editing/core/selection.ts
@@ -24,6 +24,11 @@ export function uniqIds(ids: readonly string[]): string[] {
   return Array.from(new Set(ids));
 }
 
+/** Exact ordered id-list equality for no-op emit guards. */
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
 /**
  * The clicked element's cohesion unit: every member of its group (in element
  * order), or just the element itself when ungrouped. Group cohesion is
@@ -37,6 +42,22 @@ export function groupMemberIds(el: PPTElement, elements: readonly PPTElement[]):
   if (!el.groupId) return [el.id];
   const members = elements.filter((o) => o.groupId === el.groupId).map((o) => o.id);
   return members.length > 0 ? members : [el.id];
+}
+
+/**
+ * Group-close a host-provided selection: every known selected element expands
+ * to its full group unit, while unknown ids are preserved in-place. This keeps
+ * externally controlled selection state from leaking a split group into click
+ * resolution or into the drag set it returns.
+ */
+function closeSelectionGroupIds(ids: readonly string[], elements: readonly PPTElement[]): string[] {
+  const byId = new Map(elements.map((el) => [el.id, el]));
+  const closed: string[] = [];
+  for (const id of ids) {
+    const el = byId.get(id);
+    closed.push(...(el ? groupMemberIds(el, elements) : [id]));
+  }
+  return uniqIds(closed);
 }
 
 export interface ClickSelectionInput {
@@ -57,8 +78,8 @@ export interface ClickSelectionResult {
   armDrag: boolean;
   /**
    * The ids an armed drag translates: the clicked element's group unit for a
-   * fresh plain click, or the whole current selection for a plain click on an
-   * already-selected element. Meaningless when `armDrag` is false.
+   * fresh plain click, or the group-closed current selection for a plain click
+   * on an already-selected element. Meaningless when `armDrag` is false.
    */
   dragIds: readonly string[];
 }
@@ -76,10 +97,14 @@ export interface ClickSelectionResult {
  * - selected, no modifier     → KEEP the whole selection, make the clicked
  *   element the primary (no emit when it already is), and arm a drag that
  *   translates every selected element.
+ *
+ * Invariant: this resolver never returns a selection or armed drag set that
+ * splits a group, even when the incoming controlled selection already does.
  */
 export function resolveClickSelection(input: ClickSelectionInput): ClickSelectionResult {
   const { element: el, elements, selection, modifier } = input;
-  const ids = selection.elementIds;
+  const rawIds = selection.elementIds;
+  const ids = closeSelectionGroupIds(rawIds, elements);
   const inSelection = ids.includes(el.id);
   const unit = groupMemberIds(el, elements);
 
@@ -108,10 +133,12 @@ export function resolveClickSelection(input: ClickSelectionInput): ClickSelectio
   }
 
   // Already selected, no modifier: keep the whole selection, re-point the
-  // primary at the clicked element. Skip the emit when it is already the
-  // primary so a plain click doesn't double-emit.
+  // primary at the clicked element. Skip the emit only when the incoming
+  // selection was already group-closed and already points at the clicked
+  // primary, so a cohesive plain click doesn't double-emit.
+  const unchanged = selection.primaryId === el.id && sameIds(ids, rawIds);
   return {
-    next: selection.primaryId === el.id ? null : { elementIds: ids, primaryId: el.id },
+    next: unchanged ? null : { elementIds: ids, primaryId: el.id },
     armDrag: true,
     dragIds: ids,
   };

--- a/packages/@openmaic/renderer/src/editing/core/selection.ts
+++ b/packages/@openmaic/renderer/src/editing/core/selection.ts
@@ -1,0 +1,118 @@
+import type { PPTElement } from '@openmaic/dsl';
+import type { Selection } from '../types';
+
+/**
+ * Pure click-selection resolution for the editing surface, shared by every
+ * pointer-down entry point (box hit targets and line stroke blockers) so all
+ * element kinds resolve modifiers and groups identically. No React, no store,
+ * no `@/` imports — plain data in, plain data out.
+ */
+
+/** True when a click/drag selection modifier (Ctrl/Shift/Meta) is held. Meta is
+ * included for mac parity with the resize aspect modifier — a deliberate
+ * superset of the app's Ctrl/Shift. */
+export function isSelectionModifier(e: {
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  metaKey: boolean;
+}): boolean {
+  return e.ctrlKey || e.shiftKey || e.metaKey;
+}
+
+/** Dedup ids preserving first-seen order (no lodash dep in this package). */
+export function uniqIds(ids: readonly string[]): string[] {
+  return Array.from(new Set(ids));
+}
+
+/**
+ * The clicked element's cohesion unit: every member of its group (in element
+ * order), or just the element itself when ungrouped. Group cohesion is
+ * all-or-nothing at the click entry point too (app parity): selecting,
+ * adding, or removing a grouped element always applies to the whole group,
+ * so a group can never be half-selected by clicking. Locked members are
+ * included — they may sit in the selection for feedback; the drag layer is
+ * responsible for never translating them.
+ */
+export function groupMemberIds(el: PPTElement, elements: readonly PPTElement[]): string[] {
+  if (!el.groupId) return [el.id];
+  const members = elements.filter((o) => o.groupId === el.groupId).map((o) => o.id);
+  return members.length > 0 ? members : [el.id];
+}
+
+export interface ClickSelectionInput {
+  /** The element under the pointer. */
+  element: PPTElement;
+  /** The slide's elements (group-membership lookup). */
+  elements: readonly PPTElement[];
+  /** The current controlled selection. */
+  selection: Selection;
+  /** Whether a selection modifier (Ctrl/Shift/Meta) was held at pointer-down. */
+  modifier: boolean;
+}
+
+export interface ClickSelectionResult {
+  /** The selection to publish, or `null` when nothing changes (no emit). */
+  next: Selection | null;
+  /** Whether this pointer-down arms a move gesture (plain clicks only). */
+  armDrag: boolean;
+  /**
+   * The ids an armed drag translates: the clicked element's group unit for a
+   * fresh plain click, or the whole current selection for a plain click on an
+   * already-selected element. Meaningless when `armDrag` is false.
+   */
+  dragIds: readonly string[];
+}
+
+/**
+ * Resolve a pointer-down on element `el` against the current `selection` per
+ * the modifier table (group-cohesive — `el` expands to its whole group unit):
+ * - not selected, no modifier → select only the unit (primary = clicked);
+ *   arm a drag on it.
+ * - not selected, modifier    → ADD the unit to the selection (uniq,
+ *   primary = clicked); no drag.
+ * - selected, modifier        → REMOVE the unit; no-op if that would empty
+ *   the selection; the current primary is preserved when it survives the
+ *   removal, else the last remaining id becomes primary. No drag.
+ * - selected, no modifier     → KEEP the whole selection, make the clicked
+ *   element the primary (no emit when it already is), and arm a drag that
+ *   translates every selected element.
+ */
+export function resolveClickSelection(input: ClickSelectionInput): ClickSelectionResult {
+  const { element: el, elements, selection, modifier } = input;
+  const ids = selection.elementIds;
+  const inSelection = ids.includes(el.id);
+  const unit = groupMemberIds(el, elements);
+
+  if (!inSelection && !modifier) {
+    return { next: { elementIds: unit, primaryId: el.id }, armDrag: true, dragIds: unit };
+  }
+
+  if (!inSelection && modifier) {
+    return {
+      next: { elementIds: uniqIds([...ids, ...unit]), primaryId: el.id },
+      armDrag: false,
+      dragIds: unit,
+    };
+  }
+
+  if (inSelection && modifier) {
+    const removed = new Set(unit);
+    const remaining = ids.filter((id) => !removed.has(id));
+    // A modifier click must never clear the selection to empty.
+    if (remaining.length === 0) return { next: null, armDrag: false, dragIds: unit };
+    const primaryId =
+      selection.primaryId !== undefined && remaining.includes(selection.primaryId)
+        ? selection.primaryId
+        : remaining[remaining.length - 1];
+    return { next: { elementIds: remaining, primaryId }, armDrag: false, dragIds: unit };
+  }
+
+  // Already selected, no modifier: keep the whole selection, re-point the
+  // primary at the clicked element. Skip the emit when it is already the
+  // primary so a plain click doesn't double-emit.
+  return {
+    next: selection.primaryId === el.id ? null : { elementIds: ids, primaryId: el.id },
+    armDrag: true,
+    dragIds: ids,
+  };
+}

--- a/packages/@openmaic/renderer/src/editing/core/snapping.ts
+++ b/packages/@openmaic/renderer/src/editing/core/snapping.ts
@@ -1,10 +1,15 @@
 import type { PPTElement } from '@openmaic/dsl';
 import type { SnappingOptions } from '../types';
-import { getElementRange, uniqAlignLines, type AlignLine, type ElementRange } from './geometry';
+import {
+  getEditingElementRange,
+  uniqAlignLines,
+  type AlignLine,
+  type ElementRange,
+} from './geometry';
 
 /**
  * Pure alignment-snapping math for the editing surface. Consumes Task 1's
- * geometry primitives (`getElementRange`, `uniqAlignLines`, `AlignLine`,
+ * geometry primitives (`getEditingElementRange`, `uniqAlignLines`, `AlignLine`,
  * `ElementRange`) and the DSL element shape. No React, no store, no `@/`
  * imports — ported (decoupled) from the app's `useDragElement` drag-snap math
  * and `AlignmentLine` guide shape so it can be exercised with plain unit
@@ -39,7 +44,7 @@ export function buildAlignLines(
 
   if (opts.toElements) {
     for (const el of others) {
-      const { minX, maxX, minY, maxY } = getElementRange(el);
+      const { minX, maxX, minY, maxY } = getEditingElementRange(el);
       const centerX = minX + (maxX - minX) / 2;
       const centerY = minY + (maxY - minY) / 2;
 

--- a/packages/@openmaic/renderer/src/editing/core/snapping.ts
+++ b/packages/@openmaic/renderer/src/editing/core/snapping.ts
@@ -1,19 +1,19 @@
 import type { PPTElement } from '@openmaic/dsl';
 import type { SnappingOptions } from '../types';
 import {
-  getEditingElementRange,
+  getVisualElementRange,
   uniqAlignLines,
   type AlignLine,
   type ElementRange,
 } from './geometry';
 
 /**
- * Pure alignment-snapping math for the editing surface. Consumes Task 1's
- * geometry primitives (`getEditingElementRange`, `uniqAlignLines`, `AlignLine`,
- * `ElementRange`) and the DSL element shape. No React, no store, no `@/`
- * imports — ported (decoupled) from the app's `useDragElement` drag-snap math
- * and `AlignmentLine` guide shape so it can be exercised with plain unit
- * tests and reused by any host.
+ * Pure alignment-snapping math for the editing surface. Consumes geometry
+ * primitives (`getVisualElementRange`, `uniqAlignLines`, `AlignLine`,
+ * `ElementRange`) and the DSL element shape. No React, no store, no `@/` imports
+ * — ported (decoupled) from the app's `useDragElement` drag-snap math and
+ * `AlignmentLine` guide shape so it can be exercised with plain unit tests and
+ * reused by any host.
  */
 
 /** A single alignment guide line to render during a drag/resize gesture. */
@@ -32,7 +32,11 @@ const GUIDE_OVERHANG = 50;
  * Build the candidate snap lines for a drag/resize gesture: other elements'
  * edges + centers (`toElements`) and the viewport's left/centerX/right and
  * top/centerY/bottom lines (`toCanvas`). Each axis list is deduplicated by
- * value via `uniqAlignLines`. Does not mutate `others`.
+ * value via `uniqAlignLines`. Element candidates use visual ranges: the
+ * conservative editing hull answers "could this be here?" for selection and
+ * multi-drag unions, while guides answer "what visibly aligns?" and must not
+ * point at Bezier control-hull geometry the user never sees. Does not mutate
+ * `others`.
  */
 export function buildAlignLines(
   others: PPTElement[],
@@ -44,7 +48,7 @@ export function buildAlignLines(
 
   if (opts.toElements) {
     for (const el of others) {
-      const { minX, maxX, minY, maxY } = getEditingElementRange(el);
+      const { minX, maxX, minY, maxY } = getVisualElementRange(el);
       const centerX = minX + (maxX - minX) / 2;
       const centerY = minY + (maxY - minY) / 2;
 

--- a/packages/@openmaic/renderer/src/editing/handles/MarqueeBox.tsx
+++ b/packages/@openmaic/renderer/src/editing/handles/MarqueeBox.tsx
@@ -1,0 +1,38 @@
+import type { ViewportStyles } from '../../hooks/useViewportSize';
+import type { MarqueeRect } from '../core/marquee';
+
+export interface MarqueeBoxProps {
+  /** The live marquee rectangle, normalized in canvas units. */
+  rect: MarqueeRect;
+  /** SlideCanvas centering offset — the box shares the element container's origin. */
+  viewportStyles: ViewportStyles;
+  /** Canvas → screen scale (`props.scale ?? fitScale`). */
+  canvasScale: number;
+}
+
+/**
+ * Presentational marquee (rubber-band) rectangle: a dashed border drawn over the
+ * canvas while a blank-canvas drag-select is in flight. Props-driven only — the
+ * normalized canvas-unit {@link MarqueeRect} is scaled by `canvasScale` and
+ * offset by `viewportStyles.left/top` so it lines up with the rendered elements
+ * even when the container is letterboxed. Purely visual (`pointerEvents: none`);
+ * it never hit-tests. No `@/` imports.
+ */
+export function MarqueeBox({ rect, viewportStyles, canvasScale }: MarqueeBoxProps) {
+  return (
+    <div
+      data-marquee-box=""
+      style={{
+        position: 'absolute',
+        left: `${viewportStyles.left + rect.minX * canvasScale}px`,
+        top: `${viewportStyles.top + rect.minY * canvasScale}px`,
+        width: `${(rect.maxX - rect.minX) * canvasScale}px`,
+        height: `${(rect.maxY - rect.minY) * canvasScale}px`,
+        border: '1px dashed #3b82f6',
+        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+        boxSizing: 'border-box',
+        pointerEvents: 'none',
+      }}
+    />
+  );
+}

--- a/packages/@openmaic/renderer/src/editing/useEditGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useEditGesture.ts
@@ -3,8 +3,8 @@
 import { useState, useEffect, useRef, type PointerEvent as ReactPointerEvent } from 'react';
 import type { PPTElement, Slide } from '@openmaic/dsl';
 
-import { computeDragMove } from './core/drag';
-import { moveIntent } from './core/intent';
+import { computeDragMove, computeMultiDragMove } from './core/drag';
+import { moveIntent, moveManyIntent } from './core/intent';
 import type { Guide } from './core/snapping';
 import type { EditIntent, Selection, SnappingOptions } from './types';
 
@@ -40,15 +40,38 @@ interface Working {
   guides: Guide[];
 }
 
+/** True when a click/drag modifier (Ctrl/Shift/Meta) is held. Meta is included
+ * for mac parity with the resize aspect modifier — a deliberate superset of the
+ * app's Ctrl/Shift. */
+function hasModifier(e: ReactPointerEvent): boolean {
+  return e.ctrlKey || e.shiftKey || e.metaKey;
+}
+
+/** Dedup ids preserving first-seen order (no lodash dep in this package). */
+function uniqIds(ids: readonly string[]): string[] {
+  return Array.from(new Set(ids));
+}
+
 /**
- * Owns one drag/click gesture for a single element. Pointer-down arms the
- * gesture and records the pointer start + the base slide/element; window
- * pointer-move (converted screen→canvas via `scale`) runs `computeDragMove`
- * against the *other* elements and republishes a working copy for live
- * feedback; pointer-up commits exactly one `element.update` intent when the
- * pointer moved past `DRAG_THRESHOLD_PX`, otherwise reports a selection click.
- * Emits one intent per completed gesture — never per frame — and clears the
- * working copy so the host's controlled `slide` takes over again.
+ * Owns one drag/click gesture. Pointer-down resolves the selection per the
+ * modifier table below, then — for the cases that start a move — arms a drag and
+ * records the pointer start + the base slide; window pointer-move (converted
+ * screen→canvas via `scale`) republishes a working copy for live feedback;
+ * pointer-up commits the move as ONE intent when the pointer moved past
+ * `DRAG_THRESHOLD_PX`, otherwise reports a selection click. Emits one intent per
+ * completed gesture — never per frame — and clears the working copy so the
+ * host's controlled `slide` takes over again.
+ *
+ * Selection on pointer-down (element `el`, current `selection`):
+ * - not selected, no modifier → select only `[el]`, arm a SINGLE drag on it.
+ * - not selected, modifier    → ADD `el` to the selection (uniq); no drag.
+ * - selected, modifier        → REMOVE `el`; no-op if that would empty the
+ *   selection; no drag.
+ * - selected, no modifier      → KEEP the whole selection, make `el` the primary
+ *   (handle), and arm a MULTI drag that translates every selected element.
+ *
+ * A single-element move commits `element.update` (backward compat with hosts);
+ * a multi-element move commits ONE `element.updateMany` = one host undo entry.
  *
  * `onElementPointerDown` closes over the current render's props, so each gesture
  * captures a consistent snapshot of the controlled slide at pointer-down.
@@ -89,25 +112,66 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
     if (el.lock) return;
     // Ignore additional pointer-downs while a gesture is already in flight.
     if (activePointerRef.current !== null) return;
-    activePointerRef.current = e.pointerId;
 
-    // Select-on-pointer-down: both a click and a drag then operate on a selected
-    // element, and — crucially — a drag ends with the dragged element selected
-    // (the controlled `selection` never goes stale against what's being moved).
-    // Skip the emit when this element is already the sole/primary selection so a
-    // plain click doesn't double-emit (down here + a redundant up). Multi-select
-    // is out of scope: starting a drag on any element collapses to just it.
-    const alreadySolePrimary =
-      selection.primaryId === el.id &&
-      selection.elementIds.length === 1 &&
-      selection.elementIds[0] === el.id;
-    if (!alreadySolePrimary) {
+    // Resolve selection on pointer-down per the modifier table (see the hook
+    // JSDoc). `armDrag` decides whether this gesture becomes a move; `dragIds`
+    // is the set the move translates (the whole selection for a multi-drag).
+    const modifier = hasModifier(e);
+    const ids = selection.elementIds;
+    const inSelection = ids.includes(el.id);
+
+    let armDrag: boolean;
+    let dragIds: readonly string[];
+
+    if (!inSelection && !modifier) {
+      // Select only this element and arm a single-element drag. A drag then ends
+      // with the dragged element selected (the controlled `selection` never goes
+      // stale against what's being moved).
       onSelectionChange?.({ elementIds: [el.id], primaryId: el.id });
+      armDrag = true;
+      dragIds = [el.id];
+    } else if (!inSelection && modifier) {
+      // Additive: extend the selection by this element (uniq); a modifier click
+      // is a pure selection action, so no drag is armed.
+      onSelectionChange?.({ elementIds: uniqIds([...ids, el.id]), primaryId: el.id });
+      armDrag = false;
+      dragIds = [el.id];
+    } else if (inSelection && modifier) {
+      // Subtractive: drop this element — unless it is the last one, since a
+      // modifier click must never clear the selection to empty. No drag.
+      const next = ids.filter((id) => id !== el.id);
+      if (next.length > 0) {
+        onSelectionChange?.({ elementIds: next, primaryId: next[next.length - 1] });
+      }
+      armDrag = false;
+      dragIds = [el.id];
+    } else {
+      // Already selected, no modifier: keep the whole selection, make this
+      // element the primary/handle, and arm a drag that moves every selected
+      // element together. Skip the emit when it is already the primary so a
+      // plain click doesn't double-emit (down here + a redundant up).
+      if (selection.primaryId !== el.id) {
+        onSelectionChange?.({ elementIds: ids, primaryId: el.id });
+      }
+      armDrag = true;
+      dragIds = ids;
     }
+
+    // A pure selection action (modifier add/remove): no move gesture is armed,
+    // so DON'T claim the active pointer — leave the hook ready for the next one.
+    if (!armDrag) return;
+    activePointerRef.current = e.pointerId;
 
     const startX = e.clientX;
     const startY = e.clientY;
-    const others = slide.elements.filter((o) => o.id !== el.id);
+    // Base snapshots captured at pointer-down. `selectedElements` is the rigid
+    // set the drag translates; `others` are the snap candidates (everything
+    // NOT being dragged). A 1-element selection routes through `computeDragMove`
+    // for exact backward compatibility; N > 1 routes through the multi core.
+    const selectedSet = new Set(dragIds);
+    const selectedElements = slide.elements.filter((o) => selectedSet.has(o.id));
+    const others = slide.elements.filter((o) => !selectedSet.has(o.id));
+    const isMulti = selectedElements.length > 1;
     const viewport = {
       width: slide.viewportSize,
       height: slide.viewportSize * slide.viewportRatio,
@@ -120,17 +184,38 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
       // jsdom / unsupported: pointer capture is a best-effort nicety.
     }
 
-    const compute = (clientX: number, clientY: number) =>
-      computeDragMove({
+    // Normalize both cores to a list of per-element `{id, props}` updates so the
+    // working-copy and commit paths are identical regardless of selection size.
+    const compute = (
+      clientX: number,
+      clientY: number,
+    ): {
+      updates: Array<{ id: string; props: { left: number; top: number } }>;
+      guides: Guide[];
+    } => {
+      const deltaCanvas = {
+        x: (clientX - startX) / effectiveScale,
+        y: (clientY - startY) / effectiveScale,
+      };
+      if (isMulti) {
+        return computeMultiDragMove({
+          handleElement: el,
+          selected: selectedElements,
+          others,
+          viewport,
+          deltaCanvas,
+          snapping,
+        });
+      }
+      const { props, guides } = computeDragMove({
         element: el,
         others,
         viewport,
-        deltaCanvas: {
-          x: (clientX - startX) / effectiveScale,
-          y: (clientY - startY) / effectiveScale,
-        },
+        deltaCanvas,
         snapping,
       });
+      return { updates: [{ id: el.id, props }], guides };
+    };
 
     const handleMove = (ev: PointerEvent) => {
       if (ev.pointerId !== activePointerRef.current) return;
@@ -139,12 +224,14 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
       // snap back on pointer-up. Skip live movement entirely when there's no
       // mutation channel — the gesture only ends up selecting (see handleUp).
       if (!onElementsChange) return;
-      const { props, guides } = compute(ev.clientX, ev.clientY);
+      const { updates, guides } = compute(ev.clientX, ev.clientY);
+      const patch = new Map(updates.map((u) => [u.id, u.props]));
       const live: Slide = {
         ...slide,
-        elements: slide.elements.map((o) =>
-          o.id === el.id ? ({ ...o, ...props } as PPTElement) : o,
-        ),
+        elements: slide.elements.map((o) => {
+          const props = patch.get(o.id);
+          return props ? ({ ...o, ...props } as PPTElement) : o;
+        }),
       };
       setWorking({ id: el.id, live, guides });
     };
@@ -167,12 +254,16 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
 
       // A move intent is only meaningful when the host can mutate. When it moved
       // past the threshold and there's a mutation channel, emit exactly one move
-      // intent. Otherwise (a click, or a drag on a select-only host) there is
-      // nothing extra to emit here: the element was already selected on
-      // pointer-down, so re-emitting would be a redundant double selection.
+      // intent — `element.update` for a lone element (backward compat), a single
+      // `element.updateMany` for a multi-drag (one host undo entry). Otherwise (a
+      // click, or a drag on a select-only host) there is nothing extra to emit:
+      // the element was already selected on pointer-down.
       if (movedPast && onElementsChange) {
-        const { props } = compute(ev.clientX, ev.clientY);
-        onElementsChange([moveIntent(el.id, props)]);
+        const { updates } = compute(ev.clientX, ev.clientY);
+        const intent = isMulti
+          ? moveManyIntent(updates)
+          : moveIntent(updates[0].id, updates[0].props);
+        onElementsChange([intent]);
       }
 
       setWorking(null);

--- a/packages/@openmaic/renderer/src/editing/useEditGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useEditGesture.ts
@@ -5,6 +5,7 @@ import type { PPTElement, Slide } from '@openmaic/dsl';
 
 import { computeDragMove, computeMultiDragMove } from './core/drag';
 import { moveIntent, moveManyIntent } from './core/intent';
+import { isSelectionModifier, resolveClickSelection } from './core/selection';
 import type { Guide } from './core/snapping';
 import type { EditIntent, Selection, SnappingOptions } from './types';
 
@@ -40,35 +41,22 @@ interface Working {
   guides: Guide[];
 }
 
-/** True when a click/drag modifier (Ctrl/Shift/Meta) is held. Meta is included
- * for mac parity with the resize aspect modifier — a deliberate superset of the
- * app's Ctrl/Shift. */
-function hasModifier(e: ReactPointerEvent): boolean {
-  return e.ctrlKey || e.shiftKey || e.metaKey;
-}
-
-/** Dedup ids preserving first-seen order (no lodash dep in this package). */
-function uniqIds(ids: readonly string[]): string[] {
-  return Array.from(new Set(ids));
-}
-
 /**
  * Owns one drag/click gesture. Pointer-down resolves the selection per the
- * modifier table below, then — for the cases that start a move — arms a drag and
- * records the pointer start + the base slide; window pointer-move (converted
- * screen→canvas via `scale`) republishes a working copy for live feedback;
- * pointer-up commits the move as ONE intent when the pointer moved past
- * `DRAG_THRESHOLD_PX`, otherwise reports a selection click. Emits one intent per
- * completed gesture — never per frame — and clears the working copy so the
- * host's controlled `slide` takes over again.
+ * modifier table in {@link resolveClickSelection} (group-cohesive: a click on a
+ * grouped element applies to its whole group), then — for the cases that start
+ * a move — arms a drag and records the pointer start + the base slide; window
+ * pointer-move (converted screen→canvas via `scale`) republishes a working copy
+ * for live feedback; pointer-up commits the move as ONE intent when the pointer
+ * moved past `DRAG_THRESHOLD_PX`, otherwise reports a selection click. Emits one
+ * intent per completed gesture — never per frame — and clears the working copy
+ * so the host's controlled `slide` takes over again.
  *
- * Selection on pointer-down (element `el`, current `selection`):
- * - not selected, no modifier → select only `[el]`, arm a SINGLE drag on it.
- * - not selected, modifier    → ADD `el` to the selection (uniq); no drag.
- * - selected, modifier        → REMOVE `el`; no-op if that would empty the
- *   selection; no drag.
- * - selected, no modifier      → KEEP the whole selection, make `el` the primary
- *   (handle), and arm a MULTI drag that translates every selected element.
+ * Locked elements in a multi-selection are never translated: they may stay in
+ * the controlled selection for feedback, but the drag set excludes them and they
+ * remain snap candidates. Holding Shift while the drag is in flight locks the
+ * translation to the dominant axis (Shift at pointer-down is a selection
+ * modifier and never arms a drag).
  *
  * A single-element move commits `element.update` (backward compat with hosts);
  * a multi-element move commits ONE `element.updateMany` = one host undo entry.
@@ -113,49 +101,17 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
     // Ignore additional pointer-downs while a gesture is already in flight.
     if (activePointerRef.current !== null) return;
 
-    // Resolve selection on pointer-down per the modifier table (see the hook
-    // JSDoc). `armDrag` decides whether this gesture becomes a move; `dragIds`
-    // is the set the move translates (the whole selection for a multi-drag).
-    const modifier = hasModifier(e);
-    const ids = selection.elementIds;
-    const inSelection = ids.includes(el.id);
-
-    let armDrag: boolean;
-    let dragIds: readonly string[];
-
-    if (!inSelection && !modifier) {
-      // Select only this element and arm a single-element drag. A drag then ends
-      // with the dragged element selected (the controlled `selection` never goes
-      // stale against what's being moved).
-      onSelectionChange?.({ elementIds: [el.id], primaryId: el.id });
-      armDrag = true;
-      dragIds = [el.id];
-    } else if (!inSelection && modifier) {
-      // Additive: extend the selection by this element (uniq); a modifier click
-      // is a pure selection action, so no drag is armed.
-      onSelectionChange?.({ elementIds: uniqIds([...ids, el.id]), primaryId: el.id });
-      armDrag = false;
-      dragIds = [el.id];
-    } else if (inSelection && modifier) {
-      // Subtractive: drop this element — unless it is the last one, since a
-      // modifier click must never clear the selection to empty. No drag.
-      const next = ids.filter((id) => id !== el.id);
-      if (next.length > 0) {
-        onSelectionChange?.({ elementIds: next, primaryId: next[next.length - 1] });
-      }
-      armDrag = false;
-      dragIds = [el.id];
-    } else {
-      // Already selected, no modifier: keep the whole selection, make this
-      // element the primary/handle, and arm a drag that moves every selected
-      // element together. Skip the emit when it is already the primary so a
-      // plain click doesn't double-emit (down here + a redundant up).
-      if (selection.primaryId !== el.id) {
-        onSelectionChange?.({ elementIds: ids, primaryId: el.id });
-      }
-      armDrag = true;
-      dragIds = ids;
-    }
+    // Resolve selection on pointer-down per the shared modifier table
+    // ({@link resolveClickSelection} — group-cohesive). `armDrag` decides
+    // whether this gesture becomes a move; `dragIds` is the set the move
+    // translates (the whole selection for a multi-drag).
+    const { next, armDrag, dragIds } = resolveClickSelection({
+      element: el,
+      elements: slide.elements,
+      selection,
+      modifier: isSelectionModifier(e),
+    });
+    if (next) onSelectionChange?.(next);
 
     // A pure selection action (modifier add/remove): no move gesture is armed,
     // so DON'T claim the active pointer — leave the hook ready for the next one.
@@ -166,11 +122,15 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
     const startY = e.clientY;
     // Base snapshots captured at pointer-down. `selectedElements` is the rigid
     // set the drag translates; `others` are the snap candidates (everything
-    // NOT being dragged). A 1-element selection routes through `computeDragMove`
-    // for exact backward compatibility; N > 1 routes through the multi core.
+    // NOT being dragged). Locked elements never move: even when selected they
+    // are excluded from the translated set (selection keeps them for feedback)
+    // and stay in `others` as snap candidates. A 1-mover drag routes through
+    // `computeDragMove` for exact backward compatibility; N > 1 routes through
+    // the multi core.
     const selectedSet = new Set(dragIds);
-    const selectedElements = slide.elements.filter((o) => selectedSet.has(o.id));
-    const others = slide.elements.filter((o) => !selectedSet.has(o.id));
+    const isMover = (o: PPTElement) => selectedSet.has(o.id) && !o.lock;
+    const selectedElements = slide.elements.filter(isMover);
+    const others = slide.elements.filter((o) => !isMover(o));
     const isMulti = selectedElements.length > 1;
     const viewport = {
       width: slide.viewportSize,
@@ -186,9 +146,14 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
 
     // Normalize both cores to a list of per-element `{id, props}` updates so the
     // working-copy and commit paths are identical regardless of selection size.
+    // `shiftKey` is read off the LIVE pointermove/pointerup event: holding Shift
+    // while the drag is in flight locks the translation to the dominant axis
+    // (the axis with the larger absolute delta) — Shift at pointer-down is a
+    // selection modifier and never arms a drag in the first place.
     const compute = (
       clientX: number,
       clientY: number,
+      shiftKey: boolean,
     ): {
       updates: Array<{ id: string; props: { left: number; top: number } }>;
       guides: Guide[];
@@ -197,6 +162,11 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
         x: (clientX - startX) / effectiveScale,
         y: (clientY - startY) / effectiveScale,
       };
+      const axisLock: 'x' | 'y' | undefined = shiftKey
+        ? Math.abs(deltaCanvas.x) >= Math.abs(deltaCanvas.y)
+          ? 'x'
+          : 'y'
+        : undefined;
       if (isMulti) {
         return computeMultiDragMove({
           handleElement: el,
@@ -204,6 +174,7 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
           others,
           viewport,
           deltaCanvas,
+          axisLock,
           snapping,
         });
       }
@@ -212,6 +183,7 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
         others,
         viewport,
         deltaCanvas,
+        axisLock,
         snapping,
       });
       return { updates: [{ id: el.id, props }], guides };
@@ -224,7 +196,7 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
       // snap back on pointer-up. Skip live movement entirely when there's no
       // mutation channel — the gesture only ends up selecting (see handleUp).
       if (!onElementsChange) return;
-      const { updates, guides } = compute(ev.clientX, ev.clientY);
+      const { updates, guides } = compute(ev.clientX, ev.clientY, ev.shiftKey);
       const patch = new Map(updates.map((u) => [u.id, u.props]));
       const live: Slide = {
         ...slide,
@@ -259,7 +231,7 @@ export function useEditGesture(args: UseEditGestureArgs): UseEditGestureResult {
       // click, or a drag on a select-only host) there is nothing extra to emit:
       // the element was already selected on pointer-down.
       if (movedPast && onElementsChange) {
-        const { updates } = compute(ev.clientX, ev.clientY);
+        const { updates } = compute(ev.clientX, ev.clientY, ev.shiftKey);
         const intent = isMulti
           ? moveManyIntent(updates)
           : moveIntent(updates[0].id, updates[0].props);

--- a/packages/@openmaic/renderer/src/editing/useMarqueeGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useMarqueeGesture.ts
@@ -72,6 +72,16 @@ export function useMarqueeGesture(args: UseMarqueeGestureArgs): UseMarqueeGestur
   // The pointerId owning the in-flight gesture (single-pointer guard).
   const activePointerRef = useRef<number | null>(null);
 
+  // The LIVE controlled selection, refreshed on every committed render. The
+  // window handlers below are created at pointer-down and would otherwise
+  // close over the selection as of that render; the host may update it
+  // mid-gesture, and the empty-skip/clear decisions on release must use the
+  // current value.
+  const selectionRef = useRef(selection);
+  useEffect(() => {
+    selectionRef.current = selection;
+  }, [selection]);
+
   useEffect(
     () => () => {
       teardownRef.current?.();
@@ -82,6 +92,9 @@ export function useMarqueeGesture(args: UseMarqueeGestureArgs): UseMarqueeGestur
   );
 
   const onCanvasPointerDown = (e: ReactPointerEvent) => {
+    // Only the main button arms a marquee: a secondary/middle-button press on
+    // blank canvas must neither rubber-band nor clear the selection.
+    if (e.button !== 0) return;
     // A marquee only exists as a selection action; with no selection channel
     // there is nothing to publish, so don't arm at all.
     if (!onSelectionChange) return;
@@ -146,8 +159,10 @@ export function useMarqueeGesture(args: UseMarqueeGestureArgs): UseMarqueeGestur
 
       // Sub-threshold: a blank click. Clear the selection, but skip the emit
       // when it is already empty (idempotent — no redundant selection change).
+      // Read through `selectionRef` (not the pointer-down closure) so a
+      // selection the host updated mid-gesture is judged by its live value.
       if (!rectPastThreshold(rect)) {
-        if (selection.elementIds.length > 0) onSelectionChange(EMPTY_SELECTION);
+        if (selectionRef.current.elementIds.length > 0) onSelectionChange(EMPTY_SELECTION);
         return;
       }
 
@@ -161,7 +176,7 @@ export function useMarqueeGesture(args: UseMarqueeGestureArgs): UseMarqueeGestur
       // emit only when it was already empty). The top-most matched element (last
       // in z-order) becomes the primary/handle for a subsequent multi-drag.
       if (ids.length === 0) {
-        if (selection.elementIds.length > 0) onSelectionChange(EMPTY_SELECTION);
+        if (selectionRef.current.elementIds.length > 0) onSelectionChange(EMPTY_SELECTION);
         return;
       }
       onSelectionChange({ elementIds: ids, primaryId: ids[ids.length - 1] });

--- a/packages/@openmaic/renderer/src/editing/useMarqueeGesture.ts
+++ b/packages/@openmaic/renderer/src/editing/useMarqueeGesture.ts
@@ -1,0 +1,187 @@
+'use client';
+
+import {
+  useState,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from 'react';
+import type { Slide } from '@openmaic/dsl';
+
+import { computeMarqueeSelection, marqueeRect, type MarqueeRect } from './core/marquee';
+import type { ViewportStyles } from '../hooks/useViewportSize';
+import { EMPTY_SELECTION, type Selection } from './types';
+
+/**
+ * Minimum size (canvas units) the marquee must reach on BOTH axes before it
+ * counts as a drag-select rather than a blank click. Below this the gesture is a
+ * blank click that clears the selection; at/above it the box replaces the
+ * selection with whatever it covers. App parity (`minSelectionRange = 5`).
+ */
+const MARQUEE_THRESHOLD_CANVAS = 5;
+
+export interface UseMarqueeGestureArgs {
+  slide: Slide;
+  scale: number;
+  /**
+   * The interaction overlay element. Its bounding rect (captured once per
+   * gesture, at pointer-down) plus `viewportStyles.left/top` locate the canvas
+   * origin on screen, which converts absolute pointer positions to canvas
+   * coordinates — the marquee rectangle lives in canvas units.
+   */
+  overlayRef: RefObject<HTMLElement | null>;
+  /** SlideCanvas centering offset (screen px) inside the overlay. */
+  viewportStyles: ViewportStyles;
+  selection: Selection;
+  onSelectionChange?: (next: Selection) => void;
+}
+
+export interface UseMarqueeGestureResult {
+  /** The live marquee rectangle (canvas units) while past-threshold, else `null`. */
+  marqueeRect: MarqueeRect | null;
+  /** Arm a marquee gesture from a pointer-down on the blank-canvas capture surface. */
+  onCanvasPointerDown: (e: ReactPointerEvent) => void;
+}
+
+/**
+ * Owns one blank-canvas marquee (rubber-band) gesture, mirroring the other
+ * gesture hooks. Pointer-down on the capture surface records the canvas origin
+ * and the start point; window pointer-move converts the pointer to canvas
+ * coordinates and, once the box passes {@link MARQUEE_THRESHOLD_CANVAS} on BOTH
+ * axes, republishes a normalized rectangle for a live preview; pointer-up
+ * computes the selection ({@link computeMarqueeSelection}) and REPLACES the
+ * controlled selection via `onSelectionChange`. A sub-threshold gesture is a
+ * blank click: it clears the selection (a no-op when already empty). The mode is
+ * chosen from the modifier held at release — plain drag = `contain`, Ctrl/Shift/
+ * Meta = `intersect`.
+ *
+ * Single-pointer by design (one active pointer at a time; window move/up from
+ * any other pointerId are dropped) and `pointercancel`-safe (revert, no emit).
+ * Pure gesture glue: no store, no `@/` imports.
+ */
+export function useMarqueeGesture(args: UseMarqueeGestureArgs): UseMarqueeGestureResult {
+  const { slide, scale, overlayRef, viewportStyles, selection, onSelectionChange } = args;
+
+  const [liveRect, setLiveRect] = useState<MarqueeRect | null>(null);
+
+  // Teardown for the currently-armed gesture's window listeners; the unmount
+  // effect removes any listeners still live so a late move/up can't setState on
+  // an unmounted host.
+  const teardownRef = useRef<(() => void) | null>(null);
+  // The pointerId owning the in-flight gesture (single-pointer guard).
+  const activePointerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      teardownRef.current?.();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+    },
+    [],
+  );
+
+  const onCanvasPointerDown = (e: ReactPointerEvent) => {
+    // A marquee only exists as a selection action; with no selection channel
+    // there is nothing to publish, so don't arm at all.
+    if (!onSelectionChange) return;
+    if (activePointerRef.current !== null) return;
+    // The marquee rectangle is in canvas units; without a mounted overlay the
+    // pointer position cannot be mapped to canvas coordinates, so don't arm.
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+    activePointerRef.current = e.pointerId;
+
+    const startClientX = e.clientX;
+    const startClientY = e.clientY;
+    const effectiveScale = scale || 1;
+
+    // Canvas origin in client coordinates, captured once per gesture (the
+    // canvas doesn't scroll/zoom mid-gesture; app parity).
+    const overlayRectBox = overlay.getBoundingClientRect();
+    const originX = overlayRectBox.left + viewportStyles.left;
+    const originY = overlayRectBox.top + viewportStyles.top;
+
+    const toCanvas = (clientX: number, clientY: number) => ({
+      x: (clientX - originX) / effectiveScale,
+      y: (clientY - originY) / effectiveScale,
+    });
+    const start = toCanvas(startClientX, startClientY);
+
+    try {
+      (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+    } catch {
+      // jsdom / unsupported: pointer capture is a best-effort nicety.
+    }
+
+    // Whether the marquee has passed the both-axes threshold this gesture. Only
+    // a past-threshold box is drawn and only a past-threshold release replaces
+    // the selection; a sub-threshold release is a blank click (clear).
+    const rectPastThreshold = (rect: MarqueeRect): boolean =>
+      rect.maxX - rect.minX >= MARQUEE_THRESHOLD_CANVAS &&
+      rect.maxY - rect.minY >= MARQUEE_THRESHOLD_CANVAS;
+
+    const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      const rect = marqueeRect(start, toCanvas(ev.clientX, ev.clientY));
+      // Only show the box once it is a real drag-select on both axes; below the
+      // threshold keep it hidden (matches the app, which never paints a tiny box).
+      setLiveRect(rectPastThreshold(rect) ? rect : null);
+    };
+
+    const removeListeners = () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleCancel);
+    };
+
+    const handleUp = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      removeListeners();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+      setLiveRect(null);
+
+      const rect = marqueeRect(start, toCanvas(ev.clientX, ev.clientY));
+
+      // Sub-threshold: a blank click. Clear the selection, but skip the emit
+      // when it is already empty (idempotent — no redundant selection change).
+      if (!rectPastThreshold(rect)) {
+        if (selection.elementIds.length > 0) onSelectionChange(EMPTY_SELECTION);
+        return;
+      }
+
+      // Modifier at release picks the containment rule: plain = full containment,
+      // Ctrl/Shift/Meta = intersection. Meta is included for mac parity with the
+      // resize aspect modifier — a deliberate superset of the app's Ctrl/Shift.
+      const mode = ev.ctrlKey || ev.shiftKey || ev.metaKey ? 'intersect' : 'contain';
+      const ids = computeMarqueeSelection(rect, slide.elements, { mode });
+
+      // The marquee REPLACES the selection. An empty result clears it (skip the
+      // emit only when it was already empty). The top-most matched element (last
+      // in z-order) becomes the primary/handle for a subsequent multi-drag.
+      if (ids.length === 0) {
+        if (selection.elementIds.length > 0) onSelectionChange(EMPTY_SELECTION);
+        return;
+      }
+      onSelectionChange({ elementIds: ids, primaryId: ids[ids.length - 1] });
+    };
+
+    // Browser-initiated cancel: tear down and drop the live box WITHOUT emitting
+    // any selection change, then leave the hook ready for a fresh gesture.
+    const handleCancel = (ev: PointerEvent) => {
+      if (ev.pointerId !== activePointerRef.current) return;
+      removeListeners();
+      teardownRef.current = null;
+      activePointerRef.current = null;
+      setLiveRect(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleCancel);
+    teardownRef.current = removeListeners;
+  };
+
+  return { marqueeRect: liveRect, onCanvasPointerDown };
+}

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.multiselect.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.multiselect.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import type { Slide } from '@openmaic/dsl';
+import { EditableSlideCanvas } from '../../src/editing/EditableSlideCanvas';
+import { useViewportSize } from '../../src/hooks/useViewportSize';
+
+// Mock the viewport-fit hook (jsdom reports a zero-size container) so the
+// overlay uses a known scale/offset, exactly like the other canvas tests.
+vi.mock('../../src/hooks/useViewportSize', () => ({
+  useViewportSize: vi.fn(),
+}));
+
+const textEl = {
+  id: 'a',
+  type: 'text',
+  left: 100,
+  top: 100,
+  width: 200,
+  height: 80,
+  rotate: 0,
+  content: 'x',
+  defaultFontName: 'f',
+  defaultColor: '#000',
+  lineHeight: 1,
+};
+const imageEl = {
+  id: 'b',
+  type: 'image',
+  left: 400,
+  top: 100,
+  width: 320,
+  height: 180,
+  rotate: 0,
+  fixedRatio: false,
+  src: 'x.png',
+};
+
+function makeSlide(elements: unknown[] = [textEl, imageEl]): Slide {
+  return {
+    id: 's',
+    viewportSize: 1000,
+    viewportRatio: 0.5625,
+    elements,
+  } as unknown as Slide;
+}
+
+const hit = (c: HTMLElement, id: string) =>
+  c.querySelector(`[data-element-id="${id}"]`) as HTMLElement;
+const surface = (c: HTMLElement) => c.querySelector('[data-marquee-surface]') as HTMLElement;
+
+describe('EditableSlideCanvas — marquee', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('renders a blank-canvas capture surface only when onSelectionChange is provided', () => {
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+    expect(surface(container)).not.toBeNull();
+
+    // Mutation-only mount (no onSelectionChange): no marquee surface.
+    const { container: c2 } = render(
+      <EditableSlideCanvas slide={makeSlide()} scale={1} onElementsChange={vi.fn()} />,
+    );
+    expect(surface(c2)).toBeNull();
+  });
+
+  it('a marquee past threshold REPLACES the selection with what it contains', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const s = surface(container);
+    // (0,0)→(350,250) wholly contains 'a' ([100,300]×[100,180]); 'b' is outside.
+    fireEvent.pointerDown(s, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(s, { pointerId: 1, clientX: 350, clientY: 250 });
+    // The live marquee box is drawn mid-drag.
+    expect(container.querySelector('[data-marquee-box]')).not.toBeNull();
+    fireEvent.pointerUp(s, { pointerId: 1, clientX: 350, clientY: 250 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+    // Box removed after release.
+    expect(container.querySelector('[data-marquee-box]')).toBeNull();
+  });
+
+  it('a sub-threshold blank click clears the selection', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const s = surface(container);
+    fireEvent.pointerDown(s, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(s, { pointerId: 1, clientX: 11, clientY: 11 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: [] });
+  });
+});
+
+describe('EditableSlideCanvas — click modifiers', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('a plain click on an unselected element selects only it', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'b'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(hit(container, 'b'), { pointerId: 1, clientX: 0, clientY: 0 });
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['b'], primaryId: 'b' });
+  });
+
+  it('a Ctrl-click on an unselected element ADDS it to the selection (uniq)', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'b'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    fireEvent.pointerUp(hit(container, 'b'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a', 'b'], primaryId: 'b' });
+  });
+
+  it('a Shift-click on a selected element REMOVES it', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a', 'b'], primaryId: 'b' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'b'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      shiftKey: true,
+    });
+    fireEvent.pointerUp(hit(container, 'b'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      shiftKey: true,
+    });
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+  });
+
+  it('a Ctrl-click that would empty the selection is a guarded no-op', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'a'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    fireEvent.pointerUp(hit(container, 'a'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    // Removing the last element would empty the selection → no emit.
+    expect(onSel).not.toHaveBeenCalled();
+  });
+});
+
+describe('EditableSlideCanvas — multi-drag', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('dragging a selected element in a multi-selection moves ALL and emits ONE updateMany', () => {
+    const onSel = vi.fn();
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a', 'b'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    // 'a' is already the primary; a plain drag keeps the whole selection.
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+
+    // Exactly one intent — a single element.updateMany = one host undo entry.
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.updateMany',
+        updates: [
+          { id: 'a', props: { left: 130, top: 120 } },
+          { id: 'b', props: { left: 430, top: 120 } },
+        ],
+      },
+    ]);
+    // No re-selection: 'a' was already primary.
+    expect(onSel).not.toHaveBeenCalled();
+  });
+
+  it('a multi-selection shows no operate handles (single-element gestures only)', () => {
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a', 'b'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('[data-resize-handle]')).toBeNull();
+    expect(container.querySelector('[data-rotate-handle]')).toBeNull();
+  });
+
+  it('a single-element drag still emits element.update (backward compat)', () => {
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { left: 130, top: 120 } },
+    ]);
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.multiselect.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.multiselect.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
 import { render } from '@testing-library/react';
 import { fireEvent } from '@testing-library/dom';
 import type { Slide } from '@openmaic/dsl';
 import { EditableSlideCanvas } from '../../src/editing/EditableSlideCanvas';
+import type { EditIntent, Selection } from '../../src/editing/types';
 import { useViewportSize } from '../../src/hooks/useViewportSize';
 
 // Mock the viewport-fit hook (jsdom reports a zero-size container) so the
@@ -46,9 +48,51 @@ function makeSlide(elements: unknown[] = [textEl, imageEl]): Slide {
   } as unknown as Slide;
 }
 
+const lockedEl = {
+  id: 'locked1',
+  type: 'text',
+  left: 600,
+  top: 300,
+  width: 100,
+  height: 50,
+  rotate: 0,
+  content: 'z',
+  defaultFontName: 'f',
+  defaultColor: '#000',
+  lineHeight: 1,
+  lock: true,
+};
+const lineEl = {
+  id: 'line1',
+  type: 'line',
+  left: 400,
+  top: 300,
+  start: [0, 0],
+  end: [80, 40],
+  width: 2,
+  style: 'solid',
+  color: '#333',
+  points: ['', ''],
+};
+const groupEl = (id: string, left: number) => ({
+  id,
+  type: 'text',
+  left,
+  top: 100,
+  width: 100,
+  height: 60,
+  rotate: 0,
+  content: 'g',
+  defaultFontName: 'f',
+  defaultColor: '#000',
+  lineHeight: 1,
+  groupId: 'G',
+});
+
 const hit = (c: HTMLElement, id: string) =>
   c.querySelector(`[data-element-id="${id}"]`) as HTMLElement;
 const surface = (c: HTMLElement) => c.querySelector('[data-marquee-surface]') as HTMLElement;
+const lineBlocker = (c: HTMLElement) => c.querySelector('[data-hit-kind="line"]') as Element;
 
 describe('EditableSlideCanvas — marquee', () => {
   beforeEach(() => {
@@ -58,7 +102,23 @@ describe('EditableSlideCanvas — marquee', () => {
     });
   });
 
-  it('renders a blank-canvas capture surface only when onSelectionChange is provided', () => {
+  it('renders a blank-canvas capture surface only when the mount is EDITABLE (onElementsChange)', () => {
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={vi.fn()}
+      />,
+    );
+    expect(surface(container)).not.toBeNull();
+  });
+
+  it('a select-only mount renders NO capture surface (native touch pan preserved)', () => {
+    // The surface is a full-bleed `touchAction: 'none'` layer; a select-only/
+    // viewer-ish mount (no mutation channel) must not swallow touch scrolling.
+    // Element tap-select still works via the per-element hit targets.
     const { container } = render(
       <EditableSlideCanvas
         slide={makeSlide()}
@@ -67,13 +127,9 @@ describe('EditableSlideCanvas — marquee', () => {
         onSelectionChange={vi.fn()}
       />,
     );
-    expect(surface(container)).not.toBeNull();
-
-    // Mutation-only mount (no onSelectionChange): no marquee surface.
-    const { container: c2 } = render(
-      <EditableSlideCanvas slide={makeSlide()} scale={1} onElementsChange={vi.fn()} />,
-    );
-    expect(surface(c2)).toBeNull();
+    expect(surface(container)).toBeNull();
+    // Element hit targets are still present for tap-select.
+    expect(hit(container, 'a')).not.toBeNull();
   });
 
   it('a marquee past threshold REPLACES the selection with what it contains', () => {
@@ -84,6 +140,7 @@ describe('EditableSlideCanvas — marquee', () => {
         scale={1}
         selection={{ elementIds: [] }}
         onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
       />,
     );
     const s = surface(container);
@@ -107,6 +164,7 @@ describe('EditableSlideCanvas — marquee', () => {
         scale={1}
         selection={{ elementIds: ['a'], primaryId: 'a' }}
         onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
       />,
     );
     const s = surface(container);
@@ -294,6 +352,412 @@ describe('EditableSlideCanvas — multi-drag', () => {
     expect(onCh).toHaveBeenCalledTimes(1);
     expect(onCh.mock.calls[0][0]).toEqual([
       { type: 'element.update', id: 'a', props: { left: 130, top: 120 } },
+    ]);
+  });
+
+  it('a locked element in the selection never moves: the drag set excludes it (single mover → element.update)', () => {
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([textEl, lockedEl])}
+        scale={1}
+        selection={{ elementIds: ['locked1', 'a'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    // Working copy: the locked element's blocker stays put while 'a' follows.
+    expect(hit(container, 'a').style.left).toBe('130px');
+    const blocker = container.querySelector('[data-hit-kind="blocker"]') as HTMLElement;
+    expect(blocker.style.left).toBe('600px');
+    expect(blocker.style.top).toBe('300px');
+    fireEvent.pointerUp(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    // Only ONE mover remains → single element.update, and NO entry for locked1.
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { left: 130, top: 120 } },
+    ]);
+  });
+
+  it('a locked element in a 3-element selection is absent from the updateMany', () => {
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([textEl, imageEl, lockedEl])}
+        scale={1}
+        selection={{ elementIds: ['a', 'b', 'locked1'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.updateMany',
+        updates: [
+          { id: 'a', props: { left: 130, top: 120 } },
+          { id: 'b', props: { left: 430, top: 120 } },
+        ],
+      },
+    ]);
+  });
+
+  it('multi-drag pointercancel reverts the working copy without emitting', () => {
+    const onSel = vi.fn();
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a', 'b'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    // Live: BOTH selected elements followed the pointer.
+    expect(hit(container, 'a').style.left).toBe('130px');
+    expect(hit(container, 'b').style.left).toBe('430px');
+    fireEvent.pointerCancel(hit(container, 'a'), { pointerId: 1, clientX: 30, clientY: 20 });
+    // Reverted, and no intent/selection emitted.
+    expect(hit(container, 'a').style.left).toBe('100px');
+    expect(hit(container, 'b').style.left).toBe('400px');
+    expect(onCh).not.toHaveBeenCalled();
+    expect(onSel).not.toHaveBeenCalled();
+  });
+
+  it('after a modifier click (no drag armed), a plain drag with a NEW pointerId still works', () => {
+    // A pure selection click never claims the active pointer, so a subsequent
+    // gesture from a different pointerId must arm normally.
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    // Modifier click on 'b': selection action only, pointer 1 never claimed.
+    fireEvent.pointerDown(hit(container, 'b'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    fireEvent.pointerUp(hit(container, 'b'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    // Plain drag on 'a' with a NEW pointerId commits a move.
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 2, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 2, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit(container, 'a'), { pointerId: 2, clientX: 30, clientY: 20 });
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { left: 130, top: 120 } },
+    ]);
+  });
+});
+
+describe('EditableSlideCanvas — shift axis lock (mid-drag)', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('holding shift during a SINGLE drag locks to the dominant axis', () => {
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    // Plain pointer-down (shift here would be a selection modifier, no drag);
+    // shift is engaged on the MOVE. |dx|=30 > |dy|=10 → x is dominant.
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), {
+      pointerId: 1,
+      clientX: 30,
+      clientY: 10,
+      shiftKey: true,
+    });
+    // Live working copy already reflects the lock: y stays put.
+    expect(hit(container, 'a').style.left).toBe('130px');
+    expect(hit(container, 'a').style.top).toBe('100px');
+    fireEvent.pointerUp(hit(container, 'a'), {
+      pointerId: 1,
+      clientX: 30,
+      clientY: 10,
+      shiftKey: true,
+    });
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      { type: 'element.update', id: 'a', props: { left: 130, top: 100 } },
+    ]);
+  });
+
+  it('holding shift during a MULTI drag locks the whole set to the dominant axis', () => {
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a', 'b'], primaryId: 'a' }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    // |dy|=25 > |dx|=10 → y is dominant; x deltas are dropped for BOTH.
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 25,
+      shiftKey: true,
+    });
+    fireEvent.pointerUp(hit(container, 'a'), {
+      pointerId: 1,
+      clientX: 10,
+      clientY: 25,
+      shiftKey: true,
+    });
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.updateMany',
+        updates: [
+          { id: 'a', props: { left: 100, top: 125 } },
+          { id: 'b', props: { left: 400, top: 125 } },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('EditableSlideCanvas — line selection modifiers', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  it('a Ctrl-click on a line ADDS it to the selection', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([textEl, lineEl])}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(lineBlocker(container), { clientX: 0, clientY: 0, ctrlKey: true });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a', 'line1'], primaryId: 'line1' });
+  });
+
+  it('a Ctrl-click on a selected line REMOVES it without destroying the selection', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([textEl, lineEl])}
+        scale={1}
+        selection={{ elementIds: ['a', 'line1'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(lineBlocker(container), { clientX: 0, clientY: 0, ctrlKey: true });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    // The rest of the selection survives, and the surviving primary is kept.
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+  });
+});
+
+describe('EditableSlideCanvas — group cohesion on click', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  const g1 = groupEl('g1', 100);
+  const g2 = groupEl('g2', 400);
+
+  it('a plain click on a grouped element selects ALL group members (primary = clicked)', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([g1, g2, textEl])}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'g2'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(hit(container, 'g2'), { pointerId: 1, clientX: 0, clientY: 0 });
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['g1', 'g2'], primaryId: 'g2' });
+  });
+
+  it('a modifier-add on a grouped element adds the WHOLE group (uniq)', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([g1, g2, textEl])}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'g1'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a', 'g1', 'g2'], primaryId: 'g1' });
+  });
+
+  it('a modifier-remove on a grouped element removes the WHOLE group', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([g1, g2, textEl])}
+        scale={1}
+        selection={{ elementIds: ['a', 'g1', 'g2'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+        onElementsChange={vi.fn()}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'g2'), {
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: true,
+    });
+    // Both members removed; the surviving primary 'a' is preserved.
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+  });
+
+  it('dragging a group member moves the WHOLE group (one updateMany)', () => {
+    const onSel = vi.fn();
+    const onCh = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={makeSlide([g1, g2, textEl])}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+        onElementsChange={onCh}
+        snapping={false}
+      />,
+    );
+    fireEvent.pointerDown(hit(container, 'g1'), { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'g1'), { pointerId: 1, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit(container, 'g1'), { pointerId: 1, clientX: 30, clientY: 20 });
+    // Selection landed on the whole group at pointer-down…
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['g1', 'g2'], primaryId: 'g1' });
+    // …and the drag translated every member as ONE updateMany.
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.updateMany',
+        updates: [
+          { id: 'g1', props: { left: 130, top: 120 } },
+          { id: 'g2', props: { left: 430, top: 120 } },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('EditableSlideCanvas — marquee + multi-drag integration', () => {
+  beforeEach(() => {
+    vi.mocked(useViewportSize).mockReturnValue({
+      viewportStyles: { left: 0, top: 0, width: 1000, height: 562 },
+      fitScale: 1,
+    });
+  });
+
+  /** Controlled host: routes onSelectionChange back into the selection prop. */
+  function ControlledCanvas({
+    slide,
+    onElementsChange,
+  }: {
+    slide: Slide;
+    onElementsChange: (intents: EditIntent[]) => void;
+  }) {
+    const [sel, setSel] = useState<Selection>({ elementIds: [] });
+    return (
+      <EditableSlideCanvas
+        slide={slide}
+        scale={1}
+        selection={sel}
+        onSelectionChange={setSel}
+        onElementsChange={onElementsChange}
+        snapping={false}
+      />
+    );
+  }
+
+  it('marquee-selects a line + a box, then dragging the box carries the line in the updateMany', () => {
+    const onCh = vi.fn();
+    const { container } = render(
+      <ControlledCanvas slide={makeSlide([textEl, lineEl])} onElementsChange={onCh} />,
+    );
+    // Marquee (50,50)→(700,500) contains both the box ([100,300]×[100,180])
+    // and the line's bounds ([400,480]×[300,340]).
+    const s = surface(container);
+    fireEvent.pointerDown(s, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(s, { pointerId: 1, clientX: 700, clientY: 500 });
+    fireEvent.pointerUp(s, { pointerId: 1, clientX: 700, clientY: 500 });
+
+    // Now drag the box: the whole marquee selection (box + line) translates.
+    fireEvent.pointerDown(hit(container, 'a'), { pointerId: 2, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(hit(container, 'a'), { pointerId: 2, clientX: 30, clientY: 20 });
+    fireEvent.pointerUp(hit(container, 'a'), { pointerId: 2, clientX: 30, clientY: 20 });
+
+    expect(onCh).toHaveBeenCalledTimes(1);
+    expect(onCh.mock.calls[0][0]).toEqual([
+      {
+        type: 'element.updateMany',
+        updates: [
+          { id: 'a', props: { left: 130, top: 120 } },
+          { id: 'line1', props: { left: 430, top: 320 } },
+        ],
+      },
     ]);
   });
 });

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.multiselect.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.multiselect.test.tsx
@@ -102,7 +102,7 @@ describe('EditableSlideCanvas — marquee', () => {
     });
   });
 
-  it('renders a blank-canvas capture surface only when the mount is EDITABLE (onElementsChange)', () => {
+  it('renders a blank-canvas capture surface with touch suppression when the mount is editable', () => {
     const { container } = render(
       <EditableSlideCanvas
         slide={makeSlide()}
@@ -112,13 +112,15 @@ describe('EditableSlideCanvas — marquee', () => {
         onElementsChange={vi.fn()}
       />,
     );
-    expect(surface(container)).not.toBeNull();
+    const s = surface(container);
+    expect(s).not.toBeNull();
+    expect(s.style.touchAction).toBe('none');
   });
 
-  it('a select-only mount renders NO capture surface (native touch pan preserved)', () => {
-    // The surface is a full-bleed `touchAction: 'none'` layer; a select-only/
-    // viewer-ish mount (no mutation channel) must not swallow touch scrolling.
-    // Element tap-select still works via the per-element hit targets.
+  it('a select-only mount renders a capture surface without disabling native touch pan', () => {
+    // Select-only hosts need blank clear and mouse/pen marquee, but should keep
+    // native touch scrolling because they have no mutation channel for a touch
+    // driven editing gesture.
     const { container } = render(
       <EditableSlideCanvas
         slide={makeSlide()}
@@ -127,9 +129,43 @@ describe('EditableSlideCanvas — marquee', () => {
         onSelectionChange={vi.fn()}
       />,
     );
-    expect(surface(container)).toBeNull();
+    const s = surface(container);
+    expect(s).not.toBeNull();
+    expect(s.style.touchAction).toBe('');
     // Element hit targets are still present for tap-select.
     expect(hit(container, 'a')).not.toBeNull();
+  });
+
+  it('a select-only mount can marquee-select and blank-clear through the capture surface', () => {
+    const onSel = vi.fn();
+    const { container, rerender } = render(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+      />,
+    );
+    let s = surface(container);
+    fireEvent.pointerDown(s, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(s, { pointerId: 1, clientX: 350, clientY: 250 });
+    fireEvent.pointerUp(s, { pointerId: 1, clientX: 350, clientY: 250 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenLastCalledWith({ elementIds: ['a'], primaryId: 'a' });
+
+    rerender(
+      <EditableSlideCanvas
+        slide={makeSlide()}
+        scale={1}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    s = surface(container);
+    fireEvent.pointerDown(s, { pointerId: 2, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(s, { pointerId: 2, clientX: 11, clientY: 11 });
+    expect(onSel).toHaveBeenCalledTimes(2);
+    expect(onSel).toHaveBeenLastCalledWith({ elementIds: [] });
   });
 
   it('a marquee past threshold REPLACES the selection with what it contains', () => {

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.test.tsx
@@ -39,6 +39,10 @@ function findHit(container: HTMLElement) {
   return container.querySelector('[data-element-id="a"]') as HTMLElement;
 }
 
+function findLineHit(container: HTMLElement) {
+  return container.querySelector('[data-hit-kind="line"]') as unknown as SVGPathElement;
+}
+
 describe('EditableSlideCanvas', () => {
   beforeEach(() => {
     // Default: no centering offset (matches jsdom's zero-size container), so
@@ -834,6 +838,88 @@ describe('EditableSlideCanvas', () => {
     expect(onSel).toHaveBeenCalledWith(
       expect.objectContaining({ elementIds: ['a'], primaryId: 'a' }),
     );
+  });
+
+  it('select-only host leaves box and line hit layers touch-pan friendly while preserving tap selection', () => {
+    // Touch suppression belongs to edit gestures, not selection. A select-only
+    // mount still exposes hit layers for tap-select, but native touch panning
+    // must survive when there is no mutation channel to commit a drag.
+    const onSel = vi.fn();
+    const lineSlide = {
+      ...slide,
+      elements: [
+        (slide as unknown as { elements: unknown[] }).elements[0],
+        {
+          id: 'line1',
+          type: 'line',
+          left: 10,
+          top: 10,
+          start: [0, 0],
+          end: [50, 50],
+          width: 2,
+          style: 'solid',
+          color: '#333',
+          points: ['', ''],
+        },
+      ],
+    } as unknown as Slide;
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={lineSlide}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+        snapping={false}
+      />,
+    );
+
+    const boxHit = findHit(container);
+    const lineHit = findLineHit(container);
+    expect(boxHit.style.touchAction).toBe('');
+    expect(lineHit.style.touchAction).toBe('');
+
+    fireEvent.pointerDown(boxHit, { clientX: 0, clientY: 0 });
+    expect(onSel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ elementIds: ['a'], primaryId: 'a' }),
+    );
+    fireEvent.pointerDown(lineHit, { clientX: 0, clientY: 0 });
+    expect(onSel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ elementIds: ['line1'], primaryId: 'line1' }),
+    );
+  });
+
+  it('editable host suppresses touch panning on box and line hit layers', () => {
+    const lineSlide = {
+      ...slide,
+      elements: [
+        (slide as unknown as { elements: unknown[] }).elements[0],
+        {
+          id: 'line1',
+          type: 'line',
+          left: 10,
+          top: 10,
+          start: [0, 0],
+          end: [50, 50],
+          width: 2,
+          style: 'solid',
+          color: '#333',
+          points: ['', ''],
+        },
+      ],
+    } as unknown as Slide;
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={lineSlide}
+        scale={1}
+        selection={{ elementIds: [] }}
+        onSelectionChange={vi.fn()}
+        onElementsChange={vi.fn()}
+        snapping={false}
+      />,
+    );
+
+    expect(findHit(container).style.touchAction).toBe('none');
+    expect(findLineHit(container).style.touchAction).toBe('none');
   });
 
   it('a drag emits exactly one element.update intent on pointer-up', () => {

--- a/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/EditableSlideCanvas.test.tsx
@@ -448,8 +448,8 @@ describe('EditableSlideCanvas', () => {
   });
 
   it('a pointer-down on a line selects it via onSelectionChange but emits no element.update (selectable, not draggable)', () => {
-    // Regression (reviewer, PR #859): lines regressed to unselectable — the
-    // blocker only stopped propagation. It must now select the line on
+    // Regression: lines regressed to unselectable because the blocker only
+    // stopped propagation. It must now select the line on
     // pointer-down (parity with box elements) while staying drag-inert: no
     // working copy, no move intent, ever.
     const onSel = vi.fn();
@@ -996,8 +996,8 @@ describe('EditableSlideCanvas', () => {
   });
 
   it('a locked element overlapping an unlocked one blocks the pointer instead of falling through', () => {
-    // Regression for cr-fix-4 (round-4 cross-review P2): a locked element
-    // used to be skipped entirely from the hit layer, so a pointer-down over
+    // Regression: a locked element used to be skipped entirely from the hit
+    // layer, so a pointer-down over
     // its (visually on-top) area fell through to whatever unlocked element's
     // hit target happened to occupy the same region underneath — moving/
     // selecting the WRONG element. The locked element now gets an inert

--- a/packages/@openmaic/renderer/test/editing/core/drag.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/drag.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { PPTElement } from '@openmaic/dsl';
-import { computeDragMove } from '../../../src/editing/core/drag';
-import { moveIntent } from '../../../src/editing/core/intent';
+import { computeDragMove, computeMultiDragMove } from '../../../src/editing/core/drag';
+import { moveIntent, moveManyIntent } from '../../../src/editing/core/intent';
 
 const el = (o: Partial<PPTElement> = {}) =>
   ({
@@ -83,5 +83,105 @@ describe('moveIntent', () => {
       id: 'a',
       props: { left: 130, top: 90 },
     });
+  });
+});
+
+describe('moveManyIntent', () => {
+  it('produces a single element.updateMany intent carrying every update', () => {
+    const updates = [
+      { id: 'a', props: { left: 10, top: 20 } },
+      { id: 'b', props: { left: 30, top: 40 } },
+    ];
+    expect(moveManyIntent(updates)).toEqual({ type: 'element.updateMany', updates });
+  });
+});
+
+describe('computeMultiDragMove', () => {
+  const a = () => el({ id: 'a', left: 100, top: 100, width: 50, height: 50 });
+  const b = () => el({ id: 'b', left: 300, top: 200, width: 50, height: 50 });
+
+  it('translates every selected element by the same delta (rigid, no snap)', () => {
+    const r = computeMultiDragMove({
+      handleElement: a(),
+      selected: [a(), b()],
+      others: [],
+      viewport: vp,
+      deltaCanvas: { x: 40, y: -15 },
+      snapping: false,
+    });
+    expect(r.updates).toEqual([
+      { id: 'a', props: { left: 140, top: 85 } },
+      { id: 'b', props: { left: 340, top: 185 } },
+    ]);
+    expect(r.guides).toHaveLength(0);
+  });
+
+  it('snaps the UNION bbox and applies the SAME correction to all (spacing preserved)', () => {
+    // Union of a+b shifted by +2 lands its left edge at 102; the canvas left
+    // edge (0) is out of range, but the element 'c' at left 148 provides a snap
+    // line the shifted union's right edge (352) is nowhere near — use a snap
+    // target that pulls the union's LEFT edge (a.left) onto c's left edge.
+    const c = el({ id: 'c', left: 104, top: 500, width: 10, height: 10 });
+    const r = computeMultiDragMove({
+      handleElement: a(),
+      selected: [a(), b()],
+      others: [c],
+      viewport: vp,
+      deltaCanvas: { x: 2, y: 0 },
+      snapping: { toElements: true, range: 5 },
+    });
+    // Shifted union minX = 102; snaps onto c.left 104 → +2 correction. BOTH
+    // elements move by the total (2 + 2 = 4), preserving their 200-unit spacing.
+    expect(r.updates[0].props.left).toBe(104);
+    expect(r.updates[1].props.left).toBe(304);
+    expect(r.updates[1].props.left - r.updates[0].props.left).toBe(200);
+  });
+
+  it('reduces to computeDragMove for a single selected element (parity)', () => {
+    const others = [b()];
+    const deltaCanvas = { x: 12, y: -7 };
+    const single = computeDragMove({
+      element: a(),
+      others,
+      viewport: vp,
+      deltaCanvas,
+      snapping: true,
+    });
+    const multi = computeMultiDragMove({
+      handleElement: a(),
+      selected: [a()],
+      others,
+      viewport: vp,
+      deltaCanvas,
+      snapping: true,
+    });
+    expect(multi.updates).toEqual([{ id: 'a', props: single.props }]);
+    expect(multi.guides).toEqual(single.guides);
+  });
+
+  it('carries a selected line along by the delta (unlike lone-line single drag)', () => {
+    const line = {
+      id: 'l',
+      type: 'line',
+      left: 10,
+      top: 20,
+      start: [0, 0],
+      end: [50, 50],
+      width: 2,
+      style: 'solid',
+      color: '#333',
+      points: ['', ''],
+    } as unknown as PPTElement;
+    const r = computeMultiDragMove({
+      handleElement: a(),
+      selected: [a(), line],
+      others: [],
+      viewport: vp,
+      deltaCanvas: { x: 5, y: 5 },
+      snapping: false,
+    });
+    // The line moves with the set (single-element computeDragMove leaves a lone
+    // line put; a multi-drag translates it).
+    expect(r.updates).toContainEqual({ id: 'l', props: { left: 15, top: 25 } });
   });
 });

--- a/packages/@openmaic/renderer/test/editing/core/drag.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/drag.test.ts
@@ -159,6 +159,18 @@ describe('computeMultiDragMove', () => {
     expect(multi.guides).toEqual(single.guides);
   });
 
+  it('returns a do-nothing result for an empty selection (no ±Infinity ranges)', () => {
+    const r = computeMultiDragMove({
+      handleElement: a(),
+      selected: [],
+      others: [b()],
+      viewport: vp,
+      deltaCanvas: { x: 10, y: 5 },
+      snapping: true,
+    });
+    expect(r).toEqual({ updates: [], guides: [] });
+  });
+
   it('carries a selected line along by the delta (unlike lone-line single drag)', () => {
     const line = {
       id: 'l',

--- a/packages/@openmaic/renderer/test/editing/core/drag.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/drag.test.ts
@@ -196,4 +196,34 @@ describe('computeMultiDragMove', () => {
     // line put; a multi-drag translates it).
     expect(r.updates).toContainEqual({ id: 'l', props: { left: 15, top: 25 } });
   });
+
+  it('uses a bent selected line range when snapping the multi-drag union bbox', () => {
+    const curveLine = {
+      id: 'curve',
+      type: 'line',
+      left: 300,
+      top: 100,
+      start: [0, 0],
+      end: [100, 0],
+      curve: [50, 80],
+      width: 2,
+      style: 'solid',
+      color: '#333',
+      points: ['', ''],
+    } as unknown as PPTElement;
+    const target = el({ id: 'target', left: 800, top: 181, width: 20, height: 20 });
+    const r = computeMultiDragMove({
+      handleElement: a(),
+      selected: [a(), curveLine],
+      others: [target],
+      viewport: vp,
+      deltaCanvas: { x: 0, y: 0 },
+      snapping: { toElements: true, range: 5 },
+    });
+    expect(r.updates).toEqual([
+      { id: 'a', props: { left: 100, top: 101 } },
+      { id: 'curve', props: { left: 300, top: 101 } },
+    ]);
+    expect(r.guides.some((g) => g.type === 'horizontal' && g.axis.y === 181)).toBe(true);
+  });
 });

--- a/packages/@openmaic/renderer/test/editing/core/geometry.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/geometry.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import type { PPTElement } from '@openmaic/dsl';
 import {
+  getEditingElementRange,
+  getEditingElementListRange,
   getElementRange,
   getElementListRange,
   uniqAlignLines,
@@ -46,10 +48,40 @@ describe('geometry', () => {
     // Derived from left/top + max(start,end): x ∈ [100, 220], y ∈ [50, 90]
     expect(r).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 90 });
   });
+  it('editing range includes a line curve control point beyond the chord', () => {
+    const line = {
+      id: 'curve',
+      type: 'line',
+      left: 100,
+      top: 50,
+      start: [0, 0],
+      end: [120, 0],
+      curve: [60, 80],
+    } as unknown as PPTElement;
+    expect(getElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 50 });
+    expect(getEditingElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 130 });
+  });
   it('list range is the union bbox', () => {
     expect(
       getElementListRange([box(), box({ id: 'b', left: 400, top: 0, width: 50, height: 50 })]),
     ).toEqual({ minX: 100, maxX: 450, minY: 0, maxY: 130 });
+  });
+  it('editing list range unions line control points with box ranges', () => {
+    const line = {
+      id: 'curve',
+      type: 'line',
+      left: 400,
+      top: 20,
+      start: [0, 0],
+      end: [60, 0],
+      curve: [30, 160],
+    } as unknown as PPTElement;
+    expect(getEditingElementListRange([box(), line])).toEqual({
+      minX: 100,
+      maxX: 460,
+      minY: 20,
+      maxY: 180,
+    });
   });
   it('uniqAlignLines dedups by value and merges ranges', () => {
     expect(

--- a/packages/@openmaic/renderer/test/editing/core/geometry.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { PPTElement } from '@openmaic/dsl';
+import type { PPTElement, PPTLineElement } from '@openmaic/dsl';
 import {
   getEditingElementRange,
   getEditingElementListRange,
@@ -9,6 +9,7 @@ import {
   uniqAlignLines,
   pxToCanvas,
 } from '../../../src/editing/core/geometry';
+import { getLineElementPath } from '../../../src/utils/element';
 
 const box = (over: Partial<PPTElement> = {}) =>
   ({
@@ -112,6 +113,20 @@ describe('geometry', () => {
       broken: [80, 140],
     } as unknown as PPTElement;
     expect(getVisualElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 190 });
+  });
+  it('visual range for broken2 follows the rendered orthogonal elbows', () => {
+    const line = {
+      id: 'broken2',
+      type: 'line',
+      left: 100,
+      top: 50,
+      start: [0, 0],
+      end: [120, 20],
+      broken2: [80, 140],
+    } as unknown as PPTLineElement;
+
+    expect(getLineElementPath(line)).toBe('M0,0 L80,0 L80,20 120,20');
+    expect(getVisualElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 70 });
   });
   it('visual range for non-line elements delegates to the shared element range', () => {
     const element = box({ rotate: 15 });

--- a/packages/@openmaic/renderer/test/editing/core/geometry.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/geometry.test.ts
@@ -5,6 +5,7 @@ import {
   getEditingElementListRange,
   getElementRange,
   getElementListRange,
+  getVisualElementRange,
   uniqAlignLines,
   pxToCanvas,
 } from '../../../src/editing/core/geometry';
@@ -60,6 +61,61 @@ describe('geometry', () => {
     } as unknown as PPTElement;
     expect(getElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 50 });
     expect(getEditingElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 130 });
+  });
+  it('visual range for a quadratic curve uses the Bezier extremum, not the control hull', () => {
+    const line = {
+      id: 'curve',
+      type: 'line',
+      left: 100,
+      top: 50,
+      start: [0, 0],
+      end: [120, 20],
+      curve: [60, 80],
+    } as unknown as PPTElement;
+    const t = (0 - 80) / (0 - 2 * 80 + 20);
+    const expectedMaxY = 50 + 2 * (1 - t) * t * 80 + t * t * 20;
+
+    expect(getEditingElementRange(line).maxY).toBe(130);
+    const visual = getVisualElementRange(line);
+    expect(visual.minY).toBe(50);
+    expect(visual.maxY).toBeCloseTo(expectedMaxY, 5);
+    expect(visual.maxY).not.toBe(130);
+  });
+  it('visual range for a cubic curve includes both derivative roots per axis', () => {
+    const line = {
+      id: 'cubic',
+      type: 'line',
+      left: 10,
+      top: 20,
+      start: [0, 0],
+      end: [100, 0],
+      cubic: [
+        [0, 120],
+        [100, -60],
+      ],
+    } as unknown as PPTElement;
+
+    const visual = getVisualElementRange(line);
+    expect(visual.minY).toBeLessThan(20);
+    expect(visual.maxY).toBeGreaterThan(20);
+    expect(visual.maxY).toBeLessThan(140);
+    expect(visual.minY).toBeGreaterThan(-40);
+  });
+  it('visual range for a polyline includes its rendered elbow vertex', () => {
+    const line = {
+      id: 'broken',
+      type: 'line',
+      left: 100,
+      top: 50,
+      start: [0, 0],
+      end: [120, 20],
+      broken: [80, 140],
+    } as unknown as PPTElement;
+    expect(getVisualElementRange(line)).toEqual({ minX: 100, maxX: 220, minY: 50, maxY: 190 });
+  });
+  it('visual range for non-line elements delegates to the shared element range', () => {
+    const element = box({ rotate: 15 });
+    expect(getVisualElementRange(element)).toEqual(getElementRange(element));
   });
   it('list range is the union bbox', () => {
     expect(

--- a/packages/@openmaic/renderer/test/editing/core/marquee.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/marquee.test.ts
@@ -75,6 +75,54 @@ describe('computeMarqueeSelection — containment mode', () => {
   });
 });
 
+describe('computeMarqueeSelection — bent lines (control-point-aware bounds)', () => {
+  // A quadratic 'curve' line whose bend bows BELOW the start→end chord: the
+  // chord spans y=0 only, while the control point at y=80 pulls the rendered
+  // path down to y=40 at its apex. Chord-only bounds (getElementRange) would
+  // never see the bend.
+  const curveLine = {
+    id: 'l',
+    type: 'line',
+    left: 0,
+    top: 0,
+    start: [0, 0],
+    end: [100, 0],
+    curve: [50, 80],
+    width: 2,
+    style: 'solid',
+    color: '#333',
+    points: ['', ''],
+  } as unknown as PPTElement;
+
+  it('intersect: a marquee over the bend (entirely off the chord) selects the line', () => {
+    const overBend: MarqueeRect = { minX: 30, minY: 20, maxX: 70, maxY: 60 };
+    expect(computeMarqueeSelection(overBend, [curveLine], { mode: 'intersect' })).toEqual(['l']);
+  });
+
+  it('contain: a chord-only rect does not contain the bent line; room for the control-point box does', () => {
+    // Covers the chord but not the bend: the conservative box (down to the
+    // control point at y=80) demands more room than the rendered stroke, so
+    // contain rejects — never a false positive that splits from the visual.
+    const chordOnly: MarqueeRect = { minX: -10, minY: -10, maxX: 110, maxY: 10 };
+    expect(computeMarqueeSelection(chordOnly, [curveLine], { mode: 'contain' })).toEqual([]);
+    // A rect spanning the full conservative box contains it.
+    const roomy: MarqueeRect = { minX: -10, minY: -10, maxX: 110, maxY: 90 };
+    expect(computeMarqueeSelection(roomy, [curveLine], { mode: 'contain' })).toEqual(['l']);
+  });
+
+  it('intersect: a broken (polyline) line is hit at its elbow, off the chord', () => {
+    const brokenLine = {
+      ...(curveLine as unknown as Record<string, unknown>),
+      id: 'bk',
+      curve: undefined,
+      broken: [50, 60],
+    } as unknown as PPTElement;
+    // The elbow vertex sits at (50,60); a box around it (chord is y=0) hits.
+    const overElbow: MarqueeRect = { minX: 40, minY: 40, maxX: 60, maxY: 70 };
+    expect(computeMarqueeSelection(overElbow, [brokenLine], { mode: 'intersect' })).toEqual(['bk']);
+  });
+});
+
 describe('computeMarqueeSelection — exclusions', () => {
   const rect: MarqueeRect = { minX: 0, minY: 0, maxX: 500, maxY: 500 };
 

--- a/packages/@openmaic/renderer/test/editing/core/marquee.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/marquee.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import type { PPTElement } from '@openmaic/dsl';
+import {
+  marqueeRect,
+  computeMarqueeSelection,
+  type MarqueeRect,
+} from '../../../src/editing/core/marquee';
+
+const box = (o: Partial<PPTElement> = {}) =>
+  ({
+    id: 'a',
+    type: 'text',
+    left: 100,
+    top: 100,
+    width: 100,
+    height: 60,
+    rotate: 0,
+    ...o,
+  }) as unknown as PPTElement;
+
+describe('marqueeRect — normalization', () => {
+  it('normalizes all four drag directions to the same min/max rect', () => {
+    const a = { x: 10, y: 20 };
+    const b = { x: 110, y: 220 };
+    const expected: MarqueeRect = { minX: 10, minY: 20, maxX: 110, maxY: 220 };
+    // top-left → bottom-right and every other diagonal collapse to one rect.
+    expect(marqueeRect(a, b)).toEqual(expected);
+    expect(marqueeRect(b, a)).toEqual(expected);
+    expect(marqueeRect({ x: 110, y: 20 }, { x: 10, y: 220 })).toEqual(expected);
+    expect(marqueeRect({ x: 10, y: 220 }, { x: 110, y: 20 })).toEqual(expected);
+  });
+});
+
+describe('computeMarqueeSelection — containment mode', () => {
+  const rect: MarqueeRect = { minX: 0, minY: 0, maxX: 500, maxY: 500 };
+
+  it('contain: selects only elements wholly inside the rect', () => {
+    const inside = box({ id: 'in', left: 100, top: 100, width: 100, height: 60 });
+    const straddling = box({ id: 'edge', left: 480, top: 100, width: 100, height: 60 });
+    expect(computeMarqueeSelection(rect, [inside, straddling], { mode: 'contain' })).toEqual([
+      'in',
+    ]);
+  });
+
+  it('intersect: selects any element that overlaps the rect at all', () => {
+    const inside = box({ id: 'in', left: 100, top: 100, width: 100, height: 60 });
+    const straddling = box({ id: 'edge', left: 480, top: 100, width: 100, height: 60 });
+    const outside = box({ id: 'out', left: 600, top: 600, width: 50, height: 50 });
+    expect(
+      computeMarqueeSelection(rect, [inside, straddling, outside], { mode: 'intersect' }),
+    ).toEqual(['in', 'edge']);
+  });
+
+  it('contain: a rotated element is tested by its rotation-aware AABB', () => {
+    // A 200x40 box rotated 90° about its center spans 40 wide × 200 tall. Placed
+    // so its un-rotated box would fit but its rotated bbox overflows the rect on
+    // the Y axis, contain must reject it while intersect keeps it.
+    const rotated = box({
+      id: 'rot',
+      left: 100,
+      top: 100,
+      width: 200,
+      height: 40,
+      rotate: 90,
+    });
+    const tight: MarqueeRect = { minX: 0, minY: 0, maxX: 400, maxY: 260 };
+    // Rotated bbox: center (200,120), 40 wide (180..220), 200 tall (20..220).
+    // maxY 220 <= 260 and minY 20 >= 0 → contained; widen check with a shorter rect.
+    expect(computeMarqueeSelection(tight, [rotated], { mode: 'contain' })).toEqual(['rot']);
+    const shallow: MarqueeRect = { minX: 0, minY: 0, maxX: 400, maxY: 150 };
+    // Now the rotated bbox (20..220 tall) overflows 150 → not contained,
+    // but it still overlaps → intersect keeps it.
+    expect(computeMarqueeSelection(shallow, [rotated], { mode: 'contain' })).toEqual([]);
+    expect(computeMarqueeSelection(shallow, [rotated], { mode: 'intersect' })).toEqual(['rot']);
+  });
+});
+
+describe('computeMarqueeSelection — exclusions', () => {
+  const rect: MarqueeRect = { minX: 0, minY: 0, maxX: 500, maxY: 500 };
+
+  it('never selects a locked element even when fully inside', () => {
+    const a = box({ id: 'a', left: 50, top: 50 });
+    const locked = box({ id: 'b', left: 200, top: 200, lock: true });
+    expect(computeMarqueeSelection(rect, [a, locked], { mode: 'contain' })).toEqual(['a']);
+  });
+
+  it('never selects an excludeIds member', () => {
+    const a = box({ id: 'a', left: 50, top: 50 });
+    const b = box({ id: 'b', left: 200, top: 200 });
+    expect(computeMarqueeSelection(rect, [a, b], { mode: 'contain', excludeIds: ['b'] })).toEqual([
+      'a',
+    ]);
+  });
+});
+
+describe('computeMarqueeSelection — group cohesion (all-or-nothing)', () => {
+  const g1 = box({ id: 'g1', left: 50, top: 50, groupId: 'G' });
+  const g2 = box({ id: 'g2', left: 200, top: 50, groupId: 'G' });
+  const solo = box({ id: 's', left: 50, top: 300 });
+
+  it('keeps a group only when EVERY member matched', () => {
+    // Rect covers both group members and the solo element → all kept.
+    const all: MarqueeRect = { minX: 0, minY: 0, maxX: 500, maxY: 500 };
+    expect(computeMarqueeSelection(all, [g1, g2, solo], { mode: 'contain' })).toEqual([
+      'g1',
+      'g2',
+      's',
+    ]);
+  });
+
+  it('drops partially-covered group members (never splits a group)', () => {
+    // Rect covers g1 + solo but NOT g2 (left 200..300 out of a 0..180 rect).
+    const partial: MarqueeRect = { minX: 0, minY: 0, maxX: 180, maxY: 500 };
+    // g1 matched but its group is incomplete → dropped; solo (no group) stays.
+    expect(computeMarqueeSelection(partial, [g1, g2, solo], { mode: 'contain' })).toEqual(['s']);
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/core/selection.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/selection.test.ts
@@ -191,4 +191,40 @@ describe('resolveClickSelection — group cohesion', () => {
     });
     expect(r.next).toBeNull();
   });
+
+  it('plain-click on a partially selected group member normalizes to the whole group', () => {
+    const r = resolveClickSelection({
+      element: g1,
+      elements,
+      selection: { elementIds: ['g1'], primaryId: 'g1' },
+      modifier: false,
+    });
+    expect(r.next).toEqual({ elementIds: ['g1', 'g2'], primaryId: 'g1' });
+    expect(r.armDrag).toBe(true);
+    expect(r.dragIds).toEqual(['g1', 'g2']);
+  });
+
+  it('plain-click on a partial group plus an ungrouped member normalizes both selection and drag ids', () => {
+    const r = resolveClickSelection({
+      element: g1,
+      elements,
+      selection: { elementIds: ['g1', 'a'], primaryId: 'g1' },
+      modifier: false,
+    });
+    expect(r.next).toEqual({ elementIds: ['g1', 'g2', 'a'], primaryId: 'g1' });
+    expect(r.armDrag).toBe(true);
+    expect(r.dragIds).toEqual(['g1', 'g2', 'a']);
+  });
+
+  it('plain-click on an already cohesive primary group member remains a no-op emit', () => {
+    const r = resolveClickSelection({
+      element: g1,
+      elements,
+      selection: { elementIds: ['g1', 'g2'], primaryId: 'g1' },
+      modifier: false,
+    });
+    expect(r.next).toBeNull();
+    expect(r.armDrag).toBe(true);
+    expect(r.dragIds).toEqual(['g1', 'g2']);
+  });
 });

--- a/packages/@openmaic/renderer/test/editing/core/selection.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/selection.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import type { PPTElement } from '@openmaic/dsl';
+import {
+  groupMemberIds,
+  isSelectionModifier,
+  resolveClickSelection,
+  uniqIds,
+} from '../../../src/editing/core/selection';
+
+const box = (o: Partial<PPTElement> = {}) =>
+  ({
+    id: 'a',
+    type: 'text',
+    left: 100,
+    top: 100,
+    width: 100,
+    height: 60,
+    rotate: 0,
+    ...o,
+  }) as unknown as PPTElement;
+
+const a = box({ id: 'a' });
+const b = box({ id: 'b', left: 300 });
+const c = box({ id: 'c', left: 500 });
+const g1 = box({ id: 'g1', left: 50, groupId: 'G' });
+const g2 = box({ id: 'g2', left: 200, groupId: 'G' });
+
+describe('isSelectionModifier / uniqIds', () => {
+  it('any of ctrl/shift/meta counts as a modifier', () => {
+    expect(isSelectionModifier({ ctrlKey: true, shiftKey: false, metaKey: false })).toBe(true);
+    expect(isSelectionModifier({ ctrlKey: false, shiftKey: true, metaKey: false })).toBe(true);
+    expect(isSelectionModifier({ ctrlKey: false, shiftKey: false, metaKey: true })).toBe(true);
+    expect(isSelectionModifier({ ctrlKey: false, shiftKey: false, metaKey: false })).toBe(false);
+  });
+
+  it('uniqIds dedups preserving first-seen order', () => {
+    expect(uniqIds(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('groupMemberIds', () => {
+  it('an ungrouped element is its own unit', () => {
+    expect(groupMemberIds(a, [a, b, g1, g2])).toEqual(['a']);
+  });
+
+  it('a grouped element expands to every member of its group, in element order', () => {
+    expect(groupMemberIds(g2, [a, g1, b, g2])).toEqual(['g1', 'g2']);
+  });
+});
+
+describe('resolveClickSelection — modifier table (ungrouped)', () => {
+  const elements = [a, b, c];
+
+  it('not selected + plain: selects only the element and arms a drag', () => {
+    const r = resolveClickSelection({
+      element: b,
+      elements,
+      selection: { elementIds: ['a'], primaryId: 'a' },
+      modifier: false,
+    });
+    expect(r.next).toEqual({ elementIds: ['b'], primaryId: 'b' });
+    expect(r.armDrag).toBe(true);
+    expect(r.dragIds).toEqual(['b']);
+  });
+
+  it('not selected + modifier: ADDS the element (uniq), no drag', () => {
+    const r = resolveClickSelection({
+      element: b,
+      elements,
+      selection: { elementIds: ['a'], primaryId: 'a' },
+      modifier: true,
+    });
+    expect(r.next).toEqual({ elementIds: ['a', 'b'], primaryId: 'b' });
+    expect(r.armDrag).toBe(false);
+  });
+
+  it('selected + modifier: REMOVES the element, no drag', () => {
+    const r = resolveClickSelection({
+      element: b,
+      elements,
+      selection: { elementIds: ['a', 'b'], primaryId: 'b' },
+      modifier: true,
+    });
+    expect(r.next).toEqual({ elementIds: ['a'], primaryId: 'a' });
+    expect(r.armDrag).toBe(false);
+  });
+
+  it('selected + modifier on the LAST element is a guarded no-op (never empties)', () => {
+    const r = resolveClickSelection({
+      element: a,
+      elements,
+      selection: { elementIds: ['a'], primaryId: 'a' },
+      modifier: true,
+    });
+    expect(r.next).toBeNull();
+    expect(r.armDrag).toBe(false);
+  });
+
+  it('selected + plain: keeps the whole selection, re-points primary, arms a multi drag', () => {
+    const r = resolveClickSelection({
+      element: b,
+      elements,
+      selection: { elementIds: ['a', 'b'], primaryId: 'a' },
+      modifier: false,
+    });
+    expect(r.next).toEqual({ elementIds: ['a', 'b'], primaryId: 'b' });
+    expect(r.armDrag).toBe(true);
+    expect(r.dragIds).toEqual(['a', 'b']);
+  });
+
+  it('selected + plain on the current primary emits nothing (no redundant re-emit)', () => {
+    const r = resolveClickSelection({
+      element: a,
+      elements,
+      selection: { elementIds: ['a', 'b'], primaryId: 'a' },
+      modifier: false,
+    });
+    expect(r.next).toBeNull();
+    expect(r.armDrag).toBe(true);
+    expect(r.dragIds).toEqual(['a', 'b']);
+  });
+});
+
+describe('resolveClickSelection — primary preservation on subtractive click', () => {
+  const elements = [a, b, c];
+
+  it('preserves the current primary when it SURVIVES the removal', () => {
+    const r = resolveClickSelection({
+      element: c,
+      elements,
+      selection: { elementIds: ['a', 'b', 'c'], primaryId: 'a' },
+      modifier: true,
+    });
+    expect(r.next).toEqual({ elementIds: ['a', 'b'], primaryId: 'a' });
+  });
+
+  it('reassigns primary (last remaining) only when the primary itself was removed', () => {
+    const r = resolveClickSelection({
+      element: a,
+      elements,
+      selection: { elementIds: ['a', 'b', 'c'], primaryId: 'a' },
+      modifier: true,
+    });
+    expect(r.next).toEqual({ elementIds: ['b', 'c'], primaryId: 'c' });
+  });
+});
+
+describe('resolveClickSelection — group cohesion', () => {
+  const elements = [a, g1, g2, b];
+
+  it('plain-click on a grouped element selects ALL members (primary = clicked)', () => {
+    const r = resolveClickSelection({
+      element: g2,
+      elements,
+      selection: { elementIds: [] },
+      modifier: false,
+    });
+    expect(r.next).toEqual({ elementIds: ['g1', 'g2'], primaryId: 'g2' });
+    expect(r.armDrag).toBe(true);
+    // The armed drag translates the whole group.
+    expect(r.dragIds).toEqual(['g1', 'g2']);
+  });
+
+  it('modifier-add on a grouped element adds the whole group (uniq)', () => {
+    const r = resolveClickSelection({
+      element: g1,
+      elements,
+      selection: { elementIds: ['a'], primaryId: 'a' },
+      modifier: true,
+    });
+    expect(r.next).toEqual({ elementIds: ['a', 'g1', 'g2'], primaryId: 'g1' });
+    expect(r.armDrag).toBe(false);
+  });
+
+  it('modifier-remove on a grouped element removes the whole group', () => {
+    const r = resolveClickSelection({
+      element: g1,
+      elements,
+      selection: { elementIds: ['a', 'g1', 'g2'], primaryId: 'a' },
+      modifier: true,
+    });
+    expect(r.next).toEqual({ elementIds: ['a'], primaryId: 'a' });
+  });
+
+  it('modifier-remove of a group that IS the whole selection is a guarded no-op', () => {
+    const r = resolveClickSelection({
+      element: g2,
+      elements,
+      selection: { elementIds: ['g1', 'g2'], primaryId: 'g1' },
+      modifier: true,
+    });
+    expect(r.next).toBeNull();
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/core/snapping.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/snapping.test.ts
@@ -18,24 +18,64 @@ describe('snapping', () => {
     });
     expect(vertical.map((l) => l.value)).toEqual(expect.arrayContaining([100, 200, 300])); // left,center,right
   });
-  it('builds candidate lines from a bent line editing range, not just its chord', () => {
+  it('builds candidate lines from a curve visual range, not the control hull', () => {
     const curveLine = {
       id: 'line',
       type: 'line',
       left: 100,
       top: 50,
       start: [0, 0],
-      end: [120, 0],
+      end: [120, 20],
       curve: [60, 80],
       width: 2,
       style: 'solid',
       color: '#333',
       points: ['', ''],
     } as unknown as PPTElement;
+    const t = (0 - 80) / (0 - 2 * 80 + 20);
+    const expectedMaxY = 50 + 2 * (1 - t) * t * 80 + t * t * 20;
+
     const { horizontal } = buildAlignLines([curveLine], vp, {
       toElements: true,
       toCanvas: false,
     });
+    expect(horizontal.map((l) => l.value)).toContain(50);
+    expect(horizontal.find((l) => Math.abs(l.value - expectedMaxY) < 1e-9)?.value).toBeCloseTo(
+      expectedMaxY,
+      5,
+    );
+    expect(horizontal.some((l) => l.value === 130)).toBe(false);
+  });
+  it('builds candidate lines from polyline elbow vertices', () => {
+    const brokenLine = {
+      id: 'line',
+      type: 'line',
+      left: 100,
+      top: 50,
+      start: [0, 0],
+      end: [120, 20],
+      broken: [80, 140],
+      width: 2,
+      style: 'solid',
+      color: '#333',
+      points: ['', ''],
+    } as unknown as PPTElement;
+    const { horizontal } = buildAlignLines([brokenLine], vp, {
+      toElements: true,
+      toCanvas: false,
+    });
+    expect(horizontal.map((l) => l.value)).toEqual(expect.arrayContaining([50, 120, 190]));
+  });
+  it('builds candidate lines for non-line elements unchanged', () => {
+    const { vertical, horizontal } = buildAlignLines(
+      [el({ left: 100, top: 50, width: 200, height: 80 })],
+      vp,
+      {
+        toElements: true,
+        toCanvas: false,
+      },
+    );
+    expect(vertical.map((l) => l.value)).toEqual(expect.arrayContaining([100, 200, 300]));
     expect(horizontal.map((l) => l.value)).toEqual(expect.arrayContaining([50, 90, 130]));
   });
   it('snaps a target within range and reports a guide', () => {

--- a/packages/@openmaic/renderer/test/editing/core/snapping.test.ts
+++ b/packages/@openmaic/renderer/test/editing/core/snapping.test.ts
@@ -18,6 +18,26 @@ describe('snapping', () => {
     });
     expect(vertical.map((l) => l.value)).toEqual(expect.arrayContaining([100, 200, 300])); // left,center,right
   });
+  it('builds candidate lines from a bent line editing range, not just its chord', () => {
+    const curveLine = {
+      id: 'line',
+      type: 'line',
+      left: 100,
+      top: 50,
+      start: [0, 0],
+      end: [120, 0],
+      curve: [60, 80],
+      width: 2,
+      style: 'solid',
+      color: '#333',
+      points: ['', ''],
+    } as unknown as PPTElement;
+    const { horizontal } = buildAlignLines([curveLine], vp, {
+      toElements: true,
+      toCanvas: false,
+    });
+    expect(horizontal.map((l) => l.value)).toEqual(expect.arrayContaining([50, 90, 130]));
+  });
   it('snaps a target within range and reports a guide', () => {
     const lines = buildAlignLines([], vp, { toCanvas: true });
     const target = { minX: 3, maxX: 203, minY: 100, maxY: 180 }; // left edge 3px from x=0

--- a/packages/@openmaic/renderer/test/editing/handles/MarqueeBox.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/handles/MarqueeBox.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MarqueeBox } from '../../../src/editing/handles/MarqueeBox';
+
+describe('MarqueeBox', () => {
+  it('positions and sizes the dashed rect from the canvas-unit rect × scale + offset', () => {
+    const { container } = render(
+      <MarqueeBox
+        rect={{ minX: 100, minY: 50, maxX: 300, maxY: 250 }}
+        viewportStyles={{ left: 160, top: 40, width: 1000, height: 562 }}
+        canvasScale={0.5}
+      />,
+    );
+    const box = container.querySelector('[data-marquee-box]') as HTMLElement;
+    expect(box).not.toBeNull();
+    // left = 160 + 100*0.5 = 210; top = 40 + 50*0.5 = 65.
+    expect(box.style.left).toBe('210px');
+    expect(box.style.top).toBe('65px');
+    // width = (300-100)*0.5 = 100; height = (250-50)*0.5 = 100.
+    expect(box.style.width).toBe('100px');
+    expect(box.style.height).toBe('100px');
+  });
+
+  it('is purely visual (never hit-tests)', () => {
+    const { container } = render(
+      <MarqueeBox
+        rect={{ minX: 0, minY: 0, maxX: 10, maxY: 10 }}
+        viewportStyles={{ left: 0, top: 0, width: 1000, height: 562 }}
+        canvasScale={1}
+      />,
+    );
+    const box = container.querySelector('[data-marquee-box]') as HTMLElement;
+    expect(box.style.pointerEvents).toBe('none');
+  });
+});

--- a/packages/@openmaic/renderer/test/editing/useMarqueeGesture.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/useMarqueeGesture.test.tsx
@@ -214,6 +214,62 @@ describe('useMarqueeGesture', () => {
     expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
   });
 
+  it('a non-main-button press neither arms a marquee nor clears the selection', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    // Secondary (right) button: pointer-down must not arm, so the matching
+    // pointer-up is not a blank click and the selection survives.
+    fireEvent.pointerDown(surface, { pointerId: 1, button: 2, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(surface, { pointerId: 1, button: 2, clientX: 10, clientY: 10 });
+    expect(onSel).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="live-rect"]')).toBeNull();
+    // The hook stayed unarmed: a fresh MAIN-button marquee still works.
+    fireEvent.pointerDown(surface, { pointerId: 2, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(surface, { pointerId: 2, clientX: 250, clientY: 250 });
+    fireEvent.pointerUp(surface, { pointerId: 2, clientX: 250, clientY: 250 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+  });
+
+  it('release decisions read the LIVE selection, not the pointer-down closure', () => {
+    const onSel = vi.fn();
+    const { container, rerender } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 10, clientY: 10 });
+    // The host updates the controlled selection mid-gesture (e.g. programmatic
+    // select). The blank-click decision on release must see this live value.
+    rerender(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 11, clientY: 11 });
+    // Sub-threshold blank click over a now-NON-empty selection must clear it;
+    // the stale pointer-down-time empty selection would have skipped the emit.
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: [] });
+  });
+
   it('drops window move/up from a foreign pointerId', () => {
     const onSel = vi.fn();
     const { container } = render(

--- a/packages/@openmaic/renderer/test/editing/useMarqueeGesture.test.tsx
+++ b/packages/@openmaic/renderer/test/editing/useMarqueeGesture.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useRef } from 'react';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import type { Slide } from '@openmaic/dsl';
+import { useMarqueeGesture, type UseMarqueeGestureArgs } from '../../src/editing/useMarqueeGesture';
+
+const elA = {
+  id: 'a',
+  type: 'text',
+  left: 100,
+  top: 100,
+  width: 100,
+  height: 60,
+  rotate: 0,
+  content: 'x',
+  defaultFontName: 'f',
+  defaultColor: '#000',
+  lineHeight: 1,
+};
+const elB = {
+  id: 'b',
+  type: 'image',
+  left: 300,
+  top: 300,
+  width: 50,
+  height: 50,
+  rotate: 0,
+  fixedRatio: false,
+  src: 'x.png',
+};
+
+function makeSlide(elements: unknown[] = [elA, elB]): Slide {
+  return {
+    id: 's',
+    viewportSize: 1000,
+    viewportRatio: 0.5625,
+    elements,
+  } as unknown as Slide;
+}
+
+type HarnessArgs = Omit<UseMarqueeGestureArgs, 'overlayRef'>;
+
+/**
+ * Mirrors EditableSlideCanvas's overlay: a container ref plus a capture surface
+ * wired to `onCanvasPointerDown`. jsdom reports a zero-origin bounding rect, so
+ * with `viewportStyles` at 0 the client coordinates map 1:1 to canvas units.
+ */
+function Harness(args: HarnessArgs) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const { marqueeRect, onCanvasPointerDown } = useMarqueeGesture({ ...args, overlayRef });
+  return (
+    <div ref={overlayRef} style={{ position: 'relative' }}>
+      <div data-testid="surface" onPointerDown={onCanvasPointerDown} />
+      {marqueeRect && (
+        <div data-testid="live-rect" data-min-x={marqueeRect.minX} data-max-x={marqueeRect.maxX} />
+      )}
+    </div>
+  );
+}
+
+const vp = { left: 0, top: 0, width: 1000, height: 562 };
+
+describe('useMarqueeGesture', () => {
+  it('a marquee past threshold REPLACES the selection (contain)', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: ['b'], primaryId: 'b' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    // Box (0,0)→(250,250) wholly contains 'a' ([100,200]×[100,160]); 'b' is out.
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 250, clientY: 250 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 250, clientY: 250 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+  });
+
+  it('a modifier marquee uses intersection (Ctrl keeps a straddled element)', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    // Box (0,0)→(150,150) only OVERLAPS 'a' (maxX 200 > 150): contain rejects,
+    // intersect keeps. Ctrl at release selects intersect mode.
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 150, clientY: 150 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 150, clientY: 150, ctrlKey: true });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+  });
+
+  it('the same box with NO modifier (contain) selects nothing and clears', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: ['b'], primaryId: 'b' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 150, clientY: 150 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 150, clientY: 150 });
+    // Contain covers nothing → clears the previous selection.
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: [] });
+  });
+
+  it('a sub-threshold blank click clears a non-empty selection', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: ['a'], primaryId: 'a' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 12, clientY: 12 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 12, clientY: 12 });
+    // Below the 5-unit both-axes threshold → blank click → clear.
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: [] });
+  });
+
+  it('a sub-threshold blank click on an already-empty selection emits nothing', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 11, clientY: 11 });
+    // Idempotent: already empty → no redundant selection change.
+    expect(onSel).not.toHaveBeenCalled();
+  });
+
+  it('shows the live rect only once past the both-axes threshold', () => {
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: [] }}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 0, clientY: 0 });
+    // Sub-threshold move: no box yet.
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 3, clientY: 3 });
+    expect(container.querySelector('[data-testid="live-rect"]')).toBeNull();
+    // Past threshold on both axes: the box appears, normalized.
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 40, clientY: 30 });
+    const rect = container.querySelector('[data-testid="live-rect"]') as HTMLElement;
+    expect(rect).not.toBeNull();
+    expect(rect.getAttribute('data-min-x')).toBe('0');
+    expect(rect.getAttribute('data-max-x')).toBe('40');
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 40, clientY: 30 });
+    // Cleared after release.
+    expect(container.querySelector('[data-testid="live-rect"]')).toBeNull();
+  });
+
+  it('pointercancel reverts without emitting and leaves the hook ready', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: ['b'], primaryId: 'b' }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 250, clientY: 250 });
+    fireEvent.pointerCancel(surface, { pointerId: 1, clientX: 250, clientY: 250 });
+    // Cancelled: live box gone, no selection change.
+    expect(container.querySelector('[data-testid="live-rect"]')).toBeNull();
+    expect(onSel).not.toHaveBeenCalled();
+    // Ready again: a fresh marquee still fires.
+    fireEvent.pointerDown(surface, { pointerId: 2, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(surface, { pointerId: 2, clientX: 250, clientY: 250 });
+    fireEvent.pointerUp(surface, { pointerId: 2, clientX: 250, clientY: 250 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+    expect(onSel).toHaveBeenCalledWith({ elementIds: ['a'], primaryId: 'a' });
+  });
+
+  it('drops window move/up from a foreign pointerId', () => {
+    const onSel = vi.fn();
+    const { container } = render(
+      <Harness
+        slide={makeSlide()}
+        scale={1}
+        viewportStyles={vp}
+        selection={{ elementIds: [] }}
+        onSelectionChange={onSel}
+      />,
+    );
+    const surface = container.querySelector('[data-testid="surface"]') as HTMLElement;
+    fireEvent.pointerDown(surface, { pointerId: 1, clientX: 0, clientY: 0 });
+    // A second pointer's move/up must not drive or end the gesture.
+    fireEvent.pointerMove(surface, { pointerId: 9, clientX: 250, clientY: 250 });
+    fireEvent.pointerUp(surface, { pointerId: 9, clientX: 250, clientY: 250 });
+    expect(onSel).not.toHaveBeenCalled();
+    // The active pointer still completes it.
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 250, clientY: 250 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 250, clientY: 250 });
+    expect(onSel).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Continues #851 Part A after #859 (selection + drag) and #881 (resize + rotate): the multi-select half of the Part A selection model. Merges inert — nothing in the app imports `@openmaic/renderer/editing` yet.

## What

- **Marquee (rubber-band) selection** — `core/marquee.ts` normalizes the start/current pointer pair into one min/max rect (collapsing the reference implementation's four quadrant branches into a single `contain`/`intersect` predicate pair), hit-tests rotation-aware AABBs, excludes locked elements, and applies all-or-nothing group cohesion. Lines are tested against an AABB that includes their `broken`/`curve`/`cubic` control points — a bent line's visible path can bow outside its start/end chord (conservative, by the Bézier convex-hull argument). No modifier → full containment; Ctrl/Shift/Meta → intersection (reference parity).
- **Blank-canvas capture surface + `MarqueeBox` chrome + `useMarqueeGesture`** — previously a blank click did nothing at all; now sub-threshold (5 canvas units, both axes) clears the selection and a past-threshold drag replaces it. Editable mounts only (select-only mounts keep native touch panning), main button only, cancel-safe (clear-on-up), and release decisions read the live selection rather than the pointer-down closure.
- **Click modifier table, one resolver for boxes AND lines** — `core/selection.ts`: outside the selection a plain click selects (a grouped element expands to its whole group), a modifier click adds; inside, a modifier click removes (guarded against emptying; whole group as the unit; `primaryId` preserved when it survives), and a plain pointer-down keeps the selection, sets the primary, and arms a multi-drag.
- **Multi-element drag** — `computeMultiDragMove`: rigid translation of the selected set; snapping computed on the union bounding box with the corrected delta applied to every member; selected elements excluded from snap candidates; locked members never move; lines are carried by their `left`/`top`. Shift held mid-drag engages the dominant-axis lock (shift at pointer-down remains a selection modifier). Commit emits ONE `element.updateMany` intent — the batch member of the `EditIntent` union, previously declared but unused — so a multi-drag is one host undo entry; single-element drags keep emitting `element.update`.
- Multi-selections still show no resize/rotate handles (group scaling is a later slice; the #881 gate is re-asserted in tests).

## Review

Cross-model review before pushing (Codex `exec review` high effort + an independent red-team pass over the selection-transition matrix, event layering, multi-drag geometry, and gesture protocol): no P1. All actionable findings were fixed in the second commit — the consensus one (locked elements translated when a host-controlled selection contains them), the curved-line marquee miss, lines bypassing the modifier table, group cohesion holding only at the marquee entry point, the touch-panning regression from a full-bleed capture surface, a right-click clearing the selection, the stale-closure release path, and the dead axis-lock plumbing. A second Codex pass over the full diff reports clean. Known deferral (documented in code): the single-pointer guarantee is per-hook; cross-hook pointer arbitration rides the existing multi-touch caveat.

## Tests & boundary

203 tests across the editing subpath (+69 in this PR); package build emits `dist/editing`; `tsc` clean; respects the #853 import boundary.

Part of #851 (Part A) / #720 Phase 3.
