### PR TITLE
fix(document): final-review hardening (3 P1 + 2 P2)

### DIFF
--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -3,6 +3,8 @@ import { BrowserKVStore, type DocumentStore, type KVStore } from '@openmaic/stor
 import isEqual from 'lodash/isEqual';
 
 import type { AppScene } from '@/lib/types/stage';
+import { createLogger } from '@/lib/logger';
+import { withRuntimeStorageSharedLock } from '@/lib/utils/chat-storage-lock';
 import {
   db,
   type SceneRecord,
@@ -58,6 +60,7 @@ export class DocumentLockUnavailableError extends Error {}
 
 const MARKER_PREFIX = 'document-migration:';
 let defaultKv: KVStore | undefined;
+const log = createLogger('DocumentMigration');
 
 function resolveStore(deps: DocumentMigrationDeps): DocumentStore<AppScene, AppStage> {
   return deps.store ?? getDocumentStore();
@@ -99,6 +102,10 @@ export async function withDocumentLock<T>(
 function defaultLegacyStore(): LegacyDocumentStore {
   return {
     async read(stageId) {
+      // Dexie disables auto-open after db.delete(). A migration that was
+      // queued behind clearDatabase must reopen the now-empty legacy database
+      // so it observes a missing source instead of surfacing DatabaseClosedError.
+      if (!db.isOpen()) await db.open();
       return db.transaction('r', [db.stages, db.scenes, db.stageOutlines], async () => {
         const [stage, scenes, outline] = await Promise.all([
           db.stages.get(stageId),
@@ -108,7 +115,10 @@ function defaultLegacyStore(): LegacyDocumentStore {
         return stage ? { stage, scenes, outline } : null;
       });
     },
-    listStages: () => db.stages.toArray(),
+    async listStages() {
+      if (!db.isOpen()) await db.open();
+      return db.stages.toArray();
+    },
   };
 }
 
@@ -204,25 +214,45 @@ async function migrateLocked(
   stageId: string,
   deps: DocumentMigrationDeps,
 ): Promise<DocumentAccessResult> {
-  const store = resolveStore(deps);
-  const existing = await store.loadDocument(stageId);
-  if (existing) {
-    assertValidDestination(stageId, existing);
+  // Lock order: the per-stage document lock is acquired by the caller before
+  // this global shared epoch. This matches the established per-stage -> global
+  // order and prevents clearDatabase from interleaving with migration commit.
+  return withRuntimeStorageSharedLock(async () => {
+    const store = resolveStore(deps);
+    const existing = await store.loadDocument(stageId);
+    if (existing) {
+      assertValidDestination(stageId, existing);
+      const snapshot = await getLegacyDocumentStore(deps).read(stageId);
+      if (snapshot) {
+        const kv = resolveKv(deps);
+        const markerKey = `${MARKER_PREFIX}${stageId}`;
+        if (!(await kv.get<MigrationMarker>(markerKey, 'device'))) {
+          try {
+            assertMigrationVerified(canonicalize(snapshot), existing);
+          } catch (error) {
+            log.warn(
+              `Legacy snapshot diverges from authoritative destination for stage ${stageId}; migration marker was not written`,
+              error,
+            );
+            return { document: existing, readOnlyLegacy: false };
+          }
+        }
+        await finishMigrationMetadata(snapshot, kv);
+      }
+      return { document: existing, readOnlyLegacy: false };
+    }
+
     const snapshot = await getLegacyDocumentStore(deps).read(stageId);
-    if (snapshot) await finishMigrationMetadata(snapshot, resolveKv(deps));
-    return { document: existing, readOnlyLegacy: false };
-  }
+    if (!snapshot) return { document: null, readOnlyLegacy: false };
+    const expected = canonicalize(snapshot);
+    await store.saveDocument(expected);
+    const actual = await store.loadDocument(stageId);
+    if (!actual) throw new Error(`Legacy migration lost document ${JSON.stringify(stageId)}`);
+    assertMigrationVerified(expected, actual);
 
-  const snapshot = await getLegacyDocumentStore(deps).read(stageId);
-  if (!snapshot) return { document: null, readOnlyLegacy: false };
-  const expected = canonicalize(snapshot);
-  await store.saveDocument(expected);
-  const actual = await store.loadDocument(stageId);
-  if (!actual) throw new Error(`Legacy migration lost document ${JSON.stringify(stageId)}`);
-  assertMigrationVerified(expected, actual);
-
-  await finishMigrationMetadata(snapshot, resolveKv(deps));
-  return { document: actual, readOnlyLegacy: false };
+    await finishMigrationMetadata(snapshot, resolveKv(deps));
+    return { document: actual, readOnlyLegacy: false };
+  });
 }
 
 /** Load the authoritative destination, lazily migrating one coherent legacy snapshot. */

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -628,7 +628,7 @@ export async function importDatabase(
   },
   chatOptions: ChatStorageOptions = {},
 ): Promise<void> {
-  const { canonicalizeLegacyScene, canonicalizeLegacyStage, mutateDocument, saveCurrentScene } =
+  const { canonicalizeLegacyScene, canonicalizeLegacyStage, mutateDocument } =
     await import('@/lib/document-store');
   const legacyScenesByStage = new Map<string, SceneRecord[]>();
   for (const scene of data.scenes ?? []) {
@@ -647,18 +647,28 @@ export async function importDatabase(
           .sort((a, b) => a.order - b.order),
       };
     });
-  const importedDocumentIds: string[] = [];
+  const importedDocuments: Array<{ id: string; preImage: AppDocument | null }> = [];
+  const importedCurrentScenes: Array<{ key: string; preImage: unknown | null }> = [];
+  const kv = new BrowserKVStore();
 
   try {
     for (const document of documents) {
       await mutateDocument(document.stage.id, async (_existing, store) => {
+        const preImage = (await store.loadDocument(document.stage.id)) as AppDocument | null;
         await store.saveDocument(document);
+        importedDocuments.push({ id: document.stage.id, preImage });
       });
-      importedDocumentIds.push(document.stage.id);
     }
     for (const legacyStage of data.stages ?? []) {
       if (legacyStage.currentSceneId !== undefined) {
-        await saveCurrentScene(legacyStage.id, legacyStage.currentSceneId);
+        const key = `editor-current-scene:${legacyStage.id}`;
+        const preImage = await kv.get<unknown>(key, 'device');
+        await kv.set(
+          key,
+          { sceneId: legacyStage.currentSceneId, updatedAt: new Date().toISOString() },
+          'device',
+        );
+        importedCurrentScenes.push({ key, preImage });
       }
     }
 
@@ -746,11 +756,22 @@ export async function importDatabase(
       log.info('Database imported successfully');
     });
   } catch (error) {
-    for (const stageId of importedDocumentIds.reverse()) {
+    for (const { key, preImage } of importedCurrentScenes.reverse()) {
       try {
-        await mutateDocument(stageId, async (_document, store) => store.deleteDocument(stageId));
+        if (preImage === null) await kv.remove(key, 'device');
+        else await kv.set(key, preImage, 'device');
       } catch (rollbackError) {
-        log.error(`Failed to roll back imported document ${stageId}:`, rollbackError);
+        log.error(`Failed to roll back imported current-scene key ${key}:`, rollbackError);
+      }
+    }
+    for (const { id, preImage } of importedDocuments.reverse()) {
+      try {
+        await mutateDocument(id, async (_document, store) => {
+          if (preImage) await store.saveDocument(preImage);
+          else await store.deleteDocument(id);
+        });
+      } catch (rollbackError) {
+        log.error(`Failed to roll back imported document ${id}:`, rollbackError);
       }
     }
     throw error;

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -255,21 +255,23 @@ export async function listStages(): Promise<StageListItem[]> {
         .filter((stage) => !ids.has(stage.id))
         .map(async (stage) => {
           const snapshot = await getLegacyDocumentStore().read(stage.id);
-          return { ...stage, sceneCount: snapshot?.scenes.length ?? 0 };
+          return snapshot ? { ...stage, sceneCount: snapshot.scenes.length } : null;
         }),
     );
     return [
       ...summaries,
-      ...legacyOnly.map((stage) => ({
-        id: stage.id,
-        name: stage.name,
-        description: stage.description,
-        sceneCount: stage.sceneCount,
-        createdAt: stage.createdAt,
-        updatedAt: stage.updatedAt,
-        interactiveMode: stage.interactiveMode,
-        taskEngineMode: stage.taskEngineMode,
-      })),
+      ...legacyOnly
+        .filter((stage) => stage !== null)
+        .map((stage) => ({
+          id: stage.id,
+          name: stage.name,
+          description: stage.description,
+          sceneCount: stage.sceneCount,
+          createdAt: stage.createdAt,
+          updatedAt: stage.updatedAt,
+          interactiveMode: stage.interactiveMode,
+          taskEngineMode: stage.taskEngineMode,
+        })),
     ].sort((a, b) => b.updatedAt - a.updatedAt);
   } catch (error) {
     log.error('Failed to list stages:', error);

--- a/tests/document-store/migration.test.ts
+++ b/tests/document-store/migration.test.ts
@@ -210,19 +210,28 @@ describe('legacy document migration', () => {
     }
   });
 
-  test('keeps a verified destination authoritative', async () => {
+  test('keeps a divergent destination authoritative without certifying the legacy snapshot', async () => {
     const documentStore = store();
+    const kv = new MemoryKv();
+    const legacyStore = legacy(snapshot('Legacy V2'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     await documentStore.saveDocument({
-      stage: { id: 'stage-1', name: 'Destination', createdAt: 1, updatedAt: 2 },
+      stage: { id: 'stage-1', name: 'Destination V1', createdAt: 1, updatedAt: 2 },
       scenes: [],
     });
     const result = await accessDocument('stage-1', {
       store: documentStore,
-      kv: new MemoryKv(),
-      legacyStore: legacy(snapshot('Must not win')),
+      kv,
+      legacyStore,
       lockManager: lockManager(),
     });
-    expect(result.document!.stage.name).toBe('Destination');
+    expect(result.document!.stage.name).toBe('Destination V1');
+    expect(await kv.get('document-migration:stage-1', 'device')).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('stage stage-1'));
+    await expect(legacyStore.read('stage-1')).resolves.toMatchObject({
+      stage: { name: 'Legacy V2' },
+    });
+    warn.mockRestore();
   });
 
   test('fails loud for a future-versioned destination instead of falling back', async () => {

--- a/tests/document-store/stage-list.test.ts
+++ b/tests/document-store/stage-list.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { listDocuments, listLegacyStages, readLegacyStage } = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  listLegacyStages: vi.fn(),
+  readLegacyStage: vi.fn(),
+}));
+
+vi.mock('@/lib/document-store', () => ({
+  getDocumentStore: () => ({ listDocuments }),
+  getLegacyDocumentStore: () => ({
+    listStages: listLegacyStages,
+    read: readLegacyStage,
+  }),
+}));
+
+vi.mock('@/lib/utils/database', () => ({ db: {} }));
+vi.mock('@/lib/utils/chat-storage', () => ({
+  ChatStorageLockUnavailableError: class extends Error {},
+  saveChatSessions: vi.fn(),
+  loadChatSessions: vi.fn(),
+  deleteChatSessions: vi.fn(),
+}));
+vi.mock('@/lib/playback/cursor', () => ({ clearCursor: vi.fn() }));
+vi.mock('@/lib/quiz/persistence', () => ({ clearAllForScene: vi.fn() }));
+vi.mock('@/lib/runtime/store', () => ({ beginStageRuntimeDeletionSafely: vi.fn() }));
+vi.mock('@/lib/pbl/v2/runtime/drain', () => ({ clearStageDrainWatermarks: vi.fn() }));
+vi.mock('@/lib/utils/chat-storage-lock', () => ({
+  withRuntimeStorageExclusiveLockUntilSettled: vi.fn(),
+  withRuntimeStorageSharedLock: vi.fn(),
+}));
+
+import { listStages } from '@/lib/utils/stage-storage';
+
+describe('legacy stage listing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listDocuments.mockResolvedValue([]);
+  });
+
+  it('drops a legacy stage concurrently deleted before its snapshot read', async () => {
+    listLegacyStages.mockResolvedValue([
+      { id: 'ghost-stage', name: 'Ghost', createdAt: 1_000, updatedAt: 2_000 },
+    ]);
+    readLegacyStage.mockResolvedValue(null);
+
+    await expect(listStages()).resolves.toEqual([]);
+    expect(readLegacyStage).toHaveBeenCalledExactlyOnceWith('ghost-stage');
+  });
+});

--- a/tests/runtime/database-chat-cutover.test.ts
+++ b/tests/runtime/database-chat-cutover.test.ts
@@ -443,6 +443,8 @@ describe('database runtime chat integration', () => {
   it('rolls back imported Dexie rows when restore-marker creation fails', async () => {
     const backing = new BrowserRuntimeStore({ indexedDB: globalThis.indexedDB });
     const { db, importDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore, loadCurrentScene, saveCurrentScene } =
+      await import('@/lib/document-store');
     const { loadChatSessions, saveChatSessions } = await import('@/lib/utils/chat-storage');
     await db.stages.put({
       id: 'stage-marker-failure',
@@ -450,6 +452,18 @@ describe('database runtime chat integration', () => {
       createdAt: 1_000,
       updatedAt: 2_000,
     });
+    const documentStore = getDocumentStore();
+    await documentStore.saveDocument({
+      stage: {
+        id: 'stage-marker-failure',
+        name: 'Original destination document',
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+      scenes: [],
+    });
+    await saveCurrentScene('stage-marker-failure', 'original-current-scene');
+    const originalCurrentScene = await loadCurrentScene('stage-marker-failure');
     await saveChatSessions(
       'stage-marker-failure',
       [{ ...chatSession(), title: 'Original runtime chat' }],
@@ -479,6 +493,14 @@ describe('database runtime chat integration', () => {
               name: 'Imported stage',
               createdAt: 1_000,
               updatedAt: 3_000,
+              currentSceneId: 'imported-current-scene',
+            },
+            {
+              id: 'stage-created-by-import',
+              name: 'Created by import',
+              createdAt: 1_000,
+              updatedAt: 3_000,
+              currentSceneId: 'created-current-scene',
             },
           ],
           chatSessions: [
@@ -492,9 +514,99 @@ describe('database runtime chat integration', () => {
     await expect(db.stages.get('stage-marker-failure')).resolves.toMatchObject({
       name: 'Original stage',
     });
+    await expect(documentStore.loadDocument('stage-marker-failure')).resolves.toMatchObject({
+      stage: { name: 'Original destination document' },
+    });
+    await expect(documentStore.loadDocument('stage-created-by-import')).resolves.toBeNull();
+    await expect(loadCurrentScene('stage-marker-failure')).resolves.toEqual(originalCurrentScene);
+    await expect(loadCurrentScene('stage-created-by-import')).resolves.toBeNull();
     await expect(
       loadChatSessions('stage-marker-failure', { store: backing, learnerKey }),
     ).resolves.toMatchObject([{ title: 'Original runtime chat' }]);
+  });
+
+  it('blocks lazy migration behind a runtime-wide clear and observes the deleted source', async () => {
+    vi.stubGlobal('navigator', { locks: fairLockManager() });
+    const backing = new BrowserRuntimeStore({ indexedDB: globalThis.indexedDB });
+    const { clearDatabase, db } = await import('@/lib/utils/database');
+    const { loadStageData } = await import('@/lib/utils/stage-storage');
+    await db.stages.put({
+      id: 'stage-clear-migration-race',
+      name: 'Legacy source',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    });
+
+    let releaseDeleteAll!: () => void;
+    const deleteAllGate = new Promise<void>((resolve) => {
+      releaseDeleteAll = resolve;
+    });
+    let clearAcquired!: () => void;
+    const clearHasLock = new Promise<void>((resolve) => {
+      clearAcquired = resolve;
+    });
+    const gatedStore = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'deleteAllRuntime') {
+          return async () => {
+            clearAcquired();
+            await deleteAllGate;
+            return target.deleteAllRuntime();
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    const clearing = clearDatabase(gatedStore);
+    await clearHasLock;
+    let migrationSettled = false;
+    const migrating = loadStageData('stage-clear-migration-race').finally(() => {
+      migrationSettled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(migrationSettled).toBe(false);
+
+    releaseDeleteAll();
+    await clearing;
+    await expect(migrating).resolves.toBeNull();
+  });
+
+  it('loads a divergent destination without marking or deleting its legacy source', async () => {
+    const { db } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
+    const { loadStageData } = await import('@/lib/utils/stage-storage');
+    const kv = new (await import('@openmaic/storage')).BrowserKVStore();
+    await getDocumentStore().saveDocument({
+      stage: {
+        id: 'stage-divergent-snapshot',
+        name: 'Destination V1',
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+      scenes: [],
+    });
+    await db.stages.put({
+      id: 'stage-divergent-snapshot',
+      name: 'Legacy V2',
+      createdAt: 1_000,
+      updatedAt: 3_000,
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(loadStageData('stage-divergent-snapshot')).resolves.toMatchObject({
+      stage: { name: 'Destination V1' },
+    });
+    await expect(
+      kv.get('document-migration:stage-divergent-snapshot', 'device'),
+    ).resolves.toBeNull();
+    await expect(db.stages.get('stage-divergent-snapshot')).resolves.toMatchObject({
+      name: 'Legacy V2',
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('stage stage-divergent-snapshot'));
+    warn.mockRestore();
   });
 
   it('finishes an interrupted runtime clear from the durable restore marker', async () => {


### PR DESCRIPTION
Fixes the final adversarial review findings on the document line:

- **P1** backup rollback restores pre-existing destination documents from pre-images instead of deleting them (+ imported current-scene KV rollback, P2)
- **P1** skip-migration path reconciles legacy vs destination before writing its marker; divergence logs and stays discoverable
- **P1** migration's destination write enrolls in the global shared epoch — clearDatabase can no longer race a lazy migration into resurrecting a document
- **P2** listStages drops concurrently-deleted legacy ghosts

149 tests green (3 new regression suites), tsc/eslint/prettier clean, production build green.

Found by Codex final review, fixed by Codex + Claude (session recovery after upstream disconnects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)