### PR TITLE
test(store): drain debounced saves before environment teardown

### DIFF
--- a/tests/store/stage-agents.test.ts
+++ b/tests/store/stage-agents.test.ts
@@ -42,6 +42,7 @@ function makeAgentConfig(id: string): GeneratedAgentConfig {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
   useStageStore.setState({
     stage: makeStage(),
     scenes: [],
@@ -49,8 +50,14 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  useStageStore.getState().clearStore();
+afterEach(async () => {
+  try {
+    await vi.runOnlyPendingTimersAsync();
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    useStageStore.getState().clearStore();
+    vi.useRealTimers();
+  }
 });
 
 describe('setStageAgents', () => {
@@ -89,13 +96,8 @@ describe('setStageAgents', () => {
 
 describe('setStageAgents persistence (debounced save)', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.mocked(saveStageData).mockClear();
     vi.mocked(saveGeneratedAgents).mockClear();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it('includes generatedAgentConfigs in saveStageData after debounce', async () => {

--- a/tests/store/stage-generation-complete.test.ts
+++ b/tests/store/stage-generation-complete.test.ts
@@ -71,8 +71,18 @@ beforeEach(() => {
   loadStageDataMock.mockReset();
 });
 
-afterEach(() => {
-  useStageStore.getState().clearStore();
+afterEach(async () => {
+  try {
+    if (vi.isFakeTimers()) {
+      await vi.runOnlyPendingTimersAsync();
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  } finally {
+    if (vi.isFakeTimers()) {
+      vi.useRealTimers();
+    }
+    useStageStore.getState().clearStore();
+  }
 });
 
 describe('generationComplete', () => {
@@ -126,6 +136,7 @@ describe('generationComplete', () => {
   });
 
   it('starting a new stage resets generationComplete to false', () => {
+    vi.useFakeTimers();
     useStageStore.setState({ generationComplete: true });
     useStageStore.getState().setStage(makeStage());
     expect(useStageStore.getState().generationComplete).toBe(false);
@@ -136,6 +147,10 @@ describe('generationComplete', () => {
     // flag existed, or edited without a reload so self-heal never ran) must
     // record completion when a slide is deleted — otherwise the count breaks
     // and the "Course complete" end page disappears.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
     it('marks complete when deleting from a fully-materialized deck whose flag was unset', () => {
       useStageStore.setState({
         stage: makeStage(),

--- a/tests/store/stage-insert-scene-after.test.ts
+++ b/tests/store/stage-insert-scene-after.test.ts
@@ -49,6 +49,7 @@ function makeSlideScene(id: string, order: number, stageId = 'stage-1'): Scene {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
   useStageStore.setState({
     stage: makeStage(),
     scenes: [makeSlideScene('a', 1), makeSlideScene('b', 2), makeSlideScene('c', 3)],
@@ -56,8 +57,14 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  useStageStore.getState().clearStore();
+afterEach(async () => {
+  try {
+    await vi.runOnlyPendingTimersAsync();
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    useStageStore.getState().clearStore();
+    vi.useRealTimers();
+  }
 });
 
 describe('insertSceneAfter', () => {


### PR DESCRIPTION
Split out of #893 per review feedback (keeping that PR focused on the PBL runtime outbox).

`setStageAgents` schedules `debouncedSave` + `debouncedSaveAgents`; store tests that finished without flushing left those timers firing after vitest tore the environment down, lazily importing the settings/providers chain into a dead runtime (`EnvironmentTeardownError`). Latent on main today, it becomes deterministically red for any branch that grows `lib/utils/stage-storage.ts`'s import graph — #893 trips it on every CI run, which is why these fixes exist and why #893 depends on this landing first.

The three store suites now run fake timers, drain pending debounced saves in `afterEach`, and assert zero pending timers at teardown; the same latent race in the insert-scene-after and generation-complete suites is fixed in the same style.

Tests: the three suites pass 5x consecutively; full root suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)