### PR TITLE
ci: retire completed cutover trunks from the PR whitelist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/maic-editor-v0, feat/maic-editor-v1, runtime-server-backend, integration/runtime-data-cutover, integration/document-cutover]
+    branches: [main, feat/maic-editor-v0, feat/maic-editor-v1, runtime-server-backend]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Both persistence-cutover lines have merged (#955 runtime, #965 document); their integration trunks are deleted, so the whitelist entries are dead. One line, no behavior change for any live branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)