### PR TITLE
fix(roundtable): keep the non-presentation input panel inside its card

### DIFF
--- a/components/roundtable/index.tsx
+++ b/components/roundtable/index.tsx
@@ -93,6 +93,9 @@ interface RoundtableProps {
   readonly fullscreenContainerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
+// This must stay in sync with the non-presentation textarea's max-h-[100px] class.
+const NON_PRESENTATION_INPUT_MAX_HEIGHT_PX = 100;
+
 const VOICE_WAVE_BARS = [
   { peak: 18, duration: 0.55 },
   { peak: 24, duration: 0.72 },
@@ -191,11 +194,24 @@ export function Roundtable({
   const [isVoiceOpen, setIsVoiceOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [userMessage, setUserMessage] = useState<string | null>(null);
+  const nonPresentationInputRef = useRef<HTMLTextAreaElement>(null);
   const agentScrollRef = useRef<HTMLDivElement>(null);
   const bubbleScrollRef = useRef<HTMLDivElement>(null);
   const teacherAvatarRef = useRef<HTMLDivElement>(null);
   const studentAvatarRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const userMessageClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (isPresenting) return;
+    const textarea = nonPresentationInputRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = 'auto';
+    textarea.style.height = `${Math.min(
+      textarea.scrollHeight,
+      NON_PRESENTATION_INPUT_MAX_HEIGHT_PX,
+    )}px`;
+  }, [inputValue, isInputOpen, isPresenting]);
 
   // End flash visible state (Issue 3)
   const [endFlashVisible, setEndFlashVisible] = useState(false);
@@ -1225,6 +1241,7 @@ export function Roundtable({
           </AnimatePresence>
 
           <div
+            data-testid="roundtable-non-presentation-card"
             onClick={() => {
               if (isInputOpen || isVoiceOpen) {
                 setIsInputOpen(false);
@@ -1239,6 +1256,7 @@ export function Roundtable({
               {isInputOpen && (
                 <motion.div
                   key="input-stage"
+                  data-testid="roundtable-non-presentation-input-stage"
                   initial={{
                     opacity: 0,
                     scale: 0.95,
@@ -1250,9 +1268,13 @@ export function Roundtable({
                   onClick={(e) => e.stopPropagation()}
                   className="absolute inset-x-6 bottom-4 z-20 flex items-center justify-end"
                 >
-                  <div className="relative w-fit max-w-[85%] sm:max-w-[65%] min-w-[200px] sm:min-w-[300px] bg-white/90 dark:bg-gray-800/90 backdrop-blur-md p-2 pr-2 rounded-2xl rounded-br-none shadow-2xl border border-purple-200 dark:border-purple-700 flex items-end gap-2 ring-1 ring-purple-100/50 dark:ring-purple-800/50">
+                  <div
+                    data-testid="roundtable-non-presentation-input-panel"
+                    className="relative w-fit max-w-[85%] sm:max-w-[65%] min-w-[200px] sm:min-w-[300px] bg-white/90 dark:bg-gray-800/90 backdrop-blur-md p-2 pr-2 rounded-2xl rounded-br-none shadow-2xl border border-purple-200 dark:border-purple-700 flex items-end gap-2 ring-1 ring-purple-100/50 dark:ring-purple-800/50"
+                  >
                     <div className="pl-4 flex-1 py-1 min-w-0">
                       <textarea
+                        ref={nonPresentationInputRef}
                         value={inputValue}
                         onChange={(e) => setInputValue(e.target.value)}
                         onKeyDown={(e) => {
@@ -1264,8 +1286,7 @@ export function Roundtable({
                         placeholder={t('roundtable.inputPlaceholder')}
                         autoFocus
                         rows={1}
-                        className="w-full resize-none bg-transparent border-none focus:ring-0 focus:outline-none outline-none shadow-none ring-0 text-gray-700 dark:text-gray-200 text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500 min-h-[40px] max-h-[120px]"
-                        style={{ fieldSizing: 'content' } as Record<string, string>}
+                        className="w-full resize-none overflow-y-auto bg-transparent border-none focus:ring-0 focus:outline-none outline-none shadow-none ring-0 text-gray-700 dark:text-gray-200 text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500 min-h-[40px] max-h-[100px]"
                       />
                     </div>
                     <button

--- a/e2e/tests/classroom-interaction.spec.ts
+++ b/e2e/tests/classroom-interaction.spec.ts
@@ -162,6 +162,111 @@ test.describe('Classroom Interaction', () => {
     await expect(page.getByRole('heading', { name: '光反应' })).toBeVisible();
   });
 
+  test('caps and restores the non-presentation roundtable draft height', async ({ page }) => {
+    const classroom = new ClassroomPage(page);
+    await classroom.goto(TEST_STAGE_ID);
+    await classroom.waitForLoaded();
+
+    await page.keyboard.press('T');
+    const textarea = page.getByPlaceholder('Type your message...', { exact: true });
+    const inputStage = page.getByTestId('roundtable-non-presentation-input-stage');
+    await expect(textarea).toBeVisible();
+
+    const readMetrics = () =>
+      textarea.evaluate((element) => {
+        const computedStyle = getComputedStyle(element);
+        const containingPanel = element.closest<HTMLElement>(
+          '[data-testid="roundtable-non-presentation-input-panel"]',
+        );
+        if (!containingPanel) {
+          throw new Error('Could not find the non-presentation roundtable input panel');
+        }
+
+        const overflowHiddenCard = containingPanel.closest<HTMLElement>(
+          '[data-testid="roundtable-non-presentation-card"]',
+        );
+        if (!overflowHiddenCard) {
+          throw new Error('Could not find the roundtable overflow-hidden card');
+        }
+
+        const cardStyle = getComputedStyle(overflowHiddenCard);
+        if (
+          cardStyle.overflow !== 'hidden' ||
+          cardStyle.overflowX !== 'hidden' ||
+          cardStyle.overflowY !== 'hidden'
+        ) {
+          throw new Error('The roundtable clipping card must hide overflow');
+        }
+
+        const panelRect = containingPanel.getBoundingClientRect();
+        const cardRect = overflowHiddenCard.getBoundingClientRect();
+        return {
+          computedHeight: computedStyle.height,
+          computedMaxHeight: computedStyle.maxHeight,
+          computedOverflowY: computedStyle.overflowY,
+          computedFieldSizing: computedStyle.getPropertyValue('field-sizing'),
+          inlineHeight: element.style.height,
+          inlineFieldSizing: element.style.getPropertyValue('field-sizing'),
+          boundingRectHeight: element.getBoundingClientRect().height,
+          clientHeight: element.clientHeight,
+          scrollHeight: element.scrollHeight,
+          containingPanelHeight: panelRect.height,
+          panelTop: panelRect.top,
+          cardTop: cardRect.top,
+          cardHeight: cardRect.height,
+          cardOverflow: cardStyle.overflow,
+        };
+      });
+
+    await expect(inputStage).toHaveCSS('transform', 'none');
+    const initialMetrics = await readMetrics();
+    const longDraft = Array.from({ length: 24 }, (_, index) => `Line ${index + 1}`).join('\n');
+
+    await textarea.fill(longDraft);
+    await expect.poll(async () => (await readMetrics()).inlineHeight).toBe('100px');
+    const longDraftMetrics = await readMetrics();
+
+    await test.info().attach('roundtable textarea pre-post metrics', {
+      body: JSON.stringify({ initialMetrics, longDraftMetrics }, null, 2),
+      contentType: 'application/json',
+    });
+
+    const metricSummary = JSON.stringify({ initialMetrics, longDraftMetrics });
+    expect(
+      longDraftMetrics.panelTop,
+      `Roundtable input panel must stay inside its overflow-hidden card: ${metricSummary}`,
+    ).toBeGreaterThanOrEqual(longDraftMetrics.cardTop);
+    expect(longDraftMetrics.cardOverflow).toBe('hidden');
+    expect(
+      longDraftMetrics.computedFieldSizing,
+      `Roundtable textarea metrics: ${metricSummary}`,
+    ).not.toBe('content');
+    expect(
+      longDraftMetrics.inlineFieldSizing,
+      `Roundtable textarea metrics: ${metricSummary}`,
+    ).toBe('');
+    expect(longDraftMetrics.inlineHeight).toBe('100px');
+    expect(longDraftMetrics.computedMaxHeight).toBe('100px');
+    expect(longDraftMetrics.computedOverflowY).toBe('auto');
+    expect(longDraftMetrics.boundingRectHeight).toBeLessThanOrEqual(100);
+    expect(longDraftMetrics.scrollHeight).toBeGreaterThan(longDraftMetrics.clientHeight);
+
+    await textarea.fill('Short line');
+    await expect
+      .poll(async () => (await readMetrics()).clientHeight)
+      .toBeLessThan(longDraftMetrics.clientHeight);
+    await expect.poll(async () => (await readMetrics()).inlineHeight).not.toBe('100px');
+
+    await textarea.fill(longDraft);
+    await page.keyboard.press('Escape');
+    await expect(textarea).toBeHidden();
+
+    await page.keyboard.press('T');
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue(longDraft);
+    await expect.poll(async () => (await readMetrics()).inlineHeight).toBe('100px');
+  });
+
   test('keeps body spacing stable for header menus and settings modal', async ({ page }) => {
     const classroom = new ClassroomPage(page);
     await classroom.goto(TEST_STAGE_ID);


### PR DESCRIPTION
Fixes #906 (task 2 of 2 — the input-panel clipping bug; task 1, the chat-panel line-break fix, was merged in #908).

## Root cause

The non-presentation roundtable root has a fixed height (`h-[192px]`); the card inside it measures ~151px and has `overflow-hidden`. The input panel wraps the textarea in ~32px of padding/border and is anchored `bottom-4` (16px) inside that card. With the textarea capped at `max-h-[120px]`, a 6+-line draft makes the panel ~152px + 16px offset — taller than the 151px card — so the card clips the panel's top: the top border and the first line(s) of the draft become invisible (measured: panel top 18.5px above card top in Chrome 148).

Notably, `field-sizing: content` and `max-height` were **not** at fault — the cap worked, it just never fit the fixed-height card around it.

## Changes

- Cap the non-presentation textarea at **100px** (5 lines at 20px line-height): panel 132.5px + 16px offset = 148.5px ≤ 151px card, so it always fits. The constant `NON_PRESENTATION_INPUT_MAX_HEIGHT_PX` and the `max-h-[100px]` class carry a sync comment.
- Replace `field-sizing: content` with the effect-based JS autosize already used by the PBL v2 chat input (`height = min(scrollHeight, MAX)`), with `overflow-y-auto` for internal scrolling once capped. The effect's deps (`inputValue`, `isInputOpen`, `isPresenting`) also cover remounts: the panel unmounts on Escape while keeping the draft, so reopening must re-apply the height to a fresh DOM node.
- Add `data-testid`s to the card / input stage / panel so the regression test can assert geometry robustly.
- The presentation-mode (fullscreen) input is untouched.

## Verification

- New Playwright test (reusing the existing classroom IndexedDB fixture) drives the real flow: open input with `T`, fill a 24-line draft, and assert the load-bearing behavior — **the panel stays fully inside the overflow-hidden card** (`panelTop >= cardTop`) — plus: capped at 100px, internal scroll active, height shrinks when content is deleted, and the draft persists across Escape/reopen with the height re-applied. Metrics are attached to the test report.
- Negative control: replicating the old 120px cap makes the panel-containment assertion fail with exactly the observed clipping (panel top 543 < card top 561, the 18px overflow).
- Live headed-browser check on this branch: 6 long wrapped lines → panel fully visible inside the bar (20px headroom), 720px of content scrolling inside a 100px textarea, `field-sizing` gone.
- `vitest` (2205 tests), `tsc --noEmit`, and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
