### PR TITLE
feat(storage): server-backed documents — HTTP contract, Postgres backend, one reference server for both stores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/maic-editor-v0, feat/maic-editor-v1, runtime-server-backend, integration/runtime-data-cutover, integration/document-cutover]
+    branches: [main, feat/maic-editor-v0, feat/maic-editor-v1, runtime-server-backend, integration/document-server-backend]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/storage-pg-contract.yml
+++ b/.github/workflows/storage-pg-contract.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, runtime-server-backend, feat/maic-editor-v0, feat/maic-editor-v1]
+    branches: [main, runtime-server-backend, feat/maic-editor-v0, feat/maic-editor-v1, integration/document-server-backend]
 
 concurrency:
   group: storage-pg-contract-${{ github.ref }}

--- a/lib/document-store/config.ts
+++ b/lib/document-store/config.ts
@@ -1,0 +1,103 @@
+import type { DocumentStore, SceneValidator, StageValidator } from '@openmaic/storage';
+
+import type { AppScene } from '@/lib/types/stage';
+
+import type { AppStage } from './persistence-types';
+import { validateAppScene, validateAppStage } from './validators';
+
+export interface DocumentStorageValidators {
+  validateScene: SceneValidator;
+  validateStage: StageValidator;
+}
+
+export type DocumentStoreFactory = (
+  validators: DocumentStorageValidators,
+) => DocumentStore<AppScene, AppStage>;
+
+export interface DocumentStorageOptions {
+  /**
+   * A DocumentStore instance, or a factory evaluated lazily until it first
+   * succeeds. Factories receive the app validators and must inject them into
+   * server-backed stores so every backend preserves the app write boundary.
+   */
+  store?: DocumentStore<AppScene, AppStage> | DocumentStoreFactory;
+}
+
+let options: DocumentStorageOptions | undefined;
+let resolutionStarted = false;
+
+/**
+ * Configure the app-wide document persistence backend.
+ *
+ * This is a client-bootstrap-only, single-shot API. It is not SSR-safe and is
+ * not intended for request-scoped stores. Call it at module-level bootstrap,
+ * before rendering any document consumer; a component effect is too late. A
+ * second call always throws, even if document storage has not been used yet.
+ * Once resolution has started, configuration stays sealed so a live app cannot
+ * split documents across backends. Omitting the store retains the browser
+ * IndexedDB backend.
+ *
+ * A store factory is called lazily by `getDocumentStore()` until it first
+ * succeeds. It receives `validateAppScene` and `validateAppStage`; inject those
+ * validators into a server-backed store (for example, `HttpDocumentStore`) so
+ * the app's widened scene union and stage rules remain enforced at the client
+ * write boundary.
+ *
+ * Dev-mode limitation: configuration and consumer caches live in separate
+ * modules, so partial HMR replacement can fragment their module-level state.
+ * Reload the page after changing bootstrap configuration.
+ *
+ * @example
+ * ```ts
+ * configureDocumentStorage({
+ *   store: ({ validateScene, validateStage }) =>
+ *     new HttpDocumentStore({ baseUrl: '/api', validateScene, validateStage }),
+ * });
+ * ```
+ */
+export function configureDocumentStorage(next: DocumentStorageOptions): void {
+  if (resolutionStarted) {
+    throw new Error(
+      'configureDocumentStorage must be called at module-level bootstrap, before any document consumer runs — a component effect is too late. Document storage resolution has already started; configuration remains sealed even if resolution failed. Retry the document consumer to retry resolution.',
+    );
+  }
+  if (options) {
+    throw new Error('Document storage has already been configured');
+  }
+  // Snapshot: a caller mutating its options object after configuring must not
+  // be able to swap the backend behind the sealed configuration.
+  options = { store: next.store };
+}
+
+/** Whether client bootstrap has supplied document storage configuration. */
+export function isDocumentStorageConfigured(): boolean {
+  return options !== undefined;
+}
+
+type DocumentStorageResetHook = () => void;
+const resetHooks: DocumentStorageResetHook[] = [];
+
+/**
+ * @internal Modules that latch singleton caches derived from this
+ * configuration register a clearer so the test reset below leaves no stale
+ * cache behind.
+ */
+export function registerDocumentStorageResetHook(hook: DocumentStorageResetHook): void {
+  resetHooks.push(hook);
+}
+
+/** @internal Test-only reset: clears configuration AND every latched consumer cache. */
+export function resetDocumentStorageForTests(): void {
+  options = undefined;
+  resolutionStarted = false;
+  for (const hook of resetHooks) hook();
+}
+
+/** @internal Resolve and seal the configured store override, if any. */
+export function resolveConfiguredDocumentStore(): DocumentStore<AppScene, AppStage> | undefined {
+  resolutionStarted = true;
+  const configured = options?.store;
+  return typeof configured === 'function'
+    ? configured({ validateScene: validateAppScene, validateStage: validateAppStage })
+    : configured;
+}

--- a/lib/document-store/index.ts
+++ b/lib/document-store/index.ts
@@ -11,7 +11,16 @@ export {
   canonicalizeLegacyScene,
   canonicalizeLegacyStage,
 } from './canonicalize';
-export { getDocumentStore, type DocumentStoreDeps } from './store';
+export {
+  configureDocumentStorage,
+  getDocumentStore,
+  isDocumentStorageConfigured,
+  resetDocumentStorageForTests,
+  type DocumentStorageOptions,
+  type DocumentStorageValidators,
+  type DocumentStoreDeps,
+  type DocumentStoreFactory,
+} from './store';
 export {
   accessDocument,
   documentLockName,

--- a/lib/document-store/store.ts
+++ b/lib/document-store/store.ts
@@ -2,8 +2,20 @@ import { BrowserDocumentStore, type DocumentStore } from '@openmaic/storage';
 
 import type { AppScene } from '@/lib/types/stage';
 
+import { registerDocumentStorageResetHook, resolveConfiguredDocumentStore } from './config';
 import type { AppStage } from './persistence-types';
 import { validateAppScene, validateAppStage } from './validators';
+
+export {
+  configureDocumentStorage,
+  isDocumentStorageConfigured,
+  resetDocumentStorageForTests,
+} from './config';
+export type {
+  DocumentStorageOptions,
+  DocumentStorageValidators,
+  DocumentStoreFactory,
+} from './config';
 
 const DOCUMENT_DB_NAME = 'maic-documents';
 
@@ -17,6 +29,10 @@ export interface DocumentStoreDeps {
 }
 
 let defaultStore: DocumentStore<AppScene, AppStage> | undefined;
+
+registerDocumentStorageResetHook(() => {
+  defaultStore = undefined;
+});
 
 function createBrowserStore(
   deps: Omit<DocumentStoreDeps, 'store'>,
@@ -38,5 +54,7 @@ function createBrowserStore(
 export function getDocumentStore(deps: DocumentStoreDeps = {}): DocumentStore<AppScene, AppStage> {
   if (deps.store) return deps.store;
   if (deps.indexedDB || deps.dbName) return createBrowserStore(deps);
-  return (defaultStore ??= createBrowserStore({}));
+  // `??=` assigns only after resolution succeeds: if a configured factory
+  // throws, the next call retries it rather than caching the failure.
+  return (defaultStore ??= resolveConfiguredDocumentStore() ?? createBrowserStore({}));
 }

--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -6,9 +6,9 @@ persisting app state, depending only on [`@openmaic/dsl`](../dsl).
 The DSL owns _what_ persists (document / runtime shape + validation + migration +
 the asset `StorageProvider` interface). This package owns _where / how_ it
 persists — the primitives and their backends. The pluggable seam is the
-**backend**, not the database driver: a browser backend (zero server, the
-`clone-and-run` default) and, later, an HTTP backend whose server owns a
-database.
+**backend**, not the database driver: browser backends (the zero-server
+`clone-and-run` default), HTTP clients plus a reference server, and PostgreSQL
+server backends.
 
 ## Dependency arrow (acyclic)
 
@@ -76,8 +76,9 @@ a browser.
 Each primitive has one implementation-agnostic contract suite
 (`test/kv-contract.ts`, `test/asset-contract.ts`, `test/document-contract.ts`,
 `test/runtime-contract.ts`).
-Every backend is proven by running the same suite against it, so a new backend
-(the coming HTTP one) cannot silently diverge from the primitive's semantics.
+Every backend is proven by running the same suite against it, so browser, HTTP,
+and PostgreSQL implementations cannot silently diverge from a primitive's
+semantics.
 
 ## Roadmap
 
@@ -89,7 +90,10 @@ Every backend is proven by running the same suite against it, so a new backend
 - [x] `RuntimeStore` (sessions + append-only records, runtime version line,
       per-kind payload gate) + browser backend
 - [ ] wire the app's zustand stores + ad-hoc `localStorage` through `KVStore`
-- [ ] HTTP backend + reference server + one HTTP contract
+- [x] RuntimeStore HTTP backend + reference server + HTTP contract
+- [x] RuntimeStore PostgreSQL backend
+- [x] DocumentStore HTTP backend + reference-server routes + HTTP contract
+- [x] DocumentStore PostgreSQL backend
 
 ## License
 

--- a/packages/@openmaic/storage/docs/document-http-contract.md
+++ b/packages/@openmaic/storage/docs/document-http-contract.md
@@ -21,7 +21,9 @@ This contract exposes the complete `DocumentStore` interface over JSON HTTP. All
 
 Servers run their configured `validateStage` and `validateScene` gates before writes. A full save validates the migrated aggregate and rejects duplicate scene ids, mismatched scene partitions, and non-finite order values before changing storage. `putStage` and `putScene` repeat the same boundary validation and require an existing document whose stored `dslVersion` is exactly the server's current `DSL_VERSION`. A stale document must first be loaded and saved as a full aggregate; a future document must never be downgraded. `deleteScene` has the same current-version guard, while whole-document deletion deliberately does not.
 
-HTTP implementations carry data through JSON and therefore accept only plain values that serialize without changing meaning. They fail before sending or storing values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, `undefined`, `bigint`, sparse arrays, class instances, symbol/non-enumerable properties, U+0000 strings, and circular references. The opaque outline is not DSL-validated or migrated, but it is still subject to this JSON transport rule.
+HTTP implementations carry data through JSON and therefore accept only plain values that serialize without changing meaning. They fail before sending or storing values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, `undefined`, `bigint`, sparse arrays, class instances, symbol/non-enumerable properties, U+0000 strings, and circular references. The opaque outline is not DSL-validated or migrated, but it is still subject to this JSON transport rule. A store exposed by the server MUST contain JSON-safe document, scene, outline, and summary values; the handler validates read payloads before serialization and returns `500 NOT_JSON_SAFE` with the offending path if this invariant is violated.
+
+The handler streams request bodies into a bounded buffer. `maxBodyBytes` configures the bound on `createDocumentHttpHandler` and composed/reference server factories; it defaults to 32 MiB. A body that crosses the bound is rejected immediately with `413 PAYLOAD_TOO_LARGE`.
 
 Reads are migrated on both sides of the wire. The backing store performs its normal migrate-on-read, and the HTTP client migrates the returned document again so an older server cannot leak a stale envelope into a newer application. The opaque outline is removed before DSL migration and reattached unchanged.
 
@@ -48,10 +50,12 @@ Every non-2xx response has a machine-readable JSON body:
 | Condition | HTTP status | Error code | Client behavior |
 | --- | --- | --- | --- |
 | Malformed JSON, invalid stage/scene/document, body/path mismatch, non-JSON value, duplicate scene id, or stale incremental write | `400` | `VALIDATION_FAILED` | Throw `HttpDocumentStoreError` with the server message |
+| Request body exceeds `maxBodyBytes` | `413` | `PAYLOAD_TOO_LARGE` | Throw `HttpDocumentStoreError` |
 | Document does not exist | `404` | `DOCUMENT_NOT_FOUND` | `loadDocument` returns `null`; required-parent writes throw with `missing document` semantics |
 | Scene does not exist | `404` | `SCENE_NOT_FOUND` | `getScene` returns `null` |
 | Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpDocumentStoreError` |
 | Input or stored document was written at a future DSL version | `409` | `FUTURE_VERSION` | Throw `HttpDocumentStoreError` with `newer than this client's`/version-guard semantics |
+| A server-exposed read value is not JSON-safe | `500` | `NOT_JSON_SAFE` | Throw `HttpDocumentStoreError` with the offending value path |
 | Unexpected server failure | `500` | `INTERNAL_ERROR` | Throw `HttpDocumentStoreError`; the reference handler does not expose internal details |
 
 Only the machine-readable not-found codes are translated to `null`. Status alone is not sufficient. Authentication failures use `401 UNAUTHENTICATED`, and authorization failures use `403 FORBIDDEN_DOCUMENTS`.

--- a/packages/@openmaic/storage/docs/document-http-contract.md
+++ b/packages/@openmaic/storage/docs/document-http-contract.md
@@ -1,0 +1,61 @@
+# DocumentStore HTTP contract
+
+This contract exposes the complete `DocumentStore` interface over JSON HTTP. All paths are relative to a deployment-defined base URL. Path segments are percent-encoded UTF-8 strings and MUST NOT be exactly `.` or `..`, because URL parsers normalize dot segments before routing. Request and response bodies use `application/json`; successful writes return `204 No Content`.
+
+## Endpoints
+
+| Method | Path | Purpose | Success |
+| --- | --- | --- | --- |
+| `PUT` | `/documents/{stageId}` | Save the full `MaicDocument`; body `stage.id` must match the path. The store migrates stale input, stamps `dslVersion`, replaces stage/outline data, upserts incoming scenes, and removes omitted scenes atomically. | `204` |
+| `GET` | `/documents/{stageId}` | Load and migrate one complete document. | `200` with `MaicDocument`, or `404 DOCUMENT_NOT_FOUND` |
+| `GET` | `/documents` | List version-independent summaries. | `200` with `DocumentSummary[]` |
+| `DELETE` | `/documents/{stageId}` | Cascade-delete a document, its scenes, and its outline. Idempotent and intentionally not version-guarded. | `204` |
+| `PUT` | `/documents/{stageId}/stage` | Validate and replace the stage row of an existing current-version document; body `id` must match the path. | `204` |
+| `PUT` | `/documents/{stageId}/scenes/{sceneId}` | Validate and upsert a scene in an existing current-version document; body `id` and `stageId` must match the path. | `204` |
+| `GET` | `/documents/{stageId}/scenes/{sceneId}` | Read one scene through the parent document's migrate-on-read semantics. | `200` with the scene, or `404` |
+| `DELETE` | `/documents/{stageId}/scenes/{sceneId}` | Delete one scene. Idempotent for an absent scene or document, but version-guarded when the parent exists. | `204` |
+
+`GET /documents` returns only `id`, `name`, optional `description`, optional `interactiveMode`, optional `taskEngineMode`, `createdAt`, `updatedAt`, and `sceneCount`. Those fields are independent of the DSL version. Implementations MUST NOT migrate document content to produce this list and MUST tolerate an unknown or malformed stored version stamp.
+
+## Validation, versions, and JSON
+
+Servers run their configured `validateStage` and `validateScene` gates before writes. A full save validates the migrated aggregate and rejects duplicate scene ids, mismatched scene partitions, and non-finite order values before changing storage. `putStage` and `putScene` repeat the same boundary validation and require an existing document whose stored `dslVersion` is exactly the server's current `DSL_VERSION`. A stale document must first be loaded and saved as a full aggregate; a future document must never be downgraded. `deleteScene` has the same current-version guard, while whole-document deletion deliberately does not.
+
+HTTP implementations carry data through JSON and therefore accept only plain values that serialize without changing meaning. They fail before sending or storing values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, `undefined`, `bigint`, sparse arrays, class instances, symbol/non-enumerable properties, U+0000 strings, and circular references. The opaque outline is not DSL-validated or migrated, but it is still subject to this JSON transport rule.
+
+Reads are migrated on both sides of the wire. The backing store performs its normal migrate-on-read, and the HTTP client migrates the returned document again so an older server cannot leak a stale envelope into a newer application. The opaque outline is removed before DSL migration and reattached unchanged.
+
+## Authentication and authorization
+
+Documents are author assets, not learner-partitioned data. The contract does not prescribe a tenant or ownership model; deployments enforce their policy through the injected `authenticate` and `authorizeDocuments` hooks. The reference handler requires an authenticated principal for every document route. Its default authorization permits any authenticated principal; production deployments can supply `authorizeDocuments` to apply author, tenant, role, or document-level policy.
+
+## Errors
+
+Every non-2xx response has a machine-readable JSON body:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "@openmaic/storage: invalid stage ...",
+    "details": []
+  }
+}
+```
+
+`details` is optional. Messages retain backing-store semantics so the client exposes the same useful wording as `BrowserDocumentStore`.
+
+| Condition | HTTP status | Error code | Client behavior |
+| --- | --- | --- | --- |
+| Malformed JSON, invalid stage/scene/document, body/path mismatch, non-JSON value, duplicate scene id, or stale incremental write | `400` | `VALIDATION_FAILED` | Throw `HttpDocumentStoreError` with the server message |
+| Document does not exist | `404` | `DOCUMENT_NOT_FOUND` | `loadDocument` returns `null`; required-parent writes throw with `missing document` semantics |
+| Scene does not exist | `404` | `SCENE_NOT_FOUND` | `getScene` returns `null` |
+| Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpDocumentStoreError` |
+| Input or stored document was written at a future DSL version | `409` | `FUTURE_VERSION` | Throw `HttpDocumentStoreError` with `newer than this client's`/version-guard semantics |
+| Unexpected server failure | `500` | `INTERNAL_ERROR` | Throw `HttpDocumentStoreError`; the reference handler does not expose internal details |
+
+Only the machine-readable not-found codes are translated to `null`. Status alone is not sufficient. Authentication failures use `401 UNAUTHENTICATED`, and authorization failures use `403 FORBIDDEN_DOCUMENTS`.
+
+## Retry and atomicity guarantees
+
+Full saves are atomic: validation or any failed child write leaves the previous aggregate untouched. `DELETE /documents/{stageId}` and scene deletion are safely retryable. Stage and scene puts are idempotent for the same body, subject to the current-version guard. The contract does not add conditional requests or idempotency keys; deployments that retry an ambiguous full save must rely on the caller-owned `stageId` and replacement semantics.

--- a/packages/@openmaic/storage/docs/reference-server.md
+++ b/packages/@openmaic/storage/docs/reference-server.md
@@ -20,7 +20,7 @@ The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` o
 - `authorizeMerge(principal, fromKey, toKey)` must explicitly establish that the principal may migrate the complete source partition into the destination identity. Default denial is intentional.
 - `authorizeAdmin(principal)` must require a separately protected administrative role. Default denial is intentional.
 
-The handler's `payloadValidators` option has the same whole-table replacement semantics as the `BrowserRuntimeStore` and `PgRuntimeStore` constructor option, and defaults to the DSL `chat` / `quizAttempt` skeleton table. Whatever you pass to the store, pass the same thing to the handler. `createReferenceRuntimeServer()` applies its `payloadValidators` override to both automatically.
+The handler's `payloadValidators` option has the same whole-table replacement semantics as the `BrowserRuntimeStore` and `PgRuntimeStore` constructor option, and defaults to the DSL `chat` / `quizAttempt` skeleton table. Whatever you pass to the store, pass the same thing to the handler. `createReferenceRuntimeServer()` applies its `payloadValidators` override to both automatically. Its `maxBodyBytes` option applies to runtime and document routes and defaults to 32 MiB; oversized bodies receive `413 PAYLOAD_TOO_LARGE`.
 
 The package has no PostgreSQL driver runtime dependency. A host injects its `Pool` (or another compatible `Queryable`) and owns driver lifecycle. Every transactional operation must check out a fresh connection, issue `BEGIN`, run all callback queries on that same connection, issue `COMMIT` or `ROLLBACK`, and release it in `finally`.
 

--- a/packages/@openmaic/storage/docs/reference-server.md
+++ b/packages/@openmaic/storage/docs/reference-server.md
@@ -1,6 +1,6 @@
-# RuntimeStore reference server
+# RuntimeStore and DocumentStore reference server
 
-The `@openmaic/storage/server` subpath exports a Node-only HTTP request handler implementing the [RuntimeStore HTTP contract](./runtime-http-contract.md). It accepts any injected `RuntimeStore`; the runnable `@openmaic/storage/server/reference` composition uses `PgRuntimeStore`, initializes its schema, and demonstrates the required node-postgres checkout/transaction/release pattern.
+The `@openmaic/storage/server` subpath exports a Node-only HTTP request handler implementing the [RuntimeStore HTTP contract](./runtime-http-contract.md) and, when a document store is supplied, the [DocumentStore HTTP contract](./document-http-contract.md). It accepts injected `RuntimeStore` and `DocumentStore` implementations; the runnable `@openmaic/storage/server/reference` composition creates and initializes `PgRuntimeStore`, accepts an optional host-created document store, and demonstrates the required node-postgres checkout/transaction/release pattern.
 
 This module is a reference, not a production authentication service. **The example bearer authentication is fully impersonatable.** A production host must supply its own authenticated identity and authorization policy. It must also terminate TLS, bound request sizes and timeouts, rate-limit abusive clients, keep database credentials outside the process image, and expose the service only through an appropriate application gateway.
 
@@ -16,12 +16,37 @@ DATABASE_URL=postgres://user:password@host/database PORT=3000 \
 The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` only creates and returns an unbound Node `Server`. The default bearer token payload is used directly as the demo `learnerKey`, self-merge is the only allowed merge, and admin operations are denied. Supplying `documentStore` adds the DocumentStore routes to that same server; any authenticated principal is allowed by default, or `authorizeDocuments` can enforce deployment policy. The factory also accepts `authenticate`, `authorizeMerge`, `authorizeAdmin`, and validator overrides. Replace the policy hooks before exposing a deployment:
 
 - `authenticate(req)` must validate a real credential and derive the canonical learner partition from server-controlled identity state.
+- `authorizeDocuments(principal, req)` must establish that the principal may access the requested author document operation. The default permits every authenticated principal.
 - `authorizeMerge(principal, fromKey, toKey)` must explicitly establish that the principal may migrate the complete source partition into the destination identity. Default denial is intentional.
 - `authorizeAdmin(principal)` must require a separately protected administrative role. Default denial is intentional.
 
 The handler's `payloadValidators` option has the same whole-table replacement semantics as the `BrowserRuntimeStore` and `PgRuntimeStore` constructor option, and defaults to the DSL `chat` / `quizAttempt` skeleton table. Whatever you pass to the store, pass the same thing to the handler. `createReferenceRuntimeServer()` applies its `payloadValidators` override to both automatically.
 
 The package has no PostgreSQL driver runtime dependency. A host injects its `Pool` (or another compatible `Queryable`) and owns driver lifecycle. Every transactional operation must check out a fresh connection, issue `BEGIN`, run all callback queries on that same connection, issue `COMMIT` or `ROLLBACK`, and release it in `finally`.
+
+## Document endpoints
+
+Every document route requires an authenticated principal. By default,
+`authorizeDocuments` allows any authenticated principal; production deployments
+must replace that policy when documents are tenant-, role-, or author-scoped.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `PUT` | `/documents/{stageId}` | Save a complete document |
+| `GET` | `/documents/{stageId}` | Load a complete document |
+| `GET` | `/documents` | List document summaries |
+| `DELETE` | `/documents/{stageId}` | Delete a document and its children |
+| `PUT` | `/documents/{stageId}/stage` | Replace stage metadata |
+| `PUT` | `/documents/{stageId}/scenes/{sceneId}` | Upsert one scene |
+| `GET` | `/documents/{stageId}/scenes/{sceneId}` | Read one scene |
+| `DELETE` | `/documents/{stageId}/scenes/{sceneId}` | Delete one scene |
+
+The reference composition applies its `validateScene` and `validateStage`
+overrides to the HTTP handler; the host must configure the injected document
+store with the same validators. Keep those validators in sync when composing
+the lower-level handler yourself. Full response, validation, version, and retry
+semantics are specified in the
+[DocumentStore HTTP contract](./document-http-contract.md).
 
 ## Endpoint authorization matrix
 

--- a/packages/@openmaic/storage/docs/reference-server.md
+++ b/packages/@openmaic/storage/docs/reference-server.md
@@ -13,7 +13,7 @@ DATABASE_URL=postgres://user:password@host/database PORT=3000 \
   node packages/@openmaic/storage/dist/server/reference.js
 ```
 
-The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` only creates and returns an unbound Node `Server`. The default bearer token payload is used directly as the demo `learnerKey`, self-merge is the only allowed merge, and admin operations are denied. The factory accepts optional `authenticate`, `authorizeMerge`, `authorizeAdmin`, and `payloadValidators` overrides. Replace the three policy hooks before exposing a deployment:
+The executable `main()` binds to `127.0.0.1`; `createReferenceRuntimeServer()` only creates and returns an unbound Node `Server`. The default bearer token payload is used directly as the demo `learnerKey`, self-merge is the only allowed merge, and admin operations are denied. Supplying `documentStore` adds the DocumentStore routes to that same server; any authenticated principal is allowed by default, or `authorizeDocuments` can enforce deployment policy. The factory also accepts `authenticate`, `authorizeMerge`, `authorizeAdmin`, and validator overrides. Replace the policy hooks before exposing a deployment:
 
 - `authenticate(req)` must validate a real credential and derive the canonical learner partition from server-controlled identity state.
 - `authorizeMerge(principal, fromKey, toKey)` must explicitly establish that the principal may migrate the complete source partition into the destination identity. Default denial is intentional.

--- a/packages/@openmaic/storage/docs/runtime-http-contract.md
+++ b/packages/@openmaic/storage/docs/runtime-http-contract.md
@@ -50,6 +50,8 @@ An append may also include a top-level `sessionTransition` object with `{ "statu
 
 HTTP implementations carry record payloads through JSON and therefore MUST accept only plain JSON values that survive serialization without changing meaning. They MUST fail loud before sending values such as `Map`, `Set`, `Date`, non-finite numbers, negative zero, nested `undefined`, `bigint`, sparse arrays, symbol-keyed properties, non-enumerable properties, arrays with non-index own properties, strings containing U+0000, class instances, and circular references. U+2028 and U+2029 are valid JSON string contents and MUST be accepted. This is intentionally narrower than `BrowserRuntimeStore`, whose structured-clone persistence can preserve values such as `Map`, `Set`, and `Date` that JSON cannot.
 
+The reference handler streams request bodies into a bounded buffer. `maxBodyBytes` configures the bound on the runtime, composed-storage, and reference-server factories; it defaults to 32 MiB. A body that crosses the bound is rejected immediately with `413 PAYLOAD_TOO_LARGE`.
+
 ## learnerKey security model
 
 `learnerKey` appears in paths, query parameters, and request bodies, but the server MUST derive or verify `learnerKey` from the authenticated session and MUST NOT blindly trust the client-submitted value. `learnerKey` is an opaque partition key, not proof of identity or authorization; trusting it verbatim creates a lateral-authorization vulnerability that lets one learner read, merge, or delete another learner's runtime data. The same rule applies to both keys in `mergeLearner`; authorization policy must explicitly permit the authenticated principal to migrate the source partition into the destination partition.
@@ -75,6 +77,7 @@ Every non-2xx response has this machine-readable JSON shape:
 | Condition | HTTP status | Error code | Client behavior |
 | --- | --- | --- | --- |
 | Malformed JSON, an invalid envelope or payload, invalid learner keys, a body/path mismatch, or append to a non-active session | `400` | `VALIDATION_FAILED` | Throw `HttpRuntimeStoreError` (an `Error`) with the server message |
+| Request body exceeds `maxBodyBytes` | `413` | `PAYLOAD_TOO_LARGE` | Throw `HttpRuntimeStoreError` |
 | Session does not exist | `404` | `SESSION_NOT_FOUND` | `getSession` returns `undefined`; operations that require the session throw `HttpRuntimeStoreError` with the browser store's `no session` semantics |
 | Route does not exist | `404` | `ROUTE_NOT_FOUND` | Throw `HttpRuntimeStoreError` |
 | A stored session has a future runtime DSL version | `409` | `FUTURE_VERSION` | Throw `HttpRuntimeStoreError` with the browser store's fail-loud `newer than this client's` semantics |

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/runtime/http.d.ts",
       "import": "./dist/runtime/http.js"
     },
+    "./document/http": {
+      "types": "./dist/document/http.d.ts",
+      "import": "./dist/document/http.js"
+    },
     "./runtime/pg": {
       "types": "./dist/runtime/pg.d.ts",
       "import": "./dist/runtime/pg.js"

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/document/http.d.ts",
       "import": "./dist/document/http.js"
     },
+    "./document/pg": {
+      "types": "./dist/document/pg.d.ts",
+      "import": "./dist/document/pg.js"
+    },
     "./runtime/pg": {
       "types": "./dist/runtime/pg.d.ts",
       "import": "./dist/runtime/pg.js"

--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -26,6 +26,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from './types.js';
+import { DocumentNotFoundError, DocumentVersionError } from './types.js';
 import { reassembleDocument, splitDocument, type OutlineRow, type StageRow } from './adapter.js';
 
 const STAGES = 'stages';
@@ -219,7 +220,10 @@ export class BrowserDocumentStore<
     // written by a newer client. `loadDocument` returns such documents untouched;
     // saving one back would relabel its newer-shaped rows as this older version.
     if (isFutureVersioned(doc)) {
-      throw new Error(
+      throw new DocumentVersionError(
+        doc.stage.id,
+        'future',
+        doc.dslVersion,
         `@openmaic/storage: refusing to save document ${JSON.stringify(doc.stage.id)} — it was ` +
           `written at DSL version ${JSON.stringify(dslVersionOf(doc))}, newer than this ` +
           `client's ${DSL_VERSION}`,
@@ -265,7 +269,10 @@ export class BrowserDocumentStore<
       // guard above does not catch a blind overwrite of newer stored data.
       const existingStage = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (existingStage && isFutureVersioned(existingStage)) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'future',
+          existingStage[DSL_VERSION_KEY],
           `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
             `stored copy is at DSL version ${JSON.stringify(dslVersionOf(existingStage))}, newer ` +
             `than this client's ${DSL_VERSION}`,
@@ -371,12 +378,16 @@ export class BrowserDocumentStore<
       const stages = tx.objectStore(STAGES);
       const stageRow = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (!stageRow) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putStage into missing document ${JSON.stringify(stageId)}`,
         );
       }
       if (dslVersionOf(stageRow) !== DSL_VERSION) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'not-current',
+          stageRow[DSL_VERSION_KEY],
           `@openmaic/storage: cannot putStage into document ${JSON.stringify(stageId)} at DSL ` +
             `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
             `to ${DSL_VERSION} first`,
@@ -393,7 +404,8 @@ export class BrowserDocumentStore<
       const stages = tx.objectStore(STAGES);
       const stageRow = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (!stageRow) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
         );
       }
@@ -403,7 +415,10 @@ export class BrowserDocumentStore<
       // below the migrate-on-read line; if it is newer, this client must not
       // downgrade it. Either way, require a full load + save to normalize first.
       if (dslVersionOf(stageRow) !== DSL_VERSION) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'not-current',
+          stageRow[DSL_VERSION_KEY],
           `@openmaic/storage: cannot putScene into document ${JSON.stringify(stageId)} at DSL ` +
             `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
             `to ${DSL_VERSION} first`,
@@ -447,7 +462,10 @@ export class BrowserDocumentStore<
       // A whole-document removal (deleteDocument) is a deliberate coarse action
       // and is intentionally NOT version-guarded.
       if (dslVersionOf(stageRow) !== DSL_VERSION) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'not-current',
+          stageRow[DSL_VERSION_KEY],
           `@openmaic/storage: cannot deleteScene from document ${JSON.stringify(stageId)} at DSL ` +
             `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
             `to ${DSL_VERSION} first`,

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -9,6 +9,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from './types.js';
+import { DocumentVersionError } from './types.js';
 
 export interface HttpDocumentHeadersContext {
   method: string;
@@ -34,6 +35,10 @@ export interface HttpDocumentStoreOptions {
 
 interface ErrorResponseBody {
   error?: { code?: unknown; message?: unknown; details?: unknown };
+}
+
+interface DocumentVersionErrorDetails {
+  storedVersion?: unknown;
 }
 
 /** A server-side DocumentStore failure, retaining its machine-readable HTTP identity. */
@@ -118,8 +123,8 @@ export class HttpDocumentStore<
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly headersHook: HttpDocumentHeadersHook | undefined;
-  private readonly sceneValidator: SceneValidator;
-  private readonly stageValidator: StageValidator;
+  private readonly validateSceneFn: SceneValidator;
+  private readonly validateStageFn: StageValidator;
 
   constructor(options: HttpDocumentStoreOptions) {
     if (options.baseUrl === '') {
@@ -132,11 +137,16 @@ export class HttpDocumentStore<
     this.baseUrl = options.baseUrl.replace(/\/+$/, '');
     this.fetchImpl = fetchImpl;
     this.headersHook = options.headers;
-    this.sceneValidator = options.validateScene ?? validateScene;
-    this.stageValidator = options.validateStage ?? validateStage;
+    this.validateSceneFn = options.validateScene ?? validateScene;
+    this.validateStageFn = options.validateStage ?? validateStage;
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    versionErrorStageId?: string,
+  ): Promise<T> {
     const headers = normalizeHeaders(await this.headersHook?.({ method, path }));
     let serializedBody: string | undefined;
     if (body !== undefined) {
@@ -160,6 +170,16 @@ export class HttpDocumentStore<
         typeof errorBody?.error?.message === 'string'
           ? errorBody.error.message
           : `@openmaic/storage: DocumentStore HTTP request failed with status ${response.status}`;
+      if (
+        response.status === 409 &&
+        code === 'FUTURE_VERSION' &&
+        versionErrorStageId !== undefined
+      ) {
+        const details = errorBody?.error?.details as DocumentVersionErrorDetails | undefined;
+        const storedVersion =
+          typeof details?.storedVersion === 'string' ? details.storedVersion : undefined;
+        throw new DocumentVersionError(versionErrorStageId, 'future', storedVersion, message);
+      }
       throw new HttpDocumentStoreError(response.status, code, message, errorBody?.error?.details);
     }
     if (response.status === 204) return undefined as T;
@@ -167,7 +187,7 @@ export class HttpDocumentStore<
   }
 
   private validateSceneForWrite(stageId: string, scene: TScene): void {
-    assertValid(this.sceneValidator(scene), `scene ${scene.id}`);
+    assertValid(this.validateSceneFn(scene), `scene ${scene.id}`);
     assertStorableScene(scene, stageId);
   }
 
@@ -175,7 +195,7 @@ export class HttpDocumentStore<
     // The server repeats these checks. Running the injected gates here matches
     // BrowserDocumentStore's fail-fast boundary and avoids avoidable wire calls.
     const normalized = migrateDocument(document);
-    assertValid(this.stageValidator(normalized.stage), `stage ${normalized.stage.id}`);
+    assertValid(this.validateStageFn(normalized.stage), `stage ${normalized.stage.id}`);
     const seen = new Set<string>();
     for (const scene of normalized.scenes) {
       this.validateSceneForWrite(normalized.stage.id, scene);
@@ -188,7 +208,12 @@ export class HttpDocumentStore<
       seen.add(scene.id);
     }
     assertJsonValue(document, `document ${JSON.stringify(document.stage.id)}`);
-    await this.request<void>('PUT', `/documents/${segment(document.stage.id)}`, document);
+    await this.request<void>(
+      'PUT',
+      `/documents/${segment(document.stage.id)}`,
+      document,
+      document.stage.id,
+    );
   }
 
   async loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null> {
@@ -223,9 +248,9 @@ export class HttpDocumentStore<
   }
 
   async putStage(stageId: string, stage: TStage): Promise<void> {
-    assertValid(this.stageValidator(stage), `stage ${stage.id}`);
+    assertValid(this.validateStageFn(stage), `stage ${stage.id}`);
     assertJsonValue(stage, `stage ${JSON.stringify(stage.id)}`);
-    await this.request<void>('PUT', `/documents/${segment(stageId)}/stage`, stage);
+    await this.request<void>('PUT', `/documents/${segment(stageId)}/stage`, stage, stageId);
   }
 
   async putScene(stageId: string, scene: TScene): Promise<void> {
@@ -235,6 +260,7 @@ export class HttpDocumentStore<
       'PUT',
       `/documents/${segment(stageId)}/scenes/${segment(scene.id)}`,
       scene,
+      stageId,
     );
   }
 
@@ -256,6 +282,11 @@ export class HttpDocumentStore<
   }
 
   async deleteScene(stageId: string, sceneId: string): Promise<void> {
-    await this.request<void>('DELETE', `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`);
+    await this.request<void>(
+      'DELETE',
+      `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`,
+      undefined,
+      stageId,
+    );
   }
 }

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -42,6 +42,7 @@ export class HttpDocumentStoreError extends Error {
     readonly status: number,
     readonly code: string,
     message: string,
+    readonly details?: unknown,
   ) {
     super(message);
     this.name = 'HttpDocumentStoreError';
@@ -159,7 +160,7 @@ export class HttpDocumentStore<
         typeof errorBody?.error?.message === 'string'
           ? errorBody.error.message
           : `@openmaic/storage: DocumentStore HTTP request failed with status ${response.status}`;
-      throw new HttpDocumentStoreError(response.status, code, message);
+      throw new HttpDocumentStoreError(response.status, code, message, errorBody?.error?.details);
     }
     if (response.status === 204) return undefined as T;
     return (await response.json()) as T;

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -1,0 +1,260 @@
+import { migrate, validateScene, validateStage } from '@openmaic/dsl';
+import type { Scene, Stage } from '@openmaic/dsl';
+import { assertJsonValue } from '../runtime/json-value.js';
+import type {
+  DocumentStore,
+  DocumentSummary,
+  MaicDocument,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from './types.js';
+
+export interface HttpDocumentHeadersContext {
+  method: string;
+  path: string;
+}
+
+export type HttpDocumentHeadersHook = (
+  context: HttpDocumentHeadersContext,
+) => HeadersInit | Promise<HeadersInit>;
+
+export interface HttpDocumentStoreOptions {
+  /** Root URL before the contract's `/documents/...` paths. */
+  baseUrl: string;
+  /** Fetch implementation. Defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch;
+  /** Called for every request so deployments can attach authentication headers. */
+  headers?: HttpDocumentHeadersHook;
+  /** Client-side scene validator. Defaults to the DSL validator. */
+  validateScene?: SceneValidator;
+  /** Client-side stage validator. Defaults to the DSL validator. */
+  validateStage?: StageValidator;
+}
+
+interface ErrorResponseBody {
+  error?: { code?: unknown; message?: unknown; details?: unknown };
+}
+
+/** A server-side DocumentStore failure, retaining its machine-readable HTTP identity. */
+export class HttpDocumentStoreError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HttpDocumentStoreError';
+  }
+}
+
+function assertAddressableSegment(value: string): void {
+  if (value === '.' || value === '..') {
+    throw new Error(`@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`);
+  }
+}
+
+function segment(value: string): string {
+  assertAddressableSegment(value);
+  return encodeURIComponent(value);
+}
+
+function assertValid(result: ReturnType<StageValidator>, label: string): void {
+  if (result.valid) return;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new Error(`@openmaic/storage: invalid ${label}: ${detail}`);
+}
+
+function assertStorableScene(scene: SceneLike, stageId: string): void {
+  const value = scene as { id: unknown; stageId: unknown; order: unknown };
+  if (typeof value.id !== 'string') {
+    throw new Error(
+      `@openmaic/storage: scene id must be a string, got ${JSON.stringify(value.id)}`,
+    );
+  }
+  if (value.stageId !== stageId) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} has stageId ` +
+        `${JSON.stringify(value.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
+    );
+  }
+  if (typeof value.order !== 'number' || !Number.isFinite(value.order)) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} order must be a finite number, got ` +
+        `${JSON.stringify(value.order)}`,
+    );
+  }
+}
+
+function normalizeHeaders(init: HeadersInit | undefined): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  const set = (name: string, value: string): void => {
+    normalized[name.toLowerCase()] = value;
+  };
+  if (init === undefined) return normalized;
+  if (Array.isArray(init)) {
+    for (const [name, value] of init) set(name, value);
+  } else if (typeof (init as Headers).forEach === 'function') {
+    (init as Headers).forEach((value, name) => set(name, value));
+  } else {
+    for (const [name, value] of Object.entries(init)) set(name, value);
+  }
+  return normalized;
+}
+
+function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
+  document: MaicDocument<TScene, TStage>,
+): MaicDocument<TScene, TStage> {
+  const { outline, ...core } = document;
+  const migrated = migrate(core) as MaicDocument<TScene, TStage>;
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
+export class HttpDocumentStore<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+> implements DocumentStore<TScene, TStage> {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly headersHook: HttpDocumentHeadersHook | undefined;
+  private readonly sceneValidator: SceneValidator;
+  private readonly stageValidator: StageValidator;
+
+  constructor(options: HttpDocumentStoreOptions) {
+    if (options.baseUrl === '') {
+      throw new Error('@openmaic/storage: HttpDocumentStore baseUrl must be non-empty');
+    }
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('@openmaic/storage: HttpDocumentStore requires a fetch implementation');
+    }
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = fetchImpl;
+    this.headersHook = options.headers;
+    this.sceneValidator = options.validateScene ?? validateScene;
+    this.stageValidator = options.validateStage ?? validateStage;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const headers = normalizeHeaders(await this.headersHook?.({ method, path }));
+    let serializedBody: string | undefined;
+    if (body !== undefined) {
+      headers['content-type'] ??= 'application/json';
+      serializedBody = JSON.stringify(body);
+    }
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      ...(serializedBody === undefined ? {} : { body: serializedBody }),
+    });
+    if (!response.ok) {
+      let errorBody: ErrorResponseBody | undefined;
+      try {
+        errorBody = (await response.json()) as ErrorResponseBody;
+      } catch {
+        // Preserve a useful typed error even for a non-conforming server.
+      }
+      const code = typeof errorBody?.error?.code === 'string' ? errorBody.error.code : 'HTTP_ERROR';
+      const message =
+        typeof errorBody?.error?.message === 'string'
+          ? errorBody.error.message
+          : `@openmaic/storage: DocumentStore HTTP request failed with status ${response.status}`;
+      throw new HttpDocumentStoreError(response.status, code, message);
+    }
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  private validateSceneForWrite(stageId: string, scene: TScene): void {
+    assertValid(this.sceneValidator(scene), `scene ${scene.id}`);
+    assertStorableScene(scene, stageId);
+  }
+
+  async saveDocument(document: MaicDocument<TScene, TStage>): Promise<void> {
+    // The server repeats these checks. Running the injected gates here matches
+    // BrowserDocumentStore's fail-fast boundary and avoids avoidable wire calls.
+    const normalized = migrateDocument(document);
+    assertValid(this.stageValidator(normalized.stage), `stage ${normalized.stage.id}`);
+    const seen = new Set<string>();
+    for (const scene of normalized.scenes) {
+      this.validateSceneForWrite(normalized.stage.id, scene);
+      if (seen.has(scene.id)) {
+        throw new Error(
+          `@openmaic/storage: duplicate scene id ${JSON.stringify(scene.id)} in document ` +
+            JSON.stringify(normalized.stage.id),
+        );
+      }
+      seen.add(scene.id);
+    }
+    assertJsonValue(document, `document ${JSON.stringify(document.stage.id)}`);
+    await this.request<void>('PUT', `/documents/${segment(document.stage.id)}`, document);
+  }
+
+  async loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null> {
+    try {
+      const document = await this.request<MaicDocument<TScene, TStage>>(
+        'GET',
+        `/documents/${segment(stageId)}`,
+      );
+      return migrateDocument(document);
+    } catch (error) {
+      if (error instanceof HttpDocumentStoreError && error.code === 'DOCUMENT_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async listDocuments(): Promise<DocumentSummary[]> {
+    const summaries = await this.request<unknown>('GET', '/documents');
+    if (!Array.isArray(summaries)) {
+      throw new HttpDocumentStoreError(
+        200,
+        'MALFORMED_RESPONSE',
+        '@openmaic/storage: DocumentStore HTTP listDocuments response must be an array',
+      );
+    }
+    return summaries as DocumentSummary[];
+  }
+
+  async deleteDocument(stageId: string): Promise<void> {
+    await this.request<void>('DELETE', `/documents/${segment(stageId)}`);
+  }
+
+  async putStage(stageId: string, stage: TStage): Promise<void> {
+    assertValid(this.stageValidator(stage), `stage ${stage.id}`);
+    assertJsonValue(stage, `stage ${JSON.stringify(stage.id)}`);
+    await this.request<void>('PUT', `/documents/${segment(stageId)}/stage`, stage);
+  }
+
+  async putScene(stageId: string, scene: TScene): Promise<void> {
+    this.validateSceneForWrite(stageId, scene);
+    assertJsonValue(scene, `scene ${JSON.stringify(scene.id)}`);
+    await this.request<void>(
+      'PUT',
+      `/documents/${segment(stageId)}/scenes/${segment(scene.id)}`,
+      scene,
+    );
+  }
+
+  async getScene(stageId: string, sceneId: string): Promise<TScene | null> {
+    try {
+      return await this.request<TScene>(
+        'GET',
+        `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`,
+      );
+    } catch (error) {
+      if (
+        error instanceof HttpDocumentStoreError &&
+        (error.code === 'DOCUMENT_NOT_FOUND' || error.code === 'SCENE_NOT_FOUND')
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async deleteScene(stageId: string, sceneId: string): Promise<void> {
+    await this.request<void>('DELETE', `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`);
+  }
+}

--- a/packages/@openmaic/storage/src/document/pg.ts
+++ b/packages/@openmaic/storage/src/document/pg.ts
@@ -30,6 +30,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from './types.js';
+import { DocumentNotFoundError, DocumentVersionError } from './types.js';
 import { assertJsonValue, isLosslessJsonString } from '../runtime/json-value.js';
 import type { Queryable, WithTransaction } from '../runtime/pg.js';
 
@@ -266,8 +267,11 @@ export class PgDocumentStore<
     operation: string,
     stageId: string,
     stageRow: StageRow<TStage>,
-  ): Error {
-    return new Error(
+  ): DocumentVersionError {
+    return new DocumentVersionError(
+      stageId,
+      'not-current',
+      stageRow[DSL_VERSION_KEY],
       `@openmaic/storage: cannot ${operation} document ${JSON.stringify(stageId)} at DSL ` +
         `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
         `to ${DSL_VERSION} first`,
@@ -330,7 +334,10 @@ export class PgDocumentStore<
 
   async saveDocument(doc: MaicDocument<TScene, TStage>): Promise<void> {
     if (isFutureVersioned(doc)) {
-      throw new Error(
+      throw new DocumentVersionError(
+        doc.stage.id,
+        'future',
+        doc.dslVersion,
         `@openmaic/storage: refusing to save document ${JSON.stringify(doc.stage.id)} — it was ` +
           `written at DSL version ${JSON.stringify(dslVersionOf(doc))}, newer than this ` +
           `client's ${DSL_VERSION}`,
@@ -343,7 +350,10 @@ export class PgDocumentStore<
     await this.transaction(async (queryable) => {
       const existingStage = await this.loadStage(queryable, stageId, 'update');
       if (existingStage && isFutureVersioned(existingStage)) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'future',
+          existingStage[DSL_VERSION_KEY],
           `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
             `stored copy is at DSL version ${JSON.stringify(dslVersionOf(existingStage))}, newer ` +
             `than this client's ${DSL_VERSION}`,
@@ -448,7 +458,8 @@ export class PgDocumentStore<
     await this.transaction(async (queryable) => {
       const stored = await this.loadStage(queryable, stageId, 'update');
       if (!stored) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putStage into missing document ${JSON.stringify(stageId)}`,
         );
       }
@@ -466,7 +477,8 @@ export class PgDocumentStore<
     await this.transaction(async (queryable) => {
       const stored = await this.loadStage(queryable, stageId, 'update');
       if (!stored) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
         );
       }

--- a/packages/@openmaic/storage/src/document/pg.ts
+++ b/packages/@openmaic/storage/src/document/pg.ts
@@ -1,0 +1,545 @@
+/**
+ * PostgreSQL DocumentStore backend over the same injected query surface as the
+ * runtime backend. Full stage and scene values live in JSONB so widened app
+ * shapes round-trip without the SQL schema knowing their fields. The stage's
+ * version-independent picker metadata and each scene's order are duplicated in
+ * ordinary columns: listDocuments never needs to decode content (or its version
+ * stamp), and ordered reads do not depend on JSON operators.
+ *
+ * `withTransaction` must check out a fresh connection and open a transaction
+ * for every call, pin every query in `body` to it, then commit or roll back and
+ * release it. READ COMMITTED isolation is assumed. JSON payloads are restricted
+ * to values that round-trip losslessly through JSONB.
+ */
+import {
+  DSL_VERSION,
+  DSL_VERSION_KEY,
+  dslVersionOf,
+  migrate,
+  needsMigration,
+  validateScene,
+  validateStage,
+} from '@openmaic/dsl';
+import type { Scene, Stage } from '@openmaic/dsl';
+import { reassembleDocument, splitDocument, type OutlineRow, type StageRow } from './adapter.js';
+import type {
+  DocumentStore,
+  DocumentSummary,
+  MaicDocument,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from './types.js';
+import { assertJsonValue, isLosslessJsonString } from '../runtime/json-value.js';
+import type { Queryable, WithTransaction } from '../runtime/pg.js';
+
+export type { QueryResult, Queryable, WithTransaction } from '../runtime/pg.js';
+
+export interface PgDocumentStoreOptions {
+  /**
+   * On every call, checks out a fresh connection, opens a transaction, pins
+   * every query in `body` to it, then commits or rolls back and releases it.
+   */
+  withTransaction: WithTransaction;
+  /** Scene write-boundary validator. Defaults to the DSL validateScene. */
+  validateScene?: SceneValidator;
+  /** Stage write-boundary validator. Defaults to the DSL validateStage. */
+  validateStage?: StageValidator;
+}
+
+/** Idempotent schema for the PostgreSQL document backend. */
+export const DOCUMENT_PG_SCHEMA = `
+CREATE TABLE IF NOT EXISTS document_stages (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  interactive_mode BOOLEAN,
+  task_engine_mode BOOLEAN,
+  created_at DOUBLE PRECISION NOT NULL,
+  updated_at DOUBLE PRECISION NOT NULL,
+  data JSONB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS document_scenes (
+  stage_id TEXT NOT NULL REFERENCES document_stages(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
+  scene_order DOUBLE PRECISION NOT NULL,
+  data JSONB NOT NULL,
+  PRIMARY KEY (stage_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS document_scenes_stage_order_idx
+  ON document_scenes (stage_id, scene_order, id);
+
+CREATE TABLE IF NOT EXISTS document_outlines (
+  stage_id TEXT PRIMARY KEY REFERENCES document_stages(id) ON DELETE CASCADE,
+  data JSONB NOT NULL
+);
+`;
+
+/**
+ * Create the tables owned by this backend when absent. Safe to call repeatedly;
+ * changing an existing table requires a real migration.
+ */
+export async function ensureDocumentSchema(queryable: Queryable): Promise<void> {
+  // Keep Queryable minimal and PGlite-compatible: issue one statement at a time.
+  for (const sql of DOCUMENT_PG_SCHEMA.split(';')) {
+    const statement = sql.trim();
+    if (statement !== '') await queryable.query(statement);
+  }
+}
+
+interface StoredJsonRow extends Record<string, unknown> {
+  data: unknown;
+}
+
+interface StoredSceneRow extends StoredJsonRow {
+  id: string;
+}
+
+interface SummaryRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  description: string | null;
+  interactive_mode: boolean | null;
+  task_engine_mode: boolean | null;
+  created_at: number | string;
+  updated_at: number | string;
+  scene_count: number | string;
+}
+
+function assertValid(
+  result: { valid: true } | { valid: false; errors: { path: string; message: string }[] },
+  label: string,
+): void {
+  if (result.valid) return;
+  const detail = result.errors.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw new Error(`@openmaic/storage: invalid ${label}: ${detail}`);
+}
+
+function decodeJson<T>(value: unknown): T {
+  // node-postgres and PGlite decode JSONB for us. A host adapter may instead
+  // return object/array JSON as text, which is unambiguous for stage and scene
+  // payloads. Do not parse scalar strings: an opaque outline is allowed to be a
+  // string, and a corrupt stage scalar should reach the plain-object check.
+  if (typeof value === 'string' && /^[\s]*[{\[]/.test(value)) {
+    return JSON.parse(value) as T;
+  }
+  return value as T;
+}
+
+function isPlainObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function encodeJson(value: unknown, label: string): string {
+  try {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) throw new TypeError('value is not JSON-serializable');
+    return encoded;
+  } catch (error) {
+    throw new Error(`@openmaic/storage: ${label} is not JSON-serializable`, { cause: error });
+  }
+}
+
+function isFutureVersioned(versioned: unknown): boolean {
+  if (typeof versioned !== 'object' || versioned === null) return false;
+  return !needsMigration(versioned) && dslVersionOf(versioned) !== DSL_VERSION;
+}
+
+function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
+  doc: MaicDocument<TScene, TStage>,
+): MaicDocument<TScene, TStage> {
+  const { outline, ...core } = doc;
+  const migrated = migrate(core) as MaicDocument<TScene, TStage>;
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
+function assertStorableScene(scene: SceneLike, stageId: string): void {
+  const candidate = scene as { id: unknown; stageId: unknown; order: unknown };
+  if (typeof candidate.id !== 'string') {
+    throw new Error(
+      `@openmaic/storage: scene id must be a string, got ${JSON.stringify(candidate.id)}`,
+    );
+  }
+  if (candidate.stageId !== stageId) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(candidate.id)} has stageId ` +
+        `${JSON.stringify(candidate.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
+    );
+  }
+  if (typeof candidate.order !== 'number' || !Number.isFinite(candidate.order)) {
+    throw new Error(
+      `@openmaic/storage: scene ${JSON.stringify(candidate.id)} order must be a finite number, ` +
+        `got ${JSON.stringify(candidate.order)}`,
+    );
+  }
+}
+
+function isPgQueryableKey(value: string): boolean {
+  return isLosslessJsonString(value);
+}
+
+export class PgDocumentStore<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+> implements DocumentStore<TScene, TStage> {
+  private readonly queryable: Queryable;
+  private readonly transactionHook: WithTransaction;
+  private readonly validateScene: SceneValidator;
+  private readonly validateStage: StageValidator;
+
+  constructor(queryable: Queryable, options: PgDocumentStoreOptions) {
+    if (typeof options?.withTransaction !== 'function') {
+      throw new Error(
+        '@openmaic/storage: withTransaction is required and must pin a fresh connection and ' +
+          'transaction for every call; reusing a shared client lets concurrent transactions ' +
+          'interleave',
+      );
+    }
+    this.queryable = queryable;
+    this.transactionHook = options.withTransaction;
+    this.validateScene = options.validateScene ?? validateScene;
+    this.validateStage = options.validateStage ?? validateStage;
+  }
+
+  private async transaction<T>(body: (queryable: Queryable) => Promise<T>): Promise<T> {
+    return this.transactionHook(body);
+  }
+
+  private async loadStage(
+    queryable: Queryable,
+    stageId: string,
+    lock: 'share' | 'update' | false = false,
+  ): Promise<StageRow<TStage> | undefined> {
+    const suffix = lock === 'share' ? ' FOR SHARE' : lock === 'update' ? ' FOR UPDATE' : '';
+    const result = await queryable.query<StoredJsonRow>(
+      `SELECT data
+         FROM document_stages
+        WHERE id = $1${suffix}`,
+      [stageId],
+    );
+    const storedRow = result.rows[0];
+    if (!storedRow) return undefined;
+    const decoded = decodeJson<unknown>(storedRow.data);
+    if (!isPlainObject(decoded)) {
+      throw new Error(
+        `@openmaic/storage: corrupt stored row for document ${JSON.stringify(stageId)}: ` +
+          'data must be a plain object',
+      );
+    }
+    return decoded as StageRow<TStage>;
+  }
+
+  private async loadRows(
+    queryable: Queryable,
+    stageId: string,
+    lock: 'share' | 'update' = 'share',
+  ): Promise<
+    { stageRow: StageRow<TStage>; sceneRows: TScene[]; outlineRow?: OutlineRow } | undefined
+  > {
+    const stageRow = await this.loadStage(queryable, stageId, lock);
+    if (!stageRow) return undefined;
+    const scenes = await queryable.query<StoredJsonRow>(
+      `SELECT data
+         FROM document_scenes
+        WHERE stage_id = $1
+        ORDER BY scene_order ASC, id ASC`,
+      [stageId],
+    );
+    const outline = await queryable.query<StoredJsonRow>(
+      `SELECT data
+         FROM document_outlines
+        WHERE stage_id = $1`,
+      [stageId],
+    );
+    const sceneRows = scenes.rows.map((row) => decodeJson<TScene>(row.data));
+    const outlineRow = outline.rows[0]
+      ? { stageId, outline: decodeJson<unknown>(outline.rows[0].data) }
+      : undefined;
+    return { stageRow, sceneRows, outlineRow };
+  }
+
+  private currentVersionError(
+    operation: string,
+    stageId: string,
+    stageRow: StageRow<TStage>,
+  ): Error {
+    return new Error(
+      `@openmaic/storage: cannot ${operation} document ${JSON.stringify(stageId)} at DSL ` +
+        `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
+        `to ${DSL_VERSION} first`,
+    );
+  }
+
+  private validateForSave(
+    doc: MaicDocument<TScene, TStage>,
+  ): ReturnType<typeof splitDocument<TScene, TStage>> {
+    assertValid(this.validateStage(doc.stage), `stage ${doc.stage.id}`);
+    const stageId = doc.stage.id;
+    const seen = new Set<string>();
+    for (const scene of doc.scenes) {
+      assertValid(this.validateScene(scene), `scene ${scene.id}`);
+      assertStorableScene(scene, stageId);
+      if (seen.has(scene.id)) {
+        throw new Error(
+          `@openmaic/storage: duplicate scene id ${JSON.stringify(scene.id)} in document ` +
+            JSON.stringify(stageId),
+        );
+      }
+      seen.add(scene.id);
+    }
+    const rows = splitDocument(doc);
+    assertJsonValue(rows.stageRow, `document stage ${JSON.stringify(stageId)}`);
+    for (const scene of rows.sceneRows) {
+      assertJsonValue(scene, `document scene ${JSON.stringify(scene.id)}`);
+    }
+    if (rows.outlineRow) {
+      assertJsonValue(rows.outlineRow.outline, `document outline ${JSON.stringify(stageId)}`);
+    }
+    return rows;
+  }
+
+  private async persistStage(queryable: Queryable, stageRow: StageRow<TStage>): Promise<void> {
+    await queryable.query(
+      `INSERT INTO document_stages
+         (id, name, description, interactive_mode, task_engine_mode, created_at, updated_at, data)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+       ON CONFLICT (id) DO UPDATE
+         SET name = EXCLUDED.name,
+             description = EXCLUDED.description,
+             interactive_mode = EXCLUDED.interactive_mode,
+             task_engine_mode = EXCLUDED.task_engine_mode,
+             created_at = EXCLUDED.created_at,
+             updated_at = EXCLUDED.updated_at,
+             data = EXCLUDED.data`,
+      [
+        stageRow.id,
+        stageRow.name,
+        stageRow.description ?? null,
+        stageRow.interactiveMode ?? null,
+        stageRow.taskEngineMode ?? null,
+        stageRow.createdAt,
+        stageRow.updatedAt,
+        encodeJson(stageRow, `document stage ${JSON.stringify(stageRow.id)}`),
+      ],
+    );
+  }
+
+  async saveDocument(doc: MaicDocument<TScene, TStage>): Promise<void> {
+    if (isFutureVersioned(doc)) {
+      throw new Error(
+        `@openmaic/storage: refusing to save document ${JSON.stringify(doc.stage.id)} — it was ` +
+          `written at DSL version ${JSON.stringify(dslVersionOf(doc))}, newer than this ` +
+          `client's ${DSL_VERSION}`,
+      );
+    }
+    const normalized = migrateDocument(doc);
+    const { stageRow, sceneRows, outlineRow } = this.validateForSave(normalized);
+    const stageId = stageRow.id;
+
+    await this.transaction(async (queryable) => {
+      const existingStage = await this.loadStage(queryable, stageId, 'update');
+      if (existingStage && isFutureVersioned(existingStage)) {
+        throw new Error(
+          `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
+            `stored copy is at DSL version ${JSON.stringify(dslVersionOf(existingStage))}, newer ` +
+            `than this client's ${DSL_VERSION}`,
+        );
+      }
+
+      await this.persistStage(queryable, stageRow);
+      const existingScenes = await queryable.query<StoredSceneRow>(
+        `SELECT id, data
+           FROM document_scenes
+          WHERE stage_id = $1`,
+        [stageId],
+      );
+      const incomingIds = new Set(sceneRows.map((scene) => scene.id));
+      for (const scene of sceneRows) {
+        await queryable.query(
+          `INSERT INTO document_scenes (stage_id, id, scene_order, data)
+           VALUES ($1, $2, $3, $4::jsonb)
+           ON CONFLICT (stage_id, id) DO UPDATE
+             SET scene_order = EXCLUDED.scene_order,
+                 data = EXCLUDED.data`,
+          [
+            stageId,
+            scene.id,
+            scene.order,
+            encodeJson(scene, `document scene ${JSON.stringify(scene.id)}`),
+          ],
+        );
+      }
+      for (const scene of existingScenes.rows) {
+        if (!incomingIds.has(scene.id)) {
+          await queryable.query('DELETE FROM document_scenes WHERE stage_id = $1 AND id = $2', [
+            stageId,
+            scene.id,
+          ]);
+        }
+      }
+
+      if (outlineRow) {
+        await queryable.query(
+          `INSERT INTO document_outlines (stage_id, data)
+           VALUES ($1, $2::jsonb)
+           ON CONFLICT (stage_id) DO UPDATE SET data = EXCLUDED.data`,
+          [stageId, encodeJson(outlineRow.outline, `document outline ${JSON.stringify(stageId)}`)],
+        );
+      } else {
+        await queryable.query('DELETE FROM document_outlines WHERE stage_id = $1', [stageId]);
+      }
+    });
+  }
+
+  async loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null> {
+    if (!isPgQueryableKey(stageId)) return null;
+    const rows = await this.transaction((queryable) => this.loadRows(queryable, stageId));
+    if (!rows) return null;
+    return migrateDocument(reassembleDocument(rows.stageRow, rows.sceneRows, rows.outlineRow));
+  }
+
+  async listDocuments(): Promise<DocumentSummary[]> {
+    const result = await this.queryable.query<SummaryRow>(
+      `SELECT stages.id,
+              stages.name,
+              stages.description,
+              stages.interactive_mode,
+              stages.task_engine_mode,
+              stages.created_at,
+              stages.updated_at,
+              COUNT(scenes.id)::text AS scene_count
+         FROM document_stages AS stages
+         LEFT JOIN document_scenes AS scenes ON scenes.stage_id = stages.id
+        GROUP BY stages.id
+        ORDER BY stages.id ASC`,
+    );
+    return result.rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      ...(row.description === null ? {} : { description: row.description }),
+      ...(row.interactive_mode === null ? {} : { interactiveMode: row.interactive_mode }),
+      ...(row.task_engine_mode === null ? {} : { taskEngineMode: row.task_engine_mode }),
+      createdAt: Number(row.created_at),
+      updatedAt: Number(row.updated_at),
+      sceneCount: Number(row.scene_count),
+    }));
+  }
+
+  async deleteDocument(stageId: string): Promise<void> {
+    if (!isPgQueryableKey(stageId)) return;
+    // One statement; both child tables are removed by their FK cascades.
+    await this.queryable.query('DELETE FROM document_stages WHERE id = $1', [stageId]);
+  }
+
+  async putStage(stageId: string, stage: TStage): Promise<void> {
+    assertValid(this.validateStage(stage), `stage ${stage.id}`);
+    if (stage.id !== stageId) {
+      throw new Error(
+        `@openmaic/storage: stage ${JSON.stringify(stage.id)} does not belong to document ` +
+          JSON.stringify(stageId),
+      );
+    }
+    const stageRow = { ...stage, [DSL_VERSION_KEY]: DSL_VERSION } as StageRow<TStage>;
+    assertJsonValue(stageRow, `document stage ${JSON.stringify(stageId)}`);
+    await this.transaction(async (queryable) => {
+      const stored = await this.loadStage(queryable, stageId, 'update');
+      if (!stored) {
+        throw new Error(
+          `@openmaic/storage: cannot putStage into missing document ${JSON.stringify(stageId)}`,
+        );
+      }
+      if (dslVersionOf(stored) !== DSL_VERSION) {
+        throw this.currentVersionError('putStage into', stageId, stored);
+      }
+      await this.persistStage(queryable, stageRow);
+    });
+  }
+
+  async putScene(stageId: string, scene: TScene): Promise<void> {
+    assertValid(this.validateScene(scene), `scene ${scene.id}`);
+    assertStorableScene(scene, stageId);
+    assertJsonValue(scene, `document scene ${JSON.stringify(scene.id)}`);
+    await this.transaction(async (queryable) => {
+      const stored = await this.loadStage(queryable, stageId, 'update');
+      if (!stored) {
+        throw new Error(
+          `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
+        );
+      }
+      if (dslVersionOf(stored) !== DSL_VERSION) {
+        throw this.currentVersionError('putScene into', stageId, stored);
+      }
+      await queryable.query(
+        `INSERT INTO document_scenes (stage_id, id, scene_order, data)
+         VALUES ($1, $2, $3, $4::jsonb)
+         ON CONFLICT (stage_id, id) DO UPDATE
+           SET scene_order = EXCLUDED.scene_order,
+               data = EXCLUDED.data`,
+        [
+          stageId,
+          scene.id,
+          scene.order,
+          encodeJson(scene, `document scene ${JSON.stringify(scene.id)}`),
+        ],
+      );
+    });
+  }
+
+  async getScene(stageId: string, sceneId: string): Promise<TScene | null> {
+    if (!isPgQueryableKey(stageId) || !isPgQueryableKey(sceneId)) return null;
+    return this.transaction(async (queryable) => {
+      const stageRow = await this.loadStage(queryable, stageId, 'share');
+      if (!stageRow) return null;
+      if (!needsMigration(stageRow)) {
+        const result = await queryable.query<StoredJsonRow>(
+          `SELECT data
+             FROM document_scenes
+            WHERE stage_id = $1 AND id = $2`,
+          [stageId, sceneId],
+        );
+        return result.rows[0] ? decodeJson<TScene>(result.rows[0].data) : null;
+      }
+      const scenes = await queryable.query<StoredJsonRow>(
+        `SELECT data
+           FROM document_scenes
+          WHERE stage_id = $1
+          ORDER BY scene_order ASC, id ASC`,
+        [stageId],
+      );
+      const outline = await queryable.query<StoredJsonRow>(
+        'SELECT data FROM document_outlines WHERE stage_id = $1',
+        [stageId],
+      );
+      const outlineRow = outline.rows[0]
+        ? { stageId, outline: decodeJson<unknown>(outline.rows[0].data) }
+        : undefined;
+      const document = migrateDocument(
+        reassembleDocument(
+          stageRow,
+          scenes.rows.map((row) => decodeJson<TScene>(row.data)),
+          outlineRow,
+        ),
+      );
+      return document.scenes.find((scene) => scene.id === sceneId) ?? null;
+    });
+  }
+
+  async deleteScene(stageId: string, sceneId: string): Promise<void> {
+    if (!isPgQueryableKey(stageId) || !isPgQueryableKey(sceneId)) return;
+    await this.transaction(async (queryable) => {
+      const stored = await this.loadStage(queryable, stageId, 'update');
+      if (!stored) return;
+      if (dslVersionOf(stored) !== DSL_VERSION) {
+        throw this.currentVersionError('deleteScene from', stageId, stored);
+      }
+      await queryable.query('DELETE FROM document_scenes WHERE stage_id = $1 AND id = $2', [
+        stageId,
+        sceneId,
+      ]);
+    });
+  }
+}

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -41,6 +41,32 @@ export type StageValidator = (
   stage: unknown,
 ) => { valid: true } | { valid: false; errors: { path: string; message: string }[] };
 
+/** A document write was rejected because its persisted DSL version is incompatible. */
+export class DocumentVersionError extends Error {
+  override readonly name = 'DocumentVersionError';
+
+  constructor(
+    readonly stageId: string,
+    readonly kind: 'future' | 'not-current',
+    readonly storedVersion: string | undefined,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/** An incremental document write requires a parent document that does not exist. */
+export class DocumentNotFoundError extends Error {
+  override readonly name = 'DocumentNotFoundError';
+
+  constructor(
+    readonly stageId: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
 /**
  * The portable, embedded form of a persisted course. Storage normalizes it into
  * per-entity rows on write and reassembles it on read.

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -33,6 +33,13 @@ export type {
   StageValidator,
 } from './document/types.js';
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
+export {
+  HttpDocumentStore,
+  HttpDocumentStoreError,
+  type HttpDocumentHeadersContext,
+  type HttpDocumentHeadersHook,
+  type HttpDocumentStoreOptions,
+} from './document/http.js';
 
 export type {
   RuntimeStore,

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SceneValidator,
   StageValidator,
 } from './document/types.js';
+export { DocumentNotFoundError, DocumentVersionError } from './document/types.js';
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
 export {
   HttpDocumentStore,

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -40,6 +40,12 @@ export {
   type HttpDocumentHeadersHook,
   type HttpDocumentStoreOptions,
 } from './document/http.js';
+export {
+  PgDocumentStore,
+  DOCUMENT_PG_SCHEMA,
+  ensureDocumentSchema,
+  type PgDocumentStoreOptions,
+} from './document/pg.js';
 
 export type {
   RuntimeStore,

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -51,12 +51,14 @@ interface RuntimeAppendConflictDetails {
 export class HttpRuntimeStoreError extends Error {
   readonly status: number;
   readonly code: string;
+  readonly details: unknown;
 
-  constructor(status: number, code: string, message: string) {
+  constructor(status: number, code: string, message: string, details?: unknown) {
     super(message);
     this.name = 'HttpRuntimeStoreError';
     this.status = status;
     this.code = code;
+    this.details = details;
   }
 }
 
@@ -203,7 +205,7 @@ export class HttpRuntimeStore implements RuntimeStore {
           );
         }
       }
-      throw new HttpRuntimeStoreError(response.status, code, message);
+      throw new HttpRuntimeStoreError(response.status, code, message, errorBody?.error?.details);
     }
     if (response.status === 204) return { body: undefined as T, status: response.status };
     return { body: (await response.json()) as T, status: response.status };

--- a/packages/@openmaic/storage/src/server/document.ts
+++ b/packages/@openmaic/storage/src/server/document.ts
@@ -16,6 +16,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from '../document/types.js';
+import { assertMaxBodyBytes, DEFAULT_MAX_BODY_BYTES, readJsonObject } from './read-json.js';
 
 export interface DocumentHttpPrincipal {
   learnerKey?: string;
@@ -38,6 +39,8 @@ export interface DocumentHttpHandlerOptions {
   validateScene?: SceneValidator;
   /** Whole-validator replacement; pass the same validator configured on the store. */
   validateStage?: StageValidator;
+  /** Maximum JSON request-body size in bytes. Defaults to 32 MiB. */
+  maxBodyBytes?: number;
 }
 
 interface ErrorBody {
@@ -69,21 +72,15 @@ function validationFailure(message: string, details?: unknown): DocumentHttpErro
   return new DocumentHttpError(400, 'VALIDATION_FAILED', message, details);
 }
 
-async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req)
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  if (chunks.length === 0) throw validationFailure('request body must be a JSON object');
-  let body: unknown;
-  try {
-    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
-  } catch (error) {
-    throw validationFailure(error instanceof Error ? error.message : String(error));
-  }
-  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
-    throw validationFailure('request body must be a JSON object');
-  }
-  return body as Record<string, unknown>;
+function payloadTooLarge(message: string): DocumentHttpError {
+  return new DocumentHttpError(413, 'PAYLOAD_TOO_LARGE', message);
+}
+
+function readJson(req: IncomingMessage, maxBodyBytes: number): Promise<Record<string, unknown>> {
+  return readJsonObject(req, maxBodyBytes, {
+    invalid: validationFailure,
+    payloadTooLarge,
+  });
 }
 
 function validationError(result: ValidationResult, label: string): void {
@@ -106,6 +103,18 @@ function assertJsonRequestValue(value: unknown, label: string): void {
     assertJsonValue(value, label);
   } catch (error) {
     throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function assertJsonResponseValue(value: unknown, label: string): void {
+  try {
+    assertJsonValue(value, label);
+  } catch (error) {
+    throw new DocumentHttpError(
+      500,
+      'NOT_JSON_SAFE',
+      error instanceof Error ? error.message : String(error),
+    );
   }
 }
 
@@ -244,9 +253,10 @@ function classifyStoreError(error: unknown): never {
       message || missingDocument(stageId).message,
     );
   }
-  const versionMatch = /at DSL version ("(?:[^"\\]|\\.)*")/.exec(message);
+  const versionMatch = /at DSL version (undefined|"(?:[^"\\]|\\.)*")/.exec(message);
   if (/newer than this client's/.test(message)) throw futureVersion(message);
   if (versionMatch?.[1]) {
+    if (versionMatch[1] === 'undefined') throw validationFailure(message);
     try {
       const version = JSON.parse(versionMatch[1]) as unknown;
       if (typeof version === 'string' && isFutureVersioned({ dslVersion: version })) {
@@ -261,7 +271,7 @@ function classifyStoreError(error: unknown): never {
 }
 
 function mappedError(error: unknown): { status: number; body: ErrorBody } {
-  if (error instanceof DocumentHttpError && error.status < 500) {
+  if (error instanceof DocumentHttpError) {
     return {
       status: error.status,
       body: {
@@ -308,6 +318,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
   }
 
   const method = req.method ?? 'GET';
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
   const sceneValidator = options.validateScene ?? validateScene;
   const stageValidator = options.validateStage ?? validateStage;
   if (parts.length === 1 && method === 'GET') {
@@ -320,7 +331,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
 
   if (parts.length === 2 && method === 'PUT') {
     const document = validateDocument<TScene, TStage>(
-      await readJson(req),
+      await readJson(req, maxBodyBytes),
       stageId,
       sceneValidator,
       stageValidator,
@@ -336,6 +347,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
   if (parts.length === 2 && method === 'GET') {
     const document = await store.loadDocument(stageId);
     if (document === null) throw missingDocument(stageId);
+    assertJsonResponseValue(document, `document response ${JSON.stringify(stageId)}`);
     sendJson(res, 200, document);
     return;
   }
@@ -345,7 +357,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
     return;
   }
   if (parts.length === 3 && parts[2] === 'stage' && method === 'PUT') {
-    const stage = (await readJson(req)) as unknown as TStage;
+    const stage = (await readJson(req, maxBodyBytes)) as unknown as TStage;
     validationError(stageValidator(stage), `stage ${(stage as { id?: unknown }).id}`);
     if (stage.id !== stageId) {
       throw validationFailure(
@@ -366,7 +378,7 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
     const sceneId = parts[3]!;
     assertAddressableSegment(sceneId);
     if (method === 'PUT') {
-      const scene = (await readJson(req)) as unknown as TScene;
+      const scene = (await readJson(req, maxBodyBytes)) as unknown as TScene;
       validationError(sceneValidator(scene), `scene ${(scene as { id?: unknown }).id}`);
       assertStorableScene(scene, stageId);
       if (scene.id !== sceneId) {
@@ -384,6 +396,10 @@ async function route<TScene extends SceneLike, TStage extends Stage>(
     if (method === 'GET') {
       const scene = await store.getScene(stageId, sceneId);
       if (scene === null) throw missingScene(stageId, sceneId);
+      assertJsonResponseValue(
+        scene,
+        `scene response ${JSON.stringify(sceneId)} in document ${JSON.stringify(stageId)}`,
+      );
       sendJson(res, 200, scene);
       return;
     }
@@ -408,6 +424,7 @@ export function createDocumentHttpHandler<
   if (typeof options?.authenticate !== 'function') {
     throw new Error('@openmaic/storage: createDocumentHttpHandler requires authenticate');
   }
+  assertMaxBodyBytes(options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES);
   return (req, res) => {
     void route(req, res, store, options).catch((error: unknown) => {
       if (res.headersSent) {

--- a/packages/@openmaic/storage/src/server/document.ts
+++ b/packages/@openmaic/storage/src/server/document.ts
@@ -16,6 +16,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from '../document/types.js';
+import { DocumentNotFoundError, DocumentVersionError } from '../document/types.js';
 import { assertMaxBodyBytes, DEFAULT_MAX_BODY_BYTES, readJsonObject } from './read-json.js';
 
 export interface DocumentHttpPrincipal {
@@ -150,8 +151,8 @@ function isFutureVersioned(value: unknown): boolean {
   return !needsMigration(value) && dslVersionOf(value) !== DSL_VERSION;
 }
 
-function futureVersion(message: string): DocumentHttpError {
-  return new DocumentHttpError(409, 'FUTURE_VERSION', message);
+function futureVersion(message: string, details?: unknown): DocumentHttpError {
+  return new DocumentHttpError(409, 'FUTURE_VERSION', message, details);
 }
 
 function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
@@ -206,6 +207,7 @@ function validateDocument<TScene extends SceneLike, TStage extends Stage>(
       `@openmaic/storage: refusing to save document ${JSON.stringify(pathStageId)} — it was ` +
         `written at DSL version ${JSON.stringify(dslVersionOf(document))}, newer than this ` +
         `client's ${DSL_VERSION}`,
+      { stageId: pathStageId, storedVersion: document.dslVersion },
     );
   }
   const normalized = migrateDocument(document);
@@ -235,6 +237,16 @@ function validateDocument<TScene extends SceneLike, TStage extends Stage>(
 }
 
 function classifyStoreError(error: unknown): never {
+  if (error instanceof DocumentNotFoundError) {
+    throw new DocumentHttpError(404, 'DOCUMENT_NOT_FOUND', error.message);
+  }
+  if (error instanceof DocumentVersionError) {
+    const details = { stageId: error.stageId, storedVersion: error.storedVersion };
+    if (error.kind === 'future') throw futureVersion(error.message, details);
+    throw validationFailure(error.message, details);
+  }
+
+  // Fallback for third-party DocumentStore implementations that throw plain Errors.
   const message = error instanceof Error ? error.message : String(error);
   if (/missing document/.test(message)) {
     const match = /missing document ("(?:[^"\\]|\\.)*")/.exec(message);

--- a/packages/@openmaic/storage/src/server/document.ts
+++ b/packages/@openmaic/storage/src/server/document.ts
@@ -1,0 +1,424 @@
+import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http';
+import {
+  DSL_VERSION,
+  dslVersionOf,
+  migrate,
+  needsMigration,
+  validateScene,
+  validateStage,
+} from '@openmaic/dsl';
+import type { Scene, Stage, ValidationResult } from '@openmaic/dsl';
+import { assertJsonValue } from '../runtime/json-value.js';
+import type {
+  DocumentStore,
+  MaicDocument,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from '../document/types.js';
+
+export interface DocumentHttpPrincipal {
+  learnerKey?: string;
+}
+
+export type DocumentHttpAuthenticate = (
+  req: IncomingMessage,
+) => Promise<DocumentHttpPrincipal | undefined>;
+
+export type DocumentHttpAuthorize = (
+  principal: DocumentHttpPrincipal,
+  req: IncomingMessage,
+) => boolean | Promise<boolean>;
+
+export interface DocumentHttpHandlerOptions {
+  authenticate: DocumentHttpAuthenticate;
+  /** Defaults to allowing any authenticated principal. */
+  authorizeDocuments?: DocumentHttpAuthorize;
+  /** Whole-validator replacement; pass the same validator configured on the store. */
+  validateScene?: SceneValidator;
+  /** Whole-validator replacement; pass the same validator configured on the store. */
+  validateStage?: StageValidator;
+}
+
+interface ErrorBody {
+  error: { code: string; message: string; details?: unknown };
+}
+
+class DocumentHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function sendNoContent(res: ServerResponse): void {
+  res.writeHead(204);
+  res.end();
+}
+
+function validationFailure(message: string, details?: unknown): DocumentHttpError {
+  return new DocumentHttpError(400, 'VALIDATION_FAILED', message, details);
+}
+
+async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req)
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  if (chunks.length === 0) throw validationFailure('request body must be a JSON object');
+  let body: unknown;
+  try {
+    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw validationFailure('request body must be a JSON object');
+  }
+  return body as Record<string, unknown>;
+}
+
+function validationError(result: ValidationResult, label: string): void {
+  if (result.valid) return;
+  const details = result.errors;
+  const detail = details.map((error) => `${error.path || '/'}: ${error.message}`).join('; ');
+  throw validationFailure(`@openmaic/storage: invalid ${label}: ${detail}`, details);
+}
+
+function assertAddressableSegment(value: string): void {
+  if (value === '.' || value === '..') {
+    throw validationFailure(
+      `@openmaic/storage: URL path segment must not be ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+function assertJsonRequestValue(value: unknown, label: string): void {
+  try {
+    assertJsonValue(value, label);
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function parsePath(req: IncomingMessage): string[] {
+  try {
+    return new URL(req.url ?? '/', 'http://documents.invalid').pathname
+      .split('/')
+      .filter((part, index) => index !== 0 || part !== '')
+      .map((part) => decodeURIComponent(part));
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function missingDocument(stageId: string): DocumentHttpError {
+  return new DocumentHttpError(
+    404,
+    'DOCUMENT_NOT_FOUND',
+    `@openmaic/storage: missing document ${JSON.stringify(stageId)}`,
+  );
+}
+
+function missingScene(stageId: string, sceneId: string): DocumentHttpError {
+  return new DocumentHttpError(
+    404,
+    'SCENE_NOT_FOUND',
+    `@openmaic/storage: no scene ${JSON.stringify(sceneId)} in document ${JSON.stringify(stageId)}`,
+  );
+}
+
+function isFutureVersioned(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  return !needsMigration(value) && dslVersionOf(value) !== DSL_VERSION;
+}
+
+function futureVersion(message: string): DocumentHttpError {
+  return new DocumentHttpError(409, 'FUTURE_VERSION', message);
+}
+
+function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
+  document: MaicDocument<TScene, TStage>,
+): MaicDocument<TScene, TStage> {
+  const { outline, ...core } = document;
+  let migrated: MaicDocument<TScene, TStage>;
+  try {
+    migrated = migrate(core) as MaicDocument<TScene, TStage>;
+  } catch (error) {
+    throw validationFailure(error instanceof Error ? error.message : String(error));
+  }
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
+function assertStorableScene(scene: unknown, stageId: string): asserts scene is SceneLike {
+  const value =
+    typeof scene === 'object' && scene !== null
+      ? (scene as { id?: unknown; stageId?: unknown; order?: unknown })
+      : { id: undefined, stageId: undefined, order: undefined };
+  if (typeof value.id !== 'string') {
+    throw validationFailure(
+      `@openmaic/storage: scene id must be a string, got ${JSON.stringify(value.id)}`,
+    );
+  }
+  if (value.stageId !== stageId) {
+    throw validationFailure(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} has stageId ` +
+        `${JSON.stringify(value.stageId)} but belongs to document ${JSON.stringify(stageId)}`,
+    );
+  }
+  if (typeof value.order !== 'number' || !Number.isFinite(value.order)) {
+    throw validationFailure(
+      `@openmaic/storage: scene ${JSON.stringify(value.id)} order must be a finite number, got ` +
+        `${JSON.stringify(value.order)}`,
+    );
+  }
+}
+
+function validateDocument<TScene extends SceneLike, TStage extends Stage>(
+  body: Record<string, unknown>,
+  pathStageId: string,
+  sceneValidator: SceneValidator,
+  stageValidator: StageValidator,
+): MaicDocument<TScene, TStage> {
+  if (typeof body.stage !== 'object' || body.stage === null || !Array.isArray(body.scenes)) {
+    throw validationFailure('document requires an object stage and a scenes array');
+  }
+  const document = body as unknown as MaicDocument<TScene, TStage>;
+  if (isFutureVersioned(document)) {
+    throw futureVersion(
+      `@openmaic/storage: refusing to save document ${JSON.stringify(pathStageId)} — it was ` +
+        `written at DSL version ${JSON.stringify(dslVersionOf(document))}, newer than this ` +
+        `client's ${DSL_VERSION}`,
+    );
+  }
+  const normalized = migrateDocument(document);
+  validationError(stageValidator(normalized.stage), `stage ${normalized.stage.id}`);
+  if (normalized.stage.id !== pathStageId) {
+    throw validationFailure(
+      `@openmaic/storage: stage ${JSON.stringify(normalized.stage.id)} does not belong to ` +
+        `document ${JSON.stringify(pathStageId)}`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const scene of normalized.scenes) {
+    const sceneId =
+      typeof scene === 'object' && scene !== null ? (scene as { id?: unknown }).id : undefined;
+    validationError(sceneValidator(scene), `scene ${String(sceneId)}`);
+    assertStorableScene(scene, pathStageId);
+    if (seen.has(scene.id)) {
+      throw validationFailure(
+        `@openmaic/storage: duplicate scene id ${JSON.stringify(scene.id)} in document ` +
+          JSON.stringify(pathStageId),
+      );
+    }
+    seen.add(scene.id);
+  }
+  assertJsonRequestValue(document, `document ${JSON.stringify(pathStageId)}`);
+  return document;
+}
+
+function classifyStoreError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/missing document/.test(message)) {
+    const match = /missing document ("(?:[^"\\]|\\.)*")/.exec(message);
+    let stageId = 'unknown';
+    if (match?.[1]) {
+      try {
+        const parsed = JSON.parse(match[1]) as unknown;
+        if (typeof parsed === 'string') stageId = parsed;
+      } catch {
+        // Keep the canonical store message below when parsing fails.
+      }
+    }
+    throw new DocumentHttpError(
+      404,
+      'DOCUMENT_NOT_FOUND',
+      message || missingDocument(stageId).message,
+    );
+  }
+  const versionMatch = /at DSL version ("(?:[^"\\]|\\.)*")/.exec(message);
+  if (/newer than this client's/.test(message)) throw futureVersion(message);
+  if (versionMatch?.[1]) {
+    try {
+      const version = JSON.parse(versionMatch[1]) as unknown;
+      if (typeof version === 'string' && isFutureVersioned({ dslVersion: version })) {
+        throw futureVersion(message);
+      }
+    } catch (classificationError) {
+      if (classificationError instanceof DocumentHttpError) throw classificationError;
+    }
+    throw validationFailure(message);
+  }
+  throw error;
+}
+
+function mappedError(error: unknown): { status: number; body: ErrorBody } {
+  if (error instanceof DocumentHttpError && error.status < 500) {
+    return {
+      status: error.status,
+      body: {
+        error: {
+          code: error.code,
+          message: error.message,
+          ...(error.details === undefined ? {} : { details: error.details }),
+        },
+      },
+    };
+  }
+  return {
+    status: 500,
+    body: {
+      error: { code: 'INTERNAL_ERROR', message: '@openmaic/storage: internal server error' },
+    },
+  };
+}
+
+async function route<TScene extends SceneLike, TStage extends Stage>(
+  req: IncomingMessage,
+  res: ServerResponse,
+  store: DocumentStore<TScene, TStage>,
+  options: DocumentHttpHandlerOptions,
+): Promise<void> {
+  const parts = parsePath(req);
+  if (parts[0] !== 'documents') {
+    throw new DocumentHttpError(404, 'ROUTE_NOT_FOUND', 'route not found');
+  }
+  const principal = await options.authenticate(req);
+  if (principal === undefined) {
+    throw new DocumentHttpError(
+      401,
+      'UNAUTHENTICATED',
+      '@openmaic/storage: authentication required',
+    );
+  }
+  if (!(await (options.authorizeDocuments?.(principal, req) ?? true))) {
+    throw new DocumentHttpError(
+      403,
+      'FORBIDDEN_DOCUMENTS',
+      '@openmaic/storage: document authorization required',
+    );
+  }
+
+  const method = req.method ?? 'GET';
+  const sceneValidator = options.validateScene ?? validateScene;
+  const stageValidator = options.validateStage ?? validateStage;
+  if (parts.length === 1 && method === 'GET') {
+    sendJson(res, 200, await store.listDocuments());
+    return;
+  }
+  if (parts.length < 2) throw new DocumentHttpError(404, 'ROUTE_NOT_FOUND', 'route not found');
+  const stageId = parts[1]!;
+  assertAddressableSegment(stageId);
+
+  if (parts.length === 2 && method === 'PUT') {
+    const document = validateDocument<TScene, TStage>(
+      await readJson(req),
+      stageId,
+      sceneValidator,
+      stageValidator,
+    );
+    try {
+      await store.saveDocument(document);
+    } catch (error) {
+      classifyStoreError(error);
+    }
+    sendNoContent(res);
+    return;
+  }
+  if (parts.length === 2 && method === 'GET') {
+    const document = await store.loadDocument(stageId);
+    if (document === null) throw missingDocument(stageId);
+    sendJson(res, 200, document);
+    return;
+  }
+  if (parts.length === 2 && method === 'DELETE') {
+    await store.deleteDocument(stageId);
+    sendNoContent(res);
+    return;
+  }
+  if (parts.length === 3 && parts[2] === 'stage' && method === 'PUT') {
+    const stage = (await readJson(req)) as unknown as TStage;
+    validationError(stageValidator(stage), `stage ${(stage as { id?: unknown }).id}`);
+    if (stage.id !== stageId) {
+      throw validationFailure(
+        `@openmaic/storage: stage ${JSON.stringify(stage.id)} does not belong to document ` +
+          JSON.stringify(stageId),
+      );
+    }
+    assertJsonRequestValue(stage, `stage ${JSON.stringify((stage as { id?: unknown }).id)}`);
+    try {
+      await store.putStage(stageId, stage);
+    } catch (error) {
+      classifyStoreError(error);
+    }
+    sendNoContent(res);
+    return;
+  }
+  if (parts.length === 4 && parts[2] === 'scenes') {
+    const sceneId = parts[3]!;
+    assertAddressableSegment(sceneId);
+    if (method === 'PUT') {
+      const scene = (await readJson(req)) as unknown as TScene;
+      validationError(sceneValidator(scene), `scene ${(scene as { id?: unknown }).id}`);
+      assertStorableScene(scene, stageId);
+      if (scene.id !== sceneId) {
+        throw validationFailure('scene body id does not match the request path');
+      }
+      assertJsonRequestValue(scene, `scene ${JSON.stringify(scene.id)}`);
+      try {
+        await store.putScene(stageId, scene);
+      } catch (error) {
+        classifyStoreError(error);
+      }
+      sendNoContent(res);
+      return;
+    }
+    if (method === 'GET') {
+      const scene = await store.getScene(stageId, sceneId);
+      if (scene === null) throw missingScene(stageId, sceneId);
+      sendJson(res, 200, scene);
+      return;
+    }
+    if (method === 'DELETE') {
+      try {
+        await store.deleteScene(stageId, sceneId);
+      } catch (error) {
+        classifyStoreError(error);
+      }
+      sendNoContent(res);
+      return;
+    }
+  }
+  throw new DocumentHttpError(404, 'ROUTE_NOT_FOUND', 'route not found');
+}
+
+/** Create a Node HTTP request handler for the complete DocumentStore contract. */
+export function createDocumentHttpHandler<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+>(store: DocumentStore<TScene, TStage>, options: DocumentHttpHandlerOptions): RequestListener {
+  if (typeof options?.authenticate !== 'function') {
+    throw new Error('@openmaic/storage: createDocumentHttpHandler requires authenticate');
+  }
+  return (req, res) => {
+    void route(req, res, store, options).catch((error: unknown) => {
+      if (res.headersSent) {
+        res.destroy(error instanceof Error ? error : undefined);
+        return;
+      }
+      if (!(error instanceof DocumentHttpError) || error.status >= 500) {
+        console.error('@openmaic/storage: Document HTTP handler internal error', error);
+      }
+      const mapped = mappedError(error);
+      sendJson(res, mapped.status, mapped.body);
+    });
+  };
+}

--- a/packages/@openmaic/storage/src/server/index.ts
+++ b/packages/@openmaic/storage/src/server/index.ts
@@ -25,6 +25,17 @@ import type {
   RuntimeTailOptions,
 } from '../runtime/types.js';
 import { RuntimeAppendConflictError } from '../runtime/types.js';
+import type { Scene, Stage } from '@openmaic/dsl';
+import type { DocumentStore, SceneLike } from '../document/types.js';
+import { createDocumentHttpHandler, type DocumentHttpHandlerOptions } from './document.js';
+
+export {
+  createDocumentHttpHandler,
+  type DocumentHttpAuthenticate,
+  type DocumentHttpAuthorize,
+  type DocumentHttpHandlerOptions,
+  type DocumentHttpPrincipal,
+} from './document.js';
 
 export interface RuntimeHttpPrincipal {
   learnerKey?: string;
@@ -672,5 +683,45 @@ export function createRuntimeHttpHandler(
       const mapped = mappedError(error);
       sendJson(res, mapped.status, mapped.body);
     });
+  };
+}
+
+export interface StorageHttpHandlerOptions
+  extends
+    RuntimeHttpHandlerOptions,
+    Pick<DocumentHttpHandlerOptions, 'authorizeDocuments' | 'validateScene' | 'validateStage'> {}
+
+/**
+ * Compose the runtime and author-document contracts into one request handler.
+ * Existing runtime routing is delegated unchanged; `/documents` is dispatched
+ * to the document handler and shares the same authentication hook.
+ */
+export function createStorageHttpHandler<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+>(
+  runtimeStore: RuntimeStore,
+  documentStore: DocumentStore<TScene, TStage>,
+  options: StorageHttpHandlerOptions,
+): RequestListener {
+  const runtime = createRuntimeHttpHandler(runtimeStore, options);
+  const documents = createDocumentHttpHandler(documentStore, {
+    authenticate: options.authenticate,
+    ...(options.authorizeDocuments === undefined
+      ? {}
+      : { authorizeDocuments: options.authorizeDocuments }),
+    ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
+    ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+  });
+  return (req, res) => {
+    let pathname: string;
+    try {
+      pathname = new URL(req.url ?? '/', 'http://storage.invalid').pathname;
+    } catch {
+      runtime(req, res);
+      return;
+    }
+    if (pathname === '/documents' || pathname.startsWith('/documents/')) documents(req, res);
+    else runtime(req, res);
   };
 }

--- a/packages/@openmaic/storage/src/server/index.ts
+++ b/packages/@openmaic/storage/src/server/index.ts
@@ -28,6 +28,7 @@ import { RuntimeAppendConflictError } from '../runtime/types.js';
 import type { Scene, Stage } from '@openmaic/dsl';
 import type { DocumentStore, SceneLike } from '../document/types.js';
 import { createDocumentHttpHandler, type DocumentHttpHandlerOptions } from './document.js';
+import { assertMaxBodyBytes, DEFAULT_MAX_BODY_BYTES, readJsonObject } from './read-json.js';
 
 export {
   createDocumentHttpHandler,
@@ -64,6 +65,8 @@ export interface RuntimeHttpHandlerOptions {
    * pass the same table configured on the injected store.
    */
   payloadValidators?: Record<string, RuntimePayloadValidator>;
+  /** Maximum JSON request-body size in bytes. Defaults to 32 MiB. */
+  maxBodyBytes?: number;
 }
 
 interface ErrorBody {
@@ -95,30 +98,19 @@ function sendNoContent(res: ServerResponse): void {
   res.end();
 }
 
-async function readJson<T>(req: IncomingMessage): Promise<T> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  }
-  if (chunks.length === 0) {
-    throw validationFailure('request body must be a JSON object');
-  }
-  let body: unknown;
-  try {
-    body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
-  } catch (error) {
-    throw validationFailure(error instanceof Error ? error.message : String(error));
-  }
-  if (!isObject(body)) throw validationFailure('request body must be a JSON object');
-  return body as T;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function validationFailure(message: string, details?: unknown): RuntimeHttpError {
   return new RuntimeHttpError(400, 'VALIDATION_FAILED', message, details);
+}
+
+function payloadTooLarge(message: string): RuntimeHttpError {
+  return new RuntimeHttpError(413, 'PAYLOAD_TOO_LARGE', message);
+}
+
+function readJson<T>(req: IncomingMessage, maxBodyBytes: number): Promise<T> {
+  return readJsonObject(req, maxBodyBytes, {
+    invalid: validationFailure,
+    payloadTooLarge,
+  });
 }
 
 function validationError(result: ValidationResult, label: string): void {
@@ -417,7 +409,10 @@ async function route(
   }
 
   if (method === 'POST' && parts.length === 2 && parts[1] === 'sessions') {
-    const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(req);
+    const init = await readJson<RuntimeSessionInit & { runtimeDslVersion?: unknown }>(
+      req,
+      options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
     assertAddressableSegment(init.id);
     assertAddressableSegment(init.stageId);
     assertAddressableSegment(init.learnerKey, 'learnerKey');
@@ -468,7 +463,7 @@ async function route(
     if (method === 'PATCH' && parts.length === 4 && parts[3] === 'status') {
       const body = await readJson<
         { status: RuntimeSessionStatus; updatedAt: string } & RuntimeTailOptions
-      >(req);
+      >(req, options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES);
       const session = await writableSession(store, principal, sessionId);
       validationError(
         validateRuntimeSession({ ...session, status: body.status, updatedAt: body.updatedAt }),
@@ -504,6 +499,7 @@ async function route(
     if (method === 'POST' && parts.length === 4 && parts[3] === 'records') {
       const body = await readJson<RuntimeRecordInit & RuntimeAppendOptions & { seq?: unknown }>(
         req,
+        options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
       );
       const { expectedLastSeq, sessionTransition, ...init } = body;
       if (init.sessionId !== sessionId) {
@@ -599,7 +595,10 @@ async function route(
   }
 
   if (method === 'POST' && parts.length === 3 && parts[1] === 'learners' && parts[2] === 'merge') {
-    const body = await readJson<{ fromLearnerKey?: unknown; toLearnerKey?: unknown }>(req);
+    const body = await readJson<{ fromLearnerKey?: unknown; toLearnerKey?: unknown }>(
+      req,
+      options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    );
     if (
       typeof body.fromLearnerKey !== 'string' ||
       body.fromLearnerKey === '' ||
@@ -668,6 +667,7 @@ export function createRuntimeHttpHandler(
   if (typeof options?.authenticate !== 'function') {
     throw new Error('@openmaic/storage: createRuntimeHttpHandler requires authenticate');
   }
+  assertMaxBodyBytes(options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES);
   return (req, res) => {
     void route(req, res, store, options).catch((error: unknown) => {
       if (res.headersSent) {
@@ -712,6 +712,7 @@ export function createStorageHttpHandler<
       : { authorizeDocuments: options.authorizeDocuments }),
     ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
     ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+    ...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
   });
   return (req, res) => {
     let pathname: string;

--- a/packages/@openmaic/storage/src/server/read-json.ts
+++ b/packages/@openmaic/storage/src/server/read-json.ts
@@ -1,0 +1,45 @@
+import type { IncomingMessage } from 'node:http';
+
+export const DEFAULT_MAX_BODY_BYTES = 32 * 1024 * 1024;
+
+export interface ReadJsonErrors {
+  invalid(message: string): Error;
+  payloadTooLarge(message: string): Error;
+}
+
+export function assertMaxBodyBytes(maxBodyBytes: number): void {
+  if (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes <= 0) {
+    throw new Error('@openmaic/storage: maxBodyBytes must be a positive safe integer');
+  }
+}
+
+export async function readJsonObject<T>(
+  req: IncomingMessage,
+  maxBodyBytes: number,
+  errors: ReadJsonErrors,
+): Promise<T> {
+  const chunks: Buffer[] = [];
+  let bodyBytes = 0;
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    bodyBytes += buffer.byteLength;
+    if (bodyBytes > maxBodyBytes) {
+      throw errors.payloadTooLarge(
+        `@openmaic/storage: request body exceeds maxBodyBytes (${maxBodyBytes})`,
+      );
+    }
+    chunks.push(buffer);
+  }
+  if (chunks.length === 0) throw errors.invalid('request body must be a JSON object');
+
+  let body: unknown;
+  try {
+    body = JSON.parse(Buffer.concat(chunks, bodyBytes).toString('utf8')) as unknown;
+  } catch (error) {
+    throw errors.invalid(error instanceof Error ? error.message : String(error));
+  }
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw errors.invalid('request body must be a JSON object');
+  }
+  return body as T;
+}

--- a/packages/@openmaic/storage/src/server/reference.ts
+++ b/packages/@openmaic/storage/src/server/reference.ts
@@ -49,6 +49,8 @@ export interface ReferenceRuntimeServerOptions<
   /** Pass the same validators configured on documentStore. */
   validateScene?: SceneValidator;
   validateStage?: StageValidator;
+  /** Maximum JSON request-body size in bytes. Defaults to 32 MiB. */
+  maxBodyBytes?: number;
 }
 
 /**
@@ -116,6 +118,7 @@ export async function createReferenceRuntimeServer<
       : { authorizeDocuments: options.authorizeDocuments }),
     ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
     ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+    ...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
   };
   return createServer(
     options.documentStore === undefined

--- a/packages/@openmaic/storage/src/server/reference.ts
+++ b/packages/@openmaic/storage/src/server/reference.ts
@@ -14,23 +14,41 @@ import { pathToFileURL } from 'node:url';
 import { PgRuntimeStore, ensureSchema } from '../runtime/pg.js';
 import type { Queryable, WithTransaction } from '../runtime/pg.js';
 import type { RuntimePayloadValidator } from '../runtime/types.js';
-import { createRuntimeHttpHandler } from './index.js';
 import type {
+  DocumentStore,
+  SceneLike,
+  SceneValidator,
+  StageValidator,
+} from '../document/types.js';
+import type { Scene, Stage } from '@openmaic/dsl';
+import { createRuntimeHttpHandler, createStorageHttpHandler } from './index.js';
+import type {
+  DocumentHttpAuthorize,
   RuntimeHttpAuthenticate,
   RuntimeHttpAuthorizeAdmin,
   RuntimeHttpAuthorizeMerge,
+  StorageHttpHandlerOptions,
 } from './index.js';
 
 export interface ConnectableQueryable extends Queryable {
   connect(): Promise<Queryable & { release(): void }>;
 }
 
-export interface ReferenceRuntimeServerOptions {
+export interface ReferenceRuntimeServerOptions<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+> {
   authenticate?: RuntimeHttpAuthenticate;
   authorizeMerge?: RuntimeHttpAuthorizeMerge;
   authorizeAdmin?: RuntimeHttpAuthorizeAdmin;
   /** Whole-table replacement; pass the same validator table to the store and handler. */
   payloadValidators?: Record<string, RuntimePayloadValidator>;
+  /** When supplied, the same server also exposes the `/documents` contract. */
+  documentStore?: DocumentStore<TScene, TStage>;
+  authorizeDocuments?: DocumentHttpAuthorize;
+  /** Pass the same validators configured on documentStore. */
+  validateScene?: SceneValidator;
+  validateStage?: StageValidator;
 }
 
 /**
@@ -61,9 +79,12 @@ export function nodePostgresTransaction(pool: ConnectableQueryable): WithTransac
  * Replace it, and the default authorization hooks, before exposing the server.
  * This factory creates an unbound Server; only main() binds it to an address.
  */
-export async function createReferenceRuntimeServer(
+export async function createReferenceRuntimeServer<
+  TScene extends SceneLike = Scene,
+  TStage extends Stage = Stage,
+>(
   pool: ConnectableQueryable,
-  options: ReferenceRuntimeServerOptions = {},
+  options: ReferenceRuntimeServerOptions<TScene, TStage> = {},
 ): Promise<Server> {
   await ensureSchema(pool);
   const store = new PgRuntimeStore(pool, {
@@ -72,27 +93,34 @@ export async function createReferenceRuntimeServer(
       ? {}
       : { payloadValidators: options.payloadValidators }),
   });
+  const handlerOptions: StorageHttpHandlerOptions = {
+    authenticate:
+      options.authenticate ??
+      (async (req) => {
+        const authorization = req.headers.authorization;
+        if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
+          return undefined;
+        }
+        const learnerKey = authorization.slice('Bearer '.length);
+        return learnerKey === '' ? undefined : { learnerKey };
+      }),
+    authorizeMerge:
+      options.authorizeMerge ??
+      (async (principal, fromKey, toKey) => principal.learnerKey === fromKey && fromKey === toKey),
+    authorizeAdmin: options.authorizeAdmin ?? (async () => false),
+    ...(options.payloadValidators === undefined
+      ? {}
+      : { payloadValidators: options.payloadValidators }),
+    ...(options.authorizeDocuments === undefined
+      ? {}
+      : { authorizeDocuments: options.authorizeDocuments }),
+    ...(options.validateScene === undefined ? {} : { validateScene: options.validateScene }),
+    ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
+  };
   return createServer(
-    createRuntimeHttpHandler(store, {
-      authenticate:
-        options.authenticate ??
-        (async (req) => {
-          const authorization = req.headers.authorization;
-          if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
-            return undefined;
-          }
-          const learnerKey = authorization.slice('Bearer '.length);
-          return learnerKey === '' ? undefined : { learnerKey };
-        }),
-      authorizeMerge:
-        options.authorizeMerge ??
-        (async (principal, fromKey, toKey) =>
-          principal.learnerKey === fromKey && fromKey === toKey),
-      authorizeAdmin: options.authorizeAdmin ?? (async () => false),
-      ...(options.payloadValidators === undefined
-        ? {}
-        : { payloadValidators: options.payloadValidators }),
-    }),
+    options.documentStore === undefined
+      ? createRuntimeHttpHandler(store, handlerOptions)
+      : createStorageHttpHandler(store, options.documentStore, handlerOptions),
   );
 }
 

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { IDBFactory } from 'fake-indexeddb';
 import { DSL_VERSION, DSL_VERSION_KEY, validateScene, validateStage } from '@openmaic/dsl';
-import { BrowserDocumentStore, type MaicDocument } from '../src/index.js';
+import {
+  BrowserDocumentStore,
+  DocumentNotFoundError,
+  DocumentVersionError,
+  type MaicDocument,
+} from '../src/index.js';
 import { runDocumentStoreContract, makeDocument, slideScene } from './document-contract.js';
 
 // Open the raw DB the store uses and overwrite the stage row's version stamp,
@@ -102,13 +107,25 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // stamping the whole document current off one incremental write would
     // corrupt them — reject and require a full load + save first.
     await reStampStage(idb, dbName, 'stage-1', undefined);
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'new', 2))).rejects.toThrow();
+    const staleFailure = store.putScene('stage-1', slideScene('stage-1', 'new', 2));
+    await expect(staleFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(staleFailure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'not-current',
+      storedVersion: undefined,
+    });
     // rejected write left nothing behind (a legacy doc still migrates on read)
     expect(await store.getScene('stage-1', 'new')).toBeNull();
 
     // Future stored document: an old client must not downgrade it.
     await reStampStage(idb, dbName, 'stage-1', '99.0.0');
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'new2', 3))).rejects.toThrow();
+    const futureFailure = store.putScene('stage-1', slideScene('stage-1', 'new2', 3));
+    await expect(futureFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(futureFailure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'not-current',
+      storedVersion: '99.0.0',
+    });
     expect(await store.getScene('stage-1', 'new2')).toBeNull();
   });
 
@@ -124,7 +141,7 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // stored document — the store checks the stored row inside the write tx.
     const fresh = makeDocument();
     fresh.stage.name = 'Old Client Overwrite';
-    await expect(store.saveDocument(fresh)).rejects.toThrow();
+    await expect(store.saveDocument(fresh)).rejects.toBeInstanceOf(DocumentVersionError);
 
     const loaded = await store.loadDocument('stage-1');
     expect(loaded!.dslVersion).toBe('99.0.0');
@@ -140,7 +157,9 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // Future stored document: an old client must not mutate newer-versioned data
     // (mirrors the putScene guard — deleting a scene is an incremental mutation).
     await reStampStage(idb, dbName, 'stage-1', '99.0.0');
-    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow();
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toBeInstanceOf(
+      DocumentVersionError,
+    );
     expect((await store.loadDocument('stage-1'))!.scenes.map((s) => s.id)).toEqual([
       'scene-a',
       'scene-b',
@@ -148,7 +167,29 @@ describe('BrowserDocumentStore migrate-on-read', () => {
 
     // Stale stored document must be normalized (load + save) before incremental ops.
     await reStampStage(idb, dbName, 'stage-1', undefined);
-    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow();
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toBeInstanceOf(
+      DocumentVersionError,
+    );
+  });
+
+  test('missing incremental-write parents use DocumentNotFoundError', async () => {
+    const store = new BrowserDocumentStore({
+      indexedDB: new IDBFactory(),
+      dbName: 'maic-documents-missing-parent-error',
+    });
+
+    const putStageFailure = store.putStage('ghost', {
+      id: 'ghost',
+      name: 'Ghost',
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    await expect(putStageFailure).rejects.toBeInstanceOf(DocumentNotFoundError);
+    await expect(putStageFailure).rejects.toMatchObject({ stageId: 'ghost' });
+
+    await expect(store.putScene('ghost', slideScene('ghost', 'scene', 0))).rejects.toBeInstanceOf(
+      DocumentNotFoundError,
+    );
   });
 
   test('fails loud on a malformed stored version stamp', async () => {

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -4,47 +4,47 @@ import { DSL_VERSION, DSL_VERSION_KEY, validateScene, validateStage } from '@ope
 import { BrowserDocumentStore, type MaicDocument } from '../src/index.js';
 import { runDocumentStoreContract, makeDocument, slideScene } from './document-contract.js';
 
-// Each store gets its own in-memory IndexedDB factory so contract cases stay
-// isolated without leaning on an ambient global.
-function makeStore(): BrowserDocumentStore {
-  return new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+// Open the raw DB the store uses and overwrite the stage row's version stamp,
+// simulating a document written by an older client.
+async function reStampStage(
+  idb: IDBFactory,
+  dbName: string,
+  stageId: string,
+  version: string | undefined,
+): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = idb.open(dbName);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('stages', 'readwrite');
+    const store = tx.objectStore('stages');
+    const get = store.get(stageId);
+    get.onsuccess = () => {
+      const row = get.result as Record<string, unknown>;
+      if (version === undefined) delete row[DSL_VERSION_KEY];
+      else row[DSL_VERSION_KEY] = version;
+      store.put(row);
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
 }
 
-runDocumentStoreContract('BrowserDocumentStore', makeStore);
+let contractDb = 0;
+runDocumentStoreContract('BrowserDocumentStore', () => {
+  const idb = new IDBFactory();
+  const dbName = `maic-documents-contract-${contractDb++}`;
+  return {
+    store: new BrowserDocumentStore({ indexedDB: idb, dbName }),
+    seedStoredVersion: (stageId, version) => reStampStage(idb, dbName, stageId, version),
+  };
+});
 
-// --- backend-specific: migrate-on-read needs to seed a raw row at an old
-// version, which the public API (which always stamps the current version) can't
-// express. ---
+// --- backend-specific migrate-on-read and raw IndexedDB behavior. ---
 describe('BrowserDocumentStore migrate-on-read', () => {
-  // Open the raw DB the store uses and overwrite the stage row's version stamp,
-  // simulating a document written by an older client.
-  async function reStampStage(
-    idb: IDBFactory,
-    dbName: string,
-    stageId: string,
-    version: string | undefined,
-  ): Promise<void> {
-    const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const req = idb.open(dbName);
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error);
-    });
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction('stages', 'readwrite');
-      const store = tx.objectStore('stages');
-      const get = store.get(stageId);
-      get.onsuccess = () => {
-        const row = get.result as Record<string, unknown>;
-        if (version === undefined) delete row[DSL_VERSION_KEY];
-        else row[DSL_VERSION_KEY] = version;
-        store.put(row);
-      };
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
-    });
-    db.close();
-  }
-
   test('stamps a legacy (unversioned) document forward on load', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-documents-legacy';
@@ -112,25 +112,6 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     expect(await store.getScene('stage-1', 'new2')).toBeNull();
   });
 
-  test('putStage rejects when the stored document is not current', async () => {
-    const idb = new IDBFactory();
-    const dbName = 'maic-documents-putstage-noncurrent';
-    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
-    const doc = makeDocument();
-    await store.saveDocument(doc);
-
-    await reStampStage(idb, dbName, 'stage-1', undefined);
-    await expect(store.putStage('stage-1', { ...doc.stage, name: 'Stale Rename' })).rejects.toThrow(
-      /cannot putStage/,
-    );
-
-    await reStampStage(idb, dbName, 'stage-1', '99.0.0');
-    await expect(
-      store.putStage('stage-1', { ...doc.stage, name: 'Future Rename' }),
-    ).rejects.toThrow(/cannot putStage/);
-    expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
-  });
-
   test('refuses to overwrite a stored document written by a newer client', async () => {
     const idb = new IDBFactory();
     const dbName = 'maic-documents-overwrite-future';
@@ -183,22 +164,6 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // saveDocument reads the stored stamp inside its future-overwrite guard, so a
     // corrupt stored stamp also fails loud (recoverable via deleteDocument).
     await expect(store.saveDocument(makeDocument())).rejects.toThrow();
-  });
-
-  test('listDocuments tolerates a malformed version stamp', async () => {
-    const idb = new IDBFactory();
-    const dbName = 'maic-documents-list-malformed';
-    const store = new BrowserDocumentStore({ indexedDB: idb, dbName });
-    await store.saveDocument(makeDocument());
-    await reStampStage(idb, dbName, 'stage-1', 'not-a-version');
-
-    // listDocuments returns only version-independent summary fields and never
-    // migrates or reads content, so a corrupt stamp does not break the whole list
-    // (one bad row must not make the picker unusable) — content reads still fail loud.
-    const list = await store.listDocuments();
-    expect(list.map((d) => d.id)).toEqual(['stage-1']);
-    expect(list[0]).toMatchObject({ name: 'Intro Course', sceneCount: 2 });
-    await expect(store.loadDocument('stage-1')).rejects.toThrow();
   });
 });
 

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -7,7 +7,7 @@
 import { describe, expect, test } from 'vitest';
 import { DSL_VERSION } from '@openmaic/dsl';
 import type { Scene } from '@openmaic/dsl';
-import type { DocumentStore, MaicDocument } from '../src/index.js';
+import { DocumentVersionError, type DocumentStore, type MaicDocument } from '../src/index.js';
 
 // --- fixtures ---------------------------------------------------------------
 
@@ -287,7 +287,13 @@ export function runDocumentStoreContract(
       future.dslVersion = '99.0.0';
       future.stage.name = 'Should Not Persist';
       // an old client must not overwrite (and downgrade) a newer-versioned document
-      await expect(store.saveDocument(future)).rejects.toThrow();
+      const failure = store.saveDocument(future);
+      await expect(failure).rejects.toBeInstanceOf(DocumentVersionError);
+      await expect(failure).rejects.toMatchObject({
+        stageId: 'stage-1',
+        kind: 'future',
+        storedVersion: '99.0.0',
+      });
 
       const loaded = await store.loadDocument('stage-1');
       expect(loaded!.stage.name).toBe('Intro Course');

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -2,8 +2,8 @@
 // today, HTTP later) is proven equivalent by running this same suite against it,
 // so a new backend cannot silently diverge from the store's semantics.
 //
-// Backend-specific behaviours that need to seed raw rows (migrate-on-read,
-// forward-compat) live in the backend's own test file, not here.
+// The harness exposes a narrow raw-version seeding seam so version-guard and
+// corrupt-stamp behavior is proven identically by every backend.
 import { describe, expect, test } from 'vitest';
 import { DSL_VERSION } from '@openmaic/dsl';
 import type { Scene } from '@openmaic/dsl';
@@ -53,8 +53,17 @@ export function makeDocument(stageId = 'stage-1'): MaicDocument {
 
 // --- contract ---------------------------------------------------------------
 
-export function runDocumentStoreContract(name: string, makeStore: () => DocumentStore): void {
+export interface DocumentStoreContractHarness {
+  store: DocumentStore;
+  seedStoredVersion(stageId: string, version: string | undefined): Promise<void>;
+}
+
+export function runDocumentStoreContract(
+  name: string,
+  makeContractHarness: () => DocumentStoreContractHarness,
+): void {
   describe(`DocumentStore contract: ${name}`, () => {
+    const makeStore = (): DocumentStore => makeContractHarness().store;
     test('round-trips a full document (stage + scenes + outline)', async () => {
       const store = makeStore();
       const doc = makeDocument();
@@ -145,6 +154,41 @@ export function runDocumentStoreContract(name: string, makeStore: () => Document
           updatedAt: 2,
         }),
       ).rejects.toThrow(/missing document/);
+    });
+
+    test('putStage rejects a stale stored document', async () => {
+      const { store, seedStoredVersion } = makeContractHarness();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+      await seedStoredVersion('stage-1', undefined);
+
+      await expect(
+        store.putStage('stage-1', { ...doc.stage, name: 'Stale Rename' }),
+      ).rejects.toThrow();
+      expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+    });
+
+    test('putStage rejects a future-versioned stored document', async () => {
+      const { store, seedStoredVersion } = makeContractHarness();
+      const doc = makeDocument();
+      await store.saveDocument(doc);
+      await seedStoredVersion('stage-1', '99.0.0');
+
+      await expect(
+        store.putStage('stage-1', { ...doc.stage, name: 'Future Rename' }),
+      ).rejects.toThrow();
+      expect((await store.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+    });
+
+    test('listDocuments tolerates a corrupt stored version stamp', async () => {
+      const { store, seedStoredVersion } = makeContractHarness();
+      await store.saveDocument(makeDocument());
+      await seedStoredVersion('stage-1', 'not-a-version');
+
+      await expect(store.listDocuments()).resolves.toEqual([
+        expect.objectContaining({ id: 'stage-1', name: 'Intro Course', sceneCount: 2 }),
+      ]);
+      await expect(store.loadDocument('stage-1')).rejects.toThrow();
     });
 
     // --- validation gate ---

--- a/packages/@openmaic/storage/test/http-document-store.test.ts
+++ b/packages/@openmaic/storage/test/http-document-store.test.ts
@@ -1,0 +1,169 @@
+import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http';
+import { IDBFactory } from 'fake-indexeddb';
+import { describe, expect, test } from 'vitest';
+import { BrowserDocumentStore } from '../src/document/browser.js';
+import { HttpDocumentStore, HttpDocumentStoreError } from '../src/document/http.js';
+import { BrowserRuntimeStore } from '../src/runtime/browser.js';
+import { createStorageHttpHandler } from '../src/server/index.js';
+import { makeDocument, runDocumentStoreContract } from './document-contract.js';
+
+const BASE_URL = 'http://storage-reference.invalid';
+
+function handlerFetch(handler: RequestListener): typeof globalThis.fetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const body = await request.text();
+    const headers = Object.fromEntries(request.headers.entries());
+    headers.authorization ??= 'Bearer document-contract';
+    const fakeRequest = {
+      method: request.method,
+      url: `${url.pathname}${url.search}`,
+      headers,
+      async *[Symbol.asyncIterator]() {
+        if (body !== '') yield Buffer.from(body);
+      },
+    } as unknown as IncomingMessage;
+
+    return new Promise<Response>((resolve, reject) => {
+      let status = 200;
+      let responseHeaders: Record<string, string> = {};
+      let responseBody: string | undefined;
+      let headersSent = false;
+      const fakeResponse = {
+        get headersSent() {
+          return headersSent;
+        },
+        writeHead(nextStatus: number, nextHeaders?: Record<string, string>) {
+          status = nextStatus;
+          responseHeaders = nextHeaders ?? {};
+          headersSent = true;
+          return this;
+        },
+        end(chunk?: string | Buffer) {
+          responseBody = chunk === undefined ? undefined : chunk.toString();
+          resolve(
+            new Response(status === 204 ? null : responseBody, {
+              status,
+              headers: responseHeaders,
+            }),
+          );
+          return this;
+        },
+        destroy(error?: Error) {
+          reject(error ?? new Error('response destroyed'));
+          return this;
+        },
+      } as unknown as ServerResponse;
+      handler(fakeRequest, fakeResponse);
+    });
+  };
+}
+
+function makeHarness(authorizeDocuments: () => boolean = () => true) {
+  const documents = new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+  const runtime = new BrowserRuntimeStore({ indexedDB: new IDBFactory() });
+  const handler = createStorageHttpHandler(runtime, documents, {
+    authenticate: async (req) => {
+      const authorization = req.headers.authorization;
+      return typeof authorization === 'string' && authorization.startsWith('Bearer ')
+        ? { learnerKey: 'author' }
+        : undefined;
+    },
+    authorizeDocuments: async () => authorizeDocuments(),
+  });
+  const fetch = handlerFetch(handler);
+  return {
+    documents,
+    fetch,
+    client: new HttpDocumentStore({ baseUrl: BASE_URL, fetch }),
+  };
+}
+
+runDocumentStoreContract('reference HTTP', () => makeHarness().client);
+
+describe('HttpDocumentStore contract mapping', () => {
+  test('uses injected request headers and the reference server requires authentication', async () => {
+    const { fetch } = makeHarness();
+    const unauthenticated = await fetch(`${BASE_URL}/documents`, {
+      headers: { authorization: '' },
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    let context: { method: string; path: string } | undefined;
+    const client = new HttpDocumentStore({
+      baseUrl: BASE_URL,
+      fetch,
+      headers: (next) => {
+        context = next;
+        return { authorization: 'Bearer author' };
+      },
+    });
+    await client.listDocuments();
+    expect(context).toEqual({ method: 'GET', path: '/documents' });
+  });
+
+  test('maps document authorization denial to a typed 403', async () => {
+    const { client } = makeHarness(() => false);
+    await expect(client.listDocuments()).rejects.toMatchObject({
+      name: 'HttpDocumentStoreError',
+      status: 403,
+      code: 'FORBIDDEN_DOCUMENTS',
+    });
+  });
+
+  test('maps malformed request JSON to VALIDATION_FAILED', async () => {
+    const { fetch } = makeHarness();
+    const response = await fetch(`${BASE_URL}/documents/stage-1`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: '{',
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'VALIDATION_FAILED' },
+    });
+  });
+
+  test('maps missing required parents to typed 404 errors with browser wording', async () => {
+    const { client } = makeHarness();
+    const failure = client.putStage('ghost', {
+      id: 'ghost',
+      name: 'Ghost',
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    await expect(failure).rejects.toBeInstanceOf(HttpDocumentStoreError);
+    await expect(failure).rejects.toMatchObject({ status: 404, code: 'DOCUMENT_NOT_FOUND' });
+    await expect(failure).rejects.toThrow(/missing document/);
+  });
+
+  test('maps a future-version save to FUTURE_VERSION without overwriting current data', async () => {
+    const { client } = makeHarness();
+    await client.saveDocument(makeDocument());
+    const future = makeDocument();
+    future.dslVersion = '99.0.0';
+    future.stage.name = 'Future';
+
+    await expect(client.saveDocument(future)).rejects.toMatchObject({
+      status: 409,
+      code: 'FUTURE_VERSION',
+    });
+    expect((await client.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+  });
+
+  test('client-side validators fail before fetch', async () => {
+    let calls = 0;
+    const client = new HttpDocumentStore({
+      baseUrl: BASE_URL,
+      fetch: async () => {
+        calls += 1;
+        return new Response(null, { status: 204 });
+      },
+    });
+    const bad = makeDocument();
+    delete (bad.stage as { name?: string }).name;
+    await expect(client.saveDocument(bad)).rejects.toThrow(/invalid stage/);
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/@openmaic/storage/test/http-document-store.test.ts
+++ b/packages/@openmaic/storage/test/http-document-store.test.ts
@@ -3,6 +3,7 @@ import { IDBFactory } from 'fake-indexeddb';
 import { DSL_VERSION_KEY } from '@openmaic/dsl';
 import { describe, expect, test } from 'vitest';
 import { BrowserDocumentStore } from '../src/document/browser.js';
+import { DocumentVersionError } from '../src/document/types.js';
 import { HttpDocumentStore, HttpDocumentStoreError } from '../src/document/http.js';
 import type { StageValidator } from '../src/document/types.js';
 import { BrowserRuntimeStore } from '../src/runtime/browser.js';
@@ -259,11 +260,35 @@ describe('HttpDocumentStore contract mapping', () => {
     future.dslVersion = '99.0.0';
     future.stage.name = 'Future';
 
-    await expect(client.saveDocument(future)).rejects.toMatchObject({
-      status: 409,
-      code: 'FUTURE_VERSION',
+    const failure = client.saveDocument(future);
+    await expect(failure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(failure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'future',
+      storedVersion: '99.0.0',
     });
+    await expect(failure).rejects.toThrow(
+      `@openmaic/storage: refusing to save document "stage-1" — it was written at DSL version ` +
+        `"99.0.0", newer than this client's`,
+    );
     expect((await client.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+  });
+
+  test('rematerializes a typed future-version error classified from the backing store', async () => {
+    const { client, seedStoredVersion } = makeHarness();
+    await client.saveDocument(makeDocument());
+    await seedStoredVersion('stage-1', '99.0.0');
+    const replacement = makeDocument();
+    replacement.stage.name = 'Old Client Overwrite';
+
+    const failure = client.saveDocument(replacement);
+    await expect(failure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(failure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'future',
+      storedVersion: '99.0.0',
+    });
+    await expect(failure).rejects.toThrow(/refusing to overwrite document/);
   });
 
   test('client-side validators fail before fetch', async () => {

--- a/packages/@openmaic/storage/test/http-document-store.test.ts
+++ b/packages/@openmaic/storage/test/http-document-store.test.ts
@@ -1,11 +1,13 @@
 import type { IncomingMessage, RequestListener, ServerResponse } from 'node:http';
 import { IDBFactory } from 'fake-indexeddb';
+import { DSL_VERSION_KEY } from '@openmaic/dsl';
 import { describe, expect, test } from 'vitest';
 import { BrowserDocumentStore } from '../src/document/browser.js';
 import { HttpDocumentStore, HttpDocumentStoreError } from '../src/document/http.js';
+import type { StageValidator } from '../src/document/types.js';
 import { BrowserRuntimeStore } from '../src/runtime/browser.js';
 import { createStorageHttpHandler } from '../src/server/index.js';
-import { makeDocument, runDocumentStoreContract } from './document-contract.js';
+import { makeDocument, runDocumentStoreContract, slideScene } from './document-contract.js';
 
 const BASE_URL = 'http://storage-reference.invalid';
 
@@ -60,8 +62,41 @@ function handlerFetch(handler: RequestListener): typeof globalThis.fetch {
   };
 }
 
-function makeHarness(authorizeDocuments: () => boolean = () => true) {
-  const documents = new BrowserDocumentStore({ indexedDB: new IDBFactory() });
+async function reStampStage(
+  idb: IDBFactory,
+  dbName: string,
+  stageId: string,
+  version: string | undefined,
+): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = idb.open(dbName);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction('stages', 'readwrite');
+    const stages = transaction.objectStore('stages');
+    const request = stages.get(stageId);
+    request.onsuccess = () => {
+      const row = request.result as Record<string, unknown>;
+      if (version === undefined) delete row[DSL_VERSION_KEY];
+      else row[DSL_VERSION_KEY] = version;
+      stages.put(row);
+    };
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+  db.close();
+}
+
+let harnessDb = 0;
+function makeHarness(
+  authorizeDocuments: () => boolean = () => true,
+  options: { maxBodyBytes?: number; validateStage?: StageValidator } = {},
+) {
+  const idb = new IDBFactory();
+  const dbName = `http-document-contract-${harnessDb++}`;
+  const documents = new BrowserDocumentStore({ indexedDB: idb, dbName });
   const runtime = new BrowserRuntimeStore({ indexedDB: new IDBFactory() });
   const handler = createStorageHttpHandler(runtime, documents, {
     authenticate: async (req) => {
@@ -71,16 +106,26 @@ function makeHarness(authorizeDocuments: () => boolean = () => true) {
         : undefined;
     },
     authorizeDocuments: async () => authorizeDocuments(),
+    ...(options.maxBodyBytes === undefined ? {} : { maxBodyBytes: options.maxBodyBytes }),
+    ...(options.validateStage === undefined ? {} : { validateStage: options.validateStage }),
   });
   const fetch = handlerFetch(handler);
   return {
     documents,
     fetch,
     client: new HttpDocumentStore({ baseUrl: BASE_URL, fetch }),
+    seedStoredVersion: (stageId: string, version: string | undefined) =>
+      reStampStage(idb, dbName, stageId, version),
   };
 }
 
-runDocumentStoreContract('reference HTTP', () => makeHarness().client);
+runDocumentStoreContract('reference HTTP', () => {
+  const harness = makeHarness();
+  return {
+    store: harness.client,
+    seedStoredVersion: harness.seedStoredVersion,
+  };
+});
 
 describe('HttpDocumentStore contract mapping', () => {
   test('uses injected request headers and the reference server requires authentication', async () => {
@@ -125,6 +170,47 @@ describe('HttpDocumentStore contract mapping', () => {
     });
   });
 
+  test('rejects oversized bodies with 413 while allowing an under-limit request', async () => {
+    const { fetch } = makeHarness(() => true, { maxBodyBytes: 256 });
+    const overLimit = await fetch(`${BASE_URL}/documents/stage-1`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ padding: 'x'.repeat(300) }),
+    });
+    expect(overLimit.status).toBe(413);
+    await expect(overLimit.json()).resolves.toMatchObject({
+      error: { code: 'PAYLOAD_TOO_LARGE' },
+    });
+
+    const underLimit = await fetch(`${BASE_URL}/documents/stage-1/stage`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'stage-1',
+        name: 'Missing parent',
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    });
+    expect(underLimit.status).toBe(404);
+  });
+
+  test('fails loud when a structured-clone document is not JSON-safe on read', async () => {
+    const { documents, fetch } = makeHarness();
+    const document = makeDocument();
+    document.outline = { generatedAt: new Date('2026-01-01T00:00:00.000Z') };
+    await documents.saveDocument(document);
+
+    const response = await fetch(`${BASE_URL}/documents/stage-1`);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'NOT_JSON_SAFE',
+        message: expect.stringMatching(/document response.*outline.*Date/i),
+      },
+    });
+  });
+
   test('maps missing required parents to typed 404 errors with browser wording', async () => {
     const { client } = makeHarness();
     const failure = client.putStage('ghost', {
@@ -136,6 +222,34 @@ describe('HttpDocumentStore contract mapping', () => {
     await expect(failure).rejects.toBeInstanceOf(HttpDocumentStoreError);
     await expect(failure).rejects.toMatchObject({ status: 404, code: 'DOCUMENT_NOT_FOUND' });
     await expect(failure).rejects.toThrow(/missing document/);
+  });
+
+  test.each([
+    [
+      'putStage',
+      (client: HttpDocumentStore) =>
+        client.putStage('stage-1', {
+          id: 'stage-1',
+          name: 'Stale update',
+          createdAt: 1,
+          updatedAt: 2,
+        }),
+    ],
+    [
+      'putScene',
+      (client: HttpDocumentStore) =>
+        client.putScene('stage-1', slideScene('stage-1', 'scene-c', 2)),
+    ],
+    ['deleteScene', (client: HttpDocumentStore) => client.deleteScene('stage-1', 'scene-a')],
+  ])('maps unversioned %s to 400 VALIDATION_FAILED', async (_operation, write) => {
+    const { client, seedStoredVersion } = makeHarness();
+    await client.saveDocument(makeDocument());
+    await seedStoredVersion('stage-1', undefined);
+
+    await expect(write(client)).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_FAILED',
+    });
   });
 
   test('maps a future-version save to FUTURE_VERSION without overwriting current data', async () => {
@@ -165,5 +279,28 @@ describe('HttpDocumentStore contract mapping', () => {
     delete (bad.stage as { name?: string }).name;
     await expect(client.saveDocument(bad)).rejects.toThrow(/invalid stage/);
     expect(calls).toBe(0);
+  });
+
+  test('retains structured validator details on HttpDocumentStoreError', async () => {
+    const details = [
+      { path: '/name', message: 'name is invalid' },
+      { path: '/updatedAt', message: 'updatedAt is invalid' },
+    ];
+    const { client } = makeHarness(() => true, {
+      validateStage: () => ({ valid: false, errors: details }),
+    });
+
+    await expect(
+      client.putStage('stage-1', {
+        id: 'stage-1',
+        name: 'Rejected by server validator',
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'VALIDATION_FAILED',
+      details,
+    });
   });
 });

--- a/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
@@ -56,5 +56,20 @@ describe.skipIf(!contractUrl)('PgDocumentStore with PostgreSQL 16', () => {
     await pool.end();
   });
 
-  runDocumentStoreContract('PostgreSQL 16 (node-postgres)', () => store);
+  runDocumentStoreContract('PostgreSQL 16 (node-postgres)', () => ({
+    store,
+    seedStoredVersion: async (stageId, version) => {
+      const result = await pool.query<{ data: unknown }>(
+        'SELECT data FROM document_stages WHERE id = $1',
+        [stageId],
+      );
+      const data = result.rows[0]!.data as Record<string, unknown>;
+      if (version === undefined) delete data.dslVersion;
+      else data.dslVersion = version;
+      await pool.query('UPDATE document_stages SET data = $2::jsonb WHERE id = $1', [
+        stageId,
+        JSON.stringify(data),
+      ]);
+    },
+  }));
 });

--- a/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, beforeEach, describe } from 'vitest';
+import { Pool } from 'pg';
+import {
+  PgDocumentStore,
+  ensureDocumentSchema,
+  type Queryable,
+  type WithTransaction,
+} from '../src/document/pg.js';
+import { runDocumentStoreContract } from './document-contract.js';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+if (process.env.STORAGE_PG_CONTRACT_REQUIRED === '1' && !contractUrl) {
+  throw new Error(
+    '@openmaic/storage: STORAGE_PG_CONTRACT_REQUIRED=1 requires PG_CONTRACT_URL; ' +
+      'refusing to skip the PostgreSQL contract suite',
+  );
+}
+
+function transactionFor(pool: Pool): WithTransaction {
+  return async (body) => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client as Queryable);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the transaction body's original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+describe.skipIf(!contractUrl)('PgDocumentStore with PostgreSQL 16', () => {
+  let pool: Pool;
+  let store: PgDocumentStore;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl, max: 16 });
+    await ensureDocumentSchema(pool as Queryable);
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE document_outlines, document_scenes, document_stages');
+    store = new PgDocumentStore(pool as Queryable, { withTransaction: transactionFor(pool) });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  runDocumentStoreContract('PostgreSQL 16 (node-postgres)', () => store);
+});

--- a/packages/@openmaic/storage/test/pg-document-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { DSL_VERSION } from '@openmaic/dsl';
+import {
+  PgDocumentStore,
+  ensureDocumentSchema,
+  type PgDocumentStoreOptions,
+  type QueryResult,
+  type Queryable,
+} from '../src/document/pg.js';
+import type { DocumentStore } from '../src/document/types.js';
+import { makeDocument, runDocumentStoreContract, slideScene } from './document-contract.js';
+
+function transactionOptions(db: PGlite): PgDocumentStoreOptions {
+  return {
+    withTransaction: (body) => db.transaction((tx: Queryable) => body(tx)),
+  };
+}
+
+async function restamp(db: PGlite, stageId: string, version: string | undefined): Promise<void> {
+  const result = await db.query<{ data: unknown }>(
+    'SELECT data FROM document_stages WHERE id = $1',
+    [stageId],
+  );
+  const data = result.rows[0]!.data as Record<string, unknown>;
+  if (version === undefined) delete data.dslVersion;
+  else data.dslVersion = version;
+  await db.query('UPDATE document_stages SET data = $2::jsonb WHERE id = $1', [
+    stageId,
+    JSON.stringify(data),
+  ]);
+}
+
+describe('PgDocumentStore with PGlite', () => {
+  let db: PGlite;
+  let store: DocumentStore;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureDocumentSchema(db);
+    store = new PgDocumentStore(db, transactionOptions(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  runDocumentStoreContract('Postgres (PGlite)', () => store);
+});
+
+describe('PgDocumentStore Postgres behavior', () => {
+  let db: PGlite;
+  let store: PgDocumentStore;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureDocumentSchema(db);
+    store = new PgDocumentStore(db, transactionOptions(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  test('ensureDocumentSchema is idempotent and provisions the normalized tables', async () => {
+    await expect(ensureDocumentSchema(db)).resolves.toBeUndefined();
+    await expect(ensureDocumentSchema(db)).resolves.toBeUndefined();
+
+    const tables = await db.query<{ table_name: string }>(
+      `SELECT table_name
+         FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN ('document_stages', 'document_scenes', 'document_outlines')
+        ORDER BY table_name`,
+    );
+    expect(tables.rows.map((row) => row.table_name)).toEqual([
+      'document_outlines',
+      'document_scenes',
+      'document_stages',
+    ]);
+  });
+
+  test('requires a transaction hook at construction time', () => {
+    expect(() => new PgDocumentStore(db, {} as PgDocumentStoreOptions)).toThrow(
+      /withTransaction.*fresh.*connection.*transaction/i,
+    );
+  });
+
+  test('saveDocument uses one transaction and locks the existing stage before replacement', async () => {
+    await store.saveDocument(makeDocument());
+    let transactionCalls = 0;
+    const sql: string[] = [];
+    const instrumented = new PgDocumentStore(db, {
+      withTransaction: (body) => {
+        transactionCalls += 1;
+        return db.transaction((tx: Queryable) =>
+          body({
+            async query<TRow extends Record<string, unknown> = Record<string, unknown>>(
+              text: string,
+              params?: unknown[],
+            ): Promise<QueryResult<TRow>> {
+              sql.push(text);
+              return tx.query<TRow>(text, params);
+            },
+          }),
+        );
+      },
+    });
+    const replacement = makeDocument();
+    replacement.scenes = [slideScene('stage-1', 'scene-a', 0, 'Edited')];
+    delete replacement.outline;
+
+    await instrumented.saveDocument(replacement);
+
+    expect(transactionCalls).toBe(1);
+    expect(sql[0]).toMatch(/document_stages[\s\S]*FOR UPDATE/);
+    expect(sql.some((statement) => statement.includes('ON CONFLICT (id) DO UPDATE'))).toBe(true);
+    expect(sql.some((statement) => statement.includes('DELETE FROM document_scenes'))).toBe(true);
+    expect(sql.some((statement) => statement.includes('DELETE FROM document_outlines'))).toBe(true);
+  });
+
+  test('incremental writes lock the stage row and reject stale and future versions', async () => {
+    await store.saveDocument(makeDocument());
+
+    await restamp(db, 'stage-1', undefined);
+    await expect(store.putScene('stage-1', slideScene('stage-1', 'stale', 2))).rejects.toThrow(
+      /load and save/,
+    );
+    await expect(
+      store.putStage('stage-1', {
+        id: 'stage-1',
+        name: 'Stale',
+        createdAt: 1000,
+        updatedAt: 3000,
+      }),
+    ).rejects.toThrow(/load and save/);
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow(/load and save/);
+
+    await restamp(db, 'stage-1', '99.0.0');
+    await expect(store.putScene('stage-1', slideScene('stage-1', 'future', 2))).rejects.toThrow(
+      /load and save/,
+    );
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow(/load and save/);
+  });
+
+  test('loadDocument migrates legacy data without writing the new stamp back', async () => {
+    await store.saveDocument(makeDocument());
+    await restamp(db, 'stage-1', undefined);
+
+    expect((await store.loadDocument('stage-1'))!.dslVersion).toBe(DSL_VERSION);
+    const stored = await db.query<{ data: unknown }>(
+      'SELECT data FROM document_stages WHERE id = $1',
+      ['stage-1'],
+    );
+    expect(stored.rows[0]!.data).not.toHaveProperty('dslVersion');
+  });
+
+  test('listDocuments uses metadata columns and tolerates corrupt content/version data', async () => {
+    await store.saveDocument(makeDocument());
+    await db.query(`UPDATE document_stages SET data = '"not-an-object"'::jsonb WHERE id = $1`, [
+      'stage-1',
+    ]);
+
+    await expect(store.listDocuments()).resolves.toEqual([
+      expect.objectContaining({ id: 'stage-1', name: 'Intro Course', sceneCount: 2 }),
+    ]);
+    await expect(store.loadDocument('stage-1')).rejects.toThrow(/corrupt stored row/);
+  });
+
+  test('rejects JSONB-lossy stage, scene, and outline values before writing', async () => {
+    const stageLoss = makeDocument('stage-stage-loss');
+    Object.assign(stageLoss.stage, { extension: new Date('2026-01-01T00:00:00.000Z') });
+    await expect(store.saveDocument(stageLoss)).rejects.toThrow(/plain JSON value.*Date/i);
+
+    const sceneLoss = makeDocument('stage-scene-loss');
+    Object.assign(sceneLoss.scenes[0]!, { extension: new Map([['x', 1]]) });
+    await expect(store.saveDocument(sceneLoss)).rejects.toThrow(/plain JSON value.*Map/i);
+
+    const outlineLoss = makeDocument('stage-outline-loss');
+    outlineLoss.outline = { nested: { missing: undefined } };
+    await expect(store.saveDocument(outlineLoss)).rejects.toThrow(/undefined member/i);
+  });
+
+  test('deleteDocument is one direct statement and relies on FK cascades', async () => {
+    await store.saveDocument(makeDocument());
+    let transactionCalls = 0;
+    const directDeleteStore = new PgDocumentStore(db, {
+      withTransaction: (body) => {
+        transactionCalls += 1;
+        return db.transaction((tx: Queryable) => body(tx));
+      },
+    });
+
+    await directDeleteStore.deleteDocument('stage-1');
+
+    expect(transactionCalls).toBe(0);
+    expect((await db.query('SELECT * FROM document_scenes')).rows).toEqual([]);
+    expect((await db.query('SELECT * FROM document_outlines')).rows).toEqual([]);
+  });
+});

--- a/packages/@openmaic/storage/test/pg-document-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.test.ts
@@ -8,7 +8,11 @@ import {
   type QueryResult,
   type Queryable,
 } from '../src/document/pg.js';
-import type { DocumentStore } from '../src/document/types.js';
+import {
+  DocumentNotFoundError,
+  DocumentVersionError,
+  type DocumentStore,
+} from '../src/document/types.js';
 import { makeDocument, runDocumentStoreContract, slideScene } from './document-contract.js';
 
 function transactionOptions(db: PGlite): PgDocumentStoreOptions {
@@ -128,9 +132,13 @@ describe('PgDocumentStore Postgres behavior', () => {
     await store.saveDocument(makeDocument());
 
     await restamp(db, 'stage-1', undefined);
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'stale', 2))).rejects.toThrow(
-      /load and save/,
-    );
+    const staleFailure = store.putScene('stage-1', slideScene('stage-1', 'stale', 2));
+    await expect(staleFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(staleFailure).rejects.toMatchObject({
+      kind: 'not-current',
+      storedVersion: undefined,
+    });
+    await expect(staleFailure).rejects.toThrow(/load and save/);
     await expect(
       store.putStage('stage-1', {
         id: 'stage-1',
@@ -142,10 +150,20 @@ describe('PgDocumentStore Postgres behavior', () => {
     await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow(/load and save/);
 
     await restamp(db, 'stage-1', '99.0.0');
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'future', 2))).rejects.toThrow(
-      /load and save/,
-    );
+    const futureFailure = store.putScene('stage-1', slideScene('stage-1', 'future', 2));
+    await expect(futureFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(futureFailure).rejects.toMatchObject({
+      kind: 'not-current',
+      storedVersion: '99.0.0',
+    });
+    await expect(futureFailure).rejects.toThrow(/load and save/);
     await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow(/load and save/);
+  });
+
+  test('missing incremental-write parents use DocumentNotFoundError', async () => {
+    const failure = store.putScene('ghost', slideScene('ghost', 'scene', 0));
+    await expect(failure).rejects.toBeInstanceOf(DocumentNotFoundError);
+    await expect(failure).rejects.toMatchObject({ stageId: 'ghost' });
   });
 
   test('loadDocument migrates legacy data without writing the new stamp back', async () => {

--- a/packages/@openmaic/storage/test/pg-document-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.test.ts
@@ -46,7 +46,10 @@ describe('PgDocumentStore with PGlite', () => {
     await db.close();
   });
 
-  runDocumentStoreContract('Postgres (PGlite)', () => store);
+  runDocumentStoreContract('Postgres (PGlite)', () => ({
+    store,
+    seedStoredVersion: (stageId, version) => restamp(db, stageId, version),
+  }));
 });
 
 describe('PgDocumentStore Postgres behavior', () => {

--- a/packages/@openmaic/storage/test/runtime-reference-server.test.ts
+++ b/packages/@openmaic/storage/test/runtime-reference-server.test.ts
@@ -239,6 +239,7 @@ describe('reference HTTP handler principal capabilities', () => {
       authorizeAdmin: async () => true,
       authorizeMerge: async () => true,
       payloadValidators: {},
+      maxBodyBytes: 64,
     });
     const handler = server.listeners('request')[0] as RequestListener;
 
@@ -249,6 +250,15 @@ describe('reference HTTP handler principal capabilities', () => {
     );
     expect(response.status).toBe(204);
     expect(statements).toContain('DELETE FROM runtime_sessions');
+
+    const oversized = await handlerFetch(handler, async () => 'Bearer capability-only')(
+      `${BASE_URL}/runtime/learners/merge`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ padding: 'x'.repeat(100) }),
+      },
+    );
+    expect(oversized.status).toBe(413);
   });
 
   test('returns 403 FORBIDDEN_LEARNER on learner routes without learnerKey', async () => {
@@ -267,6 +277,30 @@ describe('reference HTTP handler principal capabilities', () => {
 });
 
 describe('reference HTTP handler validation boundary', () => {
+  test('rejects an oversized request body with 413 and accepts an under-limit body', async () => {
+    const store = new BrowserRuntimeStore({ indexedDB: new IDBFactory() });
+    const handler = createRuntimeHttpHandler(store, {
+      authenticate: async () => ({ learnerKey: 'anon:device-1' }),
+      maxBodyBytes: 256,
+    });
+    const request = handlerFetch(handler, async () => 'Bearer anon:device-1');
+
+    const oversized = await request(`${BASE_URL}/runtime/sessions`, {
+      method: 'POST',
+      body: JSON.stringify({ padding: 'x'.repeat(300) }),
+    });
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toMatchObject({
+      error: { code: 'PAYLOAD_TOO_LARGE' },
+    });
+
+    const accepted = await request(`${BASE_URL}/runtime/sessions`, {
+      method: 'POST',
+      body: JSON.stringify(makeSession({ id: 'under-limit' })),
+    });
+    expect(accepted.status).toBe(201);
+  });
+
   test.each([
     ['session id with NUL', makeSession({ id: 'bad\u0000session' })],
     ['session stageId with a lone surrogate', makeSession({ stageId: 'bad\ud800stage' })],

--- a/tests/document-store/document-storage-config.test.ts
+++ b/tests/document-store/document-storage-config.test.ts
@@ -1,0 +1,64 @@
+import type { DocumentStore } from '@openmaic/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppScene } from '@/lib/types/stage';
+
+import type { AppStage } from '@/lib/document-store/persistence-types';
+
+function stubStore(): DocumentStore<AppScene, AppStage> {
+  return {} as DocumentStore<AppScene, AppStage>;
+}
+
+describe('configureDocumentStorage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the configured factory and supplies the app validators', async () => {
+    const injected = stubStore();
+    const factory = vi.fn(() => injected);
+    const { configureDocumentStorage, getDocumentStore, validateAppScene, validateAppStage } =
+      await import('@/lib/document-store');
+    configureDocumentStorage({ store: factory });
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(getDocumentStore()).toBe(injected);
+    expect(getDocumentStore()).toBe(injected);
+    expect(factory).toHaveBeenCalledExactlyOnceWith({
+      validateScene: validateAppScene,
+      validateStage: validateAppStage,
+    });
+  });
+
+  it('stays sealed after document storage resolution starts', async () => {
+    const injected = stubStore();
+    const { configureDocumentStorage, getDocumentStore } = await import('@/lib/document-store');
+    configureDocumentStorage({ store: injected });
+    getDocumentStore();
+
+    expect(() => configureDocumentStorage({ store: stubStore() })).toThrow(
+      'configureDocumentStorage must be called at module-level bootstrap, before any document consumer runs — a component effect is too late.',
+    );
+  });
+
+  it('resetDocumentStorageForTests clears configuration and the latched store', async () => {
+    const first = stubStore();
+    const second = stubStore();
+    const {
+      configureDocumentStorage,
+      getDocumentStore,
+      isDocumentStorageConfigured,
+      resetDocumentStorageForTests,
+    } = await import('@/lib/document-store');
+
+    configureDocumentStorage({ store: first });
+    expect(getDocumentStore()).toBe(first);
+    expect(isDocumentStorageConfigured()).toBe(true);
+
+    resetDocumentStorageForTests();
+    expect(isDocumentStorageConfigured()).toBe(false);
+    configureDocumentStorage({ store: second });
+    expect(getDocumentStore()).toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary

Completes 1B of the persistence standardization: the DocumentStore contract (#965) gains its server side, mirroring the runtime line's #939 delivery. A deployment can now serve **all persisted app data** (learner runtime + documents) from PostgreSQL behind one reference server and two documented HTTP contracts, with zero app-code changes (sealed bootstrap injection on both seams).

### PR1 — HTTP contract + client + server routes (#975)
- `docs/document-http-contract.md`; `HttpDocumentStore` with browser-parity validation and migrate-on-read; document routes on the shared reference server (one server, both stores). Documents are author assets — authorization stays a deployment concern via injected hooks (any-authenticated default)

### PR2 — PgDocumentStore (#976)
- Full contract over `document_stages` / `document_scenes` / `document_outlines` (FK cascades); single-transaction aggregate replace under the stage row's FOR UPDATE lock; version-gated incremental writes; FOR SHARE consistent reads; **contract suite green on real PostgreSQL 16 in CI**

### PR3 — app bootstrap seam (#977)
- `configureDocumentStorage` mirrors the runtime seam: sealed after first resolution, factory receives the app validators, reset-for-tests. README roadmap: document HTTP/PG items done

### Final hardening (#978, adversarial review: 0 P0/P1, 3 P2 + 2 P3, all fixed)
- Legacy unversioned writes → 400 (was 500); fail-loud JSON-safety on reads (NOT_JSON_SAFE); bounded request bodies (413, default 32 MiB, configurable everywhere); putStage version guards + corrupt-stamp tolerance promoted into the shared contract suite for all four backends; structured error details retained

## Verification
- Storage package: 395 tests green; document contract suite passes on browser, HTTP, PGlite, and real PostgreSQL 16 (CI job)
- Every PR + trunk CI green across all five jobs
- Recon → 3 implementation PRs → adversarial final review, each cross-reviewed at implementation time

## Downstream
openmaic-live can retire its forked PG stages/scenes + `/api/stages` adapter by pointing `configureDocumentStorage` at `HttpDocumentStore` against these contracts — same integration shape it already uses for runtime (#1051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)