### PR TITLE
feat(document): widened-stage contracts + app document seam (PR1)

### DIFF
--- a/lib/document/canonicalize.ts
+++ b/lib/document/canonicalize.ts
@@ -1,0 +1,29 @@
+import type { StageOutlinesRecord, StageRecord } from '@/lib/utils/database';
+import type { AppScene } from '@/lib/types/stage';
+
+import type { AppDocumentOutline, AppStage } from './persistence-types';
+
+/** Separate device playback position from canonical document metadata. */
+export function canonicalizeLegacyStage<T extends StageRecord>(
+  record: T,
+): { stage: AppStage & Omit<T, 'currentSceneId'>; currentSceneId: T['currentSceneId'] } {
+  const { currentSceneId, ...stage } = record;
+  return { stage, currentSceneId };
+}
+
+/** Normalize legacy scene aliases without interpreting app-owned payloads. */
+export function canonicalizeLegacyScene(record: object): AppScene {
+  const source = record as Record<string, unknown>;
+  const { whiteboard, ...canonical } = source;
+  if (!Object.prototype.hasOwnProperty.call(canonical, 'whiteboards') && whiteboard !== undefined) {
+    canonical.whiteboards = whiteboard;
+  }
+  const content = canonical.content as { type: AppScene['type'] };
+  return { ...canonical, type: content.type } as AppScene;
+}
+
+/** Remove the legacy table key from the opaque document-outline envelope. */
+export function canonicalizeLegacyOutline(record: StageOutlinesRecord): AppDocumentOutline {
+  const { stageId: _stageId, ...outline } = record;
+  return outline;
+}

--- a/lib/document/index.ts
+++ b/lib/document/index.ts
@@ -49,3 +49,11 @@ export type {
   MediaTranscriptSegment,
 } from './types';
 export type { DocumentBundleResult, ParsedDocumentImage, ParsedDocumentPart } from './bundle';
+export type { AppDocument, AppDocumentOutline, AppStage } from './persistence-types';
+export {
+  canonicalizeLegacyOutline,
+  canonicalizeLegacyScene,
+  canonicalizeLegacyStage,
+} from './canonicalize';
+export { getDocumentStore, type DocumentStoreDeps } from './store';
+export { validateAppScene, validateAppStage } from './validators';

--- a/lib/document/persistence-types.ts
+++ b/lib/document/persistence-types.ts
@@ -1,0 +1,19 @@
+import type { MaicDocument } from '@openmaic/storage';
+import type { Stage } from '@openmaic/dsl';
+
+import type { SceneOutline } from '@/lib/types/generation';
+import type { AppScene } from '@/lib/types/stage';
+
+/** App-owned stage shape. Device playback position is not document metadata. */
+export type AppStage = Stage;
+
+/** Generation intent stored opaquely with the document aggregate. */
+export interface AppDocumentOutline {
+  outlines: SceneOutline[];
+  generationComplete?: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Canonical app document persisted through the document-store seam. */
+export type AppDocument = MaicDocument<AppScene, AppStage>;

--- a/lib/document/store.ts
+++ b/lib/document/store.ts
@@ -1,0 +1,40 @@
+import { BrowserDocumentStore, type DocumentStore } from '@openmaic/storage';
+
+import type { AppScene } from '@/lib/types/stage';
+
+import type { AppStage } from './persistence-types';
+import { validateAppScene, validateAppStage } from './validators';
+
+const DOCUMENT_DB_NAME = 'maic-documents';
+
+export interface DocumentStoreDeps {
+  /** A complete store override takes precedence over browser construction. */
+  store?: DocumentStore<AppScene, AppStage>;
+  /** IndexedDB factory for isolated browser tests. */
+  indexedDB?: IDBFactory;
+  /** Database name override for isolated browser tests. */
+  dbName?: string;
+}
+
+let defaultStore: DocumentStore<AppScene, AppStage> | undefined;
+
+function createBrowserStore(
+  deps: Omit<DocumentStoreDeps, 'store'>,
+): DocumentStore<AppScene, AppStage> {
+  if (typeof window === 'undefined' && !deps.indexedDB) {
+    throw new Error('Document persistence is client-only');
+  }
+  return new BrowserDocumentStore<AppScene, AppStage>({
+    indexedDB: deps.indexedDB,
+    dbName: deps.dbName ?? DOCUMENT_DB_NAME,
+    validateScene: validateAppScene,
+    validateStage: validateAppStage,
+  });
+}
+
+/** Resolve the app document store without opening IndexedDB at module import. */
+export function getDocumentStore(deps: DocumentStoreDeps = {}): DocumentStore<AppScene, AppStage> {
+  if (deps.store) return deps.store;
+  if (deps.indexedDB || deps.dbName) return createBrowserStore(deps);
+  return (defaultStore ??= createBrowserStore({}));
+}

--- a/lib/document/validators.ts
+++ b/lib/document/validators.ts
@@ -1,0 +1,71 @@
+import { validateScene, validateStage, type ValidationIssue } from '@openmaic/dsl';
+import type { SceneValidator, StageValidator } from '@openmaic/storage';
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function requiredString(
+  value: Record<string, unknown>,
+  key: string,
+  errors: ValidationIssue[],
+): void {
+  if (typeof value[key] !== 'string' || value[key] === '') {
+    errors.push({ path: `/${key}`, message: `expected non-empty string \`${key}\`` });
+  }
+}
+
+/** Validate the app's four-way scene union at the document write boundary. */
+export const validateAppScene: SceneValidator = (scene) => {
+  const value = objectValue(scene);
+  if (!value) {
+    return { valid: false, errors: [{ path: '/', message: 'scene must be an object' }] };
+  }
+  if (value.type === 'slide' || value.type === 'quiz') return validateScene(scene);
+
+  const errors: ValidationIssue[] = [];
+  requiredString(value, 'id', errors);
+  requiredString(value, 'stageId', errors);
+  requiredString(value, 'title', errors);
+  if (typeof value.order !== 'number' || !Number.isFinite(value.order)) {
+    errors.push({ path: '/order', message: 'expected finite number `order`' });
+  }
+
+  const content = objectValue(value.content);
+  if (value.type !== 'interactive' && value.type !== 'pbl') {
+    errors.push({
+      path: '/type',
+      message: `unknown app scene type: ${JSON.stringify(value.type)}`,
+    });
+  } else if (!content) {
+    errors.push({ path: '/content', message: 'scene `content` must be an object' });
+  } else if (content.type !== value.type) {
+    errors.push({
+      path: '/content/type',
+      message: `content type ${JSON.stringify(content.type)} does not match scene type ${JSON.stringify(value.type)}`,
+    });
+  } else if (value.type === 'interactive' && typeof content.url !== 'string') {
+    errors.push({ path: '/content/url', message: 'interactive content requires string `url`' });
+  } else if (value.type === 'pbl' && !objectValue(content.projectConfig)) {
+    errors.push({
+      path: '/content/projectConfig',
+      message: 'pbl content requires object `projectConfig`',
+    });
+  }
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+};
+
+/** Validate canonical app stage metadata and exclude device playback position. */
+export const validateAppStage: StageValidator = (stage) => {
+  const base = validateStage(stage);
+  const value = objectValue(stage);
+  if (!value || !Object.prototype.hasOwnProperty.call(value, 'currentSceneId')) return base;
+  const issue = {
+    path: '/currentSceneId',
+    message: '`currentSceneId` is device playback state and is not allowed on AppStage',
+  };
+  return base.valid
+    ? { valid: false, errors: [issue] }
+    : { valid: false, errors: [...base.errors, issue] };
+};

--- a/packages/@openmaic/storage/src/document/adapter.ts
+++ b/packages/@openmaic/storage/src/document/adapter.ts
@@ -12,7 +12,7 @@ import type { Stage } from '@openmaic/dsl';
 import type { MaicDocument, SceneLike } from './types.js';
 
 /** The stage (root) row: stage metadata plus the document's version stamp. */
-export type StageRow = Stage & { [DSL_VERSION_KEY]: string };
+export type StageRow<TStage extends Stage = Stage> = TStage & { [DSL_VERSION_KEY]: string };
 
 /** The outline row: one opaque snapshot per stage, stored only when present. */
 export interface OutlineRow {
@@ -21,8 +21,8 @@ export interface OutlineRow {
 }
 
 /** The normalized rows a document splits into. */
-export interface DocumentRows<TScene extends SceneLike> {
-  stageRow: StageRow;
+export interface DocumentRows<TScene extends SceneLike, TStage extends Stage = Stage> {
+  stageRow: StageRow<TStage>;
   sceneRows: TScene[];
   /** Present only when the document carries an outline. */
   outlineRow?: OutlineRow;
@@ -34,11 +34,11 @@ export interface DocumentRows<TScene extends SceneLike> {
  * emitted only when the document actually carries an outline — a document with
  * no outline produces no outline row (and the backend removes any stale one).
  */
-export function splitDocument<TScene extends SceneLike>(
-  doc: MaicDocument<TScene>,
-): DocumentRows<TScene> {
-  const stageRow: StageRow = { ...doc.stage, [DSL_VERSION_KEY]: DSL_VERSION };
-  const rows: DocumentRows<TScene> = { stageRow, sceneRows: doc.scenes };
+export function splitDocument<TScene extends SceneLike, TStage extends Stage = Stage>(
+  doc: MaicDocument<TScene, TStage>,
+): DocumentRows<TScene, TStage> {
+  const stageRow: StageRow<TStage> = { ...doc.stage, [DSL_VERSION_KEY]: DSL_VERSION };
+  const rows: DocumentRows<TScene, TStage> = { stageRow, sceneRows: doc.scenes };
   if (doc.outline !== undefined) {
     rows.outlineRow = { stageId: doc.stage.id, outline: doc.outline };
   }
@@ -52,14 +52,17 @@ export function splitDocument<TScene extends SceneLike>(
  * reads it), and the outline is attached only when a row exists. This is the
  * pre-migration document; the backend runs `migrate()` on the result.
  */
-export function reassembleDocument<TScene extends SceneLike>(
-  stageRow: StageRow,
+export function reassembleDocument<TScene extends SceneLike, TStage extends Stage = Stage>(
+  stageRow: StageRow<TStage>,
   sceneRows: TScene[],
   outlineRow?: OutlineRow,
-): MaicDocument<TScene> {
-  const { [DSL_VERSION_KEY]: dslVersion, ...stage } = stageRow;
+): MaicDocument<TScene, TStage> {
+  const { [DSL_VERSION_KEY]: dslVersion, ...stageFields } = stageRow;
+  // StageRow adds exactly the version stamp; removing it restores TStage. TS
+  // cannot prove that inverse for an arbitrary generic intersection.
+  const stage = stageFields as unknown as TStage;
   const scenes = [...sceneRows].sort((a, b) => a.order - b.order);
-  const doc: MaicDocument<TScene> = { stage, scenes, dslVersion };
+  const doc: MaicDocument<TScene, TStage> = { stage, scenes, dslVersion };
   if (outlineRow) doc.outline = outlineRow.outline;
   return doc;
 }

--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -10,19 +10,21 @@
  */
 import {
   DSL_VERSION,
+  DSL_VERSION_KEY,
   dslVersionOf,
   migrate,
   needsMigration,
   validateScene,
   validateStage,
 } from '@openmaic/dsl';
-import type { Scene } from '@openmaic/dsl';
+import type { Scene, Stage } from '@openmaic/dsl';
 import type {
   DocumentStore,
   DocumentSummary,
   MaicDocument,
   SceneLike,
   SceneValidator,
+  StageValidator,
 } from './types.js';
 import { reassembleDocument, splitDocument, type OutlineRow, type StageRow } from './adapter.js';
 
@@ -43,6 +45,8 @@ export interface BrowserDocumentStoreOptions {
    * accepts its own kinds, so the gate stays fail-loud for them.
    */
   validateScene?: SceneValidator;
+  /** Stage validator run at the write boundary. Defaults to the DSL `validateStage`. */
+  validateStage?: StageValidator;
 }
 
 /** Promisify a single IndexedDB request. */
@@ -122,26 +126,29 @@ function isFutureVersioned(versioned: unknown): boolean {
  * untouched. This is the deliberate asymmetry with `outline`, which the DSL owns
  * no contract for at all.
  */
-function migrateDocument<TScene extends SceneLike>(
-  doc: MaicDocument<TScene>,
-): MaicDocument<TScene> {
+function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
+  doc: MaicDocument<TScene, TStage>,
+): MaicDocument<TScene, TStage> {
   const { outline, ...core } = doc;
-  const migrated = migrate(core) as MaicDocument<TScene>;
+  const migrated = migrate(core) as MaicDocument<TScene, TStage>;
   return outline === undefined ? migrated : { ...migrated, outline };
 }
 
 export class BrowserDocumentStore<
   TScene extends SceneLike = Scene,
-> implements DocumentStore<TScene> {
+  TStage extends Stage = Stage,
+> implements DocumentStore<TScene, TStage> {
   private readonly idb: IDBFactory;
   private readonly dbName: string;
   private readonly validateScene: SceneValidator;
+  private readonly validateStage: StageValidator;
   private dbPromise?: Promise<IDBDatabase>;
 
   constructor(options: BrowserDocumentStoreOptions = {}) {
     this.idb = options.indexedDB ?? globalThis.indexedDB;
     this.dbName = options.dbName ?? 'maic-documents';
     this.validateScene = options.validateScene ?? validateScene;
+    this.validateStage = options.validateStage ?? validateStage;
   }
 
   private openDb(): Promise<IDBDatabase> {
@@ -207,7 +214,7 @@ export class BrowserDocumentStore<
     });
   }
 
-  async saveDocument(doc: MaicDocument<TScene>): Promise<void> {
+  async saveDocument(doc: MaicDocument<TScene, TStage>): Promise<void> {
     // Forward-compatibility: refuse to persist (and thereby downgrade) a document
     // written by a newer client. `loadDocument` returns such documents untouched;
     // saving one back would relabel its newer-shaped rows as this older version.
@@ -227,7 +234,7 @@ export class BrowserDocumentStore<
 
     // Validate the (normalized) aggregate BEFORE opening a transaction, so an
     // invalid stage or scene fails loud without any partial write.
-    assertValid(validateStage(normalized.stage), `stage ${normalized.stage.id}`);
+    assertValid(this.validateStage(normalized.stage), `stage ${normalized.stage.id}`);
     const stageId = normalized.stage.id;
     const seen = new Set<string>();
     for (const scene of normalized.scenes) {
@@ -256,7 +263,7 @@ export class BrowserDocumentStore<
       // refuse to overwrite a document written by a newer client — the incoming
       // document may itself be current/unversioned, so the incoming-version
       // guard above does not catch a blind overwrite of newer stored data.
-      const existingStage = await reqP<StageRow | undefined>(stages.get(stageId));
+      const existingStage = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (existingStage && isFutureVersioned(existingStage)) {
         throw new Error(
           `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
@@ -292,9 +299,11 @@ export class BrowserDocumentStore<
     });
   }
 
-  async loadDocument(stageId: string): Promise<MaicDocument<TScene> | null> {
+  async loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null> {
     const rows = await this.txRun([STAGES, SCENES, OUTLINES], 'readonly', async (tx) => {
-      const stageRow = await reqP<StageRow | undefined>(tx.objectStore(STAGES).get(stageId));
+      const stageRow = await reqP<StageRow<TStage> | undefined>(
+        tx.objectStore(STAGES).get(stageId),
+      );
       if (!stageRow) return null;
       const sceneRows = await reqP<TScene[]>(
         tx.objectStore(SCENES).index(SCENES_BY_STAGE).getAll(stageId),
@@ -316,7 +325,7 @@ export class BrowserDocumentStore<
     // `dslVersion` stamp is not read — one bad row must not break the whole list
     // (it still fails loud when the document itself is loaded).
     return this.txRun([STAGES, SCENES], 'readonly', async (tx) => {
-      const stageRows = await reqP<StageRow[]>(tx.objectStore(STAGES).getAll());
+      const stageRows = await reqP<StageRow<TStage>[]>(tx.objectStore(STAGES).getAll());
       const index = tx.objectStore(SCENES).index(SCENES_BY_STAGE);
       const summaries: DocumentSummary[] = [];
       for (const stage of stageRows) {
@@ -347,12 +356,39 @@ export class BrowserDocumentStore<
     });
   }
 
+  async putStage(stageId: string, stage: TStage): Promise<void> {
+    assertValid(this.validateStage(stage), `stage ${stage.id}`);
+    if (stage.id !== stageId) {
+      throw new Error(
+        `@openmaic/storage: stage ${JSON.stringify(stage.id)} does not belong to document ` +
+          JSON.stringify(stageId),
+      );
+    }
+    await this.txRun([STAGES], 'readwrite', async (tx) => {
+      const stages = tx.objectStore(STAGES);
+      const stageRow = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
+      if (!stageRow) {
+        throw new Error(
+          `@openmaic/storage: cannot putStage into missing document ${JSON.stringify(stageId)}`,
+        );
+      }
+      if (dslVersionOf(stageRow) !== DSL_VERSION) {
+        throw new Error(
+          `@openmaic/storage: cannot putStage into document ${JSON.stringify(stageId)} at DSL ` +
+            `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
+            `to ${DSL_VERSION} first`,
+        );
+      }
+      stages.put({ ...stage, [DSL_VERSION_KEY]: DSL_VERSION });
+    });
+  }
+
   async putScene(stageId: string, scene: TScene): Promise<void> {
     assertValid(this.validateScene(scene), `scene ${scene.id}`);
     assertStorableScene(scene, stageId);
     await this.txRun([STAGES, SCENES], 'readwrite', async (tx) => {
       const stages = tx.objectStore(STAGES);
-      const stageRow = await reqP<StageRow | undefined>(stages.get(stageId));
+      const stageRow = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (!stageRow) {
         throw new Error(
           `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
@@ -376,7 +412,7 @@ export class BrowserDocumentStore<
 
   async getScene(stageId: string, sceneId: string): Promise<TScene | null> {
     const stageRow = await this.txRun([STAGES], 'readonly', (tx) =>
-      reqP<StageRow | undefined>(tx.objectStore(STAGES).get(stageId)),
+      reqP<StageRow<TStage> | undefined>(tx.objectStore(STAGES).get(stageId)),
     );
     if (!stageRow) return null;
 
@@ -396,7 +432,9 @@ export class BrowserDocumentStore<
 
   async deleteScene(stageId: string, sceneId: string): Promise<void> {
     await this.txRun([STAGES, SCENES], 'readwrite', async (tx) => {
-      const stageRow = await reqP<StageRow | undefined>(tx.objectStore(STAGES).get(stageId));
+      const stageRow = await reqP<StageRow<TStage> | undefined>(
+        tx.objectStore(STAGES).get(stageId),
+      );
       // Idempotent: nothing to delete if the document is already gone.
       if (!stageRow) return;
       // Deleting a scene is an incremental mutation, so it takes the same guard

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -36,6 +36,11 @@ export type SceneValidator = (
   scene: unknown,
 ) => { valid: true } | { valid: false; errors: { path: string; message: string }[] };
 
+/** Validate a stage at the write boundary. Defaults to the DSL `validateStage`. */
+export type StageValidator = (
+  stage: unknown,
+) => { valid: true } | { valid: false; errors: { path: string; message: string }[] };
+
 /**
  * The portable, embedded form of a persisted course. Storage normalizes it into
  * per-entity rows on write and reassembles it on read.
@@ -53,8 +58,8 @@ export type SceneValidator = (
  * `dslVersion` is the migrate() envelope stamp ({@link DSL_VERSION_KEY}); absent
  * on legacy data written before the version field existed.
  */
-export interface MaicDocument<TScene extends SceneLike = Scene> {
-  stage: Stage;
+export interface MaicDocument<TScene extends SceneLike = Scene, TStage extends Stage = Stage> {
+  stage: TStage;
   scenes: TScene[];
   outline?: unknown;
   dslVersion?: string;
@@ -78,7 +83,7 @@ export interface DocumentSummary {
  * migrate-on-reads. The `*Scene` methods are incremental conveniences over the
  * normalized rows for scene-level editing.
  */
-export interface DocumentStore<TScene extends SceneLike = Scene> {
+export interface DocumentStore<TScene extends SceneLike = Scene, TStage extends Stage = Stage> {
   /**
    * Validate the aggregate, stamp it at the current DSL version, split it into
    * rows, write every scene, and delete scenes no longer present. Atomic: an
@@ -86,13 +91,13 @@ export interface DocumentStore<TScene extends SceneLike = Scene> {
    * opaque scene content is not attempted; cheap per-scene writes use
    * {@link putScene}.)
    */
-  saveDocument(doc: MaicDocument<TScene>): Promise<void>;
+  saveDocument(doc: MaicDocument<TScene, TStage>): Promise<void>;
 
   /**
    * Reassemble the document for `stageId` (scenes sorted by `order`, outline
    * attached), migrated forward to the current DSL version. `null` if absent.
    */
-  loadDocument(stageId: string): Promise<MaicDocument<TScene> | null>;
+  loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null>;
 
   /**
    * A summary per stored document. Returns only version-independent fields
@@ -109,6 +114,16 @@ export interface DocumentStore<TScene extends SceneLike = Scene> {
    * coarse action and is intentionally not version-guarded.
    */
   deleteDocument(stageId: string): Promise<void>;
+
+  /**
+   * Validate and upsert the stage row of an existing, already-current document
+   * without touching its scenes or outline. The stored document must be at the
+   * current DSL version for the same reason as {@link putScene}: a stale row
+   * must be normalized by a full load + save, and a newer row must not be
+   * downgraded. Throws if the document is absent, not current, or `stage.id`
+   * does not match `stageId`.
+   */
+  putStage(stageId: string, stage: TStage): Promise<void>;
 
   /**
    * Validate and upsert a single scene into an existing, already-current

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -30,6 +30,7 @@ export type {
   DocumentSummary,
   SceneLike,
   SceneValidator,
+  StageValidator,
 } from './document/types.js';
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
 

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { IDBFactory } from 'fake-indexeddb';
-import { DSL_VERSION, DSL_VERSION_KEY, validateScene } from '@openmaic/dsl';
+import { DSL_VERSION, DSL_VERSION_KEY, validateScene, validateStage } from '@openmaic/dsl';
 import { BrowserDocumentStore, type MaicDocument } from '../src/index.js';
 import { runDocumentStoreContract, makeDocument, slideScene } from './document-contract.js';
 
@@ -110,6 +110,25 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     await reStampStage(idb, dbName, 'stage-1', '99.0.0');
     await expect(store.putScene('stage-1', slideScene('stage-1', 'new2', 3))).rejects.toThrow();
     expect(await store.getScene('stage-1', 'new2')).toBeNull();
+  });
+
+  test('putStage rejects when the stored document is not current', async () => {
+    const idb = new IDBFactory();
+    const dbName = 'maic-documents-putstage-noncurrent';
+    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
+    const doc = makeDocument();
+    await store.saveDocument(doc);
+
+    await reStampStage(idb, dbName, 'stage-1', undefined);
+    await expect(store.putStage('stage-1', { ...doc.stage, name: 'Stale Rename' })).rejects.toThrow(
+      /cannot putStage/,
+    );
+
+    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
+    await expect(
+      store.putStage('stage-1', { ...doc.stage, name: 'Future Rename' }),
+    ).rejects.toThrow(/cannot putStage/);
+    expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
   });
 
   test('refuses to overwrite a stored document written by a newer client', async () => {
@@ -409,5 +428,54 @@ describe('BrowserDocumentStore with an app-widened scene union', () => {
 
     const got = await store.getScene('stage-1', 'p1');
     expect(Object.keys(got!.content.cfg)).toEqual(['b', 'a']);
+  });
+});
+
+describe('BrowserDocumentStore with an app-widened stage', () => {
+  interface AppStage {
+    id: string;
+    name: string;
+    createdAt: number;
+    updatedAt: number;
+    appMetadata: { owner: string };
+  }
+
+  test('preserves extension fields and exposes them to the injected validator', async () => {
+    const seen: unknown[] = [];
+    const store = new BrowserDocumentStore<ReturnType<typeof slideScene>, AppStage>({
+      indexedDB: new IDBFactory(),
+      validateStage: (stage) => {
+        seen.push(stage);
+        const base = validateStage(stage);
+        if (!base.valid) return base;
+        const candidate = stage as Partial<AppStage>;
+        return typeof candidate.appMetadata?.owner === 'string'
+          ? { valid: true }
+          : {
+              valid: false,
+              errors: [{ path: '/appMetadata/owner', message: 'expected string owner' }],
+            };
+      },
+    });
+    const stage: AppStage = {
+      id: 'stage-wide',
+      name: 'Wide',
+      createdAt: 1,
+      updatedAt: 2,
+      appMetadata: { owner: 'app' },
+    };
+    await store.saveDocument({
+      stage,
+      scenes: [slideScene('stage-wide', 'scene-1', 0)],
+    });
+
+    const loaded = await store.loadDocument('stage-wide');
+    expect(loaded!.stage).toEqual(stage);
+    expect(seen).toContainEqual(stage);
+
+    const renamed = { ...stage, name: 'Renamed', appMetadata: { owner: 'editor' } };
+    await store.putStage('stage-wide', renamed);
+    expect((await store.loadDocument('stage-wide'))!.stage).toEqual(renamed);
+    expect(seen).toContainEqual(renamed);
   });
 });

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -122,6 +122,31 @@ export function runDocumentStoreContract(name: string, makeStore: () => Document
       await expect(store.deleteDocument('stage-1')).resolves.toBeUndefined();
     });
 
+    test('putStage updates only the stage row of an existing document', async () => {
+      const store = makeStore();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+
+      await store.putStage('stage-1', { ...doc.stage, name: 'Renamed', updatedAt: 3000 });
+
+      const loaded = await store.loadDocument('stage-1');
+      expect(loaded!.stage).toMatchObject({ name: 'Renamed', updatedAt: 3000 });
+      expect(loaded!.scenes).toEqual(doc.scenes);
+      expect(loaded!.outline).toEqual(doc.outline);
+    });
+
+    test('putStage rejects when the document is absent', async () => {
+      const store = makeStore();
+      await expect(
+        store.putStage('ghost-stage', {
+          id: 'ghost-stage',
+          name: 'Missing',
+          createdAt: 1,
+          updatedAt: 2,
+        }),
+      ).rejects.toThrow(/missing document/);
+    });
+
     // --- validation gate ---
 
     test('rejects a document whose stage is missing required fields', async () => {

--- a/tests/document/persistence.test.ts
+++ b/tests/document/persistence.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+
+import {
+  canonicalizeLegacyOutline,
+  canonicalizeLegacyScene,
+  canonicalizeLegacyStage,
+} from '@/lib/document/canonicalize';
+import { getDocumentStore } from '@/lib/document/store';
+import type { AppDocument } from '@/lib/document/persistence-types';
+import { validateAppScene, validateAppStage } from '@/lib/document/validators';
+import type { SceneOutline } from '@/lib/types/generation';
+import type { AppScene } from '@/lib/types/stage';
+import type { SceneRecord, StageOutlinesRecord, StageRecord } from '@/lib/utils/database';
+
+const stageRecord: StageRecord = {
+  id: 'stage-1',
+  name: 'Complete stage',
+  description: 'Every legacy field',
+  createdAt: 100,
+  updatedAt: 200,
+  languageDirective: 'Use English',
+  style: 'academic',
+  currentSceneId: 'scene-1',
+  agentIds: ['teacher'],
+  videoManifest: { media: { type: 'video', prompt: 'A demo', aspectRatio: '16:9' } },
+  interactiveMode: true,
+  taskEngineMode: true,
+  generatedAgentConfigs: [
+    {
+      id: 'teacher',
+      name: 'Teacher',
+      role: 'teacher',
+      persona: 'Clear',
+      avatar: 'avatar.png',
+      color: '#fff',
+      priority: 1,
+    },
+  ],
+};
+
+function slideScene(overrides: Record<string, unknown> = {}): AppScene {
+  return {
+    id: 'slide-1',
+    stageId: 'stage-1',
+    title: 'Slide',
+    order: 0,
+    type: 'slide',
+    content: { type: 'slide', canvas: { id: 'canvas-1', elements: [] } },
+    ...overrides,
+  } as unknown as AppScene;
+}
+
+function quizScene(): AppScene {
+  return {
+    id: 'quiz-1',
+    stageId: 'stage-1',
+    title: 'Quiz',
+    order: 1,
+    type: 'quiz',
+    content: { type: 'quiz', questions: [] },
+  } as AppScene;
+}
+
+function interactiveScene(): AppScene {
+  return {
+    id: 'interactive-1',
+    stageId: 'stage-1',
+    title: 'Interactive',
+    order: 2,
+    type: 'interactive',
+    content: { type: 'interactive', url: 'https://example.test/widget' },
+  } as AppScene;
+}
+
+function pblScene(): AppScene {
+  return {
+    id: 'pbl-1',
+    stageId: 'stage-1',
+    title: 'PBL',
+    order: 3,
+    type: 'pbl',
+    content: {
+      type: 'pbl',
+      projectConfig: {
+        projectInfo: { title: 'Project', description: 'Build it' },
+        agents: [],
+        issueboard: { agent_ids: [], issues: [], current_issue_id: null },
+        chat: { messages: [] },
+      },
+    },
+  } as AppScene;
+}
+
+describe('app document persistence seam', () => {
+  test('round-trips every StageRecord field after separating playback position', async () => {
+    const canonical = canonicalizeLegacyStage(stageRecord);
+    const document: AppDocument = {
+      stage: canonical.stage,
+      scenes: [slideScene()],
+    };
+    const store = getDocumentStore({
+      indexedDB: new IDBFactory(),
+      dbName: 'app-document-stage-roundtrip',
+    });
+
+    await store.saveDocument(document);
+    const loaded = await store.loadDocument(stageRecord.id);
+
+    expect(loaded!.stage).toEqual(canonical.stage);
+    expect({ ...loaded!.stage, currentSceneId: canonical.currentSceneId }).toEqual(stageRecord);
+  });
+
+  test('round-trips the outline envelope including generationComplete', async () => {
+    const outline: SceneOutline = {
+      id: 'outline-1',
+      type: 'slide',
+      title: 'Outline',
+      description: 'Intent',
+      keyPoints: ['Point'],
+      order: 0,
+    };
+    const legacy: StageOutlinesRecord = {
+      stageId: 'stage-1',
+      outlines: [outline],
+      generationComplete: true,
+      createdAt: 10,
+      updatedAt: 20,
+    };
+    const canonical = canonicalizeLegacyOutline(legacy);
+    const store = getDocumentStore({
+      indexedDB: new IDBFactory(),
+      dbName: 'app-document-outline-roundtrip',
+    });
+    await store.saveDocument({
+      stage: canonicalizeLegacyStage(stageRecord).stage,
+      scenes: [slideScene()],
+      outline: canonical,
+    });
+
+    expect((await store.loadDocument('stage-1'))!.outline).toEqual(canonical);
+  });
+});
+
+describe('app document validators', () => {
+  test.each([
+    ['slide', slideScene()],
+    ['quiz', quizScene()],
+    ['interactive', interactiveScene()],
+    ['pbl', pblScene()],
+  ])('accepts a valid %s scene', (_kind, scene) => {
+    expect(validateAppScene(scene)).toEqual({ valid: true });
+  });
+
+  test('rejects content/type mismatches with a clear path', () => {
+    const result = validateAppScene({
+      ...interactiveScene(),
+      content: { type: 'pbl', projectConfig: {} },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid)
+      expect(result.errors).toContainEqual(expect.objectContaining({ path: '/content/type' }));
+  });
+
+  test('rejects stages carrying currentSceneId with a clear path', () => {
+    const result = validateAppStage(stageRecord);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toContainEqual(expect.objectContaining({ path: '/currentSceneId' }));
+    }
+  });
+});
+
+describe('legacy scene canonicalization', () => {
+  test('rebinds type, renames whiteboard, and preserves app and unknown fields', () => {
+    const legacy = {
+      id: 'scene-1',
+      stageId: 'stage-1',
+      type: 'quiz',
+      title: 'Legacy',
+      order: 0,
+      content: { type: 'slide', canvas: { id: 'canvas', elements: [] } },
+      actions: [],
+      whiteboard: [{ id: 'whiteboard-1', elements: [] }],
+      multiAgent: { enabled: true, agentIds: ['teacher'] },
+      outlineId: 'outline-1',
+      createdAt: 1,
+      updatedAt: 2,
+      appExtension: { retained: true },
+    } as unknown as SceneRecord & Record<string, unknown>;
+
+    const canonical = canonicalizeLegacyScene(legacy);
+
+    expect(canonical.type).toBe('slide');
+    expect(canonical.whiteboards).toEqual(legacy.whiteboard);
+    expect(canonical.outlineId).toBe('outline-1');
+    expect(canonical).toMatchObject({
+      multiAgent: legacy.multiAgent,
+      createdAt: 1,
+      updatedAt: 2,
+      appExtension: { retained: true },
+    });
+    expect(canonical).not.toHaveProperty('whiteboard');
+  });
+
+  test('keeps canonical whiteboards when both aliases are present', () => {
+    const canonicalWhiteboards = [{ id: 'canonical', elements: [] }];
+    const scene = canonicalizeLegacyScene({
+      ...slideScene(),
+      whiteboard: [{ id: 'legacy', elements: [] }],
+      whiteboards: canonicalWhiteboards,
+    });
+    expect(scene.whiteboards).toEqual(canonicalWhiteboards);
+  });
+});


### PR DESCRIPTION
PR1 of the document-cutover line (see the recon design): shape contracts only, no consumer switch.

- `@openmaic/storage`: `TStage` generic through MaicDocument/DocumentStore/StageRow/adapter/browser; injectable `validateStage`; version-guarded `putStage` (closes the rename read-modify-write race)
- `lib/document/`: AppDocument seam — four-kind scene validator, stage validator that rejects device-state `currentSceneId`, pure legacy canonicalizers (type rebinding, whiteboard→whiteboards, outline envelope)
- 308 package tests + 70 app document tests green; tsc/eslint/prettier clean

Implemented by Codex, cross-reviewed by Claude. Next: PR2 (locked resumable migration + stage-storage cutover + outline fold + currentSceneId→KV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)