### PR TITLE
fix(document): review round 2 — chat backup coverage + full fence

### DIFF
--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -277,18 +277,32 @@ function generationGuardedStore(
   deps: DocumentMigrationDeps,
 ): DocumentStore<AppScene, AppStage> {
   const store = resolveStore(deps);
+  // Every mutating method takes the fence, not just saveDocument: the others
+  // are not currently exploitable after a clear (puts throw on the missing
+  // parent, deletes are idempotent), but that safety is incidental — a future
+  // store method or semantic change must not silently bypass the fence.
+  const MUTATING_METHODS = new Set([
+    'saveDocument',
+    'putStage',
+    'putScene',
+    'deleteScene',
+    'deleteDocument',
+  ]);
   return new Proxy(store, {
     get(target, property) {
-      if (property === 'saveDocument') {
-        const save = async (document: AppDocument): Promise<void> => {
+      if (typeof property === 'string' && MUTATING_METHODS.has(property)) {
+        const method = Reflect.get(target, property, target) as (
+          ...args: unknown[]
+        ) => Promise<unknown>;
+        const guarded = async (...args: unknown[]): Promise<unknown> => {
           if ((await readGeneration(deps.kv)) !== expectedGeneration) {
             throw new DocumentStorageGenerationChangedError(stageId);
           }
-          await target.saveDocument(document);
+          return method.apply(target, args);
         };
         return deps.storageSharedLockHeld
-          ? save
-          : (document: AppDocument) => withRuntimeStorageSharedLock(() => save(document));
+          ? guarded
+          : (...args: unknown[]) => withRuntimeStorageSharedLock(() => guarded(...args));
       }
       const value = Reflect.get(target, property, target) as unknown;
       return typeof value === 'function' ? value.bind(target) : value;

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -615,11 +615,19 @@ export async function exportDatabase(chatOptions: ChatStorageOptions = {}): Prom
   }
   const legacyChats = [...legacyChatMap.values()];
   const { loadChatSessions } = await import('./chat-storage');
+  // Chat sessions live on the learner RuntimeStore — an independent seam from
+  // document migration — so legacy-only documents can still own runtime chat
+  // history. Enumerate chats for EVERY exported document, not just stored ones.
+  // The legacy chat rows are collected separately above by direct table reads,
+  // so the runtime read gets an empty legacy store: it never needs the
+  // cross-realm migration lock and therefore also works without Web Locks
+  // (where the document seam already exports legacy-only courses read-only).
   const runtimeChats = (
     await Promise.all(
-      storedDocuments.map(async ({ stage }) =>
+      documents.map(async ({ stage }) =>
         (
           await loadChatSessions(stage.id, {
+            legacyStore: { load: async () => [], clear: async () => {} },
             ...chatOptions,
             fallbackToLegacyOnError: false,
             observe: false,
@@ -825,42 +833,48 @@ export async function getScenesByStageId(stageId: string): Promise<Scene[]> {
  */
 export async function deleteStageWithRelatedData(stageId: string): Promise<void> {
   const { mutateDocument } = await import('@/lib/document-store');
-  await mutateDocument(stageId, async (_document, store) =>
-    withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
-      await store.deleteDocument(stageId);
-      await db.transaction(
-        'rw',
-        [
-          db.stages,
-          db.scenes,
-          db.chatSessions,
-          db.chatRestoreStaging,
-          db.playbackState,
-          db.stageOutlines,
-          db.mediaFiles,
-          db.generatedAgents,
-          db.agentEditSessions,
-        ],
-        async () => {
-          await db.stages.delete(stageId);
-          await db.scenes.where('stageId').equals(stageId).delete();
-          await db.chatSessions.where('stageId').equals(stageId).delete();
-          await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
-          await db.playbackState.delete(stageId);
-          await db.stageOutlines.delete(stageId);
-          await db.mediaFiles.where('stageId').equals(stageId).delete();
-          await db.generatedAgents.where('stageId').equals(stageId).delete();
-          await db.agentEditSessions.where('stageId').equals(stageId).delete();
-        },
-      );
-      // Learner-runtime data lives in a separate IndexedDB database, so it is
-      // cascaded after the Dexie transaction: it cannot join it, and a runtime
-      // failure must not abort it (the helper warns instead of throwing).
-      const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
-      await runtimeDeletion.completion;
-      releaseCaller(undefined);
-      await runtimeDeletion.settlement;
-    }),
+  // storageSharedLockHeld: the cascade holds the EXCLUSIVE epoch, which
+  // subsumes shared — the generation-guarded store must not re-acquire shared
+  // inside it (self-deadlock against our own exclusive hold).
+  await mutateDocument(
+    stageId,
+    async (_document, store) =>
+      withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
+        await store.deleteDocument(stageId);
+        await db.transaction(
+          'rw',
+          [
+            db.stages,
+            db.scenes,
+            db.chatSessions,
+            db.chatRestoreStaging,
+            db.playbackState,
+            db.stageOutlines,
+            db.mediaFiles,
+            db.generatedAgents,
+            db.agentEditSessions,
+          ],
+          async () => {
+            await db.stages.delete(stageId);
+            await db.scenes.where('stageId').equals(stageId).delete();
+            await db.chatSessions.where('stageId').equals(stageId).delete();
+            await db.chatRestoreStaging.where('stageId').equals(stageId).delete();
+            await db.playbackState.delete(stageId);
+            await db.stageOutlines.delete(stageId);
+            await db.mediaFiles.where('stageId').equals(stageId).delete();
+            await db.generatedAgents.where('stageId').equals(stageId).delete();
+            await db.agentEditSessions.where('stageId').equals(stageId).delete();
+          },
+        );
+        // Learner-runtime data lives in a separate IndexedDB database, so it is
+        // cascaded after the Dexie transaction: it cannot join it, and a runtime
+        // failure must not abort it (the helper warns instead of throwing).
+        const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
+        await runtimeDeletion.completion;
+        releaseCaller(undefined);
+        await runtimeDeletion.settlement;
+      }),
+    { storageSharedLockHeld: true },
   );
 }
 

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -177,73 +177,79 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
  * Delete stage and all related data
  */
 export async function deleteStageData(stageId: string): Promise<void> {
-  return mutateDocument(stageId, async (document, store) =>
-    // Lock order: per-stage document lock, then the exclusive runtime epoch.
-    withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
-      try {
-        // Collect scene ids before deletion so we can sweep per-scene localStorage
-        // keys (quiz draft / submitted answers / graded results).
-        const legacyScenes = await db.scenes.where('stageId').equals(stageId).toArray();
-        const sceneIds = [
-          ...new Set([
-            ...(document?.scenes.map((s) => s.id) ?? []),
-            ...legacyScenes.map((s) => s.id),
-          ]),
-        ];
-
-        await store.deleteDocument(stageId);
-
-        // Clear legacy chat rows and the device-scoped playback cursor. Runtime
-        // rows of every kind are removed by the all-kind cascade below.
-        await deleteChatSessions(stageId);
-        // An unmigrated legacy playback row must not outlive its stage.
-        await db.playbackState.delete(stageId);
+  // storageSharedLockHeld: the cascade below holds the EXCLUSIVE epoch, which
+  // subsumes the shared one — the generation-guarded store must not re-acquire
+  // shared inside it (self-deadlock against our own exclusive hold).
+  return mutateDocument(
+    stageId,
+    async (document, store) =>
+      // Lock order: per-stage document lock, then the exclusive runtime epoch.
+      withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
         try {
-          await clearCursor(stageId);
+          // Collect scene ids before deletion so we can sweep per-scene localStorage
+          // keys (quiz draft / submitted answers / graded results).
+          const legacyScenes = await db.scenes.where('stageId').equals(stageId).toArray();
+          const sceneIds = [
+            ...new Set([
+              ...(document?.scenes.map((s) => s.id) ?? []),
+              ...legacyScenes.map((s) => s.id),
+            ]),
+          ];
+
+          await store.deleteDocument(stageId);
+
+          // Clear legacy chat rows and the device-scoped playback cursor. Runtime
+          // rows of every kind are removed by the all-kind cascade below.
+          await deleteChatSessions(stageId);
+          // An unmigrated legacy playback row must not outlive its stage.
+          await db.playbackState.delete(stageId);
+          try {
+            await clearCursor(stageId);
+          } catch (error) {
+            log.warn(`Failed to clear playback cursor for stage ${stageId}:`, error);
+          }
+          try {
+            await clearCurrentScene(stageId);
+          } catch (error) {
+            log.warn(`Failed to clear editor current scene for stage ${stageId}:`, error);
+          }
+
+          // Sweep quiz persistence keys for each deleted scene.
+          for (const sceneId of sceneIds) {
+            clearAllForScene(sceneId);
+          }
+
+          // Migration retains legacy rows, but an explicit whole-stage deletion does not.
+          await db.transaction('rw', [db.stages, db.scenes, db.stageOutlines], async () => {
+            await db.stages.delete(stageId);
+            await db.scenes.where('stageId').equals(stageId).delete();
+            await db.stageOutlines.delete(stageId);
+          });
+
+          // Learner-runtime data lives in a separate IndexedDB database, so it is
+          // cascaded after the Dexie work: it cannot join those transactions, and a
+          // runtime failure must not abort them (the helper warns instead of
+          // throwing).
+          const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
+          await runtimeDeletion.completion;
+          try {
+            await clearStageDrainWatermarks(stageId);
+          } catch (error) {
+            log.warn(`Failed to clear PBL drain watermarks for stage ${stageId}:`, error);
+          }
+
+          log.info(`Deleted stage: ${stageId}`);
+          releaseCaller(undefined);
+          // The public deletion remains bounded, but this callback deliberately
+          // retains the exclusive lock until a late runtime cascade can no longer
+          // delete data written after the caller was released.
+          await runtimeDeletion.settlement;
         } catch (error) {
-          log.warn(`Failed to clear playback cursor for stage ${stageId}:`, error);
+          log.error('Failed to delete stage:', error);
+          throw error;
         }
-        try {
-          await clearCurrentScene(stageId);
-        } catch (error) {
-          log.warn(`Failed to clear editor current scene for stage ${stageId}:`, error);
-        }
-
-        // Sweep quiz persistence keys for each deleted scene.
-        for (const sceneId of sceneIds) {
-          clearAllForScene(sceneId);
-        }
-
-        // Migration retains legacy rows, but an explicit whole-stage deletion does not.
-        await db.transaction('rw', [db.stages, db.scenes, db.stageOutlines], async () => {
-          await db.stages.delete(stageId);
-          await db.scenes.where('stageId').equals(stageId).delete();
-          await db.stageOutlines.delete(stageId);
-        });
-
-        // Learner-runtime data lives in a separate IndexedDB database, so it is
-        // cascaded after the Dexie work: it cannot join those transactions, and a
-        // runtime failure must not abort them (the helper warns instead of
-        // throwing).
-        const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
-        await runtimeDeletion.completion;
-        try {
-          await clearStageDrainWatermarks(stageId);
-        } catch (error) {
-          log.warn(`Failed to clear PBL drain watermarks for stage ${stageId}:`, error);
-        }
-
-        log.info(`Deleted stage: ${stageId}`);
-        releaseCaller(undefined);
-        // The public deletion remains bounded, but this callback deliberately
-        // retains the exclusive lock until a late runtime cascade can no longer
-        // delete data written after the caller was released.
-        await runtimeDeletion.settlement;
-      } catch (error) {
-        log.error('Failed to delete stage:', error);
-        throw error;
-      }
-    }),
+      }),
+    { storageSharedLockHeld: true },
   );
 }
 

--- a/tests/runtime/database-chat-cutover.test.ts
+++ b/tests/runtime/database-chat-cutover.test.ts
@@ -1491,9 +1491,24 @@ describe('database runtime chat integration', () => {
     };
     await db.stages.put(stage);
     await db.scenes.put(scene);
+    // Chat history lives on the RuntimeStore seam, independent of document
+    // migration — a legacy-only document's chats must still reach the backup.
+    // Write it while locks exist, then export from the no-locks environment.
+    vi.stubGlobal('navigator', { locks: serialLockManager() });
+    const { saveChatSessions } = await import('@/lib/utils/chat-storage');
+    await saveChatSessions(stage.id, [{ ...chatSession(), id: 'legacy-only-chat' }], {
+      store: runtimeStore,
+      learnerKey,
+    });
+    vi.stubGlobal('navigator', {});
 
     const backup = await exportDatabase({ store: runtimeStore, learnerKey });
     const exportedDocument = backup.documents.find((document) => document.stage.id === stage.id);
+    expect(
+      backup.chatSessions.filter(
+        (session) => session.stageId === stage.id && session.id === 'legacy-only-chat',
+      ),
+    ).toHaveLength(1);
 
     expect(exportedDocument).toMatchObject({
       dslVersion: '0.1.0',


### PR DESCRIPTION
Round-2 findings from the cross-vendor review on #965:

- **P1**: backup enumerates runtime chats for every exported document (incl. legacy-only) — chat and document migrations are independent seams; empty legacy chat store injected so the export also works without Web Locks
- **P3**: the generation fence covers all mutating store methods; exclusive-epoch delete cascades pass `storageSharedLockHeld` to avoid self-deadlock

151-test surface green, tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)