### PR TITLE
fix(quiz): route chat by submission state

### DIFF
--- a/app/api/chat/pi/route.ts
+++ b/app/api/chat/pi/route.ts
@@ -104,6 +104,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const currentScene = body.storeState.scenes.find(
+      (scene) => scene.id === body.storeState.currentSceneId,
+    );
+    const hasQuizResults =
+      body.storeState.quizResults?.sceneId === body.storeState.currentSceneId &&
+      body.storeState.quizResults.results.length > 0;
+    log.info(
+      `Quiz state: sceneType=${currentScene?.content.type ?? 'none'}, uiPhase=${body.storeState.quizPhase ?? 'unknown'}, hasResults=${hasQuizResults}, quizMode=${currentScene?.content.type === 'quiz' && !hasQuizResults ? 'pre-submit' : 'review-or-non-quiz'}, phaseResultMismatch=${currentScene?.content.type === 'quiz' && body.storeState.quizPhase !== undefined && (body.storeState.quizPhase === 'reviewing') !== hasQuizResults}`,
+    );
+
     const signal = req.signal;
     const abortController = new AbortController();
     signal.addEventListener('abort', () => abortController.abort(), { once: true });

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -88,6 +88,15 @@ export async function POST(req: NextRequest) {
     log.info(
       `Agents: ${body.config.agentIds.join(', ')}, Messages: ${body.messages.length}, Turn: ${body.directorState?.turnCount ?? 0}`,
     );
+    const currentScene = body.storeState.scenes.find(
+      (scene) => scene.id === body.storeState.currentSceneId,
+    );
+    const hasQuizResults =
+      body.storeState.quizResults?.sceneId === body.storeState.currentSceneId &&
+      body.storeState.quizResults.results.length > 0;
+    log.info(
+      `Quiz state: sceneType=${currentScene?.content.type ?? 'none'}, uiPhase=${body.storeState.quizPhase ?? 'unknown'}, hasResults=${hasQuizResults}, quizMode=${currentScene?.content.type === 'quiz' && !hasQuizResults ? 'pre-submit' : 'review-or-non-quiz'}, phaseResultMismatch=${currentScene?.content.type === 'quiz' && body.storeState.quizPhase !== undefined && (body.storeState.quizPhase === 'reviewing') !== hasQuizResults}`,
+    );
 
     // Use the native request signal for abort propagation
     const signal = req.signal;

--- a/components/chat/use-chat-sessions.ts
+++ b/components/chat/use-chat-sessions.ts
@@ -30,6 +30,7 @@ import type { AgentStartItem, ActionItem } from '@/lib/buffer/stream-buffer';
 import { runAgentLoop, type AgentLoopStoreState } from '@/lib/chat/agent-loop';
 import { ActionEngine } from '@/lib/action/engine';
 import { readSubmittedState } from '@/lib/quiz/persistence';
+import { getQuizRuntimePhase } from '@/lib/quiz/runtime-phase';
 import { toast } from 'sonner';
 import { createLogger } from '@/lib/logger';
 import { isPiChatEnabled } from '@/lib/config/feature-flags';
@@ -1197,6 +1198,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: freshState.currentSceneId,
               mode: freshState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizPhase: getQuizRuntimePhase(freshState.currentSceneId),
               quizResults: buildQuizResultsForStoreState(
                 freshState.scenes,
                 freshState.currentSceneId,
@@ -1586,6 +1588,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizPhase: getQuizRuntimePhase(currentState.currentSceneId),
               quizResults: buildQuizResultsForStoreState(
                 currentState.scenes,
                 currentState.currentSceneId,
@@ -1806,6 +1809,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizPhase: getQuizRuntimePhase(currentState.currentSceneId),
               quizResults: buildQuizResultsForStoreState(
                 currentState.scenes,
                 currentState.currentSceneId,
@@ -1950,6 +1954,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               currentSceneId: currentState.currentSceneId,
               mode: currentState.mode,
               whiteboardOpen: useCanvasStore.getState().whiteboardOpen,
+              quizPhase: getQuizRuntimePhase(currentState.currentSceneId),
               quizResults: buildQuizResultsForStoreState(
                 currentState.scenes,
                 currentState.currentSceneId,

--- a/components/scene-renderers/quiz-view.tsx
+++ b/components/scene-renderers/quiz-view.tsx
@@ -32,10 +32,15 @@ import {
   writeSubmittedResults,
   type SubmittedState,
 } from '@/lib/quiz/persistence';
+import {
+  clearQuizRuntimePhase,
+  setQuizRuntimePhase,
+  type QuizRuntimePhase,
+} from '@/lib/quiz/runtime-phase';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-type Phase = 'not_started' | 'answering' | 'grading' | 'reviewing';
+type Phase = QuizRuntimePhase;
 
 interface QuizViewProps {
   readonly questions: QuizQuestion[];
@@ -703,6 +708,11 @@ export function QuizView({ questions, sceneId }: QuizViewProps) {
   const [results, setResults] = useState<QuestionResult[]>(() =>
     initialSubmitted?.kind === 'reviewing' ? initialSubmitted.results : [],
   );
+
+  useEffect(() => {
+    setQuizRuntimePhase(sceneId, phase);
+    return () => clearQuizRuntimePhase(sceneId);
+  }, [phase, sceneId]);
 
   // Draft cache for quiz answers, keyed by sceneId to isolate across classrooms
   const {

--- a/lib/chat/agent-loop.ts
+++ b/lib/chat/agent-loop.ts
@@ -26,6 +26,8 @@ export interface AgentLoopStoreState {
   currentSceneId: string | null;
   mode: string;
   whiteboardOpen: boolean;
+  /** Current QuizView phase from browser memory; diagnostic only for now. */
+  quizPhase?: import('@/lib/quiz/runtime-phase').QuizRuntimePhase;
   /**
    * Post-submit quiz state for the current scene. Hydrated from localStorage
    * client-side; absent when the active scene is not a graded quiz or the

--- a/lib/chat/pi/director-loop.ts
+++ b/lib/chat/pi/director-loop.ts
@@ -11,6 +11,7 @@ import type { SendEvent } from './types';
 import { buildCallAgentTool } from './tools/call-agent';
 import { buildCloseSessionTool } from './tools/close-session';
 import { buildCueUserTool } from './tools/cue-user';
+import { buildReadQuizStateTool } from './tools/read-quiz-state';
 
 export async function runPiDirectorLoop(opts: {
   body: StatelessChatRequest;
@@ -33,6 +34,11 @@ export async function runPiDirectorLoop(opts: {
   let teacherWrapUpUsed = false;
   let endReason: string | undefined;
   let directorToolCalls = 0;
+  let quizStateContext: string | null = null;
+  const currentScene = opts.body.storeState.scenes.find(
+    (scene) => scene.id === opts.body.storeState.currentSceneId,
+  );
+  const requiresQuizStateRead = currentScene?.content.type === 'quiz';
   const maxDirectorToolCalls = Math.max(opts.maxAgentTurns * 3, opts.maxAgentTurns + 3);
   const piAgentResponses: AgentTurnSummary[] = [];
   const piWhiteboardLedger: WhiteboardActionRecord[] = [];
@@ -111,6 +117,14 @@ export async function runPiDirectorLoop(opts: {
       },
       isUserCued: () => userCued,
       isSessionClosed: () => sessionClosed,
+      requiresQuizStateRead: () => requiresQuizStateRead,
+      getQuizStateContext: () => quizStateContext,
+    }),
+    buildReadQuizStateTool({
+      request: opts.body,
+      onRead: (context) => {
+        quizStateContext = context;
+      },
     }),
     buildCloseSessionTool({
       closeSession,

--- a/lib/chat/pi/prompts.ts
+++ b/lib/chat/pi/prompts.ts
@@ -71,6 +71,9 @@ export function buildDirectorPrompt(
     '7. Never let one child agent impersonate other classroom agents. If another perspective is needed, call that agent separately.',
     '8. When the useful classroom agent turns are complete, call exactly one terminal tool. Do not keep calling agents after the answer is sufficient.',
     '9. Keep every call_agent instruction brief. Do not ask one child agent for a full lecture, multiple examples, or multiple named-student interactions.',
+    currentScene?.content.type === 'quiz'
+      ? '10. On this Quiz scene, call `read_quiz_state` before the first `call_agent` decision. Treat its phase and policy as authoritative: PRE_SUBMIT permits only Socratic guidance; REVIEWING permits result-specific feedback.'
+      : '',
     '',
     `Session type: ${body.config.sessionType ?? 'qa'}`,
     `Current scene: ${currentScene?.title ?? currentScene?.id ?? 'none'}`,

--- a/lib/chat/pi/prompts.ts
+++ b/lib/chat/pi/prompts.ts
@@ -134,7 +134,9 @@ export function buildChildPrompt(
     '[{"type":"action","name":"spotlight","params":{"elementId":"text_1"}},{"type":"text","content":"看这里，这一步是后面机制成立的关键。"}]',
     '',
     '# Current State',
-    buildStateContext(body.storeState),
+    // Quiz details come from the mandatory read_quiz_state tool so the child
+    // receives one authoritative, phase-specific copy of that context.
+    buildStateContext(body.storeState, { includeQuizContext: false }),
     buildVirtualWhiteboardContext(body.storeState, whiteboardLedger),
     '',
     `Current scene: ${currentScene?.title ?? currentScene?.id ?? 'none'}`,

--- a/lib/chat/pi/tools/call-agent.ts
+++ b/lib/chat/pi/tools/call-agent.ts
@@ -56,6 +56,10 @@ type ActionWarning = {
   message: string;
 };
 
+export function appendQuizStateContext(instruction: string, context?: string | null): string {
+  return context ? `${instruction}\n\n${context}` : instruction;
+}
+
 const SHAPE_TYPES = new Set(['rectangle', 'circle', 'triangle']);
 const CHART_TYPES = new Set(['bar', 'column', 'line', 'pie', 'ring', 'area', 'radar', 'scatter']);
 const LINE_STYLES = new Set(['solid', 'dashed']);
@@ -519,6 +523,8 @@ export function buildCallAgentTool(opts: {
   onTeacherWrapUpDone?: () => void;
   isUserCued?: () => boolean;
   isSessionClosed?: () => boolean;
+  requiresQuizStateRead?: () => boolean;
+  getQuizStateContext?: () => string | null;
 }): AgentTool<typeof CallAgentParams> {
   // Loop-guard (model-agnostic): an empty/errored child turn used to bypass onAgentDone,
   // so getNormalTurnCount never advanced and the maxAgentTurns guard was defeated — a model
@@ -536,6 +542,18 @@ export function buildCallAgentTool(opts: {
     parameters: CallAgentParams,
     executionMode: 'sequential',
     execute: async (_toolCallId: string, params: CallAgentParams, signal?: AbortSignal) => {
+      if (opts.requiresQuizStateRead?.() && !opts.getQuizStateContext?.()) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Read the current Quiz state with read_quiz_state before calling a classroom agent.',
+            },
+          ],
+          details: { skipped: true, reason: 'quiz_state_not_read' },
+        };
+      }
+
       if (totalAgentAttempts >= maxAgentAttempts) {
         return {
           content: [
@@ -744,7 +762,11 @@ export function buildCallAgentTool(opts: {
 
       let childErrored = false;
       try {
-        await child.prompt(buildChildTurnPrompt(params.instruction, agent.role));
+        const instruction = appendQuizStateContext(
+          params.instruction,
+          opts.getQuizStateContext?.(),
+        );
+        await child.prompt(buildChildTurnPrompt(instruction, agent.role));
         await child.waitForIdle();
       } catch (error) {
         // Propagate genuine aborts; otherwise treat a failed child run as an empty turn

--- a/lib/chat/pi/tools/read-quiz-state.ts
+++ b/lib/chat/pi/tools/read-quiz-state.ts
@@ -63,15 +63,24 @@ function formatReviewContext(request: StatelessChatRequest, questions: QuizQuest
   ].join('\n');
 }
 
+function hasGradedResultsForCurrentQuiz(request: StatelessChatRequest): boolean {
+  const currentScene = request.storeState.scenes.find(
+    (scene) => scene.id === request.storeState.currentSceneId,
+  );
+  return (
+    currentScene?.content.type === 'quiz' &&
+    request.storeState.quizResults?.sceneId === currentScene.id &&
+    request.storeState.quizResults.results.length > 0
+  );
+}
+
 export function buildQuizStateContext(request: StatelessChatRequest): string | null {
   const currentScene = request.storeState.scenes.find(
     (scene) => scene.id === request.storeState.currentSceneId,
   );
   if (currentScene?.content.type !== 'quiz') return null;
 
-  const hasResults =
-    request.storeState.quizResults?.sceneId === currentScene.id &&
-    request.storeState.quizResults.results.length > 0;
+  const hasResults = hasGradedResultsForCurrentQuiz(request);
   return hasResults
     ? formatReviewContext(request, currentScene.content.questions)
     : formatPreSubmitContext(request, currentScene.content.questions);
@@ -98,10 +107,11 @@ export function buildReadQuizStateTool(opts: {
       }
 
       opts.onRead(context);
+      const hasResults = hasGradedResultsForCurrentQuiz(opts.request);
       return {
         content: [{ type: 'text', text: context }],
         details: {
-          mode: context.includes('Mode: REVIEWING') ? 'reviewing' : 'pre_submit',
+          mode: hasResults ? 'reviewing' : 'pre_submit',
           phase: opts.request.storeState.quizPhase ?? 'unknown',
         },
       };

--- a/lib/chat/pi/tools/read-quiz-state.ts
+++ b/lib/chat/pi/tools/read-quiz-state.ts
@@ -1,0 +1,110 @@
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { Type } from 'typebox';
+import type { QuizQuestion } from '@/lib/types/stage';
+import type { StatelessChatRequest } from '@/lib/types/chat';
+
+const ReadQuizStateParams = Type.Object({});
+
+function formatOptions(question: QuizQuestion): string {
+  return (question.options ?? []).map((option) => `${option.value}. ${option.label}`).join(' | ');
+}
+
+function formatPreSubmitContext(request: StatelessChatRequest, questions: QuizQuestion[]): string {
+  const phase = request.storeState.quizPhase ?? 'unknown';
+  const questionText = questions
+    .map((question, index) => {
+      const options = formatOptions(question);
+      return `${index + 1}. ${question.question}${options ? `\n   Options: ${options}` : ''}`;
+    })
+    .join('\n');
+
+  return [
+    '# Authoritative Quiz State',
+    `Mode: PRE_SUBMIT (${phase})`,
+    'The learner has no graded result for this attempt. The questions below are available; never claim they are missing.',
+    'Tutor policy: give only a question-specific Socratic reasoning step. Never name an option, reveal or paraphrase the correct answer, eliminate choices, or give a clue that uniquely identifies one choice.',
+    'If the learner says they know nothing, begin with one neutral observation task about the stem or source passage, then ask one short question.',
+    '',
+    'Questions (answer key intentionally withheld):',
+    questionText,
+  ].join('\n');
+}
+
+function formatReviewContext(request: StatelessChatRequest, questions: QuizQuestion[]): string {
+  const quizResults = request.storeState.quizResults;
+  if (!quizResults) return '';
+
+  const resultsById = new Map(quizResults.results.map((result) => [result.questionId, result]));
+  const questionText = questions
+    .map((question, index) => {
+      const result = resultsById.get(question.id);
+      const answer = quizResults.answers[question.id];
+      const learnerAnswer = Array.isArray(answer) ? answer.join(', ') : (answer ?? '(empty)');
+      const correctAnswer = question.answer?.join(', ') || '(open-ended)';
+      return [
+        `${index + 1}. ${question.question}`,
+        `   Learner answer: ${learnerAnswer}`,
+        `   Correct answer: ${correctAnswer}`,
+        `   Result: ${result?.status ?? 'ungraded'} (${result?.earned ?? 0}/${question.points ?? 1})`,
+        question.analysis ? `   Analysis: ${question.analysis}` : '',
+        result?.aiComment ? `   Grader comment: ${result.aiComment}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+    })
+    .join('\n');
+
+  return [
+    '# Authoritative Quiz State',
+    'Mode: REVIEWING',
+    'The learner has submitted and grading is complete. Give feedback tied to this attempt: focus on mistakes, explain why, and acknowledge correct answers briefly.',
+    '',
+    questionText,
+  ].join('\n');
+}
+
+export function buildQuizStateContext(request: StatelessChatRequest): string | null {
+  const currentScene = request.storeState.scenes.find(
+    (scene) => scene.id === request.storeState.currentSceneId,
+  );
+  if (currentScene?.content.type !== 'quiz') return null;
+
+  const hasResults =
+    request.storeState.quizResults?.sceneId === currentScene.id &&
+    request.storeState.quizResults.results.length > 0;
+  return hasResults
+    ? formatReviewContext(request, currentScene.content.questions)
+    : formatPreSubmitContext(request, currentScene.content.questions);
+}
+
+export function buildReadQuizStateTool(opts: {
+  request: StatelessChatRequest;
+  onRead: (context: string) => void;
+}): AgentTool<typeof ReadQuizStateParams> {
+  return {
+    name: 'read_quiz_state',
+    label: 'Read quiz state',
+    description:
+      'Read the authoritative current Quiz phase and the phase-appropriate teaching context. Required before call_agent on a Quiz scene.',
+    parameters: ReadQuizStateParams,
+    executionMode: 'sequential',
+    execute: async () => {
+      const context = buildQuizStateContext(opts.request);
+      if (!context) {
+        return {
+          content: [{ type: 'text', text: 'The current scene is not a Quiz.' }],
+          details: { mode: 'not_quiz' },
+        };
+      }
+
+      opts.onRead(context);
+      return {
+        content: [{ type: 'text', text: context }],
+        details: {
+          mode: context.includes('Mode: REVIEWING') ? 'reviewing' : 'pre_submit',
+          phase: opts.request.storeState.quizPhase ?? 'unknown',
+        },
+      };
+    },
+  };
+}

--- a/lib/orchestration/summarizers/state-context.ts
+++ b/lib/orchestration/summarizers/state-context.ts
@@ -133,7 +133,10 @@ export function summarizeElements(
 /**
  * Build context string from store state
  */
-export function buildStateContext(storeState: StatelessChatRequest['storeState']): string {
+export function buildStateContext(
+  storeState: StatelessChatRequest['storeState'],
+  options: { includeQuizContext?: boolean } = {},
+): string {
   const { stage, scenes, currentSceneId, mode, whiteboardOpen, quizResults } = storeState;
 
   const lines: string[] = [];
@@ -173,7 +176,7 @@ export function buildStateContext(storeState: StatelessChatRequest['storeState']
       // student has finished. Hydration of `quizResults` happens client-side in
       // use-chat-sessions; absent here means the student has not submitted (or
       // the active scene is not the quiz that owns the results).
-      if (currentScene.content.type === 'quiz') {
+      if (currentScene.content.type === 'quiz' && options.includeQuizContext !== false) {
         const questions = currentScene.content.questions;
         const hasGradedResults =
           !!quizResults && quizResults.sceneId === currentSceneId && quizResults.results.length > 0;

--- a/lib/quiz/runtime-phase.ts
+++ b/lib/quiz/runtime-phase.ts
@@ -1,0 +1,15 @@
+export type QuizRuntimePhase = 'not_started' | 'answering' | 'grading' | 'reviewing';
+
+const phases = new Map<string, QuizRuntimePhase>();
+
+export function setQuizRuntimePhase(sceneId: string, phase: QuizRuntimePhase): void {
+  phases.set(sceneId, phase);
+}
+
+export function clearQuizRuntimePhase(sceneId: string): void {
+  phases.delete(sceneId);
+}
+
+export function getQuizRuntimePhase(sceneId: string | null): QuizRuntimePhase | undefined {
+  return sceneId ? phases.get(sceneId) : undefined;
+}

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -214,7 +214,7 @@ export interface SendMessageRequest {
     currentSceneId: string | null;
     mode: 'autonomous' | 'playback';
     whiteboardOpen: boolean;
-    /** Current QuizView phase from browser memory; diagnostic only for now. */
+    /** Browser-reported QuizView phase shown to the model for context; graded results authorize review. */
     quizPhase?: import('@/lib/quiz/runtime-phase').QuizRuntimePhase;
   };
 }
@@ -318,7 +318,7 @@ export interface StatelessChatRequest {
     currentSceneId: string | null;
     mode: StageMode;
     whiteboardOpen: boolean;
-    /** Current QuizView phase from browser memory; diagnostic only for now. */
+    /** Browser-reported QuizView phase shown to the model for context; graded results authorize review. */
     quizPhase?: import('@/lib/quiz/runtime-phase').QuizRuntimePhase;
     /**
      * Post-submit quiz state for the CURRENT scene, hydrated by the client

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -214,6 +214,8 @@ export interface SendMessageRequest {
     currentSceneId: string | null;
     mode: 'autonomous' | 'playback';
     whiteboardOpen: boolean;
+    /** Current QuizView phase from browser memory; diagnostic only for now. */
+    quizPhase?: import('@/lib/quiz/runtime-phase').QuizRuntimePhase;
   };
 }
 
@@ -316,6 +318,8 @@ export interface StatelessChatRequest {
     currentSceneId: string | null;
     mode: StageMode;
     whiteboardOpen: boolean;
+    /** Current QuizView phase from browser memory; diagnostic only for now. */
+    quizPhase?: import('@/lib/quiz/runtime-phase').QuizRuntimePhase;
     /**
      * Post-submit quiz state for the CURRENT scene, hydrated by the client
      * from localStorage when the active scene is a graded quiz. Lets the

--- a/tests/lib/chat/pi/cue-user.test.ts
+++ b/tests/lib/chat/pi/cue-user.test.ts
@@ -204,6 +204,45 @@ describe('Pi chat cue_user tool', () => {
     expect(result.details).toEqual({ skipped: true, reason: 'user_already_cued' });
   });
 
+  it('requires read_quiz_state before call_agent on a Quiz scene', async () => {
+    const tool = buildCallAgentTool({
+      body: {
+        messages: [],
+        storeState: {
+          stage: null,
+          scenes: [],
+          currentSceneId: 'quiz-1',
+          mode: 'playback',
+          whiteboardOpen: false,
+        },
+        config: { agentIds: ['default-1'] },
+        apiKey: '',
+      } as never,
+      agentConfigs: [],
+      send: async () => {},
+      languageModel: {} as never,
+      onAgentDone: () => {},
+      onActionDone: () => {},
+      thinkingConfig: { mode: 'disabled', enabled: false },
+      abortSignal: new AbortController().signal,
+      maxAgentTurns: 6,
+      getAgentTurnCount: () => 0,
+      getAgentResponses: () => [],
+      getWhiteboardLedger: () => [],
+      maxActionsPerAgent: 1,
+      enableWhiteboardTools: false,
+      requiresQuizStateRead: () => true,
+      getQuizStateContext: () => null,
+    });
+
+    const result = await tool.execute('call-quiz', {
+      agentId: 'default-1',
+      instruction: 'Answer the Quiz question.',
+    });
+
+    expect(result.details).toEqual({ skipped: true, reason: 'quiz_state_not_read' });
+  });
+
   it('skips call_agent after the session is closed', async () => {
     const tool = buildCallAgentTool({
       body: {

--- a/tests/lib/chat/pi/prompts.test.ts
+++ b/tests/lib/chat/pi/prompts.test.ts
@@ -112,6 +112,34 @@ describe('Pi director prompt closure routing', () => {
   });
 });
 
+describe('Pi director Quiz routing', () => {
+  it('requires reading authoritative Quiz state before dispatching an agent', () => {
+    const body = makeBody({
+      storeState: {
+        stage: { id: 'stage-1', name: 'Quiz', createdAt: 1, updatedAt: 1 },
+        scenes: [
+          {
+            id: 'quiz-1',
+            stageId: 'stage-1',
+            type: 'quiz',
+            title: 'Quiz',
+            order: 0,
+            content: { type: 'quiz', questions: [] },
+          },
+        ],
+        currentSceneId: 'quiz-1',
+        mode: 'playback',
+        whiteboardOpen: false,
+      },
+    });
+
+    const prompt = buildDirectorPrompt(body, agents, 4);
+    expect(prompt).toContain('call `read_quiz_state` before');
+    expect(prompt).toContain('PRE_SUBMIT permits only Socratic guidance');
+    expect(prompt).toContain('REVIEWING permits result-specific feedback');
+  });
+});
+
 describe('Pi child prompt structured output', () => {
   it('requires JSON array output and lists available actions without tool-call wording', () => {
     const prompt = buildChildPrompt(makeBody(), agents[0], [], [], ['spotlight', 'wb_open']);

--- a/tests/lib/chat/pi/prompts.test.ts
+++ b/tests/lib/chat/pi/prompts.test.ts
@@ -141,6 +141,48 @@ describe('Pi director Quiz routing', () => {
 });
 
 describe('Pi child prompt structured output', () => {
+  it('leaves Quiz details to the mandatory read_quiz_state context', () => {
+    const body = makeBody({
+      storeState: {
+        stage: { id: 'stage-1', name: 'Quiz', createdAt: 1, updatedAt: 1 },
+        scenes: [
+          {
+            id: 'quiz-1',
+            stageId: 'stage-1',
+            type: 'quiz',
+            title: 'Quiz',
+            order: 0,
+            content: {
+              type: 'quiz',
+              questions: [
+                {
+                  id: 'q1',
+                  type: 'single',
+                  question: 'Which option is correct?',
+                  options: [
+                    { value: 'A', label: 'First' },
+                    { value: 'B', label: 'Second' },
+                  ],
+                  answer: ['B'],
+                  points: 1,
+                },
+              ],
+            },
+          },
+        ],
+        currentSceneId: 'quiz-1',
+        mode: 'playback',
+        whiteboardOpen: false,
+      },
+    });
+
+    const prompt = buildChildPrompt(body, agents[0], [], [], []);
+
+    expect(prompt).toContain('Current scene: "Quiz"');
+    expect(prompt).not.toContain('Which option is correct?');
+    expect(prompt).not.toContain('Strict rules while the quiz is unsubmitted');
+  });
+
   it('requires JSON array output and lists available actions without tool-call wording', () => {
     const prompt = buildChildPrompt(makeBody(), agents[0], [], [], ['spotlight', 'wb_open']);
 

--- a/tests/lib/chat/pi/read-quiz-state.test.ts
+++ b/tests/lib/chat/pi/read-quiz-state.test.ts
@@ -97,6 +97,17 @@ describe('read_quiz_state', () => {
     expect(result.details).toEqual({ mode: 'pre_submit', phase: 'answering' });
   });
 
+  it('reports reviewing mode from graded results rather than rendered context text', async () => {
+    const tool = buildReadQuizStateTool({
+      request: request(true),
+      onRead: () => undefined,
+    });
+
+    const result = await tool.execute('read-1', {});
+
+    expect(result.details).toEqual({ mode: 'reviewing', phase: 'reviewing' });
+  });
+
   it('appends the authoritative tool result to the child-agent instruction', () => {
     const context = buildQuizStateContext(request());
     const instruction = appendQuizStateContext('Help the learner with question 1.', context);

--- a/tests/lib/chat/pi/read-quiz-state.test.ts
+++ b/tests/lib/chat/pi/read-quiz-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import type { StatelessChatRequest } from '@/lib/types/chat';
+import { buildQuizStateContext, buildReadQuizStateTool } from '@/lib/chat/pi/tools/read-quiz-state';
+import { appendQuizStateContext } from '@/lib/chat/pi/tools/call-agent';
+
+function request(reviewing = false): StatelessChatRequest {
+  return {
+    messages: [],
+    storeState: {
+      stage: { id: 'stage-1', name: 'Stage', createdAt: 1, updatedAt: 1 },
+      scenes: [
+        {
+          id: 'quiz-1',
+          stageId: 'stage-1',
+          type: 'quiz',
+          title: 'Quiz',
+          order: 0,
+          content: {
+            type: 'quiz',
+            questions: [
+              {
+                id: 'q1',
+                type: 'single',
+                question: 'What does cope with mean?',
+                options: [
+                  { value: 'A', label: 'Ignore' },
+                  { value: 'B', label: 'Deal with' },
+                ],
+                answer: ['B'],
+                analysis: 'It means handling a difficult situation.',
+                points: 1,
+              },
+            ],
+          },
+          actions: [],
+        },
+      ],
+      currentSceneId: 'quiz-1',
+      mode: 'playback',
+      whiteboardOpen: false,
+      quizPhase: reviewing ? 'reviewing' : 'answering',
+      ...(reviewing
+        ? {
+            quizResults: {
+              sceneId: 'quiz-1',
+              answers: { q1: 'A' },
+              results: [
+                {
+                  questionId: 'q1',
+                  correct: false,
+                  status: 'incorrect' as const,
+                  earned: 0,
+                },
+              ],
+            },
+          }
+        : {}),
+    },
+    config: { agentIds: ['default-1'] },
+    apiKey: '',
+  } as StatelessChatRequest;
+}
+
+describe('read_quiz_state', () => {
+  it('withholds answers and analysis before submission', () => {
+    const context = buildQuizStateContext(request());
+
+    expect(context).toContain('Mode: PRE_SUBMIT');
+    expect(context).toContain('What does cope with mean?');
+    expect(context).toContain('A. Ignore | B. Deal with');
+    expect(context).not.toContain('Correct answer');
+    expect(context).not.toContain('handling a difficult situation');
+  });
+
+  it('returns attempt-specific results after submission', () => {
+    const context = buildQuizStateContext(request(true));
+
+    expect(context).toContain('Mode: REVIEWING');
+    expect(context).toContain('Learner answer: A');
+    expect(context).toContain('Correct answer: B');
+    expect(context).toContain('Result: incorrect (0/1)');
+    expect(context).toContain('Analysis: It means handling a difficult situation.');
+  });
+
+  it('records the authoritative context when the tool runs', async () => {
+    let saved = '';
+    const tool = buildReadQuizStateTool({
+      request: request(),
+      onRead: (context) => {
+        saved = context;
+      },
+    });
+
+    const result = await tool.execute('read-1', {});
+
+    expect(saved).toContain('Mode: PRE_SUBMIT');
+    expect(result.details).toEqual({ mode: 'pre_submit', phase: 'answering' });
+  });
+
+  it('appends the authoritative tool result to the child-agent instruction', () => {
+    const context = buildQuizStateContext(request());
+    const instruction = appendQuizStateContext('Help the learner with question 1.', context);
+
+    expect(instruction).toContain('Help the learner with question 1.');
+    expect(instruction).toContain('# Authoritative Quiz State');
+    expect(instruction).toContain('Mode: PRE_SUBMIT');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #950. Follow-up to #823.

- **Quiz chat now reads an authoritative runtime state.** `QuizView` publishes its current phase, while the existing submitted answers and grading results continue to be hydrated into `storeState` for each chat request.
- **Pi must read Quiz state before dispatching an agent.** A new `read_quiz_state` tool exposes phase-appropriate context, and `call_agent` is blocked until that state has been read.
- **Teaching behavior follows the current phase.** Before submission, the tool withholds the answer key and analysis and permits only question-specific Socratic guidance. On the result page, it provides the learner's answer, correctness, score, analysis, and grader comment for targeted review. Retrying returns the next request to the pre-submit policy.

Non-Quiz chat routing and the existing classroom session lifecycle are intentionally unchanged.

### Files

| File | What changed |
|------|--------------|
| `components/scene-renderers/quiz-view.tsx` + `lib/quiz/runtime-phase.ts` | Publish the active Quiz phase for chat requests. |
| `components/chat/use-chat-sessions.ts` + `lib/types/chat.ts` + `lib/chat/agent-loop.ts` | Carry the current Quiz phase alongside the existing submitted result context. |
| `lib/chat/pi/tools/read-quiz-state.ts` | Build phase-appropriate Quiz context: answer-free before submission, result-aware after submission. |
| `lib/chat/pi/director-loop.ts` + `lib/chat/pi/tools/call-agent.ts` + `lib/chat/pi/prompts.ts` | Require Quiz state reads and attach the authoritative context to the selected classroom agent. |
| `app/api/chat/{route,pi/route}.ts` | Add non-sensitive phase/result diagnostics. |

## Test plan

- [x] Before submission, repeatedly ask for the correct option; the agent stays within Socratic guidance and does not reveal the answer.
- [x] After submission, ask for the answer and review; the agent uses the learner's result to explain the correct answer.
- [x] Retry the Quiz after submission; chat returns to the pre-submit no-leak behavior.
- [x] Run focused Pi/Quiz tests: 8 files, 98 tests passed.
- [x] Run `pnpm exec tsc --noEmit`.
- [x] Run ESLint on the changed runtime and test files.

Tested locally and confirmed that the implementation meets all acceptance criteria.
### Screenshots：
<img width="1328" height="992" alt="截屏2026-07-21 19 44 15" src="https://github.com/user-attachments/assets/19934069-b6d4-4a8b-b906-0c11e88f2a87" />
<img width="1323" height="989" alt="截屏2026-07-21 19 43 53" src="https://github.com/user-attachments/assets/f01e753d-8e1a-4d5a-83f2-1f2542bfa98c" />
