### PR TITLE
feat(storage): RuntimeStore HTTP contract + HttpRuntimeStore client (#939 Part B)

### DIFF
--- a/packages/@openmaic/storage/docs/runtime-http-contract.md
+++ b/packages/@openmaic/storage/docs/runtime-http-contract.md
@@ -1,6 +1,6 @@
 # RuntimeStore HTTP contract
 
-This contract exposes the complete `RuntimeStore` interface over JSON HTTP. All paths below are relative to a deployment-defined base URL. Path segments and query parameter values are percent-encoded UTF-8 strings. Request and response bodies use `application/json`; successful operations with no return value respond with `204 No Content`.
+This contract exposes the complete `RuntimeStore` interface over JSON HTTP. All paths below are relative to a deployment-defined base URL. Path segments and query parameter values are percent-encoded UTF-8 strings. Identifiers used as path segments MUST NOT be exactly `.` or `..`, because URL parsers normalize those dot segments before routing. Request and response bodies use `application/json`; successful operations with no return value respond with `204 No Content`.
 
 ## Endpoints
 
@@ -27,7 +27,7 @@ Likewise, `runtimeDslVersion` is server-assigned when a session is created. If t
 
 ## Payload domain
 
-HTTP implementations carry record payloads through JSON and therefore MUST accept only plain JSON values that survive serialization without changing meaning. They MUST fail loud before sending values such as `Map`, `Set`, `Date`, non-finite numbers, nested `undefined`, `bigint`, sparse arrays, strings containing U+0000, U+2028, or U+2029, class instances, and circular references. This is intentionally narrower than `BrowserRuntimeStore`, whose structured-clone persistence can preserve values such as `Map`, `Set`, and `Date` that JSON cannot.
+HTTP implementations carry record payloads through JSON and therefore MUST accept only plain JSON values that survive serialization without changing meaning. They MUST fail loud before sending values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, nested `undefined`, `bigint`, sparse arrays, symbol-keyed properties, non-enumerable properties, arrays with non-index own properties, strings containing U+0000, class instances, and circular references. U+2028 and U+2029 are valid JSON string contents and MUST be accepted. This is intentionally narrower than `BrowserRuntimeStore`, whose structured-clone persistence can preserve values such as `Map`, `Set`, and `Date` that JSON cannot.
 
 ## learnerKey security model
 
@@ -65,5 +65,7 @@ The client MUST use the machine-readable code, not status alone, when an operati
 ## Retry and atomicity guarantees
 
 `mergeLearner`, `DELETE /runtime/sessions/{sessionId}`, `DELETE /runtime/stages/{stageId}/learners/{learnerKey}`, and `DELETE /runtime/stages/{stageId}` MUST be safely retryable. Repeating a completed merge moves `0`; repeating a delete succeeds with `204`. A merge is atomic across every matching source session and MUST NOT expose a partial move. Delete endpoints cascade atomically to the target sessions' records.
+
+The test-only conformance server may report a future-stamped-row conflict encountered mid-merge as `500 INTERNAL_ERROR`; structured classification of that specific case is deferred to the real Part D server implementation.
 
 `POST /runtime/sessions` and record append are not implicitly retry-safe: clients must not retry them after an ambiguous transport failure unless a deployment adds a separate idempotency-key policy. Session ids and record ids remain caller-owned uniqueness keys, while record `seq` remains exclusively server-owned.

--- a/packages/@openmaic/storage/docs/runtime-http-contract.md
+++ b/packages/@openmaic/storage/docs/runtime-http-contract.md
@@ -1,0 +1,61 @@
+# RuntimeStore HTTP contract
+
+This contract exposes the complete `RuntimeStore` interface over JSON HTTP. All paths below are relative to a deployment-defined base URL. Path segments and query parameter values are percent-encoded UTF-8 strings. Request and response bodies use `application/json`; successful operations with no return value respond with `204 No Content`.
+
+## Endpoints
+
+| Method | Path | Purpose | Success |
+| --- | --- | --- | --- |
+| `POST` | `/runtime/sessions` | Create a session from a `RuntimeSessionInit`. The server stamps `runtimeDslVersion`. | `201` with the full `RuntimeSession` |
+| `GET` | `/runtime/sessions/{sessionId}` | Get one session. | `200` with the `RuntimeSession`, or `404` if absent |
+| `PATCH` | `/runtime/sessions/{sessionId}/status` | Set status from `{ "status", "updatedAt" }`. | `204` |
+| `DELETE` | `/runtime/sessions/{sessionId}` | Delete a session and all of its records. | `204` |
+| `GET` | `/runtime/stages/{stageId}/learners/{learnerKey}/sessions` | List a partition's sessions, ordered by the instant represented by `createdAt`, then by `id` for deterministic ties. | `200` with `RuntimeSession[]` |
+| `POST` | `/runtime/sessions/{sessionId}/records` | Append a `RuntimeRecordInit`; body `sessionId` must match the path. | `201` with the full `RuntimeRecord` |
+| `GET` | `/runtime/sessions/{sessionId}/records` | List records ordered by `seq`. Optional `?sceneId={sceneId}` returns only records anchored to that scene and excludes unanchored records. | `200` with `RuntimeRecord[]` |
+| `POST` | `/runtime/learners/merge` | Atomically re-key all sessions across all stages from `{ "fromLearnerKey", "toLearnerKey" }`. | `200` with `{ "moved": number }` |
+| `DELETE` | `/runtime/stages/{stageId}/learners/{learnerKey}` | Delete one learner's sessions and records on one stage. | `204` |
+| `DELETE` | `/runtime/stages/{stageId}` | Cascade-delete every learner's sessions and records on one stage. | `204` |
+
+`GET /runtime/sessions/{sessionId}/records` returns an empty array when the session has no records or is absent, matching `RuntimeStore.listRecords`. Deleting an absent target succeeds.
+
+## Server-assigned sequence
+
+`seq` is server-assigned. The append request body is a `RuntimeRecordInit` and MUST NOT include `seq`. The server allocates the next per-session monotonic sequence number atomically with the insert, starting at `0`, and the response returns the full `RuntimeRecord`, including the assigned `seq`. A server MUST reject a client-submitted `seq` with `400 VALIDATION_FAILED` rather than accepting or ignoring it.
+
+## learnerKey security model
+
+`learnerKey` appears in paths, query parameters, and request bodies, but the server MUST derive or verify `learnerKey` from the authenticated session and MUST NOT blindly trust the client-submitted value. `learnerKey` is an opaque partition key, not proof of identity or authorization; trusting it verbatim creates a lateral-authorization vulnerability that lets one learner read, merge, or delete another learner's runtime data. The same rule applies to both keys in `mergeLearner`; authorization policy must explicitly permit the authenticated principal to migrate the source partition into the destination partition.
+
+## Errors
+
+Every non-2xx response has this machine-readable JSON shape:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "@openmaic/storage: invalid runtime session ...",
+    "details": []
+  }
+}
+```
+
+`details` is optional. `message` preserves the semantic wording of the backing store error so an HTTP client can reconstitute the fail-loud exceptions callers receive from `BrowserRuntimeStore`.
+
+| Condition | HTTP status | Error code | Client behavior |
+| --- | --- | --- | --- |
+| Malformed JSON, an invalid envelope or payload, invalid learner keys, a body/path mismatch, client-supplied `seq`, or append to a non-active session | `400` | `VALIDATION_FAILED` | Throw `HttpRuntimeStoreError` (an `Error`) with the server message |
+| Session does not exist | `404` | `SESSION_NOT_FOUND` | `getSession` returns `undefined`; operations that require the session throw `HttpRuntimeStoreError` with the browser store's `no session` semantics |
+| Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpRuntimeStoreError` |
+| A stored session has a future runtime DSL version | `409` | `FUTURE_VERSION` | Throw `HttpRuntimeStoreError` with the browser store's fail-loud `newer than this client's` semantics |
+| Session id already exists | `409` | `SESSION_ALREADY_EXISTS` | Throw `HttpRuntimeStoreError` with the browser store's `already exists` semantics |
+| Unexpected server failure | `500` | `INTERNAL_ERROR` | Throw `HttpRuntimeStoreError` |
+
+The client MUST use the machine-readable code, not status alone, when an operation has special behavior. In particular, only `SESSION_NOT_FOUND` is translated to `undefined` by `getSession`. Sessions returned by reads MUST be forward-migrated through the client's `migrateRuntime` before they are returned, because the server may lag the client schema version. Corrupt sessions remain fail-loud on direct reads and are omitted from partition listings, matching `BrowserRuntimeStore`.
+
+## Retry and atomicity guarantees
+
+`mergeLearner`, `DELETE /runtime/sessions/{sessionId}`, `DELETE /runtime/stages/{stageId}/learners/{learnerKey}`, and `DELETE /runtime/stages/{stageId}` MUST be safely retryable. Repeating a completed merge moves `0`; repeating a delete succeeds with `204`. A merge is atomic across every matching source session and MUST NOT expose a partial move. Delete endpoints cascade atomically to the target sessions' records.
+
+`POST /runtime/sessions` and record append are not implicitly retry-safe: clients must not retry them after an ambiguous transport failure unless a deployment adds a separate idempotency-key policy. Session ids and record ids remain caller-owned uniqueness keys, while record `seq` remains exclusively server-owned.

--- a/packages/@openmaic/storage/docs/runtime-http-contract.md
+++ b/packages/@openmaic/storage/docs/runtime-http-contract.md
@@ -6,7 +6,7 @@ This contract exposes the complete `RuntimeStore` interface over JSON HTTP. All 
 
 | Method | Path | Purpose | Success |
 | --- | --- | --- | --- |
-| `POST` | `/runtime/sessions` | Create a session from a `RuntimeSessionInit`. The server stamps `runtimeDslVersion`. | `201` with the full `RuntimeSession` |
+| `POST` | `/runtime/sessions` | Create a session from a `RuntimeSessionInit`. The server stamps `runtimeDslVersion`; a client-submitted value is ignored. | `201` with the full `RuntimeSession` |
 | `GET` | `/runtime/sessions/{sessionId}` | Get one session. | `200` with the `RuntimeSession`, or `404` if absent |
 | `PATCH` | `/runtime/sessions/{sessionId}/status` | Set status from `{ "status", "updatedAt" }`. | `204` |
 | `DELETE` | `/runtime/sessions/{sessionId}` | Delete a session and all of its records. | `204` |
@@ -21,11 +21,19 @@ This contract exposes the complete `RuntimeStore` interface over JSON HTTP. All 
 
 ## Server-assigned sequence
 
-`seq` is server-assigned. The append request body is a `RuntimeRecordInit` and MUST NOT include `seq`. The server allocates the next per-session monotonic sequence number atomically with the insert, starting at `0`, and the response returns the full `RuntimeRecord`, including the assigned `seq`. A server MUST reject a client-submitted `seq` with `400 VALIDATION_FAILED` rather than accepting or ignoring it.
+`seq` is server-assigned. The append request body is a `RuntimeRecordInit`. If it includes `seq`, that value is ignored; the store's assigned value is authoritative. The server allocates the next per-session monotonic sequence number atomically with the insert, starting at `0`, and the response returns the full `RuntimeRecord`, including the assigned `seq`.
+
+Likewise, `runtimeDslVersion` is server-assigned when a session is created. If the request body includes `runtimeDslVersion`, that value is ignored; the store's assigned value is authoritative.
+
+## Payload domain
+
+HTTP implementations carry record payloads through JSON and therefore MUST accept only plain JSON values that survive serialization without changing meaning. They MUST fail loud before sending values such as `Map`, `Set`, `Date`, non-finite numbers, nested `undefined`, `bigint`, sparse arrays, strings containing U+0000, U+2028, or U+2029, class instances, and circular references. This is intentionally narrower than `BrowserRuntimeStore`, whose structured-clone persistence can preserve values such as `Map`, `Set`, and `Date` that JSON cannot.
 
 ## learnerKey security model
 
 `learnerKey` appears in paths, query parameters, and request bodies, but the server MUST derive or verify `learnerKey` from the authenticated session and MUST NOT blindly trust the client-submitted value. `learnerKey` is an opaque partition key, not proof of identity or authorization; trusting it verbatim creates a lateral-authorization vulnerability that lets one learner read, merge, or delete another learner's runtime data. The same rule applies to both keys in `mergeLearner`; authorization policy must explicitly permit the authenticated principal to migrate the source partition into the destination partition.
+
+The conformance server in this package is test-only and does not implement an authentication or authorization model; deriving `learnerKey` from authentication is left to the reference server in #939 Part D.
 
 ## Errors
 
@@ -45,7 +53,7 @@ Every non-2xx response has this machine-readable JSON shape:
 
 | Condition | HTTP status | Error code | Client behavior |
 | --- | --- | --- | --- |
-| Malformed JSON, an invalid envelope or payload, invalid learner keys, a body/path mismatch, client-supplied `seq`, or append to a non-active session | `400` | `VALIDATION_FAILED` | Throw `HttpRuntimeStoreError` (an `Error`) with the server message |
+| Malformed JSON, an invalid envelope or payload, invalid learner keys, a body/path mismatch, or append to a non-active session | `400` | `VALIDATION_FAILED` | Throw `HttpRuntimeStoreError` (an `Error`) with the server message |
 | Session does not exist | `404` | `SESSION_NOT_FOUND` | `getSession` returns `undefined`; operations that require the session throw `HttpRuntimeStoreError` with the browser store's `no session` semantics |
 | Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpRuntimeStoreError` |
 | A stored session has a future runtime DSL version | `409` | `FUTURE_VERSION` | Throw `HttpRuntimeStoreError` with the browser store's fail-loud `newer than this client's` semantics |

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./runtime/http": {
+      "types": "./dist/runtime/http.d.ts",
+      "import": "./dist/runtime/http.js"
     }
   },
   "files": [

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -58,8 +58,9 @@ function assertValidSession(session: RuntimeSession): RuntimeSession {
   const result = validateRuntimeSession(session);
   if (result.valid) return session;
   const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  const id = typeof session === 'object' && session !== null ? session.id : undefined;
   throw new Error(
-    `@openmaic/storage: invalid stored runtime session ${JSON.stringify(session.id)}: ${detail}`,
+    `@openmaic/storage: invalid stored runtime session ${JSON.stringify(id)}: ${detail}`,
   );
 }
 
@@ -69,8 +70,9 @@ function assertValidRecord<TPayload extends RuntimePayload>(
   const result = validateRuntimeRecord(record);
   if (result.valid) return record;
   const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  const id = typeof record === 'object' && record !== null ? record.id : undefined;
   throw new Error(
-    `@openmaic/storage: invalid stored runtime record ${JSON.stringify(record.id)}: ${detail}`,
+    `@openmaic/storage: invalid stored runtime record ${JSON.stringify(id)}: ${detail}`,
   );
 }
 
@@ -160,6 +162,7 @@ export class HttpRuntimeStore implements RuntimeStore {
   }
 
   async createSession(init: RuntimeSessionInit): Promise<RuntimeSession> {
+    assertJsonValue(init, `runtime session ${JSON.stringify(init.id)}`);
     const session = await this.request<RuntimeSession>('POST', '/runtime/sessions', init);
     return this.migrateSession(session);
   }
@@ -224,6 +227,7 @@ export class HttpRuntimeStore implements RuntimeStore {
     init: RuntimeRecordInit<TPayload>,
   ): Promise<RuntimeRecord<TPayload>> {
     assertJsonValue(init.payload, `runtime record ${JSON.stringify(init.id)} payload`);
+    assertJsonValue(init, `runtime record ${JSON.stringify(init.id)}`);
     const record = await this.request<RuntimeRecord<TPayload>>(
       'POST',
       `/runtime/sessions/${segment(init.sessionId)}/records`,
@@ -258,11 +262,11 @@ export class HttpRuntimeStore implements RuntimeStore {
       typeof response.body === 'object' && response.body !== null && 'moved' in response.body
         ? response.body.moved
         : undefined;
-    if (typeof moved !== 'number' || !Number.isFinite(moved)) {
+    if (typeof moved !== 'number' || !Number.isInteger(moved) || moved < 0) {
       throw new HttpRuntimeStoreError(
         response.status,
         'MALFORMED_RESPONSE',
-        '@openmaic/storage: RuntimeStore HTTP mergeLearner response moved must be a finite number',
+        '@openmaic/storage: RuntimeStore HTTP mergeLearner response moved must be a non-negative integer',
       );
     }
     return moved;

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -48,6 +48,9 @@ export class HttpRuntimeStoreError extends Error {
 }
 
 function segment(value: string): string {
+  if (value === '.' || value === '..') {
+    throw new Error(`@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`);
+  }
   return encodeURIComponent(value);
 }
 
@@ -113,7 +116,11 @@ export class HttpRuntimeStore implements RuntimeStore {
     this.headersHook = options.headers;
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async requestWithStatus<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<{ body: T; status: number }> {
     const headers = normalizeHeaders(await this.headersHook?.({ method, path }));
     let serializedBody: string | undefined;
     if (body !== undefined) {
@@ -140,8 +147,12 @@ export class HttpRuntimeStore implements RuntimeStore {
           : `@openmaic/storage: RuntimeStore HTTP request failed with status ${response.status}`;
       throw new HttpRuntimeStoreError(response.status, code, message);
     }
-    if (response.status === 204) return undefined as T;
-    return (await response.json()) as T;
+    if (response.status === 204) return { body: undefined as T, status: response.status };
+    return { body: (await response.json()) as T, status: response.status };
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    return (await this.requestWithStatus<T>(method, path, body)).body;
   }
 
   private migrateSession(session: RuntimeSession): RuntimeSession {
@@ -169,10 +180,18 @@ export class HttpRuntimeStore implements RuntimeStore {
   }
 
   async listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]> {
-    const sessions = await this.request<RuntimeSession[]>(
+    const response = await this.requestWithStatus<unknown>(
       'GET',
       `/runtime/stages/${segment(stageId)}/learners/${segment(learnerKey)}/sessions`,
     );
+    if (!Array.isArray(response.body)) {
+      throw new HttpRuntimeStoreError(
+        response.status,
+        'MALFORMED_RESPONSE',
+        '@openmaic/storage: RuntimeStore HTTP listSessions response must be an array',
+      );
+    }
+    const sessions = response.body as RuntimeSession[];
     const migrated: RuntimeSession[] = [];
     for (const session of sessions) {
       try {
@@ -215,19 +234,38 @@ export class HttpRuntimeStore implements RuntimeStore {
 
   async listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]> {
     const query = opts?.sceneId === undefined ? '' : `?sceneId=${encodeURIComponent(opts.sceneId)}`;
-    const records = await this.request<RuntimeRecord[]>(
+    const response = await this.requestWithStatus<unknown>(
       'GET',
       `/runtime/sessions/${segment(sessionId)}/records${query}`,
     );
+    if (!Array.isArray(response.body)) {
+      throw new HttpRuntimeStoreError(
+        response.status,
+        'MALFORMED_RESPONSE',
+        '@openmaic/storage: RuntimeStore HTTP listRecords response must be an array',
+      );
+    }
+    const records = response.body as RuntimeRecord[];
     return records.map((record) => assertValidRecord(record)).sort((a, b) => a.seq - b.seq);
   }
 
   async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {
-    const result = await this.request<{ moved: number }>('POST', '/runtime/learners/merge', {
+    const response = await this.requestWithStatus<unknown>('POST', '/runtime/learners/merge', {
       fromLearnerKey,
       toLearnerKey,
     });
-    return result.moved;
+    const moved =
+      typeof response.body === 'object' && response.body !== null && 'moved' in response.body
+        ? response.body.moved
+        : undefined;
+    if (typeof moved !== 'number' || !Number.isFinite(moved)) {
+      throw new HttpRuntimeStoreError(
+        response.status,
+        'MALFORMED_RESPONSE',
+        '@openmaic/storage: RuntimeStore HTTP mergeLearner response moved must be a finite number',
+      );
+    }
+    return moved;
   }
 
   async deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void> {

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -58,9 +58,17 @@ function segment(value: string): string {
   return encodeURIComponent(value);
 }
 
-function withoutTopLevelUndefined<T extends object>(value: T): T {
+const OPTIONAL_RECORD_ANCHORS = ['sceneId', 'actionIndex', 'subAnchor'] as const;
+
+/**
+ * Drop the DSL-declared optional anchors when they are explicitly undefined —
+ * for those keys undefined means "omitted" throughout the DSL and JSON
+ * produces the identical envelope. Any other undefined member still reaches
+ * the JSON gate and fails loud, so unknown fields cannot be dropped silently.
+ */
+function withoutUndefinedAnchors<T extends object>(value: T): T {
   const descriptors = Object.getOwnPropertyDescriptors(value);
-  for (const key of Reflect.ownKeys(descriptors)) {
+  for (const key of OPTIONAL_RECORD_ANCHORS) {
     const descriptor = descriptors[key as keyof typeof descriptors];
     if (descriptor && 'value' in descriptor && descriptor.value === undefined) {
       delete descriptors[key as keyof typeof descriptors];
@@ -245,7 +253,7 @@ export class HttpRuntimeStore implements RuntimeStore {
     init: RuntimeRecordInit<TPayload>,
   ): Promise<RuntimeRecord<TPayload>> {
     assertJsonValue(init.payload, `runtime record ${JSON.stringify(init.id)} payload`);
-    const normalizedInit = withoutTopLevelUndefined(init);
+    const normalizedInit = withoutUndefinedAnchors(init);
     assertJsonValue(normalizedInit, `runtime record ${JSON.stringify(init.id)}`);
     const record = await this.request<RuntimeRecord<TPayload>>(
       'POST',

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -47,11 +47,26 @@ export class HttpRuntimeStoreError extends Error {
   }
 }
 
-function segment(value: string): string {
+function assertAddressableSegment(value: string): void {
   if (value === '.' || value === '..') {
     throw new Error(`@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`);
   }
+}
+
+function segment(value: string): string {
+  assertAddressableSegment(value);
   return encodeURIComponent(value);
+}
+
+function withoutTopLevelUndefined<T extends object>(value: T): T {
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    const descriptor = descriptors[key as keyof typeof descriptors];
+    if (descriptor && 'value' in descriptor && descriptor.value === undefined) {
+      delete descriptors[key as keyof typeof descriptors];
+    }
+  }
+  return Object.create(Object.getPrototypeOf(value), descriptors) as T;
 }
 
 function assertValidSession(session: RuntimeSession): RuntimeSession {
@@ -163,6 +178,9 @@ export class HttpRuntimeStore implements RuntimeStore {
 
   async createSession(init: RuntimeSessionInit): Promise<RuntimeSession> {
     assertJsonValue(init, `runtime session ${JSON.stringify(init.id)}`);
+    assertAddressableSegment(init.id);
+    assertAddressableSegment(init.stageId);
+    assertAddressableSegment(init.learnerKey);
     const session = await this.request<RuntimeSession>('POST', '/runtime/sessions', init);
     return this.migrateSession(session);
   }
@@ -227,11 +245,12 @@ export class HttpRuntimeStore implements RuntimeStore {
     init: RuntimeRecordInit<TPayload>,
   ): Promise<RuntimeRecord<TPayload>> {
     assertJsonValue(init.payload, `runtime record ${JSON.stringify(init.id)} payload`);
-    assertJsonValue(init, `runtime record ${JSON.stringify(init.id)}`);
+    const normalizedInit = withoutTopLevelUndefined(init);
+    assertJsonValue(normalizedInit, `runtime record ${JSON.stringify(init.id)}`);
     const record = await this.request<RuntimeRecord<TPayload>>(
       'POST',
       `/runtime/sessions/${segment(init.sessionId)}/records`,
-      init,
+      normalizedInit,
     );
     return assertValidRecord(record);
   }
@@ -254,6 +273,9 @@ export class HttpRuntimeStore implements RuntimeStore {
   }
 
   async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {
+    assertJsonValue(fromLearnerKey, 'runtime learner merge fromLearnerKey');
+    assertJsonValue(toLearnerKey, 'runtime learner merge toLearnerKey');
+    assertAddressableSegment(toLearnerKey);
     const response = await this.requestWithStatus<unknown>('POST', '/runtime/learners/merge', {
       fromLearnerKey,
       toLearnerKey,

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -1,4 +1,4 @@
-import { migrateRuntime, validateRuntimeSession } from '@openmaic/dsl';
+import { migrateRuntime, validateRuntimeRecord, validateRuntimeSession } from '@openmaic/dsl';
 import type {
   RuntimePayload,
   RuntimeRecord,
@@ -7,6 +7,7 @@ import type {
   RuntimeSessionStatus,
 } from '@openmaic/dsl';
 import type { RuntimeSessionInit, RuntimeStore } from './types.js';
+import { assertJsonValue } from './json-value.js';
 
 export interface HttpRuntimeHeadersContext {
   method: string;
@@ -59,6 +60,36 @@ function assertValidSession(session: RuntimeSession): RuntimeSession {
   );
 }
 
+function assertValidRecord<TPayload extends RuntimePayload>(
+  record: RuntimeRecord<TPayload>,
+): RuntimeRecord<TPayload> {
+  const result = validateRuntimeRecord(record);
+  if (result.valid) return record;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new Error(
+    `@openmaic/storage: invalid stored runtime record ${JSON.stringify(record.id)}: ${detail}`,
+  );
+}
+
+function normalizeHeaders(init: HeadersInit | undefined): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  const set = (name: string, value: string): void => {
+    normalized[name.toLowerCase()] = value;
+  };
+
+  if (init === undefined) return normalized;
+  if (Array.isArray(init)) {
+    for (const [name, value] of init) set(name, value);
+    return normalized;
+  }
+  if (typeof (init as Headers).forEach === 'function') {
+    (init as Headers).forEach((value, name) => set(name, value));
+    return normalized;
+  }
+  for (const [name, value] of Object.entries(init)) set(name, value);
+  return normalized;
+}
+
 /**
  * RuntimeStore client for the JSON HTTP contract. Session reads migrate again
  * on the client so a server running an older schema cannot leak stale envelopes
@@ -83,10 +114,10 @@ export class HttpRuntimeStore implements RuntimeStore {
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const headers = new Headers(await this.headersHook?.({ method, path }));
+    const headers = normalizeHeaders(await this.headersHook?.({ method, path }));
     let serializedBody: string | undefined;
     if (body !== undefined) {
-      if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+      headers['content-type'] ??= 'application/json';
       serializedBody = JSON.stringify(body);
     }
 
@@ -173,19 +204,22 @@ export class HttpRuntimeStore implements RuntimeStore {
   async appendRecord<TPayload extends RuntimePayload>(
     init: RuntimeRecordInit<TPayload>,
   ): Promise<RuntimeRecord<TPayload>> {
-    return this.request<RuntimeRecord<TPayload>>(
+    assertJsonValue(init.payload, `runtime record ${JSON.stringify(init.id)} payload`);
+    const record = await this.request<RuntimeRecord<TPayload>>(
       'POST',
       `/runtime/sessions/${segment(init.sessionId)}/records`,
       init,
     );
+    return assertValidRecord(record);
   }
 
   async listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]> {
     const query = opts?.sceneId === undefined ? '' : `?sceneId=${encodeURIComponent(opts.sceneId)}`;
-    return this.request<RuntimeRecord[]>(
+    const records = await this.request<RuntimeRecord[]>(
       'GET',
       `/runtime/sessions/${segment(sessionId)}/records${query}`,
     );
+    return records.map((record) => assertValidRecord(record)).sort((a, b) => a.seq - b.seq);
   }
 
   async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -1,0 +1,209 @@
+import { migrateRuntime, validateRuntimeSession } from '@openmaic/dsl';
+import type {
+  RuntimePayload,
+  RuntimeRecord,
+  RuntimeRecordInit,
+  RuntimeSession,
+  RuntimeSessionStatus,
+} from '@openmaic/dsl';
+import type { RuntimeSessionInit, RuntimeStore } from './types.js';
+
+export interface HttpRuntimeHeadersContext {
+  method: string;
+  path: string;
+}
+
+export type HttpRuntimeHeadersHook = (
+  context: HttpRuntimeHeadersContext,
+) => HeadersInit | Promise<HeadersInit>;
+
+export interface HttpRuntimeStoreOptions {
+  /** Root URL before the contract's `/runtime/...` paths. */
+  baseUrl: string;
+  /** Fetch implementation. Defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch;
+  /** Called for every request so deployments can attach authentication headers. */
+  headers?: HttpRuntimeHeadersHook;
+}
+
+interface ErrorResponseBody {
+  error?: {
+    code?: unknown;
+    message?: unknown;
+  };
+}
+
+/** A server-side RuntimeStore failure, retaining its machine-readable HTTP identity. */
+export class HttpRuntimeStoreError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = 'HttpRuntimeStoreError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function segment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function assertValidSession(session: RuntimeSession): RuntimeSession {
+  const result = validateRuntimeSession(session);
+  if (result.valid) return session;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new Error(
+    `@openmaic/storage: invalid stored runtime session ${JSON.stringify(session.id)}: ${detail}`,
+  );
+}
+
+/**
+ * RuntimeStore client for the JSON HTTP contract. Session reads migrate again
+ * on the client so a server running an older schema cannot leak stale envelopes
+ * into a newer application.
+ */
+export class HttpRuntimeStore implements RuntimeStore {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly headersHook: HttpRuntimeHeadersHook | undefined;
+
+  constructor(options: HttpRuntimeStoreOptions) {
+    if (options.baseUrl === '') {
+      throw new Error('@openmaic/storage: HttpRuntimeStore baseUrl must be non-empty');
+    }
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('@openmaic/storage: HttpRuntimeStore requires a fetch implementation');
+    }
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = fetchImpl;
+    this.headersHook = options.headers;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const headers = new Headers(await this.headersHook?.({ method, path }));
+    let serializedBody: string | undefined;
+    if (body !== undefined) {
+      if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+      serializedBody = JSON.stringify(body);
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      ...(serializedBody === undefined ? {} : { body: serializedBody }),
+    });
+    if (!response.ok) {
+      let errorBody: ErrorResponseBody | undefined;
+      try {
+        errorBody = (await response.json()) as ErrorResponseBody;
+      } catch {
+        // A non-conforming server still becomes a useful typed HTTP error.
+      }
+      const code = typeof errorBody?.error?.code === 'string' ? errorBody.error.code : 'HTTP_ERROR';
+      const message =
+        typeof errorBody?.error?.message === 'string'
+          ? errorBody.error.message
+          : `@openmaic/storage: RuntimeStore HTTP request failed with status ${response.status}`;
+      throw new HttpRuntimeStoreError(response.status, code, message);
+    }
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  private migrateSession(session: RuntimeSession): RuntimeSession {
+    return assertValidSession(migrateRuntime(session) as RuntimeSession);
+  }
+
+  async createSession(init: RuntimeSessionInit): Promise<RuntimeSession> {
+    const session = await this.request<RuntimeSession>('POST', '/runtime/sessions', init);
+    return this.migrateSession(session);
+  }
+
+  async getSession(sessionId: string): Promise<RuntimeSession | undefined> {
+    try {
+      const session = await this.request<RuntimeSession>(
+        'GET',
+        `/runtime/sessions/${segment(sessionId)}`,
+      );
+      return this.migrateSession(session);
+    } catch (error) {
+      if (error instanceof HttpRuntimeStoreError && error.code === 'SESSION_NOT_FOUND') {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]> {
+    const sessions = await this.request<RuntimeSession[]>(
+      'GET',
+      `/runtime/stages/${segment(stageId)}/learners/${segment(learnerKey)}/sessions`,
+    );
+    const migrated: RuntimeSession[] = [];
+    for (const session of sessions) {
+      try {
+        migrated.push(this.migrateSession(session));
+      } catch {
+        // Match BrowserRuntimeStore: corrupt partition rows are omitted.
+      }
+    }
+    return migrated.sort(
+      (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt) || a.id.localeCompare(b.id),
+    );
+  }
+
+  async setSessionStatus(
+    sessionId: string,
+    status: RuntimeSessionStatus,
+    updatedAt: string,
+  ): Promise<void> {
+    await this.request<void>('PATCH', `/runtime/sessions/${segment(sessionId)}/status`, {
+      status,
+      updatedAt,
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.request<void>('DELETE', `/runtime/sessions/${segment(sessionId)}`);
+  }
+
+  async appendRecord<TPayload extends RuntimePayload>(
+    init: RuntimeRecordInit<TPayload>,
+  ): Promise<RuntimeRecord<TPayload>> {
+    return this.request<RuntimeRecord<TPayload>>(
+      'POST',
+      `/runtime/sessions/${segment(init.sessionId)}/records`,
+      init,
+    );
+  }
+
+  async listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]> {
+    const query = opts?.sceneId === undefined ? '' : `?sceneId=${encodeURIComponent(opts.sceneId)}`;
+    return this.request<RuntimeRecord[]>(
+      'GET',
+      `/runtime/sessions/${segment(sessionId)}/records${query}`,
+    );
+  }
+
+  async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {
+    const result = await this.request<{ moved: number }>('POST', '/runtime/learners/merge', {
+      fromLearnerKey,
+      toLearnerKey,
+    });
+    return result.moved;
+  }
+
+  async deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void> {
+    await this.request<void>(
+      'DELETE',
+      `/runtime/stages/${segment(stageId)}/learners/${segment(learnerKey)}`,
+    );
+  }
+
+  async deleteStageRuntime(stageId: string): Promise<void> {
+    await this.request<void>('DELETE', `/runtime/stages/${segment(stageId)}`);
+  }
+}

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -1,16 +1,19 @@
 /**
  * Shared payload guard for JSON-carrying backends (HTTP transport, Postgres
  * JSONB). The browser backend persists payloads via structured clone, which
- * preserves values JSON cannot represent (Map, Set, Date, NaN, nested
- * undefined, bigint). A JSON backend that accepted those would silently hand
- * back different data on the next read — appendRecord's return value and a
- * later listRecords would disagree. JSON backends therefore narrow the
- * accepted payload domain and fail loud at the write boundary.
+ * preserves values JSON cannot represent (Map, Set, Date, NaN, negative zero,
+ * nested undefined, bigint, symbol-keyed or non-enumerable properties). A JSON
+ * backend that accepted those would silently hand back different data on the
+ * next read — appendRecord's return value and a later listRecords would
+ * disagree. JSON backends therefore narrow the accepted payload domain and
+ * fail loud at the write boundary.
  *
- * JSONB note: Postgres jsonb cannot store the NUL code point (U+0000) inside
- * strings (error 22P05), so strings containing it are rejected here too —
- * keeping the payload domain identical across JSON backends rather than
- * letting one accept what another must refuse.
+ * The narrowing is exactly "survives JSON.stringify/JSON.parse losslessly":
+ * characters that round-trip through JSON (including U+2028/U+2029, legal in
+ * JSON strings per RFC 8259) are accepted. The one string exception is the
+ * NUL code point (U+0000): Postgres jsonb cannot store it (error 22P05), so
+ * it is rejected here too — keeping the payload domain identical across JSON
+ * backends rather than letting one accept what another must refuse.
  */
 
 interface NonJsonValue {
@@ -23,6 +26,11 @@ function isPlainPrototype(value: object): boolean {
   return prototype === Object.prototype || prototype === null;
 }
 
+function isCanonicalIndex(key: string, length: number): boolean {
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
 function findNonJsonValue(
   value: unknown,
   pointer: string,
@@ -30,20 +38,15 @@ function findNonJsonValue(
 ): NonJsonValue | undefined {
   if (value === null || typeof value === 'boolean') return undefined;
   if (typeof value === 'number') {
+    if (Object.is(value, -0)) {
+      return { pointer, reason: 'negative zero (JSON serializes it as 0)' };
+    }
     if (Number.isFinite(value)) return undefined;
     return { pointer, reason: `non-finite number ${String(value)}` };
   }
   if (typeof value === 'string') {
-    if (value.includes('\u0000')) {
-      return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
-    }
-    if (value.includes('\u2028') || value.includes('\u2029')) {
-      return {
-        pointer,
-        reason: 'string contains a line or paragraph separator (\\u2028/\\u2029)',
-      };
-    }
-    return undefined;
+    if (!value.includes('\u0000')) return undefined;
+    return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
   }
   if (typeof value !== 'object') {
     return { pointer, reason: `${typeof value} is not a JSON value` };
@@ -52,6 +55,15 @@ function findNonJsonValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
+      for (const key of Reflect.ownKeys(value)) {
+        if (key === 'length') continue;
+        if (typeof key !== 'string' || !isCanonicalIndex(key, value.length)) {
+          return {
+            pointer: `${pointer}/${String(key)}`,
+            reason: 'array carries a non-index own property (dropped by JSON)',
+          };
+        }
+      }
       for (let index = 0; index < value.length; index += 1) {
         if (!(index in value)) {
           return { pointer: `${pointer}/${index}`, reason: 'sparse array hole' };
@@ -67,12 +79,22 @@ function findNonJsonValue(
         reason: 'not a plain object (Map, Set, Date, class instances do not survive JSON)',
       };
     }
-    for (const [key, member] of Object.entries(value)) {
-      const memberPointer = `${pointer}/${key}`;
-      if (member === undefined) {
-        return { pointer: memberPointer, reason: 'undefined member (dropped by JSON)' };
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') {
+        return { pointer, reason: 'symbol-keyed own property (dropped by JSON)' };
       }
-      const nested = findNonJsonValue(member, memberPointer, seen);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor !== undefined && !descriptor.enumerable) {
+        return {
+          pointer: `${pointer}/${key}`,
+          reason: 'non-enumerable own property (dropped by JSON)',
+        };
+      }
+      const member = (value as Record<string, unknown>)[key];
+      if (member === undefined) {
+        return { pointer: `${pointer}/${key}`, reason: 'undefined member (dropped by JSON)' };
+      }
+      const nested = findNonJsonValue(member, `${pointer}/${key}`, seen);
       if (nested) return nested;
     }
     return undefined;

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -10,10 +10,12 @@
  *
  * The narrowing is exactly "survives JSON.stringify/JSON.parse losslessly":
  * characters that round-trip through JSON (including U+2028/U+2029, legal in
- * JSON strings per RFC 8259) are accepted. The one string exception is the
- * NUL code point (U+0000): Postgres jsonb cannot store it (error 22P05), so
- * it is rejected here too — keeping the payload domain identical across JSON
- * backends rather than letting one accept what another must refuse.
+ * JSON strings per RFC 8259) are accepted. Two string exceptions — applied to
+ * object keys as well as values — keep the payload domain identical across
+ * JSON backends rather than letting one accept what another must refuse: the
+ * NUL code point (U+0000), which Postgres jsonb cannot store (error 22P05),
+ * and unpaired UTF-16 surrogates, which jsonb rejects (22P02) and which other
+ * JSON stacks silently replace with U+FFFD.
  */
 
 interface NonJsonValue {
@@ -31,6 +33,20 @@ function isCanonicalIndex(key: string, length: number): boolean {
   return Number.isInteger(index) && index >= 0 && index < length && String(index) === key;
 }
 
+// In u-mode a surrogate pair is consumed as one astral code point, so this
+// class matches exactly the unpaired surrogates.
+const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
+
+function findNonJsonString(value: string, pointer: string): NonJsonValue | undefined {
+  if (value.includes('\u0000')) {
+    return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
+  }
+  if (LONE_SURROGATE.test(value)) {
+    return { pointer, reason: 'string contains an unpaired UTF-16 surrogate' };
+  }
+  return undefined;
+}
+
 function findNonJsonValue(
   value: unknown,
   pointer: string,
@@ -45,8 +61,7 @@ function findNonJsonValue(
     return { pointer, reason: `non-finite number ${String(value)}` };
   }
   if (typeof value === 'string') {
-    if (!value.includes('\u0000')) return undefined;
-    return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
+    return findNonJsonString(value, pointer);
   }
   if (typeof value !== 'object') {
     return { pointer, reason: `${typeof value} is not a JSON value` };
@@ -89,6 +104,10 @@ function findNonJsonValue(
           pointer: `${pointer}/${key}`,
           reason: 'non-enumerable own property (dropped by JSON)',
         };
+      }
+      const keyIssue = findNonJsonString(key, `${pointer}/${key}`);
+      if (keyIssue) {
+        return { pointer: keyIssue.pointer, reason: `object key: ${keyIssue.reason}` };
       }
       const member = (value as Record<string, unknown>)[key];
       if (member === undefined) {

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -41,6 +41,15 @@ function isCanonicalIndex(key: string, length: number): boolean {
 // class matches exactly the unpaired surrogates.
 const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
 
+function definesToJson(value: object): boolean {
+  let current: object | null = value;
+  while (current !== null) {
+    if (Object.getOwnPropertyDescriptor(current, 'toJSON') !== undefined) return true;
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return false;
+}
+
 function findNonJsonString(value: string, pointer: string): NonJsonValue | undefined {
   if (value.includes('\u0000')) {
     return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
@@ -83,8 +92,12 @@ function findNonJsonValue(
   if (seen.has(value)) return { pointer, reason: 'circular reference' };
   // toJSON is the one channel through which a prototype can alter JSON output
   // (prototype properties themselves never serialize, and own accessors are
-  // rejected below), so refusing it closes prototype influence entirely.
-  if (typeof (value as { toJSON?: unknown }).toJSON === 'function') {
+  // rejected below), so refusing it closes prototype influence entirely. The
+  // probe walks descriptors instead of reading the property: a [[Get]] would
+  // execute an inherited accessor, letting a stateful getter hide from the
+  // check and reappear at stringify time. Mutating the object graph after
+  // validation is out of scope, as it is for every other validated property.
+  if (definesToJson(value)) {
     return { pointer, reason: 'value defines toJSON (would serialize differently than validated)' };
   }
   seen.add(value);

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -42,9 +42,17 @@ function isCanonicalIndex(key: string, length: number): boolean {
 const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
 
 function definesToJson(value: object): boolean {
+  // Mirror JSON.stringify exactly: it reads the own-most 'toJSON' and only
+  // invokes it when callable. A non-callable data value shadows anything
+  // above it and is an ordinary member, so it is safe; an accessor cannot be
+  // inspected without invoking it, so it is rejected outright.
   let current: object | null = value;
   while (current !== null) {
-    if (Object.getOwnPropertyDescriptor(current, 'toJSON') !== undefined) return true;
+    const descriptor = Object.getOwnPropertyDescriptor(current, 'toJSON');
+    if (descriptor !== undefined) {
+      if ('value' in descriptor) return typeof descriptor.value === 'function';
+      return true;
+    }
     current = Object.getPrototypeOf(current) as object | null;
   }
   return false;

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -81,6 +81,12 @@ function findNonJsonValue(
     return { pointer, reason: `${typeof value} is not a JSON value` };
   }
   if (seen.has(value)) return { pointer, reason: 'circular reference' };
+  // toJSON is the one channel through which a prototype can alter JSON output
+  // (prototype properties themselves never serialize, and own accessors are
+  // rejected below), so refusing it closes prototype influence entirely.
+  if (typeof (value as { toJSON?: unknown }).toJSON === 'function') {
+    return { pointer, reason: 'value defines toJSON (would serialize differently than validated)' };
+  }
   seen.add(value);
   try {
     if (Array.isArray(value)) {

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -70,6 +70,12 @@ function findNonJsonValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
+      if (Object.getPrototypeOf(value) !== Array.prototype) {
+        return {
+          pointer,
+          reason: 'array with a non-Array prototype (subclass/null-proto) does not survive JSON',
+        };
+      }
       for (const key of Reflect.ownKeys(value)) {
         if (key === 'length') continue;
         if (typeof key !== 'string' || !isCanonicalIndex(key, value.length)) {
@@ -78,9 +84,16 @@ function findNonJsonValue(
             reason: 'array carries a non-index own property (dropped by JSON)',
           };
         }
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (descriptor && (descriptor.get || descriptor.set)) {
+          return {
+            pointer: `${pointer}/${key}`,
+            reason: 'accessor property (its value can change between validation and JSON)',
+          };
+        }
       }
       for (let index = 0; index < value.length; index += 1) {
-        if (!(index in value)) {
+        if (!Object.hasOwn(value, index)) {
           return { pointer: `${pointer}/${index}`, reason: 'sparse array hole' };
         }
         const nested = findNonJsonValue(value[index], `${pointer}/${index}`, seen);
@@ -103,6 +116,12 @@ function findNonJsonValue(
         return {
           pointer: `${pointer}/${key}`,
           reason: 'non-enumerable own property (dropped by JSON)',
+        };
+      }
+      if (descriptor && (descriptor.get || descriptor.set)) {
+        return {
+          pointer: `${pointer}/${key}`,
+          reason: 'accessor property (its value can change between validation and JSON)',
         };
       }
       const keyIssue = findNonJsonString(key, `${pointer}/${key}`);

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -24,8 +24,12 @@ interface NonJsonValue {
 }
 
 function isPlainPrototype(value: object): boolean {
+  // Realm-agnostic: a plain object's chain is value -> (some realm's)
+  // Object.prototype -> null, or value -> null for null-proto objects.
+  // Identity against this realm's Object.prototype would reject ordinary
+  // objects from another realm (vm, iframe), which JSON round-trips fine.
   const prototype = Object.getPrototypeOf(value) as object | null;
-  return prototype === Object.prototype || prototype === null;
+  return prototype === null || Object.getPrototypeOf(prototype) === null;
 }
 
 function isCanonicalIndex(key: string, length: number): boolean {
@@ -45,6 +49,16 @@ function findNonJsonString(value: string, pointer: string): NonJsonValue | undef
     return { pointer, reason: 'string contains an unpaired UTF-16 surrogate' };
   }
   return undefined;
+}
+
+/**
+ * True when `value` contains neither of the two string exceptions above.
+ * SQL backends also use this to decide that a lookup key can never match a
+ * stored row (the write gate provably refuses such keys), so this predicate
+ * and the write-side string rule must stay coupled — hence the shared export.
+ */
+export function isLosslessJsonString(value: string): boolean {
+  return findNonJsonString(value, '') === undefined;
 }
 
 function findNonJsonValue(
@@ -70,7 +84,15 @@ function findNonJsonValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
-      if (Object.getPrototypeOf(value) !== Array.prototype) {
+      // Realm-agnostic plain-array check: a plain array's chain is
+      // arr -> Array.prototype -> Object.prototype -> null. Subclasses add a
+      // hop and null-proto arrays short-circuit; comparing against this
+      // realm's Array.prototype identity would reject ordinary arrays from
+      // another realm (vm, iframe), which JSON round-trips fine.
+      const arrayProto = Object.getPrototypeOf(value) as object | null;
+      const objectProto =
+        arrayProto === null ? null : (Object.getPrototypeOf(arrayProto) as object | null);
+      if (objectProto === null || Object.getPrototypeOf(objectProto) !== null) {
         return {
           pointer,
           reason: 'array with a non-Array prototype (subclass/null-proto) does not survive JSON',

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared payload guard for JSON-carrying backends (HTTP transport, Postgres
+ * JSONB). The browser backend persists payloads via structured clone, which
+ * preserves values JSON cannot represent (Map, Set, Date, NaN, nested
+ * undefined, bigint). A JSON backend that accepted those would silently hand
+ * back different data on the next read — appendRecord's return value and a
+ * later listRecords would disagree. JSON backends therefore narrow the
+ * accepted payload domain and fail loud at the write boundary.
+ *
+ * JSONB note: Postgres jsonb cannot store the NUL code point (U+0000) inside
+ * strings (error 22P05), so strings containing it are rejected here too —
+ * keeping the payload domain identical across JSON backends rather than
+ * letting one accept what another must refuse.
+ */
+
+interface NonJsonValue {
+  pointer: string;
+  reason: string;
+}
+
+function isPlainPrototype(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function findNonJsonValue(
+  value: unknown,
+  pointer: string,
+  seen: Set<object>,
+): NonJsonValue | undefined {
+  if (value === null || typeof value === 'boolean') return undefined;
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) return undefined;
+    return { pointer, reason: `non-finite number ${String(value)}` };
+  }
+  if (typeof value === 'string') {
+    if (value.includes('\u0000')) {
+      return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
+    }
+    if (value.includes('\u2028') || value.includes('\u2029')) {
+      return {
+        pointer,
+        reason: 'string contains a line or paragraph separator (\\u2028/\\u2029)',
+      };
+    }
+    return undefined;
+  }
+  if (typeof value !== 'object') {
+    return { pointer, reason: `${typeof value} is not a JSON value` };
+  }
+  if (seen.has(value)) return { pointer, reason: 'circular reference' };
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!(index in value)) {
+          return { pointer: `${pointer}/${index}`, reason: 'sparse array hole' };
+        }
+        const nested = findNonJsonValue(value[index], `${pointer}/${index}`, seen);
+        if (nested) return nested;
+      }
+      return undefined;
+    }
+    if (!isPlainPrototype(value)) {
+      return {
+        pointer,
+        reason: 'not a plain object (Map, Set, Date, class instances do not survive JSON)',
+      };
+    }
+    for (const [key, member] of Object.entries(value)) {
+      const memberPointer = `${pointer}/${key}`;
+      if (member === undefined) {
+        return { pointer: memberPointer, reason: 'undefined member (dropped by JSON)' };
+      }
+      const nested = findNonJsonValue(member, memberPointer, seen);
+      if (nested) return nested;
+    }
+    return undefined;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+/** Throw unless `value` survives JSON serialization losslessly. */
+export function assertJsonValue(value: unknown, label: string): void {
+  const offender = findNonJsonValue(value, '', new Set());
+  if (offender) {
+    throw new Error(
+      `@openmaic/storage: ${label} is not a plain JSON value at ` +
+        `'${offender.pointer || '/'}': ${offender.reason}`,
+    );
+  }
+}

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -61,8 +61,20 @@ async function readJson<T>(req: IncomingMessage): Promise<T> {
   for await (const chunk of req) {
     chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
   }
-  if (chunks.length === 0) throw new Error('request body must be JSON');
-  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+  if (chunks.length === 0) {
+    throw new ConformanceHttpError(400, 'VALIDATION_FAILED', 'request body must be a JSON object');
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ConformanceHttpError(400, 'VALIDATION_FAILED', message);
+  }
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new ConformanceHttpError(400, 'VALIDATION_FAILED', 'request body must be a JSON object');
+  }
+  return body as T;
 }
 
 function errorResponse(error: unknown): { status: number; body: ErrorBody } {

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -1,6 +1,18 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { IDBFactory } from 'fake-indexeddb';
-import type { RuntimeRecordInit, RuntimeSessionStatus } from '@openmaic/dsl';
+import {
+  needsRuntimeMigration,
+  RUNTIME_DSL_VERSION,
+  runtimeDslVersionOf,
+  validateRuntimeRecord,
+  validateRuntimeSession,
+} from '@openmaic/dsl';
+import type {
+  RuntimeRecordInit,
+  RuntimeSession,
+  RuntimeSessionStatus,
+  ValidationResult,
+} from '@openmaic/dsl';
 import { BrowserRuntimeStore } from '../src/runtime/browser.js';
 import type { RuntimeSessionInit, RuntimeStore } from '../src/runtime/types.js';
 
@@ -20,6 +32,16 @@ interface ErrorBody {
     code: string;
     message: string;
   };
+}
+
+class ConformanceHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -46,32 +68,50 @@ function errorResponse(error: unknown): { status: number; body: ErrorBody } {
   if (error instanceof SyntaxError) {
     return { status: 400, body: { error: { code: 'VALIDATION_FAILED', message } } };
   }
-  if (/newer than this client's/i.test(message)) {
-    return { status: 409, body: { error: { code: 'FUTURE_VERSION', message } } };
-  }
-  if (/already exists/i.test(message)) {
-    return { status: 409, body: { error: { code: 'SESSION_ALREADY_EXISTS', message } } };
-  }
-  if (/no session/i.test(message)) {
-    return { status: 404, body: { error: { code: 'SESSION_NOT_FOUND', message } } };
-  }
-  if (
-    /invalid|must be|may only be appended|non-empty|request body|unexpected|does not match/i.test(
-      message,
-    )
-  ) {
-    return { status: 400, body: { error: { code: 'VALIDATION_FAILED', message } } };
+  if (error instanceof ConformanceHttpError) {
+    return { status: error.status, body: { error: { code: error.code, message } } };
   }
   return { status: 500, body: { error: { code: 'INTERNAL_ERROR', message } } };
 }
 
+function validationError(result: ValidationResult, label: string): void {
+  if (result.valid) return;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new ConformanceHttpError(400, 'VALIDATION_FAILED', `${label}: ${detail}`);
+}
+
+function missingSessionError(sessionId: string): ConformanceHttpError {
+  return new ConformanceHttpError(
+    404,
+    'SESSION_NOT_FOUND',
+    `@openmaic/storage: no session ${JSON.stringify(sessionId)}`,
+  );
+}
+
+function assertNotFutureSession(session: RuntimeSession): void {
+  const version = runtimeDslVersionOf(session);
+  if (!needsRuntimeMigration(session) && version !== RUNTIME_DSL_VERSION) {
+    throw new ConformanceHttpError(
+      409,
+      'FUTURE_VERSION',
+      `@openmaic/storage: session ${JSON.stringify(session.id)} was written at runtime DSL ` +
+        `version ${JSON.stringify(version)}, newer than this client's ${RUNTIME_DSL_VERSION}`,
+    );
+  }
+}
+
+async function requireSession(store: RuntimeStore, sessionId: string): Promise<RuntimeSession> {
+  const session = await store.getSession(sessionId);
+  if (session === undefined) throw missingSessionError(sessionId);
+  return session;
+}
+
 function pathParts(req: IncomingMessage): { parts: string[]; url: URL } {
   const url = new URL(req.url ?? '/', 'http://conformance.invalid');
+  const parts = url.pathname.split('/');
+  if (parts[0] === '') parts.shift();
   return {
-    parts: url.pathname
-      .split('/')
-      .filter(Boolean)
-      .map((part) => decodeURIComponent(part)),
+    parts: parts.map((part) => decodeURIComponent(part)),
     url,
   };
 }
@@ -91,8 +131,16 @@ async function route(
 
   if (method === 'POST' && parts.length === 2 && parts[1] === 'sessions') {
     const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(req);
-    if (Object.hasOwn(init, 'runtimeDslVersion')) {
-      throw new Error('invalid runtime session: request body must not include runtimeDslVersion');
+    validationError(
+      validateRuntimeSession({ ...init, runtimeDslVersion: RUNTIME_DSL_VERSION }),
+      `@openmaic/storage: invalid runtime session ${JSON.stringify(init.id)}`,
+    );
+    if (await store.getSession(init.id)) {
+      throw new ConformanceHttpError(
+        409,
+        'SESSION_ALREADY_EXISTS',
+        `@openmaic/storage: runtime session ${JSON.stringify(init.id)} already exists`,
+      );
     }
     sendJson(res, 201, await store.createSession(init));
     return;
@@ -116,6 +164,12 @@ async function route(
     }
     if (method === 'PATCH' && parts.length === 4 && parts[3] === 'status') {
       const body = await readJson<{ status: RuntimeSessionStatus; updatedAt: string }>(req);
+      const session = await requireSession(store, sessionId);
+      assertNotFutureSession(session);
+      validationError(
+        validateRuntimeSession({ ...session, status: body.status, updatedAt: body.updatedAt }),
+        `@openmaic/storage: invalid runtime session ${JSON.stringify(sessionId)}`,
+      );
       await store.setSessionStatus(sessionId, body.status, body.updatedAt);
       sendNoContent(res);
       return;
@@ -127,11 +181,26 @@ async function route(
     }
     if (method === 'POST' && parts.length === 4 && parts[3] === 'records') {
       const init = await readJson<RuntimeRecordInit & { seq?: unknown }>(req);
-      if (Object.hasOwn(init, 'seq')) {
-        throw new Error('invalid runtime record: append request body must not include seq');
-      }
       if (init.sessionId !== sessionId) {
-        throw new Error('invalid runtime record: body sessionId does not match the request path');
+        throw new ConformanceHttpError(
+          400,
+          'VALIDATION_FAILED',
+          'invalid runtime record: body sessionId does not match the request path',
+        );
+      }
+      validationError(
+        validateRuntimeRecord({ ...init, seq: 0 }),
+        `@openmaic/storage: invalid runtime record ${JSON.stringify(init.id)}`,
+      );
+      const session = await requireSession(store, sessionId);
+      assertNotFutureSession(session);
+      if (session.status !== 'active') {
+        throw new ConformanceHttpError(
+          400,
+          'VALIDATION_FAILED',
+          `@openmaic/storage: cannot append to session ${JSON.stringify(sessionId)} with ` +
+            `status '${session.status}' — records may only be appended to an active session`,
+        );
       }
       sendJson(res, 201, await store.appendRecord(init));
       return;

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -1,0 +1,284 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { IDBFactory } from 'fake-indexeddb';
+import type { RuntimeRecordInit, RuntimeSessionStatus } from '@openmaic/dsl';
+import { BrowserRuntimeStore } from '../src/runtime/browser.js';
+import type { RuntimeSessionInit, RuntimeStore } from '../src/runtime/types.js';
+
+export interface HttpConformanceServer {
+  baseUrl: string;
+  fetch: typeof globalThis.fetch;
+  close(): Promise<void>;
+}
+
+export interface HttpConformanceServerOptions {
+  /** Bind a loopback TCP port. Tests can disable this in network-restricted sandboxes. */
+  listen?: boolean;
+}
+
+interface ErrorBody {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function sendNoContent(res: ServerResponse): void {
+  res.writeHead(204);
+  res.end();
+}
+
+async function readJson<T>(req: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) throw new Error('request body must be JSON');
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+}
+
+function errorResponse(error: unknown): { status: number; body: ErrorBody } {
+  const message = error instanceof Error ? error.message : String(error);
+  if (error instanceof SyntaxError) {
+    return { status: 400, body: { error: { code: 'VALIDATION_FAILED', message } } };
+  }
+  if (/newer than this client's/i.test(message)) {
+    return { status: 409, body: { error: { code: 'FUTURE_VERSION', message } } };
+  }
+  if (/already exists/i.test(message)) {
+    return { status: 409, body: { error: { code: 'SESSION_ALREADY_EXISTS', message } } };
+  }
+  if (/no session/i.test(message)) {
+    return { status: 404, body: { error: { code: 'SESSION_NOT_FOUND', message } } };
+  }
+  if (
+    /invalid|must be|may only be appended|non-empty|request body|unexpected|does not match/i.test(
+      message,
+    )
+  ) {
+    return { status: 400, body: { error: { code: 'VALIDATION_FAILED', message } } };
+  }
+  return { status: 500, body: { error: { code: 'INTERNAL_ERROR', message } } };
+}
+
+function pathParts(req: IncomingMessage): { parts: string[]; url: URL } {
+  const url = new URL(req.url ?? '/', 'http://conformance.invalid');
+  return {
+    parts: url.pathname
+      .split('/')
+      .filter(Boolean)
+      .map((part) => decodeURIComponent(part)),
+    url,
+  };
+}
+
+async function route(
+  req: IncomingMessage,
+  res: ServerResponse,
+  store: RuntimeStore,
+): Promise<void> {
+  const { parts, url } = pathParts(req);
+  const method = req.method ?? 'GET';
+
+  if (parts[0] !== 'runtime') {
+    sendJson(res, 404, { error: { code: 'ROUTE_NOT_FOUND', message: 'route not found' } });
+    return;
+  }
+
+  if (method === 'POST' && parts.length === 2 && parts[1] === 'sessions') {
+    const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(req);
+    if (Object.hasOwn(init, 'runtimeDslVersion')) {
+      throw new Error('invalid runtime session: request body must not include runtimeDslVersion');
+    }
+    sendJson(res, 201, await store.createSession(init));
+    return;
+  }
+
+  if (parts[1] === 'sessions' && parts.length >= 3) {
+    const sessionId = parts[2]!;
+    if (method === 'GET' && parts.length === 3) {
+      const session = await store.getSession(sessionId);
+      if (session === undefined) {
+        sendJson(res, 404, {
+          error: {
+            code: 'SESSION_NOT_FOUND',
+            message: `@openmaic/storage: no session ${JSON.stringify(sessionId)}`,
+          },
+        });
+      } else {
+        sendJson(res, 200, session);
+      }
+      return;
+    }
+    if (method === 'PATCH' && parts.length === 4 && parts[3] === 'status') {
+      const body = await readJson<{ status: RuntimeSessionStatus; updatedAt: string }>(req);
+      await store.setSessionStatus(sessionId, body.status, body.updatedAt);
+      sendNoContent(res);
+      return;
+    }
+    if (method === 'DELETE' && parts.length === 3) {
+      await store.deleteSession(sessionId);
+      sendNoContent(res);
+      return;
+    }
+    if (method === 'POST' && parts.length === 4 && parts[3] === 'records') {
+      const init = await readJson<RuntimeRecordInit & { seq?: unknown }>(req);
+      if (Object.hasOwn(init, 'seq')) {
+        throw new Error('invalid runtime record: append request body must not include seq');
+      }
+      if (init.sessionId !== sessionId) {
+        throw new Error('invalid runtime record: body sessionId does not match the request path');
+      }
+      sendJson(res, 201, await store.appendRecord(init));
+      return;
+    }
+    if (method === 'GET' && parts.length === 4 && parts[3] === 'records') {
+      const sceneId = url.searchParams.get('sceneId');
+      sendJson(
+        res,
+        200,
+        await store.listRecords(sessionId, sceneId === null ? undefined : { sceneId }),
+      );
+      return;
+    }
+  }
+
+  if (
+    parts[1] === 'stages' &&
+    parts.length === 6 &&
+    parts[3] === 'learners' &&
+    parts[5] === 'sessions' &&
+    method === 'GET'
+  ) {
+    sendJson(res, 200, await store.listSessions(parts[2]!, parts[4]!));
+    return;
+  }
+
+  if (parts[1] === 'learners' && parts[2] === 'merge' && parts.length === 3 && method === 'POST') {
+    const body = await readJson<{ fromLearnerKey: string; toLearnerKey: string }>(req);
+    sendJson(res, 200, {
+      moved: await store.mergeLearner(body.fromLearnerKey, body.toLearnerKey),
+    });
+    return;
+  }
+
+  if (
+    parts[1] === 'stages' &&
+    parts.length === 5 &&
+    parts[3] === 'learners' &&
+    method === 'DELETE'
+  ) {
+    await store.deleteLearnerRuntime(parts[2]!, parts[4]!);
+    sendNoContent(res);
+    return;
+  }
+
+  if (parts[1] === 'stages' && parts.length === 3 && method === 'DELETE') {
+    await store.deleteStageRuntime(parts[2]!);
+    sendNoContent(res);
+    return;
+  }
+
+  sendJson(res, 404, { error: { code: 'ROUTE_NOT_FOUND', message: 'route not found' } });
+}
+
+/**
+ * Start a test-only HTTP adapter. Each `x-runtime-store-id` value selects a
+ * fresh BrowserRuntimeStore so factories used by the shared contract remain
+ * isolated without duplicating any persistence logic in this server.
+ */
+export async function startHttpConformanceServer(
+  options: HttpConformanceServerOptions = {},
+): Promise<HttpConformanceServer> {
+  const stores = new Map<string, RuntimeStore>();
+  const storeFor = (req: IncomingMessage): RuntimeStore => {
+    const id = req.headers['x-runtime-store-id'];
+    const namespace = typeof id === 'string' && id !== '' ? id : 'default';
+    let store = stores.get(namespace);
+    if (!store) {
+      store = new BrowserRuntimeStore({
+        indexedDB: new IDBFactory(),
+        dbName: `http-runtime-${namespace}`,
+      });
+      stores.set(namespace, store);
+    }
+    return store;
+  };
+
+  const server = createServer((req, res) => {
+    void route(req, res, storeFor(req)).catch((error: unknown) => {
+      const mapped = errorResponse(error);
+      sendJson(res, mapped.status, mapped.body);
+    });
+  });
+
+  let baseUrl = 'http://runtime-conformance.invalid';
+  if (options.listen !== false) {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('HTTP conformance server did not bind a TCP port');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  const injectedFetch: typeof globalThis.fetch = async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const requestBody = await request.text();
+    const fakeRequest = {
+      method: request.method,
+      url: `${url.pathname}${url.search}`,
+      headers: Object.fromEntries(request.headers.entries()),
+      async *[Symbol.asyncIterator]() {
+        if (requestBody !== '') yield Buffer.from(requestBody);
+      },
+    } as unknown as IncomingMessage;
+
+    let status = 200;
+    let responseHeaders: Record<string, string> = {};
+    let responseBody: string | undefined;
+    const fakeResponse = {
+      writeHead(nextStatus: number, headers?: Record<string, string>) {
+        status = nextStatus;
+        responseHeaders = headers ?? {};
+        return this;
+      },
+      end(chunk?: string) {
+        responseBody = chunk;
+        return this;
+      },
+    } as unknown as ServerResponse;
+
+    try {
+      await route(fakeRequest, fakeResponse, storeFor(fakeRequest));
+    } catch (error) {
+      const mapped = errorResponse(error);
+      status = mapped.status;
+      responseHeaders = { 'content-type': 'application/json' };
+      responseBody = JSON.stringify(mapped.body);
+    }
+    return new Response(status === 204 ? null : responseBody, {
+      status,
+      headers: responseHeaders,
+    });
+  };
+
+  return {
+    baseUrl,
+    fetch: injectedFetch,
+    close: () =>
+      server.listening
+        ? new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          })
+        : Promise.resolve(),
+  };
+}

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -16,6 +16,7 @@ import type {
   ValidationResult,
 } from '@openmaic/dsl';
 import { BrowserRuntimeStore } from '../src/runtime/browser.js';
+import { assertJsonValue } from '../src/runtime/json-value.js';
 import type { RuntimeSessionInit, RuntimeStore } from '../src/runtime/types.js';
 
 export interface HttpConformanceServer {
@@ -94,6 +95,25 @@ function validationError(result: ValidationResult, label: string): void {
   throw new ConformanceHttpError(400, 'VALIDATION_FAILED', `${label}: ${detail}`);
 }
 
+function assertAddressableSegment(value: string): void {
+  if (value === '.' || value === '..') {
+    throw new ConformanceHttpError(
+      400,
+      'VALIDATION_FAILED',
+      `@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+function assertJsonRequestValue(value: unknown, label: string): void {
+  try {
+    assertJsonValue(value, label);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ConformanceHttpError(400, 'VALIDATION_FAILED', message);
+  }
+}
+
 function missingSessionError(sessionId: string): ConformanceHttpError {
   return new ConformanceHttpError(
     404,
@@ -164,6 +184,9 @@ async function route(
 
   if (method === 'POST' && parts.length === 2 && parts[1] === 'sessions') {
     const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(req);
+    assertAddressableSegment(init.id);
+    assertAddressableSegment(init.stageId);
+    assertAddressableSegment(init.learnerKey);
     validationError(
       validateRuntimeSession({ ...init, runtimeDslVersion: RUNTIME_DSL_VERSION }),
       `@openmaic/storage: invalid runtime session ${JSON.stringify(init.id)}`,
@@ -288,6 +311,9 @@ async function route(
         '@openmaic/storage: learner keys must be non-empty strings',
       );
     }
+    assertJsonRequestValue(body.fromLearnerKey, 'runtime learner merge fromLearnerKey');
+    assertJsonRequestValue(body.toLearnerKey, 'runtime learner merge toLearnerKey');
+    assertAddressableSegment(body.toLearnerKey);
     sendJson(res, 200, {
       moved: await store.mergeLearner(body.fromLearnerKey, body.toLearnerKey),
     });

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -1,6 +1,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { IDBFactory } from 'fake-indexeddb';
 import {
+  isChatMessageSkeleton,
+  isQuizAttemptSkeleton,
   needsRuntimeMigration,
   RUNTIME_DSL_VERSION,
   runtimeDslVersionOf,
@@ -100,6 +102,25 @@ function assertNotFutureSession(session: RuntimeSession): void {
   }
 }
 
+function validatePayloadForKind(session: RuntimeSession, payload: unknown): void {
+  if (session.kind === 'chat' && !isChatMessageSkeleton(payload)) {
+    throw new ConformanceHttpError(
+      400,
+      'VALIDATION_FAILED',
+      '@openmaic/storage: invalid runtime record: /payload: chat payload must match ' +
+        'ChatMessageSkeleton (role + content)',
+    );
+  }
+  if (session.kind === 'quizAttempt' && !isQuizAttemptSkeleton(payload)) {
+    throw new ConformanceHttpError(
+      400,
+      'VALIDATION_FAILED',
+      '@openmaic/storage: invalid runtime record: /payload: quizAttempt payload must match ' +
+        'QuizAttemptSkeleton (phase + answers)',
+    );
+  }
+}
+
 async function requireSession(store: RuntimeStore, sessionId: string): Promise<RuntimeSession> {
   const session = await store.getSession(sessionId);
   if (session === undefined) throw missingSessionError(sessionId);
@@ -142,7 +163,20 @@ async function route(
         `@openmaic/storage: runtime session ${JSON.stringify(init.id)} already exists`,
       );
     }
-    sendJson(res, 201, await store.createSession(init));
+    let created: RuntimeSession;
+    try {
+      created = await store.createSession(init);
+    } catch (error) {
+      if (await store.getSession(init.id)) {
+        throw new ConformanceHttpError(
+          409,
+          'SESSION_ALREADY_EXISTS',
+          `@openmaic/storage: runtime session ${JSON.stringify(init.id)} already exists`,
+        );
+      }
+      throw error;
+    }
+    sendJson(res, 201, created);
     return;
   }
 
@@ -194,6 +228,7 @@ async function route(
       );
       const session = await requireSession(store, sessionId);
       assertNotFutureSession(session);
+      validatePayloadForKind(session, init.payload);
       if (session.status !== 'active') {
         throw new ConformanceHttpError(
           400,
@@ -228,7 +263,19 @@ async function route(
   }
 
   if (parts[1] === 'learners' && parts[2] === 'merge' && parts.length === 3 && method === 'POST') {
-    const body = await readJson<{ fromLearnerKey: string; toLearnerKey: string }>(req);
+    const body = await readJson<{ fromLearnerKey?: unknown; toLearnerKey?: unknown }>(req);
+    if (
+      typeof body.fromLearnerKey !== 'string' ||
+      body.fromLearnerKey === '' ||
+      typeof body.toLearnerKey !== 'string' ||
+      body.toLearnerKey === ''
+    ) {
+      throw new ConformanceHttpError(
+        400,
+        'VALIDATION_FAILED',
+        '@openmaic/storage: learner keys must be non-empty strings',
+      );
+    }
     sendJson(res, 200, {
       moved: await store.mergeLearner(body.fromLearnerKey, body.toLearnerKey),
     });

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -311,6 +311,7 @@ async function route(
         '@openmaic/storage: learner keys must be non-empty strings',
       );
     }
+    assertAddressableSegment(body.toLearnerKey);
     assertJsonRequestValue(body.fromLearnerKey, 'runtime learner merge fromLearnerKey');
     assertJsonRequestValue(body.toLearnerKey, 'runtime learner merge toLearnerKey');
     assertAddressableSegment(body.toLearnerKey);

--- a/packages/@openmaic/storage/test/http-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/http-runtime-store.test.ts
@@ -121,6 +121,66 @@ describe('HttpRuntimeStore error mapping', () => {
     await expect(failure).rejects.toMatchObject({ status: 409, code: 'FUTURE_VERSION' });
     await expect(failure).rejects.toThrow(/newer than this client's/);
   });
+
+  test('maps concurrent duplicate session creation to one success and one 409', async () => {
+    const storeId = `duplicate-race-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+
+    const results = await Promise.allSettled([
+      store.createSession(makeSession('duplicate-race')),
+      store.createSession(makeSession('duplicate-race')),
+    ]);
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]).toMatchObject({
+      reason: expect.objectContaining({
+        status: 409,
+        code: 'SESSION_ALREADY_EXISTS',
+      }),
+    });
+  });
+
+  test('maps invalid kind-specific append payloads to 400 validation failures', async () => {
+    const storeId = `payload-gate-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(makeSession('chat-session', { kind: 'chat' }));
+    await store.createSession(makeSession('quiz-session', { kind: 'quizAttempt' }));
+
+    await expect(
+      store.appendRecord(makeRecord('chat-session', { role: 'tool', content: 'invalid' })),
+    ).rejects.toMatchObject({ status: 400, code: 'VALIDATION_FAILED' });
+    await expect(
+      store.appendRecord(makeRecord('quiz-session', { phase: 'graded', answers: {} })),
+    ).rejects.toMatchObject({ status: 400, code: 'VALIDATION_FAILED' });
+  });
+
+  test('maps empty merge learner keys to 400 validation failures', async () => {
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': `merge-validation-${namespace++}` }),
+    });
+
+    await expect(store.mergeLearner('', 'learner-2')).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_FAILED',
+    });
+    await expect(store.mergeLearner('learner-1', '')).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_FAILED',
+    });
+  });
 });
 
 describe('HttpRuntimeStore HTTP hardening', () => {
@@ -137,16 +197,22 @@ describe('HttpRuntimeStore HTTP hardening', () => {
     sparse[1] = 'present';
     const circular: Record<string, unknown> = {};
     circular.self = circular;
+    const symbolKeyed = { [Symbol('k')]: 1 };
+    const nonEnumerable = Object.defineProperty({}, 'k', { value: 1, enumerable: false });
+    const arrayWithExtraProperty = Object.assign([1, 2], { meta: 'x' });
     const rejected: [string, unknown][] = [
       ['Map', new Map([['key', 'value']])],
       ['Set', new Set(['value'])],
       ['Date', new Date(T0)],
       ['NaN', Number.NaN],
+      ['negative zero', -0],
       ['nested undefined', { nested: undefined }],
       ['bigint', (globalThis as unknown as { BigInt(value: number): unknown }).BigInt(1)],
       ['sparse array', sparse],
-      ['line separator', `before\u2028after`],
-      ['paragraph separator', `before\u2029after`],
+      ['NUL', `before\u0000after`],
+      ['symbol key', symbolKeyed],
+      ['non-enumerable property', nonEnumerable],
+      ['array extra own property', arrayWithExtraProperty],
       ['circular reference', circular],
     ];
 
@@ -155,6 +221,70 @@ describe('HttpRuntimeStore HTTP hardening', () => {
         /not a plain JSON value/,
       );
     }
+  });
+
+  test('accepts JSON strings containing line and paragraph separators', async () => {
+    const storeId = `json-separators-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(makeSession('json-separators'));
+
+    await expect(
+      store.appendRecord(makeRecord('json-separators', `before\u2028after`)),
+    ).resolves.toMatchObject({ payload: `before\u2028after` });
+    await expect(
+      store.appendRecord(makeRecord('json-separators', `before\u2029after`)),
+    ).resolves.toMatchObject({ payload: `before\u2029after` });
+  });
+
+  test('rejects dot-only path segments before URL construction', async () => {
+    const store = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => {
+        throw new Error('fetch must not be called');
+      },
+    });
+
+    await expect(store.getSession('.')).rejects.toThrow(/must not be ['"]\.['"]/);
+    await expect(store.getSession('..')).rejects.toThrow(/must not be ['"]\.\.['"]/);
+  });
+
+  test('maps non-array list response containers to malformed-response errors', async () => {
+    const sessionsStore = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse({ sessions: [] }, 206),
+    });
+    const recordsStore = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse({ records: [] }, 202),
+    });
+
+    await expect(sessionsStore.listSessions('stage', 'learner')).rejects.toMatchObject({
+      status: 206,
+      code: 'MALFORMED_RESPONSE',
+    });
+    await expect(recordsStore.listRecords('session')).rejects.toMatchObject({
+      status: 202,
+      code: 'MALFORMED_RESPONSE',
+    });
+  });
+
+  test.each([
+    ['non-numeric', '1'],
+    ['non-finite', Number.POSITIVE_INFINITY],
+  ])('maps a %s merge moved field to a malformed-response error', async (_name, moved) => {
+    const store = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse({ moved }, 201),
+    });
+
+    await expect(store.mergeLearner('from', 'to')).rejects.toMatchObject({
+      status: 201,
+      code: 'MALFORMED_RESPONSE',
+    });
   });
 
   test('validates append responses and every listed record, including seq', async () => {

--- a/packages/@openmaic/storage/test/http-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/http-runtime-store.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { RUNTIME_DSL_VERSION } from '@openmaic/dsl';
+import type { RuntimePayload, RuntimeRecord, RuntimeRecordInit } from '@openmaic/dsl';
 import { HttpRuntimeStore, HttpRuntimeStoreError } from '../src/runtime/http.js';
+import type { RuntimeSessionInit } from '../src/runtime/types.js';
 import { runRuntimeStoreContract } from './runtime-contract.js';
 import {
   startHttpConformanceServer,
@@ -9,6 +12,36 @@ import {
 const T0 = '2026-01-01T00:00:00.000Z';
 let server: HttpConformanceServer;
 let namespace = 0;
+
+function makeSession(id: string, overrides: Partial<RuntimeSessionInit> = {}): RuntimeSessionInit {
+  return {
+    id,
+    kind: 'playback',
+    stageId: 'stage-1',
+    learnerKey: 'learner-1',
+    status: 'active',
+    createdAt: T0,
+    updatedAt: T0,
+    ...overrides,
+  };
+}
+
+function makeRecord(sessionId: string, payload: unknown = { value: 'ok' }): RuntimeRecordInit {
+  return {
+    id: `record-${namespace++}`,
+    sessionId,
+    createdAt: T0,
+    payload: payload as RuntimePayload,
+  };
+}
+
+function fakeJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
 
 beforeAll(async () => {
   server = await startHttpConformanceServer({ listen: false });
@@ -88,4 +121,185 @@ describe('HttpRuntimeStore error mapping', () => {
     await expect(failure).rejects.toMatchObject({ status: 409, code: 'FUTURE_VERSION' });
     await expect(failure).rejects.toThrow(/newer than this client's/);
   });
+});
+
+describe('HttpRuntimeStore HTTP hardening', () => {
+  test('rejects payload values that cannot be represented faithfully by JSON', async () => {
+    const storeId = `json-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(makeSession('json-session'));
+
+    const sparse = Array.from({ length: 2 }) as unknown[];
+    sparse[1] = 'present';
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const rejected: [string, unknown][] = [
+      ['Map', new Map([['key', 'value']])],
+      ['Set', new Set(['value'])],
+      ['Date', new Date(T0)],
+      ['NaN', Number.NaN],
+      ['nested undefined', { nested: undefined }],
+      ['bigint', (globalThis as unknown as { BigInt(value: number): unknown }).BigInt(1)],
+      ['sparse array', sparse],
+      ['line separator', `before\u2028after`],
+      ['paragraph separator', `before\u2029after`],
+      ['circular reference', circular],
+    ];
+
+    for (const [name, payload] of rejected) {
+      await expect(store.appendRecord(makeRecord('json-session', payload)), name).rejects.toThrow(
+        /not a plain JSON value/,
+      );
+    }
+  });
+
+  test('validates append responses and every listed record, including seq', async () => {
+    const baseRecord = {
+      id: 'record',
+      sessionId: 'session',
+      createdAt: T0,
+      payload: null,
+    };
+    const invalidRecords: unknown[] = [
+      { ...baseRecord, seq: -1 },
+      { ...baseRecord, seq: Number.NaN },
+      { ...baseRecord, seq: 0.5 },
+      baseRecord,
+    ];
+
+    for (const invalid of invalidRecords) {
+      const store = new HttpRuntimeStore({
+        baseUrl: 'https://runtime.invalid',
+        fetch: async () => fakeJsonResponse(invalid, 201),
+      });
+      await expect(store.appendRecord(makeRecord('session', null))).rejects.toThrow(/seq/);
+    }
+
+    const listStore = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse([{ ...baseRecord, seq: 1 }, invalidRecords[0]]),
+    });
+    await expect(listStore.listRecords('session')).rejects.toThrow(/seq/);
+  });
+
+  test('sorts validated listRecords responses by seq ascending', async () => {
+    const records: RuntimeRecord[] = [
+      { id: 'two', sessionId: 'session', seq: 2, createdAt: T0, payload: null },
+      { id: 'zero', sessionId: 'session', seq: 0, createdAt: T0, payload: null },
+      { id: 'one', sessionId: 'session', seq: 1, createdAt: T0, payload: null },
+    ];
+    const store = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse(records),
+    });
+
+    await expect(store.listRecords('session')).resolves.toMatchObject([
+      { seq: 0 },
+      { seq: 1 },
+      { seq: 2 },
+    ]);
+  });
+
+  test('normalizes a Headers instance without consulting the global Headers constructor', async () => {
+    const HeadersConstructor = globalThis.Headers;
+    const suppliedHeaders = new HeadersConstructor([['X-Test-Header', 'present']]);
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'Headers');
+    const fetch: typeof globalThis.fetch = async (_input, init) => {
+      expect(init?.headers).toEqual({ 'x-test-header': 'present' });
+      return fakeJsonResponse(undefined, 204);
+    };
+    const store = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch,
+      headers: () => suppliedHeaders,
+    });
+
+    Reflect.deleteProperty(globalThis, 'Headers');
+    try {
+      await store.deleteStageRuntime('stage');
+    } finally {
+      if (descriptor) Object.defineProperty(globalThis, 'Headers', descriptor);
+    }
+  });
+
+  test('caller-controlled error substrings do not hijack structured status classification', async () => {
+    const storeId = `malicious-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    const maliciousId = `no session already exists newer than this client's`;
+
+    const failure = store.createSession(makeSession(maliciousId, { learnerKey: '' }));
+    await expect(failure).rejects.toMatchObject({ status: 400, code: 'VALIDATION_FAILED' });
+  });
+
+  test('preserves empty segments and keeps empty-key deletes idempotent and route-local', async () => {
+    const storeId = `empty-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(
+      makeSession('route-sentinel', { stageId: 'learners', learnerKey: 'sentinel' }),
+    );
+
+    await expect(store.getSession('')).resolves.toBeUndefined();
+    await expect(store.deleteSession('')).resolves.toBeUndefined();
+    await expect(store.deleteLearnerRuntime('', '')).resolves.toBeUndefined();
+    await expect(store.getSession('route-sentinel')).resolves.toMatchObject({
+      id: 'route-sentinel',
+    });
+  });
+
+  test('ignores client-submitted runtimeDslVersion and seq in favor of store values', async () => {
+    const storeId = `assigned-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    const session = await store.createSession({
+      ...makeSession('assigned-session'),
+      runtimeDslVersion: '99.0.0',
+    } as RuntimeSessionInit);
+    const record = await store.appendRecord({
+      ...makeRecord('assigned-session'),
+      seq: 99,
+    } as RuntimeRecordInit);
+
+    expect(session.runtimeDslVersion).toBe(RUNTIME_DSL_VERSION);
+    expect(record.seq).toBe(0);
+  });
+});
+
+test('real fetch reaches the listening conformance server over loopback', async ({ skip }) => {
+  let networkServer: HttpConformanceServer;
+  try {
+    networkServer = await startHttpConformanceServer();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+      skip('sandbox does not permit binding a 127.0.0.1 listener');
+    }
+    throw error;
+  }
+  try {
+    const store = new HttpRuntimeStore({
+      baseUrl: networkServer.baseUrl,
+      headers: () => ({ 'x-runtime-store-id': 'real-network' }),
+    });
+    await store.createSession(makeSession('network-session'));
+    await store.appendRecord(makeRecord('network-session'));
+    await expect(store.listRecords('network-session')).resolves.toMatchObject([
+      { sessionId: 'network-session', seq: 0 },
+    ]);
+  } finally {
+    await networkServer.close();
+  }
 });

--- a/packages/@openmaic/storage/test/http-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/http-runtime-store.test.ts
@@ -61,6 +61,23 @@ runRuntimeStoreContract('HTTP', () => {
 });
 
 describe('HttpRuntimeStore error mapping', () => {
+  test.each([
+    ['empty', undefined],
+    ['unparseable', '{'],
+    ['null', 'null'],
+  ])('maps a %s JSON request body to a 400 validation failure', async (_name, body) => {
+    const response = await server.fetch(`${server.baseUrl}/runtime/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      ...(body === undefined ? {} : { body }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'VALIDATION_FAILED' },
+    });
+  });
+
   test('reconstitutes a 400 validation failure as an Error with its code and message', async () => {
     const store = new HttpRuntimeStore({
       baseUrl: server.baseUrl,
@@ -210,6 +227,9 @@ describe('HttpRuntimeStore HTTP hardening', () => {
       ['bigint', (globalThis as unknown as { BigInt(value: number): unknown }).BigInt(1)],
       ['sparse array', sparse],
       ['NUL', `before\u0000after`],
+      ['NUL object key', { 'bad key\u0000': 1 }],
+      ['unpaired surrogate string', '\uD800'],
+      ['unpaired surrogate object key', { ['\uD800']: 1 }],
       ['symbol key', symbolKeyed],
       ['non-enumerable property', nonEnumerable],
       ['array extra own property', arrayWithExtraProperty],
@@ -238,6 +258,40 @@ describe('HttpRuntimeStore HTTP hardening', () => {
     await expect(
       store.appendRecord(makeRecord('json-separators', `before\u2029after`)),
     ).resolves.toMatchObject({ payload: `before\u2029after` });
+  });
+
+  test('accepts a valid surrogate pair string', async () => {
+    const storeId = `json-surrogate-pair-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(makeSession('json-surrogate-pair'));
+
+    await expect(store.appendRecord(makeRecord('json-surrogate-pair', '𐀀'))).resolves.toMatchObject(
+      { payload: '𐀀' },
+    );
+  });
+
+  test('rejects non-JSON properties and NUL ids across full write envelopes', async () => {
+    const store = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => {
+        throw new Error('fetch must not be called');
+      },
+    });
+    const sessionWithDate = Object.assign(makeSession('session-date'), { extra: new Date(T0) });
+    const recordWithDate = Object.assign(makeRecord('session'), { extra: new Date(T0) });
+
+    await expect(store.createSession(sessionWithDate)).rejects.toThrow(/not a plain JSON value/);
+    await expect(store.appendRecord(recordWithDate)).rejects.toThrow(/not a plain JSON value/);
+    await expect(store.createSession(makeSession('bad\u0000session'))).rejects.toThrow(
+      /not a plain JSON value/,
+    );
+    await expect(
+      store.appendRecord({ ...makeRecord('session'), id: 'bad\u0000record' }),
+    ).rejects.toThrow(/not a plain JSON value/);
   });
 
   test('rejects dot-only path segments before URL construction', async () => {
@@ -275,6 +329,8 @@ describe('HttpRuntimeStore HTTP hardening', () => {
   test.each([
     ['non-numeric', '1'],
     ['non-finite', Number.POSITIVE_INFINITY],
+    ['negative', -3],
+    ['fractional', 2.5],
   ])('maps a %s merge moved field to a malformed-response error', async (_name, moved) => {
     const store = new HttpRuntimeStore({
       baseUrl: 'https://runtime.invalid',
@@ -314,6 +370,35 @@ describe('HttpRuntimeStore HTTP hardening', () => {
       fetch: async () => fakeJsonResponse([{ ...baseRecord, seq: 1 }, invalidRecords[0]]),
     });
     await expect(listStore.listRecords('session')).rejects.toThrow(/seq/);
+  });
+
+  test('reports null session and record response bodies as readable storage errors', async () => {
+    const nullStore = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse(null),
+    });
+    const nullListStore = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => fakeJsonResponse([null]),
+    });
+    const operations: [string, () => Promise<unknown>][] = [
+      ['session', () => nullStore.getSession('session')],
+      ['session', () => nullStore.createSession(makeSession('session'))],
+      ['record', () => nullStore.appendRecord(makeRecord('session'))],
+      ['record', () => nullListStore.listRecords('session')],
+    ];
+
+    for (const [kind, operation] of operations) {
+      const error = await operation().then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(TypeError);
+      expect(error).toMatchObject({
+        message: expect.stringContaining(`invalid stored runtime ${kind}`),
+      });
+    }
   });
 
   test('sorts validated listRecords responses by seq ascending', async () => {

--- a/packages/@openmaic/storage/test/http-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/http-runtime-store.test.ts
@@ -198,6 +198,54 @@ describe('HttpRuntimeStore error mapping', () => {
       code: 'VALIDATION_FAILED',
     });
   });
+
+  test.each([
+    ['createSession id', '/runtime/sessions', makeSession('.')],
+    ['createSession stageId', '/runtime/sessions', makeSession('dot-stage', { stageId: '..' })],
+    [
+      'createSession learnerKey',
+      '/runtime/sessions',
+      makeSession('dot-learner', { learnerKey: '.' }),
+    ],
+    [
+      'mergeLearner target',
+      '/runtime/learners/merge',
+      { fromLearnerKey: 'learner-1', toLearnerKey: '..' },
+    ],
+  ])('maps a dot-only %s body field to a 400 validation failure', async (_name, path, body) => {
+    const response = await server.fetch(`${server.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: expect.stringContaining('URL path segment must not be'),
+      },
+    });
+  });
+
+  test.each([
+    ['NUL', 'from\u0000learner', 'to-learner'],
+    ['unpaired surrogate', 'from-learner', '\uD800'],
+  ])(
+    'maps a merge learner key containing %s to a 400 validation failure',
+    async (_name, fromLearnerKey, toLearnerKey) => {
+      const response = await server.fetch(`${server.baseUrl}/runtime/learners/merge`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fromLearnerKey, toLearnerKey }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 'VALIDATION_FAILED' },
+      });
+    },
+  );
 });
 
 describe('HttpRuntimeStore HTTP hardening', () => {
@@ -210,13 +258,19 @@ describe('HttpRuntimeStore HTTP hardening', () => {
     });
     await store.createSession(makeSession('json-session'));
 
-    const sparse = Array.from({ length: 2 }) as unknown[];
-    sparse[1] = 'present';
+    const sparse = [, 'present'];
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     const symbolKeyed = { [Symbol('k')]: 1 };
     const nonEnumerable = Object.defineProperty({}, 'k', { value: 1, enumerable: false });
     const arrayWithExtraProperty = Object.assign([1, 2], { meta: 'x' });
+    const enumerableAccessor = Object.defineProperty({}, 'value', {
+      enumerable: true,
+      get: () => 'x',
+    });
+    const ArraySubclass = class extends Array {};
+    const arraySubclass = Object.assign(new ArraySubclass(), { 0: 'x', length: 1 });
+    const fakeDense = Object.setPrototypeOf([, 1], { 0: 'x' });
     const rejected: [string, unknown][] = [
       ['Map', new Map([['key', 'value']])],
       ['Set', new Set(['value'])],
@@ -225,7 +279,6 @@ describe('HttpRuntimeStore HTTP hardening', () => {
       ['negative zero', -0],
       ['nested undefined', { nested: undefined }],
       ['bigint', (globalThis as unknown as { BigInt(value: number): unknown }).BigInt(1)],
-      ['sparse array', sparse],
       ['NUL', `before\u0000after`],
       ['NUL object key', { 'bad key\u0000': 1 }],
       ['unpaired surrogate string', '\uD800'],
@@ -233,8 +286,15 @@ describe('HttpRuntimeStore HTTP hardening', () => {
       ['symbol key', symbolKeyed],
       ['non-enumerable property', nonEnumerable],
       ['array extra own property', arrayWithExtraProperty],
+      ['enumerable accessor property', enumerableAccessor],
+      ['Array subclass', arraySubclass],
+      ['prototype-provided array index', fakeDense],
       ['circular reference', circular],
     ];
+
+    await expect(store.appendRecord(makeRecord('json-session', sparse))).rejects.toThrow(
+      /sparse array hole/,
+    );
 
     for (const [name, payload] of rejected) {
       await expect(store.appendRecord(makeRecord('json-session', payload)), name).rejects.toThrow(
@@ -304,6 +364,70 @@ describe('HttpRuntimeStore HTTP hardening', () => {
 
     await expect(store.getSession('.')).rejects.toThrow(/must not be ['"]\.['"]/);
     await expect(store.getSession('..')).rejects.toThrow(/must not be ['"]\.\.['"]/);
+  });
+
+  test.each([
+    ['session id', (store: HttpRuntimeStore) => store.createSession(makeSession('.'))],
+    [
+      'stage id',
+      (store: HttpRuntimeStore) => store.createSession(makeSession('dot-stage', { stageId: '..' })),
+    ],
+    [
+      'session learner key',
+      (store: HttpRuntimeStore) =>
+        store.createSession(makeSession('dot-learner', { learnerKey: '.' })),
+    ],
+    ['merge target learner key', (store: HttpRuntimeStore) => store.mergeLearner('from', '..')],
+  ])('rejects a dot-only %s body field before sending a request', async (_name, operation) => {
+    const store = new HttpRuntimeStore({
+      baseUrl: 'https://runtime.invalid',
+      fetch: async () => {
+        throw new Error('fetch must not be called');
+      },
+    });
+
+    await expect(operation(store)).rejects.toThrow(/URL path segment must not be/);
+  });
+
+  test.each([
+    ['from NUL', 'from\u0000learner', 'to-learner'],
+    ['to NUL', 'from-learner', 'to\u0000learner'],
+    ['from unpaired surrogate', '\uD800', 'to-learner'],
+    ['to unpaired surrogate', 'from-learner', '\uD800'],
+  ])(
+    'rejects a merge learner key containing %s before sending a request',
+    async (_name, fromLearnerKey, toLearnerKey) => {
+      const store = new HttpRuntimeStore({
+        baseUrl: 'https://runtime.invalid',
+        fetch: async () => {
+          throw new Error('fetch must not be called');
+        },
+      });
+
+      await expect(store.mergeLearner(fromLearnerKey, toLearnerKey)).rejects.toThrow(
+        /not a plain JSON value/,
+      );
+    },
+  );
+
+  test('treats a top-level undefined record anchor identically to an omitted anchor', async () => {
+    const storeId = `undefined-anchor-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(makeSession('undefined-anchor'));
+
+    const explicit = await store.appendRecord({
+      ...makeRecord('undefined-anchor', { source: 'explicit' }),
+      sceneId: undefined,
+    });
+    const omitted = await store.appendRecord(makeRecord('undefined-anchor', { source: 'omitted' }));
+
+    expect('sceneId' in explicit).toBe(false);
+    expect('sceneId' in omitted).toBe(false);
+    await expect(store.listRecords('undefined-anchor')).resolves.toEqual([explicit, omitted]);
   });
 
   test('maps non-array list response containers to malformed-response errors', async () => {

--- a/packages/@openmaic/storage/test/http-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/http-runtime-store.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { HttpRuntimeStore, HttpRuntimeStoreError } from '../src/runtime/http.js';
+import { runRuntimeStoreContract } from './runtime-contract.js';
+import {
+  startHttpConformanceServer,
+  type HttpConformanceServer,
+} from './http-conformance-server.js';
+
+const T0 = '2026-01-01T00:00:00.000Z';
+let server: HttpConformanceServer;
+let namespace = 0;
+
+beforeAll(async () => {
+  server = await startHttpConformanceServer({ listen: false });
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+runRuntimeStoreContract('HTTP', () => {
+  const storeId = `contract-${namespace++}`;
+  return new HttpRuntimeStore({
+    baseUrl: server.baseUrl,
+    fetch: server.fetch,
+    headers: () => ({ 'x-runtime-store-id': storeId }),
+  });
+});
+
+describe('HttpRuntimeStore error mapping', () => {
+  test('reconstitutes a 400 validation failure as an Error with its code and message', async () => {
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': `errors-${namespace++}` }),
+    });
+
+    const failure = store.createSession({
+      id: 'invalid',
+      kind: 'chat',
+      stageId: 'stage-1',
+      learnerKey: '',
+      status: 'active',
+      createdAt: T0,
+      updatedAt: T0,
+    });
+
+    await expect(failure).rejects.toMatchObject({
+      name: 'HttpRuntimeStoreError',
+      status: 400,
+      code: 'VALIDATION_FAILED',
+    });
+    await expect(failure).rejects.toThrow(/learnerKey/);
+  });
+
+  test('reconstitutes a 404 missing-session response with browser-store semantics', async () => {
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': `errors-${namespace++}` }),
+    });
+
+    const failure = store.setSessionStatus('ghost', 'completed', T0);
+    await expect(failure).rejects.toMatchObject({
+      name: 'HttpRuntimeStoreError',
+      status: 404,
+      code: 'SESSION_NOT_FOUND',
+    });
+    await expect(failure).rejects.toThrow(/no session/i);
+  });
+
+  test('reconstitutes a 409 future-version response with fail-loud semantics', async () => {
+    const fetch: typeof globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 'FUTURE_VERSION',
+            message:
+              '@openmaic/storage: session "future" was written at runtime DSL version "99.0.0", newer than this client\'s 1.0.0',
+          },
+        }),
+        { status: 409, headers: { 'content-type': 'application/json' } },
+      );
+    const store = new HttpRuntimeStore({ baseUrl: 'https://runtime.invalid', fetch });
+
+    const failure = store.setSessionStatus('future', 'completed', T0);
+    await expect(failure).rejects.toBeInstanceOf(HttpRuntimeStoreError);
+    await expect(failure).rejects.toMatchObject({ status: 409, code: 'FUTURE_VERSION' });
+    await expect(failure).rejects.toThrow(/newer than this client's/);
+  });
+});

--- a/packages/@openmaic/storage/test/http-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/http-runtime-store.test.ts
@@ -430,6 +430,23 @@ describe('HttpRuntimeStore HTTP hardening', () => {
     await expect(store.listRecords('undefined-anchor')).resolves.toEqual([explicit, omitted]);
   });
 
+  test('rejects an unknown top-level record field that is explicitly undefined', async () => {
+    const storeId = `undefined-ext-${namespace++}`;
+    const store = new HttpRuntimeStore({
+      baseUrl: server.baseUrl,
+      fetch: server.fetch,
+      headers: () => ({ 'x-runtime-store-id': storeId }),
+    });
+    await store.createSession(makeSession('undefined-ext'));
+
+    await expect(
+      store.appendRecord({
+        ...makeRecord('undefined-ext', { source: 'extension' }),
+        ext: undefined,
+      } as never),
+    ).rejects.toThrow(/undefined member/);
+  });
+
   test('maps non-array list response containers to malformed-response errors', async () => {
     const sessionsStore = new HttpRuntimeStore({
       baseUrl: 'https://runtime.invalid',


### PR DESCRIPTION
Part B of #939, targeting the `runtime-server-backend` integration branch (final review happens when the branch merges to `main`).

## What

- **HTTP contract** (`docs/runtime-http-contract.md`): JSON endpoints covering every `RuntimeStore` operation. Contract-level guarantees spelled out: `seq` is server-assigned (append bodies structurally omit it), `learnerKey` MUST be derived/verified from the authenticated session — trusting the client value verbatim is a lateral-authorization hole — and error responses carry machine-readable codes (400 `VALIDATION_FAILED`, 404 `SESSION_NOT_FOUND`, 409 `FUTURE_VERSION` / `SESSION_ALREADY_EXISTS`).
- **`HttpRuntimeStore`** (`src/runtime/http.ts`, new `./runtime/http` subpath): implements the store interface over injected `fetch` + an async headers hook for deployment auth. All session reads — including `createSession` responses — run `migrateRuntime` client-side so a server on an older schema cannot leak stale envelopes.
- **Conformance server** (test-only): bridges the contract onto the existing browser backend (fake-indexeddb), so `runRuntimeStoreContract` runs unchanged against the HTTP client — no duplicated store logic.

## Boundaries

- Additive only: no changes to `browser.ts` / `types.ts` / `runtime-contract.ts` (avoids conflicts with #926).
- Zero new runtime dependencies (fetch is injected).

## Testing

- `pnpm check` / `pnpm lint` / `tsc --noEmit` clean
- `runRuntimeStoreContract` + error-mapping cases: 23/23 green over HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)