### PR TITLE
feat(document-store): configureDocumentStorage bootstrap seam (1B PR3)

### DIFF
--- a/lib/document-store/config.ts
+++ b/lib/document-store/config.ts
@@ -1,0 +1,103 @@
+import type { DocumentStore, SceneValidator, StageValidator } from '@openmaic/storage';
+
+import type { AppScene } from '@/lib/types/stage';
+
+import type { AppStage } from './persistence-types';
+import { validateAppScene, validateAppStage } from './validators';
+
+export interface DocumentStorageValidators {
+  validateScene: SceneValidator;
+  validateStage: StageValidator;
+}
+
+export type DocumentStoreFactory = (
+  validators: DocumentStorageValidators,
+) => DocumentStore<AppScene, AppStage>;
+
+export interface DocumentStorageOptions {
+  /**
+   * A DocumentStore instance, or a factory evaluated lazily until it first
+   * succeeds. Factories receive the app validators and must inject them into
+   * server-backed stores so every backend preserves the app write boundary.
+   */
+  store?: DocumentStore<AppScene, AppStage> | DocumentStoreFactory;
+}
+
+let options: DocumentStorageOptions | undefined;
+let resolutionStarted = false;
+
+/**
+ * Configure the app-wide document persistence backend.
+ *
+ * This is a client-bootstrap-only, single-shot API. It is not SSR-safe and is
+ * not intended for request-scoped stores. Call it at module-level bootstrap,
+ * before rendering any document consumer; a component effect is too late. A
+ * second call always throws, even if document storage has not been used yet.
+ * Once resolution has started, configuration stays sealed so a live app cannot
+ * split documents across backends. Omitting the store retains the browser
+ * IndexedDB backend.
+ *
+ * A store factory is called lazily by `getDocumentStore()` until it first
+ * succeeds. It receives `validateAppScene` and `validateAppStage`; inject those
+ * validators into a server-backed store (for example, `HttpDocumentStore`) so
+ * the app's widened scene union and stage rules remain enforced at the client
+ * write boundary.
+ *
+ * Dev-mode limitation: configuration and consumer caches live in separate
+ * modules, so partial HMR replacement can fragment their module-level state.
+ * Reload the page after changing bootstrap configuration.
+ *
+ * @example
+ * ```ts
+ * configureDocumentStorage({
+ *   store: ({ validateScene, validateStage }) =>
+ *     new HttpDocumentStore({ baseUrl: '/api', validateScene, validateStage }),
+ * });
+ * ```
+ */
+export function configureDocumentStorage(next: DocumentStorageOptions): void {
+  if (resolutionStarted) {
+    throw new Error(
+      'configureDocumentStorage must be called at module-level bootstrap, before any document consumer runs — a component effect is too late. Document storage resolution has already started; configuration remains sealed even if resolution failed. Retry the document consumer to retry resolution.',
+    );
+  }
+  if (options) {
+    throw new Error('Document storage has already been configured');
+  }
+  // Snapshot: a caller mutating its options object after configuring must not
+  // be able to swap the backend behind the sealed configuration.
+  options = { store: next.store };
+}
+
+/** Whether client bootstrap has supplied document storage configuration. */
+export function isDocumentStorageConfigured(): boolean {
+  return options !== undefined;
+}
+
+type DocumentStorageResetHook = () => void;
+const resetHooks: DocumentStorageResetHook[] = [];
+
+/**
+ * @internal Modules that latch singleton caches derived from this
+ * configuration register a clearer so the test reset below leaves no stale
+ * cache behind.
+ */
+export function registerDocumentStorageResetHook(hook: DocumentStorageResetHook): void {
+  resetHooks.push(hook);
+}
+
+/** @internal Test-only reset: clears configuration AND every latched consumer cache. */
+export function resetDocumentStorageForTests(): void {
+  options = undefined;
+  resolutionStarted = false;
+  for (const hook of resetHooks) hook();
+}
+
+/** @internal Resolve and seal the configured store override, if any. */
+export function resolveConfiguredDocumentStore(): DocumentStore<AppScene, AppStage> | undefined {
+  resolutionStarted = true;
+  const configured = options?.store;
+  return typeof configured === 'function'
+    ? configured({ validateScene: validateAppScene, validateStage: validateAppStage })
+    : configured;
+}

--- a/lib/document-store/index.ts
+++ b/lib/document-store/index.ts
@@ -11,7 +11,16 @@ export {
   canonicalizeLegacyScene,
   canonicalizeLegacyStage,
 } from './canonicalize';
-export { getDocumentStore, type DocumentStoreDeps } from './store';
+export {
+  configureDocumentStorage,
+  getDocumentStore,
+  isDocumentStorageConfigured,
+  resetDocumentStorageForTests,
+  type DocumentStorageOptions,
+  type DocumentStorageValidators,
+  type DocumentStoreDeps,
+  type DocumentStoreFactory,
+} from './store';
 export {
   accessDocument,
   documentLockName,

--- a/lib/document-store/store.ts
+++ b/lib/document-store/store.ts
@@ -2,8 +2,20 @@ import { BrowserDocumentStore, type DocumentStore } from '@openmaic/storage';
 
 import type { AppScene } from '@/lib/types/stage';
 
+import { registerDocumentStorageResetHook, resolveConfiguredDocumentStore } from './config';
 import type { AppStage } from './persistence-types';
 import { validateAppScene, validateAppStage } from './validators';
+
+export {
+  configureDocumentStorage,
+  isDocumentStorageConfigured,
+  resetDocumentStorageForTests,
+} from './config';
+export type {
+  DocumentStorageOptions,
+  DocumentStorageValidators,
+  DocumentStoreFactory,
+} from './config';
 
 const DOCUMENT_DB_NAME = 'maic-documents';
 
@@ -17,6 +29,10 @@ export interface DocumentStoreDeps {
 }
 
 let defaultStore: DocumentStore<AppScene, AppStage> | undefined;
+
+registerDocumentStorageResetHook(() => {
+  defaultStore = undefined;
+});
 
 function createBrowserStore(
   deps: Omit<DocumentStoreDeps, 'store'>,
@@ -38,5 +54,7 @@ function createBrowserStore(
 export function getDocumentStore(deps: DocumentStoreDeps = {}): DocumentStore<AppScene, AppStage> {
   if (deps.store) return deps.store;
   if (deps.indexedDB || deps.dbName) return createBrowserStore(deps);
-  return (defaultStore ??= createBrowserStore({}));
+  // `??=` assigns only after resolution succeeds: if a configured factory
+  // throws, the next call retries it rather than caching the failure.
+  return (defaultStore ??= resolveConfiguredDocumentStore() ?? createBrowserStore({}));
 }

--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -6,9 +6,9 @@ persisting app state, depending only on [`@openmaic/dsl`](../dsl).
 The DSL owns _what_ persists (document / runtime shape + validation + migration +
 the asset `StorageProvider` interface). This package owns _where / how_ it
 persists — the primitives and their backends. The pluggable seam is the
-**backend**, not the database driver: a browser backend (zero server, the
-`clone-and-run` default) and, later, an HTTP backend whose server owns a
-database.
+**backend**, not the database driver: browser backends (the zero-server
+`clone-and-run` default), HTTP clients plus a reference server, and PostgreSQL
+server backends.
 
 ## Dependency arrow (acyclic)
 
@@ -76,8 +76,9 @@ a browser.
 Each primitive has one implementation-agnostic contract suite
 (`test/kv-contract.ts`, `test/asset-contract.ts`, `test/document-contract.ts`,
 `test/runtime-contract.ts`).
-Every backend is proven by running the same suite against it, so a new backend
-(the coming HTTP one) cannot silently diverge from the primitive's semantics.
+Every backend is proven by running the same suite against it, so browser, HTTP,
+and PostgreSQL implementations cannot silently diverge from a primitive's
+semantics.
 
 ## Roadmap
 
@@ -89,7 +90,10 @@ Every backend is proven by running the same suite against it, so a new backend
 - [x] `RuntimeStore` (sessions + append-only records, runtime version line,
       per-kind payload gate) + browser backend
 - [ ] wire the app's zustand stores + ad-hoc `localStorage` through `KVStore`
-- [ ] HTTP backend + reference server + one HTTP contract
+- [x] RuntimeStore HTTP backend + reference server + HTTP contract
+- [x] RuntimeStore PostgreSQL backend
+- [x] DocumentStore HTTP backend + reference-server routes + HTTP contract
+- [x] DocumentStore PostgreSQL backend
 
 ## License
 

--- a/packages/@openmaic/storage/docs/reference-server.md
+++ b/packages/@openmaic/storage/docs/reference-server.md
@@ -1,6 +1,6 @@
-# RuntimeStore reference server
+# RuntimeStore and DocumentStore reference server
 
-The `@openmaic/storage/server` subpath exports a Node-only HTTP request handler implementing the [RuntimeStore HTTP contract](./runtime-http-contract.md). It accepts any injected `RuntimeStore`; the runnable `@openmaic/storage/server/reference` composition uses `PgRuntimeStore`, initializes its schema, and demonstrates the required node-postgres checkout/transaction/release pattern.
+The `@openmaic/storage/server` subpath exports a Node-only HTTP request handler implementing the [RuntimeStore HTTP contract](./runtime-http-contract.md) and, when a document store is supplied, the [DocumentStore HTTP contract](./document-http-contract.md). It accepts injected `RuntimeStore` and `DocumentStore` implementations; the runnable `@openmaic/storage/server/reference` composition creates and initializes `PgRuntimeStore`, accepts an optional host-created document store, and demonstrates the required node-postgres checkout/transaction/release pattern.
 
 This module is a reference, not a production authentication service. **The example bearer authentication is fully impersonatable.** A production host must supply its own authenticated identity and authorization policy. It must also terminate TLS, bound request sizes and timeouts, rate-limit abusive clients, keep database credentials outside the process image, and expose the service only through an appropriate application gateway.
 
@@ -16,12 +16,37 @@ DATABASE_URL=postgres://user:password@host/database PORT=3000 \
 The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` only creates and returns an unbound Node `Server`. The default bearer token payload is used directly as the demo `learnerKey`, self-merge is the only allowed merge, and admin operations are denied. Supplying `documentStore` adds the DocumentStore routes to that same server; any authenticated principal is allowed by default, or `authorizeDocuments` can enforce deployment policy. The factory also accepts `authenticate`, `authorizeMerge`, `authorizeAdmin`, and validator overrides. Replace the policy hooks before exposing a deployment:
 
 - `authenticate(req)` must validate a real credential and derive the canonical learner partition from server-controlled identity state.
+- `authorizeDocuments(principal, req)` must establish that the principal may access the requested author document operation. The default permits every authenticated principal.
 - `authorizeMerge(principal, fromKey, toKey)` must explicitly establish that the principal may migrate the complete source partition into the destination identity. Default denial is intentional.
 - `authorizeAdmin(principal)` must require a separately protected administrative role. Default denial is intentional.
 
 The handler's `payloadValidators` option has the same whole-table replacement semantics as the `BrowserRuntimeStore` and `PgRuntimeStore` constructor option, and defaults to the DSL `chat` / `quizAttempt` skeleton table. Whatever you pass to the store, pass the same thing to the handler. `createReferenceRuntimeServer()` applies its `payloadValidators` override to both automatically.
 
 The package has no PostgreSQL driver runtime dependency. A host injects its `Pool` (or another compatible `Queryable`) and owns driver lifecycle. Every transactional operation must check out a fresh connection, issue `BEGIN`, run all callback queries on that same connection, issue `COMMIT` or `ROLLBACK`, and release it in `finally`.
+
+## Document endpoints
+
+Every document route requires an authenticated principal. By default,
+`authorizeDocuments` allows any authenticated principal; production deployments
+must replace that policy when documents are tenant-, role-, or author-scoped.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `PUT` | `/documents/{stageId}` | Save a complete document |
+| `GET` | `/documents/{stageId}` | Load a complete document |
+| `GET` | `/documents` | List document summaries |
+| `DELETE` | `/documents/{stageId}` | Delete a document and its children |
+| `PUT` | `/documents/{stageId}/stage` | Replace stage metadata |
+| `PUT` | `/documents/{stageId}/scenes/{sceneId}` | Upsert one scene |
+| `GET` | `/documents/{stageId}/scenes/{sceneId}` | Read one scene |
+| `DELETE` | `/documents/{stageId}/scenes/{sceneId}` | Delete one scene |
+
+The reference composition applies its `validateScene` and `validateStage`
+overrides to the HTTP handler; the host must configure the injected document
+store with the same validators. Keep those validators in sync when composing
+the lower-level handler yourself. Full response, validation, version, and retry
+semantics are specified in the
+[DocumentStore HTTP contract](./document-http-contract.md).
 
 ## Endpoint authorization matrix
 

--- a/tests/document-store/document-storage-config.test.ts
+++ b/tests/document-store/document-storage-config.test.ts
@@ -1,0 +1,64 @@
+import type { DocumentStore } from '@openmaic/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppScene } from '@/lib/types/stage';
+
+import type { AppStage } from '@/lib/document-store/persistence-types';
+
+function stubStore(): DocumentStore<AppScene, AppStage> {
+  return {} as DocumentStore<AppScene, AppStage>;
+}
+
+describe('configureDocumentStorage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the configured factory and supplies the app validators', async () => {
+    const injected = stubStore();
+    const factory = vi.fn(() => injected);
+    const { configureDocumentStorage, getDocumentStore, validateAppScene, validateAppStage } =
+      await import('@/lib/document-store');
+    configureDocumentStorage({ store: factory });
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(getDocumentStore()).toBe(injected);
+    expect(getDocumentStore()).toBe(injected);
+    expect(factory).toHaveBeenCalledExactlyOnceWith({
+      validateScene: validateAppScene,
+      validateStage: validateAppStage,
+    });
+  });
+
+  it('stays sealed after document storage resolution starts', async () => {
+    const injected = stubStore();
+    const { configureDocumentStorage, getDocumentStore } = await import('@/lib/document-store');
+    configureDocumentStorage({ store: injected });
+    getDocumentStore();
+
+    expect(() => configureDocumentStorage({ store: stubStore() })).toThrow(
+      'configureDocumentStorage must be called at module-level bootstrap, before any document consumer runs — a component effect is too late.',
+    );
+  });
+
+  it('resetDocumentStorageForTests clears configuration and the latched store', async () => {
+    const first = stubStore();
+    const second = stubStore();
+    const {
+      configureDocumentStorage,
+      getDocumentStore,
+      isDocumentStorageConfigured,
+      resetDocumentStorageForTests,
+    } = await import('@/lib/document-store');
+
+    configureDocumentStorage({ store: first });
+    expect(getDocumentStore()).toBe(first);
+    expect(isDocumentStorageConfigured()).toBe(true);
+
+    resetDocumentStorageForTests();
+    expect(isDocumentStorageConfigured()).toBe(false);
+    configureDocumentStorage({ store: second });
+    expect(getDocumentStore()).toBe(second);
+  });
+});


### PR DESCRIPTION
Closes the line: sealed bootstrap injection for the document backend, mirroring `configureRuntimeStorage` — factory receives the app validators (server-backed stores can't skip them), sealed-after-resolution, reset-for-tests. README roadmap ticked for document HTTP/PG.

59 targeted + 380 package tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)