### PR TITLE
fix(storage): store image files as array buffers

### DIFF
--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -99,7 +99,7 @@ export interface AudioFileRecord {
  */
 export interface ImageFileRecord {
   id: string; // Primary key
-  blob: Blob; // Image binary data
+  blob: Blob | ArrayBuffer; // Image binary data
   filename: string; // Original filename
   mimeType: string; // image/png, image/jpeg, etc.
   size: number; // File size (bytes)

--- a/lib/utils/image-storage.ts
+++ b/lib/utils/image-storage.ts
@@ -2,7 +2,7 @@
  * Image Storage Utilities
  *
  * Store PDF images in IndexedDB to avoid sessionStorage 5MB limit.
- * Images are stored as Blobs for efficient storage.
+ * Images are stored as ArrayBuffers for cross-browser IndexedDB compatibility.
  */
 
 import { db, type ImageFileRecord } from './database';
@@ -13,9 +13,12 @@ const log = createLogger('ImageStorage');
 const SESSION_ID_LENGTH = 10;
 
 /**
- * Convert base64 data URL to Blob
+ * Decode a base64 data URL into its binary payload and MIME type.
  */
-function base64ToBlob(base64DataUrl: string): Blob {
+function decodeBase64DataUrl(base64DataUrl: string): {
+  buffer: ArrayBuffer;
+  mimeType: string;
+} {
   const parts = base64DataUrl.split(',');
   const mimeMatch = parts[0].match(/:(.*?);/);
   const mimeType = mimeMatch ? mimeMatch[1] : 'image/png';
@@ -28,7 +31,18 @@ function base64ToBlob(base64DataUrl: string): Blob {
     uint8Array[i] = byteString.charCodeAt(i);
   }
 
-  return new Blob([uint8Array], { type: mimeType });
+  return { buffer: arrayBuffer, mimeType };
+}
+
+/**
+ * Convert a stored binary value to the Blob expected by callers.
+ */
+function storedBinaryToBlob(value: Blob | ArrayBuffer, mimeType: string): Blob {
+  if (value instanceof ArrayBuffer) {
+    return new Blob([value], { type: mimeType });
+  }
+
+  return value.type ? value : new Blob([value], { type: mimeType });
 }
 
 /**
@@ -57,19 +71,17 @@ export async function storeImages(
   try {
     for (const img of images) {
       currentImageId = img.id;
-      const blob = base64ToBlob(img.src);
-      const mimeMatch = img.src.match(/data:(.*?);/);
-      const mimeType = mimeMatch ? mimeMatch[1] : 'image/png';
+      const { buffer, mimeType } = decodeBase64DataUrl(img.src);
 
       // Use session-prefixed ID to allow cleanup
       const storageId = `session_${sessionId}_${img.id}`;
 
       const record: ImageFileRecord = {
         id: storageId,
-        blob,
+        blob: buffer,
         filename: `${img.id}.png`,
         mimeType,
-        size: blob.size,
+        size: buffer.byteLength,
         createdAt: Date.now(),
       };
 
@@ -100,7 +112,8 @@ export async function loadImageMapping(imageIds: string[]): Promise<Record<strin
     try {
       const record = await db.imageFiles.get(storageId);
       if (record) {
-        const base64 = await blobToBase64(record.blob);
+        const blob = storedBinaryToBlob(record.blob, record.mimeType);
+        const base64 = await blobToBase64(blob);
         const originalId = extractOriginalImageId(storageId);
         if (!originalId) {
           log.warn(`Skipping image with malformed storage ID: ${storageId}`);
@@ -166,21 +179,19 @@ export async function getImageStorageSize(): Promise<number> {
 }
 
 /**
- * Store a PDF file as a Blob in IndexedDB.
- * Returns a storage key that can be used to retrieve the blob later.
+ * Store a PDF file as an ArrayBuffer in IndexedDB.
+ * Returns a storage key that callers can use to retrieve the file as a Blob.
  */
 export async function storePdfBlob(file: File): Promise<string> {
   const storageKey = `pdf_${nanoid(10)}`;
-  const blob = new Blob([await file.arrayBuffer()], {
-    type: file.type || 'application/pdf',
-  });
+  const buffer = await file.arrayBuffer();
 
   const record: ImageFileRecord = {
     id: storageKey,
-    blob,
+    blob: buffer,
     filename: file.name,
     mimeType: file.type || 'application/pdf',
-    size: blob.size,
+    size: buffer.byteLength,
     createdAt: Date.now(),
   };
 
@@ -193,7 +204,7 @@ export async function storePdfBlob(file: File): Promise<string> {
  */
 export async function loadPdfBlob(key: string): Promise<Blob | null> {
   const record = await db.imageFiles.get(key);
-  return record?.blob ?? null;
+  return record ? storedBinaryToBlob(record.blob, record.mimeType) : null;
 }
 
 /**

--- a/tests/utils/image-storage.test.ts
+++ b/tests/utils/image-storage.test.ts
@@ -1,5 +1,169 @@
-import { describe, expect, it } from 'vitest';
-import { extractOriginalImageId } from '@/lib/utils/image-storage';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const imageFilesMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/database', () => ({
+  db: {
+    imageFiles: imageFilesMock,
+  },
+}));
+
+import {
+  extractOriginalImageId,
+  loadImageMapping,
+  loadPdfBlob,
+  storeImages,
+  storePdfBlob,
+} from '@/lib/utils/image-storage';
+
+class TestFileReader {
+  result: string | ArrayBuffer | null = null;
+  onloadend: FileReader['onloadend'] = null;
+  onerror: FileReader['onerror'] = null;
+
+  readAsDataURL(blob: Blob): void {
+    void blob.arrayBuffer().then(
+      (buffer) => {
+        this.result = `data:${blob.type};base64,${Buffer.from(buffer).toString('base64')}`;
+        this.onloadend?.call(this as unknown as FileReader, {} as ProgressEvent<FileReader>);
+      },
+      () => {
+        this.onerror?.call(this as unknown as FileReader, {} as ProgressEvent<FileReader>);
+      },
+    );
+  }
+}
+
+function bytesOf(buffer: ArrayBuffer): number[] {
+  return Array.from(new Uint8Array(buffer));
+}
+
+beforeAll(() => {
+  vi.stubGlobal('FileReader', TestFileReader);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  imageFilesMock.get.mockReset();
+  imageFilesMock.put.mockReset();
+  imageFilesMock.delete.mockReset();
+});
+
+describe('image file persistence', () => {
+  it('stores a PDF as an ArrayBuffer with its exact metadata', async () => {
+    const bytes = [0x25, 0x50, 0x44, 0x46, 0x01, 0xff];
+    const file = new File([Uint8Array.from(bytes)], 'lesson.pdf', {
+      type: 'application/pdf',
+    });
+
+    const storageKey = await storePdfBlob(file);
+
+    expect(imageFilesMock.put).toHaveBeenCalledOnce();
+    const record = imageFilesMock.put.mock.calls[0][0];
+    expect(record.id).toBe(storageKey);
+    expect(record.blob).toBeInstanceOf(ArrayBuffer);
+    expect(bytesOf(record.blob)).toEqual(bytes);
+    expect(record.mimeType).toBe('application/pdf');
+    expect(record.filename).toBe('lesson.pdf');
+    expect(record.size).toBe(record.blob.byteLength);
+  });
+
+  it('stores a page image as an ArrayBuffer with its decoded bytes and MIME type', async () => {
+    const bytes = [0x00, 0x01, 0x02, 0xfd, 0xfe];
+    const src = `data:image/jpeg;base64,${Buffer.from(bytes).toString('base64')}`;
+
+    await storeImages([{ id: 'img_1', src, pageNumber: 1 }]);
+
+    expect(imageFilesMock.put).toHaveBeenCalledOnce();
+    const record = imageFilesMock.put.mock.calls[0][0];
+    expect(record.blob).toBeInstanceOf(ArrayBuffer);
+    expect(bytesOf(record.blob)).toEqual(bytes);
+    expect(record.mimeType).toBe('image/jpeg');
+    expect(record.size).toBe(record.blob.byteLength);
+  });
+
+  it('loads an ArrayBuffer PDF record as a Blob with exact bytes and MIME type', async () => {
+    const bytes = [0x25, 0x50, 0x44, 0x46, 0x02];
+    imageFilesMock.get.mockResolvedValue({
+      blob: Uint8Array.from(bytes).buffer,
+      mimeType: 'application/pdf',
+    });
+
+    const blob = await loadPdfBlob('pdf-key');
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob?.type).toBe('application/pdf');
+    expect(bytesOf(await blob!.arrayBuffer())).toEqual(bytes);
+  });
+
+  it('returns a legacy typed Blob unchanged', async () => {
+    const legacyBlob = new Blob([Uint8Array.from([1, 2, 3])], { type: 'application/pdf' });
+    imageFilesMock.get.mockResolvedValue({
+      blob: legacyBlob,
+      mimeType: 'application/pdf',
+    });
+
+    await expect(loadPdfBlob('legacy-pdf')).resolves.toBe(legacyBlob);
+  });
+
+  it('reconstructs a legacy empty-type Blob with the record MIME type and exact bytes', async () => {
+    const bytes = [3, 1, 4, 1, 5];
+    const legacyBlob = new Blob([Uint8Array.from(bytes)]);
+    imageFilesMock.get.mockResolvedValue({
+      blob: legacyBlob,
+      mimeType: 'application/pdf',
+    });
+
+    const blob = await loadPdfBlob('legacy-empty-type-pdf');
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob).not.toBe(legacyBlob);
+    expect(blob?.type).toBe('application/pdf');
+    expect(bytesOf(await blob!.arrayBuffer())).toEqual(bytes);
+  });
+
+  it('loads an ArrayBuffer page-image record as an exact data URL mapping', async () => {
+    const bytes = [0xde, 0xad, 0xbe, 0xef];
+    imageFilesMock.get.mockResolvedValue({
+      blob: Uint8Array.from(bytes).buffer,
+      mimeType: 'image/webp',
+    });
+
+    await expect(loadImageMapping(['session_abc123def4_img_1'])).resolves.toEqual({
+      img_1: `data:image/webp;base64,${Buffer.from(bytes).toString('base64')}`,
+    });
+  });
+
+  it('rolls back every earlier image when a later write fails and preserves the cause', async () => {
+    const writeFailure = new Error('IndexedDB write failed');
+    imageFilesMock.put
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(writeFailure);
+    imageFilesMock.delete.mockResolvedValue(undefined);
+    const images = [
+      { id: 'img_1', src: 'data:image/png;base64,AQ==' },
+      { id: 'img_2', src: 'data:image/png;base64,Ag==' },
+      { id: 'img_3', src: 'data:image/png;base64,Aw==' },
+    ];
+
+    const result = storeImages(images);
+
+    await expect(result).rejects.toMatchObject({
+      message: 'Failed to store image bundle at image img_3',
+      cause: writeFailure,
+    });
+    const successfulIds = imageFilesMock.put.mock.calls.slice(0, 2).map(([record]) => record.id);
+    expect(imageFilesMock.delete.mock.calls.map(([id]) => id)).toEqual(successfulIds);
+  });
+});
 
 describe('extractOriginalImageId', () => {
   it('extracts an image id from a normal session storage id', () => {


### PR DESCRIPTION
## Summary

- persist new `imageFiles` PDF and page-image payloads as `ArrayBuffer`
- reconstruct `Blob` values on read while remaining compatible with historical Blob records
- keep the existing Dexie schema/version and leave other Blob-backed tables unchanged

## Root cause

WebKit can fail while serializing Blob/File values for IndexedDB with `UnknownError: Error preparing Blob/File data to be stored in object store`. The document storage path still wrote Blob values into `imageFiles`, even after copying uploaded files into memory. Storing structured-clone-compatible `ArrayBuffer` values avoids that WebKit Blob serialization path.

## Implementation

- widen `ImageFileRecord.blob` to `Blob | ArrayBuffer`
- decode image data URLs once into bytes and MIME type
- store PDFs and parsed page images as `ArrayBuffer` with byte-accurate sizes
- normalize both new ArrayBuffer records and legacy Blob records back to Blob on reads
- retain document aliases, cleanup behavior, error propagation, and storage accounting

No database migration is required because `blob` is not an indexed field. Audio, generated-media, voice-profile, and voice-cache Blob fields are intentionally out of scope.

## Verification

- `pnpm exec vitest run tests/utils/image-storage.test.ts --reporter=dot` — 12 passed
- `pnpm exec eslint lib/utils/image-storage.ts lib/utils/database.ts tests/utils/image-storage.test.ts` — passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm test -- --reporter=dot` — 2,285 passed, 1 skipped
- Safari 26.5 normal window: uploaded a PDF containing an embedded page image, completed document extraction, stored page images, and entered the generated classroom without the IndexedDB Blob error

Safari 17 and iOS Chrome still need confirmation on the affected devices. If a later write to another Blob-backed table fails on those devices, that should be tracked as a separate follow-up rather than expanding this fix.

Fixes #910
