### PR TITLE
fix(home): clarify Interactive Mode selected state

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,6 +60,7 @@ import { SpeechButton } from '@/components/audio/speech-button';
 import { useImportClassroom } from '@/lib/import/use-import-classroom';
 import { shouldShowVocationalTestUi } from '@/lib/config/feature-flags';
 import { useImportPptx } from '@/lib/import/use-import-pptx';
+import { InteractiveModeButton } from '@/components/generation/interactive-mode-button';
 
 const log = createLogger('Home');
 
@@ -577,28 +578,11 @@ function HomePage() {
               {/* Interactive mode toggle */}
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <motion.button
-                    whileTap={{ scale: 0.95 }}
-                    transition={{ type: 'spring', stiffness: 400, damping: 17 }}
-                    onClick={() => updateForm('interactiveMode', !form.interactiveMode)}
-                    className={cn(
-                      'relative inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all cursor-pointer select-none whitespace-nowrap border shrink-0 h-8',
-                      form.interactiveMode
-                        ? 'bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 border-cyan-500 shadow-[0_0_12px_rgba(6,182,212,0.35)] dark:shadow-[0_0_12px_rgba(6,182,212,0.25)]'
-                        : 'border-cyan-300/60 text-cyan-600 dark:text-cyan-400 hover:bg-cyan-50 dark:hover:bg-cyan-900/20',
-                    )}
-                  >
-                    {form.interactiveMode && (
-                      <span
-                        className="absolute inset-[-4px] rounded-full border border-cyan-400/40 dark:border-cyan-400/25"
-                        style={{
-                          animation: 'interactive-mode-breathe 2s ease-in-out infinite',
-                        }}
-                      />
-                    )}
-                    <Atom className="size-3.5 relative z-10 animate-[spin_3s_linear_infinite]" />
-                    <span className="relative z-10">{t('toolbar.interactiveModeLabel')}</span>
-                  </motion.button>
+                  <InteractiveModeButton
+                    pressed={form.interactiveMode}
+                    label={t('toolbar.interactiveModeLabel')}
+                    onPressedChange={(pressed) => updateForm('interactiveMode', pressed)}
+                  />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="text-xs">
                   {t('toolbar.interactiveModeHint')}

--- a/components/generation/interactive-mode-button.tsx
+++ b/components/generation/interactive-mode-button.tsx
@@ -44,7 +44,7 @@ export const InteractiveModeButton = forwardRef<HTMLButtonElement, InteractiveMo
         {pressed && (
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute inset-[-4px] rounded-full border border-cyan-300/40 motion-reduce:animate-none dark:border-cyan-300/60 dark:animate-[interactive-mode-breathe_2s_ease-in-out_infinite]"
+            className="pointer-events-none absolute inset-[-4px] rounded-full border border-cyan-300/40 dark:border-cyan-300/60 motion-safe:dark:animate-[interactive-mode-breathe_2s_ease-in-out_infinite]"
           />
         )}
         {pressed ? (

--- a/components/generation/interactive-mode-button.tsx
+++ b/components/generation/interactive-mode-button.tsx
@@ -36,7 +36,7 @@ export const InteractiveModeButton = forwardRef<HTMLButtonElement, InteractiveMo
         className={cn(
           'relative inline-flex h-8 shrink-0 cursor-pointer select-none items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-all active:scale-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-700 motion-reduce:transition-none motion-reduce:active:scale-100 dark:focus-visible:outline-cyan-300',
           pressed
-            ? 'border-cyan-700 bg-cyan-500 text-slate-950 shadow-[0_0_16px_rgba(6,182,212,0.45)] dark:border-cyan-200 dark:bg-cyan-400 dark:shadow-[0_0_18px_rgba(34,211,238,0.45)]'
+            ? 'border-cyan-400 bg-cyan-100 text-cyan-900 shadow-sm shadow-cyan-200/60 dark:border-cyan-200 dark:bg-cyan-400 dark:text-slate-950 dark:shadow-[0_0_18px_rgba(34,211,238,0.45)]'
             : 'border-cyan-600 bg-transparent text-cyan-700 hover:bg-cyan-50 dark:border-cyan-700 dark:text-cyan-300 dark:hover:bg-cyan-950/50',
           className,
         )}
@@ -44,7 +44,7 @@ export const InteractiveModeButton = forwardRef<HTMLButtonElement, InteractiveMo
         {pressed && (
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute inset-[-4px] rounded-full border border-cyan-300/70 animate-[interactive-mode-breathe_2s_ease-in-out_infinite] motion-reduce:animate-none dark:border-cyan-300/60"
+            className="pointer-events-none absolute inset-[-4px] rounded-full border border-cyan-300/40 motion-reduce:animate-none dark:border-cyan-300/60 dark:animate-[interactive-mode-breathe_2s_ease-in-out_infinite]"
           />
         )}
         {pressed ? (

--- a/components/generation/interactive-mode-button.tsx
+++ b/components/generation/interactive-mode-button.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import { Atom, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type DataAttributes = {
+  [key: `data-${string}`]: string | number | boolean | undefined;
+};
+
+type InteractiveModeButtonProps = Omit<
+  ComponentPropsWithoutRef<'button'>,
+  'aria-pressed' | 'children'
+> &
+  DataAttributes & {
+    pressed: boolean;
+    label: string;
+    onPressedChange: (pressed: boolean) => void;
+  };
+
+export const InteractiveModeButton = forwardRef<HTMLButtonElement, InteractiveModeButtonProps>(
+  function InteractiveModeButton(
+    { pressed, label, onPressedChange, className, onClick, ...buttonProps },
+    ref,
+  ) {
+    return (
+      <button
+        {...buttonProps}
+        ref={ref}
+        type="button"
+        aria-pressed={pressed}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) onPressedChange(!pressed);
+        }}
+        className={cn(
+          'relative inline-flex h-8 shrink-0 cursor-pointer select-none items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-all active:scale-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-700 motion-reduce:transition-none motion-reduce:active:scale-100 dark:focus-visible:outline-cyan-300',
+          pressed
+            ? 'border-cyan-700 bg-cyan-500 text-slate-950 shadow-[0_0_16px_rgba(6,182,212,0.45)] dark:border-cyan-200 dark:bg-cyan-400 dark:shadow-[0_0_18px_rgba(34,211,238,0.45)]'
+            : 'border-cyan-600 bg-transparent text-cyan-700 hover:bg-cyan-50 dark:border-cyan-700 dark:text-cyan-300 dark:hover:bg-cyan-950/50',
+          className,
+        )}
+      >
+        {pressed && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-[-4px] rounded-full border border-cyan-300/70 animate-[interactive-mode-breathe_2s_ease-in-out_infinite] motion-reduce:animate-none dark:border-cyan-300/60"
+          />
+        )}
+        {pressed ? (
+          <Check aria-hidden="true" className="relative z-10 size-3.5" />
+        ) : (
+          <Atom aria-hidden="true" className="relative z-10 size-3.5" />
+        )}
+        <span className="relative z-10">{label}</span>
+      </button>
+    );
+  },
+);

--- a/tests/ui/interactive-mode-button.test.ts
+++ b/tests/ui/interactive-mode-button.test.ts
@@ -34,7 +34,8 @@ describe('InteractiveModeButton markup contract', () => {
     expect(html).toContain('border-cyan-600 bg-transparent text-cyan-700');
     expect(html).toContain('dark:border-cyan-700 dark:text-cyan-300');
     expect(html).toContain('lucide-atom');
-    expect(html).not.toContain('bg-cyan-500');
+    expect(html).not.toContain('bg-cyan-100');
+    expect(html).not.toContain('dark:bg-cyan-400');
   });
 
   it('forwards wrapper-injected attributes and classes to the DOM button', () => {

--- a/tests/ui/interactive-mode-button.test.ts
+++ b/tests/ui/interactive-mode-button.test.ts
@@ -1,0 +1,65 @@
+import { createElement, type ComponentProps } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { InteractiveModeButton } from '@/components/generation/interactive-mode-button';
+
+function renderButton(
+  pressed: boolean,
+  extraProps: Partial<ComponentProps<typeof InteractiveModeButton>> = {},
+) {
+  return renderToStaticMarkup(
+    createElement(InteractiveModeButton, {
+      pressed,
+      label: 'Interactive Mode',
+      onPressedChange: () => undefined,
+      ...extraProps,
+    }),
+  );
+}
+
+describe('InteractiveModeButton markup contract', () => {
+  it('emits explicit selected-state visual and semantic tokens', () => {
+    const html = renderButton(true);
+
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain('border-cyan-700 bg-cyan-500 text-slate-950');
+    expect(html).toContain('dark:border-cyan-200 dark:bg-cyan-400');
+    expect(html).toContain('lucide-check');
+  });
+
+  it('emits a distinct unselected-state token set', () => {
+    const html = renderButton(false);
+
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain('border-cyan-600 bg-transparent text-cyan-700');
+    expect(html).toContain('dark:border-cyan-700 dark:text-cyan-300');
+    expect(html).toContain('lucide-atom');
+    expect(html).not.toContain('bg-cyan-500');
+  });
+
+  it('forwards wrapper-injected attributes and classes to the DOM button', () => {
+    const html = renderButton(false, {
+      'aria-describedby': 'interactive-mode-hint',
+      'data-state': 'closed',
+      className: 'tooltip-trigger-class',
+      title: 'Interactive mode hint',
+    });
+
+    expect(html).toContain('aria-describedby="interactive-mode-hint"');
+    expect(html).toContain('data-state="closed"');
+    expect(html).toContain('tooltip-trigger-class');
+    expect(html).toContain('title="Interactive mode hint"');
+  });
+
+  it('retains reduced-motion override utilities for both animations', () => {
+    const selectedHtml = renderButton(true);
+    const unselectedHtml = renderButton(false);
+
+    expect(selectedHtml).toContain('interactive-mode-breathe');
+    expect(selectedHtml).toContain('motion-reduce:animate-none');
+    expect(unselectedHtml).toContain('active:scale-95');
+    expect(unselectedHtml).toContain('motion-reduce:active:scale-100');
+    expect(unselectedHtml).toContain('motion-reduce:transition-none');
+    expect(unselectedHtml).not.toContain('spin_3s_linear_infinite');
+  });
+});

--- a/tests/ui/interactive-mode-button.test.ts
+++ b/tests/ui/interactive-mode-button.test.ts
@@ -22,7 +22,7 @@ describe('InteractiveModeButton markup contract', () => {
     const html = renderButton(true);
 
     expect(html).toContain('aria-pressed="true"');
-    expect(html).toContain('border-cyan-700 bg-cyan-500 text-slate-950');
+    expect(html).toContain('border-cyan-400 bg-cyan-100 text-cyan-900');
     expect(html).toContain('dark:border-cyan-200 dark:bg-cyan-400');
     expect(html).toContain('lucide-check');
   });

--- a/tests/ui/interactive-mode-button.test.ts
+++ b/tests/ui/interactive-mode-button.test.ts
@@ -51,12 +51,14 @@ describe('InteractiveModeButton markup contract', () => {
     expect(html).toContain('title="Interactive mode hint"');
   });
 
-  it('retains reduced-motion override utilities for both animations', () => {
+  it('limits the dark breathing animation to motion-safe environments', () => {
     const selectedHtml = renderButton(true);
     const unselectedHtml = renderButton(false);
 
-    expect(selectedHtml).toContain('interactive-mode-breathe');
-    expect(selectedHtml).toContain('motion-reduce:animate-none');
+    expect(selectedHtml).toContain(
+      'motion-safe:dark:animate-[interactive-mode-breathe_2s_ease-in-out_infinite]',
+    );
+    expect(selectedHtml).not.toContain(' dark:animate-[interactive-mode-breathe');
     expect(unselectedHtml).toContain('active:scale-95');
     expect(unselectedHtml).toContain('motion-reduce:active:scale-100');
     expect(unselectedHtml).toContain('motion-reduce:transition-none');


### PR DESCRIPTION
## Summary

Make the home-page Interactive Mode toggle immediately distinguishable in both light and dark themes, including non-color state cues and accessible pressed-state semantics.

> AI-assisted: implemented with Codex and independently cross-reviewed by Claude and Codex before submission.

## Related Issues

Closes #898

## Changes

- Extract the toggle into a focused `InteractiveModeButton` component.
- Use a theme-aware selected state: a restrained light-cyan treatment in light mode, a high-contrast cyan fill in dark mode, a Check icon, and `aria-pressed`.
- Preserve Radix Tooltip `asChild` refs, attributes, and composed click behavior.
- Add keyboard focus outlines plus reduced-motion-safe press/breathing animations.
- Add markup contract tests for selected/unselected styles, wrapper prop forwarding, and reduced-motion utilities.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open the home page in dark mode.
2. Toggle Interactive Mode in the generation toolbar.
3. Confirm the selected state uses a filled cyan pill and Check icon, while the unselected state remains outlined with the Atom icon.
4. Tab to the control and confirm the focus outline and tooltip semantics remain present.

### What you personally verified

- `pnpm exec vitest run tests/ui/interactive-mode-button.test.ts` — 4/4 passed.
- `pnpm exec vitest run --testTimeout=30000` — 254 files / 2073 tests passed.
- `pnpm check` — passed.
- `pnpm lint` — no errors; only the repository's 15 existing warnings.
- `pnpm exec tsc --noEmit` — passed.
- `pnpm build` — passed on the latest `main` base.
- Cross-vendor CR loop completed: the reduced-motion specificity issue and stale test assertion were fixed; the final fresh Claude + Codex audit converged to zero actionable findings.
- Real-browser light- and dark-mode E2E passed: selected/unselected contrast, `aria-pressed`, Tab focus, Space activation, and tooltip behavior verified; browser console had 0 errors/warnings.
- The default 5-second timeout is too short locally for the pre-existing remote-image round-trip test; that test completes in about 10.5 seconds and passes with the 30-second timeout.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (not applicable)
- [x] My changes do not introduce new warnings
