### PR TITLE
test(store): settle dynamic imports before environment teardown

### DIFF
--- a/tests/store/stage-agents.test.ts
+++ b/tests/store/stage-agents.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { setSelectedAgentIds } = vi.hoisted(() => ({
+  setSelectedAgentIds: vi.fn(),
+}));
+
 // IndexedDB / stage-storage modules are imported dynamically inside the
 // store's save/load actions. Mock them so the debounced save doesn't try
 // to talk to a real (or jsdom) IndexedDB in the test environment.
@@ -12,6 +16,11 @@ vi.mock('@/lib/utils/database', () => ({
 }));
 vi.mock('@/lib/orchestration/registry/store', () => ({
   saveGeneratedAgents: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/lib/store/settings', () => ({
+  useSettingsStore: {
+    getState: () => ({ setSelectedAgentIds }),
+  },
 }));
 
 import { useStageStore } from '@/lib/store/stage';
@@ -53,6 +62,7 @@ beforeEach(() => {
 afterEach(async () => {
   try {
     await vi.runOnlyPendingTimersAsync();
+    await vi.dynamicImportSettled();
     expect(vi.getTimerCount()).toBe(0);
   } finally {
     useStageStore.getState().clearStore();
@@ -98,6 +108,7 @@ describe('setStageAgents persistence (debounced save)', () => {
   beforeEach(() => {
     vi.mocked(saveStageData).mockClear();
     vi.mocked(saveGeneratedAgents).mockClear();
+    setSelectedAgentIds.mockClear();
   });
 
   it('includes generatedAgentConfigs in saveStageData after debounce', async () => {


### PR DESCRIPTION
Follow-up to #897, same latent-race class, second escape hatch: draining fake timers is not enough when the drained callback is an **un-awaited async function** — its `await import('@/lib/store/settings')` can still land after vitest tears the environment down (the settings store lazily reaches the audio module chain, which is where the `EnvironmentTeardownError` points). Deterministically red on #893's CI after its latest main merge; latent everywhere else.

Fix (test-side, one file): the stage-agents suite now mocks the settings store and awaits `vi.dynamicImportSettled()` after draining timers, so no dynamic import escapes teardown.

Split out per the review convention established on #897; #893 is sequenced behind this landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)