### PR TITLE
feat(storage): DocumentStore HTTP contract + client + server routes (1B PR1)

### DIFF
--- a/packages/@openmaic/storage/docs/document-http-contract.md
+++ b/packages/@openmaic/storage/docs/document-http-contract.md
@@ -1,0 +1,61 @@
+# DocumentStore HTTP contract
+
+This contract exposes the complete `DocumentStore` interface over JSON HTTP. All paths are relative to a deployment-defined base URL. Path segments are percent-encoded UTF-8 strings and MUST NOT be exactly `.` or `..`, because URL parsers normalize dot segments before routing. Request and response bodies use `application/json`; successful writes return `204 No Content`.
+
+## Endpoints
+
+| Method | Path | Purpose | Success |
+| --- | --- | --- | --- |
+| `PUT` | `/documents/{stageId}` | Save the full `MaicDocument`; body `stage.id` must match the path. The store migrates stale input, stamps `dslVersion`, replaces stage/outline data, upserts incoming scenes, and removes omitted scenes atomically. | `204` |
+| `GET` | `/documents/{stageId}` | Load and migrate one complete document. | `200` with `MaicDocument`, or `404 DOCUMENT_NOT_FOUND` |
+| `GET` | `/documents` | List version-independent summaries. | `200` with `DocumentSummary[]` |
+| `DELETE` | `/documents/{stageId}` | Cascade-delete a document, its scenes, and its outline. Idempotent and intentionally not version-guarded. | `204` |
+| `PUT` | `/documents/{stageId}/stage` | Validate and replace the stage row of an existing current-version document; body `id` must match the path. | `204` |
+| `PUT` | `/documents/{stageId}/scenes/{sceneId}` | Validate and upsert a scene in an existing current-version document; body `id` and `stageId` must match the path. | `204` |
+| `GET` | `/documents/{stageId}/scenes/{sceneId}` | Read one scene through the parent document's migrate-on-read semantics. | `200` with the scene, or `404` |
+| `DELETE` | `/documents/{stageId}/scenes/{sceneId}` | Delete one scene. Idempotent for an absent scene or document, but version-guarded when the parent exists. | `204` |
+
+`GET /documents` returns only `id`, `name`, optional `description`, optional `interactiveMode`, optional `taskEngineMode`, `createdAt`, `updatedAt`, and `sceneCount`. Those fields are independent of the DSL version. Implementations MUST NOT migrate document content to produce this list and MUST tolerate an unknown or malformed stored version stamp.
+
+## Validation, versions, and JSON
+
+Servers run their configured `validateStage` and `validateScene` gates before writes. A full save validates the migrated aggregate and rejects duplicate scene ids, mismatched scene partitions, and non-finite order values before changing storage. `putStage` and `putScene` repeat the same boundary validation and require an existing document whose stored `dslVersion` is exactly the server's current `DSL_VERSION`. A stale document must first be loaded and saved as a full aggregate; a future document must never be downgraded. `deleteScene` has the same current-version guard, while whole-document deletion deliberately does not.
+
+HTTP implementations carry data through JSON and therefore accept only plain values that serialize without changing meaning. They fail before sending or storing values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, `undefined`, `bigint`, sparse arrays, class instances, symbol/non-enumerable properties, U+0000 strings, and circular references. The opaque outline is not DSL-validated or migrated, but it is still subject to this JSON transport rule.
+
+Reads are migrated on both sides of the wire. The backing store performs its normal migrate-on-read, and the HTTP client migrates the returned document again so an older server cannot leak a stale envelope into a newer application. The opaque outline is removed before DSL migration and reattached unchanged.
+
+## Authentication and authorization
+
+Documents are author assets, not learner-partitioned data. The contract does not prescribe a tenant or ownership model; deployments enforce their policy through the injected `authenticate` and `authorizeDocuments` hooks. The reference handler requires an authenticated principal for every document route. Its default authorization permits any authenticated principal; production deployments can supply `authorizeDocuments` to apply author, tenant, role, or document-level policy.
+
+## Errors
+
+Every non-2xx response has a machine-readable JSON body:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "@openmaic/storage: invalid stage ...",
+    "details": []
+  }
+}
+```
+
+`details` is optional. Messages retain backing-store semantics so the client exposes the same useful wording as `BrowserDocumentStore`.
+
+| Condition | HTTP status | Error code | Client behavior |
+| --- | --- | --- | --- |
+| Malformed JSON, invalid stage/scene/document, body/path mismatch, non-JSON value, duplicate scene id, or stale incremental write | `400` | `VALIDATION_FAILED` | Throw `HttpDocumentStoreError` with the server message |
+| Document does not exist | `404` | `DOCUMENT_NOT_FOUND` | `loadDocument` returns `null`; required-parent writes throw with `missing document` semantics |
+| Scene does not exist | `404` | `SCENE_NOT_FOUND` | `getScene` returns `null` |
+| Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpDocumentStoreError` |
+| Input or stored document was written at a future DSL version | `409` | `FUTURE_VERSION` | Throw `HttpDocumentStoreError` with `newer than this client's`/version-guard semantics |
+| Unexpected server failure | `500` | `INTERNAL_ERROR` | Throw `HttpDocumentStoreError`; the reference handler does not expose internal details |
+
+Only the machine-readable not-found codes are translated to `null`. Status alone is not sufficient. Authentication failures use `401 UNAUTHENTICATED`, and authorization failures use `403 FORBIDDEN_DOCUMENTS`.
+
+## Retry and atomicity guarantees
+
+Full saves are atomic: validation or any failed child write leaves the previous aggregate untouched. `DELETE /documents/{stageId}` and scene deletion are safely retryable. Stage and scene puts are idempotent for the same body, subject to the current-version guard. The contract does not add conditional requests or idempotency keys; deployments that retry an ambiguous full save must rely on the caller-owned `stageId` and replacement semantics.

--- a/packages/@openmaic/storage/docs/reference-server.md
+++ b/packages/@openmaic/storage/docs/reference-server.md
@@ -13,7 +13,7 @@ DATABASE_URL=postgres://user:password@host/database PORT=3000 \
   node packages/@openmaic/storage/dist/server/reference.js
 ```
 
-The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` only creates and returns an unbound Node `Server`. The default bearer token payload is used directly as the demo `learnerKey`, self-merge is the only allowed merge, and admin operations are denied. The factory accepts optional `authenticate`, `authorizeMerge`, `authorizeAdmin`, and `payloadValidators` overrides. Replace the three policy hooks before exposing a deployment:
+The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` only creates and returns an unbound Node `Server`. The default bearer token payload is used directly as the demo `learnerKey`, self-merge is the only allowed merge, and admin operations are denied. Supplying `documentStore` adds the DocumentStore routes to that same server; any authenticated principal is allowed by default, or `authorizeDocuments` can enforce deployment policy. The factory also accepts `authenticate`, `authorizeMerge`, `authorizeAdmin`, and validator overrides. Replace the policy hooks before exposing a deployment:
 
 - `authenticate(req)` must validate a real credential and derive the canonical learner partition from server-controlled identity state.
 - `authorizeMerge(principal, fromKey, toKey)` must explicitly establish that the principal may migrate the complete source partition into the destination identity. Default denial is intentional.

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/runtime/http.d.ts",
       "import": "./dist/runtime/http.js"
     },
+    "./document/http": {
+      "types": "./dist/document/http.d.ts",
+      "import": "./dist/document/http.js"
+    },
     "./runtime/pg": {
       "types": "./dist/runtime/pg.d.ts",
       "import": "./dist/runtime/pg.js"

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -1,0 +1,260 @@
+import { migrate, validateScene, validateStage } from '@openmaic/dsl';
+import type { Scene, Stage } from '@openmaic/dsl';
+import { assertJsonValue } from '../runtime/json-value.js';
+import type {
+  DocumentStore,
+  DocumentSummary,
+  MaicDocument,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from './types.js';
+
+export interface HttpDocumentHeadersContext {
+  method: string;
+  path: string;
+}
+
+export type HttpDocumentHeadersHook = (
+  context: HttpDocumentHeadersContext,
+) => HeadersInit | Promise<HeadersInit>;
+
+export interface HttpDocumentStoreOptions {
+  /** Root URL before the contract's `/documents/...` paths. */
+  baseUrl: string;
+  /** Fetch implementation. Defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch;
+  /** Called for every request so deployments can attach authentication headers. */
+  headers?: HttpDocumentHeadersHook;
+  /** Client-side scene validator. Defaults to the DSL validator. */
+  validateScene?: SceneValidator;
+  /** Client-side stage validator. Defaults to the DSL validator. */
+  validateStage?: StageValidator;
+}
+
+interface ErrorResponseBody {
+  error?: { code?: unknown; message?: unknown; details?: unknown };
+}
+
+/** A server-side DocumentStore failure, retaining its machine-readable HTTP identity. */
+export class HttpDocumentStoreError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HttpDocumentStoreError';
+  }
+}
+
+function assertAddressableSegment(value: string): void {
+  if (value === '.' || value === '..') {
+    throw new Error(`@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`);
+  }
+}
+
+function segment(value: string): string {
+  assertAddressableSegment(value);
+  return encodeURIComponent(value);
+}
+
+function assertValid(result: ReturnType<StageValidator>, label: string): void {
+  if (result.valid) return;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new Error(`@openmaic/storage: invalid ${label}: ${detail}`);
+}
+
+function assertStorableScene(scene: SceneLike, stageId: string): void {
+  const value = scene as { id: unknown; stageId: unknown; order: unknown };
+  if (typeof value.id !== 'string') {
+    throw new Error(
+      `@openmaic/storage: scene id must be a string, got ${JSON.stringify(value.id)}`,
+    );
+  }
+  if (value.stageId !== stageId) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} has stageId ` +
+        `${JSON.stringify(value.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
+    );
+  }
+  if (typeof value.order !== 'number' || !Number.isFinite(value.order)) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} order must be a finite number, got ` +
+        `${JSON.stringify(value.order)}`,
+    );
+  }
+}
+
+function normalizeHeaders(init: HeadersInit | undefined): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  const set = (name: string, value: string): void => {
+    normalized[name.toLowerCase()] = value;
+  };
+  if (init === undefined) return normalized;
+  if (Array.isArray(init)) {
+    for (const [name, value] of init) set(name, value);
+  } else if (typeof (init as Headers).forEach === 'function') {
+    (init as Headers).forEach((value, name) => set(name, value));
+  } else {
+    for (const [name, value] of Object.entries(init)) set(name, value);
+  }
+  return normalized;
+}
+
+function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
+  document: MaicDocument<TScene, TStage>,
+): MaicDocument<TScene, TStage> {
+  const { outline, ...core } = document;
+  const migrated = migrate(core) as MaicDocument<TScene, TStage>;
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
+export class HttpDocumentStore<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+> implements DocumentStore<TScene, TStage> {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly headersHook: HttpDocumentHeadersHook | undefined;
+  private readonly sceneValidator: SceneValidator;
+  private readonly stageValidator: StageValidator;
+
+  constructor(options: HttpDocumentStoreOptions) {
+    if (options.baseUrl === '') {
+      throw new Error('@openmaic/storage: HttpDocumentStore baseUrl must be non-empty');
+    }
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('@openmaic/storage: HttpDocumentStore requires a fetch implementation');
+    }
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = fetchImpl;
+    this.headersHook = options.headers;
+    this.sceneValidator = options.validateScene ?? validateScene;
+    this.stageValidator = options.validateStage ?? validateStage;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const headers = normalizeHeaders(await this.headersHook?.({ method, path }));
+    let serializedBody: string | undefined;
+    if (body !== undefined) {
+      headers['content-type'] ??= 'application/json';
+      serializedBody = JSON.stringify(body);
+    }
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      ...(serializedBody === undefined ? {} : { body: serializedBody }),
+    });
+    if (!response.ok) {
+      let errorBody: ErrorResponseBody | undefined;
+      try {
+        errorBody = (await response.json()) as ErrorResponseBody;
+      } catch {
+        // Preserve a useful typed error even for a non-conforming server.
+      }
+      const code = typeof errorBody?.error?.code === 'string' ? errorBody.error.code : 'HTTP_ERROR';
+      const message =
+        typeof errorBody?.error?.message === 'string'
+          ? errorBody.error.message
+          : `@openmaic/storage: DocumentStore HTTP request failed with status ${response.status}`;
+      throw new HttpDocumentStoreError(response.status, code, message);
+    }
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  private validateSceneForWrite(stageId: string, scene: TScene): void {
+    assertValid(this.sceneValidator(scene), `scene ${scene.id}`);
+    assertStorableScene(scene, stageId);
+  }
+
+  async saveDocument(document: MaicDocument<TScene, TStage>): Promise<void> {
+    // The server repeats these checks. Running the injected gates here matches
+    // BrowserDocumentStore's fail-fast boundary and avoids avoidable wire calls.
+    const normalized = migrateDocument(document);
+    assertValid(this.stageValidator(normalized.stage), `stage ${normalized.stage.id}`);
+    const seen = new Set<string>();
+    for (const scene of normalized.scenes) {
+      this.validateSceneForWrite(normalized.stage.id, scene);
+      if (seen.has(scene.id)) {
+        throw new Error(
+          `@openmaic/storage: duplicate scene id ${JSON.stringify(scene.id)} in document ` +
+            JSON.stringify(normalized.stage.id),
+        );
+      }
+      seen.add(scene.id);
+    }
+    assertJsonValue(document, `document ${JSON.stringify(document.stage.id)}`);
+    await this.request<void>('PUT', `/documents/${segment(document.stage.id)}`, document);
+  }
+
+  async loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null> {
+    try {
+      const document = await this.request<MaicDocument<TScene, TStage>>(
+        'GET',
+        `/documents/${segment(stageId)}`,
+      );
+      return migrateDocument(document);
+    } catch (error) {
+      if (error instanceof HttpDocumentStoreError && error.code === 'DOCUMENT_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async listDocuments(): Promise<DocumentSummary[]> {
+    const summaries = await this.request<unknown>('GET', '/documents');
+    if (!Array.isArray(summaries)) {
+      throw new HttpDocumentStoreError(
+        200,
+        'MALFORMED_RESPONSE',
+        '@openmaic/storage: DocumentStore HTTP listDocuments response must be an array',
+      );
+    }
+    return summaries as DocumentSummary[];
+  }
+
+  async deleteDocument(stageId: string): Promise<void> {
+    await this.request<void>('DELETE', `/documents/${segment(stageId)}`);
+  }
+
+  async putStage(stageId: string, stage: TStage): Promise<void> {
+    assertValid(this.stageValidator(stage), `stage ${stage.id}`);
+    assertJsonValue(stage, `stage ${JSON.stringify(stage.id)}`);
+    await this.request<void>('PUT', `/documents/${segment(stageId)}/stage`, stage);
+  }
+
+  async putScene(stageId: string, scene: TScene): Promise<void> {
+    this.validateSceneForWrite(stageId, scene);
+    assertJsonValue(scene, `scene ${JSON.stringify(scene.id)}`);
+    await this.request<void>(
+      'PUT',
+      `/documents/${segment(stageId)}/scenes/${segment(scene.id)}`,
+      scene,
+    );
+  }
+
+  async getScene(stageId: string, sceneId: string): Promise<TScene | null> {
+    try {
+      return await this.request<TScene>(
+        'GET',
+        `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`,
+      );
+    } catch (error) {
+      if (
+        error instanceof HttpDocumentStoreError &&
+        (error.code === 'DOCUMENT_NOT_FOUND' || error.code === 'SCENE_NOT_FOUND')
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async deleteScene(stageId: string, sceneId: string): Promise<void> {
+    await this.request<void>('DELETE', `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`);
+  }
+}

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -33,6 +33,13 @@ export type {
   StageValidator,
 } from './document/types.js';
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
+export {
+  HttpDocumentStore,
+  HttpDocumentStoreError,
+  type HttpDocumentHeadersContext,
+  type HttpDocumentHeadersHook,
+  type HttpDocumentStoreOptions,
+} from './document/http.js';
 
 export type {
   RuntimeStore,

--- a/packages/@openmaic/storage/src/server/document.ts
+++ b/packages/@openmaic/storage/src/server/document.ts
@@ -1,0 +1,424 @@
+import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http';
+import {
+  DSL_VERSION,
+  dslVersionOf,
+  migrate,
+  needsMigration,
+  validateScene,
+  validateStage,
+} from '@openmaic/dsl';
+import type { Scene, Stage, ValidationResult } from '@openmaic/dsl';
+import { assertJsonValue } from '../runtime/json-value.js';
+import type {
+  DocumentStore,
+  MaicDocument,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from '../document/types.js';
+
+export interface DocumentHttpPrincipal {
+  learnerKey?: string;
+}
+
+export type DocumentHttpAuthenticate = (
+  req: IncomingMessage,
+) => Promise<DocumentHttpPrincipal | undefined>;
+
+export type DocumentHttpAuthorize = (
+  principal: DocumentHttpPrincipal,
+  req: IncomingMessage,
+) => boolean | Promise<boolean>;
+
+export interface DocumentHttpHandlerOptions {
+  authenticate: DocumentHttpAuthenticate;
+  /** Defaults to allowing any authenticated principal. */
+  authorizeDocuments?: DocumentHttpAuthorize;
+  /** Whole-validator replacement; pass the same validator configured on the store. */
+  validateScene?: SceneValidator;
+  /** Whole-validator replacement; pass the same validator configured on the store. */
+  validateStage?: StageValidator;
+}
+
+interface ErrorBody {
+  error: { code: string; message: string; details?: unknown };
+}
+
+class DocumentHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function sendNoContent(res: ServerResponse): void {
+  res.writeHead(204);
+  res.end();
+}
+
+function validationFailure(message: string, details?: unknown): DocumentHttpError {
+  return new DocumentHttpError(400, 'VALIDATION_FAILED', message, details);
+}
+
+async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req)
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  if (chunks.length === 0) throw validationFailure('request body must be a JSON object');
+  let body: unknown;
+  try {
+    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw validationFailure('request body must be a JSON object');
+  }
+  return body as Record<string, unknown>;
+}
+
+function validationError(result: ValidationResult, label: string): void {
+  if (result.valid) return;
+  const details = result.errors;
+  const detail = details.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw validationFailure(`@openmaic/storage: invalid ${label}: ${detail}`, details);
+}
+
+function assertAddressableSegment(value: string): void {
+  if (value === '.' || value === '..') {
+    throw validationFailure(
+      `@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+function assertJsonRequestValue(value: unknown, label: string): void {
+  try {
+    assertJsonValue(value, label);
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function parsePath(req: IncomingMessage): string[] {
+  try {
+    return new URL(req.url ?? '/', 'http://documents.invalid').pathname
+      .split('/')
+      .filter((part, index) => index !== 0 || part !== '')
+      .map((part) => decodeURIComponent(part));
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function missingDocument(stageId: string): DocumentHttpError {
+  return new DocumentHttpError(
+    404,
+    'DOCUMENT_NOT_FOUND',
+    `@openmaic/storage: missing document ${JSON.stringify(stageId)}`,
+  );
+}
+
+function missingScene(stageId: string, sceneId: string): DocumentHttpError {
+  return new DocumentHttpError(
+    404,
+    'SCENE_NOT_FOUND',
+    `@openmaic/storage: no scene ${JSON.stringify(sceneId)} in document ${JSON.stringify(stageId)}`,
+  );
+}
+
+function isFutureVersioned(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  return !needsMigration(value) && dslVersionOf(value) !== DSL_VERSION;
+}
+
+function futureVersion(message: string): DocumentHttpError {
+  return new DocumentHttpError(409, 'FUTURE_VERSION', message);
+}
+
+function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
+  document: MaicDocument<TScene, TStage>,
+): MaicDocument<TScene, TStage> {
+  const { outline, ...core } = document;
+  let migrated: MaicDocument<TScene, TStage>;
+  try {
+    migrated = migrate(core) as MaicDocument<TScene, TStage>;
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
+function assertStorableScene(scene: unknown, stageId: string): asserts scene is SceneLike {
+  const value =
+    typeof scene === 'object' && scene !== null
+      ? (scene as { id?: unknown; stageId?: unknown; order?: unknown })
+      : { id: undefined, stageId: undefined, order: undefined };
+  if (typeof value.id !== 'string') {
+    throw validationFailure(
+      `@openmaic/storage: scene id must be a string, got ${JSON.stringify(value.id)}`,
+    );
+  }
+  if (value.stageId !== stageId) {
+    throw validationFailure(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} has stageId ` +
+        `${JSON.stringify(value.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
+    );
+  }
+  if (typeof value.order !== 'number' || !Number.isFinite(value.order)) {
+    throw validationFailure(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} order must be a finite number, got ` +
+        `${JSON.stringify(value.order)}`,
+    );
+  }
+}
+
+function validateDocument<TScene extends SceneLike, TStage extends Stage>(
+  body: Record<string, unknown>,
+  pathStageId: string,
+  sceneValidator: SceneValidator,
+  stageValidator: StageValidator,
+): MaicDocument<TScene, TStage> {
+  if (typeof body.stage !== 'object' || body.stage === null || !Array.isArray(body.scenes)) {
+    throw validationFailure('document requires an object stage and a scenes array');
+  }
+  const document = body as unknown as MaicDocument<TScene, TStage>;
+  if (isFutureVersioned(document)) {
+    throw futureVersion(
+      `@openmaic/storage: refusing to save document ${JSON.stringify(pathStageId)} — it was ` +
+        `written at DSL version ${JSON.stringify(dslVersionOf(document))}, newer than this ` +
+        `client's ${DSL_VERSION}`,
+    );
+  }
+  const normalized = migrateDocument(document);
+  validationError(stageValidator(normalized.stage), `stage ${normalized.stage.id}`);
+  if (normalized.stage.id !== pathStageId) {
+    throw validationFailure(
+      `@openmaic/storage: stage ${JSON.stringify(normalized.stage.id)} does not belong to ` +
+        `document ${JSON.stringify(pathStageId)}`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const scene of normalized.scenes) {
+    const sceneId =
+      typeof scene === 'object' && scene !== null ? (scene as { id?: unknown }).id : undefined;
+    validationError(sceneValidator(scene), `scene ${String(sceneId)}`);
+    assertStorableScene(scene, pathStageId);
+    if (seen.has(scene.id)) {
+      throw validationFailure(
+        `@openmaic/storage: duplicate scene id ${JSON.stringify(scene.id)} in document ` +
+          JSON.stringify(pathStageId),
+      );
+    }
+    seen.add(scene.id);
+  }
+  assertJsonRequestValue(document, `document ${JSON.stringify(pathStageId)}`);
+  return document;
+}
+
+function classifyStoreError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/missing document/.test(message)) {
+    const match = /missing document ("(?:[^"\\]|\\.)*")/.exec(message);
+    let stageId = 'unknown';
+    if (match?.[1]) {
+      try {
+        const parsed = JSON.parse(match[1]) as unknown;
+        if (typeof parsed === 'string') stageId = parsed;
+      } catch {
+        // Keep the canonical store message below when parsing fails.
+      }
+    }
+    throw new DocumentHttpError(
+      404,
+      'DOCUMENT_NOT_FOUND',
+      message || missingDocument(stageId).message,
+    );
+  }
+  const versionMatch = /at DSL version ("(?:[^"\\]|\\.)*")/.exec(message);
+  if (/newer than this client's/.test(message)) throw futureVersion(message);
+  if (versionMatch?.[1]) {
+    try {
+      const version = JSON.parse(versionMatch[1]) as unknown;
+      if (typeof version === 'string' && isFutureVersioned({ dslVersion: version })) {
+        throw futureVersion(message);
+      }
+    } catch (classificationError) {
+      if (classificationError instanceof DocumentHttpError) throw classificationError;
+    }
+    throw validationFailure(message);
+  }
+  throw error;
+}
+
+function mappedError(error: unknown): { status: number; body: ErrorBody } {
+  if (error instanceof DocumentHttpError && error.status < 500) {
+    return {
+      status: error.status,
+      body: {
+        error: {
+          code: error.code,
+          message: error.message,
+          ...(error.details === undefined ? {} : { details: error.details }),
+        },
+      },
+    };
+  }
+  return {
+    status: 500,
+    body: {
+      error: { code: 'INTERNAL_ERROR', message: '@openmaic/storage: internal server error' },
+    },
+  };
+}
+
+async function route<TScene extends SceneLike, TStage extends Stage>(
+  req: IncomingMessage,
+  res: ServerResponse,
+  store: DocumentStore<TScene, TStage>,
+  options: DocumentHttpHandlerOptions,
+): Promise<void> {
+  const parts = parsePath(req);
+  if (parts[0] !== 'documents') {
+    throw new DocumentHttpError(404, 'ROUTE_NOT_FOUND', 'route not found');
+  }
+  const principal = await options.authenticate(req);
+  if (principal === undefined) {
+    throw new DocumentHttpError(
+      401,
+      'UNAUTHENTICATED',
+      '@openmaic/storage: authentication required',
+    );
+  }
+  if (!(await (options.authorizeDocuments?.(principal, req) ?? true))) {
+    throw new DocumentHttpError(
+      403,
+      'FORBIDDEN_DOCUMENTS',
+      '@openmaic/storage: document authorization required',
+    );
+  }
+
+  const method = req.method ?? 'GET';
+  const sceneValidator = options.validateScene ?? validateScene;
+  const stageValidator = options.validateStage ?? validateStage;
+  if (parts.length === 1 && method === 'GET') {
+    sendJson(res, 200, await store.listDocuments());
+    return;
+  }
+  if (parts.length < 2) throw new DocumentHttpError(404, 'ROUTE_NOT_FOUND', 'route not found');
+  const stageId = parts[1]!;
+  assertAddressableSegment(stageId);
+
+  if (parts.length === 2 && method === 'PUT') {
+    const document = validateDocument<TScene, TStage>(
+      await readJson(req),
+      stageId,
+      sceneValidator,
+      stageValidator,
+    );
+    try {
+      await store.saveDocument(document);
+    } catch (error) {
+      classifyStoreError(error);
+    }
+    sendNoContent(res);
+    return;
+  }
+  if (parts.length === 2 && method === 'GET') {
+    const document = await store.loadDocument(stageId);
+    if (document === null) throw missingDocument(stageId);
+    sendJson(res, 200, document);
+    return;
+  }
+  if (parts.length === 2 && method === 'DELETE') {
+    await store.deleteDocument(stageId);
+    sendNoContent(res);
+    return;
+  }
+  if (parts.length === 3 && parts[2] === 'stage' && method === 'PUT') {
+    const stage = (await readJson(req)) as unknown as TStage;
+    validationError(stageValidator(stage), `stage ${(stage as { id?: unknown }).id}`);
+    if (stage.id !== stageId) {
+      throw validationFailure(
+        `@openmaic/storage: stage ${JSON.stringify(stage.id)} does not belong to document ` +
+          JSON.stringify(stageId),
+      );
+    }
+    assertJsonRequestValue(stage, `stage ${JSON.stringify((stage as { id?: unknown }).id)}`);
+    try {
+      await store.putStage(stageId, stage);
+    } catch (error) {
+      classifyStoreError(error);
+    }
+    sendNoContent(res);
+    return;
+  }
+  if (parts.length === 4 && parts[2] === 'scenes') {
+    const sceneId = parts[3]!;
+    assertAddressableSegment(sceneId);
+    if (method === 'PUT') {
+      const scene = (await readJson(req)) as unknown as TScene;
+      validationError(sceneValidator(scene), `scene ${(scene as { id?: unknown }).id}`);
+      assertStorableScene(scene, stageId);
+      if (scene.id !== sceneId) {
+        throw validationFailure('scene body id does not match the request path');
+      }
+      assertJsonRequestValue(scene, `scene ${JSON.stringify(scene.id)}`);
+      try {
+        await store.putScene(stageId, scene);
+      } catch (error) {
+        classifyStoreError(error);
+      }
+      sendNoContent(res);
+      return;
+    }
+    if (method === 'GET') {
+      const scene = await store.getScene(stageId, sceneId);
+      if (scene === null) throw missingScene(stageId, sceneId);
+      sendJson(res, 200, scene);
+      return;
+    }
+    if (method === 'DELETE') {
+      try {
+        await store.deleteScene(stageId, sceneId);
+      } catch (error) {
+        classifyStoreError(error);
+      }
+      sendNoContent(res);
+      return;
+    }
+  }
+  throw new DocumentHttpError(404, 'ROUTE_NOT_FOUND', 'route not found');
+}
+
+/** Create a Node HTTP request handler for the complete DocumentStore contract. */
+export function createDocumentHttpHandler<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+>(store: DocumentStore<TScene, TStage>, options: DocumentHttpHandlerOptions): RequestListener {
+  if (typeof options?.authenticate !== 'function') {
+    throw new Error('@openmaic/storage: createDocumentHttpHandler requires authenticate');
+  }
+  return (req, res) => {
+    void route(req, res, store, options).catch((error: unknown) => {
+      if (res.headersSent) {
+        res.destroy(error instanceof Error ? error : undefined);
+        return;
+      }
+      if (!(error instanceof DocumentHttpError) || error.status >= 500) {
+        console.error('@openmaic/storage: Document HTTP handler internal error', error);
+      }
+      const mapped = mappedError(error);
+      sendJson(res, mapped.status, mapped.body);
+    });
+  };
+}

--- a/packages/@openmaic/storage/src/server/index.ts
+++ b/packages/@openmaic/storage/src/server/index.ts
@@ -25,6 +25,17 @@ import type {
   RuntimeTailOptions,
 } from '../runtime/types.js';
 import { RuntimeAppendConflictError } from '../runtime/types.js';
+import type { Scene, Stage } from '@openmaic/dsl';
+import type { DocumentStore, SceneLike } from '../document/types.js';
+import { createDocumentHttpHandler, type DocumentHttpHandlerOptions } from './document.js';
+
+export {
+  createDocumentHttpHandler,
+  type DocumentHttpAuthenticate,
+  type DocumentHttpAuthorize,
+  type DocumentHttpHandlerOptions,
+  type DocumentHttpPrincipal,
+} from './document.js';
 
 export interface RuntimeHttpPrincipal {
   learnerKey?: string;
@@ -672,5 +683,45 @@ export function createRuntimeHttpHandler(
       const mapped = mappedError(error);
       sendJson(res, mapped.status, mapped.body);
     });
+  };
+}
+
+export interface StorageHttpHandlerOptions
+  extends
+    RuntimeHttpHandlerOptions,
+    Pick<DocumentHttpHandlerOptions, 'authorizeDocuments' | 'validateScene' | 'validateStage'> {}
+
+/**
+ * Compose the runtime and author-document contracts into one request handler.
+ * Existing runtime routing is delegated unchanged; `/documents` is dispatched
+ * to the document handler and shares the same authentication hook.
+ */
+export function createStorageHttpHandler<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+>(
+  runtimeStore: RuntimeStore,
+  documentStore: DocumentStore<TScene, TStage>,
+  options: StorageHttpHandlerOptions,
+): RequestListener {
+  const runtime = createRuntimeHttpHandler(runtimeStore, options);
+  const documents = createDocumentHttpHandler(documentStore, {
+    authenticate: options.authenticate,
+    ...(options.authorizeDocuments === undefined
+      ? {}
+      : { authorizeDocuments: options.authorizeDocuments }),
+    ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
+    ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+  });
+  return (req, res) => {
+    let pathname: string;
+    try {
+      pathname = new URL(req.url ?? '/', 'http://storage.invalid').pathname;
+    } catch {
+      runtime(req, res);
+      return;
+    }
+    if (pathname === '/documents' || pathname.startsWith('/documents/')) documents(req, res);
+    else runtime(req, res);
   };
 }

--- a/packages/@openmaic/storage/src/server/reference.ts
+++ b/packages/@openmaic/storage/src/server/reference.ts
@@ -14,23 +14,41 @@ import { pathToFileURL } from 'node:url';
 import { PgRuntimeStore, ensureSchema } from '../runtime/pg.js';
 import type { Queryable, WithTransaction } from '../runtime/pg.js';
 import type { RuntimePayloadValidator } from '../runtime/types.js';
-import { createRuntimeHttpHandler } from './index.js';
 import type {
+  DocumentStore,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from '../document/types.js';
+import type { Scene, Stage } from '@openmaic/dsl';
+import { createRuntimeHttpHandler, createStorageHttpHandler } from './index.js';
+import type {
+  DocumentHttpAuthorize,
   RuntimeHttpAuthenticate,
   RuntimeHttpAuthorizeAdmin,
   RuntimeHttpAuthorizeMerge,
+  StorageHttpHandlerOptions,
 } from './index.js';
 
 export interface ConnectableQueryable extends Queryable {
   connect(): Promise<Queryable & { release(): void }>;
 }
 
-export interface ReferenceRuntimeServerOptions {
+export interface ReferenceRuntimeServerOptions<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+> {
   authenticate?: RuntimeHttpAuthenticate;
   authorizeMerge?: RuntimeHttpAuthorizeMerge;
   authorizeAdmin?: RuntimeHttpAuthorizeAdmin;
   /** Whole-table replacement; pass the same validator table to the store and handler. */
   payloadValidators?: Record<string, RuntimePayloadValidator>;
+  /** When supplied, the same server also exposes the `/documents` contract. */
+  documentStore?: DocumentStore<TScene, TStage>;
+  authorizeDocuments?: DocumentHttpAuthorize;
+  /** Pass the same validators configured on documentStore. */
+  validateScene?: SceneValidator;
+  validateStage?: StageValidator;
 }
 
 /**
@@ -61,9 +79,12 @@ export function nodePostgresTransaction(pool: ConnectableQueryable): WithTransac
  * Replace it, and the default authorization hooks, before exposing the server.
  * This factory creates an unbound Server; only main() binds it to an address.
  */
-export async function createReferenceRuntimeServer(
+export async function createReferenceRuntimeServer<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+>(
   pool: ConnectableQueryable,
-  options: ReferenceRuntimeServerOptions = {},
+  options: ReferenceRuntimeServerOptions<TScene, TStage> = {},
 ): Promise<Server> {
   await ensureSchema(pool);
   const store = new PgRuntimeStore(pool, {
@@ -72,27 +93,34 @@ export async function createReferenceRuntimeServer(
       ? {}
       : { payloadValidators: options.payloadValidators }),
   });
+  const handlerOptions: StorageHttpHandlerOptions = {
+    authenticate:
+      options.authenticate ??
+      (async (req) => {
+        const authorization = req.headers.authorization;
+        if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
+          return undefined;
+        }
+        const learnerKey = authorization.slice('Bearer '.length);
+        return learnerKey === '' ? undefined : { learnerKey };
+      }),
+    authorizeMerge:
+      options.authorizeMerge ??
+      (async (principal, fromKey, toKey) => principal.learnerKey === fromKey && fromKey === toKey),
+    authorizeAdmin: options.authorizeAdmin ?? (async () => false),
+    ...(options.payloadValidators === undefined
+      ? {}
+      : { payloadValidators: options.payloadValidators }),
+    ...(options.authorizeDocuments === undefined
+      ? {}
+      : { authorizeDocuments: options.authorizeDocuments }),
+    ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
+    ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+  };
   return createServer(
-    createRuntimeHttpHandler(store, {
-      authenticate:
-        options.authenticate ??
-        (async (req) => {
-          const authorization = req.headers.authorization;
-          if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
-            return undefined;
-          }
-          const learnerKey = authorization.slice('Bearer '.length);
-          return learnerKey === '' ? undefined : { learnerKey };
-        }),
-      authorizeMerge:
-        options.authorizeMerge ??
-        (async (principal, fromKey, toKey) =>
-          principal.learnerKey === fromKey && fromKey === toKey),
-      authorizeAdmin: options.authorizeAdmin ?? (async () => false),
-      ...(options.payloadValidators === undefined
-        ? {}
-        : { payloadValidators: options.payloadValidators }),
-    }),
+    options.documentStore === undefined
+      ? createRuntimeHttpHandler(store, handlerOptions)
+      : createStorageHttpHandler(store, options.documentStore, handlerOptions),
   );
 }
 

--- a/packages/@openmaic/storage/test/http-document-store.test.ts
+++ b/packages/@openmaic/storage/test/http-document-store.test.ts
@@ -1,0 +1,169 @@
+import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http';
+import { IDBFactory } from 'fake-indexeddb';
+import { describe, expect, test } from 'vitest';
+import { BrowserDocumentStore } from '../src/document/browser.js';
+import { HttpDocumentStore, HttpDocumentStoreError } from '../src/document/http.js';
+import { BrowserRuntimeStore } from '../src/runtime/browser.js';
+import { createStorageHttpHandler } from '../src/server/index.js';
+import { makeDocument, runDocumentStoreContract } from './document-contract.js';
+
+const BASE_URL = 'http://storage-reference.invalid';
+
+function handlerFetch(handler: RequestListener): typeof globalThis.fetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const body = await request.text();
+    const headers = Object.fromEntries(request.headers.entries());
+    headers.authorization ??= 'Bearer document-contract';
+    const fakeRequest = {
+      method: request.method,
+      url: `${url.pathname}${url.search}`,
+      headers,
+      async *[Symbol.asyncIterator]() {
+        if (body !== '') yield Buffer.from(body);
+      },
+    } as unknown as IncomingMessage;
+
+    return new Promise<Response>((resolve, reject) => {
+      let status = 200;
+      let responseHeaders: Record<string, string> = {};
+      let responseBody: string | undefined;
+      let headersSent = false;
+      const fakeResponse = {
+        get headersSent() {
+          return headersSent;
+        },
+        writeHead(nextStatus: number, nextHeaders?: Record<string, string>) {
+          status = nextStatus;
+          responseHeaders = nextHeaders ?? {};
+          headersSent = true;
+          return this;
+        },
+        end(chunk?: string | Buffer) {
+          responseBody = chunk === undefined ? undefined : chunk.toString();
+          resolve(
+            new Response(status === 204 ? null : responseBody, {
+              status,
+              headers: responseHeaders,
+            }),
+          );
+          return this;
+        },
+        destroy(error?: Error) {
+          reject(error ?? new Error('response destroyed'));
+          return this;
+        },
+      } as unknown as ServerResponse;
+      handler(fakeRequest, fakeResponse);
+    });
+  };
+}
+
+function makeHarness(authorizeDocuments: () => boolean = () => true) {
+  const documents = new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+  const runtime = new BrowserRuntimeStore({ indexedDB: new IDBFactory() });
+  const handler = createStorageHttpHandler(runtime, documents, {
+    authenticate: async (req) => {
+      const authorization = req.headers.authorization;
+      return typeof authorization === 'string' && authorization.startsWith('Bearer ')
+        ? { learnerKey: 'author' }
+        : undefined;
+    },
+    authorizeDocuments: async () => authorizeDocuments(),
+  });
+  const fetch = handlerFetch(handler);
+  return {
+    documents,
+    fetch,
+    client: new HttpDocumentStore({ baseUrl: BASE_URL, fetch }),
+  };
+}
+
+runDocumentStoreContract('reference HTTP', () => makeHarness().client);
+
+describe('HttpDocumentStore contract mapping', () => {
+  test('uses injected request headers and the reference server requires authentication', async () => {
+    const { fetch } = makeHarness();
+    const unauthenticated = await fetch(`${BASE_URL}/documents`, {
+      headers: { authorization: '' },
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    let context: { method: string; path: string } | undefined;
+    const client = new HttpDocumentStore({
+      baseUrl: BASE_URL,
+      fetch,
+      headers: (next) => {
+        context = next;
+        return { authorization: 'Bearer author' };
+      },
+    });
+    await client.listDocuments();
+    expect(context).toEqual({ method: 'GET', path: '/documents' });
+  });
+
+  test('maps document authorization denial to a typed 403', async () => {
+    const { client } = makeHarness(() => false);
+    await expect(client.listDocuments()).rejects.toMatchObject({
+      name: 'HttpDocumentStoreError',
+      status: 403,
+      code: 'FORBIDDEN_DOCUMENTS',
+    });
+  });
+
+  test('maps malformed request JSON to VALIDATION_FAILED', async () => {
+    const { fetch } = makeHarness();
+    const response = await fetch(`${BASE_URL}/documents/stage-1`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: '{',
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'VALIDATION_FAILED' },
+    });
+  });
+
+  test('maps missing required parents to typed 404 errors with browser wording', async () => {
+    const { client } = makeHarness();
+    const failure = client.putStage('ghost', {
+      id: 'ghost',
+      name: 'Ghost',
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    await expect(failure).rejects.toBeInstanceOf(HttpDocumentStoreError);
+    await expect(failure).rejects.toMatchObject({ status: 404, code: 'DOCUMENT_NOT_FOUND' });
+    await expect(failure).rejects.toThrow(/missing document/);
+  });
+
+  test('maps a future-version save to FUTURE_VERSION without overwriting current data', async () => {
+    const { client } = makeHarness();
+    await client.saveDocument(makeDocument());
+    const future = makeDocument();
+    future.dslVersion = '99.0.0';
+    future.stage.name = 'Future';
+
+    await expect(client.saveDocument(future)).rejects.toMatchObject({
+      status: 409,
+      code: 'FUTURE_VERSION',
+    });
+    expect((await client.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+  });
+
+  test('client-side validators fail before fetch', async () => {
+    let calls = 0;
+    const client = new HttpDocumentStore({
+      baseUrl: BASE_URL,
+      fetch: async () => {
+        calls += 1;
+        return new Response(null, { status: 204 });
+      },
+    });
+    const bad = makeDocument();
+    delete (bad.stage as { name?: string }).name;
+    await expect(client.saveDocument(bad)).rejects.toThrow(/invalid stage/);
+    expect(calls).toBe(0);
+  });
+});


### PR DESCRIPTION
PR1 of the document-server-backend line (mirrors #939 Parts B+D for documents):

- `docs/document-http-contract.md` — /documents routes, error taxonomy, injected-auth model (documents are author assets, not learner-partitioned)
- `src/document/http.ts` — HttpDocumentStore with browser-parity validation + migrate-on-read
- `src/server/document.ts` — document routes on the shared reference server (runtime routes untouched)
- Document contract suite green on browser AND http backends (343+35 tests)

Next: PR2 PgDocumentStore + PG16 contract CI; PR3 app configureDocumentStorage seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)