### PR TITLE
refactor(storage): typed version errors — standards review response

### DIFF
--- a/packages/@openmaic/storage/src/document/browser.ts
+++ b/packages/@openmaic/storage/src/document/browser.ts
@@ -26,6 +26,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from './types.js';
+import { DocumentNotFoundError, DocumentVersionError } from './types.js';
 import { reassembleDocument, splitDocument, type OutlineRow, type StageRow } from './adapter.js';
 
 const STAGES = 'stages';
@@ -219,7 +220,10 @@ export class BrowserDocumentStore<
     // written by a newer client. `loadDocument` returns such documents untouched;
     // saving one back would relabel its newer-shaped rows as this older version.
     if (isFutureVersioned(doc)) {
-      throw new Error(
+      throw new DocumentVersionError(
+        doc.stage.id,
+        'future',
+        doc.dslVersion,
         `@openmaic/storage: refusing to save document ${JSON.stringify(doc.stage.id)} — it was ` +
           `written at DSL version ${JSON.stringify(dslVersionOf(doc))}, newer than this ` +
           `client's ${DSL_VERSION}`,
@@ -265,7 +269,10 @@ export class BrowserDocumentStore<
       // guard above does not catch a blind overwrite of newer stored data.
       const existingStage = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (existingStage && isFutureVersioned(existingStage)) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'future',
+          existingStage[DSL_VERSION_KEY],
           `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
             `stored copy is at DSL version ${JSON.stringify(dslVersionOf(existingStage))}, newer ` +
             `than this client's ${DSL_VERSION}`,
@@ -371,12 +378,16 @@ export class BrowserDocumentStore<
       const stages = tx.objectStore(STAGES);
       const stageRow = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (!stageRow) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putStage into missing document ${JSON.stringify(stageId)}`,
         );
       }
       if (dslVersionOf(stageRow) !== DSL_VERSION) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'not-current',
+          stageRow[DSL_VERSION_KEY],
           `@openmaic/storage: cannot putStage into document ${JSON.stringify(stageId)} at DSL ` +
             `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
             `to ${DSL_VERSION} first`,
@@ -393,7 +404,8 @@ export class BrowserDocumentStore<
       const stages = tx.objectStore(STAGES);
       const stageRow = await reqP<StageRow<TStage> | undefined>(stages.get(stageId));
       if (!stageRow) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
         );
       }
@@ -403,7 +415,10 @@ export class BrowserDocumentStore<
       // below the migrate-on-read line; if it is newer, this client must not
       // downgrade it. Either way, require a full load + save to normalize first.
       if (dslVersionOf(stageRow) !== DSL_VERSION) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'not-current',
+          stageRow[DSL_VERSION_KEY],
           `@openmaic/storage: cannot putScene into document ${JSON.stringify(stageId)} at DSL ` +
             `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
             `to ${DSL_VERSION} first`,
@@ -447,7 +462,10 @@ export class BrowserDocumentStore<
       // A whole-document removal (deleteDocument) is a deliberate coarse action
       // and is intentionally NOT version-guarded.
       if (dslVersionOf(stageRow) !== DSL_VERSION) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'not-current',
+          stageRow[DSL_VERSION_KEY],
           `@openmaic/storage: cannot deleteScene from document ${JSON.stringify(stageId)} at DSL ` +
             `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
             `to ${DSL_VERSION} first`,

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -9,6 +9,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from './types.js';
+import { DocumentVersionError } from './types.js';
 
 export interface HttpDocumentHeadersContext {
   method: string;
@@ -34,6 +35,10 @@ export interface HttpDocumentStoreOptions {
 
 interface ErrorResponseBody {
   error?: { code?: unknown; message?: unknown; details?: unknown };
+}
+
+interface DocumentVersionErrorDetails {
+  storedVersion?: unknown;
 }
 
 /** A server-side DocumentStore failure, retaining its machine-readable HTTP identity. */
@@ -118,8 +123,8 @@ export class HttpDocumentStore<
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly headersHook: HttpDocumentHeadersHook | undefined;
-  private readonly sceneValidator: SceneValidator;
-  private readonly stageValidator: StageValidator;
+  private readonly validateSceneFn: SceneValidator;
+  private readonly validateStageFn: StageValidator;
 
   constructor(options: HttpDocumentStoreOptions) {
     if (options.baseUrl === '') {
@@ -132,11 +137,16 @@ export class HttpDocumentStore<
     this.baseUrl = options.baseUrl.replace(/\/+$/, '');
     this.fetchImpl = fetchImpl;
     this.headersHook = options.headers;
-    this.sceneValidator = options.validateScene ?? validateScene;
-    this.stageValidator = options.validateStage ?? validateStage;
+    this.validateSceneFn = options.validateScene ?? validateScene;
+    this.validateStageFn = options.validateStage ?? validateStage;
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    versionErrorStageId?: string,
+  ): Promise<T> {
     const headers = normalizeHeaders(await this.headersHook?.({ method, path }));
     let serializedBody: string | undefined;
     if (body !== undefined) {
@@ -160,6 +170,16 @@ export class HttpDocumentStore<
         typeof errorBody?.error?.message === 'string'
           ? errorBody.error.message
           : `@openmaic/storage: DocumentStore HTTP request failed with status ${response.status}`;
+      if (
+        response.status === 409 &&
+        code === 'FUTURE_VERSION' &&
+        versionErrorStageId !== undefined
+      ) {
+        const details = errorBody?.error?.details as DocumentVersionErrorDetails | undefined;
+        const storedVersion =
+          typeof details?.storedVersion === 'string' ? details.storedVersion : undefined;
+        throw new DocumentVersionError(versionErrorStageId, 'future', storedVersion, message);
+      }
       throw new HttpDocumentStoreError(response.status, code, message, errorBody?.error?.details);
     }
     if (response.status === 204) return undefined as T;
@@ -167,7 +187,7 @@ export class HttpDocumentStore<
   }
 
   private validateSceneForWrite(stageId: string, scene: TScene): void {
-    assertValid(this.sceneValidator(scene), `scene ${scene.id}`);
+    assertValid(this.validateSceneFn(scene), `scene ${scene.id}`);
     assertStorableScene(scene, stageId);
   }
 
@@ -175,7 +195,7 @@ export class HttpDocumentStore<
     // The server repeats these checks. Running the injected gates here matches
     // BrowserDocumentStore's fail-fast boundary and avoids avoidable wire calls.
     const normalized = migrateDocument(document);
-    assertValid(this.stageValidator(normalized.stage), `stage ${normalized.stage.id}`);
+    assertValid(this.validateStageFn(normalized.stage), `stage ${normalized.stage.id}`);
     const seen = new Set<string>();
     for (const scene of normalized.scenes) {
       this.validateSceneForWrite(normalized.stage.id, scene);
@@ -188,7 +208,12 @@ export class HttpDocumentStore<
       seen.add(scene.id);
     }
     assertJsonValue(document, `document ${JSON.stringify(document.stage.id)}`);
-    await this.request<void>('PUT', `/documents/${segment(document.stage.id)}`, document);
+    await this.request<void>(
+      'PUT',
+      `/documents/${segment(document.stage.id)}`,
+      document,
+      document.stage.id,
+    );
   }
 
   async loadDocument(stageId: string): Promise<MaicDocument<TScene, TStage> | null> {
@@ -223,9 +248,9 @@ export class HttpDocumentStore<
   }
 
   async putStage(stageId: string, stage: TStage): Promise<void> {
-    assertValid(this.stageValidator(stage), `stage ${stage.id}`);
+    assertValid(this.validateStageFn(stage), `stage ${stage.id}`);
     assertJsonValue(stage, `stage ${JSON.stringify(stage.id)}`);
-    await this.request<void>('PUT', `/documents/${segment(stageId)}/stage`, stage);
+    await this.request<void>('PUT', `/documents/${segment(stageId)}/stage`, stage, stageId);
   }
 
   async putScene(stageId: string, scene: TScene): Promise<void> {
@@ -235,6 +260,7 @@ export class HttpDocumentStore<
       'PUT',
       `/documents/${segment(stageId)}/scenes/${segment(scene.id)}`,
       scene,
+      stageId,
     );
   }
 
@@ -256,6 +282,11 @@ export class HttpDocumentStore<
   }
 
   async deleteScene(stageId: string, sceneId: string): Promise<void> {
-    await this.request<void>('DELETE', `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`);
+    await this.request<void>(
+      'DELETE',
+      `/documents/${segment(stageId)}/scenes/${segment(sceneId)}`,
+      undefined,
+      stageId,
+    );
   }
 }

--- a/packages/@openmaic/storage/src/document/pg.ts
+++ b/packages/@openmaic/storage/src/document/pg.ts
@@ -30,6 +30,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from './types.js';
+import { DocumentNotFoundError, DocumentVersionError } from './types.js';
 import { assertJsonValue, isLosslessJsonString } from '../runtime/json-value.js';
 import type { Queryable, WithTransaction } from '../runtime/pg.js';
 
@@ -266,8 +267,11 @@ export class PgDocumentStore<
     operation: string,
     stageId: string,
     stageRow: StageRow<TStage>,
-  ): Error {
-    return new Error(
+  ): DocumentVersionError {
+    return new DocumentVersionError(
+      stageId,
+      'not-current',
+      stageRow[DSL_VERSION_KEY],
       `@openmaic/storage: cannot ${operation} document ${JSON.stringify(stageId)} at DSL ` +
         `version ${JSON.stringify(dslVersionOf(stageRow))} — load and save it to bring it ` +
         `to ${DSL_VERSION} first`,
@@ -330,7 +334,10 @@ export class PgDocumentStore<
 
   async saveDocument(doc: MaicDocument<TScene, TStage>): Promise<void> {
     if (isFutureVersioned(doc)) {
-      throw new Error(
+      throw new DocumentVersionError(
+        doc.stage.id,
+        'future',
+        doc.dslVersion,
         `@openmaic/storage: refusing to save document ${JSON.stringify(doc.stage.id)} — it was ` +
           `written at DSL version ${JSON.stringify(dslVersionOf(doc))}, newer than this ` +
           `client's ${DSL_VERSION}`,
@@ -343,7 +350,10 @@ export class PgDocumentStore<
     await this.transaction(async (queryable) => {
       const existingStage = await this.loadStage(queryable, stageId, 'update');
       if (existingStage && isFutureVersioned(existingStage)) {
-        throw new Error(
+        throw new DocumentVersionError(
+          stageId,
+          'future',
+          existingStage[DSL_VERSION_KEY],
           `@openmaic/storage: refusing to overwrite document ${JSON.stringify(stageId)} — the ` +
             `stored copy is at DSL version ${JSON.stringify(dslVersionOf(existingStage))}, newer ` +
             `than this client's ${DSL_VERSION}`,
@@ -448,7 +458,8 @@ export class PgDocumentStore<
     await this.transaction(async (queryable) => {
       const stored = await this.loadStage(queryable, stageId, 'update');
       if (!stored) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putStage into missing document ${JSON.stringify(stageId)}`,
         );
       }
@@ -466,7 +477,8 @@ export class PgDocumentStore<
     await this.transaction(async (queryable) => {
       const stored = await this.loadStage(queryable, stageId, 'update');
       if (!stored) {
-        throw new Error(
+        throw new DocumentNotFoundError(
+          stageId,
           `@openmaic/storage: cannot putScene into missing document ${JSON.stringify(stageId)}`,
         );
       }

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -41,6 +41,32 @@ export type StageValidator = (
   stage: unknown,
 ) => { valid: true } | { valid: false; errors: { path: string; message: string }[] };
 
+/** A document write was rejected because its persisted DSL version is incompatible. */
+export class DocumentVersionError extends Error {
+  override readonly name = 'DocumentVersionError';
+
+  constructor(
+    readonly stageId: string,
+    readonly kind: 'future' | 'not-current',
+    readonly storedVersion: string | undefined,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/** An incremental document write requires a parent document that does not exist. */
+export class DocumentNotFoundError extends Error {
+  override readonly name = 'DocumentNotFoundError';
+
+  constructor(
+    readonly stageId: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
 /**
  * The portable, embedded form of a persisted course. Storage normalizes it into
  * per-entity rows on write and reassembles it on read.

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SceneValidator,
   StageValidator,
 } from './document/types.js';
+export { DocumentNotFoundError, DocumentVersionError } from './document/types.js';
 export { BrowserDocumentStore, type BrowserDocumentStoreOptions } from './document/browser.js';
 export {
   HttpDocumentStore,

--- a/packages/@openmaic/storage/src/server/document.ts
+++ b/packages/@openmaic/storage/src/server/document.ts
@@ -16,6 +16,7 @@ import type {
   SceneValidator,
   StageValidator,
 } from '../document/types.js';
+import { DocumentNotFoundError, DocumentVersionError } from '../document/types.js';
 import { assertMaxBodyBytes, DEFAULT_MAX_BODY_BYTES, readJsonObject } from './read-json.js';
 
 export interface DocumentHttpPrincipal {
@@ -150,8 +151,8 @@ function isFutureVersioned(value: unknown): boolean {
   return !needsMigration(value) && dslVersionOf(value) !== DSL_VERSION;
 }
 
-function futureVersion(message: string): DocumentHttpError {
-  return new DocumentHttpError(409, 'FUTURE_VERSION', message);
+function futureVersion(message: string, details?: unknown): DocumentHttpError {
+  return new DocumentHttpError(409, 'FUTURE_VERSION', message, details);
 }
 
 function migrateDocument<TScene extends SceneLike, TStage extends Stage>(
@@ -206,6 +207,7 @@ function validateDocument<TScene extends SceneLike, TStage extends Stage>(
       `@openmaic/storage: refusing to save document ${JSON.stringify(pathStageId)} — it was ` +
         `written at DSL version ${JSON.stringify(dslVersionOf(document))}, newer than this ` +
         `client's ${DSL_VERSION}`,
+      { stageId: pathStageId, storedVersion: document.dslVersion },
     );
   }
   const normalized = migrateDocument(document);
@@ -235,6 +237,16 @@ function validateDocument<TScene extends SceneLike, TStage extends Stage>(
 }
 
 function classifyStoreError(error: unknown): never {
+  if (error instanceof DocumentNotFoundError) {
+    throw new DocumentHttpError(404, 'DOCUMENT_NOT_FOUND', error.message);
+  }
+  if (error instanceof DocumentVersionError) {
+    const details = { stageId: error.stageId, storedVersion: error.storedVersion };
+    if (error.kind === 'future') throw futureVersion(error.message, details);
+    throw validationFailure(error.message, details);
+  }
+
+  // Fallback for third-party DocumentStore implementations that throw plain Errors.
   const message = error instanceof Error ? error.message : String(error);
   if (/missing document/.test(message)) {
     const match = /missing document ("(?:[^"\\]|\\.)*")/.exec(message);

--- a/packages/@openmaic/storage/test/document-browser.test.ts
+++ b/packages/@openmaic/storage/test/document-browser.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { IDBFactory } from 'fake-indexeddb';
 import { DSL_VERSION, DSL_VERSION_KEY, validateScene, validateStage } from '@openmaic/dsl';
-import { BrowserDocumentStore, type MaicDocument } from '../src/index.js';
+import {
+  BrowserDocumentStore,
+  DocumentNotFoundError,
+  DocumentVersionError,
+  type MaicDocument,
+} from '../src/index.js';
 import { runDocumentStoreContract, makeDocument, slideScene } from './document-contract.js';
 
 // Open the raw DB the store uses and overwrite the stage row's version stamp,
@@ -102,13 +107,25 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // stamping the whole document current off one incremental write would
     // corrupt them — reject and require a full load + save first.
     await reStampStage(idb, dbName, 'stage-1', undefined);
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'new', 2))).rejects.toThrow();
+    const staleFailure = store.putScene('stage-1', slideScene('stage-1', 'new', 2));
+    await expect(staleFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(staleFailure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'not-current',
+      storedVersion: undefined,
+    });
     // rejected write left nothing behind (a legacy doc still migrates on read)
     expect(await store.getScene('stage-1', 'new')).toBeNull();
 
     // Future stored document: an old client must not downgrade it.
     await reStampStage(idb, dbName, 'stage-1', '99.0.0');
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'new2', 3))).rejects.toThrow();
+    const futureFailure = store.putScene('stage-1', slideScene('stage-1', 'new2', 3));
+    await expect(futureFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(futureFailure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'not-current',
+      storedVersion: '99.0.0',
+    });
     expect(await store.getScene('stage-1', 'new2')).toBeNull();
   });
 
@@ -124,7 +141,7 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // stored document — the store checks the stored row inside the write tx.
     const fresh = makeDocument();
     fresh.stage.name = 'Old Client Overwrite';
-    await expect(store.saveDocument(fresh)).rejects.toThrow();
+    await expect(store.saveDocument(fresh)).rejects.toBeInstanceOf(DocumentVersionError);
 
     const loaded = await store.loadDocument('stage-1');
     expect(loaded!.dslVersion).toBe('99.0.0');
@@ -140,7 +157,9 @@ describe('BrowserDocumentStore migrate-on-read', () => {
     // Future stored document: an old client must not mutate newer-versioned data
     // (mirrors the putScene guard — deleting a scene is an incremental mutation).
     await reStampStage(idb, dbName, 'stage-1', '99.0.0');
-    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow();
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toBeInstanceOf(
+      DocumentVersionError,
+    );
     expect((await store.loadDocument('stage-1'))!.scenes.map((s) => s.id)).toEqual([
       'scene-a',
       'scene-b',
@@ -148,7 +167,29 @@ describe('BrowserDocumentStore migrate-on-read', () => {
 
     // Stale stored document must be normalized (load + save) before incremental ops.
     await reStampStage(idb, dbName, 'stage-1', undefined);
-    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow();
+    await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toBeInstanceOf(
+      DocumentVersionError,
+    );
+  });
+
+  test('missing incremental-write parents use DocumentNotFoundError', async () => {
+    const store = new BrowserDocumentStore({
+      indexedDB: new IDBFactory(),
+      dbName: 'maic-documents-missing-parent-error',
+    });
+
+    const putStageFailure = store.putStage('ghost', {
+      id: 'ghost',
+      name: 'Ghost',
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    await expect(putStageFailure).rejects.toBeInstanceOf(DocumentNotFoundError);
+    await expect(putStageFailure).rejects.toMatchObject({ stageId: 'ghost' });
+
+    await expect(store.putScene('ghost', slideScene('ghost', 'scene', 0))).rejects.toBeInstanceOf(
+      DocumentNotFoundError,
+    );
   });
 
   test('fails loud on a malformed stored version stamp', async () => {

--- a/packages/@openmaic/storage/test/document-contract.ts
+++ b/packages/@openmaic/storage/test/document-contract.ts
@@ -7,7 +7,7 @@
 import { describe, expect, test } from 'vitest';
 import { DSL_VERSION } from '@openmaic/dsl';
 import type { Scene } from '@openmaic/dsl';
-import type { DocumentStore, MaicDocument } from '../src/index.js';
+import { DocumentVersionError, type DocumentStore, type MaicDocument } from '../src/index.js';
 
 // --- fixtures ---------------------------------------------------------------
 
@@ -287,7 +287,13 @@ export function runDocumentStoreContract(
       future.dslVersion = '99.0.0';
       future.stage.name = 'Should Not Persist';
       // an old client must not overwrite (and downgrade) a newer-versioned document
-      await expect(store.saveDocument(future)).rejects.toThrow();
+      const failure = store.saveDocument(future);
+      await expect(failure).rejects.toBeInstanceOf(DocumentVersionError);
+      await expect(failure).rejects.toMatchObject({
+        stageId: 'stage-1',
+        kind: 'future',
+        storedVersion: '99.0.0',
+      });
 
       const loaded = await store.loadDocument('stage-1');
       expect(loaded!.stage.name).toBe('Intro Course');

--- a/packages/@openmaic/storage/test/http-document-store.test.ts
+++ b/packages/@openmaic/storage/test/http-document-store.test.ts
@@ -3,6 +3,7 @@ import { IDBFactory } from 'fake-indexeddb';
 import { DSL_VERSION_KEY } from '@openmaic/dsl';
 import { describe, expect, test } from 'vitest';
 import { BrowserDocumentStore } from '../src/document/browser.js';
+import { DocumentVersionError } from '../src/document/types.js';
 import { HttpDocumentStore, HttpDocumentStoreError } from '../src/document/http.js';
 import type { StageValidator } from '../src/document/types.js';
 import { BrowserRuntimeStore } from '../src/runtime/browser.js';
@@ -259,11 +260,35 @@ describe('HttpDocumentStore contract mapping', () => {
     future.dslVersion = '99.0.0';
     future.stage.name = 'Future';
 
-    await expect(client.saveDocument(future)).rejects.toMatchObject({
-      status: 409,
-      code: 'FUTURE_VERSION',
+    const failure = client.saveDocument(future);
+    await expect(failure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(failure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'future',
+      storedVersion: '99.0.0',
     });
+    await expect(failure).rejects.toThrow(
+      `@openmaic/storage: refusing to save document "stage-1" — it was written at DSL version ` +
+        `"99.0.0", newer than this client's`,
+    );
     expect((await client.loadDocument('stage-1'))!.stage.name).toBe('Intro Course');
+  });
+
+  test('rematerializes a typed future-version error classified from the backing store', async () => {
+    const { client, seedStoredVersion } = makeHarness();
+    await client.saveDocument(makeDocument());
+    await seedStoredVersion('stage-1', '99.0.0');
+    const replacement = makeDocument();
+    replacement.stage.name = 'Old Client Overwrite';
+
+    const failure = client.saveDocument(replacement);
+    await expect(failure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(failure).rejects.toMatchObject({
+      stageId: 'stage-1',
+      kind: 'future',
+      storedVersion: '99.0.0',
+    });
+    await expect(failure).rejects.toThrow(/refusing to overwrite document/);
   });
 
   test('client-side validators fail before fetch', async () => {

--- a/packages/@openmaic/storage/test/pg-document-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.test.ts
@@ -8,7 +8,11 @@ import {
   type QueryResult,
   type Queryable,
 } from '../src/document/pg.js';
-import type { DocumentStore } from '../src/document/types.js';
+import {
+  DocumentNotFoundError,
+  DocumentVersionError,
+  type DocumentStore,
+} from '../src/document/types.js';
 import { makeDocument, runDocumentStoreContract, slideScene } from './document-contract.js';
 
 function transactionOptions(db: PGlite): PgDocumentStoreOptions {
@@ -128,9 +132,13 @@ describe('PgDocumentStore Postgres behavior', () => {
     await store.saveDocument(makeDocument());
 
     await restamp(db, 'stage-1', undefined);
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'stale', 2))).rejects.toThrow(
-      /load and save/,
-    );
+    const staleFailure = store.putScene('stage-1', slideScene('stage-1', 'stale', 2));
+    await expect(staleFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(staleFailure).rejects.toMatchObject({
+      kind: 'not-current',
+      storedVersion: undefined,
+    });
+    await expect(staleFailure).rejects.toThrow(/load and save/);
     await expect(
       store.putStage('stage-1', {
         id: 'stage-1',
@@ -142,10 +150,20 @@ describe('PgDocumentStore Postgres behavior', () => {
     await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow(/load and save/);
 
     await restamp(db, 'stage-1', '99.0.0');
-    await expect(store.putScene('stage-1', slideScene('stage-1', 'future', 2))).rejects.toThrow(
-      /load and save/,
-    );
+    const futureFailure = store.putScene('stage-1', slideScene('stage-1', 'future', 2));
+    await expect(futureFailure).rejects.toBeInstanceOf(DocumentVersionError);
+    await expect(futureFailure).rejects.toMatchObject({
+      kind: 'not-current',
+      storedVersion: '99.0.0',
+    });
+    await expect(futureFailure).rejects.toThrow(/load and save/);
     await expect(store.deleteScene('stage-1', 'scene-a')).rejects.toThrow(/load and save/);
+  });
+
+  test('missing incremental-write parents use DocumentNotFoundError', async () => {
+    const failure = store.putScene('ghost', slideScene('ghost', 'scene', 0));
+    await expect(failure).rejects.toBeInstanceOf(DocumentNotFoundError);
+    await expect(failure).rejects.toMatchObject({ stageId: 'ghost' });
   });
 
   test('loadDocument migrates legacy data without writing the new stamp back', async () => {


### PR DESCRIPTION
Response to the standards review on #979:

- **Finding 1 (fixed)**: `DocumentVersionError`/`DocumentNotFoundError` typed classes thrown by browser/pg and matched by `instanceof` in the server — mirroring `RuntimeAppendConflictError`. Prose regex kept only as a documented third-party fallback after the typed checks. Client rematerializes 409s for symmetry.
- **Finding 3 (clarified + hardened)**: the public options were already `validateScene`/`validateStage` on all three backends — the divergence was http.ts's *private* field names, now renamed to remove the misread source.
- Finding 2: no change per the review's own conclusion (matches in-package precedent).

398 package tests green (new instanceof assertions across contract/browser/pg/server/client suites); message texts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)