### PR TITLE
fix(chat): preserve message line breaks in the chat panel

### DIFF
--- a/components/chat/chat-session.tsx
+++ b/components/chat/chat-session.tsx
@@ -116,7 +116,7 @@ const MessageBubble = memo(function MessageBubble({
             : 'bg-indigo-50 dark:bg-indigo-900/20 text-indigo-900 dark:text-indigo-200 border border-indigo-100/50 dark:border-indigo-800/50 rounded-tl-sm',
       )}
     >
-      <span className="break-words">
+      <span className="whitespace-pre-wrap break-words">
         {parts.map((part: MessagePart, i: number) => {
           if (part.type === 'text' || part.type === 'step-start') {
             const text = part.type === 'text' ? part.text : '';

--- a/tests/chat/chat-session-markup.test.ts
+++ b/tests/chat/chat-session-markup.test.ts
@@ -1,0 +1,40 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatSessionComponent } from '@/components/chat/chat-session';
+import type { ChatSession } from '@/lib/types/chat';
+
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+describe('ChatSessionComponent markup contract', () => {
+  it('preserves newlines in the shared message text wrapper', () => {
+    const session: ChatSession = {
+      id: 'session-1',
+      type: 'qa',
+      title: 'Q&A',
+      status: 'active',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'first line\nsecond line' }],
+          metadata: { originalRole: 'user', senderName: 'You' },
+        },
+      ],
+      config: { agentIds: ['default-1'] },
+      toolCalls: [],
+      pendingToolCalls: [],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(ChatSessionComponent, { session, isActive: false }),
+    );
+
+    expect(html).toContain('class="whitespace-pre-wrap break-words"');
+    expect(html).toContain('first line\nsecond line');
+  });
+});


### PR DESCRIPTION
Part of #906 

## What

User messages typed with Shift+Enter line breaks were rendered flattened onto one line in the classroom's right-side chat panel. The newlines survive the whole input/send/storage path and are only lost at render time: the `MessageBubble` text wrapper in `components/chat/chat-session.tsx` had `break-words` but no `whitespace-pre-wrap`, so HTML whitespace collapsing turned `\n` into a space.

- Add `whitespace-pre-wrap` to the shared text wrapper in `MessageBubble`, matching the on-stage roundtable bubble which already renders with `whitespace-pre-wrap break-words`.
- The rule applies to all text parts (user, teacher, agent), so intentional paragraph breaks in agent/teacher replies also render properly.
- Input, sending, storage, streaming, and action-tag behavior are unchanged.

## Verification

- New regression test `tests/chat/chat-session-markup.test.ts` renders a session containing newline text and asserts the wrapper keeps both `whitespace-pre-wrap` and `break-words` and that the newline survives in the markup. Passes.
- `pnpm tsc --noEmit` and `eslint` on the touched files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
