### PR TITLE
chore: tighten GitHub issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
 
+        Before submitting, please search existing issues for duplicates and remove API keys, access tokens, and other secrets from logs or screenshots.
+
   - type: textarea
     id: description
     attributes:
@@ -58,24 +60,61 @@ body:
       required: true
 
   - type: input
+    id: version
+    attributes:
+      label: OpenMAIC Version
+      description: Which release, commit SHA, or Docker image tag are you using?
+      placeholder: e.g. v0.4.2, 40ff80a, or latest
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      description: Which part of OpenMAIC is affected?
+      options:
+        - Classroom generation
+        - Playback / presentation
+        - Editor / canvas
+        - Import / export
+        - Model / provider integration
+        - Storage / persistence
+        - Deployment / infrastructure
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
     id: browser
     attributes:
       label: Browser
-      description: Which browser are you using?
-      placeholder: e.g. Chrome 120, Firefox 121, Safari 17
+      description: Which browser are you using? Enter "Not applicable" for non-browser issues.
+      placeholder: e.g. Chrome 120, Firefox 121, Safari 17, or Not applicable
+    validations:
+      required: true
 
   - type: input
     id: os
     attributes:
       label: Operating System
       placeholder: e.g. macOS 14.2, Windows 11, Ubuntu 22.04
+    validations:
+      required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: Relevant Logs / Screenshots
-      description: Paste any error messages, console logs, or screenshots.
+      label: Relevant Logs
+      description: Paste error messages and console or server logs after removing secrets and personal data.
       render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Recordings
+      description: Attach any screenshots or recordings that make the problem easier to reproduce.
 
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
 
-        Before submitting, please search existing issues for duplicates and remove API keys, access tokens, and other secrets from logs or screenshots.
+        Before submitting, please search existing issues for duplicates and remove API keys, access tokens, personal data, and other secrets from logs, screenshots, or recordings.
 
   - type: textarea
     id: description
@@ -99,7 +99,8 @@ body:
     id: os
     attributes:
       label: Operating System
-      placeholder: e.g. macOS 14.2, Windows 11, Ubuntu 22.04
+      description: Which operating system are you using? Enter "Not applicable" for non-runtime issues.
+      placeholder: e.g. macOS 14.2, Windows 11, Ubuntu 22.04, or Not applicable
     validations:
       required: true
 
@@ -114,7 +115,7 @@ body:
     id: screenshots
     attributes:
       label: Screenshots or Recordings
-      description: Attach any screenshots or recordings that make the problem easier to reproduce.
+      description: Attach screenshots or recordings after removing secrets and personal data.
 
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Discord Community
     url: https://discord.gg/p8Pf2r3SaG

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a Security Vulnerability
+    url: https://github.com/THU-MAIC/OpenMAIC/security/advisories/new
+    about: Privately report a security vulnerability instead of opening a public issue
   - name: Discord Community
     url: https://discord.gg/p8Pf2r3SaG
     about: Ask questions and discuss with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting a feature! Please describe your idea below.
+        Thanks for suggesting a feature! Please search existing issues for duplicates, then describe the user problem and a testable outcome below.
 
   - type: textarea
     id: problem
@@ -26,6 +26,18 @@ body:
       required: true
 
   - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What observable outcomes would make this feature complete?
+      placeholder: |
+        - [ ] A user can ...
+        - [ ] The system shows ...
+        - [ ] Existing ... continues to work
+    validations:
+      required: true
+
+  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives Considered
@@ -39,13 +51,16 @@ body:
       options:
         - Classroom generation
         - Multi-agent interaction
-        - Slides / Whiteboard
+        - Playback / presentation
+        - Editor / canvas
+        - Import / export
+        - Storage / persistence
         - Quiz / Assessment
-        - TTS / Voice
+        - Model / provider integration
         - Interactive simulations
         - OpenClaw integration
         - UI / UX
-        - API / Backend
+        - Deployment / infrastructure
         - Documentation
         - Other
     validations:

--- a/components/edit/SlideNavRail/ThumbItem.tsx
+++ b/components/edit/SlideNavRail/ThumbItem.tsx
@@ -103,6 +103,7 @@ function ThumbItemComponent({
       <div
         role="button"
         tabIndex={0}
+        data-testid="scene-item"
         data-active={active}
         onClick={renaming ? undefined : onActivate}
         onKeyDown={(e) => {
@@ -178,6 +179,7 @@ function ThumbItemComponent({
               />
             ) : (
               <span
+                data-testid="scene-title"
                 onDoubleClick={(e) => {
                   e.stopPropagation();
                   startRename();


### PR DESCRIPTION
## Summary

- disable blank issues while keeping support questions routed to Discord
- add a private GitHub Security Advisory route for vulnerability reports
- require version, affected area, browser, and operating system on bug reports, with non-applicable paths where appropriate
- separate logs from screenshots/recordings and add explicit secret/personal-data redaction guidance
- require testable acceptance criteria on feature requests
- align area choices with the current issue taxonomy
- preserve the existing `scene-item` / `scene-title` test contract in the Pro-mode navigation rail

## Why

The current forms allow reports without enough environment or completion detail, which increases triage round-trips and leaves issues hard to classify. Disabling blank issues also needs a private security-reporting path so vulnerability reports are not redirected to public issues or Discord.

The selector parity change is testability-only. CI traces showed the playback sidebar being replaced by the Pro-mode rail during an existing E2E, while the new rail did not expose the Page Object's established scene selectors.

## Codex review loop

- round 1: 3 actionable findings (private security route, recording redaction, OS non-applicable guidance)
- round 2 after fixes: 0 actionable findings
- round 3 after the E2E selector fix: 0 actionable findings

## Checks

- parsed all issue-template YAML files
- verified unique issue-form field IDs
- Prettier
- `git diff --check`
- CodeQL: passed
- Lint, Typecheck & Unit Tests: passed
- Playwright E2E: passed (24 tests)
