### PR TITLE
fix(storage): 1B final-review hardening (3 P2 + 2 P3)

### DIFF
--- a/packages/@openmaic/storage/docs/document-http-contract.md
+++ b/packages/@openmaic/storage/docs/document-http-contract.md
@@ -21,7 +21,9 @@ This contract exposes the complete `DocumentStore` interface over JSON HTTP. All
 
 Servers run their configured `validateStage` and `validateScene` gates before writes. A full save validates the migrated aggregate and rejects duplicate scene ids, mismatched scene partitions, and non-finite order values before changing storage. `putStage` and `putScene` repeat the same boundary validation and require an existing document whose stored `dslVersion` is exactly the server's current `DSL_VERSION`. A stale document must first be loaded and saved as a full aggregate; a future document must never be downgraded. `deleteScene` has the same current-version guard, while whole-document deletion deliberately does not.
 
-HTTP implementations carry data through JSON and therefore accept only plain values that serialize without changing meaning. They fail before sending or storing values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, `undefined`, `bigint`, sparse arrays, class instances, symbol/non-enumerable properties, U+0000 strings, and circular references. The opaque outline is not DSL-validated or migrated, but it is still subject to this JSON transport rule.
+HTTP implementations carry data through JSON and therefore accept only plain values that serialize without changing meaning. They fail before sending or storing values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, `undefined`, `bigint`, sparse arrays, class instances, symbol/non-enumerable properties, U+0000 strings, and circular references. The opaque outline is not DSL-validated or migrated, but it is still subject to this JSON transport rule. A store exposed by the server MUST contain JSON-safe document, scene, outline, and summary values; the handler validates read payloads before serialization and returns `500 NOT_JSON_SAFE` with the offending path if this invariant is violated.
+
+The handler streams request bodies into a bounded buffer. `maxBodyBytes` configures the bound on `createDocumentHttpHandler` and composed/reference server factories; it defaults to 32 MiB. A body that crosses the bound is rejected immediately with `413 PAYLOAD_TOO_LARGE`.
 
 Reads are migrated on both sides of the wire. The backing store performs its normal migrate-on-read, and the HTTP client migrates the returned document again so an older server cannot leak a stale envelope into a newer application. The opaque outline is removed before DSL migration and reattached unchanged.
 
@@ -48,10 +50,12 @@ Every non-2xx response has a machine-readable JSON body:
 | Condition | HTTP status | Error code | Client behavior |
 | --- | --- | --- | --- |
 | Malformed JSON, invalid stage/scene/document, body/path mismatch, non-JSON value, duplicate scene id, or stale incremental write | `400` | `VALIDATION_FAILED` | Throw `HttpDocumentStoreError` with the server message |
+| Request body exceeds `maxBodyBytes` | `413` | `PAYLOAD_TOO_LARGE` | Throw `HttpDocumentStoreError` |
 | Document does not exist | `404` | `DOCUMENT_NOT_FOUND` | `loadDocument` returns `null`; required-parent writes throw with `missing document` semantics |
 | Scene does not exist | `404` | `SCENE_NOT_FOUND` | `getScene` returns `null` |
 | Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpDocumentStoreError` |
 | Input or stored document was written at a future DSL version | `409` | `FUTURE_VERSION` | Throw `HttpDocumentStoreError` with `newer than this client's`/version-guard semantics |
+| A server-exposed read value is not JSON-safe | `500` | `NOT_JSON_SAFE` | Throw `HttpDocumentStoreError` with the offending value path |
 | Unexpected server failure | `500` | `INTERNAL_ERROR` | Throw `HttpDocumentStoreError`; the reference handler does not expose internal details |
 
 Only the machine-readable not-found codes are translated to `null`. Status alone is not sufficient. Authentication failures use `401 UNAUTHENTICATED`, and authorization failures use `403 FORBIDDEN_DOCUMENTS`.

--- a/packages/@openmaic/storage/docs/reference-server.md
+++ b/packages/@openmaic/storage/docs/reference-server.md
@@ -20,7 +20,7 @@ The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` o
 - `authorizeMerge(principal, fromKey, toKey)` must explicitly establish that the principal may migrate the complete source partition into the destination identity. Default denial is intentional.
 - `authorizeAdmin(principal)` must require a separately protected administrative role. Default denial is intentional.
 
-The handler's `payloadValidators` option has the same whole-table replacement semantics as the `BrowserRuntimeStore` and `PgRuntimeStore` constructor option, and defaults to the DSL `chat` / `quizAttempt` skeleton table. Whatever you pass to the store, pass the same thing to the handler. `createReferenceRuntimeServer()` applies its `payloadValidators` override to both automatically.
+The handler's `payloadValidators` option has the same whole-table replacement semantics as the `BrowserRuntimeStore` and `PgRuntimeStore` constructor option, and defaults to the DSL `chat` / `quizAttempt` skeleton table. Whatever you pass to the store, pass the same thing to the handler. `createReferenceRuntimeServer()` applies its `payloadValidators` override to both automatically. Its `maxBodyBytes` option applies to runtime and document routes and defaults to 32 MiB; oversized bodies receive `413 PAYLOAD_TOO_LARGE`.
 
 The package has no PostgreSQL driver runtime dependency. A host injects its `Pool` (or another compatible `Queryable`) and owns driver lifecycle. Every transactional operation must check out a fresh connection, issue `BEGIN`, run all callback queries on that same connection, issue `COMMIT` or `ROLLBACK`, and release it in `finally`.
 

--- a/packages/@openmaic/storage/docs/runtime-http-contract.md
+++ b/packages/@openmaic/storage/docs/runtime-http-contract.md
@@ -50,6 +50,8 @@ An append may also include a top-level `sessionTransition` object with `{ "statu
 
 HTTP implementations carry record payloads through JSON and therefore MUST accept only plain JSON values that survive serialization without changing meaning. They MUST fail loud before sending values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, nested `undefined`, `bigint`, sparse arrays, symbol-keyed properties, non-enumerable properties, arrays with non-index own properties, strings containing U+0000, class instances, and circular references. U+2028 and U+2029 are valid JSON string contents and MUST be accepted. This is intentionally narrower than `BrowserRuntimeStore`, whose structured-clone persistence can preserve values such as `Map`, `Set`, and `Date` that JSON cannot.
 
+The reference handler streams request bodies into a bounded buffer. `maxBodyBytes` configures the bound on the runtime, composed-storage, and reference-server factories; it defaults to 32 MiB. A body that crosses the bound is rejected immediately with `413 PAYLOAD_TOO_LARGE`.
+
 ## learnerKey security model
 
 `learnerKey` appears in paths, query parameters, and request bodies, but the server MUST derive or verify `learnerKey` from the authenticated session and MUST NOT blindly trust the client-submitted value. `learnerKey` is an opaque partition key, not proof of identity or authorization; trusting it verbatim creates a lateral-authorization vulnerability that lets one learner read, merge, or delete another learner's runtime data. The same rule applies to both keys in `mergeLearner`; authorization policy must explicitly permit the authenticated principal to migrate the source partition into the destination partition.
@@ -75,6 +77,7 @@ Every non-2xx response has this machine-readable JSON shape:
 | Condition | HTTP status | Error code | Client behavior |
 | --- | --- | --- | --- |
 | Malformed JSON, an invalid envelope or payload, invalid learner keys, a body/path mismatch, or append to a non-active session | `400` | `VALIDATION_FAILED` | Throw `HttpRuntimeStoreError` (an `Error`) with the server message |
+| Request body exceeds `maxBodyBytes` | `413` | `PAYLOAD_TOO_LARGE` | Throw `HttpRuntimeStoreError` |
 | Session does not exist | `404` | `SESSION_NOT_FOUND` | `getSession` returns `undefined`; operations that require the session throw `HttpRuntimeStoreError` with the browser store's `no session` semantics |
 | Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpRuntimeStoreError` |
 | A stored session has a future runtime DSL version | `409` | `FUTURE_VERSION` | Throw `HttpRuntimeStoreError` with the browser store's fail-loud `newer than this client's` semantics |

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -42,6 +42,7 @@ export class HttpDocumentStoreError extends Error {
     readonly status: number,
     readonly code: string,
     message: string,
+    readonly details?: unknown,
   ) {
     super(message);
     this.name = 'HttpDocumentStoreError';
@@ -159,7 +160,7 @@ export class HttpDocumentStore<
         typeof errorBody?.error?.message === 'string'
           ? errorBody.error.message
           : `@openmaic/storage: DocumentStore HTTP request failed with status ${response.status}`;
-      throw new HttpDocumentStoreError(response.status, code, message);
+      throw new HttpDocumentStoreError(response.status, code, message, errorBody?.error?.details);
     }
     if (response.status === 204) return undefined as T;
     return (await response.json()) as T;

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -51,12 +51,14 @@ interface RuntimeAppendConflictDetails {
 export class HttpRuntimeStoreError extends Error {
   readonly status: number;
   readonly code: string;
+  readonly details: unknown;
 
-  constructor(status: number, code: string, message: string) {
+  constructor(status: number, code: string, message: string, details?: unknown) {
     super(message);
     this.name = 'HttpRuntimeStoreError';
     this.status = status;
     this.code = code;
+    this.details = details;
   }
 }
 
@@ -203,7 +205,7 @@ export class HttpRuntimeStore implements RuntimeStore {
           );
         }
       }
-      throw new HttpRuntimeStoreError(response.status, code, message);
+      throw new HttpRuntimeStoreError(response.status, code, message, errorBody?.error?.details);
     }
     if (response.status === 204) return { body: undefined as T, status: response.status };
     return { body: (await response.json()) as T, status: response.status };

--- a/packages/@openmaic/storage/src/server/document.ts
+++ b/packages/@openmaic/storage/src/server/document.ts
@@ -16,6 +16,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from '../document/types.js';
+import { assertMaxBodyBytes, DEFAULT_MAX_BODY_BYTES, readJsonObject } from './read-json.js';
 
 export interface DocumentHttpPrincipal {
   learnerKey?: string;
@@ -38,6 +39,8 @@ export interface DocumentHttpHandlerOptions {
   validateScene?: SceneValidator;
   /** Whole-validator replacement; pass the same validator configured on the store. */
   validateStage?: StageValidator;
+  /** Maximum JSON request-body size in bytes. Defaults to 32 MiB. */
+  maxBodyBytes?: number;
 }
 
 interface ErrorBody {
@@ -69,21 +72,15 @@ function validationFailure(message: string, details?: unknown): DocumentHttpErro
   return new DocumentHttpError(400, 'VALIDATION_FAILED', message, details);
 }
 
-async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req)
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  if (chunks.length === 0) throw validationFailure('request body must be a JSON object');
-  let body: unknown;
-  try {
-    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
-  } catch (error) {
-    throw validationFailure(error instanceof Error ? error.message : String(error));
-  }
-  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
-    throw validationFailure('request body must be a JSON object');
-  }
-  return body as Record<string, unknown>;
+function payloadTooLarge(message: string): DocumentHttpError {
+  return new DocumentHttpError(413, 'PAYLOAD_TOO_LARGE', message);
+}
+
+function readJson(req: IncomingMessage, maxBodyBytes: number): Promise<Record<string, unknown>> {
+  return readJsonObject(req, maxBodyBytes, {
+    invalid: validationFailure,
+    payloadTooLarge,
+  });
 }
 
 function validationError(result: ValidationResult, label: string): void {
@@ -106,6 +103,18 @@ function assertJsonRequestValue(value: unknown, label: string): void {
     assertJsonValue(value, label);
   } catch (error) {
     throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function assertJsonResponseValue(value: unknown, label: string): void {
+  try {
+    assertJsonValue(value, label);
+  } catch (error) {
+    throw new DocumentHttpError(
+      500,
+      'NOT_JSON_SAFE',
+      error instanceof Error ? error.message : String(error),
+    );
   }
 }
 
@@ -244,9 +253,10 @@ function classifyStoreError(error: unknown): never {
       message || missingDocument(stageId).message,
     );
   }
-  const versionMatch = /at DSL version ("(?:[^"\\]|\\.)*")/.exec(message);
+  const versionMatch = /at DSL version (undefined|"(?:[^"\\]|\\.)*")/.exec(message);
   if (/newer than this client's/.test(message)) throw futureVersion(message);
   if (versionMatch?.[1]) {
+    if (versionMatch[1] === 'undefined') throw validationFailure(message);
     try {
       const version = JSON.parse(versionMatch[1]) as unknown;
       if (typeof version === 'string' && isFutureVersioned({ dslVersion: version })) {
@@ -261,7 +271,7 @@ function classifyStoreError(error: unknown): never {
 }
 
 function mappedError(error: unknown): { status: number; body: ErrorBody } {
-  if (error instanceof DocumentHttpError && error.status < 500) {
+  if (error instanceof DocumentHttpError) {
     return {
       status: error.status,
       body: {
@@ -308,6 +318,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
   }
 
   const method = req.method ?? 'GET';
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
   const sceneValidator = options.validateScene ?? validateScene;
   const stageValidator = options.validateStage ?? validateStage;
   if (parts.length === 1 && method === 'GET') {
@@ -320,7 +331,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
 
   if (parts.length === 2 && method === 'PUT') {
     const document = validateDocument<TScene, TStage>(
-      await readJson(req),
+      await readJson(req, maxBodyBytes),
       stageId,
       sceneValidator,
       stageValidator,
@@ -336,6 +347,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
   if (parts.length === 2 && method === 'GET') {
     const document = await store.loadDocument(stageId);
     if (document === null) throw missingDocument(stageId);
+    assertJsonResponseValue(document, `document response ${JSON.stringify(stageId)}`);
     sendJson(res, 200, document);
     return;
   }
@@ -345,7 +357,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
     return;
   }
   if (parts.length === 3 && parts[2] === 'stage' && method === 'PUT') {
-    const stage = (await readJson(req)) as unknown as TStage;
+    const stage = (await readJson(req, maxBodyBytes)) as unknown as TStage;
     validationError(stageValidator(stage), `stage ${(stage as { id?: unknown }).id}`);
     if (stage.id !== stageId) {
       throw validationFailure(
@@ -366,7 +378,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
     const sceneId = parts[3]!;
     assertAddressableSegment(sceneId);
     if (method === 'PUT') {
-      const scene = (await readJson(req)) as unknown as TScene;
+      const scene = (await readJson(req, maxBodyBytes)) as unknown as TScene;
       validationError(sceneValidator(scene), `scene ${(scene as { id?: unknown }).id}`);
       assertStorableScene(scene, stageId);
       if (scene.id !== sceneId) {
@@ -384,6 +396,10 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
     if (method === 'GET') {
       const scene = await store.getScene(stageId, sceneId);
       if (scene === null) throw missingScene(stageId, sceneId);
+      assertJsonResponseValue(
+        scene,
+        `scene response ${JSON.stringify(sceneId)} in document ${JSON.stringify(stageId)}`,
+      );
       sendJson(res, 200, scene);
       return;
     }
@@ -408,6 +424,7 @@ export function createDocumentHttpHandler<
   if (typeof options?.authenticate !== 'function') {
     throw new Error('@openmaic/storage: createDocumentHttpHandler requires authenticate');
   }
+  assertMaxBodyBytes(options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES);
   return (req, res) => {
     void route(req, res, store, options).catch((error: unknown) => {
       if (res.headersSent) {

--- a/packages/@openmaic/storage/src/server/index.ts
+++ b/packages/@openmaic/storage/src/server/index.ts
@@ -28,6 +28,7 @@ import { RuntimeAppendConflictError } from '../runtime/types.js';
 import type { Scene, Stage } from '@openmaic/dsl';
 import type { DocumentStore, SceneLike } from '../document/types.js';
 import { createDocumentHttpHandler, type DocumentHttpHandlerOptions } from './document.js';
+import { assertMaxBodyBytes, DEFAULT_MAX_BODY_BYTES, readJsonObject } from './read-json.js';
 
 export {
   createDocumentHttpHandler,
@@ -64,6 +65,8 @@ export interface RuntimeHttpHandlerOptions {
    * pass the same table configured on the injected store.
    */
   payloadValidators?: Record<string, RuntimePayloadValidator>;
+  /** Maximum JSON request-body size in bytes. Defaults to 32 MiB. */
+  maxBodyBytes?: number;
 }
 
 interface ErrorBody {
@@ -95,30 +98,19 @@ function sendNoContent(res: ServerResponse): void {
   res.end();
 }
 
-async function readJson<T>(req: IncomingMessage): Promise<T> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  }
-  if (chunks.length === 0) {
-    throw validationFailure('request body must be a JSON object');
-  }
-  let body: unknown;
-  try {
-    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
-  } catch (error) {
-    throw validationFailure(error instanceof Error ? error.message : String(error));
-  }
-  if (!isObject(body)) throw validationFailure('request body must be a JSON object');
-  return body as T;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function validationFailure(message: string, details?: unknown): RuntimeHttpError {
   return new RuntimeHttpError(400, 'VALIDATION_FAILED', message, details);
+}
+
+function payloadTooLarge(message: string): RuntimeHttpError {
+  return new RuntimeHttpError(413, 'PAYLOAD_TOO_LARGE', message);
+}
+
+function readJson<T>(req: IncomingMessage, maxBodyBytes: number): Promise<T> {
+  return readJsonObject(req, maxBodyBytes, {
+    invalid: validationFailure,
+    payloadTooLarge,
+  });
 }
 
 function validationError(result: ValidationResult, label: string): void {
@@ -417,7 +409,10 @@ async function route(
   }
 
   if (method === 'POST' && parts.length === 2 && parts[1] === 'sessions') {
-    const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(req);
+    const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(
+      req,
+      options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
     assertAddressableSegment(init.id);
     assertAddressableSegment(init.stageId);
     assertAddressableSegment(init.learnerKey, 'learnerKey');
@@ -468,7 +463,7 @@ async function route(
     if (method === 'PATCH' && parts.length === 4 && parts[3] === 'status') {
       const body = await readJson<
         { status: RuntimeSessionStatus; updatedAt: string } & RuntimeTailOptions
-      >(req);
+      >(req, options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES);
       const session = await writableSession(store, principal, sessionId);
       validationError(
         validateRuntimeSession({ ...session, status: body.status, updatedAt: body.updatedAt }),
@@ -504,6 +499,7 @@ async function route(
     if (method === 'POST' && parts.length === 4 && parts[3] === 'records') {
       const body = await readJson<RuntimeRecordInit & RuntimeAppendOptions & { seq?: unknown }>(
         req,
+        options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
       );
       const { expectedLastSeq, sessionTransition, ...init } = body;
       if (init.sessionId !== sessionId) {
@@ -599,7 +595,10 @@ async function route(
   }
 
   if (method === 'POST' && parts.length === 3 && parts[1] === 'learners' && parts[2] === 'merge') {
-    const body = await readJson<{ fromLearnerKey?: unknown; toLearnerKey?: unknown }>(req);
+    const body = await readJson<{ fromLearnerKey?: unknown; toLearnerKey?: unknown }>(
+      req,
+      options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
     if (
       typeof body.fromLearnerKey !== 'string' ||
       body.fromLearnerKey === '' ||
@@ -668,6 +667,7 @@ export function createRuntimeHttpHandler(
   if (typeof options?.authenticate !== 'function') {
     throw new Error('@openmaic/storage: createRuntimeHttpHandler requires authenticate');
   }
+  assertMaxBodyBytes(options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES);
   return (req, res) => {
     void route(req, res, store, options).catch((error: unknown) => {
       if (res.headersSent) {
@@ -712,6 +712,7 @@ export function createStorageHttpHandler<
       : { authorizeDocuments: options.authorizeDocuments }),
     ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
     ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+    ...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
   });
   return (req, res) => {
     let pathname: string;

--- a/packages/@openmaic/storage/src/server/read-json.ts
+++ b/packages/@openmaic/storage/src/server/read-json.ts
@@ -1,0 +1,45 @@
+import type { IncomingMessage } from 'node:http';
+
+export const DEFAULT_MAX_BODY_BYTES = 32 * 1024 * 1024;
+
+export interface ReadJsonErrors {
+  invalid(message: string): Error;
+  payloadTooLarge(message: string): Error;
+}
+
+export function assertMaxBodyBytes(maxBodyBytes: number): void {
+  if (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes <= 0) {
+    throw new Error('@openmaic/storage: maxBodyBytes must be a positive safe integer');
+  }
+}
+
+export async function readJsonObject<T>(
+  req: IncomingMessage,
+  maxBodyBytes: number,
+  errors: ReadJsonErrors,
+): Promise<T> {
+  const chunks: Buffer[] = [];
+  let bodyBytes = 0;
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    bodyBytes += buffer.byteLength;
+    if (bodyBytes > maxBodyBytes) {
+      throw errors.payloadTooLarge(
+        `@openmaic/storage: request body exceeds maxBodyBytes (${maxBodyBytes})`,
+      );
+    }
+    chunks.push(buffer);
+  }
+  if (chunks.length === 0) throw errors.invalid('request body must be a JSON object');
+
+  let body: unknown;
+  try {
+    body = JSON.parse(Buffer.concat(chunks, bodyBytes).toString('utf8')) as unknown;
+  } catch (error) {
+    throw errors.invalid(error instanceof Error ? error.message : String(error));
+  }
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw errors.invalid('request body must be a JSON object');
+  }
+  return body as T;
+}

--- a/packages/@openmaic/storage/src/server/reference.ts
+++ b/packages/@openmaic/storage/src/server/reference.ts
@@ -49,6 +49,8 @@ export interface ReferenceRuntimeServerOptions<
   /** Pass the same validators configured on documentStore. */
   validateScene?: SceneValidator;
   validateStage?: StageValidator;
+  /** Maximum JSON request-body size in bytes. Defaults to 32 MiB. */
+  maxBodyBytes?: number;
 }
 
 /**
@@ -116,6 +118,7 @@ export async function createReferenceRuntimeServer<
       : { authorizeDocuments: options.authorizeDocuments }),
     ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
     ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+    ...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
   };
   return createServer(
     options.documentStore === undefined

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -4,47 +4,47 @@ import { DSL_VERSION, DSL_VERSION_KEY, validateScene, validateStage } from '@ope
 import { BrowserDocumentStore, type MaicDocument } from '../src/index.js';
 import { runDocumentStoreContract, makeDocument, slideScene } from './document-contract.js';
 
-// Each store gets its own in-memory IndexedDB factory so contract cases stay
-// isolated without leaning on an ambient global.
-function makeStore(): BrowserDocumentStore {
-  return new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+// Open the raw DB the store uses and overwrite the stage row's version stamp,
+// simulating a document written by an older client.
+async function reStampStage(
+  idb: IDBFactory,
+  dbName: string,
+  stageId: string,
+  version: string | undefined,
+): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = idb.open(dbName);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('stages', 'readwrite');
+    const store = tx.objectStore('stages');
+    const get = store.get(stageId);
+    get.onsuccess = () => {
+      const row = get.result as Record<string, unknown>;
+      if (version === undefined) delete row[DSL_VERSION_KEY];
+      else row[DSL_VERSION_KEY] = version;
+      store.put(row);
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
 }
 
-runDocumentStoreContract('BrowserDocumentStore', makeStore);
+let contractDb = 0;
+runDocumentStoreContract('BrowserDocumentStore', () => {
+  const idb = new IDBFactory();
+  const dbName = `maic-documents-contract-${contractDb++}`;
+  return {
+    store: new BrowserDocumentStore({ indexedDB: idb, dbName }),
+    seedStoredVersion: (stageId, version) => reStampStage(idb, dbName, stageId, version),
+  };
+});
 
-// --- backend-specific: migrate-on-read needs to seed a raw row at an old
-// version, which the public API (which always stamps the current version) can't
-// express. ---
+// --- backend-specific migrate-on-read and raw IndexedDB behavior. ---
 describe('BrowserDocumentStore migrate-on-read', () => {
-  // Open the raw DB the store uses and overwrite the stage row's version stamp,
-  // simulating a document written by an older client.
-  async function reStampStage(
-    idb: IDBFactory,
-    dbName: string,
-    stageId: string,
-    version: string | undefined,
-  ): Promise<void> {
-    const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const req = idb.open(dbName);
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error);
-    });
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction('stages', 'readwrite');
-      const store = tx.objectStore('stages');
-      const get = store.get(stageId);
-      get.onsuccess = () => {
-        const row = get.result as Record<string, unknown>;
-        if (version === undefined) delete row[DSL_VERSION_KEY];
-        else row[DSL_VERSION_KEY] = version;
-        store.put(row);
-      };
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
-    });
-    db.close();
-  }
-
   test('stamps a legacy (unversioned) document forward on load', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-documents-legacy';
@@ -112,25 +112,6 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     expect(await store.getScene('stage-1', 'new2')).toBeNull();
   });
 
-  test('putStage rejects when the stored document is not current', async () => {
-    const idb = new IDBFactory();
-    const dbName = 'maic-documents-putstage-noncurrent';
-    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
-    const doc = makeDocument();
-    await store.saveDocument(doc);
-
-    await reStampStage(idb, dbName, 'stage-1', undefined);
-    await expect(store.putStage('stage-1', { ...doc.stage, name: 'Stale Rename' })).rejects.toThrow(
-      /cannot putStage/,
-    );
-
-    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
-    await expect(
-      store.putStage('stage-1', { ...doc.stage, name: 'Future Rename' }),
-    ).rejects.toThrow(/cannot putStage/);
-    expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
-  });
-
   test('refuses to overwrite a stored document written by a newer client', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-documents-overwrite-future';
@@ -183,22 +164,6 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // saveDocument reads the stored stamp inside its future-overwrite guard, so a
     // corrupt stored stamp also fails loud (recoverable via deleteDocument).
     await expect(store.saveDocument(makeDocument())).rejects.toThrow();
-  });
-
-  test('listDocuments tolerates a malformed version stamp', async () => {
-    const idb = new IDBFactory();
-    const dbName = 'maic-documents-list-malformed';
-    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
-    await store.saveDocument(makeDocument());
-    await reStampStage(idb, dbName, 'stage-1', 'not-a-version');
-
-    // listDocuments returns only version-independent summary fields and never
-    // migrates or reads content, so a corrupt stamp does not break the whole list
-    // (one bad row must not make the picker unusable) — content reads still fail loud.
-    const list = await store.listDocuments();
-    expect(list.map((d) => d.id)).toEqual(['stage-1']);
-    expect(list[0]).toMatchObject({ name: 'Intro Course', sceneCount: 2 });
-    await expect(store.loadDocument('stage-1')).rejects.toThrow();
   });
 });
 

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -2,8 +2,8 @@
 // today, HTTP later) is proven equivalent by running this same suite against it,
 // so a new backend cannot silently diverge from the store's semantics.
 //
-// Backend-specific behaviours that need to seed raw rows (migrate-on-read,
-// forward-compat) live in the backend's own test file, not here.
+// The harness exposes a narrow raw-version seeding seam so version-guard and
+// corrupt-stamp behavior is proven identically by every backend.
 import { describe, expect, test } from 'vitest';
 import { DSL_VERSION } from '@openmaic/dsl';
 import type { Scene } from '@openmaic/dsl';
@@ -53,8 +53,17 @@ export function makeDocument(stageId = 'stage-1'): MaicDocument {
 
 // --- contract ---------------------------------------------------------------
 
-export function runDocumentStoreContract(name: string, makeStore: () => DocumentStore): void {
+export interface DocumentStoreContractHarness {
+  store: DocumentStore;
+  seedStoredVersion(stageId: string, version: string | undefined): Promise<void>;
+}
+
+export function runDocumentStoreContract(
+  name: string,
+  makeContractHarness: () => DocumentStoreContractHarness,
+): void {
   describe(`DocumentStore contract: ${name}`, () => {
+    const makeStore = (): DocumentStore => makeContractHarness().store;
     test('round-trips a full document (stage + scenes + outline)', async () => {
       const store = makeStore();
       const doc = makeDocument();
@@ -145,6 +154,41 @@ export function runDocumentStoreContract(name: string, makeStore: () => Document
           updatedAt: 2,
         }),
       ).rejects.toThrow(/missing document/);
+    });
+
+    test('putStage rejects a stale stored document', async () => {
+      const { store, seedStoredVersion } = makeContractHarness();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+      await seedStoredVersion('stage-1', undefined);
+
+      await expect(
+        store.putStage('stage-1', { ...doc.stage, name: 'Stale Rename' }),
+      ).rejects.toThrow();
+      expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+    });
+
+    test('putStage rejects a future-versioned stored document', async () => {
+      const { store, seedStoredVersion } = makeContractHarness();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+      await seedStoredVersion('stage-1', '99.0.0');
+
+      await expect(
+        store.putStage('stage-1', { ...doc.stage, name: 'Future Rename' }),
+      ).rejects.toThrow();
+      expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+    });
+
+    test('listDocuments tolerates a corrupt stored version stamp', async () => {
+      const { store, seedStoredVersion } = makeContractHarness();
+      await store.saveDocument(makeDocument());
+      await seedStoredVersion('stage-1', 'not-a-version');
+
+      await expect(store.listDocuments()).resolves.toEqual([
+        expect.objectContaining({ id: 'stage-1', name: 'Intro Course', sceneCount: 2 }),
+      ]);
+      await expect(store.loadDocument('stage-1')).rejects.toThrow();
     });
 
     // --- validation gate ---

--- a/packages/@openmaic/storage/test/http-document-store.test.ts
+++ b/packages/@openmaic/storage/test/http-document-store.test.ts
@@ -1,11 +1,13 @@
 import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http';
 import { IDBFactory } from 'fake-indexeddb';
+import { DSL_VERSION_KEY } from '@openmaic/dsl';
 import { describe, expect, test } from 'vitest';
 import { BrowserDocumentStore } from '../src/document/browser.js';
 import { HttpDocumentStore, HttpDocumentStoreError } from '../src/document/http.js';
+import type { StageValidator } from '../src/document/types.js';
 import { BrowserRuntimeStore } from '../src/runtime/browser.js';
 import { createStorageHttpHandler } from '../src/server/index.js';
-import { makeDocument, runDocumentStoreContract } from './document-contract.js';
+import { makeDocument, runDocumentStoreContract, slideScene } from './document-contract.js';
 
 const BASE_URL = 'http://storage-reference.invalid';
 
@@ -60,8 +62,41 @@ function handlerFetch(handler: RequestListener): typeof globalThis.fetch {
   };
 }
 
-function makeHarness(authorizeDocuments: () => boolean = () => true) {
-  const documents = new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+async function reStampStage(
+  idb: IDBFactory,
+  dbName: string,
+  stageId: string,
+  version: string | undefined,
+): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = idb.open(dbName);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction('stages', 'readwrite');
+    const stages = transaction.objectStore('stages');
+    const request = stages.get(stageId);
+    request.onsuccess = () => {
+      const row = request.result as Record<string, unknown>;
+      if (version === undefined) delete row[DSL_VERSION_KEY];
+      else row[DSL_VERSION_KEY] = version;
+      stages.put(row);
+    };
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+  db.close();
+}
+
+let harnessDb = 0;
+function makeHarness(
+  authorizeDocuments: () => boolean = () => true,
+  options: { maxBodyBytes?: number; validateStage?: StageValidator } = {},
+) {
+  const idb = new IDBFactory();
+  const dbName = `http-document-contract-${harnessDb++}`;
+  const documents = new BrowserDocumentStore({ indexedDB: idb, dbName });
   const runtime = new BrowserRuntimeStore({ indexedDB: new IDBFactory() });
   const handler = createStorageHttpHandler(runtime, documents, {
     authenticate: async (req) => {
@@ -71,16 +106,26 @@ function makeHarness(authorizeDocuments: () => boolean = () => true) {
         : undefined;
     },
     authorizeDocuments: async () => authorizeDocuments(),
+    ...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
+    ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
   });
   const fetch = handlerFetch(handler);
   return {
     documents,
     fetch,
     client: new HttpDocumentStore({ baseUrl: BASE_URL, fetch }),
+    seedStoredVersion: (stageId: string, version: string | undefined) =>
+      reStampStage(idb, dbName, stageId, version),
   };
 }
 
-runDocumentStoreContract('reference HTTP', () => makeHarness().client);
+runDocumentStoreContract('reference HTTP', () => {
+  const harness = makeHarness();
+  return {
+    store: harness.client,
+    seedStoredVersion: harness.seedStoredVersion,
+  };
+});
 
 describe('HttpDocumentStore contract mapping', () => {
   test('uses injected request headers and the reference server requires authentication', async () => {
@@ -125,6 +170,47 @@ describe('HttpDocumentStore contract mapping', () => {
     });
   });
 
+  test('rejects oversized bodies with 413 while allowing an under-limit request', async () => {
+    const { fetch } = makeHarness(() => true, { maxBodyBytes: 256 });
+    const overLimit = await fetch(`${BASE_URL}/documents/stage-1`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ padding: 'x'.repeat(300) }),
+    });
+    expect(overLimit.status).toBe(413);
+    await expect(overLimit.json()).resolves.toMatchObject({
+      error: { code: 'PAYLOAD_TOO_LARGE' },
+    });
+
+    const underLimit = await fetch(`${BASE_URL}/documents/stage-1/stage`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'stage-1',
+        name: 'Missing parent',
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    });
+    expect(underLimit.status).toBe(404);
+  });
+
+  test('fails loud when a structured-clone document is not JSON-safe on read', async () => {
+    const { documents, fetch } = makeHarness();
+    const document = makeDocument();
+    document.outline = { generatedAt: new Date('2026-01-01T00:00:00.000Z') };
+    await documents.saveDocument(document);
+
+    const response = await fetch(`${BASE_URL}/documents/stage-1`);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'NOT_JSON_SAFE',
+        message: expect.stringMatching(/document response.*outline.*Date/i),
+      },
+    });
+  });
+
   test('maps missing required parents to typed 404 errors with browser wording', async () => {
     const { client } = makeHarness();
     const failure = client.putStage('ghost', {
@@ -136,6 +222,34 @@ describe('HttpDocumentStore contract mapping', () => {
     await expect(failure).rejects.toBeInstanceOf(HttpDocumentStoreError);
     await expect(failure).rejects.toMatchObject({ status: 404, code: 'DOCUMENT_NOT_FOUND' });
     await expect(failure).rejects.toThrow(/missing document/);
+  });
+
+  test.each([
+    [
+      'putStage',
+      (client: HttpDocumentStore) =>
+        client.putStage('stage-1', {
+          id: 'stage-1',
+          name: 'Stale update',
+          createdAt: 1,
+          updatedAt: 2,
+        }),
+    ],
+    [
+      'putScene',
+      (client: HttpDocumentStore) =>
+        client.putScene('stage-1', slideScene('stage-1', 'scene-c', 2)),
+    ],
+    ['deleteScene', (client: HttpDocumentStore) => client.deleteScene('stage-1', 'scene-a')],
+  ])('maps unversioned %s to 400 VALIDATION_FAILED', async (_operation, write) => {
+    const { client, seedStoredVersion } = makeHarness();
+    await client.saveDocument(makeDocument());
+    await seedStoredVersion('stage-1', undefined);
+
+    await expect(write(client)).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_FAILED',
+    });
   });
 
   test('maps a future-version save to FUTURE_VERSION without overwriting current data', async () => {
@@ -165,5 +279,28 @@ describe('HttpDocumentStore contract mapping', () => {
     delete (bad.stage as { name?: string }).name;
     await expect(client.saveDocument(bad)).rejects.toThrow(/invalid stage/);
     expect(calls).toBe(0);
+  });
+
+  test('retains structured validator details on HttpDocumentStoreError', async () => {
+    const details = [
+      { path: '/name', message: 'name is invalid' },
+      { path: '/updatedAt', message: 'updatedAt is invalid' },
+    ];
+    const { client } = makeHarness(() => true, {
+      validateStage: () => ({ valid: false, errors: details }),
+    });
+
+    await expect(
+      client.putStage('stage-1', {
+        id: 'stage-1',
+        name: 'Rejected by server validator',
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_FAILED',
+      details,
+    });
   });
 });

--- a/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
@@ -56,5 +56,20 @@ describe.skipIf(!contractUrl)('PgDocumentStore with PostgreSQL 16', () => {
     await pool.end();
   });
 
-  runDocumentStoreContract('PostgreSQL 16 (node-postgres)', () => store);
+  runDocumentStoreContract('PostgreSQL 16 (node-postgres)', () => ({
+    store,
+    seedStoredVersion: async (stageId, version) => {
+      const result = await pool.query<{ data: unknown }>(
+        'SELECT data FROM document_stages WHERE id = $1',
+        [stageId],
+      );
+      const data = result.rows[0]!.data as Record<string, unknown>;
+      if (version === undefined) delete data.dslVersion;
+      else data.dslVersion = version;
+      await pool.query('UPDATE document_stages SET data = $2::jsonb WHERE id = $1', [
+        stageId,
+        JSON.stringify(data),
+      ]);
+    },
+  }));
 });

--- a/packages/@openmaic/storage/test/pg-document-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.test.ts
@@ -46,7 +46,10 @@ describe('PgDocumentStore with PGlite', () => {
     await db.close();
   });
 
-  runDocumentStoreContract('Postgres (PGlite)', () => store);
+  runDocumentStoreContract('Postgres (PGlite)', () => ({
+    store,
+    seedStoredVersion: (stageId, version) => restamp(db, stageId, version),
+  }));
 });
 
 describe('PgDocumentStore Postgres behavior', () => {

--- a/packages/@openmaic/storage/test/runtime-reference-server.test.ts
+++ b/packages/@openmaic/storage/test/runtime-reference-server.test.ts
@@ -239,6 +239,7 @@ describe('reference HTTP handler principal capabilities', () => {
       authorizeAdmin: async () => true,
       authorizeMerge: async () => true,
       payloadValidators: {},
+      maxBodyBytes: 64,
     });
     const handler = server.listeners('request')[0] as RequestListener;
 
@@ -249,6 +250,15 @@ describe('reference HTTP handler principal capabilities', () => {
     );
     expect(response.status).toBe(204);
     expect(statements).toContain('DELETE FROM runtime_sessions');
+
+    const oversized = await handlerFetch(handler, async () => 'Bearer capability-only')(
+      `${BASE_URL}/runtime/learners/merge`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ padding: 'x'.repeat(100) }),
+      },
+    );
+    expect(oversized.status).toBe(413);
   });
 
   test('returns 403 FORBIDDEN_LEARNER on learner routes without learnerKey', async () => {
@@ -267,6 +277,30 @@ describe('reference HTTP handler principal capabilities', () => {
 });
 
 describe('reference HTTP handler validation boundary', () => {
+  test('rejects an oversized request body with 413 and accepts an under-limit body', async () => {
+    const store = new BrowserRuntimeStore({ indexedDB: new IDBFactory() });
+    const handler = createRuntimeHttpHandler(store, {
+      authenticate: async () => ({ learnerKey: 'anon:device-1' }),
+      maxBodyBytes: 256,
+    });
+    const request = handlerFetch(handler, async () => 'Bearer anon:device-1');
+
+    const oversized = await request(`${BASE_URL}/runtime/sessions`, {
+      method: 'POST',
+      body: JSON.stringify({ padding: 'x'.repeat(300) }),
+    });
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toMatchObject({
+      error: { code: 'PAYLOAD_TOO_LARGE' },
+    });
+
+    const accepted = await request(`${BASE_URL}/runtime/sessions`, {
+      method: 'POST',
+      body: JSON.stringify(makeSession({ id: 'under-limit' })),
+    });
+    expect(accepted.status).toBe(201);
+  });
+
   test.each([
     ['session id with NUL', makeSession({ id: 'bad\u0000session' })],
     ['session stageId with a lone surrogate', makeSession({ stageId: 'bad\ud800stage' })],


### PR DESCRIPTION
All five findings from the adversarial final review: legacy-write 500 misclassification → 400; fail-loud JSON-safety on reads (NOT_JSON_SAFE); bounded request bodies (413, default 32 MiB, configurable on every factory); putStage version guards + corrupt-stamp tolerance promoted into the shared contract suite (all four backends); structured error details retained on both HTTP store errors.

395 package tests green; contract docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)