### PR TITLE
fix(storage): bind default fetch to globalThis in both HTTP store clients

### DIFF
--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -130,7 +130,11 @@ export class HttpDocumentStore<
     if (options.baseUrl === '') {
       throw new Error('@openmaic/storage: HttpDocumentStore baseUrl must be non-empty');
     }
-    const fetchImpl = options.fetch ?? globalThis.fetch;
+    // Bind explicitly: browsers require fetch to be invoked with `this === globalThis`
+    // (calling a stored reference as `this.fetchImpl(...)` throws "Illegal
+    // invocation"), while node's undici does not care — which is exactly why
+    // node-only test suites cannot catch the unbound form.
+    const fetchImpl = (options.fetch ?? globalThis.fetch)?.bind(globalThis);
     if (typeof fetchImpl !== 'function') {
       throw new Error('@openmaic/storage: HttpDocumentStore requires a fetch implementation');
     }

--- a/packages/@openmaic/storage/src/document/http.ts
+++ b/packages/@openmaic/storage/src/document/http.ts
@@ -134,10 +134,13 @@ export class HttpDocumentStore<
     // (calling a stored reference as `this.fetchImpl(...)` throws "Illegal
     // invocation"), while node's undici does not care — which is exactly why
     // node-only test suites cannot catch the unbound form.
-    const fetchImpl = (options.fetch ?? globalThis.fetch)?.bind(globalThis);
-    if (typeof fetchImpl !== 'function') {
+    // Validate BEFORE binding: .bind on a non-function throws a native
+    // TypeError that would preempt the documented error below.
+    const selectedFetch = options.fetch ?? globalThis.fetch;
+    if (typeof selectedFetch !== 'function') {
       throw new Error('@openmaic/storage: HttpDocumentStore requires a fetch implementation');
     }
+    const fetchImpl = selectedFetch.bind(globalThis);
     this.baseUrl = options.baseUrl.replace(/\/+$/, '');
     this.fetchImpl = fetchImpl;
     this.headersHook = options.headers;

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -147,7 +147,11 @@ export class HttpRuntimeStore implements RuntimeStore {
     if (options.baseUrl === '') {
       throw new Error('@openmaic/storage: HttpRuntimeStore baseUrl must be non-empty');
     }
-    const fetchImpl = options.fetch ?? globalThis.fetch;
+    // Bind explicitly: browsers require fetch to be invoked with `this === globalThis`
+    // (calling a stored reference as `this.fetchImpl(...)` throws "Illegal
+    // invocation"), while node's undici does not care — which is exactly why
+    // node-only test suites cannot catch the unbound form.
+    const fetchImpl = (options.fetch ?? globalThis.fetch)?.bind(globalThis);
     if (typeof fetchImpl !== 'function') {
       throw new Error('@openmaic/storage: HttpRuntimeStore requires a fetch implementation');
     }

--- a/packages/@openmaic/storage/src/runtime/http.ts
+++ b/packages/@openmaic/storage/src/runtime/http.ts
@@ -151,10 +151,13 @@ export class HttpRuntimeStore implements RuntimeStore {
     // (calling a stored reference as `this.fetchImpl(...)` throws "Illegal
     // invocation"), while node's undici does not care — which is exactly why
     // node-only test suites cannot catch the unbound form.
-    const fetchImpl = (options.fetch ?? globalThis.fetch)?.bind(globalThis);
-    if (typeof fetchImpl !== 'function') {
+    // Validate BEFORE binding: .bind on a non-function throws a native
+    // TypeError that would preempt the documented error below.
+    const selectedFetch = options.fetch ?? globalThis.fetch;
+    if (typeof selectedFetch !== 'function') {
       throw new Error('@openmaic/storage: HttpRuntimeStore requires a fetch implementation');
     }
+    const fetchImpl = selectedFetch.bind(globalThis);
     this.baseUrl = options.baseUrl.replace(/\/+$/, '');
     this.fetchImpl = fetchImpl;
     this.headersHook = options.headers;

--- a/packages/@openmaic/storage/test/http-fetch-binding.test.ts
+++ b/packages/@openmaic/storage/test/http-fetch-binding.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { HttpDocumentStore } from '../src/document/http.js';
+import { HttpRuntimeStore } from '../src/runtime/http.js';
+
+/**
+ * Browsers require fetch to be invoked with `this === globalThis`; a stored
+ * reference called as `this.fetchImpl(...)` throws "Illegal invocation".
+ * Node's undici does not enforce this, so only an explicit this-check can
+ * guard the regression in a node test run.
+ */
+function strictFetch(): typeof globalThis.fetch {
+  const marker = globalThis;
+  return vi.fn(function (this: unknown) {
+    if (this !== marker && this !== undefined) {
+      throw new TypeError('Illegal invocation');
+    }
+    // `bind(globalThis)` makes `this` the global; an unbound store-field call
+    // would surface the store instance here instead.
+    return Promise.resolve(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe('HTTP store fetch binding', () => {
+  const original = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = original;
+  });
+
+  it('HttpDocumentStore invokes the default global fetch without an instance receiver', async () => {
+    const spy = strictFetch();
+    globalThis.fetch = new Proxy(spy, {
+      apply(target, thisArg, args) {
+        if (thisArg !== globalThis && thisArg !== undefined) {
+          throw new TypeError('Illegal invocation');
+        }
+        return Reflect.apply(target, thisArg, args as Parameters<typeof fetch>);
+      },
+    }) as typeof globalThis.fetch;
+    const store = new HttpDocumentStore({ baseUrl: 'http://example.test' });
+
+    await expect(store.listDocuments()).resolves.toEqual([]);
+  });
+
+  it('HttpRuntimeStore invokes the default global fetch without an instance receiver', async () => {
+    const spy = strictFetch();
+    globalThis.fetch = new Proxy(spy, {
+      apply(target, thisArg, args) {
+        if (thisArg !== globalThis && thisArg !== undefined) {
+          throw new TypeError('Illegal invocation');
+        }
+        return Reflect.apply(target, thisArg, args as Parameters<typeof fetch>);
+      },
+    }) as typeof globalThis.fetch;
+    const store = new HttpRuntimeStore({ baseUrl: 'http://example.test' });
+
+    await expect(store.listSessions('stage-1', 'learner-1')).resolves.toEqual([]);
+  });
+});

--- a/packages/@openmaic/storage/test/http-fetch-binding.test.ts
+++ b/packages/@openmaic/storage/test/http-fetch-binding.test.ts
@@ -62,3 +62,14 @@ describe('HTTP store fetch binding', () => {
     await expect(store.listSessions('stage-1', 'learner-1')).resolves.toEqual([]);
   });
 });
+
+describe('HTTP store fetch validation order', () => {
+  it('reports the documented error for a non-function fetch option instead of a native bind TypeError', () => {
+    expect(() => new HttpDocumentStore({ baseUrl: 'http://x', fetch: {} as never })).toThrowError(
+      /requires a fetch implementation/,
+    );
+    expect(() => new HttpRuntimeStore({ baseUrl: 'http://x', fetch: {} as never })).toThrowError(
+      /requires a fetch implementation/,
+    );
+  });
+});


### PR DESCRIPTION
Found by a downstream end-to-end test: with server persistence enabled, the page runtime never reached PostgreSQL. The bootstrap was configuring the HTTP stores correctly — but the very first request threw `TypeError: Illegal invocation`, because both clients stored `globalThis.fetch` as an instance field and invoked it as `this.fetchImpl(...)`. Browsers require `this === globalThis` for fetch; node's undici does not — which is exactly why every node-side contract suite stayed green while every real browser failed on request one.

- `(options.fetch ?? globalThis.fetch)?.bind(globalThis)` in HttpDocumentStore + HttpRuntimeStore
- Strict-receiver regression test (Proxy enforcing the browser's receiver rule) guarding the gap node cannot catch natively
- Verified in a real browser against a live stack: homepage now issues `GET /api/persistence/documents`, zero console errors, PG schema auto-provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)