### PR TITLE
feat(document): secondary consumers + maintenance paths (PR3)

### DIFF
--- a/e2e/tests/interactive-iframe-keepalive-619.spec.ts
+++ b/e2e/tests/interactive-iframe-keepalive-619.spec.ts
@@ -48,10 +48,17 @@ async function seedDatabase(page: import('@playwright/test').Page) {
   await page.evaluate(
     ({ stageId, interactiveId, html, theme }) => {
       return new Promise<void>((resolve, reject) => {
-        const request = indexedDB.open('MAIC-Database');
+        const request = indexedDB.open('maic-documents', 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          db.createObjectStore('stages', { keyPath: 'id' });
+          const scenes = db.createObjectStore('scenes', { keyPath: ['stageId', 'id'] });
+          scenes.createIndex('by-stage', 'stageId');
+          db.createObjectStore('outlines', { keyPath: 'stageId' });
+        };
         request.onsuccess = (event) => {
           const db = (event.target as IDBOpenDBRequest).result;
-          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+          const tx = db.transaction(['stages', 'scenes', 'outlines'], 'readwrite');
           const now = Date.now();
 
           tx.objectStore('stages').put({
@@ -60,9 +67,9 @@ async function seedDatabase(page: import('@playwright/test').Page) {
             description: '',
             language: 'en-US',
             style: 'professional',
-            currentSceneId: interactiveId,
             createdAt: now,
             updatedAt: now,
+            dslVersion: '0.1.0',
           });
 
           tx.objectStore('scenes').put({
@@ -105,12 +112,15 @@ async function seedDatabase(page: import('@playwright/test').Page) {
             updatedAt: now,
           });
 
-          tx.objectStore('stageOutlines').put({
+          tx.objectStore('outlines').put({
             stageId,
-            outlines: [],
-            createdAt: now,
-            updatedAt: now,
+            outline: { outlines: [], createdAt: now, updatedAt: now },
           });
+
+          localStorage.setItem(
+            `maic:device:editor-current-scene:${stageId}`,
+            JSON.stringify({ sceneId: interactiveId, updatedAt: new Date(now).toISOString() }),
+          );
 
           tx.oncomplete = () => {
             db.close();

--- a/e2e/tests/playback-resume-cutover.spec.ts
+++ b/e2e/tests/playback-resume-cutover.spec.ts
@@ -15,29 +15,17 @@ const STAGE_ID = 'stage-playback-e2e';
 const SCENE_ID = 'scene-playback-e2e';
 
 async function seedStage(page: Page) {
-  // Loading a classroom route forces the app to open (and version) the Dexie
-  // database even when it is empty; only then do the object stores exist.
   await page.goto('/classroom/warmup-nonexistent');
-  await page.waitForFunction(
-    async () => {
-      const dbs = await indexedDB.databases();
-      if (!dbs.some((d) => d.name === 'MAIC-Database')) return false;
-      const open = indexedDB.open('MAIC-Database');
-      const db: IDBDatabase = await new Promise((resolve, reject) => {
-        open.onsuccess = () => resolve(open.result);
-        open.onerror = () => reject(open.error);
-      });
-      const ready =
-        db.objectStoreNames.contains('stages') && db.objectStoreNames.contains('scenes');
-      db.close();
-      return ready;
-    },
-    undefined,
-    { timeout: 30_000 },
-  );
   await page.evaluate(
     async ({ stageId, sceneId }) => {
-      const open = indexedDB.open('MAIC-Database');
+      const open = indexedDB.open('maic-documents', 1);
+      open.onupgradeneeded = () => {
+        const db = open.result;
+        db.createObjectStore('stages', { keyPath: 'id' });
+        const scenes = db.createObjectStore('scenes', { keyPath: ['stageId', 'id'] });
+        scenes.createIndex('by-stage', 'stageId');
+        db.createObjectStore('outlines', { keyPath: 'stageId' });
+      };
       const db: IDBDatabase = await new Promise((resolve, reject) => {
         open.onsuccess = () => resolve(open.result);
         open.onerror = () => reject(open.error);
@@ -49,8 +37,12 @@ async function seedStage(page: Page) {
         name: 'Playback E2E Stage',
         createdAt: now,
         updatedAt: now,
-        currentSceneId: sceneId,
+        dslVersion: '0.1.0',
       });
+      localStorage.setItem(
+        `maic:device:editor-current-scene:${stageId}`,
+        JSON.stringify({ sceneId, updatedAt: new Date(now).toISOString() }),
+      );
       tx.objectStore('scenes').put({
         id: sceneId,
         stageId,

--- a/e2e/tests/quiz-content-surface-657.spec.ts
+++ b/e2e/tests/quiz-content-surface-657.spec.ts
@@ -29,10 +29,17 @@ async function seedQuiz(page: Page, stageId: string, questions: QuizQuestion[]) 
   await page.evaluate(
     ({ id, qs }) => {
       return new Promise<void>((resolve, reject) => {
-        const request = indexedDB.open('MAIC-Database');
+        const request = indexedDB.open('maic-documents', 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          db.createObjectStore('stages', { keyPath: 'id' });
+          const scenes = db.createObjectStore('scenes', { keyPath: ['stageId', 'id'] });
+          scenes.createIndex('by-stage', 'stageId');
+          db.createObjectStore('outlines', { keyPath: 'stageId' });
+        };
         request.onsuccess = (event) => {
           const db = (event.target as IDBOpenDBRequest).result;
-          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+          const tx = db.transaction(['stages', 'scenes', 'outlines'], 'readwrite');
           const now = Date.now();
           tx.objectStore('stages').put({
             id,
@@ -42,6 +49,7 @@ async function seedQuiz(page: Page, stageId: string, questions: QuizQuestion[]) 
             style: 'professional',
             createdAt: now,
             updatedAt: now,
+            dslVersion: '0.1.0',
           });
           tx.objectStore('scenes').put({
             id: 'scene-quiz',
@@ -53,11 +61,9 @@ async function seedQuiz(page: Page, stageId: string, questions: QuizQuestion[]) 
             createdAt: now,
             updatedAt: now,
           });
-          tx.objectStore('stageOutlines').put({
+          tx.objectStore('outlines').put({
             stageId: id,
-            outlines: [],
-            createdAt: now,
-            updatedAt: now,
+            outline: { outlines: [], createdAt: now, updatedAt: now },
           });
           tx.oncomplete = () => {
             db.close();

--- a/e2e/tests/recent-video-thumbnail.spec.ts
+++ b/e2e/tests/recent-video-thumbnail.spec.ts
@@ -47,10 +47,7 @@ async function seedVideoThumbnailStage({
 
         request.onsuccess = (event) => {
           const db = (event.target as IDBOpenDBRequest).result;
-          const tx = db.transaction(
-            ['stages', 'scenes', 'stageOutlines', 'mediaFiles'],
-            'readwrite',
-          );
+          const tx = db.transaction(['mediaFiles'], 'readwrite');
           const now = Date.now();
           const videoBytes = new Uint8Array([
             0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50, 0, 0, 0, 0, 109, 112, 52, 50, 105,
@@ -78,17 +75,7 @@ async function seedVideoThumbnailStage({
             });
           };
 
-          tx.objectStore('stages').put({
-            id: stageId,
-            name: courseName,
-            description: '',
-            language: 'en-US',
-            style: 'professional',
-            createdAt: now,
-            updatedAt: now,
-          });
-
-          tx.objectStore('scenes').put({
+          const documentScene = {
             id: 'scene-video-thumbnail',
             stageId,
             type: 'slide',
@@ -120,14 +107,7 @@ async function seedVideoThumbnailStage({
             },
             createdAt: now,
             updatedAt: now,
-          });
-
-          tx.objectStore('stageOutlines').put({
-            stageId,
-            outlines: [],
-            createdAt: now,
-            updatedAt: now,
-          });
+          };
 
           putVideoRecord(storedMediaRef, storedError);
           for (const mediaRef of extraStoredMediaRefs) {
@@ -136,7 +116,44 @@ async function seedVideoThumbnailStage({
 
           tx.oncomplete = () => {
             db.close();
-            resolve();
+            const documentRequest = indexedDB.open('maic-documents', 1);
+            documentRequest.onupgradeneeded = () => {
+              const documentDb = documentRequest.result;
+              documentDb.createObjectStore('stages', { keyPath: 'id' });
+              const scenes = documentDb.createObjectStore('scenes', {
+                keyPath: ['stageId', 'id'],
+              });
+              scenes.createIndex('by-stage', 'stageId');
+              documentDb.createObjectStore('outlines', { keyPath: 'stageId' });
+            };
+            documentRequest.onsuccess = () => {
+              const documentDb = documentRequest.result;
+              const documentTx = documentDb.transaction(
+                ['stages', 'scenes', 'outlines'],
+                'readwrite',
+              );
+              documentTx.objectStore('stages').put({
+                id: stageId,
+                name: courseName,
+                description: '',
+                language: 'en-US',
+                style: 'professional',
+                createdAt: now,
+                updatedAt: now,
+                dslVersion: '0.1.0',
+              });
+              documentTx.objectStore('scenes').put(documentScene);
+              documentTx.objectStore('outlines').put({
+                stageId,
+                outline: { outlines: [], createdAt: now, updatedAt: now },
+              });
+              documentTx.oncomplete = () => {
+                documentDb.close();
+                resolve();
+              };
+              documentTx.onerror = () => reject(documentTx.error);
+            };
+            documentRequest.onerror = () => reject(documentRequest.error);
           };
           tx.onerror = () => reject(tx.error);
         };

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -5,7 +5,7 @@ import { saveAs } from 'file-saver';
 import { toast } from 'sonner';
 import { useStageStore } from '@/lib/store/stage';
 import { useI18n } from '@/lib/hooks/use-i18n';
-import { db, getGeneratedAgentsByStageId } from '@/lib/utils/database';
+import { getGeneratedAgentsByStageId } from '@/lib/utils/database';
 import {
   CLASSROOM_ZIP_FORMAT_VERSION,
   CLASSROOM_ZIP_EXTENSION,
@@ -27,6 +27,7 @@ import {
 import { createProxiedFetch } from './proxied-fetch';
 import type { SceneContent } from '@/lib/types/stage';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
+import { accessDocument } from '@/lib/document-store';
 
 export async function inlineSceneContent(
   content: SceneContent,
@@ -57,9 +58,9 @@ export function useExportClassroom() {
       const zip = new JSZip();
       const documentScenes = await preparePBLScenesForDocumentPersistence(stage.id, scenes);
 
-      // 1. Read latest stage name from IndexedDB (may have been renamed on home page)
-      const freshStage = await db.stages.get(stage.id);
-      const latestName = freshStage?.name || stage.name;
+      // 1. Read latest stage name from the document aggregate (it may have been renamed at home).
+      const freshDocument = await accessDocument(stage.id);
+      const latestName = freshDocument.document?.stage.name || stage.name;
 
       // 2. Collect agents from DB
       const agentRecords = await getGeneratedAgentsByStageId(stage.id);

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -9,6 +9,7 @@ import type { AudioFileRecord, MediaFileRecord, GeneratedAgentRecord } from '@/l
 import type { ClassroomManifest, ManifestScene } from '@/lib/export/classroom-zip-types';
 import { rewriteAudioRefsToIds } from '@/lib/export/classroom-zip-utils';
 import { createLogger } from '@/lib/logger';
+import { canonicalizeLegacyScene, mutateDocument, type AppDocument } from '@/lib/document-store';
 
 const log = createLogger('ImportClassroom');
 
@@ -42,6 +43,8 @@ export function useImportClassroom(onSuccess?: () => void) {
       setPhase('parsing');
       const toastId = toast.loading(t('import.parsing'));
 
+      let importedStageId: string | undefined;
+      const importedAudioIds: string[] = [];
       try {
         // 0. Size check — warn for files over 200MB
         const MAX_SAFE_SIZE = 200 * 1024 * 1024;
@@ -79,6 +82,7 @@ export function useImportClassroom(onSuccess?: () => void) {
 
         // 3. Generate new IDs
         const newStageId = nanoid();
+        importedStageId = newStageId;
         const now = Date.now();
 
         // Agent ID mapping: index → new ID
@@ -131,6 +135,7 @@ export function useImportClassroom(onSuccess?: () => void) {
             createdAt: now,
           };
           await db.audioFiles.put(record);
+          importedAudioIds.push(newId);
         }
 
         // Write generated media files one at a time
@@ -166,17 +171,49 @@ export function useImportClassroom(onSuccess?: () => void) {
         setPhase('writingCourse');
         toast.loading(t('import.writingCourse'), { id: toastId });
 
-        // Write stage
-        await db.stages.put({
-          id: newStageId,
-          name: manifest.stage.name || 'Imported Classroom',
-          description: manifest.stage.description,
-          languageDirective: manifest.stage.language,
-          style: manifest.stage.style,
-          createdAt: manifest.stage.createdAt || now,
-          updatedAt: now,
-          agentIds: newAgentIds.length > 0 ? newAgentIds : undefined,
-        });
+        const document: AppDocument = {
+          stage: {
+            id: newStageId,
+            name: manifest.stage.name || 'Imported Classroom',
+            description: manifest.stage.description,
+            languageDirective: manifest.stage.language,
+            style: manifest.stage.style,
+            createdAt: manifest.stage.createdAt || now,
+            updatedAt: now,
+            agentIds: newAgentIds.length > 0 ? newAgentIds : undefined,
+          },
+          scenes: manifest.scenes.map((mScene: ManifestScene, index: number) => {
+            const newSceneId = nanoid();
+            const actions = mScene.actions
+              ? rewriteAudioRefsToIds(mScene.actions, audioRefToNewId, {
+                  agentIds: newAgentIds,
+                  fallbackDiscussionAgentIndex,
+                })
+              : undefined;
+            const multiAgent = mScene.multiAgent?.enabled
+              ? {
+                  enabled: true,
+                  agentIds: (mScene.multiAgent.agentIndices ?? [])
+                    .map((idx) => newAgentIds[idx])
+                    .filter(Boolean),
+                  directorPrompt: mScene.multiAgent.directorPrompt,
+                }
+              : undefined;
+
+            return canonicalizeLegacyScene({
+              id: newSceneId,
+              stageId: newStageId,
+              title: mScene.title,
+              order: mScene.order ?? index,
+              content: mScene.content,
+              actions,
+              whiteboards: mScene.whiteboards,
+              multiAgent,
+              createdAt: now,
+              updatedAt: now,
+            });
+          }),
+        };
 
         // Write agents
         if (manifest.agents?.length) {
@@ -194,43 +231,8 @@ export function useImportClassroom(onSuccess?: () => void) {
           await db.generatedAgents.bulkPut(agentRecords);
         }
 
-        // Write scenes with rewritten references
-        const sceneRecords = manifest.scenes.map((mScene: ManifestScene, index: number) => {
-          const newSceneId = nanoid();
-
-          const actions = mScene.actions
-            ? rewriteAudioRefsToIds(mScene.actions, audioRefToNewId, {
-                agentIds: newAgentIds,
-                fallbackDiscussionAgentIndex,
-              })
-            : undefined;
-
-          let multiAgent = undefined;
-          if (mScene.multiAgent?.enabled) {
-            multiAgent = {
-              enabled: true,
-              agentIds: (mScene.multiAgent.agentIndices ?? [])
-                .map((idx) => newAgentIds[idx])
-                .filter(Boolean),
-              directorPrompt: mScene.multiAgent.directorPrompt,
-            };
-          }
-
-          return {
-            id: newSceneId,
-            stageId: newStageId,
-            type: mScene.type,
-            title: mScene.title,
-            order: mScene.order ?? index,
-            content: mScene.content,
-            actions,
-            whiteboard: mScene.whiteboards,
-            multiAgent,
-            createdAt: now,
-            updatedAt: now,
-          };
-        });
-        await db.scenes.bulkPut(sceneRecords);
+        // The document is the commit point: one aggregate write under its per-stage lock.
+        await mutateDocument(newStageId, async (_existing, store) => store.saveDocument(document));
 
         // 6. Done
         setPhase('done');
@@ -238,6 +240,32 @@ export function useImportClassroom(onSuccess?: () => void) {
         onSuccess?.();
       } catch (error) {
         log.error('Classroom ZIP import failed:', error);
+        // Media/agents are separate legacy domains and cannot join the document transaction.
+        // Compensate every row this import could have created, logging individual failures.
+        const cleanup = async (label: string, operation: () => Promise<unknown>) => {
+          try {
+            await operation();
+          } catch (cleanupError) {
+            log.error(`Failed to undo imported ${label}:`, cleanupError);
+          }
+        };
+        if (importedStageId) {
+          const stageId = importedStageId;
+          await cleanup('document', async () => {
+            await mutateDocument(stageId, async (_document, store) =>
+              store.deleteDocument(stageId),
+            );
+          });
+          await cleanup('generated agents', () =>
+            db.generatedAgents.where('stageId').equals(stageId).delete(),
+          );
+          await cleanup('generated media', () =>
+            db.mediaFiles.where('stageId').equals(stageId).delete(),
+          );
+        }
+        if (importedAudioIds.length > 0) {
+          await cleanup('audio files', () => db.audioFiles.bulkDelete(importedAudioIds));
+        }
         const isQuotaError = error instanceof DOMException && error.name === 'QuotaExceededError';
         toast.error(isQuotaError ? t('import.error.storageFull') : t('import.error.invalidZip'), {
           id: toastId,

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -29,6 +29,8 @@ import {
   withRuntimeStorageSharedLock,
 } from './chat-storage-lock';
 import type { ChatStorageOptions } from './chat-storage';
+import type { AppDocument } from '@/lib/document-store';
+import { BrowserKVStore } from '@openmaic/storage';
 
 const log = createLogger('Database');
 
@@ -513,9 +515,29 @@ export async function clearDatabase(runtimeStore?: RuntimeStore): Promise<void> 
   // must fail loud: reporting success while runtime data remains is misleading.
   await withRuntimeStorageExclusiveLock(async () => {
     await (runtimeStore ?? getRuntimeStore()).deleteAllRuntime();
+    await deleteAllDocuments();
+    await clearDocumentStoreKeys();
     await db.delete();
   });
   log.info('Database cleared');
+}
+
+/** Delete every aggregate without bypassing the document store's open connection. */
+export async function deleteAllDocuments(): Promise<void> {
+  const { getDocumentStore } = await import('@/lib/document-store');
+  const store = getDocumentStore();
+  const documents = await store.listDocuments();
+  await Promise.all(documents.map((document) => store.deleteDocument(document.id)));
+}
+
+/** Remove device-local metadata owned by the document cutover. */
+export async function clearDocumentStoreKeys(): Promise<void> {
+  if (typeof localStorage === 'undefined') return;
+  const kv = new BrowserKVStore();
+  for (const prefix of ['document-migration:', 'editor-current-scene:']) {
+    const keys = await kv.keys(prefix, 'device');
+    await Promise.all(keys.map((key) => kv.remove(key, 'device')));
+  }
 }
 
 function toChatSessionRecord(stageId: string, session: ChatSession): ChatSessionRecord {
@@ -540,12 +562,21 @@ function toChatSessionRecord(stageId: string, session: ChatSession): ChatSession
  * Export database contents (for backup)
  */
 export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Promise<{
-  stages: StageRecord[];
-  scenes: SceneRecord[];
+  documents: AppDocument[];
   chatSessions: ChatSessionRecord[];
   playbackState: PlaybackStateRecord[];
 }> {
-  const stages = await db.stages.toArray();
+  const { accessDocument, getDocumentStore, getLegacyDocumentStore } =
+    await import('@/lib/document-store');
+  const documentStore = getDocumentStore();
+  // Backups must not strand courses that have not yet been opened since cutover.
+  // Route them through the normal lazy-migration seam before enumerating aggregates.
+  const legacyStages = await getLegacyDocumentStore().listStages();
+  await Promise.all(legacyStages.map((stage) => accessDocument(stage.id)));
+  const summaries = await documentStore.listDocuments();
+  const documents = (
+    await Promise.all(summaries.map((summary) => documentStore.loadDocument(summary.id)))
+  ).filter((document): document is AppDocument => document !== null);
   const legacyChatMap = new Map<string, ChatSessionRecord>();
   for (const session of [
     ...(await db.chatSessions.toArray()),
@@ -557,7 +588,7 @@ export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Prom
   const { loadChatSessions } = await import('./chat-storage');
   const runtimeChats = (
     await Promise.all(
-      stages.map(async (stage) =>
+      documents.map(async ({ stage }) =>
         (
           await loadChatSessions(stage.id, {
             ...chatOptions,
@@ -573,8 +604,7 @@ export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Prom
   );
 
   return {
-    stages,
-    scenes: await db.scenes.toArray(),
+    documents,
     chatSessions: [
       ...runtimeChats,
       ...legacyChats.filter(
@@ -590,6 +620,7 @@ export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Prom
  */
 export async function importDatabase(
   data: {
+    documents?: AppDocument[];
     stages?: StageRecord[];
     scenes?: SceneRecord[];
     chatSessions?: ChatSessionRecord[];
@@ -597,101 +628,133 @@ export async function importDatabase(
   },
   chatOptions: ChatStorageOptions = {},
 ): Promise<void> {
-  return withRuntimeStorageSharedLock(async () => {
-    const restoredChatStageIds =
-      data.chatSessions === undefined
-        ? []
-        : [
-            ...new Set([
-              ...(data.stages ?? []).map((stage) => stage.id),
-              ...data.chatSessions.map((session) => session.stageId),
-            ]),
-          ];
-    const restoreRows = () =>
-      db.transaction(
-        'rw',
-        [db.stages, db.scenes, db.chatSessions, db.chatRestoreStaging, db.playbackState],
-        async () => {
-          if (data.stages) await db.stages.bulkPut(data.stages);
-          if (data.scenes) await db.scenes.bulkPut(data.scenes);
-          if (data.chatSessions) {
-            for (const stageId of restoredChatStageIds) {
-              await db.chatSessions.where('stageId').equals(stageId).delete();
-              await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
-            }
-            await db.chatRestoreStaging.bulkPut(data.chatSessions);
-          }
-          if (data.playbackState) await db.playbackState.bulkPut(data.playbackState);
-        },
-      );
-    if (data.chatSessions !== undefined) {
-      // RuntimeStore cannot join Dexie's transaction. Keep a rollback image
-      // until durable restore markers have been created for every affected
-      // runtime partition; marker creation failure must not commit half an
-      // imported backup.
-      const rollbackImage = await db.transaction(
-        'r',
-        [db.stages, db.scenes, db.chatSessions, db.chatRestoreStaging, db.playbackState],
-        async () => ({
-          stages: (await db.stages.bulkGet((data.stages ?? []).map((stage) => stage.id))).filter(
-            (stage): stage is StageRecord => stage !== undefined,
-          ),
-          scenes: (await db.scenes.bulkGet((data.scenes ?? []).map((scene) => scene.id))).filter(
-            (scene): scene is SceneRecord => scene !== undefined,
-          ),
-          chatSessions: (
-            await Promise.all(
-              restoredChatStageIds.map((stageId) =>
-                db.chatSessions.where('stageId').equals(stageId).toArray(),
-              ),
-            )
-          ).flat(),
-          chatRestoreStaging: (
-            await Promise.all(
-              restoredChatStageIds.map((stageId) =>
-                db.chatRestoreStaging.where('stageId').equals(stageId).toArray(),
-              ),
-            )
-          ).flat(),
-          playbackState: (
-            await db.playbackState.bulkGet(
-              (data.playbackState ?? []).map((playback) => playback.stageId),
-            )
-          ).filter((playback): playback is PlaybackStateRecord => playback !== undefined),
-        }),
-      );
-      const rollbackRows = () =>
+  const { canonicalizeLegacyScene, canonicalizeLegacyStage, mutateDocument, saveCurrentScene } =
+    await import('@/lib/document-store');
+  const legacyScenesByStage = new Map<string, SceneRecord[]>();
+  for (const scene of data.scenes ?? []) {
+    const scenes = legacyScenesByStage.get(scene.stageId) ?? [];
+    scenes.push(scene);
+    legacyScenesByStage.set(scene.stageId, scenes);
+  }
+  const documents =
+    data.documents ??
+    (data.stages ?? []).map((legacyStage): AppDocument => {
+      const { stage } = canonicalizeLegacyStage(legacyStage);
+      return {
+        stage,
+        scenes: (legacyScenesByStage.get(legacyStage.id) ?? [])
+          .map(canonicalizeLegacyScene)
+          .sort((a, b) => a.order - b.order),
+      };
+    });
+  const importedDocumentIds: string[] = [];
+
+  try {
+    for (const document of documents) {
+      await mutateDocument(document.stage.id, async (_existing, store) => {
+        await store.saveDocument(document);
+      });
+      importedDocumentIds.push(document.stage.id);
+    }
+    for (const legacyStage of data.stages ?? []) {
+      if (legacyStage.currentSceneId !== undefined) {
+        await saveCurrentScene(legacyStage.id, legacyStage.currentSceneId);
+      }
+    }
+
+    await withRuntimeStorageSharedLock(async () => {
+      const restoredChatStageIds =
+        data.chatSessions === undefined
+          ? []
+          : [
+              ...new Set([
+                ...documents.map((document) => document.stage.id),
+                ...data.chatSessions.map((session) => session.stageId),
+              ]),
+            ];
+      const restoreRows = () =>
         db.transaction(
           'rw',
           [db.stages, db.scenes, db.chatSessions, db.chatRestoreStaging, db.playbackState],
           async () => {
-            await db.stages.bulkDelete((data.stages ?? []).map((stage) => stage.id));
-            await db.scenes.bulkDelete((data.scenes ?? []).map((scene) => scene.id));
-            for (const stageId of restoredChatStageIds) {
-              await db.chatSessions.where('stageId').equals(stageId).delete();
-              await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
+            if (data.chatSessions) {
+              for (const stageId of restoredChatStageIds) {
+                await db.chatSessions.where('stageId').equals(stageId).delete();
+                await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
+              }
+              await db.chatRestoreStaging.bulkPut(data.chatSessions);
             }
-            await db.playbackState.bulkDelete(
-              (data.playbackState ?? []).map((playback) => playback.stageId),
-            );
-            await db.stages.bulkPut(rollbackImage.stages);
-            await db.scenes.bulkPut(rollbackImage.scenes);
-            await db.chatSessions.bulkPut(rollbackImage.chatSessions);
-            await db.chatRestoreStaging.bulkPut(rollbackImage.chatRestoreStaging);
-            await db.playbackState.bulkPut(rollbackImage.playbackState);
+            if (data.playbackState) await db.playbackState.bulkPut(data.playbackState);
           },
         );
-      const { restoreChatSessionsFromBackup } = await import('./chat-storage');
-      await restoreChatSessionsFromBackup(restoredChatStageIds, restoreRows, {
-        ...chatOptions,
-        globalLockHeld: true,
-        rollbackLegacyRows: rollbackRows,
-      });
-    } else {
-      await restoreRows();
+      if (data.chatSessions !== undefined) {
+        // RuntimeStore cannot join Dexie's transaction. Keep a rollback image
+        // until durable restore markers have been created for every affected
+        // runtime partition; marker creation failure must not commit half an
+        // imported backup.
+        const rollbackImage = await db.transaction(
+          'r',
+          [db.stages, db.scenes, db.chatSessions, db.chatRestoreStaging, db.playbackState],
+          async () => ({
+            chatSessions: (
+              await Promise.all(
+                restoredChatStageIds.map((stageId) =>
+                  db.chatSessions.where('stageId').equals(stageId).toArray(),
+                ),
+              )
+            ).flat(),
+            chatRestoreStaging: (
+              await Promise.all(
+                restoredChatStageIds.map((stageId) =>
+                  db.chatRestoreStaging.where('stageId').equals(stageId).toArray(),
+                ),
+              )
+            ).flat(),
+            playbackState: (
+              await db.playbackState.bulkGet(
+                (data.playbackState ?? []).map((playback) => playback.stageId),
+              )
+            ).filter((playback): playback is PlaybackStateRecord => playback !== undefined),
+          }),
+        );
+        const rollbackRows = () =>
+          db.transaction(
+            'rw',
+            [db.stages, db.scenes, db.chatSessions, db.chatRestoreStaging, db.playbackState],
+            async () => {
+              for (const stageId of restoredChatStageIds) {
+                await db.chatSessions.where('stageId').equals(stageId).delete();
+                await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
+              }
+              await db.playbackState.bulkDelete(
+                (data.playbackState ?? []).map((playback) => playback.stageId),
+              );
+              await db.chatSessions.bulkPut(rollbackImage.chatSessions);
+              await db.chatRestoreStaging.bulkPut(rollbackImage.chatRestoreStaging);
+              await db.playbackState.bulkPut(rollbackImage.playbackState);
+            },
+          );
+        const { restoreChatSessionsFromBackup } = await import('./chat-storage');
+        await restoreChatSessionsFromBackup(restoredChatStageIds, restoreRows, {
+          ...chatOptions,
+          globalLockHeld: true,
+          rollbackLegacyRows: rollbackRows,
+        });
+      } else {
+        await restoreRows();
+      }
+      log.info('Database imported successfully');
+    });
+  } catch (error) {
+    for (const stageId of importedDocumentIds.reverse()) {
+      try {
+        await mutateDocument(stageId, async (_document, store) => store.deleteDocument(stageId));
+      } catch (rollbackError) {
+        log.error(`Failed to roll back imported document ${stageId}:`, rollbackError);
+      }
     }
-    log.info('Database imported successfully');
-  });
+    throw error;
+  }
 }
 
 // ==================== Convenience Query Functions ====================
@@ -699,48 +762,56 @@ export async function importDatabase(
 /**
  * Get all scenes for a course
  */
-export async function getScenesByStageId(stageId: string): Promise<SceneRecord[]> {
-  return db.scenes.where('stageId').equals(stageId).sortBy('order');
+export async function getScenesByStageId(stageId: string): Promise<Scene[]> {
+  const { accessDocument } = await import('@/lib/document-store');
+  return (await accessDocument(stageId)).document?.scenes ?? [];
 }
 
 /**
  * Delete a course and all its related data
+ *
+ * @deprecated No production caller remains. `deleteStageData` is the primary
+ * stage-deletion path; this compatibility helper retains its broader author-side cascade.
  */
 export async function deleteStageWithRelatedData(stageId: string): Promise<void> {
-  await withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
-    await db.transaction(
-      'rw',
-      [
-        db.stages,
-        db.scenes,
-        db.chatSessions,
-        db.chatRestoreStaging,
-        db.playbackState,
-        db.stageOutlines,
-        db.mediaFiles,
-        db.generatedAgents,
-        db.agentEditSessions,
-      ],
-      async () => {
-        await db.stages.delete(stageId);
-        await db.scenes.where('stageId').equals(stageId).delete();
-        await db.chatSessions.where('stageId').equals(stageId).delete();
-        await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
-        await db.playbackState.delete(stageId);
-        await db.stageOutlines.delete(stageId);
-        await db.mediaFiles.where('stageId').equals(stageId).delete();
-        await db.generatedAgents.where('stageId').equals(stageId).delete();
-        await db.agentEditSessions.where('stageId').equals(stageId).delete();
-      },
-    );
-    // Learner-runtime data lives in a separate IndexedDB database, so it is
-    // cascaded after the Dexie transaction: it cannot join it, and a runtime
-    // failure must not abort it (the helper warns instead of throwing).
-    const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
-    await runtimeDeletion.completion;
-    releaseCaller(undefined);
-    await runtimeDeletion.settlement;
-  });
+  const { mutateDocument } = await import('@/lib/document-store');
+  await mutateDocument(stageId, async (_document, store) =>
+    withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
+      await store.deleteDocument(stageId);
+      await db.transaction(
+        'rw',
+        [
+          db.stages,
+          db.scenes,
+          db.chatSessions,
+          db.chatRestoreStaging,
+          db.playbackState,
+          db.stageOutlines,
+          db.mediaFiles,
+          db.generatedAgents,
+          db.agentEditSessions,
+        ],
+        async () => {
+          await db.stages.delete(stageId);
+          await db.scenes.where('stageId').equals(stageId).delete();
+          await db.chatSessions.where('stageId').equals(stageId).delete();
+          await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
+          await db.playbackState.delete(stageId);
+          await db.stageOutlines.delete(stageId);
+          await db.mediaFiles.where('stageId').equals(stageId).delete();
+          await db.generatedAgents.where('stageId').equals(stageId).delete();
+          await db.agentEditSessions.where('stageId').equals(stageId).delete();
+        },
+      );
+      // Learner-runtime data lives in a separate IndexedDB database, so it is
+      // cascaded after the Dexie transaction: it cannot join it, and a runtime
+      // failure must not abort it (the helper warns instead of throwing).
+      const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
+      await runtimeDeletion.completion;
+      releaseCaller(undefined);
+      await runtimeDeletion.settlement;
+    }),
+  );
 }
 
 /**
@@ -756,9 +827,13 @@ export async function getGeneratedAgentsByStageId(
  * Get database statistics
  */
 export async function getDatabaseStats() {
+  const { getDocumentStore } = await import('@/lib/document-store');
+  const documents = await getDocumentStore().listDocuments();
   return {
-    stages: await db.stages.count(),
-    scenes: await db.scenes.count(),
+    documents: documents.length,
+    documentScenes: documents.reduce((total, document) => total + document.sceneCount, 0),
+    legacyStages: await db.stages.count(),
+    legacyScenes: await db.scenes.count(),
     audioFiles: await db.audioFiles.count(),
     imageFiles: await db.imageFiles.count(),
     snapshots: await db.snapshots.count(),

--- a/lib/video-export-app/build-export-zip.ts
+++ b/lib/video-export-app/build-export-zip.ts
@@ -16,7 +16,7 @@
  */
 import { compileVideoTimeline, emitHyperframes } from '@/lib/video-export';
 import { useStageStore } from '@/lib/store';
-import { db } from '@/lib/utils/database';
+import { accessDocument } from '@/lib/document-store';
 import { createVideoTimelineDeps } from './timeline-deps';
 import { collectVideoAssets } from './collect';
 import { packageVideoZip } from './package-zip';
@@ -61,8 +61,8 @@ export async function buildExportZip(resolution: VideoResolution): Promise<Build
 
   const { width, height } = VIDEO_RESOLUTIONS[resolution];
 
-  const latest = await db.stages.get(stage.id).catch(() => undefined);
-  const stageName = latest?.name || stage.name || 'classroom';
+  const latest = await accessDocument(stage.id).catch(() => undefined);
+  const stageName = latest?.document?.stage.name || stage.name || 'classroom';
 
   // 1. DI deps (Dexie durations + asset presence) → 2. pure compile to IR.
   const deps = await createVideoTimelineDeps({ stage: { id: stage.id }, scenes });

--- a/tests/runtime/database-chat-cutover.test.ts
+++ b/tests/runtime/database-chat-cutover.test.ts
@@ -157,6 +157,7 @@ describe('database runtime chat integration', () => {
     vi.resetModules();
     vi.stubGlobal('indexedDB', new IDBFactory());
     vi.stubGlobal('navigator', { locks: serialLockManager() });
+    stubMemoryLocalStorage();
   });
 
   afterEach(() => {
@@ -498,7 +499,8 @@ describe('database runtime chat integration', () => {
 
   it('finishes an interrupted runtime clear from the durable restore marker', async () => {
     const backing = new BrowserRuntimeStore({ indexedDB: globalThis.indexedDB });
-    const { db, importDatabase } = await import('@/lib/utils/database');
+    const { importDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
     const { loadChatSessions, saveChatSessions } = await import('@/lib/utils/chat-storage');
     await saveChatSessions(
       'stage-interrupted-restore',
@@ -543,9 +545,7 @@ describe('database runtime chat integration', () => {
         { store: failingDeleteStore, learnerKey },
       ),
     ).rejects.toThrow('restore delete failed');
-    await expect(db.stages.get('stage-interrupted-restore')).resolves.toMatchObject({
-      name: 'Imported stage',
-    });
+    await expect(getDocumentStore().loadDocument('stage-interrupted-restore')).resolves.toBeNull();
 
     await expect(
       loadChatSessions('stage-interrupted-restore', { store: backing, learnerKey }),
@@ -718,7 +718,7 @@ describe('database runtime chat integration', () => {
     });
     vi.spyOn(db, 'transaction').mockImplementation(((...args: unknown[]) =>
       originalTransaction(...args).then(async (result) => {
-        if (!Array.isArray(args[1])) return result;
+        if (args[0] !== 'rw' || !Array.isArray(args[1])) return result;
         transactionCommitted();
         await importMayContinue;
         return result;
@@ -1404,6 +1404,7 @@ describe('database runtime chat integration', () => {
       dbName: 'clear-without-web-locks',
     });
     const { clearDatabase, db } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
     await db.stages.put({
       id: 'stage-clear-no-lock',
       name: 'Clear without locks',
@@ -1419,11 +1420,103 @@ describe('database runtime chat integration', () => {
       createdAt: new Date(1_000).toISOString(),
       updatedAt: new Date(2_000).toISOString(),
     });
+    await getDocumentStore().saveDocument({
+      stage: {
+        id: 'stage-clear-document',
+        name: 'Document to clear',
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+      scenes: [],
+    });
+    localStorage.setItem('maic:device:document-migration:stage-clear-document', '{}');
+    localStorage.setItem('maic:device:editor-current-scene:stage-clear-document', '{}');
 
     await expect(clearDatabase(runtimeStore)).resolves.toBeUndefined();
     await expect(runtimeStore.listSessions('stage-clear-no-lock', learnerKey)).resolves.toEqual([]);
     await db.open();
     await expect(db.stages.count()).resolves.toBe(0);
+    await expect(getDocumentStore().loadDocument('stage-clear-document')).resolves.toBeNull();
+    expect(localStorage.getItem('maic:device:document-migration:stage-clear-document')).toBeNull();
+    expect(
+      localStorage.getItem('maic:device:editor-current-scene:stage-clear-document'),
+    ).toBeNull();
+  });
+
+  it('round-trips versioned document backups including outline envelopes', async () => {
+    const runtimeStore = new BrowserRuntimeStore({ indexedDB: globalThis.indexedDB });
+    const { exportDatabase, importDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
+    const documentStore = getDocumentStore();
+    await documentStore.saveDocument({
+      stage: {
+        id: 'stage-document-backup',
+        name: 'Aggregate backup',
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+      scenes: [],
+      outline: { outlines: [], generationComplete: true, createdAt: 1_000, updatedAt: 2_000 },
+    });
+
+    const backup = await exportDatabase({ store: runtimeStore, learnerKey });
+    expect(backup).not.toHaveProperty('stages');
+    expect(backup).not.toHaveProperty('scenes');
+    expect(backup.documents).toMatchObject([
+      {
+        stage: { id: 'stage-document-backup', name: 'Aggregate backup' },
+        outline: { generationComplete: true },
+        dslVersion: '0.1.0',
+      },
+    ]);
+
+    await documentStore.deleteDocument('stage-document-backup');
+    await importDatabase(backup, { store: runtimeStore, learnerKey });
+    await expect(documentStore.loadDocument('stage-document-backup')).resolves.toMatchObject({
+      stage: { name: 'Aggregate backup' },
+      outline: { generationComplete: true },
+      dslVersion: '0.1.0',
+    });
+  });
+
+  it('accepts legacy stage/scene backups and canonicalizes whiteboards', async () => {
+    const { importDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore, loadCurrentScene } = await import('@/lib/document-store');
+    await importDatabase({
+      stages: [
+        {
+          id: 'stage-legacy-backup',
+          name: 'Legacy backup',
+          currentSceneId: 'scene-legacy-backup',
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      ],
+      scenes: [
+        {
+          id: 'scene-legacy-backup',
+          stageId: 'stage-legacy-backup',
+          type: 'quiz',
+          title: 'Legacy scene',
+          order: 0,
+          content: {
+            type: 'quiz',
+            questions: [],
+          },
+          whiteboard: [],
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      ],
+    });
+
+    const restored = await getDocumentStore().loadDocument('stage-legacy-backup');
+    expect(restored?.stage).not.toHaveProperty('currentSceneId');
+    expect(restored?.scenes[0]).toHaveProperty('whiteboards');
+    expect(restored?.scenes[0]).not.toHaveProperty('whiteboard');
+    await expect(loadCurrentScene('stage-legacy-backup')).resolves.toMatchObject({
+      sceneId: 'scene-legacy-backup',
+    });
   });
 
   it('fails loud without deleting documents when the runtime-wide clear fails', async () => {


### PR DESCRIPTION
PR3 of the document-cutover line, per recon §2.2/§2.3.

- ZIP classroom/video export + import through the seam; import writes canonical `whiteboards` (bug fix) with saga cleanup on failure
- Backup format: versioned document aggregates incl. outline envelopes (previously silently dropped); old-format backups accepted via canonicalizers
- `clearDatabase` clears `maic-documents` + seam KV keys; `deleteStageWithRelatedData` deprecated
- 4 e2e seeders → `maic-documents`; `classroom-interaction` stays legacy-seeded as the live lazy-migration exercise
- 144+33 unit tests green, tsc/eslint/prettier clean, webpack build green, reseeded playback e2e passing locally

Implemented by Codex, cross-reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)