### PR TITLE
fix(export): resource pack unresponsive for interactive-only decks

### DIFF
--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -20,6 +20,7 @@ import { svg2Base64 } from '@/lib/export/svg2base64';
 import { latexToOmml } from '@/lib/export/latex-to-omml';
 import { createLogger } from '@/lib/logger';
 import { inlineHtmlAssets, createAssetFetcher } from './inline-assets';
+import type { FetchAsset } from './inline-assets';
 import { createProxiedFetch } from './proxied-fetch';
 
 const log = createLogger('ExportPPTX');
@@ -1091,6 +1092,81 @@ export async function buildPptxBlob(
   return (await pptx.write({ outputType: 'blob' })) as Blob;
 }
 
+// ── Resource Pack assembly (PPTX + interactive HTML pages as ZIP) ──
+// Pure/async builder extracted from the hook so the assembly logic — which
+// scenes make it into the ZIP, whether the PPTX builder runs — is unit-testable
+// without a React/jsdom harness. The hook stays the only runtime caller.
+//
+// `getPptxBlob` is invoked only when slide scenes exist, so an interactive-only
+// deck never touches the PPTX builder. Returns `empty: true` (and a null blob)
+// when there is nothing to ship.
+
+export interface ResourcePackResult {
+  /** Generated ZIP blob, or null when there is nothing to ship. */
+  blob: Blob | null;
+  /** True when the deck has interactive pages but no slides (PPTX skipped). */
+  skippedPptx: boolean;
+  /** True when neither slides nor interactive pages could be exported. */
+  empty: boolean;
+  /** External asset URLs that could not be inlined into the HTML pages. */
+  failedAssetUrls: string[];
+}
+
+export async function buildResourcePackZip(
+  scenes: Scene[],
+  slides: Slide[],
+  slideScenes: Scene[],
+  opts: {
+    viewportRatio: number;
+    viewportSize: number;
+    ratioPx2Inch: number;
+    ratioPx2Pt: number;
+    fileName: string;
+    /** Called only when `slides.length > 0`; produces the PPTX blob. */
+    getPptxBlob: () => Promise<Blob>;
+    /** Passed through to `inlineHtmlAssets`; tests inject a no-op fetcher. */
+    fetcher?: FetchAsset;
+  },
+): Promise<ResourcePackResult> {
+  const JSZip = (await import('jszip')).default;
+  const zip = new JSZip();
+  const failedAssetUrls: string[] = [];
+
+  // 1. Add interactive HTML pages (independent of slides)
+  let interactiveIndex = 0;
+  for (const scene of scenes) {
+    if (scene.content.type === 'interactive' && scene.content.html) {
+      interactiveIndex++;
+      const safeName = scene.title.replace(/[\\/:*?"<>|]/g, '_');
+      const htmlFileName = `interactive/${String(interactiveIndex).padStart(2, '0')}_${safeName}.html`;
+      const { html: inlinedHtml, report } = await inlineHtmlAssets(scene.content.html, {
+        fetcher: opts.fetcher,
+      });
+      for (const f of report.failed) {
+        if (!failedAssetUrls.includes(f.url)) failedAssetUrls.push(f.url);
+      }
+      zip.file(htmlFileName, inlinedHtml);
+    }
+  }
+
+  // Nothing to ship: no slides and no interactive pages.
+  if (interactiveIndex === 0 && slides.length === 0) {
+    return { blob: null, skippedPptx: false, empty: true, failedAssetUrls };
+  }
+
+  // 2. Generate PPTX only when slide scenes exist.
+  const skippedPptx = slides.length === 0;
+  if (!skippedPptx) {
+    const pptxBlob = await opts.getPptxBlob();
+    // Convert to ArrayBuffer so jszip stores a plain byte buffer rather than a
+    // Blob (which it can't reliably round-trip outside the browser).
+    zip.file(`${opts.fileName}.pptx`, await pptxBlob.arrayBuffer());
+  }
+
+  const blob = await zip.generateAsync({ type: 'blob' });
+  return { blob, skippedPptx, empty: false, failedAssetUrls };
+}
+
 // ── Hook ──
 
 export function useExportPPTX() {
@@ -1109,10 +1185,17 @@ export function useExportPPTX() {
   const slideScenes = scenes.filter((s) => s.content.type === 'slide');
   const slides = slideScenes.map((s) => (s.content as SlideContent).canvas);
 
-  // Shared guard + state wrapper for export actions
+  // Shared guard + state wrapper for export actions.
+  // `requireSlides` controls whether the guard rejects a deck with no slide
+  // scenes (PPTX export needs them; the resource pack can ship interactive
+  // pages alone). When it rejects, callers get a toast instead of silence.
   const withExportGuard = useCallback(
-    (action: () => Promise<void>) => {
-      if (exportingRef.current || slides.length === 0) return;
+    (action: () => Promise<void>, requireSlides = true) => {
+      if (exportingRef.current) return;
+      if (requireSlides && slides.length === 0) {
+        toast.warning(t('export.noSlides'));
+        return;
+      }
       exportingRef.current = true;
       setExporting(true);
       setTimeout(async () => {
@@ -1158,54 +1241,41 @@ export function useExportPPTX() {
   ]);
 
   // ── Export Resource Pack (PPTX + interactive HTML pages as ZIP) ──
+  // `requireSlides` is false: a deck with only interactive scenes still ships
+  // its interactive pages as the resource pack (PPTX is skipped with a toast).
   const exportResourcePack = useCallback(() => {
     withExportGuard(async () => {
-      const JSZip = (await import('jszip')).default;
-      const zip = new JSZip();
       const fileName = stage?.name || 'slides';
+      const sharedFetcher = createAssetFetcher({ fetchImpl: createProxiedFetch() });
 
-      // 1. Generate PPTX
-      const pptxBlob = await buildPptxBlob(
-        slides,
-        slideScenes,
+      const result = await buildResourcePackZip(scenes, slides, slideScenes, {
         viewportRatio,
         viewportSize,
         ratioPx2Inch,
         ratioPx2Pt,
-      );
-      zip.file(`${fileName}.pptx`, pptxBlob);
+        fileName,
+        fetcher: sharedFetcher,
+        getPptxBlob: () =>
+          buildPptxBlob(slides, slideScenes, viewportRatio, viewportSize, ratioPx2Inch, ratioPx2Pt),
+      });
 
-      // 2. Add interactive HTML pages
-      const sharedFetcher = createAssetFetcher({ fetchImpl: createProxiedFetch() });
-      let interactiveIndex = 0;
-      const failedAssetUrls = new Set<string>();
-      for (const scene of scenes) {
-        if (scene.content.type === 'interactive' && scene.content.html) {
-          interactiveIndex++;
-          const safeName = scene.title.replace(/[\\/:*?"<>|]/g, '_');
-          const htmlFileName = `interactive/${String(interactiveIndex).padStart(2, '0')}_${safeName}.html`;
-          const { html: inlinedHtml, report } = await inlineHtmlAssets(scene.content.html, {
-            fetcher: sharedFetcher,
-          });
-          if (report.failed.length > 0) {
-            log.warn(
-              'Resource Pack: some interactive-scene assets could not be inlined:',
-              report.failed,
-            );
-            for (const f of report.failed) failedAssetUrls.add(f.url);
-          }
-          zip.file(htmlFileName, inlinedHtml);
-        }
+      if (result.empty) {
+        toast.warning(t('export.nothingToExport'));
+        return;
       }
-
-      // 3. Download ZIP
-      const zipBlob = await zip.generateAsync({ type: 'blob' });
-      saveAs(zipBlob, `${fileName}.zip`);
+      if (result.skippedPptx) {
+        toast.info(t('export.noSlidesSkipped'));
+      }
+      saveAs(result.blob!, `${fileName}.zip`);
       toast.success(t('export.exportSuccess'));
-      if (failedAssetUrls.size > 0) {
+      if (result.failedAssetUrls.length > 0) {
+        log.warn(
+          'Resource Pack: some interactive-scene assets could not be inlined:',
+          result.failedAssetUrls,
+        );
         const hosts = [
           ...new Set(
-            [...failedAssetUrls].map((u) => {
+            result.failedAssetUrls.map((u) => {
               try {
                 return new URL(u).host;
               } catch {
@@ -1214,11 +1284,11 @@ export function useExportPPTX() {
             }),
           ),
         ];
-        toast.warning(t('export.inlinePartial', { count: failedAssetUrls.size }), {
+        toast.warning(t('export.inlinePartial', { count: result.failedAssetUrls.length }), {
           description: hosts.join(', '),
         });
       }
-    });
+    }, false);
   }, [
     withExportGuard,
     slides,

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -60,7 +60,10 @@
     "videoPackaging": "جارٍ تحزيم مشروع الفيديو...",
     "videoSuccess": "تم تصدير مشروع الفيديو",
     "videoFailed": "فشل تصدير الفيديو",
-    "videoWarnings": "{{assets}} من الموارد مفقودة و {{diagnostics}} من المشكلات في تقرير التصدير."
+    "videoWarnings": "{{assets}} من الموارد مفقودة و {{diagnostics}} من المشكلات في تقرير التصدير.",
+    "noSlides": "لا توجد شرائح للتصدير",
+    "noSlidesSkipped": "لا توجد شرائح في هذه الدورة — تم تخطي PPTX",
+    "nothingToExport": "لا يوجد محتوى للتصدير"
   },
   "import": {
     "classroom": "استيراد فصل",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -60,7 +60,10 @@
     "videoPackaging": "Packaging video project...",
     "videoSuccess": "Video project exported",
     "videoFailed": "Video export failed",
-    "videoWarnings": "{{assets}} asset(s) missing and {{diagnostics}} issue(s) in the export report."
+    "videoWarnings": "{{assets}} asset(s) missing and {{diagnostics}} issue(s) in the export report.",
+    "noSlides": "No slides to export",
+    "noSlidesSkipped": "No slides in this course — PPTX skipped",
+    "nothingToExport": "Nothing to export"
   },
   "import": {
     "classroom": "Import Classroom",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -60,7 +60,10 @@
     "videoPackaging": "動画プロジェクトをパッケージ中...",
     "videoSuccess": "動画プロジェクトをエクスポートしました",
     "videoFailed": "動画のエクスポートに失敗しました",
-    "videoWarnings": "{{assets}} 個の素材が不足しており、エクスポートレポートに {{diagnostics}} 件の問題があります。"
+    "videoWarnings": "{{assets}} 個の素材が不足しており、エクスポートレポートに {{diagnostics}} 件の問題があります。",
+    "noSlides": "エクスポート可能なスライドがありません",
+    "noSlidesSkipped": "このコースにスライドがないため、PPTX をスキップしました",
+    "nothingToExport": "エクスポートできるものがありません"
   },
   "import": {
     "classroom": "教室をインポート",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -60,7 +60,10 @@
     "videoPackaging": "동영상 프로젝트 패키징 중...",
     "videoSuccess": "동영상 프로젝트를 내보냈습니다",
     "videoFailed": "동영상 내보내기 실패",
-    "videoWarnings": "{{assets}}개의 에셋이 누락되었고 내보내기 보고서에 {{diagnostics}}개의 문제가 있습니다."
+    "videoWarnings": "{{assets}}개의 에셋이 누락되었고 내보내기 보고서에 {{diagnostics}}개의 문제가 있습니다.",
+    "noSlides": "내보낼 슬라이드가 없습니다",
+    "noSlidesSkipped": "이 코스에 슬라이드가 없어 PPTX를 건너뛰었습니다",
+    "nothingToExport": "내보낼 항목이 없습니다"
   },
   "import": {
     "classroom": "교실 가져오기",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -60,7 +60,10 @@
     "videoPackaging": "Empacotando o projeto de vídeo...",
     "videoSuccess": "Projeto de vídeo exportado",
     "videoFailed": "Falha na exportação do vídeo",
-    "videoWarnings": "{{assets}} recurso(s) ausente(s) e {{diagnostics}} problema(s) no relatório de exportação."
+    "videoWarnings": "{{assets}} recurso(s) ausente(s) e {{diagnostics}} problema(s) no relatório de exportação.",
+    "noSlides": "Não há slides para exportar",
+    "noSlidesSkipped": "Este curso não tem slides — PPTX ignorado",
+    "nothingToExport": "Nada para exportar"
   },
   "import": {
     "classroom": "Importar Sala de Aula",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -60,7 +60,10 @@
     "videoPackaging": "Упаковка видеопроекта...",
     "videoSuccess": "Видеопроект экспортирован",
     "videoFailed": "Ошибка экспорта видео",
-    "videoWarnings": "Отсутствует ресурсов: {{assets}}; проблем в отчёте об экспорте: {{diagnostics}}."
+    "videoWarnings": "Отсутствует ресурсов: {{assets}}; проблем в отчёте об экспорте: {{diagnostics}}.",
+    "noSlides": "Нет слайдов для экспорта",
+    "noSlidesSkipped": "В этом курсе нет слайдов — PPTX пропущен",
+    "nothingToExport": "Нет данных для экспорта"
   },
   "import": {
     "classroom": "Импорт класса",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -60,7 +60,10 @@
     "videoPackaging": "正在打包视频工程...",
     "videoSuccess": "视频工程已导出",
     "videoFailed": "视频导出失败",
-    "videoWarnings": "有 {{assets}} 个素材缺失，导出报告中有 {{diagnostics}} 个问题。"
+    "videoWarnings": "有 {{assets}} 个素材缺失，导出报告中有 {{diagnostics}} 个问题。",
+    "noSlides": "无可导出的幻灯片",
+    "noSlidesSkipped": "本课程无幻灯片，已跳过 PPTX",
+    "nothingToExport": "没有可导出的内容"
   },
   "import": {
     "classroom": "导入课堂",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -60,7 +60,10 @@
     "videoPackaging": "正在打包影片專案...",
     "videoSuccess": "影片專案已匯出",
     "videoFailed": "影片匯出失敗",
-    "videoWarnings": "有 {{assets}} 個素材缺失，匯出報告中有 {{diagnostics}} 個問題。"
+    "videoWarnings": "有 {{assets}} 個素材缺失，匯出報告中有 {{diagnostics}} 個問題。",
+    "noSlides": "無可匯出的幻燈片",
+    "noSlidesSkipped": "本課程無幻燈片，已跳過 PPTX",
+    "nothingToExport": "沒有可匯出的內容"
   },
   "import": {
     "classroom": "匯入課堂",

--- a/tests/export/resource-pack-export.test.ts
+++ b/tests/export/resource-pack-export.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+import JSZip from 'jszip';
+import { buildResourcePackZip } from '@/lib/export/use-export-pptx';
+import type { Scene } from '@/lib/types/stage';
+
+// Scenes with no external assets, so inlineHtmlAssets does no network fetches.
+const interactiveHtml = '<!DOCTYPE html><html><body><h1>Spin the frame</h1></body></html>';
+
+function interactiveScene(overrides: Partial<Scene> = {}): Scene {
+  return {
+    id: 's1',
+    stageId: 'stg1',
+    title: 'Interactive demo',
+    order: 1,
+    type: 'interactive',
+    content: { type: 'interactive', url: '', html: interactiveHtml },
+    ...overrides,
+  } as unknown as Scene;
+}
+
+async function readZipFiles(blob: Blob): Promise<Record<string, Uint8Array>> {
+  // JSZip in Node can't consume a web Blob directly — convert to ArrayBuffer first.
+  const buf = await blob.arrayBuffer();
+  const zip = await JSZip.loadAsync(buf);
+  const entries: Record<string, Uint8Array> = {};
+  const files = Object.keys(zip.files).filter((n) => !zip.files[n].dir);
+  await Promise.all(
+    files.map(async (name) => {
+      entries[name] = await zip.files[name].async('uint8array');
+    }),
+  );
+  return entries;
+}
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+describe('buildResourcePackZip', () => {
+  describe('interactive-only deck (no slides)', () => {
+    it('does not invoke the PPTX builder', async () => {
+      const getPptxBlob = vi.fn(async () => new Blob(['pptx-bytes']));
+
+      const result = await buildResourcePackZip([interactiveScene()], [], [], {
+        viewportRatio: 0.5625,
+        viewportSize: 960,
+        ratioPx2Inch: 96,
+        ratioPx2Pt: 96 / 72,
+        fileName: 'demo',
+        getPptxBlob,
+      });
+
+      expect(result.empty).toBe(false);
+      expect(getPptxBlob).not.toHaveBeenCalled();
+    });
+
+    it('ships a ZIP containing the interactive HTML page and no PPTX', async () => {
+      const getPptxBlob = vi.fn(async () => new Blob(['pptx-bytes']));
+
+      const result = await buildResourcePackZip([interactiveScene()], [], [], {
+        viewportRatio: 0.5625,
+        viewportSize: 960,
+        ratioPx2Inch: 96,
+        ratioPx2Pt: 96 / 72,
+        fileName: 'demo',
+        getPptxBlob,
+      });
+
+      expect(result.blob).not.toBeNull();
+      expect(result.skippedPptx).toBe(true);
+
+      const files = await readZipFiles(result.blob!);
+      const names = Object.keys(files);
+      // The interactive HTML page made it into the ZIP.
+      expect(names.some((n) => n.startsWith('interactive/'))).toBe(true);
+      const htmlEntry = names.find((n) => n.startsWith('interactive/'))!;
+      expect(decode(files[htmlEntry])).toBe(interactiveHtml);
+      // No PPTX shipped for an interactive-only deck.
+      expect(names.some((n) => n.endsWith('.pptx'))).toBe(false);
+    });
+  });
+
+  describe('deck with slides', () => {
+    it('invokes the PPTX builder and includes the PPTX in the ZIP', async () => {
+      // jszip reliably round-trips Uint8Array entries in Node; a Blob-backed
+      // entry can confuse loadAsync when reading back.
+      const pptxBytes = new Uint8Array([1, 2, 3, 4]);
+      const getPptxBlob = vi.fn(async () => new Blob([pptxBytes]));
+
+      const slideScene = {
+        id: 's2',
+        stageId: 'stg1',
+        title: 'A slide',
+        order: 1,
+        type: 'slide',
+        content: { type: 'slide', canvas: { width: 960, height: 540, elements: [] } },
+      } as unknown as Scene;
+
+      // The real slides' content isn't read — getPptxBlob is mocked, so the
+      // builder only needs slides.length > 0 to decide PPTX is included.
+      const placeholderSlide = { id: 'sl1' } as unknown as Parameters<
+        typeof buildResourcePackZip
+      >[1][number];
+
+      const result = await buildResourcePackZip([slideScene], [placeholderSlide], [slideScene], {
+        viewportRatio: 0.5625,
+        viewportSize: 960,
+        ratioPx2Inch: 96,
+        ratioPx2Pt: 96 / 72,
+        fileName: 'deck',
+        getPptxBlob,
+      });
+
+      expect(result.empty).toBe(false);
+      expect(result.skippedPptx).toBe(false);
+      expect(getPptxBlob).toHaveBeenCalledTimes(1);
+
+      // The PPTX entry is present in the generated ZIP.
+      const buf = await result.blob!.arrayBuffer();
+      const zip = await JSZip.loadAsync(buf);
+      expect(Object.keys(zip.files)).toContain('deck.pptx');
+    });
+  });
+
+  describe('empty deck (no slides, no interactive pages)', () => {
+    it('returns empty and does not build anything', async () => {
+      const getPptxBlob = vi.fn(async () => new Blob(['pptx-bytes']));
+
+      const result = await buildResourcePackZip([], [], [], {
+        viewportRatio: 0.5625,
+        viewportSize: 960,
+        ratioPx2Inch: 96,
+        ratioPx2Pt: 96 / 72,
+        fileName: 'empty',
+        getPptxBlob,
+      });
+
+      expect(result.empty).toBe(true);
+      expect(result.blob).toBeNull();
+      expect(getPptxBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('interactive scene without html', () => {
+    it('treats an interactive scene lacking an html payload as non-exportable', async () => {
+      const getPptxBlob = vi.fn(async () => new Blob(['pptx-bytes']));
+      const sceneNoHtml = interactiveScene({
+        content: { type: 'interactive', url: 'https://example.com', html: '' },
+      });
+
+      const result = await buildResourcePackZip([sceneNoHtml], [], [], {
+        viewportRatio: 0.5625,
+        viewportSize: 960,
+        ratioPx2Inch: 96,
+        ratioPx2Pt: 96 / 72,
+        fileName: 'demo',
+        getPptxBlob,
+      });
+
+      // No html + no slides ⇒ nothing to ship.
+      expect(result.empty).toBe(true);
+      expect(result.blob).toBeNull();
+      expect(getPptxBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('multiple interactive scenes', () => {
+    it('numbers each HTML page and sanitizes titles in the filename', async () => {
+      const getPptxBlob = vi.fn(async () => new Blob(['pptx-bytes']));
+      const scenes = [
+        interactiveScene({ id: 'a', title: 'First/Widget', order: 1 }),
+        interactiveScene({ id: 'b', title: 'Second', order: 2 }),
+        interactiveScene({ id: 'c', title: 'Third: Map', order: 3 }),
+      ];
+
+      const result = await buildResourcePackZip(scenes, [], [], {
+        viewportRatio: 0.5625,
+        viewportSize: 960,
+        ratioPx2Inch: 96,
+        ratioPx2Pt: 96 / 72,
+        fileName: 'demo',
+        getPptxBlob,
+      });
+
+      expect(result.empty).toBe(false);
+      const files = await readZipFiles(result.blob!);
+      const names = Object.keys(files);
+      // Three distinct HTML pages, zero-padded indices, forbidden chars scrubbed.
+      // Regex /[\\/:*?"<>|]/g replaces / and : with _, but spaces are kept.
+      expect(names).toContain('interactive/01_First_Widget.html');
+      expect(names).toContain('interactive/02_Second.html');
+      expect(names).toContain('interactive/03_Third_ Map.html');
+      // No name collision: all three pages survived.
+      expect(names.filter((n) => n.startsWith('interactive/'))).toHaveLength(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a silent no-op when exporting the Resource Pack from a deck that contains only interactive scenes (no slide scenes). The export button stays clickable but nothing downloads and no feedback is shown.

## Related Issues

Closes #932

## Changes

- `withExportGuard` gains a `requireSlides` flag (default `true`). When it rejects a no-slides deck it now toasts (`export.noSlides`) instead of returning silently.
- `exportResourcePack` passes `requireSlides = false`: the PPTX builder now runs **only when slide scenes exist**. An interactive-only deck still ships a ZIP containing the interactive HTML pages, and surfaces `export.noSlidesSkipped` so the user knows PPTX was omitted.
- When a deck has neither slides nor interactive pages, `export.nothingToExport` is shown instead of producing an empty ZIP.
- The resource-pack assembly logic is extracted into a pure async function `buildResourcePackZip` (alongside the existing `buildPptxBlob`) so it is unit-testable without a React/jsdom harness. The hook remains the only runtime caller.
- New i18n keys `export.noSlides` / `export.noSlidesSkipped` / `export.nothingToExport` added to all 8 locales.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open a classroom whose scenes are all `interactive` (zero `slide` scenes).
2. Click **Export Resource Pack**.
3. Before: silent no-op. After: a ZIP downloads containing the interactive HTML pages, with an info toast noting PPTX was skipped.

### What you personally verified

- Decks **with** slides are unaffected: `exportPPTX` and the resource-pack PPTX path behave exactly as before (backward compatible — `requireSlides` defaults to `true`, and `slides.length > 0` takes the original branch).
- `tsc --noEmit`: no new type errors from the changed files.
- `pnpm lint`: passes on changed files.
- `prettier --check`: passes on all changed files.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally

New regression test suite (`tests/export/resource-pack-export.test.ts`, 6 tests, all passing):

```
✓ interactive-only deck (no slides) > does not invoke the PPTX builder
✓ interactive-only deck (no slides) > ships a ZIP containing the interactive HTML page and no PPTX
✓ deck with slides > invokes the PPTX builder and includes the PPTX in the ZIP
✓ empty deck (no slides, no interactive pages) > returns empty and does not build anything
✓ interactive scene without html > treats an interactive scene lacking an html payload as non-exportable
✓ multiple interactive scenes > numbers each HTML page and sanitizes titles in the filename
```

The full `tests/export/` suite (78 existing + 6 new = 84 tests across 9 files) passes.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
