### PR TITLE
feat(storage): PgRuntimeStore — Postgres runtime backend (#939 Part C)

### DIFF
--- a/.github/workflows/storage-pg-contract.yml
+++ b/.github/workflows/storage-pg-contract.yml
@@ -1,0 +1,45 @@
+name: Storage PostgreSQL Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, feat/maic-editor-v0, feat/maic-editor-v1]
+
+concurrency:
+  group: storage-pg-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  storage-pg-contract:
+    name: Storage Contract (PostgreSQL 16)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: openmaic
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d openmaic"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      PG_CONTRACT_URL: postgresql://postgres:postgres@localhost:5432/openmaic
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Storage PostgreSQL contract
+        run: pnpm --filter @openmaic/storage test

--- a/.github/workflows/storage-pg-contract.yml
+++ b/.github/workflows/storage-pg-contract.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/maic-editor-v0, feat/maic-editor-v1]
+    branches: [main, runtime-server-backend, feat/maic-editor-v0, feat/maic-editor-v1]
 
 concurrency:
   group: storage-pg-contract-${{ github.ref }}
@@ -29,6 +29,7 @@ jobs:
           --health-retries 5
     env:
       PG_CONTRACT_URL: postgresql://postgres:postgres@localhost:5432/openmaic
+      STORAGE_PG_CONTRACT_REQUIRED: '1'
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -53,7 +53,9 @@
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.3.14",
+    "@types/pg": "^8.15.5",
     "fake-indexeddb": "^6.0.0",
+    "pg": "^8.16.3",
     "typescript": "^5",
     "vitest": "^4.1.8"
   }

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./runtime/pg": {
+      "types": "./dist/runtime/pg.d.ts",
+      "import": "./dist/runtime/pg.js"
     }
   },
   "files": [
@@ -48,6 +52,7 @@
     "@openmaic/dsl": "workspace:*"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.3.14",
     "fake-indexeddb": "^6.0.0",
     "typescript": "^5",
     "vitest": "^4.1.8"

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -1,16 +1,19 @@
 /**
  * Shared payload guard for JSON-carrying backends (HTTP transport, Postgres
  * JSONB). The browser backend persists payloads via structured clone, which
- * preserves values JSON cannot represent (Map, Set, Date, NaN, nested
- * undefined, bigint). A JSON backend that accepted those would silently hand
- * back different data on the next read — appendRecord's return value and a
- * later listRecords would disagree. JSON backends therefore narrow the
- * accepted payload domain and fail loud at the write boundary.
+ * preserves values JSON cannot represent (Map, Set, Date, NaN, negative zero,
+ * nested undefined, bigint, symbol-keyed or non-enumerable properties). A JSON
+ * backend that accepted those would silently hand back different data on the
+ * next read — appendRecord's return value and a later listRecords would
+ * disagree. JSON backends therefore narrow the accepted payload domain and
+ * fail loud at the write boundary.
  *
- * JSONB note: Postgres jsonb cannot store the NUL code point (U+0000) inside
- * strings (error 22P05), so strings containing it are rejected here too —
- * keeping the payload domain identical across JSON backends rather than
- * letting one accept what another must refuse.
+ * The narrowing is exactly "survives JSON.stringify/JSON.parse losslessly":
+ * characters that round-trip through JSON (including U+2028/U+2029, legal in
+ * JSON strings per RFC 8259) are accepted. The one string exception is the
+ * NUL code point (U+0000): Postgres jsonb cannot store it (error 22P05), so
+ * it is rejected here too — keeping the payload domain identical across JSON
+ * backends rather than letting one accept what another must refuse.
  */
 
 interface NonJsonValue {
@@ -23,6 +26,11 @@ function isPlainPrototype(value: object): boolean {
   return prototype === Object.prototype || prototype === null;
 }
 
+function isCanonicalIndex(key: string, length: number): boolean {
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
 function findNonJsonValue(
   value: unknown,
   pointer: string,
@@ -30,6 +38,9 @@ function findNonJsonValue(
 ): NonJsonValue | undefined {
   if (value === null || typeof value === 'boolean') return undefined;
   if (typeof value === 'number') {
+    if (Object.is(value, -0)) {
+      return { pointer, reason: 'negative zero (JSON serializes it as 0)' };
+    }
     if (Number.isFinite(value)) return undefined;
     return { pointer, reason: `non-finite number ${String(value)}` };
   }
@@ -44,6 +55,15 @@ function findNonJsonValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
+      for (const key of Reflect.ownKeys(value)) {
+        if (key === 'length') continue;
+        if (typeof key !== 'string' || !isCanonicalIndex(key, value.length)) {
+          return {
+            pointer: `${pointer}/${String(key)}`,
+            reason: 'array carries a non-index own property (dropped by JSON)',
+          };
+        }
+      }
       for (let index = 0; index < value.length; index += 1) {
         if (!(index in value)) {
           return { pointer: `${pointer}/${index}`, reason: 'sparse array hole' };
@@ -59,12 +79,22 @@ function findNonJsonValue(
         reason: 'not a plain object (Map, Set, Date, class instances do not survive JSON)',
       };
     }
-    for (const [key, member] of Object.entries(value)) {
-      const memberPointer = `${pointer}/${key}`;
-      if (member === undefined) {
-        return { pointer: memberPointer, reason: 'undefined member (dropped by JSON)' };
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') {
+        return { pointer, reason: 'symbol-keyed own property (dropped by JSON)' };
       }
-      const nested = findNonJsonValue(member, memberPointer, seen);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor !== undefined && !descriptor.enumerable) {
+        return {
+          pointer: `${pointer}/${key}`,
+          reason: 'non-enumerable own property (dropped by JSON)',
+        };
+      }
+      const member = (value as Record<string, unknown>)[key];
+      if (member === undefined) {
+        return { pointer: `${pointer}/${key}`, reason: 'undefined member (dropped by JSON)' };
+      }
+      const nested = findNonJsonValue(member, `${pointer}/${key}`, seen);
       if (nested) return nested;
     }
     return undefined;

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -10,10 +10,12 @@
  *
  * The narrowing is exactly "survives JSON.stringify/JSON.parse losslessly":
  * characters that round-trip through JSON (including U+2028/U+2029, legal in
- * JSON strings per RFC 8259) are accepted. The one string exception is the
- * NUL code point (U+0000): Postgres jsonb cannot store it (error 22P05), so
- * it is rejected here too — keeping the payload domain identical across JSON
- * backends rather than letting one accept what another must refuse.
+ * JSON strings per RFC 8259) are accepted. Two string exceptions — applied to
+ * object keys as well as values — keep the payload domain identical across
+ * JSON backends rather than letting one accept what another must refuse: the
+ * NUL code point (U+0000), which Postgres jsonb cannot store (error 22P05),
+ * and unpaired UTF-16 surrogates, which jsonb rejects (22P02) and which other
+ * JSON stacks silently replace with U+FFFD.
  */
 
 interface NonJsonValue {
@@ -31,6 +33,20 @@ function isCanonicalIndex(key: string, length: number): boolean {
   return Number.isInteger(index) && index >= 0 && index < length && String(index) === key;
 }
 
+// In u-mode a surrogate pair is consumed as one astral code point, so this
+// class matches exactly the unpaired surrogates.
+const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
+
+function findNonJsonString(value: string, pointer: string): NonJsonValue | undefined {
+  if (value.includes('\u0000')) {
+    return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
+  }
+  if (LONE_SURROGATE.test(value)) {
+    return { pointer, reason: 'string contains an unpaired UTF-16 surrogate' };
+  }
+  return undefined;
+}
+
 function findNonJsonValue(
   value: unknown,
   pointer: string,
@@ -45,8 +61,7 @@ function findNonJsonValue(
     return { pointer, reason: `non-finite number ${String(value)}` };
   }
   if (typeof value === 'string') {
-    if (!value.includes('\u0000')) return undefined;
-    return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
+    return findNonJsonString(value, pointer);
   }
   if (typeof value !== 'object') {
     return { pointer, reason: `${typeof value} is not a JSON value` };
@@ -89,6 +104,10 @@ function findNonJsonValue(
           pointer: `${pointer}/${key}`,
           reason: 'non-enumerable own property (dropped by JSON)',
         };
+      }
+      const keyIssue = findNonJsonString(key, `${pointer}/${key}`);
+      if (keyIssue) {
+        return { pointer: keyIssue.pointer, reason: `object key: ${keyIssue.reason}` };
       }
       const member = (value as Record<string, unknown>)[key];
       if (member === undefined) {

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared payload guard for JSON-carrying backends (HTTP transport, Postgres
+ * JSONB). The browser backend persists payloads via structured clone, which
+ * preserves values JSON cannot represent (Map, Set, Date, NaN, nested
+ * undefined, bigint). A JSON backend that accepted those would silently hand
+ * back different data on the next read — appendRecord's return value and a
+ * later listRecords would disagree. JSON backends therefore narrow the
+ * accepted payload domain and fail loud at the write boundary.
+ *
+ * JSONB note: Postgres jsonb cannot store the NUL code point (U+0000) inside
+ * strings (error 22P05), so strings containing it are rejected here too —
+ * keeping the payload domain identical across JSON backends rather than
+ * letting one accept what another must refuse.
+ */
+
+interface NonJsonValue {
+  pointer: string;
+  reason: string;
+}
+
+function isPlainPrototype(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function findNonJsonValue(
+  value: unknown,
+  pointer: string,
+  seen: Set<object>,
+): NonJsonValue | undefined {
+  if (value === null || typeof value === 'boolean') return undefined;
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) return undefined;
+    return { pointer, reason: `non-finite number ${String(value)}` };
+  }
+  if (typeof value === 'string') {
+    if (!value.includes('\u0000')) return undefined;
+    return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
+  }
+  if (typeof value !== 'object') {
+    return { pointer, reason: `${typeof value} is not a JSON value` };
+  }
+  if (seen.has(value)) return { pointer, reason: 'circular reference' };
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!(index in value)) {
+          return { pointer: `${pointer}/${index}`, reason: 'sparse array hole' };
+        }
+        const nested = findNonJsonValue(value[index], `${pointer}/${index}`, seen);
+        if (nested) return nested;
+      }
+      return undefined;
+    }
+    if (!isPlainPrototype(value)) {
+      return {
+        pointer,
+        reason: 'not a plain object (Map, Set, Date, class instances do not survive JSON)',
+      };
+    }
+    for (const [key, member] of Object.entries(value)) {
+      const memberPointer = `${pointer}/${key}`;
+      if (member === undefined) {
+        return { pointer: memberPointer, reason: 'undefined member (dropped by JSON)' };
+      }
+      const nested = findNonJsonValue(member, memberPointer, seen);
+      if (nested) return nested;
+    }
+    return undefined;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+/** Throw unless `value` survives JSON serialization losslessly. */
+export function assertJsonValue(value: unknown, label: string): void {
+  const offender = findNonJsonValue(value, '', new Set());
+  if (offender) {
+    throw new Error(
+      `@openmaic/storage: ${label} is not a plain JSON value at ` +
+        `'${offender.pointer || '/'}': ${offender.reason}`,
+    );
+  }
+}

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -41,6 +41,15 @@ function isCanonicalIndex(key: string, length: number): boolean {
 // class matches exactly the unpaired surrogates.
 const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
 
+function definesToJson(value: object): boolean {
+  let current: object | null = value;
+  while (current !== null) {
+    if (Object.getOwnPropertyDescriptor(current, 'toJSON') !== undefined) return true;
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return false;
+}
+
 function findNonJsonString(value: string, pointer: string): NonJsonValue | undefined {
   if (value.includes('\u0000')) {
     return { pointer, reason: 'string contains the NUL code point (\\u0000)' };
@@ -83,8 +92,12 @@ function findNonJsonValue(
   if (seen.has(value)) return { pointer, reason: 'circular reference' };
   // toJSON is the one channel through which a prototype can alter JSON output
   // (prototype properties themselves never serialize, and own accessors are
-  // rejected below), so refusing it closes prototype influence entirely.
-  if (typeof (value as { toJSON?: unknown }).toJSON === 'function') {
+  // rejected below), so refusing it closes prototype influence entirely. The
+  // probe walks descriptors instead of reading the property: a [[Get]] would
+  // execute an inherited accessor, letting a stateful getter hide from the
+  // check and reappear at stringify time. Mutating the object graph after
+  // validation is out of scope, as it is for every other validated property.
+  if (definesToJson(value)) {
     return { pointer, reason: 'value defines toJSON (would serialize differently than validated)' };
   }
   seen.add(value);

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -42,9 +42,17 @@ function isCanonicalIndex(key: string, length: number): boolean {
 const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
 
 function definesToJson(value: object): boolean {
+  // Mirror JSON.stringify exactly: it reads the own-most 'toJSON' and only
+  // invokes it when callable. A non-callable data value shadows anything
+  // above it and is an ordinary member, so it is safe; an accessor cannot be
+  // inspected without invoking it, so it is rejected outright.
   let current: object | null = value;
   while (current !== null) {
-    if (Object.getOwnPropertyDescriptor(current, 'toJSON') !== undefined) return true;
+    const descriptor = Object.getOwnPropertyDescriptor(current, 'toJSON');
+    if (descriptor !== undefined) {
+      if ('value' in descriptor) return typeof descriptor.value === 'function';
+      return true;
+    }
     current = Object.getPrototypeOf(current) as object | null;
   }
   return false;

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -81,6 +81,12 @@ function findNonJsonValue(
     return { pointer, reason: `${typeof value} is not a JSON value` };
   }
   if (seen.has(value)) return { pointer, reason: 'circular reference' };
+  // toJSON is the one channel through which a prototype can alter JSON output
+  // (prototype properties themselves never serialize, and own accessors are
+  // rejected below), so refusing it closes prototype influence entirely.
+  if (typeof (value as { toJSON?: unknown }).toJSON === 'function') {
+    return { pointer, reason: 'value defines toJSON (would serialize differently than validated)' };
+  }
   seen.add(value);
   try {
     if (Array.isArray(value)) {

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -70,6 +70,12 @@ function findNonJsonValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
+      if (Object.getPrototypeOf(value) !== Array.prototype) {
+        return {
+          pointer,
+          reason: 'array with a non-Array prototype (subclass/null-proto) does not survive JSON',
+        };
+      }
       for (const key of Reflect.ownKeys(value)) {
         if (key === 'length') continue;
         if (typeof key !== 'string' || !isCanonicalIndex(key, value.length)) {
@@ -78,9 +84,16 @@ function findNonJsonValue(
             reason: 'array carries a non-index own property (dropped by JSON)',
           };
         }
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (descriptor && (descriptor.get || descriptor.set)) {
+          return {
+            pointer: `${pointer}/${key}`,
+            reason: 'accessor property (its value can change between validation and JSON)',
+          };
+        }
       }
       for (let index = 0; index < value.length; index += 1) {
-        if (!(index in value)) {
+        if (!Object.hasOwn(value, index)) {
           return { pointer: `${pointer}/${index}`, reason: 'sparse array hole' };
         }
         const nested = findNonJsonValue(value[index], `${pointer}/${index}`, seen);
@@ -103,6 +116,12 @@ function findNonJsonValue(
         return {
           pointer: `${pointer}/${key}`,
           reason: 'non-enumerable own property (dropped by JSON)',
+        };
+      }
+      if (descriptor && (descriptor.get || descriptor.set)) {
+        return {
+          pointer: `${pointer}/${key}`,
+          reason: 'accessor property (its value can change between validation and JSON)',
         };
       }
       const keyIssue = findNonJsonString(key, `${pointer}/${key}`);

--- a/packages/@openmaic/storage/src/runtime/json-value.ts
+++ b/packages/@openmaic/storage/src/runtime/json-value.ts
@@ -24,8 +24,12 @@ interface NonJsonValue {
 }
 
 function isPlainPrototype(value: object): boolean {
+  // Realm-agnostic: a plain object's chain is value -> (some realm's)
+  // Object.prototype -> null, or value -> null for null-proto objects.
+  // Identity against this realm's Object.prototype would reject ordinary
+  // objects from another realm (vm, iframe), which JSON round-trips fine.
   const prototype = Object.getPrototypeOf(value) as object | null;
-  return prototype === Object.prototype || prototype === null;
+  return prototype === null || Object.getPrototypeOf(prototype) === null;
 }
 
 function isCanonicalIndex(key: string, length: number): boolean {
@@ -45,6 +49,16 @@ function findNonJsonString(value: string, pointer: string): NonJsonValue | undef
     return { pointer, reason: 'string contains an unpaired UTF-16 surrogate' };
   }
   return undefined;
+}
+
+/**
+ * True when `value` contains neither of the two string exceptions above.
+ * SQL backends also use this to decide that a lookup key can never match a
+ * stored row (the write gate provably refuses such keys), so this predicate
+ * and the write-side string rule must stay coupled — hence the shared export.
+ */
+export function isLosslessJsonString(value: string): boolean {
+  return findNonJsonString(value, '') === undefined;
 }
 
 function findNonJsonValue(
@@ -70,7 +84,15 @@ function findNonJsonValue(
   seen.add(value);
   try {
     if (Array.isArray(value)) {
-      if (Object.getPrototypeOf(value) !== Array.prototype) {
+      // Realm-agnostic plain-array check: a plain array's chain is
+      // arr -> Array.prototype -> Object.prototype -> null. Subclasses add a
+      // hop and null-proto arrays short-circuit; comparing against this
+      // realm's Array.prototype identity would reject ordinary arrays from
+      // another realm (vm, iframe), which JSON round-trips fine.
+      const arrayProto = Object.getPrototypeOf(value) as object | null;
+      const objectProto =
+        arrayProto === null ? null : (Object.getPrototypeOf(arrayProto) as object | null);
+      if (objectProto === null || Object.getPrototypeOf(objectProto) !== null) {
         return {
           pointer,
           reason: 'array with a non-Array prototype (subclass/null-proto) does not survive JSON',

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -2,6 +2,14 @@
  * PostgreSQL RuntimeStore backend over an injected query interface. The module
  * deliberately imports no PostgreSQL driver: node-postgres, PGlite, and host
  * adapters can all supply the small Queryable surface below.
+ *
+ * `withTransaction` must check out a fresh connection and open a transaction
+ * for every call, pin every query in `body` to it, then commit or roll back and
+ * release it. READ COMMITTED isolation is assumed. A shortcut such as
+ * `(body) => body(sharedClient)` is unsafe because concurrent calls can
+ * interleave in one transaction. Payloads are narrowed to plain JSON values
+ * that round-trip losslessly through JSONB; values such as Date, Map, nested
+ * undefined, non-finite numbers, and strings containing NUL are rejected.
  */
 import {
   RUNTIME_DSL_VERSION,
@@ -21,6 +29,7 @@ import type {
   RuntimeSessionStatus,
 } from '@openmaic/dsl';
 import type { RuntimePayloadValidator, RuntimeSessionInit, RuntimeStore } from './types.js';
+import { assertJsonValue } from './json-value.js';
 
 export interface QueryResult<TRow extends Record<string, unknown> = Record<string, unknown>> {
   rows: TRow[];
@@ -38,12 +47,12 @@ export type WithTransaction = <T>(body: (queryable: Queryable) => Promise<T>) =>
 
 export interface PgRuntimeStoreOptions {
   /**
-   * Pins every query in `body` to one SQL transaction. A node-postgres Pool
-   * supplies this by checking out a Client; PGlite supplies it with
-   * `db.transaction`. If omitted, the injected Queryable itself must be a
-   * connection-pinned client on which BEGIN/COMMIT are meaningful.
+   * On every call, checks out a fresh connection, opens a transaction, pins
+   * every query in `body` to it, then commits or rolls back and releases it.
+   * READ COMMITTED isolation is assumed. `(body) => body(sharedClient)` is not
+   * valid because concurrent calls would interleave within one transaction.
    */
-  withTransaction?: WithTransaction;
+  withTransaction: WithTransaction;
   /** Replaces the default chat / quizAttempt skeleton validator map. */
   payloadValidators?: Record<string, RuntimePayloadValidator>;
 }
@@ -65,8 +74,6 @@ CREATE INDEX IF NOT EXISTS runtime_sessions_stage_learner_idx
   ON runtime_sessions (stage_id, learner_key);
 CREATE INDEX IF NOT EXISTS runtime_sessions_learner_idx
   ON runtime_sessions (learner_key);
-CREATE INDEX IF NOT EXISTS runtime_sessions_stage_idx
-  ON runtime_sessions (stage_id);
 
 CREATE TABLE IF NOT EXISTS runtime_records (
   id TEXT NOT NULL,
@@ -82,10 +89,15 @@ CREATE INDEX IF NOT EXISTS runtime_records_session_scene_idx
   ON runtime_records (session_id, scene_id);
 `;
 
-/** Create or upgrade the tables owned by this backend. Safe to call repeatedly. */
+/**
+ * Create the tables owned by this backend when absent. Safe to call repeatedly;
+ * changing an existing table requires a real migration.
+ */
 export async function ensureSchema(queryable: Queryable): Promise<void> {
   // Keep Queryable minimal: PGlite's query() intentionally accepts one
   // statement at a time, while node-postgres also accepts each statement.
+  // This split is deliberately simple and would break on semicolons inside SQL
+  // string literals; replace it with a migration runner before adding such SQL.
   for (const sql of RUNTIME_PG_SCHEMA.split(';')) {
     const statement = sql.trim();
     if (statement !== '') await queryable.query(statement);
@@ -176,36 +188,32 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
+function isRetryableAppendError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === '23505' || code === '40001' || code === '40P01';
+}
+
 export class PgRuntimeStore implements RuntimeStore {
   private readonly queryable: Queryable;
-  private readonly transactionHook?: WithTransaction;
+  private readonly transactionHook: WithTransaction;
   private readonly payloadValidators: Record<string, RuntimePayloadValidator>;
 
-  constructor(queryable: Queryable, options: PgRuntimeStoreOptions = {}) {
+  constructor(queryable: Queryable, options: PgRuntimeStoreOptions) {
+    if (typeof options?.withTransaction !== 'function') {
+      throw new Error(
+        '@openmaic/storage: withTransaction is required and must pin a fresh connection and ' +
+          'transaction for every call; reusing a shared client lets concurrent transactions ' +
+          'interleave',
+      );
+    }
     this.queryable = queryable;
     this.transactionHook = options.withTransaction;
     this.payloadValidators = options.payloadValidators ?? DEFAULT_PAYLOAD_VALIDATORS;
   }
 
   private async transaction<T>(body: (queryable: Queryable) => Promise<T>): Promise<T> {
-    if (this.transactionHook) return this.transactionHook(body);
-
-    // This fallback is for a connection-pinned Queryable (pg Client, not a
-    // Pool). Pool users must inject withTransaction so BEGIN/body/COMMIT all
-    // execute on the same checked-out Client.
-    await this.queryable.query('BEGIN');
-    try {
-      const result = await body(this.queryable);
-      await this.queryable.query('COMMIT');
-      return result;
-    } catch (error) {
-      try {
-        await this.queryable.query('ROLLBACK');
-      } catch {
-        // Preserve the operation's original error if rollback itself fails.
-      }
-      throw error;
-    }
+    return this.transactionHook(body);
   }
 
   private validatorFor(kind: string): RuntimePayloadValidator | undefined {
@@ -333,9 +341,7 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    await this.transaction(async (queryable) => {
-      await queryable.query('DELETE FROM runtime_sessions WHERE id = $1', [sessionId]);
-    });
+    await this.queryable.query('DELETE FROM runtime_sessions WHERE id = $1', [sessionId]);
   }
 
   async appendRecord<TPayload extends RuntimePayload>(
@@ -345,6 +351,7 @@ export class PgRuntimeStore implements RuntimeStore {
       validateRuntimeRecord({ ...init, seq: 0 }),
       `runtime record ${JSON.stringify(init.id)}`,
     );
+    assertJsonValue(init.payload, `runtime record ${JSON.stringify(init.id)} payload`);
 
     // The session-row lock serializes appenders for one session. Computing
     // MAX(seq)+1 and inserting happen in that same transaction, so rollback
@@ -401,7 +408,11 @@ export class PgRuntimeStore implements RuntimeStore {
           return record;
         });
       } catch (error) {
-        if (!isUniqueViolation(error) || attempt === 4) throw error;
+        // Under the assumed READ COMMITTED isolation, each retry starts a fresh
+        // transaction and repeats the locked read, MAX(seq), and INSERT. A
+        // failed attempt cannot commit partial effects, so retrying uniqueness,
+        // serialization, and deadlock aborts preserves monotonic sequences.
+        if (!isRetryableAppendError(error) || attempt === 4) throw error;
       }
     }
     throw new Error('@openmaic/storage: unreachable append retry state');
@@ -462,17 +473,13 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void> {
-    await this.transaction(async (queryable) => {
-      await queryable.query(
-        'DELETE FROM runtime_sessions WHERE stage_id = $1 AND learner_key = $2',
-        [stageId, learnerKey],
-      );
-    });
+    await this.queryable.query(
+      'DELETE FROM runtime_sessions WHERE stage_id = $1 AND learner_key = $2',
+      [stageId, learnerKey],
+    );
   }
 
   async deleteStageRuntime(stageId: string): Promise<void> {
-    await this.transaction(async (queryable) => {
-      await queryable.query('DELETE FROM runtime_sessions WHERE stage_id = $1', [stageId]);
-    });
+    await this.queryable.query('DELETE FROM runtime_sessions WHERE stage_id = $1', [stageId]);
   }
 }

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -194,6 +194,15 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
+// PostgreSQL text parameters reject NUL and unpaired UTF-16 surrogates before
+// SQL can apply absence semantics. In Unicode mode, a valid surrogate pair is
+// consumed as one astral code point, so this class matches only lone halves.
+const PG_UNQUERYABLE_KEY = /\u0000|[\uD800-\uDFFF]/u;
+
+function isPgQueryableKey(value: string): boolean {
+  return !PG_UNQUERYABLE_KEY.test(value);
+}
+
 // 40001 is not reachable under the READ COMMITTED isolation this store assumes,
 // but remains retryable in case a host injects REPEATABLE READ or SERIALIZABLE
 // at the connection or session level. appendRecord intentionally owns the only
@@ -313,6 +322,7 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async getSession(sessionId: string): Promise<RuntimeSession | undefined> {
+    if (!isPgQueryableKey(sessionId)) return undefined;
     const row = await this.loadSession(this.queryable, sessionId);
     if (!row) return undefined;
     const session = migrateSession(row);
@@ -324,6 +334,7 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]> {
+    if (!isPgQueryableKey(stageId) || !isPgQueryableKey(learnerKey)) return [];
     const result = await this.queryable.query<StoredJsonRow>(
       `SELECT data
          FROM runtime_sessions
@@ -353,6 +364,9 @@ export class PgRuntimeStore implements RuntimeStore {
     status: RuntimeSessionStatus,
     updatedAt: string,
   ): Promise<void> {
+    if (!isPgQueryableKey(sessionId)) {
+      throw new Error(`@openmaic/storage: no session ${JSON.stringify(sessionId)}`);
+    }
     await this.transaction(async (queryable) => {
       const row = await this.loadSession(queryable, sessionId, true);
       if (!row) throw new Error(`@openmaic/storage: no session ${JSON.stringify(sessionId)}`);
@@ -364,6 +378,7 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
+    if (!isPgQueryableKey(sessionId)) return;
     await this.queryable.query('DELETE FROM runtime_sessions WHERE id = $1', [sessionId]);
   }
 
@@ -415,7 +430,11 @@ export class PgRuntimeStore implements RuntimeStore {
           const seq = Number(last.rows[0]?.last_seq ?? -1) + 1;
           const record: RuntimeRecord<TPayload> = { ...init, seq };
           assertValid(validateRuntimeRecord(record), `runtime record ${JSON.stringify(init.id)}`);
-          assertJsonValue(record, `runtime record ${JSON.stringify(record.id)}`);
+          const jsonRecord = { ...record } as Record<string, unknown>;
+          for (const [key, value] of Object.entries(jsonRecord)) {
+            if (value === undefined) delete jsonRecord[key];
+          }
+          assertJsonValue(jsonRecord, `runtime record ${JSON.stringify(record.id)}`);
           await queryable.query(
             `INSERT INTO runtime_records
                (id, session_id, seq, scene_id, created_at, data)
@@ -443,6 +462,12 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]> {
+    if (
+      !isPgQueryableKey(sessionId) ||
+      (opts?.sceneId !== undefined && !isPgQueryableKey(opts.sceneId))
+    ) {
+      return [];
+    }
     const params: unknown[] = [sessionId];
     let filter = '';
     if (opts?.sceneId !== undefined) {
@@ -468,6 +493,8 @@ export class PgRuntimeStore implements RuntimeStore {
     ) {
       throw new Error('@openmaic/storage: learner keys must be non-empty strings');
     }
+    assertJsonValue(toLearnerKey, 'target learner key');
+    if (!isPgQueryableKey(fromLearnerKey)) return 0;
     if (fromLearnerKey === toLearnerKey) return 0;
 
     // This lock set grows without bound with the source learner's session count,
@@ -501,6 +528,7 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void> {
+    if (!isPgQueryableKey(stageId) || !isPgQueryableKey(learnerKey)) return;
     await this.queryable.query(
       'DELETE FROM runtime_sessions WHERE stage_id = $1 AND learner_key = $2',
       [stageId, learnerKey],
@@ -508,6 +536,7 @@ export class PgRuntimeStore implements RuntimeStore {
   }
 
   async deleteStageRuntime(stageId: string): Promise<void> {
+    if (!isPgQueryableKey(stageId)) return;
     await this.queryable.query('DELETE FROM runtime_sessions WHERE stage_id = $1', [stageId]);
   }
 }

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -1,0 +1,478 @@
+/**
+ * PostgreSQL RuntimeStore backend over an injected query interface. The module
+ * deliberately imports no PostgreSQL driver: node-postgres, PGlite, and host
+ * adapters can all supply the small Queryable surface below.
+ */
+import {
+  RUNTIME_DSL_VERSION,
+  isChatMessageSkeleton,
+  isQuizAttemptSkeleton,
+  migrateRuntime,
+  needsRuntimeMigration,
+  runtimeDslVersionOf,
+  validateRuntimeRecord,
+  validateRuntimeSession,
+} from '@openmaic/dsl';
+import type {
+  RuntimePayload,
+  RuntimeRecord,
+  RuntimeRecordInit,
+  RuntimeSession,
+  RuntimeSessionStatus,
+} from '@openmaic/dsl';
+import type { RuntimePayloadValidator, RuntimeSessionInit, RuntimeStore } from './types.js';
+
+export interface QueryResult<TRow extends Record<string, unknown> = Record<string, unknown>> {
+  rows: TRow[];
+}
+
+/** The common query surface implemented by a node-postgres Pool/Client and PGlite. */
+export interface Queryable {
+  query<TRow extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+  ): Promise<QueryResult<TRow>>;
+}
+
+export type WithTransaction = <T>(body: (queryable: Queryable) => Promise<T>) => Promise<T>;
+
+export interface PgRuntimeStoreOptions {
+  /**
+   * Pins every query in `body` to one SQL transaction. A node-postgres Pool
+   * supplies this by checking out a Client; PGlite supplies it with
+   * `db.transaction`. If omitted, the injected Queryable itself must be a
+   * connection-pinned client on which BEGIN/COMMIT are meaningful.
+   */
+  withTransaction?: WithTransaction;
+  /** Replaces the default chat / quizAttempt skeleton validator map. */
+  payloadValidators?: Record<string, RuntimePayloadValidator>;
+}
+
+/** Idempotent schema for the PostgreSQL runtime backend. */
+export const RUNTIME_PG_SCHEMA = `
+CREATE TABLE IF NOT EXISTS runtime_sessions (
+  id TEXT PRIMARY KEY,
+  stage_id TEXT NOT NULL,
+  learner_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  data JSONB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS runtime_sessions_stage_learner_idx
+  ON runtime_sessions (stage_id, learner_key);
+CREATE INDEX IF NOT EXISTS runtime_sessions_learner_idx
+  ON runtime_sessions (learner_key);
+CREATE INDEX IF NOT EXISTS runtime_sessions_stage_idx
+  ON runtime_sessions (stage_id);
+
+CREATE TABLE IF NOT EXISTS runtime_records (
+  id TEXT NOT NULL,
+  session_id TEXT NOT NULL REFERENCES runtime_sessions(id) ON DELETE CASCADE,
+  seq BIGINT NOT NULL CHECK (seq >= 0),
+  scene_id TEXT,
+  created_at TEXT NOT NULL,
+  data JSONB NOT NULL,
+  CONSTRAINT runtime_records_session_seq_unique UNIQUE (session_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS runtime_records_session_scene_idx
+  ON runtime_records (session_id, scene_id);
+`;
+
+/** Create or upgrade the tables owned by this backend. Safe to call repeatedly. */
+export async function ensureSchema(queryable: Queryable): Promise<void> {
+  // Keep Queryable minimal: PGlite's query() intentionally accepts one
+  // statement at a time, while node-postgres also accepts each statement.
+  for (const sql of RUNTIME_PG_SCHEMA.split(';')) {
+    const statement = sql.trim();
+    if (statement !== '') await queryable.query(statement);
+  }
+}
+
+const DEFAULT_PAYLOAD_VALIDATORS: Record<string, RuntimePayloadValidator> = {
+  chat: (payload) =>
+    isChatMessageSkeleton(payload)
+      ? { valid: true }
+      : {
+          valid: false,
+          errors: [
+            {
+              path: '/payload',
+              message: 'chat payload must match ChatMessageSkeleton (role + content)',
+            },
+          ],
+        },
+  quizAttempt: (payload) =>
+    isQuizAttemptSkeleton(payload)
+      ? { valid: true }
+      : {
+          valid: false,
+          errors: [
+            {
+              path: '/payload',
+              message: 'quizAttempt payload must match QuizAttemptSkeleton (phase + answers)',
+            },
+          ],
+        },
+};
+
+interface StoredJsonRow extends Record<string, unknown> {
+  data: unknown;
+}
+
+interface LastSeqRow extends Record<string, unknown> {
+  last_seq: string | number;
+}
+
+function assertValid(
+  result: { valid: true } | { valid: false; errors: { path: string; message: string }[] },
+  label: string,
+): void {
+  if (result.valid) return;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new Error(`@openmaic/storage: invalid ${label}: ${detail}`);
+}
+
+function decodeJson<T>(value: unknown): T {
+  return (typeof value === 'string' ? JSON.parse(value) : value) as T;
+}
+
+function encodeJson(value: unknown, label: string): string {
+  try {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) throw new TypeError('value is not JSON-serializable');
+    return encoded;
+  } catch (error) {
+    throw new Error(`@openmaic/storage: ${label} is not JSON-serializable`, { cause: error });
+  }
+}
+
+function isFutureRuntimeVersioned(row: unknown): boolean {
+  if (typeof row !== 'object' || row === null) return false;
+  return !needsRuntimeMigration(row) && runtimeDslVersionOf(row) !== RUNTIME_DSL_VERSION;
+}
+
+function futureSessionError(sessionId: string, row: RuntimeSession): Error {
+  return new Error(
+    `@openmaic/storage: session ${JSON.stringify(sessionId)} was written at runtime DSL ` +
+      `version ${JSON.stringify(runtimeDslVersionOf(row))}, newer than this client's ` +
+      `${RUNTIME_DSL_VERSION}`,
+  );
+}
+
+function migrateSession(row: RuntimeSession): RuntimeSession {
+  return needsRuntimeMigration(row) ? (migrateRuntime(row) as RuntimeSession) : row;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === '23505'
+  );
+}
+
+export class PgRuntimeStore implements RuntimeStore {
+  private readonly queryable: Queryable;
+  private readonly transactionHook?: WithTransaction;
+  private readonly payloadValidators: Record<string, RuntimePayloadValidator>;
+
+  constructor(queryable: Queryable, options: PgRuntimeStoreOptions = {}) {
+    this.queryable = queryable;
+    this.transactionHook = options.withTransaction;
+    this.payloadValidators = options.payloadValidators ?? DEFAULT_PAYLOAD_VALIDATORS;
+  }
+
+  private async transaction<T>(body: (queryable: Queryable) => Promise<T>): Promise<T> {
+    if (this.transactionHook) return this.transactionHook(body);
+
+    // This fallback is for a connection-pinned Queryable (pg Client, not a
+    // Pool). Pool users must inject withTransaction so BEGIN/body/COMMIT all
+    // execute on the same checked-out Client.
+    await this.queryable.query('BEGIN');
+    try {
+      const result = await body(this.queryable);
+      await this.queryable.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await this.queryable.query('ROLLBACK');
+      } catch {
+        // Preserve the operation's original error if rollback itself fails.
+      }
+      throw error;
+    }
+  }
+
+  private validatorFor(kind: string): RuntimePayloadValidator | undefined {
+    return Object.hasOwn(this.payloadValidators, kind) ? this.payloadValidators[kind] : undefined;
+  }
+
+  private async loadSession(
+    queryable: Queryable,
+    sessionId: string,
+    lock = false,
+  ): Promise<RuntimeSession | undefined> {
+    const result = await queryable.query<StoredJsonRow>(
+      `SELECT data
+         FROM runtime_sessions
+        WHERE id = $1${lock ? ' FOR UPDATE' : ''}`,
+      [sessionId],
+    );
+    return result.rows[0] ? decodeJson<RuntimeSession>(result.rows[0].data) : undefined;
+  }
+
+  private async persistSession(queryable: Queryable, session: RuntimeSession): Promise<void> {
+    await queryable.query(
+      `UPDATE runtime_sessions
+          SET stage_id = $2,
+              learner_key = $3,
+              kind = $4,
+              status = $5,
+              created_at = $6,
+              updated_at = $7,
+              data = $8::jsonb
+        WHERE id = $1`,
+      [
+        session.id,
+        session.stageId,
+        session.learnerKey,
+        session.kind,
+        session.status,
+        session.createdAt,
+        session.updatedAt,
+        encodeJson(session, `runtime session ${JSON.stringify(session.id)}`),
+      ],
+    );
+  }
+
+  async createSession(init: RuntimeSessionInit): Promise<RuntimeSession> {
+    const stamped: RuntimeSession = { ...init, runtimeDslVersion: RUNTIME_DSL_VERSION };
+    assertValid(validateRuntimeSession(stamped), `runtime session ${JSON.stringify(stamped.id)}`);
+
+    try {
+      await this.queryable.query(
+        `INSERT INTO runtime_sessions
+           (id, stage_id, learner_key, kind, status, created_at, updated_at, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+        [
+          stamped.id,
+          stamped.stageId,
+          stamped.learnerKey,
+          stamped.kind,
+          stamped.status,
+          stamped.createdAt,
+          stamped.updatedAt,
+          encodeJson(stamped, `runtime session ${JSON.stringify(stamped.id)}`),
+        ],
+      );
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new Error(`@openmaic/storage: session ${JSON.stringify(stamped.id)} already exists`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    return stamped;
+  }
+
+  async getSession(sessionId: string): Promise<RuntimeSession | undefined> {
+    const row = await this.loadSession(this.queryable, sessionId);
+    if (!row) return undefined;
+    const session = migrateSession(row);
+    assertValid(
+      validateRuntimeSession(session),
+      `stored runtime session ${JSON.stringify(sessionId)}`,
+    );
+    return session;
+  }
+
+  async listSessions(stageId: string, learnerKey: string): Promise<RuntimeSession[]> {
+    const result = await this.queryable.query<StoredJsonRow>(
+      `SELECT data
+         FROM runtime_sessions
+        WHERE stage_id = $1 AND learner_key = $2`,
+      [stageId, learnerKey],
+    );
+    const sessions: RuntimeSession[] = [];
+    for (const row of result.rows) {
+      try {
+        const session = migrateSession(decodeJson<RuntimeSession>(row.data));
+        assertValid(
+          validateRuntimeSession(session),
+          `stored runtime session ${JSON.stringify(session.id)}`,
+        );
+        sessions.push(session);
+      } catch {
+        // Listings omit corrupt rows; direct reads remain fail-loud.
+      }
+    }
+    return sessions.sort(
+      (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt) || a.id.localeCompare(b.id),
+    );
+  }
+
+  async setSessionStatus(
+    sessionId: string,
+    status: RuntimeSessionStatus,
+    updatedAt: string,
+  ): Promise<void> {
+    await this.transaction(async (queryable) => {
+      const row = await this.loadSession(queryable, sessionId, true);
+      if (!row) throw new Error(`@openmaic/storage: no session ${JSON.stringify(sessionId)}`);
+      if (isFutureRuntimeVersioned(row)) throw futureSessionError(sessionId, row);
+      const updated: RuntimeSession = { ...migrateSession(row), status, updatedAt };
+      assertValid(validateRuntimeSession(updated), `runtime session ${JSON.stringify(sessionId)}`);
+      await this.persistSession(queryable, updated);
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.transaction(async (queryable) => {
+      await queryable.query('DELETE FROM runtime_sessions WHERE id = $1', [sessionId]);
+    });
+  }
+
+  async appendRecord<TPayload extends RuntimePayload>(
+    init: RuntimeRecordInit<TPayload>,
+  ): Promise<RuntimeRecord<TPayload>> {
+    assertValid(
+      validateRuntimeRecord({ ...init, seq: 0 }),
+      `runtime record ${JSON.stringify(init.id)}`,
+    );
+
+    // The session-row lock serializes appenders for one session. Computing
+    // MAX(seq)+1 and inserting happen in that same transaction, so rollback
+    // cannot leave a hole. UNIQUE(session_id, seq) is the final safety net;
+    // retrying the whole transaction handles a competing non-cooperating SQL
+    // writer without ever returning a duplicate sequence.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      try {
+        return await this.transaction(async (queryable) => {
+          const row = await this.loadSession(queryable, init.sessionId, true);
+          if (!row) {
+            throw new Error(`@openmaic/storage: no session ${JSON.stringify(init.sessionId)}`);
+          }
+          if (isFutureRuntimeVersioned(row)) throw futureSessionError(init.sessionId, row);
+
+          let session = row;
+          if (needsRuntimeMigration(row)) {
+            session = migrateSession(row);
+            await this.persistSession(queryable, session);
+          }
+          if (session.status !== 'active') {
+            throw new Error(
+              `@openmaic/storage: cannot append to session ${JSON.stringify(init.sessionId)} ` +
+                `with status '${session.status}' — records may only be appended to an active session`,
+            );
+          }
+          const validator = this.validatorFor(session.kind);
+          if (validator) {
+            assertValid(validator(init.payload), `runtime record ${JSON.stringify(init.id)}`);
+          }
+
+          const last = await queryable.query<LastSeqRow>(
+            `SELECT COALESCE(MAX(seq), -1)::text AS last_seq
+               FROM runtime_records
+              WHERE session_id = $1`,
+            [init.sessionId],
+          );
+          const seq = Number(last.rows[0]?.last_seq ?? -1) + 1;
+          const record: RuntimeRecord<TPayload> = { ...init, seq };
+          assertValid(validateRuntimeRecord(record), `runtime record ${JSON.stringify(init.id)}`);
+          await queryable.query(
+            `INSERT INTO runtime_records
+               (id, session_id, seq, scene_id, created_at, data)
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+            [
+              record.id,
+              record.sessionId,
+              record.seq,
+              record.sceneId ?? null,
+              record.createdAt,
+              encodeJson(record, `runtime record ${JSON.stringify(record.id)}`),
+            ],
+          );
+          return record;
+        });
+      } catch (error) {
+        if (!isUniqueViolation(error) || attempt === 4) throw error;
+      }
+    }
+    throw new Error('@openmaic/storage: unreachable append retry state');
+  }
+
+  async listRecords(sessionId: string, opts?: { sceneId?: string }): Promise<RuntimeRecord[]> {
+    const params: unknown[] = [sessionId];
+    let filter = '';
+    if (opts?.sceneId !== undefined) {
+      params.push(opts.sceneId);
+      filter = ' AND scene_id = $2';
+    }
+    const result = await this.queryable.query<StoredJsonRow>(
+      `SELECT data
+         FROM runtime_records
+        WHERE session_id = $1${filter}
+        ORDER BY seq ASC`,
+      params,
+    );
+    return result.rows.map((row) => decodeJson<RuntimeRecord>(row.data));
+  }
+
+  async mergeLearner(fromLearnerKey: string, toLearnerKey: string): Promise<number> {
+    if (
+      typeof fromLearnerKey !== 'string' ||
+      fromLearnerKey === '' ||
+      typeof toLearnerKey !== 'string' ||
+      toLearnerKey === ''
+    ) {
+      throw new Error('@openmaic/storage: learner keys must be non-empty strings');
+    }
+    if (fromLearnerKey === toLearnerKey) return 0;
+
+    return this.transaction(async (queryable) => {
+      const result = await queryable.query<StoredJsonRow>(
+        `SELECT data
+           FROM runtime_sessions
+          WHERE learner_key = $1
+          FOR UPDATE`,
+        [fromLearnerKey],
+      );
+      const updatedSessions = result.rows.map((row) => {
+        const stored = decodeJson<RuntimeSession>(row.data);
+        if (isFutureRuntimeVersioned(stored)) throw futureSessionError(stored.id, stored);
+        const updated: RuntimeSession = {
+          ...migrateSession(stored),
+          learnerKey: toLearnerKey,
+        };
+        assertValid(
+          validateRuntimeSession(updated),
+          `runtime session ${JSON.stringify(updated.id)}`,
+        );
+        return updated;
+      });
+      for (const session of updatedSessions) await this.persistSession(queryable, session);
+      return updatedSessions.length;
+    });
+  }
+
+  async deleteLearnerRuntime(stageId: string, learnerKey: string): Promise<void> {
+    await this.transaction(async (queryable) => {
+      await queryable.query(
+        'DELETE FROM runtime_sessions WHERE stage_id = $1 AND learner_key = $2',
+        [stageId, learnerKey],
+      );
+    });
+  }
+
+  async deleteStageRuntime(stageId: string): Promise<void> {
+    await this.transaction(async (queryable) => {
+      await queryable.query('DELETE FROM runtime_sessions WHERE stage_id = $1', [stageId]);
+    });
+  }
+}

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -194,6 +194,13 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
+// 40001 is not reachable under the READ COMMITTED isolation this store assumes,
+// but remains retryable in case a host injects REPEATABLE READ or SERIALIZABLE
+// at the connection or session level. appendRecord intentionally owns the only
+// write-conflict retry loop: a non-cooperating external writer can deadlock its
+// multi-statement lock/read/insert sequence. mergeLearner acquires its complete
+// lock set in one statement, so it cannot form a lock-acquisition cycle, while
+// setSessionStatus takes only one row lock; neither path needs conflict retries.
 function isRetryableAppendError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null || !('code' in error)) return false;
   const code = (error as { code?: unknown }).code;
@@ -276,6 +283,7 @@ export class PgRuntimeStore implements RuntimeStore {
   async createSession(init: RuntimeSessionInit): Promise<RuntimeSession> {
     const stamped: RuntimeSession = { ...init, runtimeDslVersion: RUNTIME_DSL_VERSION };
     assertValid(validateRuntimeSession(stamped), `runtime session ${JSON.stringify(stamped.id)}`);
+    assertJsonValue(stamped, `runtime session ${JSON.stringify(stamped.id)}`);
 
     try {
       await this.queryable.query(
@@ -407,6 +415,7 @@ export class PgRuntimeStore implements RuntimeStore {
           const seq = Number(last.rows[0]?.last_seq ?? -1) + 1;
           const record: RuntimeRecord<TPayload> = { ...init, seq };
           assertValid(validateRuntimeRecord(record), `runtime record ${JSON.stringify(init.id)}`);
+          assertJsonValue(record, `runtime record ${JSON.stringify(record.id)}`);
           await queryable.query(
             `INSERT INTO runtime_records
                (id, session_id, seq, scene_id, created_at, data)
@@ -461,6 +470,10 @@ export class PgRuntimeStore implements RuntimeStore {
     }
     if (fromLearnerKey === toLearnerKey) return 0;
 
+    // This lock set grows without bound with the source learner's session count,
+    // and the following updates hold it across N round-trips. That is a known
+    // contention/scalability surface, not a correctness issue; deployments that
+    // need to cap the wait can mitigate it with PostgreSQL's lock_timeout.
     return this.transaction(async (queryable) => {
       const result = await queryable.query<StoredJsonRow>(
         `SELECT data

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -29,7 +29,7 @@ import type {
   RuntimeSessionStatus,
 } from '@openmaic/dsl';
 import type { RuntimePayloadValidator, RuntimeSessionInit, RuntimeStore } from './types.js';
-import { assertJsonValue } from './json-value.js';
+import { assertJsonValue, isLosslessJsonString } from './json-value.js';
 
 export interface QueryResult<TRow extends Record<string, unknown> = Record<string, unknown>> {
   rows: TRow[];
@@ -195,12 +195,11 @@ function isUniqueViolation(error: unknown): boolean {
 }
 
 // PostgreSQL text parameters reject NUL and unpaired UTF-16 surrogates before
-// SQL can apply absence semantics. In Unicode mode, a valid surrogate pair is
-// consumed as one astral code point, so this class matches only lone halves.
-const PG_UNQUERYABLE_KEY = /\u0000|[\uD800-\uDFFF]/u;
-
+// SQL can apply absence semantics.
 function isPgQueryableKey(value: string): boolean {
-  return !PG_UNQUERYABLE_KEY.test(value);
+  // Shared with the write gate: a key the gate refuses can never be stored,
+  // so treating it as absent on the read/delete side is provably sound.
+  return isLosslessJsonString(value);
 }
 
 // 40001 is not reachable under the READ COMMITTED isolation this store assumes,
@@ -390,6 +389,10 @@ export class PgRuntimeStore implements RuntimeStore {
       `runtime record ${JSON.stringify(init.id)}`,
     );
     assertJsonValue(init.payload, `runtime record ${JSON.stringify(init.id)} payload`);
+    if (!isPgQueryableKey(init.sessionId)) {
+      // A text column can never hold such a key, so no session can exist.
+      throw new Error(`@openmaic/storage: no session ${JSON.stringify(init.sessionId)}`);
+    }
 
     // The session-row lock serializes appenders for one session. Computing
     // MAX(seq)+1 and inserting happen in that same transaction, so rollback
@@ -430,9 +433,11 @@ export class PgRuntimeStore implements RuntimeStore {
           const seq = Number(last.rows[0]?.last_seq ?? -1) + 1;
           const record: RuntimeRecord<TPayload> = { ...init, seq };
           assertValid(validateRuntimeRecord(record), `runtime record ${JSON.stringify(init.id)}`);
+          // Only the DSL-declared optional anchors get omitted-value treatment;
+          // any other undefined member still fails the JSON gate loud.
           const jsonRecord = { ...record } as Record<string, unknown>;
-          for (const [key, value] of Object.entries(jsonRecord)) {
-            if (value === undefined) delete jsonRecord[key];
+          for (const key of ['sceneId', 'actionIndex', 'subAnchor']) {
+            if (jsonRecord[key] === undefined) delete jsonRecord[key];
           }
           assertJsonValue(jsonRecord, `runtime record ${JSON.stringify(record.id)}`);
           await queryable.query(

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -152,6 +152,12 @@ function decodeJson<T>(value: unknown): T {
   return (typeof value === 'string' ? JSON.parse(value) : value) as T;
 }
 
+function isPlainObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 function encodeJson(value: unknown, label: string): string {
   try {
     const encoded = JSON.stringify(value);
@@ -231,7 +237,16 @@ export class PgRuntimeStore implements RuntimeStore {
         WHERE id = $1${lock ? ' FOR UPDATE' : ''}`,
       [sessionId],
     );
-    return result.rows[0] ? decodeJson<RuntimeSession>(result.rows[0].data) : undefined;
+    const storedRow = result.rows[0];
+    if (!storedRow) return undefined;
+    const decoded = decodeJson<unknown>(storedRow.data);
+    if (!isPlainObject(decoded)) {
+      throw new Error(
+        `@openmaic/storage: corrupt stored row for session ${JSON.stringify(sessionId)}: ` +
+          'data must be a plain object',
+      );
+    }
+    return decoded as RuntimeSession;
   }
 
   private async persistSession(queryable: Queryable, session: RuntimeSession): Promise<void> {

--- a/packages/@openmaic/storage/test/json-value.test.ts
+++ b/packages/@openmaic/storage/test/json-value.test.ts
@@ -84,6 +84,23 @@ describe('cross-realm and shared-predicate behavior', () => {
     expect(() => assertJsonValue(crafted, 'payload')).toThrow(/toJSON/);
   });
 
+  test('detects an inherited toJSON accessor without invoking it', () => {
+    let invoked = 0;
+    const proto = Object.create(null) as object;
+    Object.defineProperty(proto, 'toJSON', {
+      get() {
+        invoked += 1;
+        return undefined;
+      },
+      enumerable: false,
+      configurable: true,
+    });
+    const crafted = Object.create(proto) as Record<string, unknown>;
+    crafted.real = 1;
+    expect(() => assertJsonValue(crafted, 'payload')).toThrow(/toJSON/);
+    expect(invoked).toBe(0);
+  });
+
   test('isLosslessJsonString mirrors the string gate', () => {
     expect(isLosslessJsonString('plain text')).toBe(true);
     expect(isLosslessJsonString('a\u0000b')).toBe(false);

--- a/packages/@openmaic/storage/test/json-value.test.ts
+++ b/packages/@openmaic/storage/test/json-value.test.ts
@@ -24,3 +24,42 @@ describe('assertJsonValue string guards', () => {
     expect(() => assertJsonValue({ value: '𐀀' }, 'value')).not.toThrow();
   });
 });
+
+describe('assertJsonValue structural guards', () => {
+  test('rejects an enumerable accessor own property', () => {
+    const value = Object.defineProperty({}, 'dynamic', {
+      enumerable: true,
+      get: () => 'value',
+    });
+
+    expect(() => assertJsonValue(value, 'value')).toThrow(/accessor property/i);
+  });
+
+  test('rejects an Array subclass instance', () => {
+    class JsonLookingArray extends Array<number> {}
+
+    expect(() => assertJsonValue(new JsonLookingArray(1, 2), 'value')).toThrow(
+      /array with a non-Array prototype/i,
+    );
+  });
+
+  test('rejects a sparse array even when its prototype provides the missing index', () => {
+    const sparse = new Array<string>(1);
+    let thrown: unknown;
+    Object.defineProperty(Array.prototype, '0', {
+      configurable: true,
+      value: 'inherited',
+      writable: true,
+    });
+    try {
+      assertJsonValue(sparse, 'value');
+    } catch (error) {
+      thrown = error;
+    } finally {
+      delete Array.prototype[0];
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/sparse array hole/i);
+  });
+});

--- a/packages/@openmaic/storage/test/json-value.test.ts
+++ b/packages/@openmaic/storage/test/json-value.test.ts
@@ -101,6 +101,11 @@ describe('cross-realm and shared-predicate behavior', () => {
     expect(invoked).toBe(0);
   });
 
+  test('accepts a plain non-callable toJSON data field', () => {
+    expect(() => assertJsonValue({ toJSON: 'metadata' }, 'payload')).not.toThrow();
+    expect(() => assertJsonValue({ toJSON: null }, 'payload')).not.toThrow();
+  });
+
   test('isLosslessJsonString mirrors the string gate', () => {
     expect(isLosslessJsonString('plain text')).toBe(true);
     expect(isLosslessJsonString('a\u0000b')).toBe(false);

--- a/packages/@openmaic/storage/test/json-value.test.ts
+++ b/packages/@openmaic/storage/test/json-value.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { assertJsonValue } from '../src/runtime/json-value.js';
+import { runInNewContext } from 'node:vm';
+import { assertJsonValue, isLosslessJsonString } from '../src/runtime/json-value.js';
 
 describe('assertJsonValue string guards', () => {
   test('rejects an object key containing NUL', () => {
@@ -61,5 +62,23 @@ describe('assertJsonValue structural guards', () => {
 
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toMatch(/sparse array hole/i);
+  });
+});
+
+describe('cross-realm and shared-predicate behavior', () => {
+  test('accepts plain arrays and objects created in another realm', () => {
+    const foreign = runInNewContext('[1, { nested: true }]') as unknown;
+    expect(() => assertJsonValue(foreign, 'payload')).not.toThrow();
+  });
+
+  test('rejects an Array subclass created in another realm', () => {
+    const foreign = runInNewContext('new (class Sub extends Array {})()') as unknown;
+    expect(() => assertJsonValue(foreign, 'payload')).toThrow(/non-Array prototype/);
+  });
+
+  test('isLosslessJsonString mirrors the string gate', () => {
+    expect(isLosslessJsonString('plain text')).toBe(true);
+    expect(isLosslessJsonString('a\u0000b')).toBe(false);
+    expect(isLosslessJsonString('\uD800')).toBe(false);
   });
 });

--- a/packages/@openmaic/storage/test/json-value.test.ts
+++ b/packages/@openmaic/storage/test/json-value.test.ts
@@ -76,6 +76,14 @@ describe('cross-realm and shared-predicate behavior', () => {
     expect(() => assertJsonValue(foreign, 'payload')).toThrow(/non-Array prototype/);
   });
 
+  test('rejects values whose prototype smuggles a toJSON hook', () => {
+    const proto = Object.create(null) as { toJSON?: () => unknown };
+    proto.toJSON = () => 'different';
+    const crafted = Object.create(proto as object) as Record<string, unknown>;
+    crafted.real = 1;
+    expect(() => assertJsonValue(crafted, 'payload')).toThrow(/toJSON/);
+  });
+
   test('isLosslessJsonString mirrors the string gate', () => {
     expect(isLosslessJsonString('plain text')).toBe(true);
     expect(isLosslessJsonString('a\u0000b')).toBe(false);

--- a/packages/@openmaic/storage/test/json-value.test.ts
+++ b/packages/@openmaic/storage/test/json-value.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { assertJsonValue } from '../src/runtime/json-value.js';
+
+describe('assertJsonValue string guards', () => {
+  test('rejects an object key containing NUL', () => {
+    expect(() => assertJsonValue({ ['key\u0000suffix']: true }, 'value')).toThrow(
+      /object key.*NUL code point/i,
+    );
+  });
+
+  test('rejects a string value containing an unpaired UTF-16 surrogate', () => {
+    expect(() => assertJsonValue({ value: '\uD800' }, 'value')).toThrow(
+      /unpaired UTF-16 surrogate/i,
+    );
+  });
+
+  test('rejects a string key containing an unpaired UTF-16 surrogate', () => {
+    expect(() => assertJsonValue({ ['key\uD800']: true }, 'value')).toThrow(
+      /object key.*unpaired UTF-16 surrogate/i,
+    );
+  });
+
+  test('accepts a valid UTF-16 surrogate pair', () => {
+    expect(() => assertJsonValue({ value: '𐀀' }, 'value')).not.toThrow();
+  });
+});

--- a/packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { Pool } from 'pg';
+import {
+  PgRuntimeStore,
+  ensureSchema,
+  type Queryable,
+  type WithTransaction,
+} from '../src/runtime/pg.js';
+import { makeRecordInit, makeSession, runRuntimeStoreContract } from './runtime-contract.js';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+function transactionFor(pool: Pool, afterBegin?: () => Promise<void>): WithTransaction {
+  return async (body) => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await afterBegin?.();
+      const result = await body(client as Queryable);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the transaction body's original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+function makeBarrier(parties: number): () => Promise<void> {
+  let arrived = 0;
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return async () => {
+    arrived += 1;
+    if (arrived === parties) release();
+    await ready;
+  };
+}
+
+describe.skipIf(!contractUrl)('PgRuntimeStore with PostgreSQL 16', () => {
+  let pool: Pool;
+  let store: PgRuntimeStore;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl, max: 16 });
+    await ensureSchema(pool as Queryable);
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE runtime_records, runtime_sessions');
+    store = new PgRuntimeStore(pool as Queryable, { withTransaction: transactionFor(pool) });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  runRuntimeStoreContract('PostgreSQL 16 (node-postgres)', () => store);
+
+  test('genuinely concurrent appends assign distinct gapless sequences', async () => {
+    const concurrentTransactions = 8;
+    await store.createSession(makeSession({ kind: 'playback' }));
+    const allTransactionsStarted = makeBarrier(concurrentTransactions);
+    const concurrentStore = new PgRuntimeStore(pool as Queryable, {
+      withTransaction: transactionFor(pool, allTransactionsStarted),
+    });
+
+    const appended = await Promise.all(
+      Array.from({ length: concurrentTransactions }, (_, index) =>
+        concurrentStore.appendRecord(
+          makeRecordInit('sess-1', {
+            id: `pg-concurrent-${index}`,
+            payload: { index },
+          }),
+        ),
+      ),
+    );
+
+    const seqs = appended.map((record) => record.seq).sort((a, b) => a - b);
+    expect(seqs).toEqual(Array.from({ length: concurrentTransactions }, (_, index) => index));
+    expect(new Set(seqs).size).toBe(concurrentTransactions);
+  });
+});

--- a/packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts
@@ -95,4 +95,115 @@ describe.skipIf(!contractUrl)('PgRuntimeStore with PostgreSQL 16', () => {
     expect(seqs).toEqual(Array.from({ length: concurrentTransactions }, (_, index) => index));
     expect(new Set(seqs).size).toBe(concurrentTransactions);
   });
+
+  test('retries after a real unique violation from an independent writer', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+    const writer = await pool.connect();
+    let attempts = 0;
+    let collisionErrorCode: unknown;
+    const collisionStore = new PgRuntimeStore(pool as Queryable, {
+      withTransaction: async (body) => {
+        attempts += 1;
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN ISOLATION LEVEL REPEATABLE READ');
+          if (attempts === 1) {
+            // Establish the store transaction's snapshot before the external
+            // row commits, so MAX(seq) still chooses the colliding value.
+            await client.query('SELECT COUNT(*) FROM runtime_records');
+            await writer.query(
+              `INSERT INTO runtime_records
+                 (id, session_id, seq, scene_id, created_at, data)
+               VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+              [
+                'external-collision',
+                'sess-1',
+                0,
+                null,
+                '2026-01-01T00:01:00.000Z',
+                JSON.stringify({
+                  id: 'external-collision',
+                  sessionId: 'sess-1',
+                  seq: 0,
+                  createdAt: '2026-01-01T00:01:00.000Z',
+                  payload: { source: 'external' },
+                }),
+              ],
+            );
+          }
+          const result = await body(client as Queryable);
+          await client.query('COMMIT');
+          return result;
+        } catch (error) {
+          if (attempts === 1) collisionErrorCode = (error as { code?: unknown }).code;
+          await client.query('ROLLBACK');
+          throw error;
+        } finally {
+          client.release();
+        }
+      },
+    });
+
+    try {
+      const appended = await collisionStore.appendRecord(
+        makeRecordInit('sess-1', { id: 'store-after-collision', payload: { source: 'store' } }),
+      );
+
+      expect(attempts).toBe(2);
+      expect(collisionErrorCode).toBe('23505');
+      expect(appended.seq).toBe(1);
+      expect((await store.listRecords('sess-1')).map((record) => record.seq)).toEqual([0, 1]);
+    } finally {
+      writer.release();
+    }
+  });
+
+  test('a real aborted transaction does not poison the next store operation', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+    const baseTransaction = transactionFor(pool);
+    let injectFailure = true;
+    let initialErrorCode: unknown;
+    let abortedErrorCode: unknown;
+    const recoveryStore = new PgRuntimeStore(pool as Queryable, {
+      withTransaction: (body) =>
+        baseTransaction((queryable) =>
+          body({
+            async query<TRow extends Record<string, unknown> = Record<string, unknown>>(
+              text: string,
+              params?: unknown[],
+            ) {
+              if (injectFailure && text.includes('SELECT COALESCE(MAX(seq)')) {
+                injectFailure = false;
+                try {
+                  await queryable.query('SELECT 1 / 0');
+                } catch (error) {
+                  initialErrorCode = (error as { code?: unknown }).code;
+                  try {
+                    await queryable.query('SELECT 1');
+                  } catch (abortedError) {
+                    abortedErrorCode = (abortedError as { code?: unknown }).code;
+                  }
+                  throw error;
+                }
+              }
+              return queryable.query<TRow>(text, params);
+            },
+          }),
+        ),
+    });
+
+    await expect(
+      recoveryStore.appendRecord(
+        makeRecordInit('sess-1', { id: 'aborted-attempt', payload: { attempt: 1 } }),
+      ),
+    ).rejects.toMatchObject({ code: '22012' });
+    expect(initialErrorCode).toBe('22012');
+    expect(abortedErrorCode).toBe('25P02');
+
+    await expect(
+      recoveryStore.appendRecord(
+        makeRecordInit('sess-1', { id: 'after-abort', payload: { attempt: 2 } }),
+      ),
+    ).resolves.toMatchObject({ id: 'after-abort', seq: 0 });
+  });
 });

--- a/packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts
@@ -10,6 +10,13 @@ import { makeRecordInit, makeSession, runRuntimeStoreContract } from './runtime-
 
 const contractUrl = process.env.PG_CONTRACT_URL;
 
+if (process.env.STORAGE_PG_CONTRACT_REQUIRED === '1' && !contractUrl) {
+  throw new Error(
+    '@openmaic/storage: STORAGE_PG_CONTRACT_REQUIRED=1 requires PG_CONTRACT_URL; ' +
+      'refusing to skip the PostgreSQL contract suite',
+  );
+}
+
 function transactionFor(pool: Pool, afterBegin?: () => Promise<void>): WithTransaction {
   return async (body) => {
     const client = await pool.connect();

--- a/packages/@openmaic/storage/test/pg-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.test.ts
@@ -4,6 +4,7 @@ import {
   PgRuntimeStore,
   ensureSchema,
   type PgRuntimeStoreOptions,
+  type QueryResult,
   type Queryable,
 } from '../src/runtime/pg.js';
 import type { RuntimeStore } from '../src/runtime/types.js';
@@ -12,6 +13,19 @@ import { makeRecordInit, makeSession, runRuntimeStoreContract } from './runtime-
 function transactionOptions(db: PGlite): PgRuntimeStoreOptions {
   return {
     withTransaction: (body) => db.transaction((tx: Queryable) => body(tx)),
+  };
+}
+
+function makeBarrier(parties: number): () => Promise<void> {
+  let arrived = 0;
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return async () => {
+    arrived += 1;
+    if (arrived === parties) release();
+    await ready;
   };
 }
 
@@ -63,6 +77,115 @@ describe('PgRuntimeStore Postgres behavior', () => {
       'runtime_records',
       'runtime_sessions',
     ]);
+  });
+
+  test('requires a transaction hook at construction time', () => {
+    expect(() => new PgRuntimeStore(db, {} as PgRuntimeStoreOptions)).toThrow(
+      /withTransaction.*fresh.*connection.*transaction/i,
+    );
+  });
+
+  test.each([
+    ['Date', new Date('2026-01-01T00:00:00.000Z'), /plain JSON value.*Date/i],
+    ['Map', new Map([['key', 'value']]), /plain JSON value.*Map/i],
+    ['nested undefined', { nested: { missing: undefined } }, /undefined member.*dropped by JSON/i],
+    ['NaN', { value: Number.NaN }, /non-finite number NaN/i],
+    ['NUL string', { value: 'before\u0000after' }, /NUL code point/i],
+  ])(
+    'appendRecord rejects a %s payload with an actionable error',
+    async (_name, payload, error) => {
+      await store.createSession(makeSession({ kind: 'playback' }));
+
+      await expect(store.appendRecord(makeRecordInit('sess-1', { payload }))).rejects.toThrow(
+        error,
+      );
+    },
+  );
+
+  test('single-statement deletes do not invoke the transaction hook', async () => {
+    let transactionCalls = 0;
+    const directDeleteStore = new PgRuntimeStore(db, {
+      withTransaction: (body) => {
+        transactionCalls += 1;
+        return db.transaction((tx: Queryable) => body(tx));
+      },
+    });
+    await directDeleteStore.createSession(makeSession({ id: 'by-id' }));
+    await directDeleteStore.createSession(makeSession({ id: 'by-learner' }));
+    await directDeleteStore.createSession(makeSession({ id: 'by-stage', learnerKey: 'user:42' }));
+
+    await directDeleteStore.deleteSession('by-id');
+    await directDeleteStore.deleteLearnerRuntime('stage-1', 'anon:device-1');
+    await directDeleteStore.deleteStageRuntime('stage-1');
+
+    expect(transactionCalls).toBe(0);
+  });
+
+  test('deterministically retries two appends interleaved between MAX(seq) and INSERT', async () => {
+    const afterMax = makeBarrier(2);
+    const beforeInsert = makeBarrier(2);
+    let maxReads = 0;
+    let inserts = 0;
+    const instrumented: Queryable = {
+      async query<TRow extends Record<string, unknown> = Record<string, unknown>>(
+        text: string,
+        params?: unknown[],
+      ): Promise<QueryResult<TRow>> {
+        if (text.includes('SELECT COALESCE(MAX(seq)')) {
+          const result = (await db.query(text, params)) as QueryResult<TRow>;
+          maxReads += 1;
+          if (maxReads <= 2) await afterMax();
+          return result;
+        }
+        if (text.includes('INSERT INTO runtime_records')) {
+          inserts += 1;
+          if (inserts <= 2) await beforeInsert();
+        }
+        return (await db.query(text, params)) as QueryResult<TRow>;
+      },
+    };
+    const interleavedStore = new PgRuntimeStore(instrumented, {
+      withTransaction: (body) => body(instrumented),
+    });
+    await interleavedStore.createSession(makeSession({ kind: 'playback' }));
+
+    const appended = await Promise.all([
+      interleavedStore.appendRecord(
+        makeRecordInit('sess-1', { id: 'interleaved-a', payload: { caller: 'a' } }),
+      ),
+      interleavedStore.appendRecord(
+        makeRecordInit('sess-1', { id: 'interleaved-b', payload: { caller: 'b' } }),
+      ),
+    ]);
+
+    expect(appended.map((record) => record.seq).sort()).toEqual([0, 1]);
+    expect(inserts).toBe(3);
+  });
+
+  test.each(['40001', '40P01'])('retries append after PostgreSQL error %s', async (code) => {
+    let failed = false;
+    const retryableErrorStore = new PgRuntimeStore(db, {
+      withTransaction: (body) =>
+        db.transaction((tx: Queryable) =>
+          body({
+            async query<TRow extends Record<string, unknown> = Record<string, unknown>>(
+              text: string,
+              params?: unknown[],
+            ): Promise<QueryResult<TRow>> {
+              if (!failed && text.includes('INSERT INTO runtime_records')) {
+                failed = true;
+                throw Object.assign(new Error(`injected PostgreSQL error ${code}`), { code });
+              }
+              return tx.query<TRow>(text, params);
+            },
+          }),
+        ),
+    });
+    await retryableErrorStore.createSession(makeSession({ kind: 'playback' }));
+
+    await expect(
+      retryableErrorStore.appendRecord(makeRecordInit('sess-1', { payload: { code } })),
+    ).resolves.toMatchObject({ seq: 0 });
   });
 
   test('concurrent appends assign a gapless, duplicate-free per-session seq', async () => {

--- a/packages/@openmaic/storage/test/pg-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.test.ts
@@ -158,6 +158,63 @@ describe('PgRuntimeStore Postgres behavior', () => {
     await expect(rejection).rejects.not.toMatchObject({ code: '22P05' });
   });
 
+  test('appendRecord tolerates an explicit undefined optional anchor like an omitted anchor', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+
+    const explicit = await store.appendRecord(
+      makeRecordInit('sess-1', { id: 'explicit-undefined', sceneId: undefined }),
+    );
+    const omitted = await store.appendRecord(makeRecordInit('sess-1', { id: 'omitted-anchor' }));
+
+    expect(explicit).toMatchObject({ id: 'explicit-undefined', seq: 0 });
+    expect(omitted).toMatchObject({ id: 'omitted-anchor', seq: 1 });
+    const listed = await store.listRecords('sess-1');
+    expect(listed.map(({ id, seq }) => ({ id, seq }))).toEqual([
+      { id: 'explicit-undefined', seq: 0 },
+      { id: 'omitted-anchor', seq: 1 },
+    ]);
+    expect(listed[0]).not.toHaveProperty('sceneId');
+    expect(listed[1]).not.toHaveProperty('sceneId');
+  });
+
+  test.each([
+    ['NUL', 'bad\u0000key'],
+    ['lone surrogate', 'bad\uD800key'],
+  ])(
+    'treats %s query and delete keys as absent without leaking PostgreSQL errors',
+    async (_, key) => {
+      await store.createSession(makeSession({ kind: 'playback' }));
+      await store.appendRecord(makeRecordInit('sess-1'));
+
+      await expect(store.getSession(key)).resolves.toBeUndefined();
+      await expect(store.listSessions(key, 'anon:device-1')).resolves.toEqual([]);
+      await expect(store.listSessions('stage-1', key)).resolves.toEqual([]);
+      await expect(store.listRecords(key)).resolves.toEqual([]);
+      await expect(store.listRecords('sess-1', { sceneId: key })).resolves.toEqual([]);
+      await expect(store.deleteSession(key)).resolves.toBeUndefined();
+      await expect(store.deleteLearnerRuntime(key, 'anon:device-1')).resolves.toBeUndefined();
+      await expect(store.deleteLearnerRuntime('stage-1', key)).resolves.toBeUndefined();
+      await expect(store.deleteStageRuntime(key)).resolves.toBeUndefined();
+      await expect(store.mergeLearner(key, 'user:42')).resolves.toBe(0);
+
+      const statusRejection = store.setSessionStatus(key, 'completed', '2026-01-01T00:01:00.000Z');
+      await expect(statusRejection).rejects.toThrow(/no session/i);
+      await expect(statusRejection).rejects.not.toMatchObject({ code: '22021' });
+      await expect(statusRejection).rejects.not.toMatchObject({ code: '22P05' });
+
+      expect(await store.getSession('sess-1')).toBeDefined();
+      expect(await store.listRecords('sess-1')).toHaveLength(1);
+    },
+  );
+
+  test('mergeLearner rejects a non-JSON target key before PostgreSQL', async () => {
+    await store.createSession(makeSession());
+    const rejection = store.mergeLearner('anon:device-1', 'user:\uD800');
+
+    await expect(rejection).rejects.toThrow(/target learner key.*unpaired UTF-16 surrogate/i);
+    await expect(rejection).rejects.not.toMatchObject({ code: '22P05' });
+  });
+
   test('single-statement deletes do not invoke the transaction hook', async () => {
     let transactionCalls = 0;
     const directDeleteStore = new PgRuntimeStore(db, {

--- a/packages/@openmaic/storage/test/pg-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.test.ts
@@ -139,6 +139,25 @@ describe('PgRuntimeStore Postgres behavior', () => {
     await expect(rejection).rejects.not.toMatchObject({ code: '22P05' });
   });
 
+  test('createSession rejects an extraneous Date property before PostgreSQL', async () => {
+    const init = Object.assign(makeSession(), {
+      diagnosticTimestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await expect(store.createSession(init)).rejects.toThrow(/plain JSON value.*Date/i);
+    await expect(store.getSession(init.id)).resolves.toBeUndefined();
+  });
+
+  test('appendRecord rejects NUL in the record envelope before PostgreSQL', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+    const rejection = store.appendRecord(
+      makeRecordInit('sess-1', { sceneId: 'scene-before\u0000after' }),
+    );
+
+    await expect(rejection).rejects.toThrow(/runtime record.*sceneId.*NUL code point/i);
+    await expect(rejection).rejects.not.toMatchObject({ code: '22P05' });
+  });
+
   test('single-statement deletes do not invoke the transaction hook', async () => {
     let transactionCalls = 0;
     const directDeleteStore = new PgRuntimeStore(db, {

--- a/packages/@openmaic/storage/test/pg-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.test.ts
@@ -29,6 +29,12 @@ function makeBarrier(parties: number): () => Promise<void> {
   };
 }
 
+const symbolPropertyPayload = { visible: true, [Symbol('hidden')]: 'x' };
+const nonEnumerablePropertyPayload = Object.defineProperty({ visible: true }, 'hidden', {
+  value: 'x',
+  enumerable: false,
+});
+
 describe('PgRuntimeStore with PGlite', () => {
   let db: PGlite;
   let store: RuntimeStore;
@@ -90,7 +96,18 @@ describe('PgRuntimeStore Postgres behavior', () => {
     ['Map', new Map([['key', 'value']]), /plain JSON value.*Map/i],
     ['nested undefined', { nested: { missing: undefined } }, /undefined member.*dropped by JSON/i],
     ['NaN', { value: Number.NaN }, /non-finite number NaN/i],
-    ['NUL string', { value: 'before\u0000after' }, /NUL code point/i],
+    ['negative zero', { value: -0 }, /negative zero.*serializes it as 0/i],
+    ['symbol-keyed property', symbolPropertyPayload, /symbol-keyed own property.*dropped by JSON/i],
+    [
+      'non-enumerable property',
+      nonEnumerablePropertyPayload,
+      /non-enumerable own property.*dropped by JSON/i,
+    ],
+    [
+      'non-index array property',
+      Object.assign([1, 2], { meta: 'x' }),
+      /non-index own property.*dropped by JSON/i,
+    ],
   ])(
     'appendRecord rejects a %s payload with an actionable error',
     async (_name, payload, error) => {
@@ -101,6 +118,26 @@ describe('PgRuntimeStore Postgres behavior', () => {
       );
     },
   );
+
+  test('appendRecord accepts U+2028 and U+2029 in strings', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+
+    await expect(
+      store.appendRecord(
+        makeRecordInit('sess-1', { payload: { separators: 'line\u2028paragraph\u2029end' } }),
+      ),
+    ).resolves.toMatchObject({ payload: { separators: 'line\u2028paragraph\u2029end' } });
+  });
+
+  test('appendRecord rejects NUL with a human-readable error before PostgreSQL', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+    const rejection = store.appendRecord(
+      makeRecordInit('sess-1', { payload: { value: 'before\u0000after' } }),
+    );
+
+    await expect(rejection).rejects.toThrow(/NUL code point/i);
+    await expect(rejection).rejects.not.toMatchObject({ code: '22P05' });
+  });
 
   test('single-statement deletes do not invoke the transaction hook', async () => {
     let transactionCalls = 0;
@@ -260,5 +297,12 @@ describe('PgRuntimeStore Postgres behavior', () => {
 
     await expect(store.getSession(created.id)).rejects.toThrow();
     await expect(store.appendRecord(makeRecordInit(created.id))).rejects.toThrow();
+  });
+
+  test('getSession fails loud when a stored row contains JSON null', async () => {
+    const created = await store.createSession(makeSession());
+    await db.query(`UPDATE runtime_sessions SET data = 'null'::jsonb WHERE id = $1`, [created.id]);
+
+    await expect(store.getSession(created.id)).rejects.toThrow(/corrupt stored row.*"sess-1"/i);
   });
 });

--- a/packages/@openmaic/storage/test/pg-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import {
+  PgRuntimeStore,
+  ensureSchema,
+  type PgRuntimeStoreOptions,
+  type Queryable,
+} from '../src/runtime/pg.js';
+import type { RuntimeStore } from '../src/runtime/types.js';
+import { makeRecordInit, makeSession, runRuntimeStoreContract } from './runtime-contract.js';
+
+function transactionOptions(db: PGlite): PgRuntimeStoreOptions {
+  return {
+    withTransaction: (body) => db.transaction((tx: Queryable) => body(tx)),
+  };
+}
+
+describe('PgRuntimeStore with PGlite', () => {
+  let db: PGlite;
+  let store: RuntimeStore;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureSchema(db);
+    store = new PgRuntimeStore(db, transactionOptions(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  runRuntimeStoreContract('Postgres (PGlite)', () => store);
+});
+
+describe('PgRuntimeStore Postgres behavior', () => {
+  let db: PGlite;
+  let store: PgRuntimeStore;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureSchema(db);
+    store = new PgRuntimeStore(db, transactionOptions(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  test('ensureSchema is idempotent', async () => {
+    await expect(ensureSchema(db)).resolves.toBeUndefined();
+    await expect(ensureSchema(db)).resolves.toBeUndefined();
+
+    const tables = await db.query<{ table_name: string }>(
+      `SELECT table_name
+         FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN ('runtime_sessions', 'runtime_records')
+        ORDER BY table_name`,
+    );
+    expect(tables.rows.map((row: { table_name: string }) => row.table_name)).toEqual([
+      'runtime_records',
+      'runtime_sessions',
+    ]);
+  });
+
+  test('concurrent appends assign a gapless, duplicate-free per-session seq', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+
+    const appended = await Promise.all(
+      Array.from({ length: 32 }, (_, index) =>
+        store.appendRecord(
+          makeRecordInit('sess-1', {
+            id: `concurrent-${index}`,
+            payload: { index },
+          }),
+        ),
+      ),
+    );
+
+    const seqs = appended.map((record) => record.seq).sort((a, b) => a - b);
+    expect(seqs).toEqual(Array.from({ length: 32 }, (_, index) => index));
+    expect(new Set(seqs).size).toBe(32);
+    expect((await store.listRecords('sess-1')).map((record) => record.seq)).toEqual(seqs);
+  });
+
+  test('mergeLearner is repeatably idempotent and preserves target sessions and records', async () => {
+    await store.createSession(makeSession({ id: 'source', kind: 'playback' }));
+    await store.appendRecord(
+      makeRecordInit('source', { id: 'source-record', payload: { owner: 'source' } }),
+    );
+    await store.createSession(
+      makeSession({ id: 'target', learnerKey: 'user:42', kind: 'playback' }),
+    );
+    await store.appendRecord(
+      makeRecordInit('target', { id: 'target-record', payload: { owner: 'target' } }),
+    );
+
+    await expect(store.mergeLearner('anon:device-1', 'user:42')).resolves.toBe(1);
+    await expect(store.mergeLearner('anon:device-1', 'user:42')).resolves.toBe(0);
+    await expect(store.mergeLearner('anon:device-1', 'user:42')).resolves.toBe(0);
+
+    expect(
+      (await store.listSessions('stage-1', 'user:42')).map((session) => session.id).sort(),
+    ).toEqual(['source', 'target']);
+    expect((await store.listRecords('source')).map((record) => record.id)).toEqual([
+      'source-record',
+    ]);
+    expect((await store.listRecords('target')).map((record) => record.id)).toEqual([
+      'target-record',
+    ]);
+  });
+
+  test('writes fail loud for a future-stamped stored session', async () => {
+    const created = await store.createSession(makeSession());
+    await db.query('UPDATE runtime_sessions SET data = $2::jsonb WHERE id = $1', [
+      created.id,
+      JSON.stringify({ ...created, runtimeDslVersion: '99.0.0' }),
+    ]);
+
+    await expect(
+      store.setSessionStatus(created.id, 'completed', created.updatedAt),
+    ).rejects.toThrow(/newer than this client's/);
+    await expect(store.appendRecord(makeRecordInit(created.id))).rejects.toThrow(
+      /newer than this client's/,
+    );
+  });
+
+  test('a document-line envelope stored as a session fails loud', async () => {
+    const created = await store.createSession(makeSession());
+    const { runtimeDslVersion: _runtimeDslVersion, ...withoutRuntimeStamp } = created;
+    await db.query('UPDATE runtime_sessions SET data = $2::jsonb WHERE id = $1', [
+      created.id,
+      JSON.stringify({ ...withoutRuntimeStamp, dslVersion: '0.1.0' }),
+    ]);
+
+    await expect(store.getSession(created.id)).rejects.toThrow();
+    await expect(store.appendRecord(makeRecordInit(created.id))).rejects.toThrow();
+  });
+});

--- a/packages/@openmaic/storage/test/pg-runtime-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-runtime-store.test.ts
@@ -177,6 +177,13 @@ describe('PgRuntimeStore Postgres behavior', () => {
     expect(listed[1]).not.toHaveProperty('sceneId');
   });
 
+  test('rejects an unknown top-level record field that is explicitly undefined', async () => {
+    await store.createSession(makeSession({ kind: 'playback' }));
+    await expect(
+      store.appendRecord({ ...makeRecordInit('sess-1'), ext: undefined } as never),
+    ).rejects.toThrow(/undefined member/);
+  });
+
   test.each([
     ['NUL', 'bad\u0000key'],
     ['lone surrogate', 'bad\uD800key'],
@@ -201,6 +208,11 @@ describe('PgRuntimeStore Postgres behavior', () => {
       await expect(statusRejection).rejects.toThrow(/no session/i);
       await expect(statusRejection).rejects.not.toMatchObject({ code: '22021' });
       await expect(statusRejection).rejects.not.toMatchObject({ code: '22P05' });
+
+      const appendRejection = store.appendRecord(makeRecordInit(key));
+      await expect(appendRejection).rejects.toThrow(/no session/i);
+      await expect(appendRejection).rejects.not.toMatchObject({ code: '22021' });
+      await expect(appendRejection).rejects.not.toMatchObject({ code: '22P05' });
 
       expect(await store.getSession('sess-1')).toBeDefined();
       expect(await store.listRecords('sess-1')).toHaveLength(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 1.2.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@copilotkit/backend':
         specifier: ^0.37.0
-        version: 0.37.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(playwright@1.58.2)(ws@8.19.0)
+        version: 0.37.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(pg@8.22.0)(playwright@1.58.2)(ws@8.19.0)
       '@copilotkit/runtime':
         specifier: ^1.51.2
         version: 1.53.0(@ag-ui/encoder@0.0.47)(@cfworker/json-schema@4.1.1)(@copilotkitnext/shared@1.53.0)(@langchain/core@1.1.31(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@4.3.6)))(@langchain/langgraph-sdk@1.7.1(@langchain/core@1.1.31(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)
@@ -627,9 +627,15 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.3.14
         version: 0.3.16
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
       fake-indexeddb:
         specifier: ^6.0.0
         version: 6.2.5
+      pg:
+        specifier: ^8.16.3
+        version: 8.22.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -5633,6 +5639,9 @@ packages:
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -10764,6 +10773,40 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   phoenix@1.8.5:
     resolution: {integrity: sha512-Oj5nlRV/NKXkjBx8uMgCMmgMf1twd/B2qOcO30cHLH1PCGR8149o4T1lRIaqN4nq2KQJAeMqPiLdh1Asd0wQFg==}
 
@@ -10859,6 +10902,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   posthog-node@4.18.0:
     resolution: {integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==}
@@ -14678,14 +14737,14 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
-  '@copilotkit/backend@0.37.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(playwright@1.58.2)(ws@8.19.0)':
+  '@copilotkit/backend@0.37.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(pg@8.22.0)(playwright@1.58.2)(ws@8.19.0)':
     dependencies:
       '@copilotkit/shared': 0.37.0
       '@google/generative-ai': 0.11.5
       '@langchain/core': 0.1.63(openai@4.104.0(ws@8.19.0)(zod@4.3.6))
       '@langchain/openai': 0.0.28(ws@8.19.0)
       js-tiktoken: 1.0.21
-      langchain: 0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(playwright@1.58.2)(ws@8.19.0)
+      langchain: 0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(pg@8.22.0)(playwright@1.58.2)(ws@8.19.0)
       openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -15805,7 +15864,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)':
+  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(pg@8.22.0)(ws@8.19.0)':
     dependencies:
       '@langchain/core': 0.1.63(openai@4.104.0(ws@8.19.0)(zod@4.3.6))
       '@langchain/openai': 0.0.28(ws@8.19.0)
@@ -15822,6 +15881,7 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       jsdom: 29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3)
       lodash: 4.17.23
+      pg: 8.22.0
       ws: 8.19.0
     transitivePeerDependencies:
       - encoding
@@ -18493,6 +18553,12 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -23003,10 +23069,10 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  langchain@0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(playwright@1.58.2)(ws@8.19.0):
+  langchain@0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(axios@1.13.6)(fast-xml-parser@5.7.3)(ignore@5.3.2)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(pg@8.22.0)(playwright@1.58.2)(ws@8.19.0):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1
-      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)
+      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.1048.0)(@aws-sdk/credential-provider-node@3.972.57)(@smithy/util-utf8@2.3.0)(jsdom@29.1.1(@noble/hashes@1.8.0)(canvas@3.2.3))(lodash@4.17.23)(openai@4.104.0(ws@8.19.0)(zod@4.3.6))(pg@8.22.0)(ws@8.19.0)
       '@langchain/core': 0.1.63(openai@4.104.0(ws@8.19.0)(zod@4.3.6))
       '@langchain/openai': 0.0.28(ws@8.19.0)
       '@langchain/textsplitters': 0.0.3(openai@4.104.0(ws@8.19.0)(zod@4.3.6))
@@ -24638,6 +24704,41 @@ snapshots:
 
   performance-now@2.1.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   phoenix@1.8.5: {}
 
   picocolors@0.2.1: {}
@@ -24743,6 +24844,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   posthog-node@4.18.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
         specifier: workspace:*
         version: link:../dsl
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.3.14
+        version: 0.3.16
       fake-indexeddb:
         specifier: ^6.0.0
         version: 6.2.5
@@ -2038,6 +2041,9 @@ packages:
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@electric-sql/pglite@0.3.16':
+    resolution: {integrity: sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -14991,6 +14997,8 @@ snapshots:
   '@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
+
+  '@electric-sql/pglite@0.3.16': {}
 
   '@emnapi/core@1.8.1':
     dependencies:


### PR DESCRIPTION
Part C of #939, targeting the `runtime-server-backend` integration branch (final review happens when the branch merges to `main`).

## What

- **`PgRuntimeStore`** (`src/runtime/pg.ts`, new `./runtime/pg` subpath): implements `RuntimeStore` over a minimal injected `Queryable` — the same injection idiom as the browser backend's `IDBFactory`. node-postgres and PGlite both satisfy the surface, so the package adds **zero runtime dependencies**.
- **Schema**: `runtime_sessions` / `runtime_records`, exported as `RUNTIME_PG_SCHEMA` + idempotent `ensureSchema()`. `UNIQUE(session_id, seq)`, FK cascade, partition indexes.
- **`seq` atomicity**: appends take a session-row lock (`SELECT … FOR UPDATE`), compute `MAX(seq)+1` and insert in one transaction — rollback can't leave holes, different sessions still append concurrently. The unique constraint plus a bounded retry backstops non-cooperating SQL writers.
- **Envelope semantics mirror the browser backend**: `RUNTIME_DSL_VERSION` stamping, session/record validation gates, injected per-kind payload validators, migrate-on-read, fail-loud on future-stamped rows.

## Testing

- Full `runRuntimeStoreContract` green on PGlite, plus PG-specific cases: concurrent-append `seq` atomicity (interleaved `Promise.all` appends), `ensureSchema` idempotence, `mergeLearner` idempotence.
- Whole storage package suite: 130/130.
- `pnpm check` / `pnpm lint` / `tsc --noEmit` clean.

## Boundaries

- Additive only: no changes to `browser.ts` / `types.ts` / `runtime-contract.ts` (avoids conflicts with #926).
- `@electric-sql/pglite` enters devDependencies only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)