### PR TITLE
fix(storage): conform HTTP/PG backends to the post-#926 RuntimeStore interface

### DIFF
--- a/packages/@openmaic/storage/docs/runtime-http-contract.md
+++ b/packages/@openmaic/storage/docs/runtime-http-contract.md
@@ -16,6 +16,7 @@ This contract exposes the complete `RuntimeStore` interface over JSON HTTP. All 
 | `POST` | `/runtime/learners/merge` | Atomically re-key all sessions across all stages from `{ "fromLearnerKey", "toLearnerKey" }`. | `200` with `{ "moved": number }` |
 | `DELETE` | `/runtime/stages/{stageId}/learners/{learnerKey}` | Delete one learner's sessions and records on one stage. | `204` |
 | `DELETE` | `/runtime/stages/{stageId}` | Cascade-delete every learner's sessions and records on one stage. | `204` |
+| `DELETE` | `/runtime` | Delete every runtime session and record. Idempotent; an administrative operation — servers MUST gate it behind an operator-level authorization check, never expose it to learner credentials. | `204` |
 
 `GET /runtime/sessions/{sessionId}/records` returns an empty array when the session has no records or is absent, matching `RuntimeStore.listRecords`. Deleting an absent target succeeds.
 

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -312,4 +312,8 @@ export class HttpRuntimeStore implements RuntimeStore {
   async deleteStageRuntime(stageId: string): Promise<void> {
     await this.request<void>('DELETE', `/runtime/stages/${segment(stageId)}`);
   }
+
+  async deleteAllRuntime(): Promise<void> {
+    await this.request<void>('DELETE', '/runtime');
+  }
 }

--- a/packages/@openmaic/storage/src/runtime/pg.ts
+++ b/packages/@openmaic/storage/src/runtime/pg.ts
@@ -544,4 +544,9 @@ export class PgRuntimeStore implements RuntimeStore {
     if (!isPgQueryableKey(stageId)) return;
     await this.queryable.query('DELETE FROM runtime_sessions WHERE stage_id = $1', [stageId]);
   }
+
+  async deleteAllRuntime(): Promise<void> {
+    // Single statement; the FK cascade clears runtime_records with it.
+    await this.queryable.query('DELETE FROM runtime_sessions');
+  }
 }

--- a/packages/@openmaic/storage/test/http-conformance-server.ts
+++ b/packages/@openmaic/storage/test/http-conformance-server.ts
@@ -338,6 +338,12 @@ async function route(
     return;
   }
 
+  if (parts.length === 1 && method === 'DELETE') {
+    await store.deleteAllRuntime();
+    sendNoContent(res);
+    return;
+  }
+
   sendJson(res, 404, { error: { code: 'ROUTE_NOT_FOUND', message: 'route not found' } });
 }
 


### PR DESCRIPTION
The integration branch's back-merge of `main` brought in #926, which added `deleteAllRuntime()` to the `RuntimeStore` contract. The HTTP (#940) and Postgres (#941) backends were written against the pre-#926 interface, leaving the branch red on typecheck and two contract cases.

- `PgRuntimeStore.deleteAllRuntime()`: single-statement wipe; the FK cascade clears `runtime_records`.
- `HttpRuntimeStore.deleteAllRuntime()` + contract endpoint `DELETE /runtime`, documented as an administrative operation servers MUST gate behind operator-level authorization (the Part D reference server enforces this).
- Conformance server routes it; both previously failing contract cases now pass.

Full storage suite: 232 passed. `tsc --noEmit` green repo-wide again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)