### PR TITLE
fix(document): review P1 pair — no-lock backup coverage + clear generation fence

### DIFF
--- a/lib/document-store/index.ts
+++ b/lib/document-store/index.ts
@@ -19,11 +19,13 @@ export {
   mutateDocument,
   withDocumentLock,
   DocumentLockUnavailableError,
+  DocumentStorageGenerationChangedError,
   type DocumentAccessResult,
   type DocumentMigrationDeps,
   type LegacyDocumentSnapshot,
   type LegacyDocumentStore,
 } from './migration';
+export { bumpGeneration, readGeneration } from './storage-generation';
 export {
   clearCurrentScene,
   loadCurrentScene,

--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -23,6 +23,7 @@ import {
   type CurrentSceneValue,
 } from './current-scene';
 import type { AppDocument, AppDocumentOutline, AppStage } from './persistence-types';
+import { readGeneration } from './storage-generation';
 import { getDocumentStore } from './store';
 import { validateAppScene, validateAppStage } from './validators';
 
@@ -42,6 +43,8 @@ export interface DocumentMigrationDeps {
   kv?: KVStore;
   legacyStore?: LegacyDocumentStore;
   lockManager?: LockManager | null;
+  /** The mutation callback acquires the runtime shared epoch before writing. */
+  storageSharedLockHeld?: boolean;
 }
 
 export interface DocumentAccessResult {
@@ -57,6 +60,15 @@ interface MigrationMarker {
 }
 
 export class DocumentLockUnavailableError extends Error {}
+
+export class DocumentStorageGenerationChangedError extends Error {
+  constructor(stageId: string) {
+    super(
+      `Document ${JSON.stringify(stageId)} was not saved because storage was cleared during the mutation`,
+    );
+    this.name = 'DocumentStorageGenerationChangedError';
+  }
+}
 
 const MARKER_PREFIX = 'document-migration:';
 let defaultKv: KVStore | undefined;
@@ -213,6 +225,7 @@ async function finishMigrationMetadata(
 async function migrateLocked(
   stageId: string,
   deps: DocumentMigrationDeps,
+  expectedGeneration: number,
 ): Promise<DocumentAccessResult> {
   // Lock order: the per-stage document lock is acquired by the caller before
   // this global shared epoch. This matches the established per-stage -> global
@@ -245,6 +258,9 @@ async function migrateLocked(
     const snapshot = await getLegacyDocumentStore(deps).read(stageId);
     if (!snapshot) return { document: null, readOnlyLegacy: false };
     const expected = canonicalize(snapshot);
+    if ((await readGeneration(deps.kv)) !== expectedGeneration) {
+      throw new DocumentStorageGenerationChangedError(stageId);
+    }
     await store.saveDocument(expected);
     const actual = await store.loadDocument(stageId);
     if (!actual) throw new Error(`Legacy migration lost document ${JSON.stringify(stageId)}`);
@@ -255,13 +271,42 @@ async function migrateLocked(
   });
 }
 
+function generationGuardedStore(
+  stageId: string,
+  expectedGeneration: number,
+  deps: DocumentMigrationDeps,
+): DocumentStore<AppScene, AppStage> {
+  const store = resolveStore(deps);
+  return new Proxy(store, {
+    get(target, property) {
+      if (property === 'saveDocument') {
+        const save = async (document: AppDocument): Promise<void> => {
+          if ((await readGeneration(deps.kv)) !== expectedGeneration) {
+            throw new DocumentStorageGenerationChangedError(stageId);
+          }
+          await target.saveDocument(document);
+        };
+        return deps.storageSharedLockHeld
+          ? save
+          : (document: AppDocument) => withRuntimeStorageSharedLock(() => save(document));
+      }
+      const value = Reflect.get(target, property, target) as unknown;
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
 /** Load the authoritative destination, lazily migrating one coherent legacy snapshot. */
 export async function accessDocument(
   stageId: string,
   deps: DocumentMigrationDeps = {},
 ): Promise<DocumentAccessResult> {
   try {
-    return await withDocumentLock(stageId, () => migrateLocked(stageId, deps), deps);
+    return await withDocumentLock(
+      stageId,
+      async () => migrateLocked(stageId, deps, await readGeneration(deps.kv)),
+      deps,
+    );
   } catch (error) {
     if (!(error instanceof DocumentLockUnavailableError)) throw error;
     const destination = await resolveStore(deps).loadDocument(stageId);
@@ -285,9 +330,11 @@ export function mutateDocument<T>(
   work: (document: AppDocument | null, store: DocumentStore<AppScene, AppStage>) => Promise<T>,
   deps: DocumentMigrationDeps = {},
 ): Promise<T> {
+  const entryGeneration = readGeneration(deps.kv);
   const mutateLocked = async (): Promise<T> => {
-    const access = await migrateLocked(stageId, deps);
-    return work(access.document, resolveStore(deps));
+    const expectedGeneration = await entryGeneration;
+    const access = await migrateLocked(stageId, deps, expectedGeneration);
+    return work(access.document, generationGuardedStore(stageId, expectedGeneration, deps));
   };
   return withDocumentLock(stageId, mutateLocked, deps).catch(async (error: unknown) => {
     if (!(error instanceof DocumentLockUnavailableError)) throw error;
@@ -300,10 +347,12 @@ export function mutateDocument<T>(
     const destination = await store.loadDocument(stageId);
     if (destination) {
       assertValidDestination(stageId, destination);
-      return work(destination, store);
+      const expectedGeneration = await entryGeneration;
+      return work(destination, generationGuardedStore(stageId, expectedGeneration, deps));
     }
     if (await getLegacyDocumentStore(deps).read(stageId)) throw error;
-    return work(null, store);
+    const expectedGeneration = await entryGeneration;
+    return work(null, generationGuardedStore(stageId, expectedGeneration, deps));
   });
 }
 

--- a/lib/document-store/storage-generation.ts
+++ b/lib/document-store/storage-generation.ts
@@ -1,0 +1,26 @@
+import { BrowserKVStore, type KVStore } from '@openmaic/storage';
+
+const STORAGE_GENERATION_KEY = 'document-storage-generation';
+let defaultKv: KVStore | undefined;
+
+function resolveKv(kv?: KVStore): KVStore {
+  if (kv) return kv;
+  if (typeof localStorage === 'undefined') {
+    throw new Error('Document storage generation requires localStorage (client-only)');
+  }
+  return (defaultKv ??= new BrowserKVStore());
+}
+
+export async function readGeneration(kv?: KVStore): Promise<number> {
+  const generation = await resolveKv(kv).get<unknown>(STORAGE_GENERATION_KEY, 'device');
+  return typeof generation === 'number' && Number.isSafeInteger(generation) && generation >= 0
+    ? generation
+    : 0;
+}
+
+export async function bumpGeneration(kv?: KVStore): Promise<number> {
+  const store = resolveKv(kv);
+  const generation = (await readGeneration(store)) + 1;
+  await store.set(STORAGE_GENERATION_KEY, generation, 'device');
+  return generation;
+}

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -1,4 +1,5 @@
 import Dexie, { type EntityTable, type Table } from 'dexie';
+import { DSL_VERSION } from '@openmaic/dsl';
 import type {
   Scene,
   SceneType,
@@ -514,6 +515,8 @@ export async function clearDatabase(runtimeStore?: RuntimeStore): Promise<void> 
   // earlier best-effort stage deletion. This user-requested destructive action
   // must fail loud: reporting success while runtime data remains is misleading.
   await withRuntimeStorageExclusiveLock(async () => {
+    const { bumpGeneration } = await import('@/lib/document-store/storage-generation');
+    await bumpGeneration();
     await (runtimeStore ?? getRuntimeStore()).deleteAllRuntime();
     await deleteAllDocuments();
     await clearDocumentStoreKeys();
@@ -566,17 +569,43 @@ export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Prom
   chatSessions: ChatSessionRecord[];
   playbackState: PlaybackStateRecord[];
 }> {
-  const { accessDocument, getDocumentStore, getLegacyDocumentStore } =
-    await import('@/lib/document-store');
+  const {
+    accessDocument,
+    canonicalizeLegacyOutline,
+    canonicalizeLegacyScene,
+    canonicalizeLegacyStage,
+    getDocumentStore,
+    getLegacyDocumentStore,
+  } = await import('@/lib/document-store');
   const documentStore = getDocumentStore();
   // Backups must not strand courses that have not yet been opened since cutover.
   // Route them through the normal lazy-migration seam before enumerating aggregates.
   const legacyStages = await getLegacyDocumentStore().listStages();
   await Promise.all(legacyStages.map((stage) => accessDocument(stage.id)));
   const summaries = await documentStore.listDocuments();
-  const documents = (
+  const storedDocuments = (
     await Promise.all(summaries.map((summary) => documentStore.loadDocument(summary.id)))
   ).filter((document): document is AppDocument => document !== null);
+  const storedIds = new Set(summaries.map((summary) => summary.id));
+  const legacyOnlyDocuments = (
+    await Promise.all(
+      legacyStages
+        .filter((stage) => !storedIds.has(stage.id))
+        .map(async (stage): Promise<AppDocument | null> => {
+          const snapshot = await getLegacyDocumentStore().read(stage.id);
+          if (!snapshot) return null;
+          const { stage: canonicalStage } = canonicalizeLegacyStage(snapshot.stage);
+          const document: AppDocument = {
+            stage: canonicalStage,
+            scenes: snapshot.scenes.map(canonicalizeLegacyScene).sort((a, b) => a.order - b.order),
+            dslVersion: DSL_VERSION,
+          };
+          if (snapshot.outline) document.outline = canonicalizeLegacyOutline(snapshot.outline);
+          return document;
+        }),
+    )
+  ).filter((document): document is AppDocument => document !== null);
+  const documents = [...storedDocuments, ...legacyOnlyDocuments];
   const legacyChatMap = new Map<string, ChatSessionRecord>();
   for (const session of [
     ...(await db.chatSessions.toArray()),
@@ -588,7 +617,7 @@ export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Prom
   const { loadChatSessions } = await import('./chat-storage');
   const runtimeChats = (
     await Promise.all(
-      documents.map(async ({ stage }) =>
+      storedDocuments.map(async ({ stage }) =>
         (
           await loadChatSessions(stage.id, {
             ...chatOptions,

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -65,55 +65,60 @@ export interface StageListItem {
 export async function saveStageData(stageId: string, data: StageStoreData): Promise<void> {
   try {
     const now = Date.now();
-    await mutateDocument(stageId, async (existing, store) => {
-      // Lock order: per-stage document lock, then the global runtime epoch.
-      // Maintenance may wait for this save, but this save never waits on a
-      // document lock while already occupying the shared epoch.
-      await withRuntimeStorageSharedLock(async () => {
-        const existingOutline = existing?.outline as AppDocumentOutline | undefined;
-        const outline = data.outline ??
-          existingOutline ?? {
-            outlines: [],
-            createdAt: now,
-            updatedAt: now,
-          };
-        await store.saveDocument({
-          stage: {
-            ...data.stage,
-            id: stageId,
-            name: data.stage.name || 'Untitled Stage',
-            createdAt: data.stage.createdAt || now,
-            updatedAt: now,
-          },
-          scenes: data.scenes.map((scene, index) => ({
-            ...scene,
-            stageId,
-            order: scene.order ?? index,
-            createdAt: scene.createdAt || now,
-            updatedAt: scene.updatedAt || now,
-          })),
-          outline: {
-            ...outline,
-            createdAt: existingOutline?.createdAt ?? outline.createdAt,
-          },
-        });
-        await saveCurrentScene(stageId, data.currentSceneId);
+    await mutateDocument(
+      stageId,
+      async (existing, store) => {
+        // Lock order: per-stage document lock, then the global runtime epoch.
+        // Maintenance may wait for this save, but this save never waits on a
+        // document lock while already occupying the shared epoch.
+        await withRuntimeStorageSharedLock(async () => {
+          const existingOutline = existing?.outline as AppDocumentOutline | undefined;
+          const outline = data.outline ??
+            existingOutline ?? {
+              outlines: [],
+              createdAt: now,
+              updatedAt: now,
+            };
+          await store.saveDocument({
+            stage: {
+              ...data.stage,
+              id: stageId,
+              name: data.stage.name || 'Untitled Stage',
+              createdAt: data.stage.createdAt || now,
+              updatedAt: now,
+            },
+            scenes: data.scenes.map((scene, index) => ({
+              ...scene,
+              stageId,
+              order: scene.order ?? index,
+              createdAt: scene.createdAt || now,
+              updatedAt: scene.updatedAt || now,
+            })),
+            outline: {
+              ...outline,
+              createdAt: existingOutline?.createdAt ?? outline.createdAt,
+            },
+          });
+          await saveCurrentScene(stageId, data.currentSceneId);
 
-        // Chat sessions live in the learner RuntimeStore, outside the document DB.
-        if (data.chats) {
-          try {
-            await saveChatSessions(stageId, data.chats, {
-              globalLockHeld: true,
-              snapshot: data.chatSnapshot,
-            });
-          } catch (error) {
-            const unchangedSnapshot = isEqual(data.chatSnapshot?.sessions ?? [], data.chats);
-            if (error instanceof ChatStorageLockUnavailableError && !unchangedSnapshot) throw error;
-            log.warn(`Document saved but chat sessions failed for stage ${stageId}:`, error);
+          // Chat sessions live in the learner RuntimeStore, outside the document DB.
+          if (data.chats) {
+            try {
+              await saveChatSessions(stageId, data.chats, {
+                globalLockHeld: true,
+                snapshot: data.chatSnapshot,
+              });
+            } catch (error) {
+              const unchangedSnapshot = isEqual(data.chatSnapshot?.sessions ?? [], data.chats);
+              if (error instanceof ChatStorageLockUnavailableError && !unchangedSnapshot)
+                throw error;
+              log.warn(`Document saved but chat sessions failed for stage ${stageId}:`, error);
+            }
           }
-        }
-      });
-    });
+        });
+      },
+      { storageSharedLockHeld: true },
+    );
     log.info(`Saved stage: ${stageId}`);
   } catch (error) {
     log.error('Failed to save stage:', error);

--- a/tests/runtime/database-chat-cutover.test.ts
+++ b/tests/runtime/database-chat-cutover.test.ts
@@ -574,6 +574,71 @@ describe('database runtime chat integration', () => {
     await expect(migrating).resolves.toBeNull();
   });
 
+  it('rejects a stage save that resumes after a database clear and allows a fresh save', async () => {
+    vi.stubGlobal('navigator', { locks: fairLockManager() });
+    const runtimeStore = new BrowserRuntimeStore({
+      indexedDB: globalThis.indexedDB,
+      dbName: 'clear-document-save-race',
+    });
+    const { clearDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
+    const { saveStageData } = await import('@/lib/utils/stage-storage');
+    const documentStore = getDocumentStore();
+    const stage = {
+      id: 'stage-clear-save-race',
+      name: 'Before clear',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    await documentStore.saveDocument({ stage, scenes: [] });
+
+    let releaseMigrationLoad!: () => void;
+    const migrationLoadGate = new Promise<void>((resolve) => {
+      releaseMigrationLoad = resolve;
+    });
+    let migrationLoadEntered!: () => void;
+    const migrationLoadStarted = new Promise<void>((resolve) => {
+      migrationLoadEntered = resolve;
+    });
+    const originalLoad = documentStore.loadDocument.bind(documentStore);
+    let gateNextLoad = true;
+    vi.spyOn(documentStore, 'loadDocument').mockImplementation(async (stageId) => {
+      const document = await originalLoad(stageId);
+      if (stageId === stage.id && gateNextLoad) {
+        gateNextLoad = false;
+        migrationLoadEntered();
+        await migrationLoadGate;
+      }
+      return document;
+    });
+
+    const staleSave = saveStageData(stage.id, {
+      stage: { ...stage, name: 'Stale save' },
+      scenes: [],
+      currentSceneId: null,
+      chats: [],
+    });
+    await migrationLoadStarted;
+    const clearing = clearDatabase(runtimeStore);
+    releaseMigrationLoad();
+
+    await expect(clearing).resolves.toBeUndefined();
+    await expect(staleSave).rejects.toThrow('storage was cleared during the mutation');
+    await expect(documentStore.loadDocument(stage.id)).resolves.toBeNull();
+
+    await expect(
+      saveStageData(stage.id, {
+        stage: { ...stage, name: 'Fresh save' },
+        scenes: [],
+        currentSceneId: null,
+        chats: [],
+      }),
+    ).resolves.toBeUndefined();
+    await expect(documentStore.loadDocument(stage.id)).resolves.toMatchObject({
+      stage: { name: 'Fresh save' },
+    });
+  });
+
   it('loads a divergent destination without marking or deleting its legacy source', async () => {
     const { db } = await import('@/lib/utils/database');
     const { getDocumentStore } = await import('@/lib/document-store');
@@ -1395,6 +1460,56 @@ describe('database runtime chat integration', () => {
     await expect(
       db.chatSessions.where('stageId').equals('stage-legacy-no-lock').count(),
     ).resolves.toBe(1);
+  });
+
+  it('exports a canonical legacy-only document without Web Locks and leaves legacy data untouched', async () => {
+    vi.stubGlobal('navigator', {});
+    stubMemoryLocalStorage();
+    const runtimeStore = new BrowserRuntimeStore({
+      indexedDB: globalThis.indexedDB,
+      dbName: 'legacy-only-export-no-locks',
+    });
+    const { db, exportDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
+    const stage = {
+      id: 'stage-legacy-only-export',
+      name: 'Legacy-only export',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      currentSceneId: 'scene-legacy-only-export',
+    };
+    const scene = {
+      id: 'scene-legacy-only-export',
+      stageId: stage.id,
+      type: 'quiz' as const,
+      title: 'Legacy scene',
+      order: 0,
+      content: { type: 'slide' as const, canvas: { id: 'canvas-legacy', elements: [] } as never },
+      whiteboard: [{ id: 'whiteboard-legacy', elements: [] } as never],
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    await db.stages.put(stage);
+    await db.scenes.put(scene);
+
+    const backup = await exportDatabase({ store: runtimeStore, learnerKey });
+    const exportedDocument = backup.documents.find((document) => document.stage.id === stage.id);
+
+    expect(exportedDocument).toMatchObject({
+      dslVersion: '0.1.0',
+      stage: { id: stage.id, name: 'Legacy-only export' },
+      scenes: [
+        {
+          id: scene.id,
+          type: 'slide',
+          whiteboards: [{ id: 'whiteboard-legacy' }],
+        },
+      ],
+    });
+    expect(exportedDocument!.stage).not.toHaveProperty('currentSceneId');
+    await expect(getDocumentStore().loadDocument(stage.id)).resolves.toBeNull();
+    await expect(db.stages.get(stage.id)).resolves.toEqual(stage);
+    await expect(db.scenes.get(scene.id)).resolves.toEqual(scene);
   });
 
   it('keeps unrelated document saves available for an unchanged read-only legacy snapshot', async () => {


### PR DESCRIPTION
Fixes both P1s from the cross-vendor review on #965:

- Backup export appends canonicalized read-only aggregates for legacy-only stages when Web Locks are unavailable (migration discipline unchanged — nothing is persisted or marked migrated)
- `clearDatabase` bumps a device-scoped storage generation inside its exclusive section; document saves/migration commits record it at entry and re-check inside the shared epoch immediately before writing, failing loud instead of resurrecting documents into a wiped store

Regression tests for both interleavings; 149 tests green; tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)