### PR TITLE
feat(roster): single-source the generated agent roster on the stage document

### DIFF
--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -19,7 +19,6 @@ import {
   applyClassroomStageAndScenes,
   defaultClassroomLoadDeps,
   runClassroomLoad,
-  saveGeneratedAgentsForCurrentLoad,
 } from '@/lib/classroom/load-classroom';
 
 const log = createLogger('Classroom');
@@ -59,13 +58,12 @@ export default function ClassroomDetailPage() {
             isCurrent,
             applyStageAndScenes: applyClassroomStageAndScenes,
           }),
-        saveGeneratedAgents: (stageId, agents) =>
-          saveGeneratedAgentsForCurrentLoad(stageId, agents, isCurrent),
         loadRestoredMediaTasks: defaultClassroomLoadDeps.loadRestoredMediaTasks,
         applyRestoredMediaTasks: defaultClassroomLoadDeps.applyRestoredMediaTasks,
         discardRestoredMediaTasks: defaultClassroomLoadDeps.discardRestoredMediaTasks,
-        loadGeneratedAgentRecords: defaultClassroomLoadDeps.loadGeneratedAgentRecords,
-        applyGeneratedAgentRecords: defaultClassroomLoadDeps.applyGeneratedAgentRecords,
+        loadLegacyAgentFallbacks: defaultClassroomLoadDeps.loadLegacyAgentFallbacks,
+        commitMigratedAgentConfigs: defaultClassroomLoadDeps.commitMigratedAgentConfigs,
+        applyGeneratedAgents: defaultClassroomLoadDeps.applyGeneratedAgents,
         getSettings: () => useSettingsStore.getState(),
         getAgent: (id) => useAgentRegistry.getState().getAgent(id),
         restoreAgentSelection: defaultClassroomLoadDeps.restoreAgentSelection,

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -39,7 +39,7 @@ import {
 } from '@/lib/document/bundle';
 import { buildVideoManifestFromOutlines } from '@/lib/media/video-manifest';
 import { nanoid } from 'nanoid';
-import type { Stage } from '@/lib/types/stage';
+import type { GeneratedAgentConfig, Stage } from '@/lib/types/stage';
 import type {
   SceneOutline,
   PdfImage,
@@ -866,11 +866,17 @@ function GenerationPreviewContent() {
           const agentData = await agentResp.json();
           if (!agentData.success) throw new Error(agentData.error || 'Agent generation failed');
 
-          // Save to IndexedDB and registry. The agent-profile LLM has already
-          // bound each agent's voice (from availableVoices); the fallback for an
-          // invalid/unavailable voice is applied later at the live TTS call.
-          const { saveGeneratedAgents } = await import('@/lib/orchestration/registry/store');
-          const savedIds = await saveGeneratedAgents(stage.id, agentData.agents);
+          // Embed the roster (including its voice binding) on the stage — it
+          // persists with the stage document via saveToStorage below — and
+          // mirror it into the in-memory registry. The agent-profile LLM has
+          // already bound each agent's voice (from availableVoices); the
+          // fallback for an invalid/unavailable voice is applied later at the
+          // live TTS call.
+          const generatedConfigs = agentData.agents as GeneratedAgentConfig[];
+          stage.generatedAgentConfigs = generatedConfigs;
+          const { applyGeneratedAgentsToRegistry } =
+            await import('@/lib/orchestration/registry/store');
+          const savedIds = applyGeneratedAgentsToRegistry(stage.id, generatedConfigs);
           settings.setSelectedAgentIds(savedIds);
           // Stage-derived, not a user choice — must not carry across classrooms.
           settings.setAgentSelectionIsUserSet(false);

--- a/components/edit/AgentsView/useAgentRoster.ts
+++ b/components/edit/AgentsView/useAgentRoster.ts
@@ -80,15 +80,18 @@ export function useAgentRoster(): AgentRosterController {
     () => histState.present[0]?.id ?? null,
   );
 
-  // Guard: only persist after a real user edit, not on initial materialization.
+  // Guard: only commit after a real user edit, not on initial materialization.
   // Set to true inside every mutation path (applyOp, add, undo, redo) so the
   // effect below is a no-op until the user actually touches the roster.
   const isDirtyRef = useRef(false);
 
-  // Persist roster edits to the store. Depends only on `histState.present`.
-  // `stage` is intentionally excluded: setStageAgents mutates `stage`, so
-  // depending on it would re-trigger this effect in an infinite loop (React #185).
-  // setStageAgents already no-ops when there is no stage (lib/store/stage.ts:287).
+  // Commit roster edits to the stage store. setStageAgents updates the stage
+  // document (persisted through the shared pending-change scheduler) and
+  // synchronously mirrors the roster into the agent registry + selection.
+  // Depends only on `histState.present`; `stage` is intentionally excluded:
+  // setStageAgents replaces `stage`, so depending on it would re-trigger this
+  // effect in an infinite loop (React #185). setStageAgents already no-ops
+  // when there is no stage.
   useEffect(() => {
     if (!isDirtyRef.current) return;
     setStageAgents(histState.present);

--- a/lib/audio/constants.ts
+++ b/lib/audio/constants.ts
@@ -36,6 +36,7 @@ import type {
   ASRProviderId,
   ASRProviderConfig,
 } from './types';
+import { isCustomTTSProvider } from './types';
 import {
   VOXCPM_AUTO_VOICE,
   VOXCPM_AUTO_VOICE_ID,
@@ -1308,6 +1309,16 @@ export function getAllTTSProviders(
   const builtIn = Object.values(TTS_PROVIDERS);
   const custom = customProviders ? Object.values(customProviders) : [];
   return [...builtIn, ...custom];
+}
+
+/**
+ * Narrow an arbitrary string (e.g. from a persisted document or an imported
+ * manifest, where the contract keeps providerId an open string) to a known
+ * TTS provider id: a registered built-in provider or the user-defined
+ * custom-provider namespace. Anything else must be treated as "no voice".
+ */
+export function isKnownTTSProviderId(id: string): id is TTSProviderId {
+  return id in TTS_PROVIDERS || isCustomTTSProvider(id);
 }
 
 /**

--- a/lib/audio/constants.ts
+++ b/lib/audio/constants.ts
@@ -1318,7 +1318,9 @@ export function getAllTTSProviders(
  * custom-provider namespace. Anything else must be treated as "no voice".
  */
 export function isKnownTTSProviderId(id: string): id is TTSProviderId {
-  return id in TTS_PROVIDERS || isCustomTTSProvider(id);
+  // Object.hasOwn, not `in`: prototype-chain keys ('toString', 'constructor',
+  // …) must not pass a whitelist built from an object literal.
+  return Object.hasOwn(TTS_PROVIDERS, id) || isCustomTTSProvider(id);
 }
 
 /**
@@ -1328,7 +1330,7 @@ export function getTTSProvider(
   providerId: TTSProviderId,
   customProviders?: Record<string, TTSProviderConfig>,
 ): TTSProviderConfig | undefined {
-  if (providerId in TTS_PROVIDERS) {
+  if (Object.hasOwn(TTS_PROVIDERS, providerId)) {
     return TTS_PROVIDERS[providerId as BuiltInTTSProviderId];
   }
   return customProviders?.[providerId];
@@ -1362,7 +1364,7 @@ export function getASRProvider(
   providerId: ASRProviderId,
   customProviders?: Record<string, ASRProviderConfig>,
 ): ASRProviderConfig | undefined {
-  if (providerId in ASR_PROVIDERS) {
+  if (Object.hasOwn(ASR_PROVIDERS, providerId)) {
     return ASR_PROVIDERS[providerId as BuiltInASRProviderId];
   }
   return customProviders?.[providerId];

--- a/lib/audio/voice-design.ts
+++ b/lib/audio/voice-design.ts
@@ -5,13 +5,14 @@
  * 3-layer recipe. It is consumed by any TTS provider: as an inline voice
  * prompt where supported, or as the seed for a registered/cloned voice
  * (see `voice-registration.ts`). Nothing here is VoxCPM-specific.
+ *
+ * The type itself lives in `@openmaic/dsl` (it is part of the persisted
+ * `GeneratedAgentConfig` contract, so the roster's voice travels with the
+ * stage document); this module re-exports it and owns the runtime helpers.
  */
+import type { VoiceDesign } from '@openmaic/dsl';
 
-export interface VoiceDesign {
-  identity: string; // gender / age / role
-  texture: string; // pitch / vocal quality
-  delivery: string; // emotion / pace
-}
+export type { VoiceDesign } from '@openmaic/dsl';
 
 const VOICE_DESIGN_PROMPT_MAX_CHARS = 200;
 

--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -305,7 +305,11 @@ export function findVoiceDisplayName(
     const voice = customVoices?.find((v) => v.id === voiceId);
     return voice?.name ?? voiceId;
   }
-  const provider = TTS_PROVIDERS[providerId as keyof typeof TTS_PROVIDERS];
+  // Object.hasOwn, not a bare index: a prototype-chain key ('toString', …)
+  // would resolve to a function and crash the `.voices` access below.
+  const provider = Object.hasOwn(TTS_PROVIDERS, providerId)
+    ? TTS_PROVIDERS[providerId as keyof typeof TTS_PROVIDERS]
+    : undefined;
   if (!provider) return voiceId;
   const voice = provider.voices.find((v) => v.id === voiceId);
   return voice?.name ?? voiceId;

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -14,6 +14,7 @@ import {
   type StageSceneLoadToken,
 } from '@/lib/store/stage';
 import type { MediaFileRecord } from '@/lib/utils/database';
+import { unmarkStageDeleted } from '@/lib/utils/deleted-stages';
 import type { GeneratedAgentConfig, Scene, Stage } from '@/lib/types/stage';
 
 export interface ClassroomPayload {
@@ -59,8 +60,10 @@ export interface RunClassroomLoadArgs<TMediaTasks = unknown> {
    * Read the legacy per-stage roster mirror (read-only migration source) as
    * contract-shaped configs. Used only to backfill a document whose configs
    * predate the single-source model (missing roster or missing voice fields).
+   * Returns `null` when the read FAILED (as opposed to an empty mirror), so
+   * the caller can retry on a later load instead of memoizing the failure.
    */
-  loadLegacyAgentFallbacks: (stageId: string) => Promise<GeneratedAgentConfig[]>;
+  loadLegacyAgentFallbacks: (stageId: string) => Promise<GeneratedAgentConfig[] | null>;
   /** Commit lazily migrated configs onto the in-memory stage + mark it dirty. */
   commitMigratedAgentConfigs: (stageId: string, configs: GeneratedAgentConfig[]) => void;
   /** Synchronously mirror the roster into the in-memory agent registry. */
@@ -74,12 +77,14 @@ export interface RunClassroomLoadArgs<TMediaTasks = unknown> {
 }
 
 /**
- * Stages whose legacy-mirror probe came back with nothing to merge this
- * session. `rosterNeedsLegacyFallback` cannot distinguish "predates voice
- * persistence" from "the producer never bound a voice" (server-generated
- * classrooms emit voiceless rosters by design), so without this memo such
- * classrooms would re-query the mirror on every load forever. Session-scoped
- * on purpose: no persistent marker is introduced for a pure read optimization.
+ * Stages whose legacy-mirror probe SUCCEEDED and came back with nothing to
+ * merge this session. `rosterNeedsLegacyFallback` cannot distinguish
+ * "predates voice persistence" from "the producer never bound a voice"
+ * (server-generated classrooms emit voiceless rosters by design), so without
+ * this memo such classrooms would re-query the mirror on every load forever.
+ * A FAILED mirror read is never memoized — the next load retries the probe.
+ * Session-scoped on purpose: no persistent marker is introduced for a pure
+ * read optimization.
  */
 const fruitlessLegacyProbeStageIds = new Set<string>();
 
@@ -150,7 +155,8 @@ export async function runClassroomLoad<TMediaTasks = unknown>({
     // mirror rows, or nothing mergeable — e.g. server-generated rosters whose
     // producer never bound a voice) is remembered for the session so the
     // mirror is not re-queried on every load of a classroom that has nothing
-    // to migrate.
+    // to migrate. A FAILED mirror read is neither merged nor remembered — the
+    // next load retries the probe.
     if (!isCurrent()) return;
     const stageForRoster = getCurrentStage();
     const documentConfigs =
@@ -165,15 +171,22 @@ export async function runClassroomLoad<TMediaTasks = unknown>({
       // The registry is a global singleton: after any await, re-check that this
       // load is still current before letting the merged roster land anywhere.
       if (!isCurrent()) return;
-      const merged = mergeLegacyAgentFallbacks(documentConfigs, fallbacks);
-      if (merged.changed) {
-        effectiveConfigs = merged.configs;
-        commitMigratedAgentConfigs(classroomId, merged.configs);
-      } else {
-        // Nothing to migrate for this stage; don't probe again this session.
-        // (A successful merge is NOT memoized: if its flush fails, the next
-        // load must retry the merge until the document carries the voices.)
-        fruitlessLegacyProbeStageIds.add(classroomId);
+      // `null` = the mirror read FAILED (not "mirror is empty"). Skip both
+      // the merge and the memo so the next load retries the probe once
+      // storage recovers — a transient IndexedDB error must not become a
+      // session-long migration skip.
+      if (fallbacks !== null) {
+        const merged = mergeLegacyAgentFallbacks(documentConfigs, fallbacks);
+        if (merged.changed) {
+          effectiveConfigs = merged.configs;
+          commitMigratedAgentConfigs(classroomId, merged.configs);
+        } else {
+          // The read SUCCEEDED and confirmed nothing to migrate for this
+          // stage; don't probe again this session. (A successful merge is NOT
+          // memoized: if its flush fails, the next load must retry the merge
+          // until the document carries the voices.)
+          fruitlessLegacyProbeStageIds.add(classroomId);
+        }
       }
     }
 
@@ -234,6 +247,13 @@ export function applyClassroomStageAndScenes(
     chatSnapshot?: ChatStorageSnapshot;
   } = {},
 ): void {
+  // Explicit document (re)creation point: deletion only removes client-side
+  // data, so revisiting the classroom URL restores the server copy under the
+  // SAME id. Lift any same-session tombstone before the store write, or every
+  // subsequent edit of the restored classroom would be silently dropped until
+  // a reload. This is a deliberate restore, not an in-flight flush — exactly
+  // the distinction `deleted-stages.ts` requires.
+  unmarkStageDeleted(stage.id);
   const nextScenes = [...scenes];
   useStageStore.setState((state) => ({
     stage,
@@ -371,11 +391,13 @@ export function mergeLegacyAgentFallbacks(
  * Read the legacy roster mirror for a stage as contract-shaped configs.
  * Read-only: production code only reads this table as a migration source for
  * pre-single-source classrooms (plus deletion hygiene when a stage is
- * removed); nothing writes new rows.
+ * removed); nothing writes new rows. Returns `null` when the read fails so
+ * the caller can distinguish "empty mirror" (memoizable) from "read failed"
+ * (retry on the next load).
  */
 export async function loadLegacyAgentFallbacksFromDB(
   stageId: string,
-): Promise<GeneratedAgentConfig[]> {
+): Promise<GeneratedAgentConfig[] | null> {
   try {
     const { getGeneratedAgentsByStageId } = await import('@/lib/utils/database');
     const records = await getGeneratedAgentsByStageId(stageId);
@@ -397,7 +419,9 @@ export async function loadLegacyAgentFallbacksFromDB(
       };
     });
   } catch {
-    return [];
+    // Signal failure (vs. an empty mirror): the probe memo must not treat a
+    // transient IndexedDB error as "nothing to migrate".
+    return null;
   }
 }
 

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -159,9 +159,14 @@ export async function runClassroomLoad<TMediaTasks = unknown>({
     // next load retries the probe.
     if (!isCurrent()) return;
     const stageForRoster = getCurrentStage();
+    // The absent-vs-empty distinction is load-bearing and deliberately NOT
+    // collapsed here: `undefined` means the document predates roster
+    // persistence (probe the mirror, possibly lifting a whole roster), while
+    // an explicit `[]` is an authoritative empty roster that must never be
+    // resurrected from the stale read-only mirror.
     const documentConfigs =
-      stageForRoster?.id === classroomId ? (stageForRoster.generatedAgentConfigs ?? []) : [];
-    let effectiveConfigs = documentConfigs;
+      stageForRoster?.id === classroomId ? stageForRoster.generatedAgentConfigs : undefined;
+    let effectiveConfigs = documentConfigs ?? [];
     if (
       stageForRoster?.id === classroomId &&
       rosterNeedsLegacyFallback(documentConfigs) &&
@@ -176,7 +181,7 @@ export async function runClassroomLoad<TMediaTasks = unknown>({
       // storage recovers — a transient IndexedDB error must not become a
       // session-long migration skip.
       if (fallbacks !== null) {
-        const merged = mergeLegacyAgentFallbacks(documentConfigs, fallbacks);
+        const merged = mergeLegacyAgentFallbacks(documentConfigs ?? [], fallbacks);
         if (merged.changed) {
           effectiveConfigs = merged.configs;
           commitMigratedAgentConfigs(classroomId, merged.configs);
@@ -341,16 +346,28 @@ export function discardRestoredMediaTasks(tasks: Record<string, MediaTask>): voi
 }
 
 /**
- * True when the persisted roster MAY still need the legacy mirror consulted:
- * either the document carries no roster at all (it may predate roster
- * persistence on the document), or some agent is missing its voice fields —
- * which can mean the voice lives only in the mirror, but can also mean the
- * producer never bound one (server-generated rosters are voiceless by
- * design). Callers pair this check with the per-session fruitless-probe memo
- * so the second case does not re-query the mirror on every load.
+ * True when the persisted roster MAY still need the legacy mirror consulted.
+ * The absent-vs-empty distinction matters:
+ *
+ * - `undefined` (no roster field on the document) → the document may predate
+ *   roster persistence entirely; the mirror may hold the whole roster, so
+ *   probe it (the full-lift branch of `mergeLegacyAgentFallbacks`).
+ * - `[]` (an explicitly persisted empty roster) → authoritative; never probe.
+ *   No current writer produces `[]` (the roster editor enforces a non-empty
+ *   roster, and import/generation only write the field when non-empty), but
+ *   any future writer that does must not have its empty roster resurrected
+ *   from the stale read-only mirror on every load.
+ * - Non-empty with an agent missing both voice fields → the voice may live
+ *   only in the mirror, but can also mean the producer never bound one
+ *   (server-generated rosters are voiceless by design). Callers pair this
+ *   check with the per-session fruitless-probe memo so the second case does
+ *   not re-query the mirror on every load.
  */
-export function rosterNeedsLegacyFallback(configs: readonly GeneratedAgentConfig[]): boolean {
-  if (configs.length === 0) return true;
+export function rosterNeedsLegacyFallback(
+  configs: readonly GeneratedAgentConfig[] | undefined,
+): boolean {
+  if (configs === undefined) return true;
+  if (configs.length === 0) return false;
   return configs.some((config) => !config.voiceDesign && !config.voiceConfig);
 }
 
@@ -358,7 +375,10 @@ export function rosterNeedsLegacyFallback(configs: readonly GeneratedAgentConfig
  * Merge the legacy mirror's roster into the document's configs. Pure.
  *
  * - Document configs empty + mirror has agents → lift the full mirror roster
- *   (sorted by priority desc for a stable, teacher-first order).
+ *   (sorted by priority desc for a stable, teacher-first order). The caller
+ *   only routes a roster here when the document carried no roster field at
+ *   all — an explicitly persisted `[]` never reaches the merge (see
+ *   `rosterNeedsLegacyFallback`).
  * - Document configs present → only backfill missing voice fields, matched by
  *   agent id. Document fields always win; the mirror never overwrites.
  *

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -249,10 +249,14 @@ export function applyClassroomStageAndScenes(
 ): void {
   // Explicit document (re)creation point: deletion only removes client-side
   // data, so revisiting the classroom URL restores the server copy under the
-  // SAME id. Lift any same-session tombstone before the store write, or every
-  // subsequent edit of the restored classroom would be silently dropped until
-  // a reload. This is a deliberate restore, not an in-flight flush — exactly
-  // the distinction `deleted-stages.ts` requires.
+  // SAME id. Lift any same-session deleted flag before the store write, or
+  // every subsequent edit of the restored classroom would be silently dropped
+  // until a reload. This is a deliberate restore, not an in-flight flush —
+  // exactly the distinction `deleted-stages.ts` requires. The deletion EPOCH
+  // stays bumped: a pre-delete flush still in flight remains permanently
+  // stale and cannot overwrite the restored document, while the
+  // `saveToStorage` below (and every later edit) captures the current epoch
+  // and persists normally.
   unmarkStageDeleted(stage.id);
   const nextScenes = [...scenes];
   useStageStore.setState((state) => ({

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -73,6 +73,21 @@ export interface RunClassroomLoadArgs<TMediaTasks = unknown> {
   log: Logger;
 }
 
+/**
+ * Stages whose legacy-mirror probe came back with nothing to merge this
+ * session. `rosterNeedsLegacyFallback` cannot distinguish "predates voice
+ * persistence" from "the producer never bound a voice" (server-generated
+ * classrooms emit voiceless rosters by design), so without this memo such
+ * classrooms would re-query the mirror on every load forever. Session-scoped
+ * on purpose: no persistent marker is introduced for a pure read optimization.
+ */
+const fruitlessLegacyProbeStageIds = new Set<string>();
+
+/** Test hook: forget which stages already had a fruitless legacy-mirror probe. */
+export function resetLegacyAgentFallbackProbes(): void {
+  fruitlessLegacyProbeStageIds.clear();
+}
+
 export async function runClassroomLoad<TMediaTasks = unknown>({
   classroomId,
   loadToken,
@@ -127,17 +142,25 @@ export async function runClassroomLoad<TMediaTasks = unknown>({
     applyRestoredMediaTasks(mediaTasks);
 
     // ── Roster hydration: the stage document is the source of truth ──
-    // The legacy IndexedDB mirror is consulted only as a one-time, read-only
-    // migration source: it backfills a roster (or its voice fields) written
-    // before the roster was persisted on the document. The merged result is
+    // The legacy IndexedDB mirror is consulted as a read-only, per-stage
+    // migration probe: it backfills a roster (or its voice fields) written
+    // before the roster was persisted on the document. A successful merge is
     // committed back onto the stage so the next flush makes it durable, after
-    // which subsequent loads find nothing to merge (idempotent).
+    // which subsequent loads find nothing to merge. A fruitless probe (no
+    // mirror rows, or nothing mergeable — e.g. server-generated rosters whose
+    // producer never bound a voice) is remembered for the session so the
+    // mirror is not re-queried on every load of a classroom that has nothing
+    // to migrate.
     if (!isCurrent()) return;
     const stageForRoster = getCurrentStage();
     const documentConfigs =
       stageForRoster?.id === classroomId ? (stageForRoster.generatedAgentConfigs ?? []) : [];
     let effectiveConfigs = documentConfigs;
-    if (stageForRoster?.id === classroomId && rosterNeedsLegacyFallback(documentConfigs)) {
+    if (
+      stageForRoster?.id === classroomId &&
+      rosterNeedsLegacyFallback(documentConfigs) &&
+      !fruitlessLegacyProbeStageIds.has(classroomId)
+    ) {
       const fallbacks = await loadLegacyAgentFallbacks(classroomId);
       // The registry is a global singleton: after any await, re-check that this
       // load is still current before letting the merged roster land anywhere.
@@ -146,6 +169,11 @@ export async function runClassroomLoad<TMediaTasks = unknown>({
       if (merged.changed) {
         effectiveConfigs = merged.configs;
         commitMigratedAgentConfigs(classroomId, merged.configs);
+      } else {
+        // Nothing to migrate for this stage; don't probe again this session.
+        // (A successful merge is NOT memoized: if its flush fails, the next
+        // load must retry the merge until the document carries the voices.)
+        fruitlessLegacyProbeStageIds.add(classroomId);
       }
     }
 
@@ -289,10 +317,13 @@ export function discardRestoredMediaTasks(tasks: Record<string, MediaTask>): voi
 }
 
 /**
- * True when the persisted roster still needs the legacy mirror consulted:
+ * True when the persisted roster MAY still need the legacy mirror consulted:
  * either the document carries no roster at all (it may predate roster
- * persistence on the document), or some agent is missing its voice fields
- * (voice historically lived only in the mirror).
+ * persistence on the document), or some agent is missing its voice fields —
+ * which can mean the voice lives only in the mirror, but can also mean the
+ * producer never bound one (server-generated rosters are voiceless by
+ * design). Callers pair this check with the per-session fruitless-probe memo
+ * so the second case does not re-query the mirror on every load.
  */
 export function rosterNeedsLegacyFallback(configs: readonly GeneratedAgentConfig[]): boolean {
   if (configs.length === 0) return true;
@@ -338,8 +369,9 @@ export function mergeLegacyAgentFallbacks(
 
 /**
  * Read the legacy roster mirror for a stage as contract-shaped configs.
- * Read-only: the mirror table has no remaining writers and serves purely as a
- * migration source for pre-single-source classrooms.
+ * Read-only: production code only reads this table as a migration source for
+ * pre-single-source classrooms (plus deletion hygiene when a stage is
+ * removed); nothing writes new rows.
  */
 export async function loadLegacyAgentFallbacksFromDB(
   stageId: string,

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -1,6 +1,5 @@
 import { restoreAgentSelection } from '@/lib/orchestration/registry/agent-selection';
-import { useAgentRegistry } from '@/lib/orchestration/registry/store';
-import { getActionsForRole } from '@/lib/orchestration/registry/types';
+import { applyGeneratedAgentsToRegistry } from '@/lib/orchestration/registry/store';
 import {
   applyHydratedClassroomFallbackScenes,
   hydrateClassroomFallbackChats,
@@ -8,12 +7,14 @@ import {
 } from '@/lib/classroom/pbl-fallback-hydration';
 import type { ChatStorageSnapshot } from '@/lib/utils/chat-storage';
 import type { ChatSession } from '@/lib/types/chat';
-import type { TTSProviderId } from '@/lib/audio/types';
-import type { VoiceDesign } from '@/lib/audio/voice-design';
 import { useMediaGenerationStore, type MediaTask } from '@/lib/store/media-generation';
-import { useStageStore, type StageSceneLoadToken } from '@/lib/store/stage';
-import type { GeneratedAgentRecord, MediaFileRecord } from '@/lib/utils/database';
-import type { Scene, Stage } from '@/lib/types/stage';
+import {
+  markStagePersistenceDirty,
+  useStageStore,
+  type StageSceneLoadToken,
+} from '@/lib/store/stage';
+import type { MediaFileRecord } from '@/lib/utils/database';
+import type { GeneratedAgentConfig, Scene, Stage } from '@/lib/types/stage';
 
 export interface ClassroomPayload {
   stage: Stage;
@@ -39,7 +40,7 @@ interface AgentLookupResult {
   isGenerated?: boolean;
 }
 
-export interface RunClassroomLoadArgs<TMediaTasks = unknown, TGeneratedAgentRecord = unknown> {
+export interface RunClassroomLoadArgs<TMediaTasks = unknown> {
   classroomId: string;
   loadToken: StageSceneLoadToken;
   isCurrent: () => boolean;
@@ -51,15 +52,19 @@ export interface RunClassroomLoadArgs<TMediaTasks = unknown, TGeneratedAgentReco
     stage: Stage;
     scenes: readonly Scene[];
   }) => Promise<boolean>;
-  saveGeneratedAgents: (
-    stageId: string,
-    agents: NonNullable<Stage['generatedAgentConfigs']>,
-  ) => Promise<unknown>;
   loadRestoredMediaTasks: (stageId: string) => Promise<TMediaTasks>;
   applyRestoredMediaTasks: (tasks: TMediaTasks) => void;
   discardRestoredMediaTasks: (tasks: TMediaTasks) => void;
-  loadGeneratedAgentRecords: (stageId: string) => Promise<TGeneratedAgentRecord[]>;
-  applyGeneratedAgentRecords: (records: TGeneratedAgentRecord[]) => string[];
+  /**
+   * Read the legacy per-stage roster mirror (read-only migration source) as
+   * contract-shaped configs. Used only to backfill a document whose configs
+   * predate the single-source model (missing roster or missing voice fields).
+   */
+  loadLegacyAgentFallbacks: (stageId: string) => Promise<GeneratedAgentConfig[]>;
+  /** Commit lazily migrated configs onto the in-memory stage + mark it dirty. */
+  commitMigratedAgentConfigs: (stageId: string, configs: GeneratedAgentConfig[]) => void;
+  /** Synchronously mirror the roster into the in-memory agent registry. */
+  applyGeneratedAgents: (stageId: string, configs: readonly GeneratedAgentConfig[]) => string[];
   getSettings: () => ClassroomLoadSettings;
   getAgent: (agentId: string) => AgentLookupResult | undefined;
   restoreAgentSelection: typeof restoreAgentSelection;
@@ -68,7 +73,7 @@ export interface RunClassroomLoadArgs<TMediaTasks = unknown, TGeneratedAgentReco
   log: Logger;
 }
 
-export async function runClassroomLoad<TMediaTasks = unknown, TGeneratedAgentRecord = unknown>({
+export async function runClassroomLoad<TMediaTasks = unknown>({
   classroomId,
   loadToken,
   isCurrent,
@@ -76,19 +81,19 @@ export async function runClassroomLoad<TMediaTasks = unknown, TGeneratedAgentRec
   getCurrentStage,
   fetchClassroom,
   applyFallbackScenes,
-  saveGeneratedAgents,
   loadRestoredMediaTasks,
   applyRestoredMediaTasks,
   discardRestoredMediaTasks,
-  loadGeneratedAgentRecords,
-  applyGeneratedAgentRecords,
+  loadLegacyAgentFallbacks,
+  commitMigratedAgentConfigs,
+  applyGeneratedAgents,
   getSettings,
   getAgent,
   restoreAgentSelection: restoreSelection,
   setError,
   setLoading,
   log,
-}: RunClassroomLoadArgs<TMediaTasks, TGeneratedAgentRecord>): Promise<void> {
+}: RunClassroomLoadArgs<TMediaTasks>): Promise<void> {
   try {
     await loadFromStorage(classroomId, loadToken);
     if (!isCurrent()) return;
@@ -110,13 +115,6 @@ export async function runClassroomLoad<TMediaTasks = unknown, TGeneratedAgentRec
           return;
         }
         log.info('Loaded from server-side storage:', classroomId);
-
-        if (stage.generatedAgentConfigs?.length) {
-          if (!isCurrent()) return;
-          await saveGeneratedAgents(stage.id, stage.generatedAgentConfigs);
-          if (!isCurrent()) return;
-          log.info('Hydrated server-generated agents for stage:', stage.id);
-        }
       }
     }
 
@@ -128,10 +126,31 @@ export async function runClassroomLoad<TMediaTasks = unknown, TGeneratedAgentRec
     }
     applyRestoredMediaTasks(mediaTasks);
 
+    // ── Roster hydration: the stage document is the source of truth ──
+    // The legacy IndexedDB mirror is consulted only as a one-time, read-only
+    // migration source: it backfills a roster (or its voice fields) written
+    // before the roster was persisted on the document. The merged result is
+    // committed back onto the stage so the next flush makes it durable, after
+    // which subsequent loads find nothing to merge (idempotent).
     if (!isCurrent()) return;
-    const generatedAgentRecords = await loadGeneratedAgentRecords(classroomId);
+    const stageForRoster = getCurrentStage();
+    const documentConfigs =
+      stageForRoster?.id === classroomId ? (stageForRoster.generatedAgentConfigs ?? []) : [];
+    let effectiveConfigs = documentConfigs;
+    if (stageForRoster?.id === classroomId && rosterNeedsLegacyFallback(documentConfigs)) {
+      const fallbacks = await loadLegacyAgentFallbacks(classroomId);
+      // The registry is a global singleton: after any await, re-check that this
+      // load is still current before letting the merged roster land anywhere.
+      if (!isCurrent()) return;
+      const merged = mergeLegacyAgentFallbacks(documentConfigs, fallbacks);
+      if (merged.changed) {
+        effectiveConfigs = merged.configs;
+        commitMigratedAgentConfigs(classroomId, merged.configs);
+      }
+    }
+
     if (!isCurrent()) return;
-    const generatedAgentIds = applyGeneratedAgentRecords(generatedAgentRecords);
+    const generatedAgentIds = applyGeneratedAgents(classroomId, effectiveConfigs);
 
     if (!isCurrent()) return;
     const settings = getSettings();
@@ -269,91 +288,101 @@ export function discardRestoredMediaTasks(tasks: Record<string, MediaTask>): voi
   }
 }
 
-export async function loadGeneratedAgentRecordsFromDB(
-  stageId: string,
-): Promise<GeneratedAgentRecord[]> {
-  const { getGeneratedAgentsByStageId } = await import('@/lib/utils/database');
-  return getGeneratedAgentsByStageId(stageId);
+/**
+ * True when the persisted roster still needs the legacy mirror consulted:
+ * either the document carries no roster at all (it may predate roster
+ * persistence on the document), or some agent is missing its voice fields
+ * (voice historically lived only in the mirror).
+ */
+export function rosterNeedsLegacyFallback(configs: readonly GeneratedAgentConfig[]): boolean {
+  if (configs.length === 0) return true;
+  return configs.some((config) => !config.voiceDesign && !config.voiceConfig);
 }
 
-export async function saveGeneratedAgentsForCurrentLoad(
-  stageId: string,
-  agents: NonNullable<Stage['generatedAgentConfigs']>,
-  isCurrent: () => boolean,
-): Promise<string[]> {
-  if (!isCurrent()) return [];
-  const { db } = await import('@/lib/utils/database');
-  if (!isCurrent()) return [];
-
-  const records = agents.map((agent) => ({ ...agent, stageId, createdAt: Date.now() }));
-  await db.transaction('rw', db.generatedAgents, async () => {
-    await db.generatedAgents.where('stageId').equals(stageId).delete();
-    await db.generatedAgents.bulkPut(records);
-  });
-  if (!isCurrent()) return [];
-
-  const registry = useAgentRegistry.getState();
-  for (const agent of registry.listAgents()) {
-    if (agent.isGenerated) registry.deleteAgent(agent.id);
+/**
+ * Merge the legacy mirror's roster into the document's configs. Pure.
+ *
+ * - Document configs empty + mirror has agents → lift the full mirror roster
+ *   (sorted by priority desc for a stable, teacher-first order).
+ * - Document configs present → only backfill missing voice fields, matched by
+ *   agent id. Document fields always win; the mirror never overwrites.
+ *
+ * Idempotent: once the merged result is persisted, a rerun finds nothing to
+ * change and reports `changed: false`.
+ */
+export function mergeLegacyAgentFallbacks(
+  configs: readonly GeneratedAgentConfig[],
+  fallbacks: readonly GeneratedAgentConfig[],
+): { configs: GeneratedAgentConfig[]; changed: boolean } {
+  if (configs.length === 0) {
+    if (fallbacks.length === 0) return { configs: [], changed: false };
+    const lifted = [...fallbacks].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    return { configs: lifted, changed: true };
   }
 
-  for (const record of records) {
-    const { voiceConfig, ...rest } = record as (typeof records)[number] & {
-      voiceConfig?: { providerId: string; voiceId: string };
-      voiceDesign?: VoiceDesign;
+  const byId = new Map(fallbacks.map((fallback) => [fallback.id, fallback]));
+  let changed = false;
+  const merged = configs.map((config) => {
+    if (config.voiceDesign || config.voiceConfig) return config;
+    const fallback = byId.get(config.id);
+    if (!fallback || (!fallback.voiceDesign && !fallback.voiceConfig)) return config;
+    changed = true;
+    return {
+      ...config,
+      ...(fallback.voiceConfig ? { voiceConfig: fallback.voiceConfig } : {}),
+      ...(fallback.voiceDesign ? { voiceDesign: fallback.voiceDesign } : {}),
     };
-    registry.addAgent({
-      ...rest,
-      allowedActions: getActionsForRole(record.role),
-      isDefault: false,
-      isGenerated: true,
-      boundStageId: stageId,
-      createdAt: new Date(record.createdAt),
-      updatedAt: new Date(record.createdAt),
-      ...(voiceConfig
-        ? {
-            voiceConfig: {
-              providerId: voiceConfig.providerId as TTSProviderId,
-              voiceId: voiceConfig.voiceId,
-            },
-          }
-        : {}),
-    });
-  }
-
-  void import('@/lib/audio/agent-voice')
-    .then((module) =>
-      module.warmUpAgentVoices(registry.listAgents().filter((agent) => agent.isGenerated)),
-    )
-    .catch(() => undefined);
-
-  return records.map((record) => record.id);
+  });
+  return { configs: merged, changed };
 }
 
-export function applyGeneratedAgentRecordsToRegistry(
-  records: readonly GeneratedAgentRecord[],
-): string[] {
-  const registry = useAgentRegistry.getState();
-  for (const agent of registry.listAgents()) {
-    if (agent.isGenerated) {
-      registry.deleteAgent(agent.id);
-    }
-  }
-
-  const ids: string[] = [];
-  for (const record of records) {
-    registry.addAgent({
-      ...record,
-      allowedActions: getActionsForRole(record.role),
-      isDefault: false,
-      isGenerated: true,
-      boundStageId: record.stageId,
-      createdAt: new Date(record.createdAt),
-      updatedAt: new Date(record.createdAt),
+/**
+ * Read the legacy roster mirror for a stage as contract-shaped configs.
+ * Read-only: the mirror table has no remaining writers and serves purely as a
+ * migration source for pre-single-source classrooms.
+ */
+export async function loadLegacyAgentFallbacksFromDB(
+  stageId: string,
+): Promise<GeneratedAgentConfig[]> {
+  try {
+    const { getGeneratedAgentsByStageId } = await import('@/lib/utils/database');
+    const records = await getGeneratedAgentsByStageId(stageId);
+    return records.map((record) => {
+      // Historical mirror rows spread the whole generated profile, so rows may
+      // carry a voiceConfig that never made it into the declared record type.
+      const voiceConfig = (record as { voiceConfig?: GeneratedAgentConfig['voiceConfig'] })
+        .voiceConfig;
+      return {
+        id: record.id,
+        name: record.name,
+        role: record.role,
+        persona: record.persona,
+        avatar: record.avatar,
+        color: record.color,
+        priority: record.priority,
+        ...(voiceConfig ? { voiceConfig } : {}),
+        ...(record.voiceDesign ? { voiceDesign: record.voiceDesign } : {}),
+      };
     });
-    ids.push(record.id);
+  } catch {
+    return [];
   }
-  return ids;
+}
+
+/**
+ * Commit lazily migrated roster configs onto the in-memory stage and mark the
+ * stage dirty so the merge becomes durable on the next scheduled flush.
+ * Guarded by a stage-id re-check: a classroom switch racing this commit must
+ * not write another stage's roster into the current one.
+ */
+export function commitMigratedAgentConfigsToStore(
+  stageId: string,
+  configs: GeneratedAgentConfig[],
+): void {
+  const state = useStageStore.getState();
+  if (state.stage?.id !== stageId) return;
+  useStageStore.setState({ stage: { ...state.stage, generatedAgentConfigs: configs } });
+  markStagePersistenceDirty([{ kind: 'stage' }]);
 }
 
 export const defaultClassroomLoadDeps = {
@@ -366,7 +395,8 @@ export const defaultClassroomLoadDeps = {
   loadRestoredMediaTasks: loadRestoredMediaTasksFromDB,
   applyRestoredMediaTasks,
   discardRestoredMediaTasks,
-  loadGeneratedAgentRecords: loadGeneratedAgentRecordsFromDB,
-  applyGeneratedAgentRecords: applyGeneratedAgentRecordsToRegistry,
+  loadLegacyAgentFallbacks: loadLegacyAgentFallbacksFromDB,
+  commitMigratedAgentConfigs: commitMigratedAgentConfigsToStore,
+  applyGeneratedAgents: applyGeneratedAgentsToRegistry,
   restoreAgentSelection,
 };

--- a/lib/edit/agent-roster.ts
+++ b/lib/edit/agent-roster.ts
@@ -28,9 +28,10 @@ export function materializeRoster(
   }
 
   // Step 2 — resolve preset ids. Global default presets get a fresh stage-scoped
-  // id (prevents saveGeneratedAgents from overwriting built-in defaults on the
-  // first edit). Stage-generated ids are kept as-is so existing scene references
-  // (scene.multiAgent.agentIds) remain valid after a roster edit.
+  // id (prevents the first roster edit from shadowing built-in defaults in the
+  // registry with stage-bound generated copies). Stage-generated ids are kept
+  // as-is so existing scene references (scene.multiAgent.agentIds) remain valid
+  // after a roster edit.
   let roster: AgentRoster = [];
   if (stage.agentIds && stage.agentIds.length > 0) {
     roster = stage.agentIds

--- a/lib/export/classroom-zip-types.ts
+++ b/lib/export/classroom-zip-types.ts
@@ -59,11 +59,38 @@ export function manifestAgentFromConfig(config: GeneratedAgentConfig): ManifestA
 }
 
 /**
+ * Structurally validate a manifest voice binding. Manifests are parsed JSON
+ * from user-supplied ZIPs, so the typed shape is a claim, not a guarantee: a
+ * malformed binding is dropped (the agent itself survives) rather than being
+ * written into the document and reaching the registry/TTS path.
+ */
+function sanitizeManifestVoiceConfig(value: unknown): AgentVoiceConfig | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const { providerId, voiceId } = value as Record<string, unknown>;
+  if (typeof providerId !== 'string' || typeof voiceId !== 'string') return undefined;
+  return { providerId, voiceId };
+}
+
+/** Same contract as {@link sanitizeManifestVoiceConfig}, for the 3-layer descriptor. */
+function sanitizeManifestVoiceDesign(value: unknown): VoiceDesign | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const { identity, texture, delivery } = value as Record<string, unknown>;
+  if (typeof identity !== 'string' || typeof texture !== 'string' || typeof delivery !== 'string') {
+    return undefined;
+  }
+  return { identity, texture, delivery };
+}
+
+/**
  * Rebuild a stage roster config from a manifest agent under a freshly minted
  * id — the inverse of {@link manifestAgentFromConfig}, so an export/import
- * round trip preserves the roster (voice included) up to id renaming.
+ * round trip preserves the roster (voice included) up to id renaming. The
+ * voice fields are structurally validated on the way in; malformed ones are
+ * dropped per field.
  */
 export function agentConfigFromManifest(agent: ManifestAgent, id: string): GeneratedAgentConfig {
+  const voiceConfig = sanitizeManifestVoiceConfig(agent.voiceConfig);
+  const voiceDesign = sanitizeManifestVoiceDesign(agent.voiceDesign);
   return {
     id,
     name: agent.name,
@@ -72,8 +99,8 @@ export function agentConfigFromManifest(agent: ManifestAgent, id: string): Gener
     avatar: agent.avatar,
     color: agent.color,
     priority: agent.priority,
-    ...(agent.voiceConfig ? { voiceConfig: agent.voiceConfig } : {}),
-    ...(agent.voiceDesign ? { voiceDesign: agent.voiceDesign } : {}),
+    ...(voiceConfig ? { voiceConfig } : {}),
+    ...(voiceDesign ? { voiceDesign } : {}),
   };
 }
 

--- a/lib/export/classroom-zip-types.ts
+++ b/lib/export/classroom-zip-types.ts
@@ -1,7 +1,7 @@
 // lib/export/classroom-zip-types.ts
-import type { SceneType, SceneContent } from '@/lib/types/stage';
+import type { GeneratedAgentConfig, SceneType, SceneContent } from '@/lib/types/stage';
 import type { Action } from '@/lib/types/action';
-import type { Slide } from '@openmaic/dsl';
+import type { AgentVoiceConfig, Slide, VoiceDesign } from '@openmaic/dsl';
 
 export const CLASSROOM_ZIP_FORMAT_VERSION = 1;
 export const CLASSROOM_ZIP_EXTENSION = '.maic.zip';
@@ -34,8 +34,47 @@ export interface ManifestAgent {
   avatar: string;
   color: string;
   priority: number;
-  /** Reserved for forward-compat. Not currently persisted in GeneratedAgentRecord DB schema. */
-  voiceConfig?: { providerId: string; voiceId: string };
+  /** Bound TTS voice carried over from the stage roster, when present. */
+  voiceConfig?: AgentVoiceConfig;
+  /** 3-layer vocal descriptor carried over from the stage roster, when present. */
+  voiceDesign?: VoiceDesign;
+}
+
+/**
+ * Map a stage roster config to its portable manifest shape. Agent identity is
+ * positional in the manifest (index into `manifest.agents`), so the id is
+ * dropped; the voice fields travel verbatim.
+ */
+export function manifestAgentFromConfig(config: GeneratedAgentConfig): ManifestAgent {
+  return {
+    name: config.name,
+    role: config.role,
+    persona: config.persona,
+    avatar: config.avatar,
+    color: config.color,
+    priority: config.priority,
+    ...(config.voiceConfig ? { voiceConfig: config.voiceConfig } : {}),
+    ...(config.voiceDesign ? { voiceDesign: config.voiceDesign } : {}),
+  };
+}
+
+/**
+ * Rebuild a stage roster config from a manifest agent under a freshly minted
+ * id — the inverse of {@link manifestAgentFromConfig}, so an export/import
+ * round trip preserves the roster (voice included) up to id renaming.
+ */
+export function agentConfigFromManifest(agent: ManifestAgent, id: string): GeneratedAgentConfig {
+  return {
+    id,
+    name: agent.name,
+    role: agent.role,
+    persona: agent.persona,
+    avatar: agent.avatar,
+    color: agent.color,
+    priority: agent.priority,
+    ...(agent.voiceConfig ? { voiceConfig: agent.voiceConfig } : {}),
+    ...(agent.voiceDesign ? { voiceDesign: agent.voiceDesign } : {}),
+  };
 }
 
 export interface ManifestScene {

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -5,10 +5,10 @@ import { saveAs } from 'file-saver';
 import { toast } from 'sonner';
 import { useStageStore } from '@/lib/store/stage';
 import { useI18n } from '@/lib/hooks/use-i18n';
-import { getGeneratedAgentsByStageId } from '@/lib/utils/database';
 import {
   CLASSROOM_ZIP_FORMAT_VERSION,
   CLASSROOM_ZIP_EXTENSION,
+  manifestAgentFromConfig,
   type ClassroomManifest,
   type ManifestStage,
   type ManifestAgent,
@@ -62,8 +62,9 @@ export function useExportClassroom() {
       const freshDocument = await accessDocument(stage.id);
       const latestName = freshDocument.document?.stage.name || stage.name;
 
-      // 2. Collect agents from DB
-      const agentRecords = await getGeneratedAgentsByStageId(stage.id);
+      // 2. Collect the roster from the stage document (single source of truth;
+      // the in-memory stage already carries any lazily migrated voice fields).
+      const agentConfigs = stage.generatedAgentConfigs ?? [];
 
       // 3. Collect audio files
       const audioFiles = await collectAudioFiles(scenes);
@@ -87,35 +88,11 @@ export function useExportClassroom() {
         updatedAt: stage.updatedAt,
       };
 
-      const manifestAgents: ManifestAgent[] = agentRecords.map((a) => ({
-        name: a.name,
-        role: a.role,
-        persona: a.persona,
-        avatar: a.avatar,
-        color: a.color,
-        priority: a.priority,
-      }));
-
-      // Also include generatedAgentConfigs from stage if agents not in DB
-      if (manifestAgents.length === 0 && stage.generatedAgentConfigs?.length) {
-        for (const a of stage.generatedAgentConfigs) {
-          manifestAgents.push({
-            name: a.name,
-            role: a.role,
-            persona: a.persona,
-            avatar: a.avatar,
-            color: a.color,
-            priority: a.priority,
-          });
-        }
-      }
+      const manifestAgents: ManifestAgent[] = agentConfigs.map(manifestAgentFromConfig);
 
       // Build agent ID → index mapping for multiAgent references
       const agentIdToIndex = new Map<string, number>();
-      agentRecords.forEach((a, i) => agentIdToIndex.set(a.id, i));
-      if (stage.generatedAgentConfigs?.length && agentRecords.length === 0) {
-        stage.generatedAgentConfigs.forEach((a, i) => agentIdToIndex.set(a.id, i));
-      }
+      agentConfigs.forEach((a, i) => agentIdToIndex.set(a.id, i));
 
       const aggregateReport: InlineReport = { inlined: [], failed: [] };
       const sharedFetcher = createAssetFetcher({ fetchImpl: createProxiedFetch() });

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -5,8 +5,13 @@ import { nanoid } from 'nanoid';
 import { toast } from 'sonner';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { db, mediaFileKey } from '@/lib/utils/database';
-import type { AudioFileRecord, MediaFileRecord, GeneratedAgentRecord } from '@/lib/utils/database';
-import type { ClassroomManifest, ManifestScene } from '@/lib/export/classroom-zip-types';
+import type { AudioFileRecord, MediaFileRecord } from '@/lib/utils/database';
+import type { GeneratedAgentConfig } from '@/lib/types/stage';
+import {
+  agentConfigFromManifest,
+  type ClassroomManifest,
+  type ManifestScene,
+} from '@/lib/export/classroom-zip-types';
 import { rewriteAudioRefsToIds } from '@/lib/export/classroom-zip-utils';
 import { createLogger } from '@/lib/logger';
 import { canonicalizeLegacyScene, mutateDocument, type AppDocument } from '@/lib/document-store';
@@ -171,6 +176,13 @@ export function useImportClassroom(onSuccess?: () => void) {
         setPhase('writingCourse');
         toast.loading(t('import.writingCourse'), { id: toastId });
 
+        // Rebuild the roster as stage-embedded configs: the stage document is
+        // the single source of truth for generated agents (voice included), so
+        // an import round-trips the roster without any side-table writes.
+        const importedAgentConfigs: GeneratedAgentConfig[] = (manifest.agents ?? []).map((a, i) =>
+          agentConfigFromManifest(a, newAgentIds[i]),
+        );
+
         const document: AppDocument = {
           stage: {
             id: newStageId,
@@ -181,6 +193,9 @@ export function useImportClassroom(onSuccess?: () => void) {
             createdAt: manifest.stage.createdAt || now,
             updatedAt: now,
             agentIds: newAgentIds.length > 0 ? newAgentIds : undefined,
+            ...(importedAgentConfigs.length > 0
+              ? { generatedAgentConfigs: importedAgentConfigs }
+              : {}),
           },
           scenes: manifest.scenes.map((mScene: ManifestScene, index: number) => {
             const newSceneId = nanoid();
@@ -215,22 +230,6 @@ export function useImportClassroom(onSuccess?: () => void) {
           }),
         };
 
-        // Write agents
-        if (manifest.agents?.length) {
-          const agentRecords: GeneratedAgentRecord[] = manifest.agents.map((a, i) => ({
-            id: newAgentIds[i],
-            stageId: newStageId,
-            name: a.name,
-            role: a.role,
-            persona: a.persona,
-            avatar: a.avatar,
-            color: a.color,
-            priority: a.priority,
-            createdAt: now,
-          }));
-          await db.generatedAgents.bulkPut(agentRecords);
-        }
-
         // The document is the commit point: one aggregate write under its per-stage lock.
         await mutateDocument(newStageId, async (_existing, store) => store.saveDocument(document));
 
@@ -240,7 +239,7 @@ export function useImportClassroom(onSuccess?: () => void) {
         onSuccess?.();
       } catch (error) {
         log.error('Classroom ZIP import failed:', error);
-        // Media/agents are separate legacy domains and cannot join the document transaction.
+        // Media files are a separate legacy domain and cannot join the document transaction.
         // Compensate every row this import could have created, logging individual failures.
         const cleanup = async (label: string, operation: () => Promise<unknown>) => {
           try {
@@ -256,9 +255,6 @@ export function useImportClassroom(onSuccess?: () => void) {
               store.deleteDocument(stageId),
             );
           });
-          await cleanup('generated agents', () =>
-            db.generatedAgents.where('stageId').equals(stageId).delete(),
-          );
           await cleanup('generated media', () =>
             db.mediaFiles.where('stageId').equals(stageId).delete(),
           );

--- a/lib/orchestration/registry/store.ts
+++ b/lib/orchestration/registry/store.ts
@@ -8,7 +8,7 @@ import { persist } from 'zustand/middleware';
 import type { AgentConfig } from './types';
 import { getActionsForRole } from './types';
 import type { TTSProviderId } from '@/lib/audio/types';
-import type { VoiceDesign } from '@/lib/audio/voice-design';
+import type { GeneratedAgentConfig } from '@/lib/types/stage';
 import { USER_AVATAR } from '@/lib/types/roundtable';
 import type { Participant, ParticipantRole } from '@/lib/types/roundtable';
 import { useUserProfileStore } from '@/lib/store/user-profile';
@@ -329,108 +329,58 @@ export function agentsToParticipants(
 }
 
 /**
- * Load generated agents for a stage from IndexedDB into the registry.
- * Clears any previously loaded generated agents first.
- * Returns the loaded agent IDs.
+ * Replace the registry's generated agents with the given stage roster.
+ *
+ * Pure in-memory registry side effect: the persisted source of truth for the
+ * roster is `stage.generatedAgentConfigs` on the stage document, and callers
+ * persist it through the document path — this function never writes storage.
+ * Clears previously loaded generated agents first (even when the new roster is
+ * empty) so a prior classroom's roster cannot leak into the current one.
+ * Returns the applied agent IDs.
  */
-export async function loadGeneratedAgentsForStage(stageId: string): Promise<string[]> {
-  const { getGeneratedAgentsByStageId } = await import('@/lib/utils/database');
-  const records = await getGeneratedAgentsByStageId(stageId);
-
-  const registry = useAgentRegistry.getState();
-
-  // Always clear previously loaded generated agents — even when the new stage
-  // has none — to prevent stale agents from a prior auto-classroom leaking
-  // into the current preset classroom.
-  const currentAgents = registry.listAgents();
-  for (const agent of currentAgents) {
-    if (agent.isGenerated) {
-      registry.deleteAgent(agent.id);
-    }
-  }
-
-  if (records.length === 0) return [];
-
-  // Add new ones
-  const ids: string[] = [];
-  for (const record of records) {
-    registry.addAgent({
-      ...record,
-      allowedActions: getActionsForRole(record.role),
-      isDefault: false,
-      isGenerated: true,
-      boundStageId: record.stageId,
-      createdAt: new Date(record.createdAt),
-      updatedAt: new Date(record.createdAt),
-    });
-    ids.push(record.id);
-  }
-
-  return ids;
-}
-
-/**
- * Save generated agents to IndexedDB and registry.
- * Clears old generated agents for this stage first.
- */
-export async function saveGeneratedAgents(
+export function applyGeneratedAgentsToRegistry(
   stageId: string,
-  agents: Array<{
-    id: string;
-    name: string;
-    role: string;
-    persona: string;
-    avatar: string;
-    color: string;
-    priority: number;
-    voiceConfig?: { providerId: string; voiceId: string };
-    voiceDesign?: VoiceDesign;
-  }>,
-): Promise<string[]> {
-  const { db } = await import('@/lib/utils/database');
-
-  // Clear old generated agents for this stage
-  await db.generatedAgents.where('stageId').equals(stageId).delete();
-
-  // Clear from registry
+  agents: ReadonlyArray<GeneratedAgentConfig>,
+): string[] {
   const registry = useAgentRegistry.getState();
   for (const agent of registry.listAgents()) {
     if (agent.isGenerated) registry.deleteAgent(agent.id);
   }
 
-  // Write to IndexedDB
-  const records = agents.map((a) => ({ ...a, stageId, createdAt: Date.now() }));
-  await db.generatedAgents.bulkPut(records);
-
-  // Add to registry
-  for (const record of records) {
-    const { voiceConfig, ...rest } = record;
+  const now = Date.now();
+  const ids: string[] = [];
+  for (const agent of agents) {
+    const { voiceConfig, ...rest } = agent;
     registry.addAgent({
       ...rest,
-      allowedActions: getActionsForRole(record.role),
+      allowedActions: getActionsForRole(agent.role),
       isDefault: false,
       isGenerated: true,
       boundStageId: stageId,
-      createdAt: new Date(record.createdAt),
-      updatedAt: new Date(record.createdAt),
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
       ...(voiceConfig
         ? {
             voiceConfig: {
               providerId: voiceConfig.providerId as TTSProviderId,
+              ...(voiceConfig.modelId ? { modelId: voiceConfig.modelId } : {}),
               voiceId: voiceConfig.voiceId,
             },
           }
         : {}),
     });
+    ids.push(agent.id);
   }
 
   // Eager warm-up: pre-register each generated agent's auto voice so the first
   // spoken line is already stable. Same idempotent ensure as the TTS path;
   // fire-and-forget. Dynamic import keeps this client-only dep out of the
   // server-importable store module.
-  void import('@/lib/audio/agent-voice')
-    .then((m) => m.warmUpAgentVoices(registry.listAgents().filter((a) => a.isGenerated)))
-    .catch(() => undefined);
+  if (ids.length > 0 && typeof window !== 'undefined') {
+    void import('@/lib/audio/agent-voice')
+      .then((m) => m.warmUpAgentVoices(registry.listAgents().filter((a) => a.isGenerated)))
+      .catch(() => undefined);
+  }
 
-  return records.map((r) => r.id);
+  return ids;
 }

--- a/lib/orchestration/registry/store.ts
+++ b/lib/orchestration/registry/store.ts
@@ -7,7 +7,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { AgentConfig } from './types';
 import { getActionsForRole } from './types';
-import type { TTSProviderId } from '@/lib/audio/types';
+import { isKnownTTSProviderId } from '@/lib/audio/constants';
 import type { GeneratedAgentConfig } from '@/lib/types/stage';
 import { USER_AVATAR } from '@/lib/types/roundtable';
 import type { Participant, ParticipantRole } from '@/lib/types/roundtable';
@@ -237,6 +237,15 @@ export const useAgentRegistry = create<AgentRegistryState>()(
       name: 'agent-registry-storage',
       version: 11, // Bumped: add voiceOverrides field to AgentConfig
       migrate: (persistedState: unknown) => persistedState,
+      // Generated agents are single-sourced on the stage document and rebuilt
+      // from it on every classroom load — keep them out of the localStorage
+      // snapshot entirely. The merge filter below stays as defense in depth
+      // for snapshots written before this partialize existed.
+      partialize: (state) => ({
+        agents: Object.fromEntries(
+          Object.entries(state.agents).filter(([, agent]) => !agent.isGenerated),
+        ),
+      }),
       // Merge persisted state with default agents
       // Default agents always use code-defined values (not cached)
       // Custom agents use persisted values
@@ -331,11 +340,16 @@ export function agentsToParticipants(
 /**
  * Replace the registry's generated agents with the given stage roster.
  *
- * Pure in-memory registry side effect: the persisted source of truth for the
+ * In-memory registry side effect: the persisted source of truth for the
  * roster is `stage.generatedAgentConfigs` on the stage document, and callers
- * persist it through the document path — this function never writes storage.
+ * persist it through the document path — the registry's own localStorage
+ * snapshot excludes generated agents (see the persist `partialize` above), so
+ * nothing written here becomes durable.
  * Clears previously loaded generated agents first (even when the new roster is
  * empty) so a prior classroom's roster cannot leak into the current one.
+ * The contract keeps `voiceConfig.providerId` an open string; a binding whose
+ * provider is not registered in this app is dropped here (the agent keeps its
+ * voiceDesign, and the TTS path falls back at call time).
  * Returns the applied agent IDs.
  */
 export function applyGeneratedAgentsToRegistry(
@@ -359,11 +373,10 @@ export function applyGeneratedAgentsToRegistry(
       boundStageId: stageId,
       createdAt: new Date(now),
       updatedAt: new Date(now),
-      ...(voiceConfig
+      ...(voiceConfig && isKnownTTSProviderId(voiceConfig.providerId)
         ? {
             voiceConfig: {
-              providerId: voiceConfig.providerId as TTSProviderId,
-              ...(voiceConfig.modelId ? { modelId: voiceConfig.modelId } : {}),
+              providerId: voiceConfig.providerId,
               voiceId: voiceConfig.voiceId,
             },
           }

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -14,6 +14,8 @@ import type { ChatSession } from '@/lib/types/chat';
 import type { SceneOutline } from '@/lib/types/generation';
 import { createLogger } from '@/lib/logger';
 import { useCanvasStore } from '@/lib/store/canvas';
+import { useSettingsStore } from '@/lib/store/settings';
+import { applyGeneratedAgentsToRegistry } from '@/lib/orchestration/registry/store';
 import { migrateScene } from '@/lib/edit/slide-schema';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
 import { hydratePBLScenesFromRuntime } from '@/lib/pbl/v2/runtime/hydration';
@@ -87,6 +89,15 @@ export function markStagePersistenceDirty(changes: PendingChange[]): void {
   markPendingChanges(useStageStore.getState().stage?.id, ...changes);
 }
 
+/**
+ * Drop any pending persistence work for a deleted stage. Called by the stage
+ * deletion path so a mutation still sitting in the debounce window cannot
+ * flush after the delete and resurrect the removed document.
+ */
+export function discardPendingStageChanges(stageId: string): void {
+  if (pendingStageId === stageId) resetPendingChanges();
+}
+
 export function claimStageSceneLoadToken(): StageSceneLoadToken {
   latestStageSceneLoadToken += 1;
   return latestStageSceneLoadToken;
@@ -94,30 +105,6 @@ export function claimStageSceneLoadToken(): StageSceneLoadToken {
 
 export function isCurrentStageSceneLoadToken(token: StageSceneLoadToken): boolean {
   return token === latestStageSceneLoadToken;
-}
-
-// ==================== Debounce Helper ====================
-
-/**
- * Debounce function to limit how often a function is called
- * @param func Function to debounce
- * @param delay Delay in milliseconds
- */
-function debounce<T extends (...args: Parameters<T>) => ReturnType<T>>(
-  func: T,
-  delay: number,
-): (...args: Parameters<T>) => void {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-  return (...args: Parameters<T>) => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = setTimeout(() => {
-      func(...args);
-      timeoutId = null;
-    }, delay);
-  };
 }
 
 type ToolbarState = 'design' | 'ai';
@@ -478,8 +465,12 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     const stage = get().stage;
     if (!stage) return;
     set({ stage: { ...stage, generatedAgentConfigs: configs } });
+    // The roster is part of the stage document — persistence rides the shared
+    // pending-change scheduler like every other stage mutation. The registry
+    // and selection updates below are synchronous in-memory mirrors only.
     markPendingChanges(stage.id, { kind: 'stage' });
-    debouncedSaveAgents();
+    applyGeneratedAgentsToRegistry(stage.id, configs);
+    useSettingsStore.getState().setSelectedAgentIds(configs.map((a) => a.id));
   },
 
   setGeneratingOutlines: (generatingOutlines) => set({ generatingOutlines }),
@@ -834,17 +825,3 @@ if (typeof window !== 'undefined') {
   });
   window.addEventListener('beforeunload', kickPendingSave);
 }
-
-/**
- * Debounced registry sync — fires ONLY when the agent roster is edited.
- * Keeps db.generatedAgents writes off the broad saveToStorage path so scene
- * advances (setCurrentSceneId etc.) never churn the registry mid-playback.
- */
-const debouncedSaveAgents = debounce(async () => {
-  const { stage } = useStageStore.getState();
-  if (!stage?.id || !stage.generatedAgentConfigs) return;
-  const { saveGeneratedAgents } = await import('@/lib/orchestration/registry/store');
-  await saveGeneratedAgents(stage.id, stage.generatedAgentConfigs);
-  const { useSettingsStore } = await import('@/lib/store/settings');
-  useSettingsStore.getState().setSelectedAgentIds(stage.generatedAgentConfigs.map((a) => a.id));
-}, 500);

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -21,7 +21,12 @@ import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/doc
 import { hydratePBLScenesFromRuntime } from '@/lib/pbl/v2/runtime/hydration';
 import type { ChatStorageSnapshot } from '@/lib/utils/chat-storage';
 import type { PendingChange } from '@/lib/utils/stage-storage';
-import { isStageDeleted, isStageWriteStale, stageDeletionEpoch } from '@/lib/utils/deleted-stages';
+import {
+  isStageDeleted,
+  isStageDeletionInFlight,
+  isStageWriteStale,
+  stageDeletionEpoch,
+} from '@/lib/utils/deleted-stages';
 
 const log = createLogger('StageStore');
 
@@ -167,6 +172,11 @@ export function restorePendingStageChanges(
  */
 export function clearStoreForDeletedStage(stageId: string): void {
   if (useStageStore.getState().stage?.id !== stageId) return;
+  // Re-check the deleted flag at eviction time: if a same-id restore
+  // completed (and unmarked the deletion) inside the cascade-tail window,
+  // the warm state is the RESTORED classroom, not the deleted ghost —
+  // clearing it would discard the restore and its post-restore edits.
+  if (!isStageDeleted(stageId)) return;
   useStageStore.getState().clearStore();
 }
 
@@ -332,6 +342,12 @@ async function persistDirtySnapshot(
     },
     capturedEpoch,
   );
+  // A stale drop persisted nothing, but also leaves nothing to retry: the
+  // deletion path owns the discard (and, on a failed delete, the restore) of
+  // this stage's pending dirt. Reporting no failures is deliberate — the
+  // revision guards keep any restored (re-queued) descriptors, since
+  // restores mint fresh revisions.
+  if (result === 'stale-dropped') return new Set();
   return new Set((result?.failedChanges ?? []).map(pendingChangeKey));
 }
 
@@ -687,6 +703,15 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
         capturedEpoch,
       );
 
+      // An epoch-stale drop persisted nothing: skip every piece of success
+      // bookkeeping. The chatSnapshot must not rebind to a snapshot that
+      // never landed, and the pending map must keep its dirt (the deletion
+      // path owns its discard/restore). Report the write as not durable.
+      if (result === 'stale-dropped') {
+        log.info(`Save dropped by deletion fence for stage ${stage.id}; nothing persisted`);
+        return false;
+      }
+
       const failedKeys = new Set((result?.failedChanges ?? []).map(pendingChangeKey));
       if (
         failedKeys.has('chats') &&
@@ -736,15 +761,27 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
           log.info('Stage already loaded in memory, skipping IndexedDB load:', stageId);
           return;
         }
-        // The warm copy is a ghost of a DELETED classroom (deletion evicts
-        // the store, but a partially failed cascade — or any future caller —
-        // can leave one). Short-circuiting here would starve the restore
-        // path: the classroom loader's server-fallback gate checks
-        // `getCurrentStage()`, so a warm ghost renders a fully editable
-        // classroom whose every edit is silently dropped. Discard the ghost
-        // (without claiming a new load token — the caller's token must stay
-        // current) and fall through to a full load, which finds no local
-        // data and lets the server-restore path run and lift the deletion.
+        // While the deletion cascade is still unsettled the ghost must be
+        // KEPT: the cascade can still fail before removing the document, in
+        // which case the deleted flag is lifted and the warm state (plus the
+        // pending dirt the failure path restores) is the only copy of the
+        // pre-delete edits. On success, `clearStoreForDeletedStage` evicts
+        // the warm copy at settlement and a later load takes the settled
+        // branch below.
+        if (isStageDeletionInFlight(stageId)) {
+          log.info('Warm stage is mid-deletion; keeping state until it settles:', stageId);
+          return;
+        }
+        // The warm copy is a ghost of a DELETED classroom whose deletion has
+        // SETTLED with the document removed (deletion evicts the store, but a
+        // partially failed cascade — or any future caller — can leave one).
+        // Short-circuiting here would starve the restore path: the classroom
+        // loader's server-fallback gate checks `getCurrentStage()`, so a warm
+        // ghost renders a fully editable classroom whose every edit is
+        // silently dropped. Discard the ghost (without claiming a new load
+        // token — the caller's token must stay current) and fall through to a
+        // full load, which finds no local data and lets the server-restore
+        // path run and lift the deletion.
         log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
         resetPendingChanges();
         set((s) => ({
@@ -782,6 +819,15 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
         const latestState = get();
         if (latestState.stage?.id === stageId && latestState.scenes.length > 0) {
           log.info('Stage appeared in memory during IndexedDB hydration, skipping load:', stageId);
+          return;
+        }
+        // Read-side mirror of the write fence's "re-check immediately before
+        // landing": in lock-free environments `loadStageData` can read the
+        // document mid-cascade, before `deleteDocument` lands. Landing that
+        // read would re-materialize a ghost of the deleted classroom (whose
+        // edits `markPendingChanges` refuses) until the eviction blanks it.
+        if (isStageDeleted(stageId)) {
+          log.info('Stage was deleted during hydration, skipping load:', stageId);
           return;
         }
 

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -371,8 +371,12 @@ async function persistDirtySnapshot(
     capturedEpoch,
   );
   // A stale drop persisted nothing, and also leaves nothing to retry: the
-  // deletion path owns the discard (and, on a failed delete, the restore) of
-  // this stage's pending dirt. The status is PROPAGATED, not folded into an
+  // fence is permanent for this capture (the deletion epoch outlives any
+  // restore). What a failed delete restores is scoped to what the deletion
+  // path snapshotted — the pending map plus an in-flight flush round's dirt;
+  // a departing-stage snapshot is outside that capture and is dropped by
+  // design (navigation is not a durability barrier — see setStage).
+  // The status is PROPAGATED, not folded into an
   // empty failure set, because callers must be able to tell "verified write"
   // from "fenced drop": success bookkeeping (the chatSnapshot rebind in
   // startFlushRound) after a drop would bind the baseline to chats that never
@@ -432,9 +436,14 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
               departingSnapshot,
               departingEpoch,
             );
-            // A fenced drop has nothing to retry and nothing to report as
-            // failed: the deletion path owns the discard (and, on a failed
-            // delete, the restore) of this stage's dirt.
+            // A fenced drop has nothing to retry: the deletion epoch outlives
+            // any restore, so the retry would be dropped identically. This
+            // departing snapshot is NOT covered by the deletion path's
+            // failed-delete restore (that restore is scoped to the pending
+            // map and an in-flight flush round, which this dirt already
+            // left) — on a failed delete it is fenced and dropped, an
+            // accepted consequence of navigation not being a durability
+            // barrier.
             if (result === 'stale-dropped') return;
             lastFailedKeys = result;
             if (lastFailedKeys.size === 0) return;
@@ -826,8 +835,20 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
             // The deletion failed before removing the document and lifted the
             // flag: the warm state IS the live classroom again (the failure
             // path re-queued the discarded dirt before settling) — keep it.
-            log.info('Deletion failed; keeping warm stage state:', stageId);
-            return;
+            // Mirror of the success-path identity guard below: a tokenless
+            // store writer (applyClassroomStageAndScenes via a database
+            // import) can replace the stage during the park without claiming
+            // the load token, and then there is no warm state of THIS stage
+            // left to keep — fall through to the cold load instead of
+            // reporting a classroom the store no longer holds as live.
+            if (get().stage?.id === stageId) {
+              log.info('Deletion failed; keeping warm stage state:', stageId);
+              return;
+            }
+            log.info(
+              'Deletion failed but the store no longer holds the parked stage; reloading:',
+              stageId,
+            );
           }
           // Deletion succeeded: the settlement eviction has cleared the warm
           // ghost (it runs synchronously before this microtask resumes).
@@ -843,11 +864,15 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
         // silently dropped. Discard the ghost (without claiming a new load
         // token — the caller's token must stay current) and fall through to a
         // full load, which finds no local data and lets the server-restore
-        // path run and lift the deletion.
-        log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
-        if (get().stage?.id === stageId) {
-          resetPendingChanges();
-          set((s) => clearedStageState(s));
+        // path run and lift the deletion. (Skipped when a failed deletion
+        // lifted the flag above: the document still exists, so the cold load
+        // below simply re-reads it.)
+        if (isStageDeleted(stageId)) {
+          log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
+          if (get().stage?.id === stageId) {
+            resetPendingChanges();
+            set((s) => clearedStageState(s));
+          }
         }
       }
 

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -20,12 +20,13 @@ import { migrateScene } from '@/lib/edit/slide-schema';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
 import { hydratePBLScenesFromRuntime } from '@/lib/pbl/v2/runtime/hydration';
 import type { ChatStorageSnapshot } from '@/lib/utils/chat-storage';
-import type { PendingChange } from '@/lib/utils/stage-storage';
+import type { PendingChange, StaleDroppedSave } from '@/lib/utils/stage-storage';
 import {
   isStageDeleted,
   isStageDeletionInFlight,
   isStageWriteStale,
   stageDeletionEpoch,
+  stageDeletionSettled,
 } from '@/lib/utils/deleted-stages';
 
 const log = createLogger('StageStore');
@@ -162,6 +163,24 @@ export function restorePendingStageChanges(
   markPendingChanges(stageId, ...changes);
 }
 
+/** The empty store shape shared by every reset path (epoch bump included). */
+function clearedStageState(state: Pick<StageState, 'generationEpoch'>) {
+  return {
+    stage: null,
+    scenes: [],
+    currentSceneId: null,
+    chats: [],
+    chatSnapshot: { sessions: [], restoreMarker: null },
+    outlines: [],
+    generationComplete: false,
+    generationEpoch: state.generationEpoch + 1,
+    generationStatus: 'idle' as const,
+    currentGeneratingOrder: -1,
+    failedOutlines: [],
+    generatingOutlines: [],
+  };
+}
+
 /**
  * Evict a deleted stage from the in-memory store. Called by the deletion path
  * after the cascade succeeds: a warm store would otherwise keep rendering the
@@ -177,7 +196,16 @@ export function clearStoreForDeletedStage(stageId: string): void {
   // the warm state is the RESTORED classroom, not the deleted ghost —
   // clearing it would discard the restore and its post-restore edits.
   if (!isStageDeleted(stageId)) return;
-  useStageStore.getState().clearStore();
+  // Evict WITHOUT claiming a new load token (unlike clearStore): a load that
+  // is parked on this very cascade's settlement — the mid-deletion warm
+  // branch in `loadFromStorage` — must remain the current load so it can run
+  // the cold reload that hands the emptied route to the server-restore path.
+  // Ghost re-materialization by an in-flight load is prevented by the
+  // read-side isStageDeleted re-checks before its store writes, not by token
+  // invalidation.
+  resetPendingChanges();
+  useStageStore.setState((state) => clearedStageState(state));
+  log.info('Evicted deleted stage from the store:', stageId);
 }
 
 export function claimStageSceneLoadToken(): StageSceneLoadToken {
@@ -313,7 +341,7 @@ async function persistDirtySnapshot(
   dirtySnapshot: ReadonlyMap<string, PendingEntry>,
   snapshot: StagePersistenceSnapshot,
   capturedEpoch: number,
-): Promise<Set<string>> {
+): Promise<Set<string> | StaleDroppedSave> {
   if (!snapshot.stage) return new Set();
   // A stale capture is dropped, not retried: this covers snapshots that
   // escaped `discardPendingStageChanges` because they already left the
@@ -321,7 +349,7 @@ async function persistDirtySnapshot(
   // setStage). `capturedEpoch` is the deletion epoch recorded when `snapshot`
   // was taken; a deletion after that moment permanently invalidates this
   // write, even if a same-id restore has since lifted the deleted flag.
-  if (isStageWriteStale(stageId, capturedEpoch)) return new Set();
+  if (isStageWriteStale(stageId, capturedEpoch)) return 'stale-dropped';
   stageStorageModulePromise ??= import('@/lib/utils/stage-storage');
   const { saveStageDataIncremental } = await stageStorageModulePromise;
   const result = await saveStageDataIncremental(
@@ -342,12 +370,16 @@ async function persistDirtySnapshot(
     },
     capturedEpoch,
   );
-  // A stale drop persisted nothing, but also leaves nothing to retry: the
+  // A stale drop persisted nothing, and also leaves nothing to retry: the
   // deletion path owns the discard (and, on a failed delete, the restore) of
-  // this stage's pending dirt. Reporting no failures is deliberate — the
-  // revision guards keep any restored (re-queued) descriptors, since
+  // this stage's pending dirt. The status is PROPAGATED, not folded into an
+  // empty failure set, because callers must be able to tell "verified write"
+  // from "fenced drop": success bookkeeping (the chatSnapshot rebind in
+  // startFlushRound) after a drop would bind the baseline to chats that never
+  // landed. Pending-map handling may still treat a drop as "no failures" —
+  // the revision guards keep any restored (re-queued) descriptors, since
   // restores mint fresh revisions.
-  if (result === 'stale-dropped') return new Set();
+  if (result === 'stale-dropped') return 'stale-dropped';
   return new Set((result?.failedChanges ?? []).map(pendingChangeKey));
 }
 
@@ -394,12 +426,17 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
         let lastFailedKeys = new Set<string>();
         for (let attempt = 0; attempt < 2; attempt += 1) {
           try {
-            lastFailedKeys = await persistDirtySnapshot(
+            const result = await persistDirtySnapshot(
               departingStageId,
               departingDirty,
               departingSnapshot,
               departingEpoch,
             );
+            // A fenced drop has nothing to retry and nothing to report as
+            // failed: the deletion path owns the discard (and, on a failed
+            // delete, the restore) of this stage's dirt.
+            if (result === 'stale-dropped') return;
+            lastFailedKeys = result;
             if (lastFailedKeys.size === 0) return;
           } catch (error) {
             if (attempt === 1) throw error;
@@ -761,16 +798,41 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
           log.info('Stage already loaded in memory, skipping IndexedDB load:', stageId);
           return;
         }
-        // While the deletion cascade is still unsettled the ghost must be
-        // KEPT: the cascade can still fail before removing the document, in
-        // which case the deleted flag is lifted and the warm state (plus the
-        // pending dirt the failure path restores) is the only copy of the
-        // pre-delete edits. On success, `clearStoreForDeletedStage` evicts
-        // the warm copy at settlement and a later load takes the settled
-        // branch below.
+        // While the deletion cascade is still unsettled, neither branch can
+        // be taken yet: on failure the warm state (plus the pending dirt the
+        // failure path restores) is the only copy of the pre-delete edits and
+        // must be KEPT, while on success the ghost must be discarded for a
+        // cold reload. Completing the load NOW would expose the classroom
+        // inside that window — edits would be refused by markPendingChanges
+        // without being in the deletion's pre-start snapshot (silently lost
+        // if the delete then fails), and on success the settlement eviction
+        // would blank an already-completed route with nothing left to
+        // trigger a reload. So park until the outcome is known, then branch.
+        // No deadlock: this load holds no document lock while parked, and
+        // the cascade never waits on a load to settle.
         if (isStageDeletionInFlight(stageId)) {
-          log.info('Warm stage is mid-deletion; keeping state until it settles:', stageId);
-          return;
+          log.info('Warm stage is mid-deletion; waiting for the cascade to settle:', stageId);
+          await stageDeletionSettled(stageId);
+          // Settlement can resolve long after the user navigated elsewhere;
+          // the usual token discipline keeps this parked load from touching
+          // the store the newer navigation now owns. (The success-path
+          // eviction deliberately does NOT claim a token, so it cannot trip
+          // this guard — see clearStoreForDeletedStage.)
+          if (!isCurrentStageSceneLoadToken(token)) {
+            log.info('Newer stage load started during deletion settlement, skipping:', stageId);
+            return;
+          }
+          if (!isStageDeleted(stageId)) {
+            // The deletion failed before removing the document and lifted the
+            // flag: the warm state IS the live classroom again (the failure
+            // path re-queued the discarded dirt before settling) — keep it.
+            log.info('Deletion failed; keeping warm stage state:', stageId);
+            return;
+          }
+          // Deletion succeeded: the settlement eviction has cleared the warm
+          // ghost (it runs synchronously before this microtask resumes).
+          // Fall through to the settled-deleted handling below and run the
+          // full cold load so the server-restore path can recover the route.
         }
         // The warm copy is a ghost of a DELETED classroom whose deletion has
         // SETTLED with the document removed (deletion evicts the store, but a
@@ -783,21 +845,10 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
         // full load, which finds no local data and lets the server-restore
         // path run and lift the deletion.
         log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
-        resetPendingChanges();
-        set((s) => ({
-          stage: null,
-          scenes: [],
-          currentSceneId: null,
-          chats: [],
-          chatSnapshot: { sessions: [], restoreMarker: null },
-          outlines: [],
-          generationComplete: false,
-          generationEpoch: s.generationEpoch + 1,
-          generationStatus: 'idle' as const,
-          currentGeneratingOrder: -1,
-          failedOutlines: [],
-          generatingOutlines: [],
-        }));
+        if (get().stage?.id === stageId) {
+          resetPendingChanges();
+          set((s) => clearedStageState(s));
+        }
       }
 
       const { loadStageData } = await import('@/lib/utils/stage-storage');
@@ -891,20 +942,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
   clearStore: () => {
     claimStageSceneLoadToken();
     resetPendingChanges();
-    set((s) => ({
-      stage: null,
-      scenes: [],
-      currentSceneId: null,
-      chats: [],
-      chatSnapshot: { sessions: [], restoreMarker: null },
-      outlines: [],
-      generationComplete: false,
-      generationEpoch: s.generationEpoch + 1,
-      generationStatus: 'idle' as const,
-      currentGeneratingOrder: -1,
-      failedOutlines: [],
-      generatingOutlines: [],
-    }));
+    set((s) => clearedStageState(s));
     log.info('Store cleared');
   },
 }));
@@ -933,12 +971,17 @@ function startFlushRound(): FlushRound | null {
 
   const run = (async () => {
     try {
-      const failedKeys = await persistDirtySnapshot(
-        stageId,
-        dirtySnapshot,
-        snapshot,
-        capturedEpoch,
-      );
+      const result = await persistDirtySnapshot(stageId, dirtySnapshot, snapshot, capturedEpoch);
+      // A fenced drop persisted nothing. For the pending map that is
+      // equivalent to "no failures" (nothing to retry; the deletion path owns
+      // the discard/restore, and restored descriptors survive the clearing
+      // loop below via their fresh revisions). The chat success bookkeeping
+      // below is NOT equivalent: rebinding chatSnapshot to chats that never
+      // landed would make the next saveChatSessions no-op-skip them as
+      // already durable and corrupt the cross-tab conflict baseline — mirror
+      // of the stale-dropped handling in saveToStorage.
+      const staleDropped = result === 'stale-dropped';
+      const failedKeys = result === 'stale-dropped' ? new Set<string>() : result;
       if (pendingStageId === stageId) {
         for (const [key, entry] of dirtySnapshot) {
           if (!failedKeys.has(key) && pendingChanges.get(key)?.revision === entry.revision) {
@@ -947,6 +990,7 @@ function startFlushRound(): FlushRound | null {
         }
       }
       if (
+        !staleDropped &&
         dirtySnapshot.has('chats') &&
         !failedKeys.has('chats') &&
         useStageStore.getState().stage?.id === stageId &&

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -39,6 +39,7 @@ let pendingRevision = 0;
 const pendingChanges = new Map<string, PendingEntry>();
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 type FlushRound = {
+  stageId: string;
   dirtySnapshot: ReadonlyMap<string, PendingEntry>;
   promise: Promise<Set<string>>;
 };
@@ -101,6 +102,44 @@ export function markStagePersistenceDirty(changes: PendingChange[]): void {
  */
 export function discardPendingStageChanges(stageId: string): void {
   if (pendingStageId === stageId) resetPendingChanges();
+}
+
+/**
+ * Snapshot the logical changes a deletion is about to throw away: everything
+ * still queued for the stage plus the in-flight flush round's dirt (whose
+ * write the tombstone will drop). Taken by the deletion path BEFORE the
+ * tombstone is registered, so a deletion that fails while the document still
+ * exists can hand the snapshot back to `restorePendingStageChanges` — without
+ * it, the pre-delete edits would silently live only in memory.
+ */
+export function snapshotPendingStageChangesForDeletion(stageId: string): PendingChange[] {
+  const byKey = new Map<string, PendingChange>();
+  if (flushInFlight?.stageId === stageId) {
+    for (const { change } of flushInFlight.dirtySnapshot.values()) {
+      byKey.set(pendingChangeKey(change), change);
+    }
+  }
+  if (pendingStageId === stageId) {
+    for (const { change } of pendingChanges.values()) {
+      byKey.set(pendingChangeKey(change), change);
+    }
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Re-mark the changes a failed deletion discarded, so they reach durability
+ * again through the normal scheduler. Only meaningful after the tombstone was
+ * lifted; no-ops when the store has since moved to another stage (the
+ * departing-stage snapshot owns that world).
+ */
+export function restorePendingStageChanges(
+  stageId: string,
+  changes: readonly PendingChange[],
+): void {
+  if (changes.length === 0) return;
+  if (useStageStore.getState().stage?.id !== stageId) return;
+  markPendingChanges(stageId, ...changes);
 }
 
 export function claimStageSceneLoadToken(): StageSceneLoadToken {
@@ -481,18 +520,40 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     applyGeneratedAgentsToRegistry(stage.id, configs);
     // Selection mirror honors provenance (same semantics as
     // restoreAgentSelection): a stage-derived selection tracks the roster
-    // wholesale, but a user's explicit choice is only narrowed — agents that
-    // left the roster are dropped, newcomers are never auto-selected, and
-    // `agentSelectionIsUserSet` is left untouched either way. A user-set
-    // preset selection references non-generated agents only, so a roster edit
-    // does not concern it.
+    // wholesale; a user's explicit auto choice is handled by cases below. A
+    // user-set preset selection references non-generated agents only, so a
+    // roster edit does not concern it.
     const settings = useSettingsStore.getState();
+    const nextRosterIds = configs.map((a) => a.id);
     if (!settings.agentSelectionIsUserSet) {
-      settings.setSelectedAgentIds(configs.map((a) => a.id));
+      settings.setSelectedAgentIds(nextRosterIds);
     } else if (settings.agentMode === 'auto') {
-      const rosterIds = new Set(configs.map((a) => a.id));
-      const retained = settings.selectedAgentIds.filter((id) => rosterIds.has(id));
-      if (retained.length !== settings.selectedAgentIds.length) {
+      // The AgentBar's auto toggle snapshots the whole roster as the user's
+      // selection, so "selection === pre-edit full roster" means the intent
+      // was "everyone", not "this exact subset" — keep tracking the roster
+      // wholesale (newcomers included). A genuine subset is only narrowed:
+      // departed agents are dropped, newcomers are never auto-selected.
+      const previousRosterIds = new Set((stage.generatedAgentConfigs ?? []).map((a) => a.id));
+      const selectionWasFullRoster =
+        settings.selectedAgentIds.length > 0 &&
+        settings.selectedAgentIds.length === previousRosterIds.size &&
+        settings.selectedAgentIds.every((id) => previousRosterIds.has(id));
+      const rosterIds = new Set(nextRosterIds);
+      const retained = selectionWasFullRoster
+        ? nextRosterIds
+        : settings.selectedAgentIds.filter((id) => rosterIds.has(id));
+      if (retained.length === 0) {
+        // Narrowed to nothing (every pick left the roster, or the roster was
+        // rebuilt). `restoreAgentSelection` refuses an empty user-set
+        // selection (`length > 0` gate) and falls back to the stage-derived
+        // full roster — mirror that here instead of running the classroom
+        // with zero agents until reload.
+        settings.setSelectedAgentIds(nextRosterIds);
+        settings.setAgentSelectionIsUserSet(false);
+      } else if (
+        retained.length !== settings.selectedAgentIds.length ||
+        retained.some((id, index) => id !== settings.selectedAgentIds[index])
+      ) {
         settings.setSelectedAgentIds(retained);
       }
     }
@@ -783,7 +844,7 @@ function startFlushRound(): FlushRound | null {
       if (pendingChanges.size > 0 && pendingStageId) schedulePendingSave();
     }
   })();
-  const round = { dirtySnapshot, promise: run };
+  const round = { stageId, dirtySnapshot, promise: run };
   flushInFlight = round;
   return round;
 }

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -799,79 +799,92 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
   loadFromStorage: async (stageId: string, loadToken?: StageSceneLoadToken) => {
     try {
       const token = loadToken ?? claimStageSceneLoadToken();
-      // Skip IndexedDB load if the store already has this stage with scenes
-      // (e.g. navigated from generation-preview with fresh in-memory data)
+      // Deletion handling keys on stage IDENTITY alone, deliberately BEFORE
+      // any scene-count shortcut: a warm ghost of a deleted classroom with
+      // zero scenes (a scene-less stage whose cascade failed after removing
+      // the document, so the eviction never ran) is still a ghost. Skipping
+      // the settlement handling for it would leave the ghost in the store
+      // after the cold load finds nothing, and the classroom loader's
+      // server-fallback gate (`!getCurrentStage()`) would then never restore
+      // the route — the same silently-uneditable trap as the scened case.
       const currentState = get();
-      if (currentState.stage?.id === stageId && currentState.scenes.length > 0) {
+      if (currentState.stage?.id === stageId) {
         if (!isStageDeleted(stageId)) {
-          log.info('Stage already loaded in memory, skipping IndexedDB load:', stageId);
-          return;
-        }
-        // While the deletion cascade is still unsettled, neither branch can
-        // be taken yet: on failure the warm state (plus the pending dirt the
-        // failure path restores) is the only copy of the pre-delete edits and
-        // must be KEPT, while on success the ghost must be discarded for a
-        // cold reload. Completing the load NOW would expose the classroom
-        // inside that window — edits would be refused by markPendingChanges
-        // without being in the deletion's pre-start snapshot (silently lost
-        // if the delete then fails), and on success the settlement eviction
-        // would blank an already-completed route with nothing left to
-        // trigger a reload. So park until the outcome is known, then branch.
-        // No deadlock: this load holds no document lock while parked, and
-        // the cascade never waits on a load to settle.
-        if (isStageDeletionInFlight(stageId)) {
-          log.info('Warm stage is mid-deletion; waiting for the cascade to settle:', stageId);
-          await stageDeletionSettled(stageId);
-          // Settlement can resolve long after the user navigated elsewhere;
-          // the usual token discipline keeps this parked load from touching
-          // the store the newer navigation now owns. (The success-path
-          // eviction deliberately does NOT claim a token, so it cannot trip
-          // this guard — see clearStoreForDeletedStage.)
-          if (!isCurrentStageSceneLoadToken(token)) {
-            log.info('Newer stage load started during deletion settlement, skipping:', stageId);
+          // Skip the IndexedDB load if the store already has this stage with
+          // scenes (e.g. navigated from generation-preview with fresh
+          // in-memory data). A zero-scene warm copy is not worth keeping:
+          // fall through to the cold load, which simply re-reads the document.
+          if (currentState.scenes.length > 0) {
+            log.info('Stage already loaded in memory, skipping IndexedDB load:', stageId);
             return;
           }
-          if (!isStageDeleted(stageId)) {
-            // The deletion failed before removing the document and lifted the
-            // flag: the warm state IS the live classroom again (the failure
-            // path re-queued the discarded dirt before settling) — keep it.
-            // Mirror of the success-path identity guard below: a tokenless
-            // store writer (applyClassroomStageAndScenes via a database
-            // import) can replace the stage during the park without claiming
-            // the load token, and then there is no warm state of THIS stage
-            // left to keep — fall through to the cold load instead of
-            // reporting a classroom the store no longer holds as live.
-            if (get().stage?.id === stageId) {
-              log.info('Deletion failed; keeping warm stage state:', stageId);
+        } else {
+          // While the deletion cascade is still unsettled, neither branch can
+          // be taken yet: on failure the warm state (plus the pending dirt the
+          // failure path restores) is the only copy of the pre-delete edits and
+          // must be KEPT, while on success the ghost must be discarded for a
+          // cold reload. Completing the load NOW would expose the classroom
+          // inside that window — edits would be refused by markPendingChanges
+          // without being in the deletion's pre-start snapshot (silently lost
+          // if the delete then fails), and on success the settlement eviction
+          // would blank an already-completed route with nothing left to
+          // trigger a reload. So park until the outcome is known, then branch.
+          // No deadlock: this load holds no document lock while parked, and
+          // the cascade never waits on a load to settle.
+          if (isStageDeletionInFlight(stageId)) {
+            log.info('Warm stage is mid-deletion; waiting for the cascade to settle:', stageId);
+            await stageDeletionSettled(stageId);
+            // Settlement can resolve long after the user navigated elsewhere;
+            // the usual token discipline keeps this parked load from touching
+            // the store the newer navigation now owns. (The success-path
+            // eviction deliberately does NOT claim a token, so it cannot trip
+            // this guard — see clearStoreForDeletedStage.)
+            if (!isCurrentStageSceneLoadToken(token)) {
+              log.info('Newer stage load started during deletion settlement, skipping:', stageId);
               return;
             }
-            log.info(
-              'Deletion failed but the store no longer holds the parked stage; reloading:',
-              stageId,
-            );
+            if (!isStageDeleted(stageId)) {
+              // The deletion failed before removing the document and lifted the
+              // flag: the warm state IS the live classroom again (the failure
+              // path re-queued the discarded dirt before settling) — keep it.
+              // Mirror of the success-path identity guard below: a tokenless
+              // store writer (applyClassroomStageAndScenes via a database
+              // import) can replace the stage during the park without claiming
+              // the load token, and then there is no warm state of THIS stage
+              // left to keep — fall through to the cold load instead of
+              // reporting a classroom the store no longer holds as live.
+              if (get().stage?.id === stageId) {
+                log.info('Deletion failed; keeping warm stage state:', stageId);
+                return;
+              }
+              log.info(
+                'Deletion failed but the store no longer holds the parked stage; reloading:',
+                stageId,
+              );
+            }
+            // Deletion succeeded: the settlement eviction has cleared the warm
+            // ghost (it runs synchronously before this microtask resumes).
+            // Fall through to the settled-deleted handling below and run the
+            // full cold load so the server-restore path can recover the route.
           }
-          // Deletion succeeded: the settlement eviction has cleared the warm
-          // ghost (it runs synchronously before this microtask resumes).
-          // Fall through to the settled-deleted handling below and run the
-          // full cold load so the server-restore path can recover the route.
-        }
-        // The warm copy is a ghost of a DELETED classroom whose deletion has
-        // SETTLED with the document removed (deletion evicts the store, but a
-        // partially failed cascade — or any future caller — can leave one).
-        // Short-circuiting here would starve the restore path: the classroom
-        // loader's server-fallback gate checks `getCurrentStage()`, so a warm
-        // ghost renders a fully editable classroom whose every edit is
-        // silently dropped. Discard the ghost (without claiming a new load
-        // token — the caller's token must stay current) and fall through to a
-        // full load, which finds no local data and lets the server-restore
-        // path run and lift the deletion. (Skipped when a failed deletion
-        // lifted the flag above: the document still exists, so the cold load
-        // below simply re-reads it.)
-        if (isStageDeleted(stageId)) {
-          log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
-          if (get().stage?.id === stageId) {
-            resetPendingChanges();
-            set((s) => clearedStageState(s));
+          // The warm copy is a ghost of a DELETED classroom whose deletion has
+          // SETTLED with the document removed (deletion evicts the store, but a
+          // partially failed cascade — or any future caller — can leave one).
+          // Short-circuiting here would starve the restore path: the classroom
+          // loader's server-fallback gate checks `getCurrentStage()`, so a warm
+          // ghost renders a fully editable classroom whose every edit is
+          // silently dropped. Discard the ghost (without claiming a new load
+          // token — the caller's token must stay current) and fall through to a
+          // full load, which finds no local data and lets the server-restore
+          // path run and lift the deletion. (Skipped when a failed deletion
+          // lifted the flag above: the document still exists, so the cold load
+          // below simply re-reads it.)
+          if (isStageDeleted(stageId)) {
+            log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
+            if (get().stage?.id === stageId) {
+              resetPendingChanges();
+              set((s) => clearedStageState(s));
+            }
           }
         }
       }

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -118,6 +118,11 @@ export function discardPendingStageChanges(stageId: string): void {
  * deletion is marked, so a deletion that fails while the document still
  * exists can hand the snapshot back to `restorePendingStageChanges` — without
  * it, the pre-delete edits would silently live only in memory.
+ *
+ * A direct aggregate save (`saveToStorage`) in flight at this moment is
+ * invisible here — it runs outside the pending map and the flush round.
+ * `restorePendingStageChanges` closes that gap by re-marking the full
+ * aggregate on top of this snapshot.
  */
 export function snapshotPendingStageChangesForDeletion(stageId: string): PendingChange[] {
   const byKey = new Map<string, PendingChange>();
@@ -135,17 +140,26 @@ export function snapshotPendingStageChangesForDeletion(stageId: string): Pending
 }
 
 /**
- * Re-mark the changes a failed deletion discarded, so they reach durability
- * again through the normal scheduler. Only meaningful after the deleted flag
- * was lifted; no-ops when the store has since moved to another stage (the
- * departing-stage snapshot owns that world).
+ * Recovery path for a deletion that failed before removing the document:
+ * put the discarded persistence work back on the retry path so it reaches
+ * durability again through the normal scheduler. Only meaningful after the
+ * deleted flag was lifted; no-ops when the store has since moved to another
+ * stage (the departing-stage snapshot owns that world).
  *
- * Scope: this restores the dirt captured BEFORE the deletion started (queued
- * + in-flight). Edits attempted DURING the deletion window were refused by
- * `markPendingChanges` while the deletion was in effect and are not part of
- * the snapshot — they stay memory-only until the same key is edited again
- * (deletion is driven from the home page, so such edits are not reachable in
- * the normal flow).
+ * The recovery set is the snapshot descriptors UNION a full re-mark of the
+ * aggregate. The snapshot only sees scheduler-tracked dirt — the pending map
+ * plus an in-flight flush round's descriptors. Direct aggregate saves
+ * (`saveToStorage`: generation completion, server-restore hydration) are
+ * tracked in neither: when the deletion epoch fences one mid-flight, its
+ * content survives only in memory with no descriptor anywhere to restore,
+ * and without a re-mark a later reload would lose it. Re-marking every
+ * logical unit of the aggregate is the one recovery that cannot miss such
+ * content: the next flush recaptures the CURRENT store state under the
+ * CURRENT epoch, and that state necessarily contains whatever the fenced
+ * aggregate save carried. The same recapture also covers edits attempted
+ * DURING the deletion window (refused by `markPendingChanges`, hence in no
+ * snapshot) — they, too, live in the current store state. Cost: one full
+ * re-persist after a failed deletion, a rare path priced for correctness.
  *
  * Epoch note: the failed delete bumped the stage's deletion epoch, so every
  * write captured before it is permanently stale. Restoring here is still
@@ -158,9 +172,17 @@ export function restorePendingStageChanges(
   stageId: string,
   changes: readonly PendingChange[],
 ): void {
-  if (changes.length === 0) return;
-  if (useStageStore.getState().stage?.id !== stageId) return;
-  markPendingChanges(stageId, ...changes);
+  const state = useStageStore.getState();
+  if (state.stage?.id !== stageId) return;
+  const fullAggregateRemark: PendingChange[] = [
+    { kind: 'structure' },
+    { kind: 'stage' },
+    { kind: 'outline' },
+    { kind: 'currentScene' },
+    { kind: 'chats' },
+    ...state.scenes.map((scene): PendingChange => ({ kind: 'scene', sceneId: scene.id })),
+  ];
+  markPendingChanges(stageId, ...changes, ...fullAggregateRemark);
 }
 
 /** The empty store shape shared by every reset path (epoch bump included). */
@@ -825,10 +847,11 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
           // must be KEPT, while on success the ghost must be discarded for a
           // cold reload. Completing the load NOW would expose the classroom
           // inside that window — edits would be refused by markPendingChanges
-          // without being in the deletion's pre-start snapshot (silently lost
-          // if the delete then fails), and on success the settlement eviction
-          // would blank an already-completed route with nothing left to
-          // trigger a reload. So park until the outcome is known, then branch.
+          // (recovered only via the failure path's full-aggregate re-mark; on
+          // success they are wiped with the eviction), and on success the
+          // settlement eviction would blank an already-completed route with
+          // nothing left to trigger a reload. So park until the outcome is
+          // known, then branch.
           // No deadlock: this load holds no document lock while parked, and
           // the cascade never waits on a load to settle.
           if (isStageDeletionInFlight(stageId)) {

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -21,7 +21,7 @@ import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/doc
 import { hydratePBLScenesFromRuntime } from '@/lib/pbl/v2/runtime/hydration';
 import type { ChatStorageSnapshot } from '@/lib/utils/chat-storage';
 import type { PendingChange } from '@/lib/utils/stage-storage';
-import { isStageDeleted } from '@/lib/utils/deleted-stages';
+import { isStageDeleted, isStageWriteStale, stageDeletionEpoch } from '@/lib/utils/deleted-stages';
 
 const log = createLogger('StageStore');
 
@@ -93,12 +93,13 @@ export function markStagePersistenceDirty(changes: PendingChange[]): void {
 
 /**
  * Drop any pending persistence work for a deleted stage. Called by the stage
- * deletion path (which registers the stage's tombstone first — see
- * `lib/utils/deleted-stages.ts`) so a mutation still sitting in the debounce
- * window cannot flush after the delete and resurrect the removed document.
- * Work already outside the pending map — an in-flight flush round's snapshot
- * and the departing-stage snapshot held by `setStage` — is fenced by the
- * tombstone checks in `persistDirtySnapshot` and the storage layer instead.
+ * deletion path (which marks the deletion first, bumping the stage's deletion
+ * epoch — see `lib/utils/deleted-stages.ts`) so a mutation still sitting in
+ * the debounce window cannot flush after the delete and resurrect the removed
+ * document. Work already outside the pending map — an in-flight flush round's
+ * snapshot and the departing-stage snapshot held by `setStage` — is fenced by
+ * the deletion-epoch checks in `persistDirtySnapshot` and the storage layer
+ * instead.
  */
 export function discardPendingStageChanges(stageId: string): void {
   if (pendingStageId === stageId) resetPendingChanges();
@@ -107,8 +108,8 @@ export function discardPendingStageChanges(stageId: string): void {
 /**
  * Snapshot the logical changes a deletion is about to throw away: everything
  * still queued for the stage plus the in-flight flush round's dirt (whose
- * write the tombstone will drop). Taken by the deletion path BEFORE the
- * tombstone is registered, so a deletion that fails while the document still
+ * write the deletion fence will drop). Taken by the deletion path BEFORE the
+ * deletion is marked, so a deletion that fails while the document still
  * exists can hand the snapshot back to `restorePendingStageChanges` — without
  * it, the pre-delete edits would silently live only in memory.
  */
@@ -129,9 +130,23 @@ export function snapshotPendingStageChangesForDeletion(stageId: string): Pending
 
 /**
  * Re-mark the changes a failed deletion discarded, so they reach durability
- * again through the normal scheduler. Only meaningful after the tombstone was
- * lifted; no-ops when the store has since moved to another stage (the
+ * again through the normal scheduler. Only meaningful after the deleted flag
+ * was lifted; no-ops when the store has since moved to another stage (the
  * departing-stage snapshot owns that world).
+ *
+ * Scope: this restores the dirt captured BEFORE the deletion started (queued
+ * + in-flight). Edits attempted DURING the deletion window were refused by
+ * `markPendingChanges` while the deletion was in effect and are not part of
+ * the snapshot — they stay memory-only until the same key is edited again
+ * (deletion is driven from the home page, so such edits are not reachable in
+ * the normal flow).
+ *
+ * Epoch note: the failed delete bumped the stage's deletion epoch, so every
+ * write captured before it is permanently stale. Restoring here is still
+ * safe: this function re-queues change DESCRIPTORS — the next flush round
+ * captures a fresh snapshot of the CURRENT store state under the CURRENT
+ * epoch. It never replays the pre-delete data capture, so the restored dirt
+ * cannot be dropped as epoch-stale.
  */
 export function restorePendingStageChanges(
   stageId: string,
@@ -140,6 +155,19 @@ export function restorePendingStageChanges(
   if (changes.length === 0) return;
   if (useStageStore.getState().stage?.id !== stageId) return;
   markPendingChanges(stageId, ...changes);
+}
+
+/**
+ * Evict a deleted stage from the in-memory store. Called by the deletion path
+ * after the cascade succeeds: a warm store would otherwise keep rendering the
+ * deleted classroom from memory — `loadFromStorage` short-circuits on it, the
+ * server-restore path never runs, and every edit is silently dropped (the
+ * back-button-to-a-deleted-classroom trap). No-ops when the store has since
+ * moved to another stage.
+ */
+export function clearStoreForDeletedStage(stageId: string): void {
+  if (useStageStore.getState().stage?.id !== stageId) return;
+  useStageStore.getState().clearStore();
 }
 
 export function claimStageSceneLoadToken(): StageSceneLoadToken {
@@ -274,12 +302,16 @@ async function persistDirtySnapshot(
   stageId: string,
   dirtySnapshot: ReadonlyMap<string, PendingEntry>,
   snapshot: StagePersistenceSnapshot,
+  capturedEpoch: number,
 ): Promise<Set<string>> {
   if (!snapshot.stage) return new Set();
-  // A deleted stage's dirt is dropped, not retried: this covers snapshots that
-  // escaped `discardPendingStageChanges` because they already left the pending
-  // map (an in-flight flush round, or the departing-stage retry in setStage).
-  if (isStageDeleted(stageId)) return new Set();
+  // A stale capture is dropped, not retried: this covers snapshots that
+  // escaped `discardPendingStageChanges` because they already left the
+  // pending map (an in-flight flush round, or the departing-stage retry in
+  // setStage). `capturedEpoch` is the deletion epoch recorded when `snapshot`
+  // was taken; a deletion after that moment permanently invalidates this
+  // write, even if a same-id restore has since lifted the deleted flag.
+  if (isStageWriteStale(stageId, capturedEpoch)) return new Set();
   stageStorageModulePromise ??= import('@/lib/utils/stage-storage');
   const { saveStageDataIncremental } = await stageStorageModulePromise;
   const result = await saveStageDataIncremental(
@@ -298,6 +330,7 @@ async function persistDirtySnapshot(
         updatedAt: Date.now(),
       },
     },
+    capturedEpoch,
   );
   return new Set((result?.failedChanges ?? []).map(pendingChangeKey));
 }
@@ -331,6 +364,10 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       const departingStageId = departingState.stage.id;
       const departingDirty = new Map(pendingChanges);
       const departingSnapshot = persistenceSnapshot(departingState);
+      // The deletion epoch travels with the snapshot: a deletion during the
+      // retry window permanently invalidates both attempts, even if a
+      // same-id restore lands before the retry fires.
+      const departingEpoch = stageDeletionEpoch(departingStageId);
       /**
        * Navigation is intentionally not a durability barrier. The immutable
        * departing snapshot is attempted immediately, retried once after a
@@ -345,6 +382,7 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
               departingStageId,
               departingDirty,
               departingSnapshot,
+              departingEpoch,
             );
             if (lastFailedKeys.size === 0) return;
           } catch (error) {
@@ -624,23 +662,30 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       return false;
     }
 
+    // Epoch captured with the state read above: a deletion during the PBL
+    // preparation await below permanently invalidates this write.
+    const capturedEpoch = stageDeletionEpoch(stage.id);
     const pendingAtStart = new Map(pendingChanges);
     try {
       const persistedScenes = await preparePBLScenesForDocumentPersistence(stage.id, scenes);
       const { saveStageData } = await import('@/lib/utils/stage-storage');
-      const result = await saveStageData(stage.id, {
-        stage,
-        scenes: persistedScenes,
-        currentSceneId,
-        chats,
-        chatSnapshot,
-        outline: {
-          outlines,
-          generationComplete,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
+      const result = await saveStageData(
+        stage.id,
+        {
+          stage,
+          scenes: persistedScenes,
+          currentSceneId,
+          chats,
+          chatSnapshot,
+          outline: {
+            outlines,
+            generationComplete,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
         },
-      });
+        capturedEpoch,
+      );
 
       const failedKeys = new Set((result?.failedChanges ?? []).map(pendingChangeKey));
       if (
@@ -687,8 +732,35 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
       // (e.g. navigated from generation-preview with fresh in-memory data)
       const currentState = get();
       if (currentState.stage?.id === stageId && currentState.scenes.length > 0) {
-        log.info('Stage already loaded in memory, skipping IndexedDB load:', stageId);
-        return;
+        if (!isStageDeleted(stageId)) {
+          log.info('Stage already loaded in memory, skipping IndexedDB load:', stageId);
+          return;
+        }
+        // The warm copy is a ghost of a DELETED classroom (deletion evicts
+        // the store, but a partially failed cascade — or any future caller —
+        // can leave one). Short-circuiting here would starve the restore
+        // path: the classroom loader's server-fallback gate checks
+        // `getCurrentStage()`, so a warm ghost renders a fully editable
+        // classroom whose every edit is silently dropped. Discard the ghost
+        // (without claiming a new load token — the caller's token must stay
+        // current) and fall through to a full load, which finds no local
+        // data and lets the server-restore path run and lift the deletion.
+        log.info('Warm stage is deleted; discarding ghost and reloading:', stageId);
+        resetPendingChanges();
+        set((s) => ({
+          stage: null,
+          scenes: [],
+          currentSceneId: null,
+          chats: [],
+          chatSnapshot: { sessions: [], restoreMarker: null },
+          outlines: [],
+          generationComplete: false,
+          generationEpoch: s.generationEpoch + 1,
+          generationStatus: 'idle' as const,
+          currentGeneratingOrder: -1,
+          failedOutlines: [],
+          generatingOutlines: [],
+        }));
       }
 
       const { loadStageData } = await import('@/lib/utils/stage-storage');
@@ -809,10 +881,18 @@ function startFlushRound(): FlushRound | null {
     return null;
   }
   const snapshot = persistenceSnapshot(state);
+  // Capture the deletion epoch WITH the data snapshot: the pair is what the
+  // storage layer validates immediately before each write.
+  const capturedEpoch = stageDeletionEpoch(stageId);
 
   const run = (async () => {
     try {
-      const failedKeys = await persistDirtySnapshot(stageId, dirtySnapshot, snapshot);
+      const failedKeys = await persistDirtySnapshot(
+        stageId,
+        dirtySnapshot,
+        snapshot,
+        capturedEpoch,
+      );
       if (pendingStageId === stageId) {
         for (const [key, entry] of dirtySnapshot) {
           if (!failedKeys.has(key) && pendingChanges.get(key)?.revision === entry.revision) {

--- a/lib/store/stage.ts
+++ b/lib/store/stage.ts
@@ -21,6 +21,7 @@ import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/doc
 import { hydratePBLScenesFromRuntime } from '@/lib/pbl/v2/runtime/hydration';
 import type { ChatStorageSnapshot } from '@/lib/utils/chat-storage';
 import type { PendingChange } from '@/lib/utils/stage-storage';
+import { isStageDeleted } from '@/lib/utils/deleted-stages';
 
 const log = createLogger('StageStore');
 
@@ -72,7 +73,7 @@ function schedulePendingSave(): void {
 }
 
 function markPendingChanges(stageId: string | undefined, ...changes: PendingChange[]): void {
-  if (!stageId) return;
+  if (!stageId || isStageDeleted(stageId)) return;
   if (pendingStageId !== stageId) resetPendingChanges(stageId);
   for (const change of changes) {
     pendingRevision += 1;
@@ -91,8 +92,12 @@ export function markStagePersistenceDirty(changes: PendingChange[]): void {
 
 /**
  * Drop any pending persistence work for a deleted stage. Called by the stage
- * deletion path so a mutation still sitting in the debounce window cannot
- * flush after the delete and resurrect the removed document.
+ * deletion path (which registers the stage's tombstone first — see
+ * `lib/utils/deleted-stages.ts`) so a mutation still sitting in the debounce
+ * window cannot flush after the delete and resurrect the removed document.
+ * Work already outside the pending map — an in-flight flush round's snapshot
+ * and the departing-stage snapshot held by `setStage` — is fenced by the
+ * tombstone checks in `persistDirtySnapshot` and the storage layer instead.
  */
 export function discardPendingStageChanges(stageId: string): void {
   if (pendingStageId === stageId) resetPendingChanges();
@@ -232,6 +237,10 @@ async function persistDirtySnapshot(
   snapshot: StagePersistenceSnapshot,
 ): Promise<Set<string>> {
   if (!snapshot.stage) return new Set();
+  // A deleted stage's dirt is dropped, not retried: this covers snapshots that
+  // escaped `discardPendingStageChanges` because they already left the pending
+  // map (an in-flight flush round, or the departing-stage retry in setStage).
+  if (isStageDeleted(stageId)) return new Set();
   stageStorageModulePromise ??= import('@/lib/utils/stage-storage');
   const { saveStageDataIncremental } = await stageStorageModulePromise;
   const result = await saveStageDataIncremental(
@@ -470,7 +479,23 @@ const useStageStoreBase = create<StageState>()((set, get) => ({
     // and selection updates below are synchronous in-memory mirrors only.
     markPendingChanges(stage.id, { kind: 'stage' });
     applyGeneratedAgentsToRegistry(stage.id, configs);
-    useSettingsStore.getState().setSelectedAgentIds(configs.map((a) => a.id));
+    // Selection mirror honors provenance (same semantics as
+    // restoreAgentSelection): a stage-derived selection tracks the roster
+    // wholesale, but a user's explicit choice is only narrowed — agents that
+    // left the roster are dropped, newcomers are never auto-selected, and
+    // `agentSelectionIsUserSet` is left untouched either way. A user-set
+    // preset selection references non-generated agents only, so a roster edit
+    // does not concern it.
+    const settings = useSettingsStore.getState();
+    if (!settings.agentSelectionIsUserSet) {
+      settings.setSelectedAgentIds(configs.map((a) => a.id));
+    } else if (settings.agentMode === 'auto') {
+      const rosterIds = new Set(configs.map((a) => a.id));
+      const retained = settings.selectedAgentIds.filter((id) => rosterIds.has(id));
+      if (retained.length !== settings.selectedAgentIds.length) {
+        settings.setSelectedAgentIds(retained);
+      }
+    }
   },
 
   setGeneratingOutlines: (generatingOutlines) => set({ generatingOutlines }),

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -182,7 +182,12 @@ export interface MediaFileRecord {
 }
 
 /**
- * GeneratedAgent table - AI-generated agent profiles
+ * GeneratedAgent table - AI-generated agent profiles.
+ *
+ * LEGACY, read-only. The roster now persists on the stage document
+ * (`stage.generatedAgentConfigs`); this table has no remaining writers and is
+ * kept only as a lazy-migration source for classrooms whose roster (or voice
+ * fields) predate the document-embedded model. Do not add new writers.
  */
 export interface GeneratedAgentRecord {
   id: string; // PK: agent ID (e.g. "gen-abc123")

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -692,21 +692,30 @@ export async function importDatabase(
           .sort((a, b) => a.order - b.order),
       };
     });
-  const importedDocuments: Array<{ id: string; preImage: AppDocument | null }> = [];
+  const importedDocuments: Array<{
+    id: string;
+    preImage: AppDocument | null;
+    wasDeleted: boolean;
+  }> = [];
   const importedCurrentScenes: Array<{ key: string; preImage: unknown | null }> = [];
   const kv = new BrowserKVStore();
+  const { isStageDeleted, markStageDeleted, unmarkStageDeleted } = await import('./deleted-stages');
 
   try {
     for (const document of documents) {
+      // Record the pre-import deletion state alongside the document pre-image:
+      // a failed import rolls the document back, so it must roll this back too.
+      const wasDeleted = isStageDeleted(document.stage.id);
       await mutateDocument(document.stage.id, async (_existing, store) => {
         const preImage = (await store.loadDocument(document.stage.id)) as AppDocument | null;
         await store.saveDocument(document);
-        importedDocuments.push({ id: document.stage.id, preImage });
+        importedDocuments.push({ id: document.stage.id, preImage, wasDeleted });
       });
       // Explicit document (re)creation: a backup may restore a stage deleted
-      // earlier this session under the same id. Lift the deletion tombstone so
-      // later edits of the restored document persist instead of being dropped.
-      const { unmarkStageDeleted } = await import('./deleted-stages');
+      // earlier this session under the same id. Lift the deleted flag so later
+      // edits of the restored document persist instead of being dropped. (The
+      // deletion epoch stays bumped, so pre-delete in-flight writes remain
+      // fenced off the restored document.)
       unmarkStageDeleted(document.stage.id);
     }
     for (const legacyStage of data.stages ?? []) {
@@ -814,12 +823,21 @@ export async function importDatabase(
         log.error(`Failed to roll back imported current-scene key ${key}:`, rollbackError);
       }
     }
-    for (const { id, preImage } of importedDocuments.reverse()) {
+    for (const { id, preImage, wasDeleted } of importedDocuments.reverse()) {
       try {
         await mutateDocument(id, async (_document, store) => {
           if (preImage) await store.saveDocument(preImage);
           else await store.deleteDocument(id);
         });
+        // The rollback reinstated the pre-import world; reinstate the deletion
+        // state the import lifted, or the rolled-back (absent) document would
+        // stay writable and an outstanding flush could recreate it. Re-marking
+        // bumps the epoch again — consistent either way, since every pre-import
+        // capture is already stale. Deliberately skipped when the rollback
+        // write itself failed above: the imported document then still exists,
+        // and re-marking would silently drop edits to a document that is
+        // present (the exact bug the lift exists to prevent).
+        if (wasDeleted) markStageDeleted(id);
       } catch (rollbackError) {
         log.error(`Failed to roll back imported document ${id}:`, rollbackError);
       }

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -184,10 +184,13 @@ export interface MediaFileRecord {
 /**
  * GeneratedAgent table - AI-generated agent profiles.
  *
- * LEGACY, read-only. The roster now persists on the stage document
- * (`stage.generatedAgentConfigs`); this table has no remaining writers and is
- * kept only as a lazy-migration source for classrooms whose roster (or voice
- * fields) predate the document-embedded model. Do not add new writers.
+ * LEGACY. The roster now persists on the stage document
+ * (`stage.generatedAgentConfigs`); this table is kept only as a lazy-migration
+ * source for classrooms whose roster (or voice fields) predate the
+ * document-embedded model. Production access is migration reads plus deletion
+ * hygiene: `deleteStageData` clears a deleted stage's rows (as does the
+ * deprecated `deleteStageWithRelatedData` cascade). Nothing writes new rows;
+ * do not add writers.
  */
 export interface GeneratedAgentRecord {
   id: string; // PK: agent ID (e.g. "gen-abc123")

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -703,6 +703,11 @@ export async function importDatabase(
         await store.saveDocument(document);
         importedDocuments.push({ id: document.stage.id, preImage });
       });
+      // Explicit document (re)creation: a backup may restore a stage deleted
+      // earlier this session under the same id. Lift the deletion tombstone so
+      // later edits of the restored document persist instead of being dropped.
+      const { unmarkStageDeleted } = await import('./deleted-stages');
+      unmarkStageDeleted(document.stage.id);
     }
     for (const legacyStage of data.stages ?? []) {
       if (legacyStage.currentSceneId !== undefined) {

--- a/lib/utils/deleted-stages.ts
+++ b/lib/utils/deleted-stages.ts
@@ -60,6 +60,14 @@ interface StageDeletionState {
   epoch: number;
   /** True while a deletion is in effect (until an explicit restore lifts it). */
   deleted: boolean;
+  /**
+   * True while a deletion cascade is running whose outcome is not yet known.
+   * While it holds, the deleted flag alone must not be read as "the document
+   * is gone": the cascade can still fail before removing the document, in
+   * which case the flag is lifted and the warm store state (plus restored
+   * pending dirt) is the user's only copy of the pre-delete edits.
+   */
+  cascadeInFlight: boolean;
 }
 
 const stageDeletionStates = new Map<string, StageDeletionState>();
@@ -71,7 +79,45 @@ const stageDeletionStates = new Map<string, StageDeletionState>();
  */
 export function markStageDeleted(stageId: string): void {
   const state = stageDeletionStates.get(stageId);
-  stageDeletionStates.set(stageId, { epoch: (state?.epoch ?? 0) + 1, deleted: true });
+  stageDeletionStates.set(stageId, {
+    epoch: (state?.epoch ?? 0) + 1,
+    deleted: true,
+    // Not a settlement event: an import-rollback re-mark records a document
+    // whose absence is already a settled fact, so it must not flip this bit.
+    cascadeInFlight: state?.cascadeInFlight ?? false,
+  });
+}
+
+/**
+ * Record that a deletion cascade for `stageId` has started and its outcome —
+ * document removed, or deletion failed before removal — is not yet known.
+ * Called by `deleteStageData` immediately after `markStageDeleted`; no other
+ * mark point starts a cascade.
+ */
+export function beginStageDeletionCascade(stageId: string): void {
+  const state = stageDeletionStates.get(stageId);
+  if (state) state.cascadeInFlight = true;
+}
+
+/**
+ * The cascade's outcome is now known: either the document was confirmed
+ * removed (deleted flag kept) or the deletion failed before removing it
+ * (flag lifted). Read-side consumers may act on the deleted flag again.
+ */
+export function settleStageDeletionCascade(stageId: string): void {
+  const state = stageDeletionStates.get(stageId);
+  if (state) state.cascadeInFlight = false;
+}
+
+/**
+ * True while a deletion cascade for `stageId` is running and unsettled. The
+ * warm-ghost discard in `loadFromStorage` must keep warm state (and any
+ * restorable pending dirt) until the deletion settles — discarding early
+ * would lose the only copy of pre-delete edits if the cascade then fails
+ * before removing the document.
+ */
+export function isStageDeletionInFlight(stageId: string): boolean {
+  return stageDeletionStates.get(stageId)?.cascadeInFlight ?? false;
 }
 
 /**

--- a/lib/utils/deleted-stages.ts
+++ b/lib/utils/deleted-stages.ts
@@ -1,0 +1,39 @@
+/**
+ * Session-scoped tombstones for deleted stages.
+ *
+ * Stage deletion races the debounced persistence pipeline: a flush round that
+ * already captured its dirty snapshot, or the departing-stage snapshot taken
+ * on navigation (which retries after a short delay), can outlive
+ * `discardPendingStageChanges` and — because the incremental save falls back
+ * to a full document write when the destination is missing — recreate a
+ * document the user just deleted.
+ *
+ * The deletion path registers the stage id here BEFORE removing anything, and
+ * every persistence landing point (scheduled flush, departing-stage retry,
+ * aggregate and incremental saves, including their full-save fallbacks)
+ * consults the set and drops the write instead of resurrecting the document.
+ *
+ * In-memory only, on purpose: stage ids are freshly minted nanoids, so a
+ * deleted id is never legitimately reused, and after a reload there is no
+ * surviving in-flight work to fence off.
+ */
+
+const deletedStageIds = new Set<string>();
+
+/** Register a stage as deleted. Call before the deletion cascade starts. */
+export function markStageDeleted(stageId: string): void {
+  deletedStageIds.add(stageId);
+}
+
+/**
+ * Lift a tombstone again. Only for a deletion that failed before the document
+ * was removed — the stage still exists, so later edits must persist normally.
+ */
+export function unmarkStageDeleted(stageId: string): void {
+  deletedStageIds.delete(stageId);
+}
+
+/** True when the stage was deleted this session; persistence must drop writes. */
+export function isStageDeleted(stageId: string): boolean {
+  return deletedStageIds.has(stageId);
+}

--- a/lib/utils/deleted-stages.ts
+++ b/lib/utils/deleted-stages.ts
@@ -13,9 +13,20 @@
  * aggregate and incremental saves, including their full-save fallbacks)
  * consults the set and drops the write instead of resurrecting the document.
  *
- * In-memory only, on purpose: stage ids are freshly minted nanoids, so a
- * deleted id is never legitimately reused, and after a reload there is no
- * surviving in-flight work to fence off.
+ * In-memory only, on purpose: newly created stages mint fresh nanoids, so a
+ * deleted id never collides with a NEW document, and after a reload this tab
+ * has no surviving in-flight work to fence off. A deleted id CAN legitimately
+ * come back, though — deletion only removes client-side data, so the server
+ * copy restored by the classroom loader, or a backup restore, may recreate the
+ * same document. Every such explicit (re)creation path must lift the tombstone
+ * via `unmarkStageDeleted` (see `applyClassroomStageAndScenes` and
+ * `importDatabase`); an in-flight flush must never lift it — dropping exactly
+ * those writes is the tombstone's job.
+ *
+ * Known limit: the set is per-tab. A sibling tab editing the same stage keeps
+ * its own scheduler and never sees this tab's tombstone, so its flushes can
+ * still recreate the document — deletion vs. live editing in another tab is a
+ * cross-tab invalidation problem outside this fence's scope.
  */
 
 const deletedStageIds = new Set<string>();
@@ -26,8 +37,11 @@ export function markStageDeleted(stageId: string): void {
 }
 
 /**
- * Lift a tombstone again. Only for a deletion that failed before the document
- * was removed — the stage still exists, so later edits must persist normally.
+ * Lift a tombstone again. Only for explicit document existence changes: a
+ * deletion that failed before the document was removed, or a deliberate
+ * (re)creation of the same id (server-copy restore, backup import) — in both
+ * cases the stage exists again, so later edits must persist normally. Never
+ * call this from a persistence flush path.
  */
 export function unmarkStageDeleted(stageId: string): void {
   deletedStageIds.delete(stageId);

--- a/lib/utils/deleted-stages.ts
+++ b/lib/utils/deleted-stages.ts
@@ -1,5 +1,5 @@
 /**
- * Session-scoped tombstones for deleted stages.
+ * Session-scoped deletion generations ("epochs") for deleted stages.
  *
  * Stage deletion races the debounced persistence pipeline: a flush round that
  * already captured its dirty snapshot, or the departing-stage snapshot taken
@@ -8,46 +8,109 @@
  * to a full document write when the destination is missing — recreate a
  * document the user just deleted.
  *
- * The deletion path registers the stage id here BEFORE removing anything, and
- * every persistence landing point (scheduled flush, departing-stage retry,
- * aggregate and incremental saves, including their full-save fallbacks)
- * consults the set and drops the write instead of resurrecting the document.
+ * A plain boolean tombstone cannot express the full lifecycle, because a
+ * deleted id can legitimately come back: deletion only removes client-side
+ * data, so the server copy restored by the classroom loader, or a backup
+ * import, may recreate the SAME document id. Once such a restore lifts a
+ * boolean tombstone, a pre-delete write still in flight becomes
+ * indistinguishable from a post-restore edit and can overwrite the restored
+ * document with pre-delete content.
+ *
+ * The epoch model separates the two concerns:
+ *
+ * - `stageDeletionEpoch(id)` is a monotonic per-stage generation counter
+ *   (0 = never deleted). Every deletion bumps it; nothing ever rewinds it.
+ * - `isStageDeleted(id)` is the "deletion currently in effect" flag. Explicit
+ *   document (re)creation points clear it via `unmarkStageDeleted` — the
+ *   epoch stays bumped.
+ *
+ * Write protocol: every persistence path captures `stageDeletionEpoch(id)` at
+ * the moment it captures the data it intends to write (flush-round snapshot,
+ * departing-stage snapshot, aggregate save entry), and re-checks
+ * `isStageWriteStale(id, capturedEpoch)` immediately before each actual write.
+ * A write is dropped when the stage is currently deleted OR its captured epoch
+ * is no longer current. Invariants:
+ *
+ * 1. A write captured before a deletion can never land after it — not even
+ *    when a same-id restore has lifted the deleted flag — because the
+ *    deletion bumped the epoch and the captured epoch is permanently stale.
+ * 2. A write capturing data after a restore observes the current epoch and
+ *    persists normally.
+ * 3. A deletion that fails before the document was removed lifts only the
+ *    deleted flag; the bumped epoch stays. Restored pending changes are
+ *    re-queued as change descriptors, so their eventual flush captures a
+ *    fresh snapshot of the CURRENT store state under the CURRENT epoch —
+ *    nothing replays a stale capture.
  *
  * In-memory only, on purpose: newly created stages mint fresh nanoids, so a
  * deleted id never collides with a NEW document, and after a reload this tab
- * has no surviving in-flight work to fence off. A deleted id CAN legitimately
- * come back, though — deletion only removes client-side data, so the server
- * copy restored by the classroom loader, or a backup restore, may recreate the
- * same document. Every such explicit (re)creation path must lift the tombstone
- * via `unmarkStageDeleted` (see `applyClassroomStageAndScenes` and
- * `importDatabase`); an in-flight flush must never lift it — dropping exactly
- * those writes is the tombstone's job.
+ * has no surviving in-flight work to fence off. Explicit (re)creation paths
+ * lift the deleted flag via `unmarkStageDeleted` (see
+ * `applyClassroomStageAndScenes` and `importDatabase`); an in-flight flush
+ * must never lift it — dropping exactly those writes is the fence's job.
  *
- * Known limit: the set is per-tab. A sibling tab editing the same stage keeps
- * its own scheduler and never sees this tab's tombstone, so its flushes can
- * still recreate the document — deletion vs. live editing in another tab is a
- * cross-tab invalidation problem outside this fence's scope.
+ * Known limit: the state is per-tab. A sibling tab editing the same stage
+ * keeps its own scheduler and never sees this tab's deletion state, so its
+ * flushes can still recreate the document — deletion vs. live editing in
+ * another tab is a cross-tab invalidation problem outside this fence's scope.
  */
 
-const deletedStageIds = new Set<string>();
+interface StageDeletionState {
+  /** Monotonic deletion generation; bumped by every markStageDeleted. */
+  epoch: number;
+  /** True while a deletion is in effect (until an explicit restore lifts it). */
+  deleted: boolean;
+}
 
-/** Register a stage as deleted. Call before the deletion cascade starts. */
+const stageDeletionStates = new Map<string, StageDeletionState>();
+
+/**
+ * Register a stage as deleted. Call before the deletion cascade starts.
+ * Bumps the stage's deletion epoch, permanently invalidating every write
+ * whose data was captured before this call.
+ */
 export function markStageDeleted(stageId: string): void {
-  deletedStageIds.add(stageId);
+  const state = stageDeletionStates.get(stageId);
+  stageDeletionStates.set(stageId, { epoch: (state?.epoch ?? 0) + 1, deleted: true });
 }
 
 /**
- * Lift a tombstone again. Only for explicit document existence changes: a
- * deletion that failed before the document was removed, or a deliberate
+ * Lift the deleted flag again. Only for explicit document existence changes:
+ * a deletion that failed before the document was removed, or a deliberate
  * (re)creation of the same id (server-copy restore, backup import) — in both
  * cases the stage exists again, so later edits must persist normally. Never
  * call this from a persistence flush path.
+ *
+ * The deletion epoch is deliberately NOT rewound: writes captured before the
+ * deletion stay permanently stale, so an in-flight pre-delete flush cannot
+ * masquerade as an edit of the restored document.
  */
 export function unmarkStageDeleted(stageId: string): void {
-  deletedStageIds.delete(stageId);
+  const state = stageDeletionStates.get(stageId);
+  if (state) state.deleted = false;
 }
 
-/** True when the stage was deleted this session; persistence must drop writes. */
+/** True while a deletion is in effect this session; persistence must drop writes. */
 export function isStageDeleted(stageId: string): boolean {
-  return deletedStageIds.has(stageId);
+  return stageDeletionStates.get(stageId)?.deleted ?? false;
+}
+
+/**
+ * The stage's current deletion generation (0 = never deleted this session).
+ * Persistence paths capture this together with the data they intend to write.
+ */
+export function stageDeletionEpoch(stageId: string): number {
+  return stageDeletionStates.get(stageId)?.epoch ?? 0;
+}
+
+/**
+ * True when a write whose data was captured under `capturedEpoch` must be
+ * dropped: the stage is currently deleted, or a deletion happened after the
+ * capture (epoch mismatch — stale even if a restore has since lifted the
+ * deleted flag). Check immediately before each actual write.
+ */
+export function isStageWriteStale(stageId: string, capturedEpoch: number): boolean {
+  const state = stageDeletionStates.get(stageId);
+  if (!state) return capturedEpoch !== 0;
+  return state.deleted || state.epoch !== capturedEpoch;
 }

--- a/lib/utils/deleted-stages.ts
+++ b/lib/utils/deleted-stages.ts
@@ -61,16 +61,30 @@ interface StageDeletionState {
   /** True while a deletion is in effect (until an explicit restore lifts it). */
   deleted: boolean;
   /**
-   * True while a deletion cascade is running whose outcome is not yet known.
-   * While it holds, the deleted flag alone must not be read as "the document
-   * is gone": the cascade can still fail before removing the document, in
-   * which case the flag is lifted and the warm store state (plus restored
-   * pending dirt) is the user's only copy of the pre-delete edits.
+   * Number of deletion cascades currently running whose outcome is not yet
+   * known. While it is positive, the deleted flag alone must not be read as
+   * "the document is gone": a cascade can still fail before removing the
+   * document, in which case the flag is lifted and the warm store state (plus
+   * restored pending dirt) is the user's only copy of the pre-delete edits.
+   *
+   * A counter, not a boolean: `deleteStageData` single-flights concurrent
+   * deletions of the same stage, but this module must not depend on that —
+   * with overlapping begin/settle pairs the stage stays in flight until the
+   * LAST cascade settles, instead of the first settle clearing a bit while
+   * another cascade is still undecided.
    */
-  cascadeInFlight: boolean;
+  unsettledCascades: number;
 }
 
 const stageDeletionStates = new Map<string, StageDeletionState>();
+
+/**
+ * Per-stage settlement promise for the currently in-flight cascade(s).
+ * Created when the first cascade begins, resolved (and dropped) when the last
+ * one settles, so read-side waiters can `await` the outcome instead of
+ * polling `isStageDeletionInFlight`.
+ */
+const cascadeSettlements = new Map<string, { promise: Promise<void>; resolve: () => void }>();
 
 /**
  * Register a stage as deleted. Call before the deletion cascade starts.
@@ -83,8 +97,8 @@ export function markStageDeleted(stageId: string): void {
     epoch: (state?.epoch ?? 0) + 1,
     deleted: true,
     // Not a settlement event: an import-rollback re-mark records a document
-    // whose absence is already a settled fact, so it must not flip this bit.
-    cascadeInFlight: state?.cascadeInFlight ?? false,
+    // whose absence is already a settled fact, so it must not touch the count.
+    unsettledCascades: state?.unsettledCascades ?? 0,
   });
 }
 
@@ -96,28 +110,58 @@ export function markStageDeleted(stageId: string): void {
  */
 export function beginStageDeletionCascade(stageId: string): void {
   const state = stageDeletionStates.get(stageId);
-  if (state) state.cascadeInFlight = true;
+  if (!state) return;
+  state.unsettledCascades += 1;
+  if (!cascadeSettlements.has(stageId)) {
+    let resolve!: () => void;
+    const promise = new Promise<void>((res) => {
+      resolve = res;
+    });
+    cascadeSettlements.set(stageId, { promise, resolve });
+  }
 }
 
 /**
- * The cascade's outcome is now known: either the document was confirmed
+ * A cascade's outcome is now known: either the document was confirmed
  * removed (deleted flag kept) or the deletion failed before removing it
- * (flag lifted). Read-side consumers may act on the deleted flag again.
+ * (flag lifted). Once the LAST overlapping cascade settles, read-side
+ * consumers may act on the deleted flag again and every settlement waiter is
+ * released. Extra settles (no matching begin) are no-ops — the count never
+ * underflows into a phantom cascade.
  */
 export function settleStageDeletionCascade(stageId: string): void {
   const state = stageDeletionStates.get(stageId);
-  if (state) state.cascadeInFlight = false;
+  if (!state || state.unsettledCascades === 0) return;
+  state.unsettledCascades -= 1;
+  if (state.unsettledCascades === 0) {
+    const settlement = cascadeSettlements.get(stageId);
+    cascadeSettlements.delete(stageId);
+    settlement?.resolve();
+  }
 }
 
 /**
  * True while a deletion cascade for `stageId` is running and unsettled. The
- * warm-ghost discard in `loadFromStorage` must keep warm state (and any
+ * deleted-warm branch in `loadFromStorage` must keep the warm state (and any
  * restorable pending dirt) until the deletion settles — discarding early
  * would lose the only copy of pre-delete edits if the cascade then fails
  * before removing the document.
  */
 export function isStageDeletionInFlight(stageId: string): boolean {
-  return stageDeletionStates.get(stageId)?.cascadeInFlight ?? false;
+  return (stageDeletionStates.get(stageId)?.unsettledCascades ?? 0) > 0;
+}
+
+/**
+ * Resolves when every currently in-flight deletion cascade for `stageId` has
+ * settled (already-resolved when none is in flight). Read-side consumers that
+ * cannot proceed until the outcome is known — the deleted-warm branch in
+ * `loadFromStorage` — await this instead of completing early. Never rejects:
+ * a failed cascade still settles (its `finally` runs after the failure path
+ * lifted the flag / restored dirt), so waiters observe the post-outcome flag
+ * state, not the error.
+ */
+export function stageDeletionSettled(stageId: string): Promise<void> {
+  return cascadeSettlements.get(stageId)?.promise ?? Promise.resolve();
 }
 
 /**

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -328,6 +328,11 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
  * Delete stage and all related data
  */
 export async function deleteStageData(stageId: string): Promise<void> {
+  // Drop any queued persistence work for this stage first: a mutation still in
+  // the debounce window must not flush after the delete and resurrect the
+  // document. Dynamic import avoids a static module cycle with the store.
+  const { discardPendingStageChanges } = await import('@/lib/store/stage');
+  discardPendingStageChanges(stageId);
   // storageSharedLockHeld: the cascade below holds the EXCLUSIVE epoch, which
   // subsumes the shared one — the generation-guarded store must not re-acquire
   // shared inside it (self-deadlock against our own exclusive hold).

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -153,18 +153,24 @@ export async function saveStageData(
     await mutateDocument(
       stageId,
       async (existing, store) => {
-        // Re-check under the lock: a deletion that started while this save was
-        // waiting must win — writing now would resurrect the deleted document.
+        // Re-check inside the mutation: a deletion that started while this
+        // save was waiting must win. With Web Locks this runs under the
+        // per-stage document lock; without them the callback is lock-free
+        // best-effort LWW, so additional re-checks sit immediately before
+        // each write below to shrink the check-then-act window.
         if (isStageDeleted(stageId)) return;
         // Lock order: per-stage document lock, then the global runtime epoch.
         // Maintenance may wait for this save, but this save never waits on a
         // document lock while already occupying the shared epoch.
         await withRuntimeStorageSharedLock(async () => {
           const existingOutline = existing?.outline as AppDocumentOutline | undefined;
+          if (isStageDeleted(stageId)) return;
           await store.saveDocument(documentSnapshot(stageId, data, existingOutline, now));
+          if (isStageDeleted(stageId)) return;
           await saveCurrentScene(stageId, data.currentSceneId);
 
           // Chat sessions live in the learner RuntimeStore, outside the document DB.
+          if (isStageDeleted(stageId)) return;
           if (data.chats && !(await saveStageChats(stageId, data, true))) {
             failedChanges.push({ kind: 'chats' });
           }
@@ -215,9 +221,12 @@ export async function saveStageDataIncremental(
     await mutateDocument(
       stageId,
       async (existing, store) => {
-        // Re-check under the lock: `existing === undefined` after a deletion
-        // must not be mistaken for a legacy destination — the full-save
-        // fallback below would otherwise rebuild the deleted document whole.
+        // Re-check inside the mutation: `existing === undefined` after a
+        // deletion must not be mistaken for a legacy destination — the
+        // full-save fallback below would otherwise rebuild the deleted
+        // document whole. With Web Locks this runs under the per-stage
+        // document lock; without them the callback is lock-free best-effort
+        // LWW, so each write below re-checks immediately before landing.
         if (isStageDeleted(stageId)) return;
         await withRuntimeStorageSharedLock(async () => {
           const now = Date.now();
@@ -227,6 +236,8 @@ export async function saveStageDataIncremental(
               stageId,
               data.scenes,
             );
+            // Preparation awaited: last re-check immediately before the write.
+            if (isStageDeleted(stageId)) return;
             await store.saveDocument(
               documentSnapshot(
                 stageId,
@@ -258,10 +269,14 @@ export async function saveStageDataIncremental(
               );
               for (const scene of persistedScenes) {
                 const index = data.scenes.findIndex((candidate) => candidate.id === scene.id);
+                // Preparation and prior iterations awaited: re-check before
+                // each row write (lock-free environments have no lock to win).
+                if (isStageDeleted(stageId)) return;
                 await store.putScene(stageId, stampScene(stageId, scene, index, now));
               }
             }
             if (has('stage')) {
+              if (isStageDeleted(stageId)) return;
               await store.putStage(stageId, stampStage(stageId, data.stage, now));
             }
           } catch (error) {
@@ -279,6 +294,15 @@ export async function saveStageDataIncremental(
     );
   }
 
+  // Tail writes live outside the document mutation. A delete that won the
+  // race above (dropping the document write) must also fence the
+  // currentScene KV row and the chat sessions, or this same flush would
+  // resurrect rows the deletion cascade just cleared — mirroring the
+  // aggregate path, which keeps both inside the guarded callback.
+  if (isStageDeleted(stageId)) {
+    log.info(`Dropping incremental save tail for deleted stage: ${stageId}`);
+    return { failedChanges: [] };
+  }
   if (has('currentScene')) await saveCurrentScene(stageId, data.currentSceneId);
   const failedChanges: PendingChange[] = [];
   if (has('chats') && !(await saveStageChats(stageId, data))) {
@@ -345,15 +369,25 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
  * Delete stage and all related data
  */
 export async function deleteStageData(stageId: string): Promise<void> {
-  // Tombstone first: every persistence landing point checks it, so even a
+  // Dynamic import avoids a static module cycle with the store.
+  const {
+    discardPendingStageChanges,
+    restorePendingStageChanges,
+    snapshotPendingStageChangesForDeletion,
+  } = await import('@/lib/store/stage');
+  // Snapshot the dirt this deletion is about to discard (queued + in-flight)
+  // BEFORE the tombstone exists, so a deletion that fails while the document
+  // still exists can put the edits back on the retry path instead of leaving
+  // them silently non-durable in memory.
+  const discardedChanges = snapshotPendingStageChangesForDeletion(stageId);
+  // Tombstone next: every persistence landing point checks it, so even a
   // flush round that already captured its dirty snapshot (or the
   // departing-stage retry) drops its write instead of resurrecting the
   // document after this delete.
   markStageDeleted(stageId);
   // Then drop any still-queued persistence work for this stage: a mutation
   // sitting in the debounce window must not even start a flush after the
-  // delete. Dynamic import avoids a static module cycle with the store.
-  const { discardPendingStageChanges } = await import('@/lib/store/stage');
+  // delete.
   discardPendingStageChanges(stageId);
   let documentDeleted = false;
   try {
@@ -443,10 +477,15 @@ export async function deleteStageData(stageId: string): Promise<void> {
     );
   } catch (error) {
     // If the deletion failed before the document was removed, the stage still
-    // exists — lift the tombstone so subsequent edits persist normally. Once
-    // the document is gone, the tombstone stays even on a partial cascade
-    // failure: dropping later writes is exactly what prevents resurrection.
-    if (!documentDeleted) unmarkStageDeleted(stageId);
+    // exists — lift the tombstone so subsequent edits persist normally, and
+    // put the discarded dirt back on the retry path (it was only dropped to
+    // prevent a resurrection that now cannot happen). Once the document is
+    // gone, the tombstone stays even on a partial cascade failure: dropping
+    // later writes is exactly what prevents resurrection.
+    if (!documentDeleted) {
+      unmarkStageDeleted(stageId);
+      restorePendingStageChanges(stageId, discardedChanges);
+    }
     throw error;
   }
 }

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -144,10 +144,14 @@ async function saveStageChats(
 
 /**
  * A save that was dropped by the deletion-epoch fence. Distinguishable from
- * every success shape on purpose: nothing (or at most a prefix of the writes,
- * which the deletion cascade removes) was persisted, so callers must not
- * perform success bookkeeping — no snapshot rebinding, no pending clearing,
- * no durability claims.
+ * every success shape on purpose: nothing durable survives — at most some of
+ * the writes landed before the fence tripped, and those are removed by the
+ * deletion cascade or ignored by the load path (a tail `saveCurrentScene` can
+ * land after the cascade's `clearCurrentScene`, but the orphaned cursor row
+ * is never exposed: `loadStageData` bails before reading it while the
+ * document is missing, and validates it against the document's scenes once
+ * one exists again). Callers must not perform success bookkeeping — no
+ * snapshot rebinding, no pending clearing, no durability claims.
  */
 export type StaleDroppedSave = 'stale-dropped';
 
@@ -446,9 +450,29 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
 }
 
 /**
- * Delete stage and all related data
+ * In-flight deletions, keyed by stage id. `deleteStageData` is single-flight
+ * per stage: a concurrent second call joins the first cascade instead of
+ * starting an overlapping one, so begin/settle pairs for one stage never
+ * interleave and a settling cascade cannot expose another one's keep-window
+ * (the warm-ghost retention in `loadFromStorage`) as already settled.
  */
-export async function deleteStageData(stageId: string): Promise<void> {
+const inFlightStageDeletions = new Map<string, Promise<void>>();
+
+/**
+ * Delete stage and all related data. Single-flight per stage: concurrent
+ * calls for the same id share one cascade (and its outcome).
+ */
+export function deleteStageData(stageId: string): Promise<void> {
+  const existing = inFlightStageDeletions.get(stageId);
+  if (existing) return existing;
+  const run = performStageDeletion(stageId).finally(() => {
+    inFlightStageDeletions.delete(stageId);
+  });
+  inFlightStageDeletions.set(stageId, run);
+  return run;
+}
+
+async function performStageDeletion(stageId: string): Promise<void> {
   // Dynamic import avoids a static module cycle with the store.
   const {
     clearStoreForDeletedStage,
@@ -472,9 +496,12 @@ export async function deleteStageData(stageId: string): Promise<void> {
   // deleted flag.
   markStageDeleted(stageId);
   // The cascade's outcome is unknown until it settles. Read-side consumers
-  // (the warm-ghost discard in loadFromStorage) must not treat the deleted
+  // (the deleted-warm branch in loadFromStorage) must not treat the deleted
   // flag as "document gone" while this holds — a failure before document
-  // removal lifts the flag and hands the pending dirt back.
+  // removal lifts the flag and hands the pending dirt back — so they await
+  // stageDeletionSettled instead. That wait cannot deadlock against this
+  // cascade: the cascade never waits on a load, and a parked load holds no
+  // document lock while awaiting settlement.
   beginStageDeletionCascade(stageId);
   // Then drop any still-queued persistence work for this stage: a mutation
   // sitting in the debounce window must not even start a flush after the
@@ -595,6 +622,13 @@ export async function deleteStageData(stageId: string): Promise<void> {
   // because this module already owns the deletion cascade's store-side
   // bookkeeping through the same dynamic-import seam, so every caller of
   // deleteStageData gets the invariant, not just the home page.
+  //
+  // Ordering with settlement waiters: the settle above releases any load
+  // parked in loadFromStorage's mid-deletion branch, but that waiter resumes
+  // as a microtask — this synchronous eviction runs first. The eviction
+  // deliberately keeps the current load token (see clearStoreForDeletedStage)
+  // so that resumed load stays current and performs the cold reload that
+  // hands the emptied route to the server-restore path.
   clearStoreForDeletedStage(stageId);
 }
 

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -37,7 +37,12 @@ import {
 } from './chat-storage-lock';
 import { DocumentVersionError } from '@openmaic/storage';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
-import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from './deleted-stages';
+import {
+  isStageWriteStale,
+  markStageDeleted,
+  stageDeletionEpoch,
+  unmarkStageDeleted,
+} from './deleted-stages';
 
 const log = createLogger('StageStorage');
 
@@ -137,14 +142,22 @@ async function saveStageChats(
 }
 
 /**
- * Save stage data to IndexedDB
+ * Save stage data to IndexedDB.
+ *
+ * `capturedEpoch` is the stage's deletion epoch at the moment `data` was
+ * captured (defaults to entry time for callers whose data is current at call
+ * time). Every write below is fenced by `isStageWriteStale`: it drops when a
+ * deletion is in effect OR a deletion happened after the capture — a
+ * pre-delete snapshot stays fenced even after a same-id restore lifts the
+ * deleted flag, because the restore never rewinds the epoch.
  */
 export async function saveStageData(
   stageId: string,
   data: StageStoreData,
+  capturedEpoch: number = stageDeletionEpoch(stageId),
 ): Promise<{ failedChanges: PendingChange[] } | undefined> {
-  if (isStageDeleted(stageId)) {
-    log.info(`Dropping save for deleted stage: ${stageId}`);
+  if (isStageWriteStale(stageId, capturedEpoch)) {
+    log.info(`Dropping save for deleted/stale stage: ${stageId}`);
     return undefined;
   }
   try {
@@ -158,19 +171,19 @@ export async function saveStageData(
         // per-stage document lock; without them the callback is lock-free
         // best-effort LWW, so additional re-checks sit immediately before
         // each write below to shrink the check-then-act window.
-        if (isStageDeleted(stageId)) return;
+        if (isStageWriteStale(stageId, capturedEpoch)) return;
         // Lock order: per-stage document lock, then the global runtime epoch.
         // Maintenance may wait for this save, but this save never waits on a
         // document lock while already occupying the shared epoch.
         await withRuntimeStorageSharedLock(async () => {
           const existingOutline = existing?.outline as AppDocumentOutline | undefined;
-          if (isStageDeleted(stageId)) return;
+          if (isStageWriteStale(stageId, capturedEpoch)) return;
           await store.saveDocument(documentSnapshot(stageId, data, existingOutline, now));
-          if (isStageDeleted(stageId)) return;
+          if (isStageWriteStale(stageId, capturedEpoch)) return;
           await saveCurrentScene(stageId, data.currentSceneId);
 
           // Chat sessions live in the learner RuntimeStore, outside the document DB.
-          if (isStageDeleted(stageId)) return;
+          if (isStageWriteStale(stageId, capturedEpoch)) return;
           if (data.chats && !(await saveStageChats(stageId, data, true))) {
             failedChanges.push({ kind: 'chats' });
           }
@@ -195,9 +208,13 @@ export async function saveStageDataIncremental(
   stageId: string,
   dirty: readonly PendingChange[],
   data: StageStoreData,
+  capturedEpoch: number = stageDeletionEpoch(stageId),
 ): Promise<{ failedChanges: PendingChange[] }> {
-  if (isStageDeleted(stageId)) {
-    log.info(`Dropping incremental save for deleted stage: ${stageId}`);
+  // `capturedEpoch` = the deletion epoch when `data` was captured (the flush
+  // round / departing-stage snapshot). See saveStageData for the fencing
+  // contract; a stale capture is dropped even after a same-id restore.
+  if (isStageWriteStale(stageId, capturedEpoch)) {
+    log.info(`Dropping incremental save for deleted/stale stage: ${stageId}`);
     return { failedChanges: [] };
   }
   const has = (kind: PendingChange['kind']) => dirty.some((change) => change.kind === kind);
@@ -227,17 +244,19 @@ export async function saveStageDataIncremental(
         // document whole. With Web Locks this runs under the per-stage
         // document lock; without them the callback is lock-free best-effort
         // LWW, so each write below re-checks immediately before landing.
-        if (isStageDeleted(stageId)) return;
+        // Epoch staleness also covers the delete→restore straddle: a round
+        // captured pre-delete stays fenced after the restore lifts the flag.
+        if (isStageWriteStale(stageId, capturedEpoch)) return;
         await withRuntimeStorageSharedLock(async () => {
           const now = Date.now();
           const fullSave = async () => {
-            if (isStageDeleted(stageId)) return;
+            if (isStageWriteStale(stageId, capturedEpoch)) return;
             const persistedScenes = await preparePBLScenesForDocumentPersistence(
               stageId,
               data.scenes,
             );
             // Preparation awaited: last re-check immediately before the write.
-            if (isStageDeleted(stageId)) return;
+            if (isStageWriteStale(stageId, capturedEpoch)) return;
             await store.saveDocument(
               documentSnapshot(
                 stageId,
@@ -271,12 +290,12 @@ export async function saveStageDataIncremental(
                 const index = data.scenes.findIndex((candidate) => candidate.id === scene.id);
                 // Preparation and prior iterations awaited: re-check before
                 // each row write (lock-free environments have no lock to win).
-                if (isStageDeleted(stageId)) return;
+                if (isStageWriteStale(stageId, capturedEpoch)) return;
                 await store.putScene(stageId, stampScene(stageId, scene, index, now));
               }
             }
             if (has('stage')) {
-              if (isStageDeleted(stageId)) return;
+              if (isStageWriteStale(stageId, capturedEpoch)) return;
               await store.putStage(stageId, stampStage(stageId, data.stage, now));
             }
           } catch (error) {
@@ -298,12 +317,19 @@ export async function saveStageDataIncremental(
   // race above (dropping the document write) must also fence the
   // currentScene KV row and the chat sessions, or this same flush would
   // resurrect rows the deletion cascade just cleared — mirroring the
-  // aggregate path, which keeps both inside the guarded callback.
-  if (isStageDeleted(stageId)) {
-    log.info(`Dropping incremental save tail for deleted stage: ${stageId}`);
+  // aggregate path, which keeps both inside the guarded callback. Each tail
+  // write re-checks independently: a delete can land while the previous tail
+  // write is awaiting (there is no lock spanning the tail).
+  if (isStageWriteStale(stageId, capturedEpoch)) {
+    log.info(`Dropping incremental save tail for deleted/stale stage: ${stageId}`);
     return { failedChanges: [] };
   }
   if (has('currentScene')) await saveCurrentScene(stageId, data.currentSceneId);
+  // `saveCurrentScene` awaited: re-check immediately before the chat write.
+  if (isStageWriteStale(stageId, capturedEpoch)) {
+    log.info(`Dropping incremental chat tail for deleted/stale stage: ${stageId}`);
+    return { failedChanges: [] };
+  }
   const failedChanges: PendingChange[] = [];
   if (has('chats') && !(await saveStageChats(stageId, data))) {
     failedChanges.push({ kind: 'chats' });
@@ -371,19 +397,25 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
 export async function deleteStageData(stageId: string): Promise<void> {
   // Dynamic import avoids a static module cycle with the store.
   const {
+    clearStoreForDeletedStage,
     discardPendingStageChanges,
     restorePendingStageChanges,
     snapshotPendingStageChangesForDeletion,
   } = await import('@/lib/store/stage');
   // Snapshot the dirt this deletion is about to discard (queued + in-flight)
-  // BEFORE the tombstone exists, so a deletion that fails while the document
-  // still exists can put the edits back on the retry path instead of leaving
-  // them silently non-durable in memory.
+  // BEFORE the deletion is marked, so a deletion that fails while the
+  // document still exists can put those PRE-DELETE edits back on the retry
+  // path instead of leaving them silently non-durable in memory. Scope: only
+  // dirt captured before this point is restorable — edits attempted DURING
+  // the deletion window are refused by markPendingChanges and are not in the
+  // snapshot (deletion is driven from the home page, where the deleted stage
+  // is not being edited).
   const discardedChanges = snapshotPendingStageChangesForDeletion(stageId);
-  // Tombstone next: every persistence landing point checks it, so even a
-  // flush round that already captured its dirty snapshot (or the
-  // departing-stage retry) drops its write instead of resurrecting the
-  // document after this delete.
+  // Mark the deletion next: this bumps the stage's deletion epoch, so every
+  // persistence landing point drops writes captured before this moment —
+  // even a flush round that already holds its dirty snapshot (or the
+  // departing-stage retry), and even if a same-id restore later lifts the
+  // deleted flag.
   markStageDeleted(stageId);
   // Then drop any still-queued persistence work for this stage: a mutation
   // sitting in the debounce window must not even start a flush after the
@@ -477,17 +509,29 @@ export async function deleteStageData(stageId: string): Promise<void> {
     );
   } catch (error) {
     // If the deletion failed before the document was removed, the stage still
-    // exists — lift the tombstone so subsequent edits persist normally, and
-    // put the discarded dirt back on the retry path (it was only dropped to
-    // prevent a resurrection that now cannot happen). Once the document is
-    // gone, the tombstone stays even on a partial cascade failure: dropping
-    // later writes is exactly what prevents resurrection.
+    // exists — lift the deleted flag so subsequent edits persist normally,
+    // and put the discarded dirt back on the retry path (it was only dropped
+    // to prevent a resurrection that now cannot happen). The deletion epoch
+    // stays bumped, which is safe for the restored dirt: restore re-QUEUES
+    // change descriptors, so the eventual flush captures a fresh snapshot of
+    // the CURRENT store state under the CURRENT epoch — it does not replay
+    // the pre-delete capture, so nothing it writes can be epoch-stale. Once
+    // the document is gone, the deleted flag stays even on a partial cascade
+    // failure: dropping later writes is exactly what prevents resurrection.
     if (!documentDeleted) {
       unmarkStageDeleted(stageId);
       restorePendingStageChanges(stageId, discardedChanges);
     }
     throw error;
   }
+  // Success: evict the deleted classroom from the in-memory store. A warm
+  // store would otherwise keep rendering the deleted classroom from memory —
+  // loadFromStorage short-circuits on it, the server-restore path never runs,
+  // and every edit is silently dropped. Done here (not at the UI call site)
+  // because this module already owns the deletion cascade's store-side
+  // bookkeeping through the same dynamic-import seam, so every caller of
+  // deleteStageData gets the invariant, not just the home page.
+  clearStoreForDeletedStage(stageId);
 }
 
 /**

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -39,6 +39,7 @@ import { DocumentVersionError } from '@openmaic/storage';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
 import {
   beginStageDeletionCascade,
+  isStageDeleted,
   isStageWriteStale,
   markStageDeleted,
   settleStageDeletionCascade,
@@ -461,8 +462,38 @@ const inFlightStageDeletions = new Map<string, Promise<void>>();
 /**
  * Delete stage and all related data. Single-flight per stage: concurrent
  * calls for the same id share one cascade (and its outcome).
+ *
+ * A joined call carries its own deletion intent, not just an interest in the
+ * first cascade's outcome. If a same-id restore (server copy, backup import)
+ * recreates the document while the first cascade runs, that cascade's success
+ * describes the PRE-restore document — reporting it as-is would tell the
+ * joined caller "deleted" while the restored document survives. So when the
+ * first cascade fulfills but the stage is no longer marked deleted at join
+ * resolution, one fresh cascade runs for the restored document and the joined
+ * caller reports THAT outcome. Exactly one re-check per call, not a loop: if
+ * yet another restore lands inside the re-run's own window, the re-run's
+ * outcome is returned as-is — every later delete is a new `deleteStageData`
+ * call with its own re-check, so repeated restore/delete races converge on
+ * fresh calls instead of recursing here. A REJECTED first cascade propagates
+ * unchanged to every joined caller even though failure also leaves the stage
+ * unmarked: failure already reports "nothing was deleted" truthfully (and the
+ * pending-dirt restore has run), and re-running would turn an error report
+ * into a hidden retry.
  */
 export function deleteStageData(stageId: string): Promise<void> {
+  const existing = inFlightStageDeletions.get(stageId);
+  if (!existing) return runSingleFlightStageDeletion(stageId);
+  return existing.then(() => {
+    if (isStageDeleted(stageId)) return;
+    // Restored mid-cascade: the joined intent targets the restored document.
+    // If several joined callers re-check in the same resolution turn, the
+    // first re-run's map entry is already visible to the rest, so they join
+    // it below rather than fanning out into parallel cascades.
+    return runSingleFlightStageDeletion(stageId);
+  });
+}
+
+function runSingleFlightStageDeletion(stageId: string): Promise<void> {
   const existing = inFlightStageDeletions.get(stageId);
   if (existing) return existing;
   const run = performStageDeletion(stageId).finally(() => {

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -514,11 +514,12 @@ async function performStageDeletion(stageId: string): Promise<void> {
   // Snapshot the dirt this deletion is about to discard (queued + in-flight)
   // BEFORE the deletion is marked, so a deletion that fails while the
   // document still exists can put those PRE-DELETE edits back on the retry
-  // path instead of leaving them silently non-durable in memory. Scope: only
-  // dirt captured before this point is restorable — edits attempted DURING
-  // the deletion window are refused by markPendingChanges and are not in the
-  // snapshot (deletion is driven from the home page, where the deleted stage
-  // is not being edited).
+  // path instead of leaving them silently non-durable in memory. The
+  // snapshot covers scheduler-tracked dirt only; content that never had a
+  // descriptor — a direct aggregate save (`saveToStorage`) the epoch fence
+  // drops mid-flight, or edits refused during the deletion window — is
+  // recovered by the restore's full-aggregate re-mark instead (see
+  // restorePendingStageChanges).
   const discardedChanges = snapshotPendingStageChangesForDeletion(stageId);
   // Mark the deletion next: this bumps the stage's deletion epoch, so every
   // persistence landing point drops writes captured before this moment —
@@ -628,7 +629,11 @@ async function performStageDeletion(stageId: string): Promise<void> {
     // If the deletion failed before the document was removed, the stage still
     // exists — lift the deleted flag so subsequent edits persist normally,
     // and put the discarded dirt back on the retry path (it was only dropped
-    // to prevent a resurrection that now cannot happen). The deletion epoch
+    // to prevent a resurrection that now cannot happen). The restore also
+    // re-marks the FULL aggregate: an in-flight direct aggregate save this
+    // deletion fenced has no descriptor in the snapshot, and only a flush
+    // that recaptures the whole current store state can carry its content to
+    // disk. The deletion epoch
     // stays bumped, which is safe for the restored dirt: restore re-QUEUES
     // change descriptors, so the eventual flush captures a fresh snapshot of
     // the CURRENT store state under the CURRENT epoch — it does not replay

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -37,6 +37,7 @@ import {
 } from './chat-storage-lock';
 import { DocumentVersionError } from '@openmaic/storage';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
+import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from './deleted-stages';
 
 const log = createLogger('StageStorage');
 
@@ -142,12 +143,19 @@ export async function saveStageData(
   stageId: string,
   data: StageStoreData,
 ): Promise<{ failedChanges: PendingChange[] } | undefined> {
+  if (isStageDeleted(stageId)) {
+    log.info(`Dropping save for deleted stage: ${stageId}`);
+    return undefined;
+  }
   try {
     const now = Date.now();
     const failedChanges: PendingChange[] = [];
     await mutateDocument(
       stageId,
       async (existing, store) => {
+        // Re-check under the lock: a deletion that started while this save was
+        // waiting must win — writing now would resurrect the deleted document.
+        if (isStageDeleted(stageId)) return;
         // Lock order: per-stage document lock, then the global runtime epoch.
         // Maintenance may wait for this save, but this save never waits on a
         // document lock while already occupying the shared epoch.
@@ -182,6 +190,10 @@ export async function saveStageDataIncremental(
   dirty: readonly PendingChange[],
   data: StageStoreData,
 ): Promise<{ failedChanges: PendingChange[] }> {
+  if (isStageDeleted(stageId)) {
+    log.info(`Dropping incremental save for deleted stage: ${stageId}`);
+    return { failedChanges: [] };
+  }
   const has = (kind: PendingChange['kind']) => dirty.some((change) => change.kind === kind);
   const dirtySceneIds = new Set(
     dirty.flatMap((change) => (change.kind === 'scene' ? [change.sceneId] : [])),
@@ -203,9 +215,14 @@ export async function saveStageDataIncremental(
     await mutateDocument(
       stageId,
       async (existing, store) => {
+        // Re-check under the lock: `existing === undefined` after a deletion
+        // must not be mistaken for a legacy destination — the full-save
+        // fallback below would otherwise rebuild the deleted document whole.
+        if (isStageDeleted(stageId)) return;
         await withRuntimeStorageSharedLock(async () => {
           const now = Date.now();
           const fullSave = async () => {
+            if (isStageDeleted(stageId)) return;
             const persistedScenes = await preparePBLScenesForDocumentPersistence(
               stageId,
               data.scenes,
@@ -328,85 +345,110 @@ export async function loadStageData(stageId: string): Promise<StageStoreData | n
  * Delete stage and all related data
  */
 export async function deleteStageData(stageId: string): Promise<void> {
-  // Drop any queued persistence work for this stage first: a mutation still in
-  // the debounce window must not flush after the delete and resurrect the
-  // document. Dynamic import avoids a static module cycle with the store.
+  // Tombstone first: every persistence landing point checks it, so even a
+  // flush round that already captured its dirty snapshot (or the
+  // departing-stage retry) drops its write instead of resurrecting the
+  // document after this delete.
+  markStageDeleted(stageId);
+  // Then drop any still-queued persistence work for this stage: a mutation
+  // sitting in the debounce window must not even start a flush after the
+  // delete. Dynamic import avoids a static module cycle with the store.
   const { discardPendingStageChanges } = await import('@/lib/store/stage');
   discardPendingStageChanges(stageId);
-  // storageSharedLockHeld: the cascade below holds the EXCLUSIVE epoch, which
-  // subsumes the shared one — the generation-guarded store must not re-acquire
-  // shared inside it (self-deadlock against our own exclusive hold).
-  return mutateDocument(
-    stageId,
-    async (document, store) =>
-      // Lock order: per-stage document lock, then the exclusive runtime epoch.
-      withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
-        try {
-          // Collect scene ids before deletion so we can sweep per-scene localStorage
-          // keys (quiz draft / submitted answers / graded results).
-          const legacyScenes = await db.scenes.where('stageId').equals(stageId).toArray();
-          const sceneIds = [
-            ...new Set([
-              ...(document?.scenes.map((s) => s.id) ?? []),
-              ...legacyScenes.map((s) => s.id),
-            ]),
-          ];
-
-          await store.deleteDocument(stageId);
-
-          // Clear legacy chat rows and the device-scoped playback cursor. Runtime
-          // rows of every kind are removed by the all-kind cascade below.
-          await deleteChatSessions(stageId);
-          // An unmigrated legacy playback row must not outlive its stage.
-          await db.playbackState.delete(stageId);
+  let documentDeleted = false;
+  try {
+    // storageSharedLockHeld: the cascade below holds the EXCLUSIVE epoch, which
+    // subsumes the shared one — the generation-guarded store must not re-acquire
+    // shared inside it (self-deadlock against our own exclusive hold).
+    await mutateDocument(
+      stageId,
+      async (document, store) =>
+        // Lock order: per-stage document lock, then the exclusive runtime epoch.
+        withRuntimeStorageExclusiveLockUntilSettled(async (releaseCaller) => {
           try {
-            await clearCursor(stageId);
+            // Collect scene ids before deletion so we can sweep per-scene localStorage
+            // keys (quiz draft / submitted answers / graded results).
+            const legacyScenes = await db.scenes.where('stageId').equals(stageId).toArray();
+            const sceneIds = [
+              ...new Set([
+                ...(document?.scenes.map((s) => s.id) ?? []),
+                ...legacyScenes.map((s) => s.id),
+              ]),
+            ];
+
+            await store.deleteDocument(stageId);
+            documentDeleted = true;
+
+            // Clear legacy chat rows and the device-scoped playback cursor. Runtime
+            // rows of every kind are removed by the all-kind cascade below.
+            await deleteChatSessions(stageId);
+            // An unmigrated legacy playback row must not outlive its stage.
+            await db.playbackState.delete(stageId);
+            try {
+              await clearCursor(stageId);
+            } catch (error) {
+              log.warn(`Failed to clear playback cursor for stage ${stageId}:`, error);
+            }
+            try {
+              await clearCurrentScene(stageId);
+            } catch (error) {
+              log.warn(`Failed to clear editor current scene for stage ${stageId}:`, error);
+            }
+
+            // Sweep quiz persistence keys for each deleted scene.
+            for (const sceneId of sceneIds) {
+              clearAllForScene(sceneId);
+            }
+
+            // Migration retains legacy rows, but an explicit whole-stage deletion does not.
+            await db.transaction('rw', [db.stages, db.scenes, db.stageOutlines], async () => {
+              await db.stages.delete(stageId);
+              await db.scenes.where('stageId').equals(stageId).delete();
+              await db.stageOutlines.delete(stageId);
+            });
+
+            // Mirror hygiene: the legacy roster mirror is read-only migration
+            // input, but a deleted stage needs no migration source — drop its
+            // rows. Best-effort: a failure here must not abort the deletion.
+            try {
+              await db.generatedAgents.where('stageId').equals(stageId).delete();
+            } catch (error) {
+              log.warn(`Failed to clear legacy agent mirror rows for stage ${stageId}:`, error);
+            }
+
+            // Learner-runtime data lives in a separate IndexedDB database, so it is
+            // cascaded after the Dexie work: it cannot join those transactions, and a
+            // runtime failure must not abort them (the helper warns instead of
+            // throwing).
+            const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
+            await runtimeDeletion.completion;
+            try {
+              await clearStageDrainWatermarks(stageId);
+            } catch (error) {
+              log.warn(`Failed to clear PBL drain watermarks for stage ${stageId}:`, error);
+            }
+
+            log.info(`Deleted stage: ${stageId}`);
+            releaseCaller(undefined);
+            // The public deletion remains bounded, but this callback deliberately
+            // retains the exclusive lock until a late runtime cascade can no longer
+            // delete data written after the caller was released.
+            await runtimeDeletion.settlement;
           } catch (error) {
-            log.warn(`Failed to clear playback cursor for stage ${stageId}:`, error);
+            log.error('Failed to delete stage:', error);
+            throw error;
           }
-          try {
-            await clearCurrentScene(stageId);
-          } catch (error) {
-            log.warn(`Failed to clear editor current scene for stage ${stageId}:`, error);
-          }
-
-          // Sweep quiz persistence keys for each deleted scene.
-          for (const sceneId of sceneIds) {
-            clearAllForScene(sceneId);
-          }
-
-          // Migration retains legacy rows, but an explicit whole-stage deletion does not.
-          await db.transaction('rw', [db.stages, db.scenes, db.stageOutlines], async () => {
-            await db.stages.delete(stageId);
-            await db.scenes.where('stageId').equals(stageId).delete();
-            await db.stageOutlines.delete(stageId);
-          });
-
-          // Learner-runtime data lives in a separate IndexedDB database, so it is
-          // cascaded after the Dexie work: it cannot join those transactions, and a
-          // runtime failure must not abort them (the helper warns instead of
-          // throwing).
-          const runtimeDeletion = beginStageRuntimeDeletionSafely(stageId);
-          await runtimeDeletion.completion;
-          try {
-            await clearStageDrainWatermarks(stageId);
-          } catch (error) {
-            log.warn(`Failed to clear PBL drain watermarks for stage ${stageId}:`, error);
-          }
-
-          log.info(`Deleted stage: ${stageId}`);
-          releaseCaller(undefined);
-          // The public deletion remains bounded, but this callback deliberately
-          // retains the exclusive lock until a late runtime cascade can no longer
-          // delete data written after the caller was released.
-          await runtimeDeletion.settlement;
-        } catch (error) {
-          log.error('Failed to delete stage:', error);
-          throw error;
-        }
-      }),
-    { storageSharedLockHeld: true },
-  );
+        }),
+      { storageSharedLockHeld: true },
+    );
+  } catch (error) {
+    // If the deletion failed before the document was removed, the stage still
+    // exists — lift the tombstone so subsequent edits persist normally. Once
+    // the document is gone, the tombstone stays even on a partial cascade
+    // failure: dropping later writes is exactly what prevents resurrection.
+    if (!documentDeleted) unmarkStageDeleted(stageId);
+    throw error;
+  }
 }
 
 /**

--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -38,9 +38,10 @@ import {
 import { DocumentVersionError } from '@openmaic/storage';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
 import {
+  beginStageDeletionCascade,
   isStageWriteStale,
   markStageDeleted,
-  stageDeletionEpoch,
+  settleStageDeletionCascade,
   unmarkStageDeleted,
 } from './deleted-stages';
 
@@ -142,27 +143,39 @@ async function saveStageChats(
 }
 
 /**
+ * A save that was dropped by the deletion-epoch fence. Distinguishable from
+ * every success shape on purpose: nothing (or at most a prefix of the writes,
+ * which the deletion cascade removes) was persisted, so callers must not
+ * perform success bookkeeping — no snapshot rebinding, no pending clearing,
+ * no durability claims.
+ */
+export type StaleDroppedSave = 'stale-dropped';
+
+/**
  * Save stage data to IndexedDB.
  *
  * `capturedEpoch` is the stage's deletion epoch at the moment `data` was
- * captured (defaults to entry time for callers whose data is current at call
- * time). Every write below is fenced by `isStageWriteStale`: it drops when a
- * deletion is in effect OR a deletion happened after the capture — a
- * pre-delete snapshot stays fenced even after a same-id restore lifts the
- * deleted flag, because the restore never rewinds the epoch.
+ * captured — required, so the type system enforces that the capture point and
+ * the validation point stay paired. Every write below is fenced by
+ * `isStageWriteStale`: it drops when a deletion is in effect OR a deletion
+ * happened after the capture — a pre-delete snapshot stays fenced even after
+ * a same-id restore lifts the deleted flag, because the restore never rewinds
+ * the epoch. A fenced write returns `'stale-dropped'` instead of a success
+ * shape.
  */
 export async function saveStageData(
   stageId: string,
   data: StageStoreData,
-  capturedEpoch: number = stageDeletionEpoch(stageId),
-): Promise<{ failedChanges: PendingChange[] } | undefined> {
+  capturedEpoch: number,
+): Promise<{ failedChanges: PendingChange[] } | StaleDroppedSave | undefined> {
   if (isStageWriteStale(stageId, capturedEpoch)) {
     log.info(`Dropping save for deleted/stale stage: ${stageId}`);
-    return undefined;
+    return 'stale-dropped';
   }
   try {
     const now = Date.now();
     const failedChanges: PendingChange[] = [];
+    let dropped = false;
     await mutateDocument(
       stageId,
       async (existing, store) => {
@@ -171,19 +184,31 @@ export async function saveStageData(
         // per-stage document lock; without them the callback is lock-free
         // best-effort LWW, so additional re-checks sit immediately before
         // each write below to shrink the check-then-act window.
-        if (isStageWriteStale(stageId, capturedEpoch)) return;
+        if (isStageWriteStale(stageId, capturedEpoch)) {
+          dropped = true;
+          return;
+        }
         // Lock order: per-stage document lock, then the global runtime epoch.
         // Maintenance may wait for this save, but this save never waits on a
         // document lock while already occupying the shared epoch.
         await withRuntimeStorageSharedLock(async () => {
           const existingOutline = existing?.outline as AppDocumentOutline | undefined;
-          if (isStageWriteStale(stageId, capturedEpoch)) return;
+          if (isStageWriteStale(stageId, capturedEpoch)) {
+            dropped = true;
+            return;
+          }
           await store.saveDocument(documentSnapshot(stageId, data, existingOutline, now));
-          if (isStageWriteStale(stageId, capturedEpoch)) return;
+          if (isStageWriteStale(stageId, capturedEpoch)) {
+            dropped = true;
+            return;
+          }
           await saveCurrentScene(stageId, data.currentSceneId);
 
           // Chat sessions live in the learner RuntimeStore, outside the document DB.
-          if (isStageWriteStale(stageId, capturedEpoch)) return;
+          if (isStageWriteStale(stageId, capturedEpoch)) {
+            dropped = true;
+            return;
+          }
           if (data.chats && !(await saveStageChats(stageId, data, true))) {
             failedChanges.push({ kind: 'chats' });
           }
@@ -191,6 +216,10 @@ export async function saveStageData(
       },
       { storageSharedLockHeld: true },
     );
+    if (dropped) {
+      log.info(`Dropped save mid-write for deleted/stale stage: ${stageId}`);
+      return 'stale-dropped';
+    }
     log.info(`Saved stage: ${stageId}`);
     return failedChanges.length > 0 ? { failedChanges } : undefined;
   } catch (error) {
@@ -208,14 +237,16 @@ export async function saveStageDataIncremental(
   stageId: string,
   dirty: readonly PendingChange[],
   data: StageStoreData,
-  capturedEpoch: number = stageDeletionEpoch(stageId),
-): Promise<{ failedChanges: PendingChange[] }> {
+  capturedEpoch: number,
+): Promise<{ failedChanges: PendingChange[] } | StaleDroppedSave> {
   // `capturedEpoch` = the deletion epoch when `data` was captured (the flush
-  // round / departing-stage snapshot). See saveStageData for the fencing
-  // contract; a stale capture is dropped even after a same-id restore.
+  // round / departing-stage snapshot); required so the capture point and the
+  // validation point stay paired. See saveStageData for the fencing contract;
+  // a stale capture is dropped even after a same-id restore, and a dropped
+  // write reports `'stale-dropped'` instead of a success shape.
   if (isStageWriteStale(stageId, capturedEpoch)) {
     log.info(`Dropping incremental save for deleted/stale stage: ${stageId}`);
-    return { failedChanges: [] };
+    return 'stale-dropped';
   }
   const has = (kind: PendingChange['kind']) => dirty.some((change) => change.kind === kind);
   const dirtySceneIds = new Set(
@@ -234,6 +265,7 @@ export async function saveStageDataIncremental(
     ),
   );
 
+  let dropped = false;
   if (needsDocumentWrite) {
     await mutateDocument(
       stageId,
@@ -246,17 +278,26 @@ export async function saveStageDataIncremental(
         // LWW, so each write below re-checks immediately before landing.
         // Epoch staleness also covers the delete→restore straddle: a round
         // captured pre-delete stays fenced after the restore lifts the flag.
-        if (isStageWriteStale(stageId, capturedEpoch)) return;
+        if (isStageWriteStale(stageId, capturedEpoch)) {
+          dropped = true;
+          return;
+        }
         await withRuntimeStorageSharedLock(async () => {
           const now = Date.now();
           const fullSave = async () => {
-            if (isStageWriteStale(stageId, capturedEpoch)) return;
+            if (isStageWriteStale(stageId, capturedEpoch)) {
+              dropped = true;
+              return;
+            }
             const persistedScenes = await preparePBLScenesForDocumentPersistence(
               stageId,
               data.scenes,
             );
             // Preparation awaited: last re-check immediately before the write.
-            if (isStageWriteStale(stageId, capturedEpoch)) return;
+            if (isStageWriteStale(stageId, capturedEpoch)) {
+              dropped = true;
+              return;
+            }
             await store.saveDocument(
               documentSnapshot(
                 stageId,
@@ -290,12 +331,18 @@ export async function saveStageDataIncremental(
                 const index = data.scenes.findIndex((candidate) => candidate.id === scene.id);
                 // Preparation and prior iterations awaited: re-check before
                 // each row write (lock-free environments have no lock to win).
-                if (isStageWriteStale(stageId, capturedEpoch)) return;
+                if (isStageWriteStale(stageId, capturedEpoch)) {
+                  dropped = true;
+                  return;
+                }
                 await store.putScene(stageId, stampScene(stageId, scene, index, now));
               }
             }
             if (has('stage')) {
-              if (isStageWriteStale(stageId, capturedEpoch)) return;
+              if (isStageWriteStale(stageId, capturedEpoch)) {
+                dropped = true;
+                return;
+              }
               await store.putStage(stageId, stampStage(stageId, data.stage, now));
             }
           } catch (error) {
@@ -313,6 +360,13 @@ export async function saveStageDataIncremental(
     );
   }
 
+  // A document-write drop fences the whole flush: once a deletion turned this
+  // capture stale, staleness is permanent (the epoch never rewinds), so the
+  // tail must not even be attempted.
+  if (dropped) {
+    log.info(`Dropped incremental save mid-write for deleted/stale stage: ${stageId}`);
+    return 'stale-dropped';
+  }
   // Tail writes live outside the document mutation. A delete that won the
   // race above (dropping the document write) must also fence the
   // currentScene KV row and the chat sessions, or this same flush would
@@ -322,13 +376,13 @@ export async function saveStageDataIncremental(
   // write is awaiting (there is no lock spanning the tail).
   if (isStageWriteStale(stageId, capturedEpoch)) {
     log.info(`Dropping incremental save tail for deleted/stale stage: ${stageId}`);
-    return { failedChanges: [] };
+    return 'stale-dropped';
   }
   if (has('currentScene')) await saveCurrentScene(stageId, data.currentSceneId);
   // `saveCurrentScene` awaited: re-check immediately before the chat write.
   if (isStageWriteStale(stageId, capturedEpoch)) {
     log.info(`Dropping incremental chat tail for deleted/stale stage: ${stageId}`);
-    return { failedChanges: [] };
+    return 'stale-dropped';
   }
   const failedChanges: PendingChange[] = [];
   if (has('chats') && !(await saveStageChats(stageId, data))) {
@@ -417,6 +471,11 @@ export async function deleteStageData(stageId: string): Promise<void> {
   // departing-stage retry), and even if a same-id restore later lifts the
   // deleted flag.
   markStageDeleted(stageId);
+  // The cascade's outcome is unknown until it settles. Read-side consumers
+  // (the warm-ghost discard in loadFromStorage) must not treat the deleted
+  // flag as "document gone" while this holds — a failure before document
+  // removal lifts the flag and hands the pending dirt back.
+  beginStageDeletionCascade(stageId);
   // Then drop any still-queued persistence work for this stage: a mutation
   // sitting in the debounce window must not even start a flush after the
   // delete.
@@ -523,6 +582,11 @@ export async function deleteStageData(stageId: string): Promise<void> {
       restorePendingStageChanges(stageId, discardedChanges);
     }
     throw error;
+  } finally {
+    // Settlement: whichever way the cascade ended, its outcome is now
+    // recorded — document removed (deleted flag kept) or deletion failed
+    // before removal (flag lifted above). The read side may act on the flag.
+    settleStageDeletionCascade(stageId);
   }
   // Success: evict the deleted classroom from the in-memory store. A warm
   // store would otherwise keep rendering the deleted classroom from memory —

--- a/packages/@openmaic/dsl/src/stage.ts
+++ b/packages/@openmaic/dsl/src/stage.ts
@@ -74,11 +74,12 @@ export interface VoiceDesign {
 
 /**
  * A concrete TTS voice binding for an agent. `providerId` is an open string at
- * the contract level — the set of available TTS providers is app-defined.
+ * the contract level — the set of available TTS providers is app-defined, and
+ * readers must treat an unknown provider as "no bound voice". Deliberately
+ * minimal: fields are added here only once a producer actually emits them.
  */
 export interface AgentVoiceConfig {
   providerId: string;
-  modelId?: string;
   voiceId: string;
 }
 

--- a/packages/@openmaic/dsl/src/stage.ts
+++ b/packages/@openmaic/dsl/src/stage.ts
@@ -92,8 +92,18 @@ export interface AgentVoiceConfig {
  * The voice fields are optional and additive: documents written before they
  * existed simply lack them, and readers treat an absent voice as "no bound
  * voice" (the TTS path falls back at call time). Adding them did not change
- * the meaning of any existing field, so it is not a breaking change to the
- * serialized shape and does not bump `DSL_VERSION` (see `version.ts`).
+ * the meaning of any existing field, so within this codebase — whose
+ * structural validators tolerate unknown fields — the addition is
+ * non-breaking and does not bump `DSL_VERSION` (see `version.ts`).
+ *
+ * It is NOT transparent to schema-validating consumers, however: the
+ * generated `stage.schema.json` sets `additionalProperties: false` on every
+ * definition, so a cross-language consumer validating against a pinned copy
+ * of an older published schema artifact rejects any document that carries
+ * these fields. Under strict schema validation, additive fields ARE a
+ * breaking change — such consumers must upgrade their schema artifact in
+ * lockstep with the documents they accept. (A `DSL_VERSION` bump would not
+ * help them: an old schema rejects the new documents either way.)
  */
 export interface GeneratedAgentConfig {
   id: string;

--- a/packages/@openmaic/dsl/src/stage.ts
+++ b/packages/@openmaic/dsl/src/stage.ts
@@ -57,9 +57,42 @@ export interface VideoManifestEntry {
 export type VideoManifest = Record<string, VideoManifestEntry>;
 
 /**
- * Server-generated agent configuration. Embedded in persisted classroom JSON
- * so clients can hydrate the agent registry without relying on IndexedDB
- * pre-population. Only present for API-generated classrooms.
+ * Provider-neutral vocal identity for an agent, described as a 3-layer recipe.
+ * Consumed by any TTS integration: as an inline voice prompt where supported,
+ * or as the seed for a registered/cloned voice. Part of the contract so an
+ * agent's voice travels with the document (export/import, device switches)
+ * instead of living in device-local storage.
+ */
+export interface VoiceDesign {
+  /** gender / age / role */
+  identity: string;
+  /** pitch / vocal quality */
+  texture: string;
+  /** emotion / pace */
+  delivery: string;
+}
+
+/**
+ * A concrete TTS voice binding for an agent. `providerId` is an open string at
+ * the contract level — the set of available TTS providers is app-defined.
+ */
+export interface AgentVoiceConfig {
+  providerId: string;
+  modelId?: string;
+  voiceId: string;
+}
+
+/**
+ * Generated agent configuration. Embedded in the persisted stage document
+ * (`stage.generatedAgentConfigs`) so clients can hydrate the agent registry
+ * without relying on IndexedDB pre-population. Present for generated-roster
+ * classrooms; preset classrooms carry `agentIds` instead.
+ *
+ * The voice fields are optional and additive: documents written before they
+ * existed simply lack them, and readers treat an absent voice as "no bound
+ * voice" (the TTS path falls back at call time). Adding them did not change
+ * the meaning of any existing field, so it is not a breaking change to the
+ * serialized shape and does not bump `DSL_VERSION` (see `version.ts`).
  */
 export interface GeneratedAgentConfig {
   id: string;
@@ -69,6 +102,10 @@ export interface GeneratedAgentConfig {
   avatar: string;
   color: string;
   priority: number;
+  /** Bound TTS voice, when the generation pipeline selected one. */
+  voiceConfig?: AgentVoiceConfig;
+  /** 3-layer vocal descriptor for automatic voice synthesis/registration. */
+  voiceDesign?: VoiceDesign;
 }
 
 /**

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -25,6 +25,32 @@ describe('generated JSON Schema — Stage', () => {
   it('rejects a stage missing required fields', () => {
     expect(v({ id: 's' })).toBe(false);
   });
+  it('accepts a roster with and without the optional voice fields', () => {
+    const agent = {
+      id: 'gen-1',
+      name: 'Narrator',
+      role: 'teacher',
+      persona: 'p',
+      avatar: 'a',
+      color: '#000',
+      priority: 10,
+    };
+    const voiced = {
+      ...agent,
+      id: 'gen-2',
+      voiceConfig: { providerId: 'tts', voiceId: 'v1' },
+      voiceDesign: { identity: 'adult narrator', texture: 'low', delivery: 'calm' },
+    };
+    expect(
+      v({
+        id: 's',
+        name: 'n',
+        createdAt: 1,
+        updatedAt: 2,
+        generatedAgentConfigs: [agent, voiced],
+      }),
+    ).toBe(true);
+  });
 });
 
 describe('generated JSON Schema — Action', () => {

--- a/tests/audio/tts-provider-guard.test.ts
+++ b/tests/audio/tts-provider-guard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Prototype-chain hardening for the TTS/ASR provider lookups.
+ *
+ * `TTS_PROVIDERS` / `ASR_PROVIDERS` are plain object literals, so an `in`
+ * check (or a bare index) also matches inherited Object.prototype keys —
+ * exactly the junk a persisted document or imported manifest can carry in its
+ * open-string providerId. The guards must use own-property semantics.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  getASRProvider,
+  getTTSProvider,
+  isKnownTTSProviderId,
+  TTS_PROVIDERS,
+} from '@/lib/audio/constants';
+import { findVoiceDisplayName } from '@/lib/audio/voice-resolver';
+import type { ASRProviderId, TTSProviderId } from '@/lib/audio/types';
+
+const PROTOTYPE_KEYS = ['toString', 'constructor', 'valueOf', 'hasOwnProperty'];
+
+describe('isKnownTTSProviderId', () => {
+  it('accepts every registered built-in provider and the custom namespace', () => {
+    for (const id of Object.keys(TTS_PROVIDERS)) {
+      expect(isKnownTTSProviderId(id)).toBe(true);
+    }
+    expect(isKnownTTSProviderId('custom-tts-mine')).toBe(true);
+  });
+
+  it('rejects unknown ids', () => {
+    expect(isKnownTTSProviderId('definitely-not-a-tts-provider')).toBe(false);
+    expect(isKnownTTSProviderId('')).toBe(false);
+  });
+
+  it('rejects prototype-chain keys', () => {
+    for (const junk of PROTOTYPE_KEYS) {
+      expect(isKnownTTSProviderId(junk)).toBe(false);
+    }
+  });
+});
+
+describe('getTTSProvider', () => {
+  it('never resolves a prototype-chain key to an Object.prototype member', () => {
+    for (const junk of PROTOTYPE_KEYS) {
+      expect(getTTSProvider(junk as TTSProviderId)).toBeUndefined();
+    }
+  });
+});
+
+describe('getASRProvider', () => {
+  it('never resolves a prototype-chain key to an Object.prototype member', () => {
+    for (const junk of PROTOTYPE_KEYS) {
+      expect(getASRProvider(junk as ASRProviderId)).toBeUndefined();
+    }
+  });
+});
+
+describe('findVoiceDisplayName', () => {
+  it('falls back to the raw voice id for a prototype-chain provider key instead of crashing', () => {
+    for (const junk of PROTOTYPE_KEYS) {
+      expect(findVoiceDisplayName(junk as TTSProviderId, 'voice-1')).toBe('voice-1');
+    }
+  });
+});

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -10,9 +10,12 @@ import {
 } from '@/lib/classroom/load-classroom';
 import {
   claimStageSceneLoadToken,
+  flushStageSave,
   isCurrentStageSceneLoadToken,
   useStageStore,
 } from '@/lib/store/stage';
+import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
+import { saveStageDataIncremental } from '@/lib/utils/stage-storage';
 import type { GeneratedAgentConfig, Scene, Stage } from '@/lib/types/stage';
 
 // The store flush path imports stage-storage dynamically; mock it so a pending
@@ -153,6 +156,57 @@ describe('runClassroomLoad', () => {
     expect(useStageStore.getState().scenes).toEqual([scene]);
     expect(useStageStore.getState().currentSceneId).toBe('scene-a');
     useStageStore.getState().clearStore();
+  });
+
+  it('lifts a same-session deletion tombstone on explicit server-copy restore, and edits persist again', async () => {
+    // Deletion only removes client-side data; revisiting the classroom URL
+    // restores the server copy under the SAME id. Without lifting the
+    // tombstone, every edit of the restored classroom would be silently
+    // dropped until a reload.
+    useStageStore.getState().clearStore();
+    vi.mocked(saveStageDataIncremental).mockClear();
+    markStageDeleted('stage-revived');
+    try {
+      applyClassroomStageAndScenes(
+        makeStage('stage-revived'),
+        [makeScene('scene-r', 'stage-revived')],
+        { persist: false },
+      );
+      expect(isStageDeleted('stage-revived')).toBe(false);
+
+      // An edit after the restore reaches storage again.
+      useStageStore.getState().setCurrentSceneId('scene-r');
+      await flushStageSave();
+      expect(saveStageDataIncremental).toHaveBeenCalledWith(
+        'stage-revived',
+        expect.arrayContaining([{ kind: 'currentScene' }]),
+        expect.anything(),
+      );
+    } finally {
+      unmarkStageDeleted('stage-revived');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('keeps dropping in-flight writes for a deleted classroom that was NOT restored', async () => {
+    useStageStore.getState().clearStore();
+    vi.mocked(saveStageDataIncremental).mockClear();
+    applyClassroomStageAndScenes(
+      makeStage('stage-doomed'),
+      [makeScene('scene-d', 'stage-doomed')],
+      {
+        persist: false,
+      },
+    );
+    try {
+      markStageDeleted('stage-doomed');
+      useStageStore.getState().setCurrentSceneId('scene-d');
+      await flushStageSave();
+      expect(saveStageDataIncremental).not.toHaveBeenCalled();
+    } finally {
+      unmarkStageDeleted('stage-doomed');
+      useStageStore.getState().clearStore();
+    }
   });
 
   it('resets caller-bound chat authority when fallback replaces the classroom', () => {
@@ -359,6 +413,46 @@ describe('runClassroomLoad', () => {
     expect(deps.commitMigratedAgentConfigs).not.toHaveBeenCalled();
     // The roster itself still hydrates the registry on every load.
     expect(deps.applyGeneratedAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not memoize a FAILED mirror read: the next load retries the probe', async () => {
+    // `null` = the read failed (vs. `[]` = mirror confirmed empty). A transient
+    // IndexedDB error must not become a session-long migration skip.
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue([] as GeneratedAgentConfig[]),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
+    });
+    setStage(makeStage('stage-a', [makeAgentConfig('agent-a')]));
+
+    // First load: the read fails — nothing merged, nothing memoized.
+    await runClassroomLoad(deps);
+    expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(1);
+    expect(deps.commitMigratedAgentConfigs).not.toHaveBeenCalled();
+
+    // Second load: retried; the read now succeeds empty — memoized.
+    await runClassroomLoad(deps);
+    expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(2);
+
+    // Third load: the successful empty probe is remembered.
+    await runClassroomLoad(deps);
+    expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(2);
+  });
+
+  it('still hydrates the registry from document configs when the mirror read fails', async () => {
+    const configs = [makeAgentConfig('agent-a')];
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi.fn().mockResolvedValue(null),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
+    });
+    setStage(makeStage('stage-a', configs));
+
+    await runClassroomLoad(deps);
+
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', configs);
+    expect(deps.setLoading).toHaveBeenCalledWith(false);
   });
 
   it('scopes the fruitless-probe memo per classroom', async () => {

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -181,9 +181,66 @@ describe('runClassroomLoad', () => {
         'stage-revived',
         expect.arrayContaining([{ kind: 'currentScene' }]),
         expect.anything(),
+        expect.any(Number),
       );
     } finally {
       unmarkStageDeleted('stage-revived');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('restores a deleted classroom whose ghost is still warm in the store (back-button path)', async () => {
+    // Round-2 pinned the restore with a direct applyClassroomStageAndScenes
+    // call — the cold-store cell. The natural path is warmer: open classroom →
+    // navigate home → delete → browser Back. loadFromStorage used to
+    // short-circuit on the warm store, so the server-fallback restore (the
+    // only unmark point) never ran and the classroom rendered editable while
+    // every edit was silently dropped. This drives the REAL loadFromStorage.
+    useStageStore.getState().clearStore();
+    vi.mocked(saveStageDataIncremental).mockClear();
+    const warmStage = makeStage('stage-warm-ghost');
+    applyClassroomStageAndScenes(warmStage, [makeScene('scene-w', 'stage-warm-ghost')], {
+      persist: false,
+    });
+    // Home-page delete: deletion marked while the store stays warm (the
+    // deletion path also evicts the store; a partially failed cascade can
+    // leave the ghost, which this path must still heal).
+    markStageDeleted('stage-warm-ghost');
+    try {
+      const serverStage = makeStage('stage-warm-ghost');
+      const serverScene = makeScene('scene-server', 'stage-warm-ghost');
+      const { deps } = makeDeps({
+        classroomId: 'stage-warm-ghost',
+        loadFromStorage: (id, token) => useStageStore.getState().loadFromStorage(id, token),
+        getCurrentStage: () => useStageStore.getState().stage,
+        fetchClassroom: vi.fn().mockResolvedValue({ stage: serverStage, scenes: [serverScene] }),
+        applyFallbackScenes: vi.fn().mockImplementation(async ({ stage, scenes }) => {
+          applyClassroomStageAndScenes(stage, scenes, { persist: false });
+          return true;
+        }),
+      });
+
+      await runClassroomLoad(deps);
+
+      // The warm ghost did not starve the restore: the server fallback ran,
+      // the restored classroom is live, and the deletion was lifted.
+      expect(deps.fetchClassroom).toHaveBeenCalledExactlyOnceWith('stage-warm-ghost');
+      expect(deps.applyFallbackScenes).toHaveBeenCalledOnce();
+      expect(useStageStore.getState().stage?.id).toBe('stage-warm-ghost');
+      expect(useStageStore.getState().scenes.map((s) => s.id)).toEqual(['scene-server']);
+      expect(isStageDeleted('stage-warm-ghost')).toBe(false);
+
+      // …and edits persist again end-to-end through the scheduler.
+      useStageStore.getState().setCurrentSceneId('scene-server');
+      await flushStageSave();
+      expect(saveStageDataIncremental).toHaveBeenCalledWith(
+        'stage-warm-ghost',
+        expect.arrayContaining([{ kind: 'currentScene' }]),
+        expect.anything(),
+        expect.any(Number),
+      );
+    } finally {
+      unmarkStageDeleted('stage-warm-ghost');
       useStageStore.getState().clearStore();
     }
   });

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -423,6 +423,60 @@ describe('runClassroomLoad', () => {
     }
   });
 
+  it('cold-loads after a failed delete when the store was replaced during the park (no false keep-warm)', async () => {
+    // Back parks on stage A's deletion settlement; while parked, a tokenless
+    // store writer (a database import applying another classroom through
+    // applyClassroomStageAndScenes) replaces the store contents WITHOUT
+    // claiming the load token. When the deletion then FAILS, there is no warm
+    // state of A left to keep — the keep-warm branch must re-verify store
+    // identity (mirroring the success path) and fall through to the cold
+    // load, instead of reporting the imported classroom as A's live state.
+    useStageStore.getState().clearStore();
+    vi.mocked(loadStageData).mockClear();
+    const localStage = makeStage('stage-park-replaced');
+    const localScene = makeScene('scene-p', 'stage-park-replaced');
+    applyClassroomStageAndScenes(localStage, [localScene], { persist: false });
+    markStageDeleted('stage-park-replaced');
+    beginStageDeletionCascade('stage-park-replaced');
+    try {
+      // The failed delete leaves A's document in place: the cold path re-reads it.
+      vi.mocked(loadStageData).mockResolvedValueOnce({
+        stage: localStage,
+        scenes: [localScene],
+        currentSceneId: localScene.id,
+        chats: [],
+      });
+      const token = claimStageSceneLoadToken();
+      const loading = useStageStore.getState().loadFromStorage('stage-park-replaced', token);
+      await Promise.resolve();
+      await Promise.resolve();
+      // Parked: no IndexedDB read yet.
+      expect(loadStageData).not.toHaveBeenCalled();
+
+      // An import applies ANOTHER stage mid-park, leaving the token untouched.
+      applyClassroomStageAndScenes(
+        makeStage('stage-imported'),
+        [makeScene('scene-i', 'stage-imported')],
+        { persist: false },
+      );
+
+      // The deletion fails before removing the document: flag lifted, settled.
+      unmarkStageDeleted('stage-park-replaced');
+      settleStageDeletionCascade('stage-park-replaced');
+      await loading;
+
+      // Not a false keep-warm of the imported stage: the parked load fell
+      // through to the cold path and handed the route back to A.
+      expect(loadStageData).toHaveBeenCalledExactlyOnceWith('stage-park-replaced');
+      expect(useStageStore.getState().stage?.id).toBe('stage-park-replaced');
+      expect(useStageStore.getState().scenes.map((s) => s.id)).toEqual(['scene-p']);
+    } finally {
+      settleStageDeletionCascade('stage-park-replaced');
+      unmarkStageDeleted('stage-park-replaced');
+      useStageStore.getState().clearStore();
+    }
+  });
+
   it('does not evict a classroom restored (and unmarked) during the cascade tail', () => {
     // Cascade-tail race: deleteStageData succeeded, and before its synchronous
     // continuation ran the eviction, a same-id restore completed and unmarked

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   applyClassroomStageAndScenes,
   commitMigratedAgentConfigsToStore,
   discardRestoredMediaTasks,
   mergeLegacyAgentFallbacks,
+  resetLegacyAgentFallbackProbes,
   rosterNeedsLegacyFallback,
   runClassroomLoad,
 } from '@/lib/classroom/load-classroom';
@@ -132,6 +133,11 @@ function makeDeps(overrides: Partial<Parameters<typeof runClassroomLoad>[0]> = {
     },
   };
 }
+
+// The fruitless-probe memo is session-scoped module state; isolate tests.
+beforeEach(() => {
+  resetLegacyAgentFallbackProbes();
+});
 
 describe('runClassroomLoad', () => {
   it('keeps the current load token valid when fallback scenes are committed', () => {
@@ -333,6 +339,62 @@ describe('runClassroomLoad', () => {
     const lifted = [fallbacks[1], fallbacks[0]]; // priority-desc, teacher first
     expect(deps.commitMigratedAgentConfigs).toHaveBeenCalledExactlyOnceWith('stage-a', lifted);
     expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', lifted);
+  });
+
+  it('remembers a fruitless mirror probe and skips it on later loads of the same classroom', async () => {
+    // Server-generated classrooms have voiceless rosters by design: the probe
+    // finds nothing to merge, and without the memo it would re-query the
+    // mirror on every single load, forever.
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi.fn().mockResolvedValue([]),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
+    });
+    setStage(makeStage('stage-a', [makeAgentConfig('agent-a')]));
+
+    await runClassroomLoad(deps);
+    expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(1);
+
+    await runClassroomLoad(deps);
+    expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(1);
+    expect(deps.commitMigratedAgentConfigs).not.toHaveBeenCalled();
+    // The roster itself still hydrates the registry on every load.
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it('scopes the fruitless-probe memo per classroom', async () => {
+    const first = makeDeps({ loadLegacyAgentFallbacks: vi.fn().mockResolvedValue([]) });
+    first.setStage(makeStage('stage-a', [makeAgentConfig('agent-a')]));
+    await runClassroomLoad(first.deps);
+    expect(first.deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(1);
+
+    const second = makeDeps({
+      classroomId: 'stage-b',
+      loadLegacyAgentFallbacks: vi.fn().mockResolvedValue([]),
+    });
+    second.setStage(makeStage('stage-b', [makeAgentConfig('agent-b')]));
+    await runClassroomLoad(second.deps);
+    expect(second.deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps probing until a successful merge is durably on the document (no memo on merges)', async () => {
+    // A merge that changed the roster is committed dirty; if its flush failed,
+    // the next load must probe and merge again rather than being memoized.
+    // This harness never updates the document copy, standing in for exactly
+    // that failed-flush case.
+    const voiceDesign = { identity: 'bright', texture: 'clear', delivery: 'lively' };
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi
+        .fn()
+        .mockResolvedValue([makeAgentConfig('agent-a', { voiceDesign })]),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
+    });
+    setStage(makeStage('stage-a', [makeAgentConfig('agent-a')]));
+
+    await runClassroomLoad(deps);
+    await runClassroomLoad(deps);
+
+    expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalledTimes(2);
+    expect(deps.commitMigratedAgentConfigs).toHaveBeenCalledTimes(2);
   });
 
   it('does not commit or apply a merged roster when superseded during the mirror read', async () => {

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -37,13 +37,16 @@ vi.mock('@/lib/utils/stage-storage', () => ({
   loadStageData: vi.fn().mockResolvedValue(null),
 }));
 
-function makeStage(id: string, generatedAgentConfigs: Stage['generatedAgentConfigs'] = []): Stage {
+// Omitting `generatedAgentConfigs` models a document written before roster
+// persistence existed (field absent) — distinct from an explicit `[]`, which
+// is an authoritative empty roster.
+function makeStage(id: string, generatedAgentConfigs?: Stage['generatedAgentConfigs']): Stage {
   return {
     id,
     name: id,
     createdAt: 1,
     updatedAt: 1,
-    generatedAgentConfigs,
+    ...(generatedAgentConfigs !== undefined ? { generatedAgentConfigs } : {}),
   };
 }
 
@@ -251,6 +254,58 @@ describe('runClassroomLoad', () => {
       );
     } finally {
       unmarkStageDeleted('stage-warm-ghost');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('restores a deleted classroom whose warm ghost has ZERO scenes (identity, not scene count, gates the ghost handling)', async () => {
+    // The ghost handling must key on stage identity alone: a scene-less
+    // classroom (its cascade failed AFTER removing the document, so the
+    // eviction never ran) leaves a warm ghost with zero scenes. Gating the
+    // deleted-warm handling on `scenes.length > 0` would skip the discard,
+    // the cold load would find nothing and leave the ghost in the store, and
+    // the server-fallback gate (`!getCurrentStage()`) would never run — a
+    // fully editable classroom whose every edit is silently dropped.
+    useStageStore.getState().clearStore();
+    vi.mocked(saveStageDataIncremental).mockClear();
+    applyClassroomStageAndScenes(makeStage('stage-zero-ghost'), [], { persist: false });
+    // Settled-deleted world with the ghost left warm (eviction skipped by the
+    // post-removal cascade failure).
+    markStageDeleted('stage-zero-ghost');
+    try {
+      const serverStage = makeStage('stage-zero-ghost');
+      const serverScene = makeScene('scene-server', 'stage-zero-ghost');
+      const { deps } = makeDeps({
+        classroomId: 'stage-zero-ghost',
+        loadFromStorage: (id, token) => useStageStore.getState().loadFromStorage(id, token),
+        getCurrentStage: () => useStageStore.getState().stage,
+        fetchClassroom: vi.fn().mockResolvedValue({ stage: serverStage, scenes: [serverScene] }),
+        applyFallbackScenes: vi.fn().mockImplementation(async ({ stage, scenes }) => {
+          applyClassroomStageAndScenes(stage, scenes, { persist: false });
+          return true;
+        }),
+      });
+
+      await runClassroomLoad(deps);
+
+      // The zero-scene ghost was discarded and the server restore ran.
+      expect(deps.fetchClassroom).toHaveBeenCalledExactlyOnceWith('stage-zero-ghost');
+      expect(deps.applyFallbackScenes).toHaveBeenCalledOnce();
+      expect(useStageStore.getState().stage?.id).toBe('stage-zero-ghost');
+      expect(useStageStore.getState().scenes.map((s) => s.id)).toEqual(['scene-server']);
+      expect(isStageDeleted('stage-zero-ghost')).toBe(false);
+
+      // …and edits persist again end-to-end through the scheduler.
+      useStageStore.getState().setCurrentSceneId('scene-server');
+      await flushStageSave();
+      expect(saveStageDataIncremental).toHaveBeenCalledWith(
+        'stage-zero-ghost',
+        expect.arrayContaining([{ kind: 'currentScene' }]),
+        expect.anything(),
+        expect.any(Number),
+      );
+    } finally {
+      unmarkStageDeleted('stage-zero-ghost');
       useStageStore.getState().clearStore();
     }
   });
@@ -699,13 +754,33 @@ describe('runClassroomLoad', () => {
       loadLegacyAgentFallbacks: vi.fn().mockResolvedValue(fallbacks),
       applyGeneratedAgents: vi.fn().mockReturnValue(['gen-teacher', 'gen-student']),
     });
-    setStage(makeStage('stage-a', []));
+    // No roster field at all: the document predates roster persistence.
+    setStage(makeStage('stage-a'));
 
     await runClassroomLoad(deps);
 
     const lifted = [fallbacks[1], fallbacks[0]]; // priority-desc, teacher first
     expect(deps.commitMigratedAgentConfigs).toHaveBeenCalledExactlyOnceWith('stage-a', lifted);
     expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', lifted);
+  });
+
+  it('treats an explicitly persisted empty roster as authoritative: stale mirror rows are not resurrected', async () => {
+    // The mirror is never cleaned except on stage deletion, so a device can
+    // hold stale rows for a stage whose document explicitly carries `[]`.
+    // Collapsing absent and empty would lift the whole stale roster back on
+    // every load (the merge reports `changed: true`, so not even the
+    // fruitless-probe memo would stop it). The explicit `[]` must win.
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi.fn().mockResolvedValue([makeAgentConfig('stale-mirror-row')]),
+      applyGeneratedAgents: vi.fn().mockReturnValue([]),
+    });
+    setStage(makeStage('stage-a', []));
+
+    await runClassroomLoad(deps);
+
+    expect(deps.loadLegacyAgentFallbacks).not.toHaveBeenCalled();
+    expect(deps.commitMigratedAgentConfigs).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', []);
   });
 
   it('remembers a fruitless mirror probe and skips it on later loads of the same classroom', async () => {
@@ -882,8 +957,12 @@ describe('runClassroomLoad', () => {
 });
 
 describe('rosterNeedsLegacyFallback', () => {
-  it('is true for an empty roster (the document may predate roster persistence)', () => {
-    expect(rosterNeedsLegacyFallback([])).toBe(true);
+  it('is true when the document carries no roster field (it may predate roster persistence)', () => {
+    expect(rosterNeedsLegacyFallback(undefined)).toBe(true);
+  });
+
+  it('is false for an explicitly persisted empty roster (authoritative; never lifted)', () => {
+    expect(rosterNeedsLegacyFallback([])).toBe(false);
   });
 
   it('is true when any agent lacks both voice fields', () => {
@@ -966,7 +1045,7 @@ describe('commitMigratedAgentConfigsToStore', () => {
     useStageStore.setState({ stage: makeStage('stage-b') });
     commitMigratedAgentConfigsToStore('stage-a', [makeAgentConfig('stale')]);
     expect(useStageStore.getState().stage?.id).toBe('stage-b');
-    expect(useStageStore.getState().stage?.generatedAgentConfigs).toEqual([]);
+    expect(useStageStore.getState().stage?.generatedAgentConfigs).toBeUndefined();
 
     useStageStore.getState().clearStore();
   });

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -1,31 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   applyClassroomStageAndScenes,
+  commitMigratedAgentConfigsToStore,
   discardRestoredMediaTasks,
+  mergeLegacyAgentFallbacks,
+  rosterNeedsLegacyFallback,
   runClassroomLoad,
-  saveGeneratedAgentsForCurrentLoad,
 } from '@/lib/classroom/load-classroom';
 import {
   claimStageSceneLoadToken,
   isCurrentStageSceneLoadToken,
   useStageStore,
 } from '@/lib/store/stage';
-import type { Scene, Stage } from '@/lib/types/stage';
+import type { GeneratedAgentConfig, Scene, Stage } from '@/lib/types/stage';
 
-const databaseMocks = vi.hoisted(() => ({
-  deleteGeneratedAgents: vi.fn(),
-  bulkPutGeneratedAgents: vi.fn(),
-  transaction: vi.fn(async (_mode: string, _table: unknown, work: () => Promise<void>) => work()),
-}));
-
-vi.mock('@/lib/utils/database', () => ({
-  db: {
-    generatedAgents: {
-      where: () => ({ equals: () => ({ delete: databaseMocks.deleteGeneratedAgents }) }),
-      bulkPut: databaseMocks.bulkPutGeneratedAgents,
-    },
-    transaction: databaseMocks.transaction,
-  },
+// The store flush path imports stage-storage dynamically; mock it so a pending
+// mark scheduled by commitMigratedAgentConfigsToStore can never reach a real
+// (or jsdom) IndexedDB.
+vi.mock('@/lib/utils/stage-storage', () => ({
+  saveStageData: vi.fn().mockResolvedValue(undefined),
+  saveStageDataIncremental: vi.fn().mockResolvedValue({ failedChanges: [] }),
+  loadStageData: vi.fn().mockResolvedValue(null),
 }));
 
 function makeStage(id: string, generatedAgentConfigs: Stage['generatedAgentConfigs'] = []): Stage {
@@ -36,6 +31,19 @@ function makeStage(id: string, generatedAgentConfigs: Stage['generatedAgentConfi
     updatedAt: 1,
     generatedAgentConfigs,
   };
+}
+
+function makeAgentConfig(id: string, extra: Partial<GeneratedAgentConfig> = {}) {
+  return {
+    id,
+    name: `Agent ${id}`,
+    role: 'teacher',
+    persona: 'Teach',
+    avatar: 'A',
+    color: '#000',
+    priority: 1,
+    ...extra,
+  } satisfies GeneratedAgentConfig;
 }
 
 function makeScene(id: string, stageId: string): Scene {
@@ -92,12 +100,12 @@ function makeDeps(overrides: Partial<Parameters<typeof runClassroomLoad>[0]> = {
     getCurrentStage: () => stage,
     fetchClassroom: vi.fn().mockResolvedValue(null),
     applyFallbackScenes: vi.fn().mockResolvedValue(false),
-    saveGeneratedAgents: vi.fn().mockResolvedValue([]),
     loadRestoredMediaTasks: vi.fn().mockResolvedValue({}),
     applyRestoredMediaTasks: vi.fn(),
     discardRestoredMediaTasks: vi.fn(),
-    loadGeneratedAgentRecords: vi.fn().mockResolvedValue([]),
-    applyGeneratedAgentRecords: vi.fn().mockReturnValue([]),
+    loadLegacyAgentFallbacks: vi.fn().mockResolvedValue([]),
+    commitMigratedAgentConfigs: vi.fn(),
+    applyGeneratedAgents: vi.fn().mockReturnValue([]),
     getSettings: () => settings,
     getAgent: vi.fn().mockReturnValue(undefined),
     restoreAgentSelection: vi.fn().mockReturnValue({
@@ -200,7 +208,7 @@ describe('runClassroomLoad', () => {
     expect(deps.fetchClassroom).not.toHaveBeenCalled();
     expect(deps.applyFallbackScenes).not.toHaveBeenCalled();
     expect(deps.loadRestoredMediaTasks).not.toHaveBeenCalled();
-    expect(deps.loadGeneratedAgentRecords).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).not.toHaveBeenCalled();
     expect(deps.setLoading).not.toHaveBeenCalled();
   });
 
@@ -219,7 +227,7 @@ describe('runClassroomLoad', () => {
 
     expect(deps.applyFallbackScenes).not.toHaveBeenCalled();
     expect(deps.loadRestoredMediaTasks).not.toHaveBeenCalled();
-    expect(deps.loadGeneratedAgentRecords).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).not.toHaveBeenCalled();
     expect(deps.setLoading).not.toHaveBeenCalled();
   });
 
@@ -227,17 +235,7 @@ describe('runClassroomLoad', () => {
     const applied = deferred<boolean>();
     const { deps, setCurrent } = makeDeps({
       fetchClassroom: vi.fn().mockResolvedValue({
-        stage: makeStage('stage-a', [
-          {
-            id: 'agent-a',
-            name: 'Agent A',
-            role: 'teacher',
-            persona: 'Teach',
-            avatar: 'A',
-            color: '#000',
-            priority: 1,
-          },
-        ]),
+        stage: makeStage('stage-a', [makeAgentConfig('agent-a')]),
         scenes: [makeScene('scene-a', 'stage-a')],
       }),
       applyFallbackScenes: vi.fn().mockReturnValue(applied.promise),
@@ -250,9 +248,8 @@ describe('runClassroomLoad', () => {
     applied.resolve(true);
     await loading;
 
-    expect(deps.saveGeneratedAgents).not.toHaveBeenCalled();
     expect(deps.loadRestoredMediaTasks).not.toHaveBeenCalled();
-    expect(deps.loadGeneratedAgentRecords).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).not.toHaveBeenCalled();
     expect(deps.setLoading).not.toHaveBeenCalled();
   });
 
@@ -274,68 +271,123 @@ describe('runClassroomLoad', () => {
     expect(deps.discardRestoredMediaTasks).toHaveBeenCalledWith({
       image: { elementId: 'image' },
     });
-    expect(deps.loadGeneratedAgentRecords).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).not.toHaveBeenCalled();
     expect(deps.setLoading).not.toHaveBeenCalled();
   });
 
-  it('does not apply generated agents when superseded after the agent record read', async () => {
-    const agentRead = deferred<unknown[]>();
-    const { deps, settings, setCurrent, setStage } = makeDeps({
-      loadGeneratedAgentRecords: vi.fn().mockReturnValue(agentRead.promise),
-    });
-    setStage(makeStage('stage-a'));
-
-    const loading = runClassroomLoad(deps);
-    await vi.waitFor(() => expect(deps.loadGeneratedAgentRecords).toHaveBeenCalled());
-
-    setCurrent(false);
-    agentRead.resolve([{ id: 'agent-a' }]);
-    await loading;
-
-    expect(deps.applyGeneratedAgentRecords).not.toHaveBeenCalled();
-    expect(settings.setAgentMode).not.toHaveBeenCalled();
-    expect(settings.setSelectedAgentIds).not.toHaveBeenCalled();
-    expect(settings.setAgentSelectionIsUserSet).not.toHaveBeenCalled();
-    expect(deps.setLoading).not.toHaveBeenCalled();
-  });
-
-  it('runs all phases and clears loading for the current navigation', async () => {
-    const stage = makeStage('stage-a', [
-      {
-        id: 'agent-a',
-        name: 'Agent A',
-        role: 'teacher',
-        persona: 'Teach',
-        avatar: 'A',
-        color: '#000',
-        priority: 1,
-      },
-    ]);
-    const scene = makeScene('scene-a', 'stage-a');
-    const mediaTasks = { image: { elementId: 'image' } };
-    const { deps, settings } = makeDeps({
-      fetchClassroom: vi.fn().mockResolvedValue({ stage, scenes: [scene] }),
-      applyFallbackScenes: vi.fn().mockResolvedValue(true),
-      loadRestoredMediaTasks: vi.fn().mockResolvedValue(mediaTasks),
-      loadGeneratedAgentRecords: vi.fn().mockResolvedValue([{ id: 'agent-a' }]),
-      applyGeneratedAgentRecords: vi.fn().mockReturnValue(['agent-a']),
+  it('hydrates the registry from document configs without consulting the mirror', async () => {
+    const configs = [
+      makeAgentConfig('agent-a', {
+        voiceDesign: { identity: 'warm mentor', texture: 'low', delivery: 'calm' },
+      }),
+    ];
+    const { deps, settings, setStage } = makeDeps({
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
       restoreAgentSelection: vi.fn().mockReturnValue({
         selection: { mode: 'auto', selectedAgentIds: ['agent-a'] },
         isUserSet: false,
       }),
     });
+    setStage(makeStage('stage-a', configs));
+
+    await runClassroomLoad(deps);
+
+    expect(deps.loadLegacyAgentFallbacks).not.toHaveBeenCalled();
+    expect(deps.commitMigratedAgentConfigs).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', configs);
+    expect(settings.setSelectedAgentIds).toHaveBeenCalledWith(['agent-a']);
+    expect(deps.setLoading).toHaveBeenCalledWith(false);
+  });
+
+  it('backfills missing voice fields from the legacy mirror and commits the merge', async () => {
+    const configs = [makeAgentConfig('agent-a')];
+    const voiceDesign = { identity: 'bright', texture: 'clear', delivery: 'lively' };
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi
+        .fn()
+        .mockResolvedValue([makeAgentConfig('agent-a', { voiceDesign })]),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
+    });
+    setStage(makeStage('stage-a', configs));
+
+    await runClassroomLoad(deps);
+
+    const merged = [makeAgentConfig('agent-a', { voiceDesign })];
+    expect(deps.commitMigratedAgentConfigs).toHaveBeenCalledExactlyOnceWith('stage-a', merged);
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', merged);
+  });
+
+  it('lifts a roster missing from the document entirely from the legacy mirror', async () => {
+    const fallbacks = [
+      makeAgentConfig('gen-student', { role: 'student', priority: 5 }),
+      makeAgentConfig('gen-teacher', { role: 'teacher', priority: 10 }),
+    ];
+    const { deps, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi.fn().mockResolvedValue(fallbacks),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['gen-teacher', 'gen-student']),
+    });
+    setStage(makeStage('stage-a', []));
+
+    await runClassroomLoad(deps);
+
+    const lifted = [fallbacks[1], fallbacks[0]]; // priority-desc, teacher first
+    expect(deps.commitMigratedAgentConfigs).toHaveBeenCalledExactlyOnceWith('stage-a', lifted);
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledExactlyOnceWith('stage-a', lifted);
+  });
+
+  it('does not commit or apply a merged roster when superseded during the mirror read', async () => {
+    const fallbackRead = deferred<GeneratedAgentConfig[]>();
+    const { deps, setCurrent, setStage } = makeDeps({
+      loadLegacyAgentFallbacks: vi.fn().mockReturnValue(fallbackRead.promise),
+    });
+    setStage(makeStage('stage-a', [makeAgentConfig('agent-a')]));
+
+    const loading = runClassroomLoad(deps);
+    await vi.waitFor(() => expect(deps.loadLegacyAgentFallbacks).toHaveBeenCalled());
+
+    setCurrent(false);
+    fallbackRead.resolve([
+      makeAgentConfig('agent-a', {
+        voiceDesign: { identity: 'x', texture: 'y', delivery: 'z' },
+      }),
+    ]);
+    await loading;
+
+    expect(deps.commitMigratedAgentConfigs).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).not.toHaveBeenCalled();
+    expect(deps.setLoading).not.toHaveBeenCalled();
+  });
+
+  it('runs all phases and clears loading for the current navigation', async () => {
+    const stage = makeStage('stage-a', [makeAgentConfig('agent-a')]);
+    const scene = makeScene('scene-a', 'stage-a');
+    const mediaTasks = { image: { elementId: 'image' } };
+    const { deps, settings, setStage } = makeDeps({
+      fetchClassroom: vi.fn().mockResolvedValue({ stage, scenes: [scene] }),
+      loadRestoredMediaTasks: vi.fn().mockResolvedValue(mediaTasks),
+      applyGeneratedAgents: vi.fn().mockReturnValue(['agent-a']),
+      restoreAgentSelection: vi.fn().mockReturnValue({
+        selection: { mode: 'auto', selectedAgentIds: ['agent-a'] },
+        isUserSet: false,
+      }),
+    });
+    const applyFallbackScenes = vi.fn().mockImplementation(async () => {
+      // A committed fallback puts the fetched stage into the store.
+      setStage(stage);
+      return true;
+    });
+    deps.applyFallbackScenes = applyFallbackScenes;
 
     await runClassroomLoad(deps);
 
     expect(deps.loadFromStorage).toHaveBeenCalledWith('stage-a', 1);
-    expect(deps.applyFallbackScenes).toHaveBeenCalledWith({
+    expect(applyFallbackScenes).toHaveBeenCalledWith({
       loadToken: 1,
       stage,
       scenes: [scene],
     });
-    expect(deps.saveGeneratedAgents).toHaveBeenCalledWith('stage-a', stage.generatedAgentConfigs);
     expect(deps.applyRestoredMediaTasks).toHaveBeenCalledWith(mediaTasks);
-    expect(deps.applyGeneratedAgentRecords).toHaveBeenCalledWith([{ id: 'agent-a' }]);
+    expect(deps.applyGeneratedAgents).toHaveBeenCalledWith('stage-a', stage.generatedAgentConfigs);
     expect(settings.setSelectedAgentIds).toHaveBeenCalledWith(['agent-a']);
     expect(deps.setLoading).toHaveBeenCalledWith(false);
   });
@@ -354,45 +406,100 @@ describe('runClassroomLoad', () => {
     await loading;
 
     expect(deps.loadRestoredMediaTasks).not.toHaveBeenCalled();
-    expect(deps.loadGeneratedAgentRecords).not.toHaveBeenCalled();
+    expect(deps.applyGeneratedAgents).not.toHaveBeenCalled();
     expect(deps.setError).not.toHaveBeenCalled();
     expect(deps.setLoading).not.toHaveBeenCalled();
   });
 });
 
-describe('saveGeneratedAgentsForCurrentLoad', () => {
-  it('finishes the generated-agent replacement when the load becomes stale during deletion', async () => {
-    const deletion = deferred<void>();
-    let current = true;
-    databaseMocks.deleteGeneratedAgents.mockReturnValueOnce(deletion.promise);
-    databaseMocks.bulkPutGeneratedAgents.mockResolvedValueOnce(undefined);
-    const agents = [
-      {
-        id: 'agent-a',
-        name: 'Agent A',
-        role: 'teacher',
-        persona: 'Teach',
-        avatar: 'A',
-        color: '#000',
-        priority: 1,
-      },
-    ];
+describe('rosterNeedsLegacyFallback', () => {
+  it('is true for an empty roster (the document may predate roster persistence)', () => {
+    expect(rosterNeedsLegacyFallback([])).toBe(true);
+  });
 
-    const saving = saveGeneratedAgentsForCurrentLoad('stage-a', agents, () => current);
-    await vi.waitFor(() => expect(databaseMocks.deleteGeneratedAgents).toHaveBeenCalled());
+  it('is true when any agent lacks both voice fields', () => {
+    expect(
+      rosterNeedsLegacyFallback([
+        makeAgentConfig('a', { voiceConfig: { providerId: 'p', voiceId: 'v' } }),
+        makeAgentConfig('b'),
+      ]),
+    ).toBe(true);
+  });
 
-    current = false;
-    deletion.resolve();
-    await saving;
+  it('is false once every agent carries a voice field', () => {
+    expect(
+      rosterNeedsLegacyFallback([
+        makeAgentConfig('a', { voiceConfig: { providerId: 'p', voiceId: 'v' } }),
+        makeAgentConfig('b', {
+          voiceDesign: { identity: 'i', texture: 't', delivery: 'd' },
+        }),
+      ]),
+    ).toBe(false);
+  });
+});
 
-    expect(databaseMocks.transaction).toHaveBeenCalledWith(
-      'rw',
-      expect.anything(),
-      expect.any(Function),
+describe('mergeLegacyAgentFallbacks', () => {
+  const voiceDesign = { identity: 'i', texture: 't', delivery: 'd' };
+  const voiceConfig = { providerId: 'p', voiceId: 'v' };
+
+  it('backfills voice fields by id and reports the change', () => {
+    const { configs, changed } = mergeLegacyAgentFallbacks(
+      [makeAgentConfig('a'), makeAgentConfig('b')],
+      [makeAgentConfig('a', { voiceDesign, voiceConfig })],
     );
-    expect(databaseMocks.bulkPutGeneratedAgents).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 'agent-a', stageId: 'stage-a' }),
-    ]);
+    expect(changed).toBe(true);
+    expect(configs[0]).toEqual(makeAgentConfig('a', { voiceDesign, voiceConfig }));
+    expect(configs[1]).toEqual(makeAgentConfig('b'));
+  });
+
+  it('never overwrites document-held voice fields', () => {
+    const docConfig = makeAgentConfig('a', { voiceDesign });
+    const { configs, changed } = mergeLegacyAgentFallbacks(
+      [docConfig],
+      [makeAgentConfig('a', { voiceDesign: { identity: 'x', texture: 'y', delivery: 'z' } })],
+    );
+    expect(changed).toBe(false);
+    expect(configs[0]).toBe(docConfig);
+  });
+
+  it('is idempotent: a second merge over the committed result changes nothing', () => {
+    const fallbacks = [makeAgentConfig('a', { voiceDesign })];
+    const first = mergeLegacyAgentFallbacks([makeAgentConfig('a')], fallbacks);
+    expect(first.changed).toBe(true);
+    const second = mergeLegacyAgentFallbacks(first.configs, fallbacks);
+    expect(second.changed).toBe(false);
+    expect(second.configs).toEqual(first.configs);
+  });
+
+  it('lifts a full roster when the document has none, priority-descending', () => {
+    const { configs, changed } = mergeLegacyAgentFallbacks(
+      [],
+      [makeAgentConfig('low', { priority: 3 }), makeAgentConfig('high', { priority: 9 })],
+    );
+    expect(changed).toBe(true);
+    expect(configs.map((c) => c.id)).toEqual(['high', 'low']);
+  });
+
+  it('reports no change when both sides are empty', () => {
+    expect(mergeLegacyAgentFallbacks([], [])).toEqual({ configs: [], changed: false });
+  });
+});
+
+describe('commitMigratedAgentConfigsToStore', () => {
+  it('commits onto the matching stage and leaves a different stage untouched', () => {
+    const configs = [makeAgentConfig('agent-a')];
+    useStageStore.setState({ stage: makeStage('stage-a') });
+
+    commitMigratedAgentConfigsToStore('stage-a', configs);
+    expect(useStageStore.getState().stage?.generatedAgentConfigs).toEqual(configs);
+
+    // Simulate a classroom switch racing the commit: the stale commit no-ops.
+    useStageStore.setState({ stage: makeStage('stage-b') });
+    commitMigratedAgentConfigsToStore('stage-a', [makeAgentConfig('stale')]);
+    expect(useStageStore.getState().stage?.id).toBe('stage-b');
+    expect(useStageStore.getState().stage?.generatedAgentConfigs).toEqual([]);
+
+    useStageStore.getState().clearStore();
   });
 });
 

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -10,12 +10,22 @@ import {
 } from '@/lib/classroom/load-classroom';
 import {
   claimStageSceneLoadToken,
+  clearStoreForDeletedStage,
+  discardPendingStageChanges,
   flushStageSave,
   isCurrentStageSceneLoadToken,
+  restorePendingStageChanges,
+  snapshotPendingStageChangesForDeletion,
   useStageStore,
 } from '@/lib/store/stage';
-import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
-import { saveStageDataIncremental } from '@/lib/utils/stage-storage';
+import {
+  beginStageDeletionCascade,
+  isStageDeleted,
+  markStageDeleted,
+  settleStageDeletionCascade,
+  unmarkStageDeleted,
+} from '@/lib/utils/deleted-stages';
+import { loadStageData, saveStageDataIncremental } from '@/lib/utils/stage-storage';
 import type { GeneratedAgentConfig, Scene, Stage } from '@/lib/types/stage';
 
 // The store flush path imports stage-storage dynamically; mock it so a pending
@@ -241,6 +251,106 @@ describe('runClassroomLoad', () => {
       );
     } finally {
       unmarkStageDeleted('stage-warm-ghost');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('keeps the warm classroom while its deletion cascade is unsettled, so a failed delete can restore pending edits', async () => {
+    // Browser Back lands while the home-page delete is still mid-cascade. The
+    // warm state (plus the deletion path's dirt snapshot) is the only copy of
+    // the pre-delete edits; discarding it before the cascade settles would
+    // lose them if the delete then fails before removing the document.
+    useStageStore.getState().clearStore();
+    vi.mocked(saveStageDataIncremental).mockClear();
+    vi.mocked(loadStageData).mockClear();
+    applyClassroomStageAndScenes(
+      makeStage('stage-mid-delete'),
+      [makeScene('scene-m', 'stage-mid-delete')],
+      { persist: false },
+    );
+    // A pre-delete edit sitting in the debounce window.
+    useStageStore.getState().setCurrentSceneId('scene-m');
+    try {
+      // Same ordering as deleteStageData: snapshot → mark → begin → discard.
+      const discarded = snapshotPendingStageChangesForDeletion('stage-mid-delete');
+      expect(discarded).toEqual([{ kind: 'currentScene' }]);
+      markStageDeleted('stage-mid-delete');
+      beginStageDeletionCascade('stage-mid-delete');
+      discardPendingStageChanges('stage-mid-delete');
+
+      // Back lands mid-cascade: warm state survives, no IndexedDB read.
+      await useStageStore.getState().loadFromStorage('stage-mid-delete');
+      expect(useStageStore.getState().stage?.id).toBe('stage-mid-delete');
+      expect(loadStageData).not.toHaveBeenCalled();
+
+      // The cascade fails before removing the document — deleteStageData's
+      // failure path lifts the flag, restores the dirt, then settles.
+      unmarkStageDeleted('stage-mid-delete');
+      restorePendingStageChanges('stage-mid-delete', discarded);
+      settleStageDeletionCascade('stage-mid-delete');
+
+      // The pre-delete edit reaches durability again through the scheduler.
+      await flushStageSave();
+      expect(saveStageDataIncremental).toHaveBeenCalledWith(
+        'stage-mid-delete',
+        expect.arrayContaining([{ kind: 'currentScene' }]),
+        expect.anything(),
+        expect.any(Number),
+      );
+    } finally {
+      settleStageDeletionCascade('stage-mid-delete');
+      unmarkStageDeleted('stage-mid-delete');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('evicts the warm ghost only after a successful deletion settles (Back during delete → success)', async () => {
+    useStageStore.getState().clearStore();
+    vi.mocked(loadStageData).mockClear();
+    applyClassroomStageAndScenes(
+      makeStage('stage-del-success'),
+      [makeScene('scene-s', 'stage-del-success')],
+      { persist: false },
+    );
+    markStageDeleted('stage-del-success');
+    beginStageDeletionCascade('stage-del-success');
+    try {
+      // Mid-cascade Back keeps the warm state (no discard, no reload).
+      await useStageStore.getState().loadFromStorage('stage-del-success');
+      expect(useStageStore.getState().stage?.id).toBe('stage-del-success');
+      expect(loadStageData).not.toHaveBeenCalled();
+
+      // The cascade completes: deleteStageData settles, then evicts.
+      settleStageDeletionCascade('stage-del-success');
+      clearStoreForDeletedStage('stage-del-success');
+      expect(useStageStore.getState().stage).toBeNull();
+    } finally {
+      settleStageDeletionCascade('stage-del-success');
+      unmarkStageDeleted('stage-del-success');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('does not evict a classroom restored (and unmarked) during the cascade tail', () => {
+    // Cascade-tail race: deleteStageData succeeded, and before its synchronous
+    // continuation ran the eviction, a same-id restore completed and unmarked
+    // the deletion. The eviction must recognize the warm state as the RESTORED
+    // classroom, not the deleted ghost.
+    useStageStore.getState().clearStore();
+    markStageDeleted('stage-tail-restore');
+    try {
+      applyClassroomStageAndScenes(
+        makeStage('stage-tail-restore'),
+        [makeScene('scene-t', 'stage-tail-restore')],
+        { persist: false },
+      );
+      expect(isStageDeleted('stage-tail-restore')).toBe(false);
+
+      clearStoreForDeletedStage('stage-tail-restore');
+
+      expect(useStageStore.getState().stage?.id).toBe('stage-tail-restore');
+    } finally {
+      unmarkStageDeleted('stage-tail-restore');
       useStageStore.getState().clearStore();
     }
   });

--- a/tests/classroom/load-classroom.test.ts
+++ b/tests/classroom/load-classroom.test.ts
@@ -255,11 +255,13 @@ describe('runClassroomLoad', () => {
     }
   });
 
-  it('keeps the warm classroom while its deletion cascade is unsettled, so a failed delete can restore pending edits', async () => {
+  it('parks a mid-cascade Back until the deletion settles; a failed delete keeps the warm classroom editable', async () => {
     // Browser Back lands while the home-page delete is still mid-cascade. The
     // warm state (plus the deletion path's dirt snapshot) is the only copy of
-    // the pre-delete edits; discarding it before the cascade settles would
-    // lose them if the delete then fails before removing the document.
+    // the pre-delete edits — but completing the load before the outcome is
+    // known would expose a classroom whose edits are refused and unrecorded.
+    // The load must WAIT for settlement, then keep the warm state when the
+    // delete failed (flag lifted, dirt restored).
     useStageStore.getState().clearStore();
     vi.mocked(saveStageDataIncremental).mockClear();
     vi.mocked(loadStageData).mockClear();
@@ -278,8 +280,19 @@ describe('runClassroomLoad', () => {
       beginStageDeletionCascade('stage-mid-delete');
       discardPendingStageChanges('stage-mid-delete');
 
-      // Back lands mid-cascade: warm state survives, no IndexedDB read.
-      await useStageStore.getState().loadFromStorage('stage-mid-delete');
+      // Back lands mid-cascade: the load parks on settlement instead of
+      // completing (no resolution, warm state untouched, no IndexedDB read).
+      const token = claimStageSceneLoadToken();
+      let loadSettled = false;
+      const loading = useStageStore
+        .getState()
+        .loadFromStorage('stage-mid-delete', token)
+        .then(() => {
+          loadSettled = true;
+        });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(loadSettled).toBe(false);
       expect(useStageStore.getState().stage?.id).toBe('stage-mid-delete');
       expect(loadStageData).not.toHaveBeenCalled();
 
@@ -288,6 +301,11 @@ describe('runClassroomLoad', () => {
       unmarkStageDeleted('stage-mid-delete');
       restorePendingStageChanges('stage-mid-delete', discarded);
       settleStageDeletionCascade('stage-mid-delete');
+
+      // The parked load resumes and keeps the warm (live again) classroom.
+      await loading;
+      expect(useStageStore.getState().stage?.id).toBe('stage-mid-delete');
+      expect(loadStageData).not.toHaveBeenCalled();
 
       // The pre-delete edit reaches durability again through the scheduler.
       await flushStageSave();
@@ -304,7 +322,11 @@ describe('runClassroomLoad', () => {
     }
   });
 
-  it('evicts the warm ghost only after a successful deletion settles (Back during delete → success)', async () => {
+  it('completes a mid-cascade Back with a cold server restore when the deletion succeeds', async () => {
+    // Back during delete → the deletion succeeds. The parked load must
+    // observe the settled outcome, let the settlement eviction stand, and run
+    // the full cold load so the server-restore path recovers the route —
+    // instead of leaving the user on a blanked classroom nothing reloads.
     useStageStore.getState().clearStore();
     vi.mocked(loadStageData).mockClear();
     applyClassroomStageAndScenes(
@@ -315,18 +337,88 @@ describe('runClassroomLoad', () => {
     markStageDeleted('stage-del-success');
     beginStageDeletionCascade('stage-del-success');
     try {
-      // Mid-cascade Back keeps the warm state (no discard, no reload).
-      await useStageStore.getState().loadFromStorage('stage-del-success');
-      expect(useStageStore.getState().stage?.id).toBe('stage-del-success');
-      expect(loadStageData).not.toHaveBeenCalled();
+      const serverStage = makeStage('stage-del-success');
+      const serverScene = makeScene('scene-server', 'stage-del-success');
+      const token = claimStageSceneLoadToken();
+      const { deps } = makeDeps({
+        classroomId: 'stage-del-success',
+        loadToken: token,
+        loadFromStorage: (id, t) => useStageStore.getState().loadFromStorage(id, t),
+        getCurrentStage: () => useStageStore.getState().stage,
+        fetchClassroom: vi.fn().mockResolvedValue({ stage: serverStage, scenes: [serverScene] }),
+        applyFallbackScenes: vi.fn().mockImplementation(async ({ stage, scenes }) => {
+          applyClassroomStageAndScenes(stage, scenes, { persist: false });
+          return true;
+        }),
+      });
 
-      // The cascade completes: deleteStageData settles, then evicts.
+      const loading = runClassroomLoad(deps);
+      await Promise.resolve();
+      await Promise.resolve();
+      // Parked: the classroom is not handed over mid-window.
+      expect(deps.fetchClassroom).not.toHaveBeenCalled();
+      expect(useStageStore.getState().stage?.id).toBe('stage-del-success');
+
+      // The cascade completes: deleteStageData settles, then evicts — same
+      // synchronous ordering as its finally + success tail.
       settleStageDeletionCascade('stage-del-success');
       clearStoreForDeletedStage('stage-del-success');
       expect(useStageStore.getState().stage).toBeNull();
+
+      await loading;
+
+      // The parked load fell through to a cold load (finding no local data)
+      // and the server fallback restored the classroom, lifting the deletion.
+      expect(loadStageData).toHaveBeenCalledWith('stage-del-success');
+      expect(deps.fetchClassroom).toHaveBeenCalledExactlyOnceWith('stage-del-success');
+      expect(useStageStore.getState().stage?.id).toBe('stage-del-success');
+      expect(useStageStore.getState().scenes.map((s) => s.id)).toEqual(['scene-server']);
+      expect(isStageDeleted('stage-del-success')).toBe(false);
+      expect(deps.setLoading).toHaveBeenCalledWith(false);
     } finally {
       settleStageDeletionCascade('stage-del-success');
       unmarkStageDeleted('stage-del-success');
+      useStageStore.getState().clearStore();
+    }
+  });
+
+  it('does not land the parked load when navigation moves on during deletion settlement', async () => {
+    // The user hits Back mid-cascade (load parks on settlement), then
+    // navigates to another classroom before the deletion settles. When the
+    // settlement releases the parked load, the token guard must keep it from
+    // touching the store the newer navigation now owns.
+    useStageStore.getState().clearStore();
+    vi.mocked(loadStageData).mockClear();
+    applyClassroomStageAndScenes(
+      makeStage('stage-await-nav'),
+      [makeScene('scene-n', 'stage-await-nav')],
+      { persist: false },
+    );
+    markStageDeleted('stage-await-nav');
+    beginStageDeletionCascade('stage-await-nav');
+    try {
+      const token = claimStageSceneLoadToken();
+      const loading = useStageStore.getState().loadFromStorage('stage-await-nav', token);
+
+      // A newer navigation claims the token and owns the store.
+      claimStageSceneLoadToken();
+      applyClassroomStageAndScenes(
+        makeStage('stage-other'),
+        [makeScene('scene-o', 'stage-other')],
+        { persist: false },
+      );
+
+      // The deletion settles successfully (flag kept) — releasing the parked
+      // load, which must now be a no-op.
+      settleStageDeletionCascade('stage-await-nav');
+      await loading;
+
+      expect(useStageStore.getState().stage?.id).toBe('stage-other');
+      expect(useStageStore.getState().scenes.map((s) => s.id)).toEqual(['scene-o']);
+      expect(loadStageData).not.toHaveBeenCalled();
+    } finally {
+      settleStageDeletionCascade('stage-await-nav');
+      unmarkStageDeleted('stage-await-nav');
       useStageStore.getState().clearStore();
     }
   });

--- a/tests/classroom/pbl-fallback-hydration.test.ts
+++ b/tests/classroom/pbl-fallback-hydration.test.ts
@@ -402,6 +402,7 @@ describe('classroom server fallback PBL hydration', () => {
         scenes: [serverScene],
         currentSceneId: SCENE_ID,
       }),
+      expect.any(Number),
     );
   });
 });

--- a/tests/document-store/stage-storage-incremental.test.ts
+++ b/tests/document-store/stage-storage-incremental.test.ts
@@ -132,7 +132,7 @@ beforeEach(() => {
 
 describe('saveStageDataIncremental', () => {
   it('prepares and writes exactly one dirty scene', async () => {
-    await saveStageDataIncremental('stage-1', [{ kind: 'scene', sceneId: 'scene-2' }], data);
+    await saveStageDataIncremental('stage-1', [{ kind: 'scene', sceneId: 'scene-2' }], data, 0);
 
     expect(prepareScenes).toHaveBeenCalledWith('stage-1', [scenes[1]]);
     expect(putScene).toHaveBeenCalledOnce();
@@ -143,23 +143,28 @@ describe('saveStageDataIncremental', () => {
 
   it('normalizes an undefined scene order to its document index', async () => {
     const unorderedScenes = [scenes[0], { ...scenes[1], order: undefined }] as Scene[];
-    await saveStageDataIncremental('stage-1', [{ kind: 'scene', sceneId: 'scene-2' }], {
-      ...data,
-      scenes: unorderedScenes,
-    });
+    await saveStageDataIncremental(
+      'stage-1',
+      [{ kind: 'scene', sceneId: 'scene-2' }],
+      {
+        ...data,
+        scenes: unorderedScenes,
+      },
+      0,
+    );
 
     expect(putScene.mock.calls[0]![1]).toEqual(expect.objectContaining({ order: 1 }));
   });
 
   it('uses the aggregate save for structural changes', async () => {
-    await saveStageDataIncremental('stage-1', [{ kind: 'structure' }], data);
+    await saveStageDataIncremental('stage-1', [{ kind: 'structure' }], data, 0);
     expect(prepareScenes).toHaveBeenCalledWith('stage-1', scenes);
     expect(saveDocument).toHaveBeenCalledOnce();
     expect(putScene).not.toHaveBeenCalled();
   });
 
   it('does not enter the document store for current-scene-only changes', async () => {
-    await saveStageDataIncremental('stage-1', [{ kind: 'currentScene' }], data);
+    await saveStageDataIncremental('stage-1', [{ kind: 'currentScene' }], data, 0);
     expect(mutateDocument).not.toHaveBeenCalled();
     expect(saveCurrentScene).toHaveBeenCalledWith('stage-1', 'scene-1');
   });
@@ -168,7 +173,7 @@ describe('saveStageDataIncremental', () => {
     putScene.mockRejectedValueOnce(
       new DocumentVersionError('stage-1', 'not-current', undefined, 'legacy'),
     );
-    await saveStageDataIncremental('stage-1', [{ kind: 'scene', sceneId: 'scene-1' }], data);
+    await saveStageDataIncremental('stage-1', [{ kind: 'scene', sceneId: 'scene-1' }], data, 0);
     expect(saveDocument).toHaveBeenCalledOnce();
     expect(prepareScenes).toHaveBeenLastCalledWith('stage-1', scenes);
   });
@@ -178,6 +183,7 @@ describe('saveStageDataIncremental', () => {
       'stage-1',
       [{ kind: 'scene', sceneId: 'scene-1' }, { kind: 'stage' }],
       data,
+      0,
     );
 
     expect(saveDocument).toHaveBeenCalledOnce();
@@ -188,7 +194,9 @@ describe('saveStageDataIncremental', () => {
   it('reports an isolated chat failure without failing the document flush', async () => {
     saveChatSessions.mockRejectedValueOnce(new Error('runtime unavailable'));
 
-    await expect(saveStageDataIncremental('stage-1', [{ kind: 'chats' }], data)).resolves.toEqual({
+    await expect(
+      saveStageDataIncremental('stage-1', [{ kind: 'chats' }], data, 0),
+    ).resolves.toEqual({
       failedChanges: [{ kind: 'chats' }],
     });
   });
@@ -198,7 +206,7 @@ describe('saveStageData', () => {
   it('reports a split chat failure after the document save succeeds', async () => {
     saveChatSessions.mockRejectedValueOnce(new Error('runtime unavailable'));
 
-    await expect(saveStageData('stage-1', data)).resolves.toEqual({
+    await expect(saveStageData('stage-1', data, 0)).resolves.toEqual({
       failedChanges: [{ kind: 'chats' }],
     });
     expect(saveDocument).toHaveBeenCalledOnce();

--- a/tests/export/classroom-zip.test.ts
+++ b/tests/export/classroom-zip.test.ts
@@ -280,4 +280,44 @@ describe('manifest round-trip', () => {
     expect('voiceConfig' in imported).toBe(false);
     expect('voiceDesign' in imported).toBe(false);
   });
+
+  test('malformed voice fields in a manifest are dropped without losing the agent', () => {
+    // Manifests are parsed JSON from user-supplied ZIPs: the typed shape is a
+    // claim, not a guarantee. Junk voice structures must not enter the
+    // document (and from there the registry/TTS path).
+    const junkAgent = {
+      name: 'Crafted',
+      role: 'teacher',
+      persona: 'p',
+      avatar: 'a',
+      color: '#000',
+      priority: 10,
+      voiceConfig: { providerId: { nested: true }, voiceId: 0 },
+      voiceDesign: { identity: 1, texture: null, delivery: ['x'] },
+    } as unknown as Parameters<typeof agentConfigFromManifest>[0];
+
+    const imported = agentConfigFromManifest(junkAgent, 'gen-x');
+
+    expect(imported.name).toBe('Crafted');
+    expect('voiceConfig' in imported).toBe(false);
+    expect('voiceDesign' in imported).toBe(false);
+  });
+
+  test('voice-field validation is per field: a valid design survives an invalid binding', () => {
+    const agent = {
+      name: 'Half valid',
+      role: 'student',
+      persona: 'p',
+      avatar: 'a',
+      color: '#000',
+      priority: 5,
+      voiceConfig: { providerId: 'tts', voiceId: 42 },
+      voiceDesign: { identity: 'adult', texture: 'low', delivery: 'calm' },
+    } as unknown as Parameters<typeof agentConfigFromManifest>[0];
+
+    const imported = agentConfigFromManifest(agent, 'gen-y');
+
+    expect('voiceConfig' in imported).toBe(false);
+    expect(imported.voiceDesign).toEqual({ identity: 'adult', texture: 'low', delivery: 'calm' });
+  });
 });

--- a/tests/export/classroom-zip.test.ts
+++ b/tests/export/classroom-zip.test.ts
@@ -2,9 +2,12 @@ import { describe, test, expect } from 'vitest';
 import { rewriteAudioRefsToIds, actionsToManifest } from '@/lib/export/classroom-zip-utils';
 import {
   CLASSROOM_ZIP_FORMAT_VERSION,
+  agentConfigFromManifest,
+  manifestAgentFromConfig,
   type ClassroomManifest,
 } from '@/lib/export/classroom-zip-types';
 import type { DiscussionAction, SpeechAction, SpotlightAction } from '@/lib/types/action';
+import type { GeneratedAgentConfig } from '@/lib/types/stage';
 
 // ─── rewriteAudioRefsToIds ────────────────────────────────────
 
@@ -239,5 +242,42 @@ describe('manifest round-trip', () => {
       type: 'audio',
       duration: 5.2,
     });
+  });
+
+  test('agent voice fields survive an export/import round trip (up to id renaming)', () => {
+    const config: GeneratedAgentConfig = {
+      id: 'gen-original',
+      name: 'Narrator',
+      role: 'teacher',
+      persona: 'Explains carefully',
+      avatar: '/avatars/teacher.png',
+      color: '#3b82f6',
+      priority: 10,
+      voiceConfig: { providerId: 'some-tts', voiceId: 'voice-1' },
+      voiceDesign: { identity: 'adult narrator', texture: 'low and clear', delivery: 'measured' },
+    };
+
+    const manifestAgent = JSON.parse(JSON.stringify(manifestAgentFromConfig(config)));
+    const imported = agentConfigFromManifest(manifestAgent, 'gen-new');
+
+    expect(imported).toEqual({ ...config, id: 'gen-new' });
+  });
+
+  test('agents without voice fields round-trip without inventing them', () => {
+    const config: GeneratedAgentConfig = {
+      id: 'gen-a',
+      name: 'Student',
+      role: 'student',
+      persona: 'Curious',
+      avatar: '/avatars/curious.png',
+      color: '#ec4899',
+      priority: 5,
+    };
+
+    const imported = agentConfigFromManifest(manifestAgentFromConfig(config), 'gen-b');
+
+    expect(imported).toEqual({ ...config, id: 'gen-b' });
+    expect('voiceConfig' in imported).toBe(false);
+    expect('voiceDesign' in imported).toBe(false);
   });
 });

--- a/tests/lib/orchestration/apply-generated-agents.test.ts
+++ b/tests/lib/orchestration/apply-generated-agents.test.ts
@@ -126,6 +126,18 @@ describe('applyGeneratedAgentsToRegistry', () => {
     expect(agent?.voiceDesign).toEqual(voiceDesign);
   });
 
+  it('drops a voice binding whose provider id is a prototype-chain key', () => {
+    // `'toString' in TTS_PROVIDERS` is true via Object.prototype; the guard
+    // must use own-property semantics or crafted zip manifests keep exactly
+    // the junk the whitelist was built to stop.
+    for (const junk of ['toString', 'constructor']) {
+      applyGeneratedAgentsToRegistry('stage-1', [
+        makeConfig('gen-a', { voiceConfig: { providerId: junk, voiceId: 'v1' } }),
+      ]);
+      expect(useAgentRegistry.getState().getAgent('gen-a')?.voiceConfig).toBeUndefined();
+    }
+  });
+
   it('replaces previously applied generated agents while keeping defaults', () => {
     applyGeneratedAgentsToRegistry('stage-1', [makeConfig('gen-old')]);
     applyGeneratedAgentsToRegistry('stage-2', [makeConfig('gen-new')]);

--- a/tests/lib/orchestration/apply-generated-agents.test.ts
+++ b/tests/lib/orchestration/apply-generated-agents.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/audio/agent-voice', () => ({
+  warmUpAgentVoices: vi.fn(),
+}));
+
+import {
+  applyGeneratedAgentsToRegistry,
+  useAgentRegistry,
+} from '@/lib/orchestration/registry/store';
+import type { GeneratedAgentConfig } from '@/lib/types/stage';
+
+function makeConfig(id: string, extra: Partial<GeneratedAgentConfig> = {}): GeneratedAgentConfig {
+  return {
+    id,
+    name: `Agent ${id}`,
+    role: 'teacher',
+    persona: 'Teach',
+    avatar: 'A',
+    color: '#000',
+    priority: 1,
+    ...extra,
+  };
+}
+
+function generatedAgents() {
+  return useAgentRegistry
+    .getState()
+    .listAgents()
+    .filter((agent) => agent.isGenerated);
+}
+
+beforeEach(() => {
+  // Reset: drop any generated agents left over from a previous test.
+  applyGeneratedAgentsToRegistry('reset', []);
+});
+
+describe('applyGeneratedAgentsToRegistry', () => {
+  it('adds the roster as stage-bound generated agents and returns the ids', () => {
+    const voiceDesign = { identity: 'warm', texture: 'low', delivery: 'calm' };
+    const ids = applyGeneratedAgentsToRegistry('stage-1', [
+      makeConfig('gen-a', {
+        voiceDesign,
+        voiceConfig: { providerId: 'some-tts', modelId: 'model-x', voiceId: 'voice-1' },
+      }),
+      makeConfig('gen-b', { role: 'student' }),
+    ]);
+
+    expect(ids).toEqual(['gen-a', 'gen-b']);
+    const agentA = useAgentRegistry.getState().getAgent('gen-a');
+    expect(agentA).toMatchObject({
+      isGenerated: true,
+      isDefault: false,
+      boundStageId: 'stage-1',
+      voiceDesign,
+      voiceConfig: { providerId: 'some-tts', modelId: 'model-x', voiceId: 'voice-1' },
+    });
+    const agentB = useAgentRegistry.getState().getAgent('gen-b');
+    expect(agentB?.voiceConfig).toBeUndefined();
+    // Role-based action grants: students get whiteboard-only actions.
+    expect(agentA?.allowedActions).toContain('spotlight');
+    expect(agentB?.allowedActions).not.toContain('spotlight');
+  });
+
+  it('replaces previously applied generated agents while keeping defaults', () => {
+    applyGeneratedAgentsToRegistry('stage-1', [makeConfig('gen-old')]);
+    applyGeneratedAgentsToRegistry('stage-2', [makeConfig('gen-new')]);
+
+    expect(useAgentRegistry.getState().getAgent('gen-old')).toBeUndefined();
+    expect(useAgentRegistry.getState().getAgent('gen-new')).toMatchObject({
+      boundStageId: 'stage-2',
+    });
+    expect(useAgentRegistry.getState().getAgent('default-1')?.isDefault).toBe(true);
+  });
+
+  it('clears generated agents when applying an empty roster', () => {
+    applyGeneratedAgentsToRegistry('stage-1', [makeConfig('gen-a')]);
+    const ids = applyGeneratedAgentsToRegistry('stage-2', []);
+
+    expect(ids).toEqual([]);
+    expect(generatedAgents()).toEqual([]);
+    expect(useAgentRegistry.getState().getAgent('default-1')).toBeDefined();
+  });
+});

--- a/tests/lib/orchestration/apply-generated-agents.test.ts
+++ b/tests/lib/orchestration/apply-generated-agents.test.ts
@@ -1,4 +1,41 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Give this module graph a working window.localStorage BEFORE the registry
+// store is imported: the zustand persist middleware resolves its default
+// storage from `window.localStorage` at store creation and disables itself
+// (including the whole `persist` API) when that throws, which would make the
+// persistence-exclusion behavior under test unreachable in the node env.
+vi.hoisted(() => {
+  const backing = new Map<string, string>();
+  const localStorageStub: Storage = {
+    get length() {
+      return backing.size;
+    },
+    clear: () => backing.clear(),
+    getItem: (key: string) => backing.get(key) ?? null,
+    key: (index: number) => [...backing.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      backing.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      backing.set(key, value);
+    },
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageStub,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    value: globalThis,
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  // Globals are worker-scoped: undo the stubs so other files keep a clean env.
+  delete (globalThis as { window?: unknown }).window;
+  delete (globalThis as { localStorage?: unknown }).localStorage;
+});
 
 vi.mock('@/lib/audio/agent-voice', () => ({
   warmUpAgentVoices: vi.fn(),
@@ -8,6 +45,7 @@ import {
   applyGeneratedAgentsToRegistry,
   useAgentRegistry,
 } from '@/lib/orchestration/registry/store';
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
 import type { GeneratedAgentConfig } from '@/lib/types/stage';
 
 function makeConfig(id: string, extra: Partial<GeneratedAgentConfig> = {}): GeneratedAgentConfig {
@@ -41,7 +79,7 @@ describe('applyGeneratedAgentsToRegistry', () => {
     const ids = applyGeneratedAgentsToRegistry('stage-1', [
       makeConfig('gen-a', {
         voiceDesign,
-        voiceConfig: { providerId: 'some-tts', modelId: 'model-x', voiceId: 'voice-1' },
+        voiceConfig: { providerId: 'qwen-tts', voiceId: 'voice-1' },
       }),
       makeConfig('gen-b', { role: 'student' }),
     ]);
@@ -53,13 +91,39 @@ describe('applyGeneratedAgentsToRegistry', () => {
       isDefault: false,
       boundStageId: 'stage-1',
       voiceDesign,
-      voiceConfig: { providerId: 'some-tts', modelId: 'model-x', voiceId: 'voice-1' },
+      voiceConfig: { providerId: 'qwen-tts', voiceId: 'voice-1' },
     });
     const agentB = useAgentRegistry.getState().getAgent('gen-b');
     expect(agentB?.voiceConfig).toBeUndefined();
     // Role-based action grants: students get whiteboard-only actions.
     expect(agentA?.allowedActions).toContain('spotlight');
     expect(agentB?.allowedActions).not.toContain('spotlight');
+  });
+
+  it('accepts a custom-provider voice binding (open namespace)', () => {
+    applyGeneratedAgentsToRegistry('stage-1', [
+      makeConfig('gen-a', { voiceConfig: { providerId: 'custom-tts-mine', voiceId: 'v1' } }),
+    ]);
+    expect(useAgentRegistry.getState().getAgent('gen-a')?.voiceConfig).toEqual({
+      providerId: 'custom-tts-mine',
+      voiceId: 'v1',
+    });
+  });
+
+  it('drops a voice binding whose provider is unknown, keeping the agent and its voiceDesign', () => {
+    // The contract keeps providerId an open string; a document (e.g. from an
+    // imported ZIP) can carry junk. It must not reach the TTS path via a cast.
+    const voiceDesign = { identity: 'warm', texture: 'low', delivery: 'calm' };
+    const ids = applyGeneratedAgentsToRegistry('stage-1', [
+      makeConfig('gen-a', {
+        voiceDesign,
+        voiceConfig: { providerId: 'definitely-not-a-tts-provider', voiceId: 'v1' },
+      }),
+    ]);
+    expect(ids).toEqual(['gen-a']);
+    const agent = useAgentRegistry.getState().getAgent('gen-a');
+    expect(agent?.voiceConfig).toBeUndefined();
+    expect(agent?.voiceDesign).toEqual(voiceDesign);
   });
 
   it('replaces previously applied generated agents while keeping defaults', () => {
@@ -80,5 +144,63 @@ describe('applyGeneratedAgentsToRegistry', () => {
     expect(ids).toEqual([]);
     expect(generatedAgents()).toEqual([]);
     expect(useAgentRegistry.getState().getAgent('default-1')).toBeDefined();
+  });
+});
+
+describe('registry persistence excludes generated agents', () => {
+  function makeCustomAgent(id: string): AgentConfig {
+    return {
+      id,
+      name: `Custom ${id}`,
+      role: 'student',
+      persona: 'Custom persona',
+      avatar: 'C',
+      color: '#111',
+      allowedActions: [],
+      priority: 1,
+      isDefault: false,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    };
+  }
+
+  it('serializes no generated agents to localStorage (single durable home)', () => {
+    useAgentRegistry.getState().addAgent(makeCustomAgent('custom-1'));
+    try {
+      applyGeneratedAgentsToRegistry('stage-1', [makeConfig('gen-a')]);
+
+      const raw = localStorage.getItem('agent-registry-storage');
+      expect(raw).not.toBeNull();
+      const persisted = JSON.parse(raw!) as { state: { agents: Record<string, AgentConfig> } };
+      // The roster's only durable home is the stage document.
+      expect(persisted.state.agents['gen-a']).toBeUndefined();
+      expect(Object.values(persisted.state.agents).some((agent) => agent.isGenerated)).toBe(false);
+      // Custom and default agents still persist.
+      expect(persisted.state.agents['custom-1']).toBeDefined();
+      expect(persisted.state.agents['default-1']).toBeDefined();
+    } finally {
+      useAgentRegistry.getState().deleteAgent('custom-1');
+    }
+  });
+
+  it('merge drops persisted generated agents on rehydration (defense in depth)', () => {
+    // Pre-partialize snapshots may still carry generated agents; the merge
+    // filter is the backstop that keeps them from leaking across sessions.
+    const { merge } = useAgentRegistry.persist.getOptions();
+    expect(merge).toBeDefined();
+    const persisted = {
+      agents: {
+        'gen-old': { ...makeCustomAgent('gen-old'), isGenerated: true },
+        'custom-1': makeCustomAgent('custom-1'),
+        'default-1': { ...makeCustomAgent('default-1'), name: 'stale cached teacher' },
+      },
+    };
+    const merged = merge!(persisted, useAgentRegistry.getState()) as {
+      agents: Record<string, AgentConfig>;
+    };
+    expect(merged.agents['gen-old']).toBeUndefined();
+    expect(merged.agents['custom-1']).toBeDefined();
+    // Default agents always use code-defined values, not the cached copy.
+    expect(merged.agents['default-1'].name).toBe('AI teacher');
   });
 });

--- a/tests/runtime/database-chat-cutover.test.ts
+++ b/tests/runtime/database-chat-cutover.test.ts
@@ -525,6 +525,87 @@ describe('database runtime chat integration', () => {
     ).resolves.toMatchObject([{ title: 'Original runtime chat' }]);
   });
 
+  it('lifts the deletion state when a backup import recreates a deleted stage', async () => {
+    const { importDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
+    const { isStageDeleted, markStageDeleted, stageDeletionEpoch } =
+      await import('@/lib/utils/deleted-stages');
+
+    // The stage was deleted earlier this session; the backup restores its id.
+    markStageDeleted('stage-import-revive');
+    const epochAfterDelete = stageDeletionEpoch('stage-import-revive');
+
+    await importDatabase({
+      stages: [
+        {
+          id: 'stage-import-revive',
+          name: 'Restored by import',
+          createdAt: 1_000,
+          updatedAt: 3_000,
+        },
+      ],
+    });
+
+    await expect(getDocumentStore().loadDocument('stage-import-revive')).resolves.toMatchObject({
+      stage: { name: 'Restored by import' },
+    });
+    // The deleted flag is lifted so later edits persist; the deletion epoch
+    // stays bumped so pre-delete in-flight writes remain fenced.
+    expect(isStageDeleted('stage-import-revive')).toBe(false);
+    expect(stageDeletionEpoch('stage-import-revive')).toBe(epochAfterDelete);
+  });
+
+  it('reinstates the deletion state when a failed import rolls back a restored document', async () => {
+    const backing = new BrowserRuntimeStore({ indexedDB: globalThis.indexedDB });
+    const { importDatabase } = await import('@/lib/utils/database');
+    const { getDocumentStore } = await import('@/lib/document-store');
+    const { isStageDeleted, markStageDeleted, stageDeletionEpoch } =
+      await import('@/lib/utils/deleted-stages');
+
+    // Deleted earlier this session: no document, deletion in effect.
+    markStageDeleted('stage-import-rollback');
+    const epochAfterDelete = stageDeletionEpoch('stage-import-rollback');
+
+    const markerFailureStore = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'createSession') {
+          return async (init: Parameters<RuntimeStore['createSession']>[0]) => {
+            if (init.id.startsWith('chat-restore-marker:')) {
+              throw new Error('restore marker failed');
+            }
+            return target.createSession(init);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    await expect(
+      importDatabase(
+        {
+          stages: [
+            {
+              id: 'stage-import-rollback',
+              name: 'Restored by import',
+              createdAt: 1_000,
+              updatedAt: 3_000,
+            },
+          ],
+          chatSessions: [],
+        },
+        { store: markerFailureStore, learnerKey },
+      ),
+    ).rejects.toThrow('restore marker failed');
+
+    // The rollback removed the imported document again (pre-image was absent)…
+    await expect(getDocumentStore().loadDocument('stage-import-rollback')).resolves.toBeNull();
+    // …and reinstated the deletion state the import had lifted, so an
+    // outstanding flush cannot recreate the rolled-back document.
+    expect(isStageDeleted('stage-import-rollback')).toBe(true);
+    expect(stageDeletionEpoch('stage-import-rollback')).toBeGreaterThan(epochAfterDelete);
+  });
+
   it('blocks lazy migration behind a runtime-wide clear and observes the deleted source', async () => {
     vi.stubGlobal('navigator', { locks: fairLockManager() });
     const backing = new BrowserRuntimeStore({ indexedDB: globalThis.indexedDB });

--- a/tests/runtime/database-chat-cutover.test.ts
+++ b/tests/runtime/database-chat-cutover.test.ts
@@ -693,12 +693,16 @@ describe('database runtime chat integration', () => {
       return document;
     });
 
-    const staleSave = saveStageData(stage.id, {
-      stage: { ...stage, name: 'Stale save' },
-      scenes: [],
-      currentSceneId: null,
-      chats: [],
-    });
+    const staleSave = saveStageData(
+      stage.id,
+      {
+        stage: { ...stage, name: 'Stale save' },
+        scenes: [],
+        currentSceneId: null,
+        chats: [],
+      },
+      0,
+    );
     await migrationLoadStarted;
     const clearing = clearDatabase(runtimeStore);
     releaseMigrationLoad();
@@ -708,12 +712,16 @@ describe('database runtime chat integration', () => {
     await expect(documentStore.loadDocument(stage.id)).resolves.toBeNull();
 
     await expect(
-      saveStageData(stage.id, {
-        stage: { ...stage, name: 'Fresh save' },
-        scenes: [],
-        currentSceneId: null,
-        chats: [],
-      }),
+      saveStageData(
+        stage.id,
+        {
+          stage: { ...stage, name: 'Fresh save' },
+          scenes: [],
+          currentSceneId: null,
+          chats: [],
+        },
+        0,
+      ),
     ).resolves.toBeUndefined();
     await expect(documentStore.loadDocument(stage.id)).resolves.toMatchObject({
       stage: { name: 'Fresh save' },
@@ -1079,17 +1087,21 @@ describe('database runtime chat integration', () => {
       return originalSave(document);
     });
 
-    const saving = saveStageData('stage-save-enrollment', {
-      stage: {
-        id: 'stage-save-enrollment',
-        name: 'Enrolled save',
-        createdAt: 1_000,
-        updatedAt: 2_000,
+    const saving = saveStageData(
+      'stage-save-enrollment',
+      {
+        stage: {
+          id: 'stage-save-enrollment',
+          name: 'Enrolled save',
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+        scenes: [],
+        currentSceneId: null,
+        chats: [chatSession()],
       },
-      scenes: [],
-      currentSceneId: null,
-      chats: [chatSession()],
-    });
+      0,
+    );
     await didStartDocumentWrite;
     let maintenanceStarted = false;
     const maintenance = withRuntimeStorageExclusiveLock(async () => {
@@ -1125,17 +1137,21 @@ describe('database runtime chat integration', () => {
       return originalSave(document);
     });
 
-    const saving = saveStageData('stage-epoch-order', {
-      stage: {
-        id: 'stage-epoch-order',
-        name: 'Epoch ordering',
-        createdAt: 1_000,
-        updatedAt: 2_000,
+    const saving = saveStageData(
+      'stage-epoch-order',
+      {
+        stage: {
+          id: 'stage-epoch-order',
+          name: 'Epoch ordering',
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+        scenes: [],
+        currentSceneId: null,
+        chats: [chatSession()],
       },
-      scenes: [],
-      currentSceneId: null,
-      chats: [chatSession()],
-    });
+      0,
+    );
     await didStartDocumentWrite;
     const boundedExclusive = withRuntimeStorageExclusiveLock as <T>(
       work: () => Promise<T>,
@@ -1508,17 +1524,21 @@ describe('database runtime chat integration', () => {
     const { loadStageData, saveStageData } = await import('@/lib/utils/stage-storage');
 
     await expect(
-      saveStageData('stage-no-chat', {
-        stage: {
-          id: 'stage-no-chat',
-          name: 'No chat stage',
-          createdAt: 1_000,
-          updatedAt: 2_000,
+      saveStageData(
+        'stage-no-chat',
+        {
+          stage: {
+            id: 'stage-no-chat',
+            name: 'No chat stage',
+            createdAt: 1_000,
+            updatedAt: 2_000,
+          },
+          scenes: [],
+          currentSceneId: null,
+          chats: [],
         },
-        scenes: [],
-        currentSceneId: null,
-        chats: [],
-      }),
+        0,
+      ),
     ).resolves.toBeUndefined();
     await expect(loadStageData('stage-no-chat')).resolves.toMatchObject({
       stage: { name: 'No chat stage' },
@@ -1629,10 +1649,14 @@ describe('database runtime chat integration', () => {
     const loaded = await loadStageData('stage-legacy-autosave');
 
     await expect(
-      saveStageData('stage-legacy-autosave', {
-        ...loaded!,
-        stage: { ...loaded!.stage, name: 'Updated stage' },
-      }),
+      saveStageData(
+        'stage-legacy-autosave',
+        {
+          ...loaded!,
+          stage: { ...loaded!.stage, name: 'Updated stage' },
+        },
+        0,
+      ),
     ).resolves.toBeUndefined();
     await expect(loadStageData('stage-legacy-autosave')).resolves.toMatchObject({
       stage: { name: 'Updated stage' },
@@ -1671,10 +1695,14 @@ describe('database runtime chat integration', () => {
     const loaded = await loadStageData('stage-legacy-edit');
 
     await expect(
-      saveStageData('stage-legacy-edit', {
-        ...loaded!,
-        chats: [{ ...loaded!.chats[0]!, title: 'Unsaved edit', updatedAt: 3_000 }],
-      }),
+      saveStageData(
+        'stage-legacy-edit',
+        {
+          ...loaded!,
+          chats: [{ ...loaded!.chats[0]!, title: 'Unsaved edit', updatedAt: 3_000 }],
+        },
+        0,
+      ),
     ).rejects.toThrow(/Web Locks/);
   });
 
@@ -1695,9 +1723,9 @@ describe('database runtime chat integration', () => {
     });
     const loaded = await loadStageData('stage-legacy-delete');
 
-    await expect(saveStageData('stage-legacy-delete', { ...loaded!, chats: [] })).rejects.toThrow(
-      /Web Locks/,
-    );
+    await expect(
+      saveStageData('stage-legacy-delete', { ...loaded!, chats: [] }, 0),
+    ).rejects.toThrow(/Web Locks/);
   });
 
   it('still fails non-empty chat document saves without Web Locks', async () => {
@@ -1706,17 +1734,21 @@ describe('database runtime chat integration', () => {
     const { saveStageData } = await import('@/lib/utils/stage-storage');
 
     await expect(
-      saveStageData('stage-with-chat', {
-        stage: {
-          id: 'stage-with-chat',
-          name: 'Chat stage',
-          createdAt: 1_000,
-          updatedAt: 2_000,
+      saveStageData(
+        'stage-with-chat',
+        {
+          stage: {
+            id: 'stage-with-chat',
+            name: 'Chat stage',
+            createdAt: 1_000,
+            updatedAt: 2_000,
+          },
+          scenes: [],
+          currentSceneId: null,
+          chats: [chatSession()],
         },
-        scenes: [],
-        currentSceneId: null,
-        chats: [chatSession()],
-      }),
+        0,
+      ),
     ).rejects.toThrow(/Web Locks/);
   });
 

--- a/tests/server/classroom-generation-retry.test.ts
+++ b/tests/server/classroom-generation-retry.test.ts
@@ -16,7 +16,10 @@ vi.mock('@/lib/server/resolve-model', () => ({
   resolveModel: mocks.resolveModel,
 }));
 
-vi.mock('@/lib/ai/providers', () => ({
+vi.mock('@/lib/ai/providers', async (importOriginal) => ({
+  // The module graph now reaches the settings store (stage store -> settings),
+  // whose init reads PROVIDERS - keep the real exports and stub only the probe.
+  ...(await importOriginal<typeof import('@/lib/ai/providers')>()),
   isProviderKeyRequired: mocks.isProviderKeyRequired,
 }));
 

--- a/tests/store/stage-agents.test.ts
+++ b/tests/store/stage-agents.test.ts
@@ -1,14 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { settingsState, setSelectedAgentIds, applyGeneratedAgentsToRegistry } = vi.hoisted(() => {
+const {
+  settingsState,
+  setSelectedAgentIds,
+  setAgentSelectionIsUserSet,
+  applyGeneratedAgentsToRegistry,
+} = vi.hoisted(() => {
   const setSelectedAgentIds = vi.fn();
+  const setAgentSelectionIsUserSet = vi.fn();
   return {
     setSelectedAgentIds,
+    setAgentSelectionIsUserSet,
     settingsState: {
       agentMode: 'auto' as 'preset' | 'auto',
       selectedAgentIds: [] as string[],
       agentSelectionIsUserSet: false,
       setSelectedAgentIds,
+      setAgentSelectionIsUserSet,
     },
     applyGeneratedAgentsToRegistry: vi.fn(
       (_stageId: string, configs: ReadonlyArray<{ id: string }>) => configs.map((c) => c.id),
@@ -33,7 +41,12 @@ vi.mock('@/lib/store/settings', () => ({
   },
 }));
 
-import { discardPendingStageChanges, useStageStore } from '@/lib/store/stage';
+import {
+  discardPendingStageChanges,
+  restorePendingStageChanges,
+  snapshotPendingStageChangesForDeletion,
+  useStageStore,
+} from '@/lib/store/stage';
 import { markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
 import { saveStageData, saveStageDataIncremental } from '@/lib/utils/stage-storage';
 import type { Stage } from '@/lib/types/stage';
@@ -64,6 +77,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   applyGeneratedAgentsToRegistry.mockClear();
   setSelectedAgentIds.mockClear();
+  setAgentSelectionIsUserSet.mockClear();
   settingsState.agentMode = 'auto';
   settingsState.selectedAgentIds = [];
   settingsState.agentSelectionIsUserSet = false;
@@ -167,6 +181,75 @@ describe('setStageAgents selection provenance', () => {
     useStageStore.getState().setStageAgents([makeAgentConfig('a1')]);
 
     expect(setSelectedAgentIds).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the full roster and clears the user-set flag when the intersection is empty', () => {
+    // Mirrors restoreAgentSelection's `length > 0` gate: an empty user-set
+    // selection is invalid there, so it must not be written here either —
+    // otherwise the classroom runs with zero agents until a reload heals it.
+    useStageStore.setState({
+      stage: {
+        ...makeStage(),
+        generatedAgentConfigs: [
+          makeAgentConfig('old-1'),
+          makeAgentConfig('old-2'),
+          makeAgentConfig('old-3'),
+        ],
+      },
+    });
+    settingsState.agentSelectionIsUserSet = true;
+    settingsState.agentMode = 'auto';
+    // A genuine subset (not the full roster), all of whose members leave.
+    settingsState.selectedAgentIds = ['old-1', 'old-2'];
+
+    useStageStore
+      .getState()
+      .setStageAgents([makeAgentConfig('fresh-1'), makeAgentConfig('fresh-2')]);
+
+    expect(setSelectedAgentIds).toHaveBeenCalledExactlyOnceWith(['fresh-1', 'fresh-2']);
+    expect(setAgentSelectionIsUserSet).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('keeps tracking the whole roster when the user-set selection WAS the full roster (auto-toggle intent)', () => {
+    // The AgentBar auto toggle snapshots the entire roster as a "user-set"
+    // selection. That intent is "everyone", so a roster addition must include
+    // the newcomer instead of freezing the old snapshot forever.
+    useStageStore.setState({
+      stage: {
+        ...makeStage(),
+        generatedAgentConfigs: [makeAgentConfig('a1'), makeAgentConfig('a2')],
+      },
+    });
+    settingsState.agentSelectionIsUserSet = true;
+    settingsState.agentMode = 'auto';
+    settingsState.selectedAgentIds = ['a1', 'a2'];
+
+    useStageStore
+      .getState()
+      .setStageAgents([makeAgentConfig('a1'), makeAgentConfig('a2'), makeAgentConfig('a3')]);
+
+    expect(setSelectedAgentIds).toHaveBeenCalledExactlyOnceWith(['a1', 'a2', 'a3']);
+    // Still the user's choice ("everyone") — provenance is not downgraded.
+    expect(setAgentSelectionIsUserSet).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-select newcomers when the user-set selection was a genuine subset of the roster', () => {
+    useStageStore.setState({
+      stage: {
+        ...makeStage(),
+        generatedAgentConfigs: [makeAgentConfig('a1'), makeAgentConfig('a2')],
+      },
+    });
+    settingsState.agentSelectionIsUserSet = true;
+    settingsState.agentMode = 'auto';
+    settingsState.selectedAgentIds = ['a1'];
+
+    useStageStore
+      .getState()
+      .setStageAgents([makeAgentConfig('a1'), makeAgentConfig('a2'), makeAgentConfig('a3')]);
+
+    expect(setSelectedAgentIds).not.toHaveBeenCalled();
+    expect(setAgentSelectionIsUserSet).not.toHaveBeenCalled();
   });
 });
 
@@ -281,6 +364,56 @@ describe('setStageAgents persistence (document scheduler)', () => {
 
     // The retry was dropped instead of recreating the deleted document.
     expect(stage1Attempts()).toHaveLength(1);
+  });
+
+  it('restores dirt discarded by a failed deletion so the edits still reach storage', async () => {
+    // The edit sits in the debounce window when the delete starts; the delete
+    // snapshots + discards it, then fails before the document was removed.
+    useStageStore.getState().setStageAgents([makeAgentConfig('edited')]);
+    const discarded = snapshotPendingStageChangesForDeletion('stage-1');
+    expect(discarded).toEqual(expect.arrayContaining([{ kind: 'stage' }]));
+
+    markStageDeleted('stage-1');
+    discardPendingStageChanges('stage-1');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saveStageDataIncremental).not.toHaveBeenCalled();
+
+    // Failure path: deleteStageData lifts the tombstone and restores the dirt.
+    unmarkStageDeleted('stage-1');
+    restorePendingStageChanges('stage-1', discarded);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(saveStageDataIncremental).toHaveBeenCalledOnce();
+    const [stageId, dirty] = vi.mocked(saveStageDataIncremental).mock.calls[0];
+    expect(stageId).toBe('stage-1');
+    expect(dirty).toEqual(expect.arrayContaining([{ kind: 'stage' }]));
+  });
+
+  it('includes the in-flight flush round dirt in the deletion snapshot', async () => {
+    // A round already outside the pending map (mid-await in storage) is
+    // exactly the dirt the tombstone will drop; a failed delete must be able
+    // to restore it too.
+    let release!: (value: { failedChanges: [] }) => void;
+    vi.mocked(saveStageDataIncremental).mockReturnValueOnce(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    useStageStore.getState().setStageAgents([makeAgentConfig('in-flight')]);
+    await vi.advanceTimersByTimeAsync(500); // round starts, awaiting storage
+    discardPendingStageChanges('stage-1'); // deletion wipes the pending map
+
+    expect(snapshotPendingStageChangesForDeletion('stage-1')).toEqual([{ kind: 'stage' }]);
+    expect(snapshotPendingStageChangesForDeletion('some-other-stage')).toEqual([]);
+
+    release({ failedChanges: [] });
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('restore no-ops when the store has since moved to another stage', async () => {
+    restorePendingStageChanges('stage-2', [{ kind: 'stage' }]);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saveStageDataIncremental).not.toHaveBeenCalled();
   });
 
   it('does NOT touch the registry on plain saveToStorage without a roster edit', async () => {

--- a/tests/store/stage-agents.test.ts
+++ b/tests/store/stage-agents.test.ts
@@ -1,22 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { setSelectedAgentIds } = vi.hoisted(() => ({
+const { setSelectedAgentIds, applyGeneratedAgentsToRegistry } = vi.hoisted(() => ({
   setSelectedAgentIds: vi.fn(),
+  applyGeneratedAgentsToRegistry: vi.fn(
+    (_stageId: string, configs: ReadonlyArray<{ id: string }>) => configs.map((c) => c.id),
+  ),
 }));
 
-// IndexedDB / stage-storage modules are imported dynamically inside the
-// store's save/load actions. Mock them so the debounced save doesn't try
-// to talk to a real (or jsdom) IndexedDB in the test environment.
+// Stage-storage modules are imported dynamically inside the store's save/load
+// actions. Mock them so the scheduled flush doesn't try to talk to a real (or
+// jsdom) IndexedDB in the test environment.
 vi.mock('@/lib/utils/stage-storage', () => ({
   saveStageData: vi.fn().mockResolvedValue(undefined),
   saveStageDataIncremental: vi.fn().mockResolvedValue(undefined),
   loadStageData: vi.fn().mockResolvedValue(null),
 }));
-vi.mock('@/lib/utils/database', () => ({
-  db: { stageOutlines: { put: vi.fn(), get: vi.fn() } },
-}));
 vi.mock('@/lib/orchestration/registry/store', () => ({
-  saveGeneratedAgents: vi.fn().mockResolvedValue([]),
+  applyGeneratedAgentsToRegistry,
 }));
 vi.mock('@/lib/store/settings', () => ({
   useSettingsStore: {
@@ -24,9 +24,8 @@ vi.mock('@/lib/store/settings', () => ({
   },
 }));
 
-import { useStageStore } from '@/lib/store/stage';
+import { discardPendingStageChanges, useStageStore } from '@/lib/store/stage';
 import { saveStageData, saveStageDataIncremental } from '@/lib/utils/stage-storage';
-import { saveGeneratedAgents } from '@/lib/orchestration/registry/store';
 import type { Stage } from '@/lib/types/stage';
 import type { GeneratedAgentConfig } from '@/lib/types/stage';
 
@@ -53,6 +52,8 @@ function makeAgentConfig(id: string): GeneratedAgentConfig {
 
 beforeEach(() => {
   vi.useFakeTimers();
+  applyGeneratedAgentsToRegistry.mockClear();
+  setSelectedAgentIds.mockClear();
   useStageStore.setState({
     stage: makeStage(),
     scenes: [],
@@ -60,15 +61,10 @@ beforeEach(() => {
   });
 });
 
-afterEach(async () => {
-  try {
-    await vi.runOnlyPendingTimersAsync();
-    await vi.dynamicImportSettled();
-    expect(vi.getTimerCount()).toBe(0);
-  } finally {
-    useStageStore.getState().clearStore();
-    vi.useRealTimers();
-  }
+afterEach(() => {
+  // clearStore cancels any scheduled flush timer along with pending changes.
+  useStageStore.getState().clearStore();
+  vi.useRealTimers();
 });
 
 describe('setStageAgents', () => {
@@ -103,59 +99,50 @@ describe('setStageAgents', () => {
     expect(stage?.id).toBe('stage-1');
     expect(stage?.name).toBe('Test stage');
   });
+
+  it('synchronously mirrors the roster into the registry and selection', () => {
+    const configs = [makeAgentConfig('a1'), makeAgentConfig('a2')];
+    useStageStore.getState().setStageAgents(configs);
+
+    // No timers involved: the registry/selection mirrors are in-memory side
+    // effects, not persistence.
+    expect(applyGeneratedAgentsToRegistry).toHaveBeenCalledExactlyOnceWith('stage-1', configs);
+    expect(setSelectedAgentIds).toHaveBeenCalledExactlyOnceWith(['a1', 'a2']);
+  });
 });
 
-describe('setStageAgents persistence (debounced save)', () => {
+describe('setStageAgents persistence (document scheduler)', () => {
   beforeEach(() => {
     vi.mocked(saveStageData).mockClear();
     vi.mocked(saveStageDataIncremental).mockClear();
-    vi.mocked(saveGeneratedAgents).mockClear();
+    applyGeneratedAgentsToRegistry.mockClear();
     setSelectedAgentIds.mockClear();
   });
 
-  it('includes generatedAgentConfigs in saveStageData after debounce', async () => {
-    const configs = [makeAgentConfig('x1'), makeAgentConfig('x2')];
+  it('persists generatedAgentConfigs (voice included) via the stage document flush', async () => {
+    const configs: GeneratedAgentConfig[] = [
+      {
+        ...makeAgentConfig('x1'),
+        voiceDesign: { identity: 'warm mentor', texture: 'low and clear', delivery: 'calm' },
+        voiceConfig: { providerId: 'tts-provider', voiceId: 'voice-1' },
+      },
+      makeAgentConfig('x2'),
+    ];
     useStageStore.getState().setStageAgents(configs);
 
-    // Flush the 500 ms debounce
-    await vi.runAllTimersAsync();
+    // Drain the scheduler's 500 ms debounce window.
+    await vi.advanceTimersByTimeAsync(500);
 
     expect(saveStageDataIncremental).toHaveBeenCalledOnce();
-    const [, , storeData] = vi.mocked(saveStageDataIncremental).mock.calls[0];
+    const [stageId, dirty, storeData] = vi.mocked(saveStageDataIncremental).mock.calls[0];
+    expect(stageId).toBe('stage-1');
+    expect(dirty).toEqual(expect.arrayContaining([{ kind: 'stage' }]));
     expect(storeData.stage.generatedAgentConfigs).toEqual(configs);
   });
 
-  it('calls saveGeneratedAgents with the new configs after debounce', async () => {
-    const configs = [makeAgentConfig('y1')];
-    useStageStore.getState().setStageAgents(configs);
-
-    await vi.runAllTimersAsync();
-
-    expect(saveGeneratedAgents).toHaveBeenCalledOnce();
-    const [stageId, savedConfigs] = vi.mocked(saveGeneratedAgents).mock.calls[0];
-    expect(stageId).toBe('stage-1');
-    expect(savedConfigs).toEqual(configs);
-  });
-
-  it('calls saveGeneratedAgents with empty array when roster cleared', async () => {
-    const stageWithAgents: Stage = {
-      ...makeStage(),
-      generatedAgentConfigs: [makeAgentConfig('old')],
-    };
-    useStageStore.setState({ stage: stageWithAgents });
-    useStageStore.getState().setStageAgents([]);
-
-    await vi.runAllTimersAsync();
-
-    // setStageAgents([]) → generatedAgentConfigs is [], empty array is truthy
-    expect(saveGeneratedAgents).toHaveBeenCalledOnce();
-    const [, savedConfigs] = vi.mocked(saveGeneratedAgents).mock.calls[0];
-    expect(savedConfigs).toEqual([]);
-  });
-
-  it('does NOT call saveGeneratedAgents on setCurrentSceneId (scene advance)', async () => {
-    // Regression guard for the P1 bug: scene advances during playback must
-    // never churn db.generatedAgents via the shared saveToStorage path.
+  it('does NOT touch the registry on setCurrentSceneId (scene advance)', async () => {
+    // Regression guard: scene advances during playback must never churn the
+    // agent registry through a broad save path.
     const stageWithAgents: Stage = {
       ...makeStage(),
       generatedAgentConfigs: [makeAgentConfig('a1')],
@@ -163,15 +150,37 @@ describe('setStageAgents persistence (debounced save)', () => {
     useStageStore.setState({ stage: stageWithAgents, scenes: [] });
     useStageStore.getState().setCurrentSceneId('scene-42');
 
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(500);
 
-    // Only the device-scoped incremental path fires; the document is untouched.
+    // Only the device-scoped incremental path fires; the roster mirrors stay put.
     expect(saveStageDataIncremental).toHaveBeenCalledOnce();
     expect(saveStageData).not.toHaveBeenCalled();
-    expect(saveGeneratedAgents).not.toHaveBeenCalled();
+    expect(applyGeneratedAgentsToRegistry).not.toHaveBeenCalled();
+    expect(setSelectedAgentIds).not.toHaveBeenCalled();
   });
 
-  it('does NOT call saveGeneratedAgents on plain saveToStorage without a roster edit', async () => {
+  it('drops a pending roster edit when its stage is discarded (deletion path)', async () => {
+    useStageStore.getState().setStageAgents([makeAgentConfig('doomed')]);
+    discardPendingStageChanges('stage-1');
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    // The queued flush was cancelled with the pending state: a deleted stage
+    // cannot be resurrected by a write still sitting in the debounce window.
+    expect(saveStageDataIncremental).not.toHaveBeenCalled();
+    expect(saveStageData).not.toHaveBeenCalled();
+  });
+
+  it('keeps pending work for other stages when discarding a different stage id', async () => {
+    useStageStore.getState().setStageAgents([makeAgentConfig('kept')]);
+    discardPendingStageChanges('some-other-stage');
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(saveStageDataIncremental).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT touch the registry on plain saveToStorage without a roster edit', async () => {
     const stageWithAgents: Stage = {
       ...makeStage(),
       generatedAgentConfigs: [makeAgentConfig('b1')],
@@ -180,6 +189,6 @@ describe('setStageAgents persistence (debounced save)', () => {
     await useStageStore.getState().saveToStorage();
 
     expect(saveStageData).toHaveBeenCalledOnce();
-    expect(saveGeneratedAgents).not.toHaveBeenCalled();
+    expect(applyGeneratedAgentsToRegistry).not.toHaveBeenCalled();
   });
 });

--- a/tests/store/stage-agents.test.ts
+++ b/tests/store/stage-agents.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { setSelectedAgentIds, applyGeneratedAgentsToRegistry } = vi.hoisted(() => ({
-  setSelectedAgentIds: vi.fn(),
-  applyGeneratedAgentsToRegistry: vi.fn(
-    (_stageId: string, configs: ReadonlyArray<{ id: string }>) => configs.map((c) => c.id),
-  ),
-}));
+const { settingsState, setSelectedAgentIds, applyGeneratedAgentsToRegistry } = vi.hoisted(() => {
+  const setSelectedAgentIds = vi.fn();
+  return {
+    setSelectedAgentIds,
+    settingsState: {
+      agentMode: 'auto' as 'preset' | 'auto',
+      selectedAgentIds: [] as string[],
+      agentSelectionIsUserSet: false,
+      setSelectedAgentIds,
+    },
+    applyGeneratedAgentsToRegistry: vi.fn(
+      (_stageId: string, configs: ReadonlyArray<{ id: string }>) => configs.map((c) => c.id),
+    ),
+  };
+});
 
 // Stage-storage modules are imported dynamically inside the store's save/load
 // actions. Mock them so the scheduled flush doesn't try to talk to a real (or
@@ -20,11 +29,12 @@ vi.mock('@/lib/orchestration/registry/store', () => ({
 }));
 vi.mock('@/lib/store/settings', () => ({
   useSettingsStore: {
-    getState: () => ({ setSelectedAgentIds }),
+    getState: () => settingsState,
   },
 }));
 
 import { discardPendingStageChanges, useStageStore } from '@/lib/store/stage';
+import { markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
 import { saveStageData, saveStageDataIncremental } from '@/lib/utils/stage-storage';
 import type { Stage } from '@/lib/types/stage';
 import type { GeneratedAgentConfig } from '@/lib/types/stage';
@@ -54,6 +64,9 @@ beforeEach(() => {
   vi.useFakeTimers();
   applyGeneratedAgentsToRegistry.mockClear();
   setSelectedAgentIds.mockClear();
+  settingsState.agentMode = 'auto';
+  settingsState.selectedAgentIds = [];
+  settingsState.agentSelectionIsUserSet = false;
   useStageStore.setState({
     stage: makeStage(),
     scenes: [],
@@ -64,6 +77,10 @@ beforeEach(() => {
 afterEach(() => {
   // clearStore cancels any scheduled flush timer along with pending changes.
   useStageStore.getState().clearStore();
+  // Deletion tombstones are session-scoped module state; reset every id the
+  // tests use so one test's deletion cannot fence another's writes.
+  unmarkStageDeleted('stage-1');
+  unmarkStageDeleted('stage-2');
   vi.useRealTimers();
 });
 
@@ -108,6 +125,48 @@ describe('setStageAgents', () => {
     // effects, not persistence.
     expect(applyGeneratedAgentsToRegistry).toHaveBeenCalledExactlyOnceWith('stage-1', configs);
     expect(setSelectedAgentIds).toHaveBeenCalledExactlyOnceWith(['a1', 'a2']);
+  });
+});
+
+describe('setStageAgents selection provenance', () => {
+  it('tracks the full roster only while the selection is stage-derived (not user-set)', () => {
+    settingsState.agentSelectionIsUserSet = false;
+    settingsState.selectedAgentIds = ['a1'];
+
+    useStageStore.getState().setStageAgents([makeAgentConfig('a1'), makeAgentConfig('a2')]);
+
+    expect(setSelectedAgentIds).toHaveBeenCalledExactlyOnceWith(['a1', 'a2']);
+  });
+
+  it('narrows a user-set auto selection to the surviving roster; newcomers are not auto-selected', () => {
+    settingsState.agentSelectionIsUserSet = true;
+    settingsState.agentMode = 'auto';
+    settingsState.selectedAgentIds = ['a1', 'removed'];
+
+    useStageStore.getState().setStageAgents([makeAgentConfig('a1'), makeAgentConfig('newcomer')]);
+
+    // 'removed' left the roster (dropped); 'newcomer' joined it (NOT selected).
+    expect(setSelectedAgentIds).toHaveBeenCalledExactlyOnceWith(['a1']);
+  });
+
+  it('leaves a user-set auto selection untouched when every pick is still in the roster', () => {
+    settingsState.agentSelectionIsUserSet = true;
+    settingsState.agentMode = 'auto';
+    settingsState.selectedAgentIds = ['a1'];
+
+    useStageStore.getState().setStageAgents([makeAgentConfig('a1'), makeAgentConfig('a2')]);
+
+    expect(setSelectedAgentIds).not.toHaveBeenCalled();
+  });
+
+  it('never touches a user-set preset selection (roster edits do not concern preset agents)', () => {
+    settingsState.agentSelectionIsUserSet = true;
+    settingsState.agentMode = 'preset';
+    settingsState.selectedAgentIds = ['default-1', 'default-2'];
+
+    useStageStore.getState().setStageAgents([makeAgentConfig('a1')]);
+
+    expect(setSelectedAgentIds).not.toHaveBeenCalled();
   });
 });
 
@@ -178,6 +237,50 @@ describe('setStageAgents persistence (document scheduler)', () => {
     await vi.advanceTimersByTimeAsync(500);
 
     expect(saveStageDataIncremental).toHaveBeenCalledOnce();
+  });
+
+  it('drops a scheduled flush whose stage was deleted after the dirt was queued', async () => {
+    // The in-flight-round shape of the deletion race: the dirt is already
+    // queued (and may already be snapshotted) when the delete lands. The
+    // tombstone — not the pending-map discard — must fence the write.
+    useStageStore.getState().setStageAgents([makeAgentConfig('doomed')]);
+    markStageDeleted('stage-1');
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(saveStageDataIncremental).not.toHaveBeenCalled();
+    expect(saveStageData).not.toHaveBeenCalled();
+  });
+
+  it('refuses to queue new dirt for a stage already deleted', async () => {
+    markStageDeleted('stage-1');
+    useStageStore.getState().setStageAgents([makeAgentConfig('late-edit')]);
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(saveStageDataIncremental).not.toHaveBeenCalled();
+  });
+
+  it('does not resurrect a deleted stage through the departing-stage retry window', async () => {
+    // Navigation snapshots the departing stage's dirt into local variables and
+    // retries once after a delay — outside the pending map, so the deletion
+    // path's discard cannot reach it. The tombstone must stop the retry.
+    vi.mocked(saveStageDataIncremental).mockRejectedValueOnce(new Error('transient'));
+    useStageStore.getState().setStageAgents([makeAgentConfig('doomed')]);
+
+    useStageStore.getState().setStage({ ...makeStage(), id: 'stage-2' });
+    // Let the departing snapshot's first attempt run and fail.
+    await vi.advanceTimersByTimeAsync(0);
+    const stage1Attempts = () =>
+      vi.mocked(saveStageDataIncremental).mock.calls.filter(([id]) => id === 'stage-1');
+    expect(stage1Attempts()).toHaveLength(1);
+
+    // The stage is deleted inside the 100 ms retry window.
+    markStageDeleted('stage-1');
+    await vi.advanceTimersByTimeAsync(100);
+
+    // The retry was dropped instead of recreating the deleted document.
+    expect(stage1Attempts()).toHaveLength(1);
   });
 
   it('does NOT touch the registry on plain saveToStorage without a roster edit', async () => {

--- a/tests/store/stage-agents.test.ts
+++ b/tests/store/stage-agents.test.ts
@@ -47,7 +47,11 @@ import {
   snapshotPendingStageChangesForDeletion,
   useStageStore,
 } from '@/lib/store/stage';
-import { markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
+import {
+  markStageDeleted,
+  stageDeletionEpoch,
+  unmarkStageDeleted,
+} from '@/lib/utils/deleted-stages';
 import { saveStageData, saveStageDataIncremental } from '@/lib/utils/stage-storage';
 import type { Stage } from '@/lib/types/stage';
 import type { GeneratedAgentConfig } from '@/lib/types/stage';
@@ -347,7 +351,7 @@ describe('setStageAgents persistence (document scheduler)', () => {
   it('does not resurrect a deleted stage through the departing-stage retry window', async () => {
     // Navigation snapshots the departing stage's dirt into local variables and
     // retries once after a delay — outside the pending map, so the deletion
-    // path's discard cannot reach it. The tombstone must stop the retry.
+    // path's discard cannot reach it. The deletion fence must stop the retry.
     vi.mocked(saveStageDataIncremental).mockRejectedValueOnce(new Error('transient'));
     useStageStore.getState().setStageAgents([makeAgentConfig('doomed')]);
 
@@ -366,6 +370,45 @@ describe('setStageAgents persistence (document scheduler)', () => {
     expect(stage1Attempts()).toHaveLength(1);
   });
 
+  it('drops the departing-stage retry even when a delete → restore lands inside the retry window (epoch fence)', async () => {
+    // The straddle a boolean tombstone cannot express: the departing snapshot
+    // was captured pre-delete; a same-id restore lifts the deleted flag before
+    // the retry fires. The snapshot's captured epoch is stale, so the retry
+    // must stay dropped — it would otherwise overwrite the restored document
+    // with pre-delete content.
+    vi.mocked(saveStageDataIncremental).mockRejectedValueOnce(new Error('transient'));
+    useStageStore.getState().setStageAgents([makeAgentConfig('doomed')]);
+
+    useStageStore.getState().setStage({ ...makeStage(), id: 'stage-2' });
+    await vi.advanceTimersByTimeAsync(0);
+    const stage1Attempts = () =>
+      vi.mocked(saveStageDataIncremental).mock.calls.filter(([id]) => id === 'stage-1');
+    expect(stage1Attempts()).toHaveLength(1);
+
+    // Delete AND restore both land inside the 100 ms retry window.
+    markStageDeleted('stage-1');
+    unmarkStageDeleted('stage-1');
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(stage1Attempts()).toHaveLength(1);
+  });
+
+  it('persists dirt captured after a delete → restore cycle under the new epoch', async () => {
+    // The fence must not overreach: an edit made after the restore observes
+    // the current epoch and reaches storage normally.
+    markStageDeleted('stage-1');
+    unmarkStageDeleted('stage-1');
+
+    useStageStore.getState().setStageAgents([makeAgentConfig('post-restore')]);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(saveStageDataIncremental).toHaveBeenCalledOnce();
+    const [stageId, , , capturedEpoch] = vi.mocked(saveStageDataIncremental).mock.calls[0];
+    expect(stageId).toBe('stage-1');
+    // The flush captured the CURRENT (post-delete) epoch, not a stale one.
+    expect(capturedEpoch).toBe(stageDeletionEpoch('stage-1'));
+  });
+
   it('restores dirt discarded by a failed deletion so the edits still reach storage', async () => {
     // The edit sits in the debounce window when the delete starts; the delete
     // snapshots + discards it, then fails before the document was removed.
@@ -378,15 +421,21 @@ describe('setStageAgents persistence (document scheduler)', () => {
     await vi.advanceTimersByTimeAsync(500);
     expect(saveStageDataIncremental).not.toHaveBeenCalled();
 
-    // Failure path: deleteStageData lifts the tombstone and restores the dirt.
+    // Failure path: deleteStageData lifts the deleted flag and restores the
+    // dirt (the deletion epoch stays bumped).
     unmarkStageDeleted('stage-1');
     restorePendingStageChanges('stage-1', discarded);
     await vi.advanceTimersByTimeAsync(500);
 
     expect(saveStageDataIncremental).toHaveBeenCalledOnce();
-    const [stageId, dirty] = vi.mocked(saveStageDataIncremental).mock.calls[0];
+    const [stageId, dirty, , capturedEpoch] = vi.mocked(saveStageDataIncremental).mock.calls[0];
     expect(stageId).toBe('stage-1');
     expect(dirty).toEqual(expect.arrayContaining([{ kind: 'stage' }]));
+    // The restored dirt was re-queued as descriptors, so its flush captured a
+    // fresh snapshot under the CURRENT (post-bump) epoch — it is not dropped
+    // as stale, and it does not replay the pre-delete capture.
+    expect(capturedEpoch).toBe(stageDeletionEpoch('stage-1'));
+    expect(stageDeletionEpoch('stage-1')).toBeGreaterThan(0);
   });
 
   it('includes the in-flight flush round dirt in the deletion snapshot', async () => {

--- a/tests/store/stage-deletion-aggregate-recovery.test.ts
+++ b/tests/store/stage-deletion-aggregate-recovery.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Failed-deletion recovery for content that only ever lived in a direct
+ * aggregate save.
+ *
+ * A `saveToStorage` call (generation completion, server-restore hydration) is
+ * tracked in neither the pending map nor a flush round, so the deletion
+ * snapshot cannot describe it. When a deletion bumps the epoch while such a
+ * save is in flight, the save is fenced (`'stale-dropped'`); if the deletion
+ * then fails before removing the document, the memory state is newer than
+ * storage with no descriptor anywhere to retry from — the recovery must
+ * re-mark the full aggregate so the next flush recaptures the current store
+ * state and lands it. These tests drive the REAL store scheduler and the REAL
+ * storage layer end to end (only the device stores underneath are mocked).
+ */
+
+const { fakeStore, dbMock, prepareMock } = vi.hoisted(() => {
+  const fakeStore = {
+    saveDocument: vi.fn().mockResolvedValue(undefined),
+    putScene: vi.fn().mockResolvedValue(undefined),
+    putStage: vi.fn().mockResolvedValue(undefined),
+    deleteDocument: vi.fn().mockResolvedValue(undefined),
+  };
+  const dbMock = {
+    stages: { delete: vi.fn().mockResolvedValue(undefined) },
+    scenes: {
+      where: () => ({
+        equals: () => ({
+          toArray: vi.fn().mockResolvedValue([]),
+          delete: vi.fn().mockResolvedValue(0),
+        }),
+      }),
+    },
+    stageOutlines: { delete: vi.fn().mockResolvedValue(undefined) },
+    playbackState: { delete: vi.fn().mockResolvedValue(undefined) },
+    generatedAgents: {
+      where: () => ({
+        equals: () => ({ delete: vi.fn().mockResolvedValue(0) }),
+      }),
+    },
+    transaction: vi.fn(async (_mode: string, _tables: unknown[], fn: () => Promise<void>) => fn()),
+  };
+  return {
+    fakeStore,
+    dbMock,
+    prepareMock: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/document-store', () => ({
+  accessDocument: vi.fn(),
+  clearCurrentScene: vi.fn().mockResolvedValue(undefined),
+  getDocumentStore: vi.fn(),
+  getLegacyDocumentStore: vi.fn(),
+  loadCurrentScene: vi.fn().mockResolvedValue(null),
+  mutateDocument: vi.fn(
+    async (
+      _stageId: string,
+      callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+    ) => callback(undefined, fakeStore),
+  ),
+  saveCurrentScene: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/utils/chat-storage', () => ({
+  ChatStorageLockUnavailableError: class ChatStorageLockUnavailableError extends Error {},
+  saveChatSessions: vi.fn().mockResolvedValue(undefined),
+  loadChatSessions: vi.fn().mockResolvedValue([]),
+  deleteChatSessions: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/utils/chat-storage-lock', () => ({
+  withRuntimeStorageSharedLock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withRuntimeStorageExclusiveLockUntilSettled: vi.fn(
+    async (fn: (release: (value: unknown) => void) => Promise<unknown>) => fn(() => undefined),
+  ),
+}));
+vi.mock('@/lib/utils/database', () => ({ db: dbMock }));
+vi.mock('@/lib/playback/cursor', () => ({ clearCursor: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@/lib/quiz/persistence', () => ({ clearAllForScene: vi.fn() }));
+vi.mock('@/lib/runtime/store', () => ({
+  beginStageRuntimeDeletionSafely: vi.fn(() => ({
+    completion: Promise.resolve(),
+    settlement: Promise.resolve(),
+  })),
+}));
+vi.mock('@/lib/pbl/v2/runtime/drain', () => ({
+  clearStageDrainWatermarks: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/pbl/v2/runtime/document-persistence', () => ({
+  preparePBLScenesForDocumentPersistence: prepareMock,
+}));
+vi.mock('@/lib/pbl/v2/runtime/hydration', () => ({
+  hydratePBLScenesFromRuntime: vi.fn(async (_stageId: string, scenes: unknown[]) => scenes),
+}));
+
+import {
+  flushStageSave,
+  snapshotPendingStageChangesForDeletion,
+  useStageStore,
+} from '@/lib/store/stage';
+import { deleteStageData } from '@/lib/utils/stage-storage';
+import { isStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
+import { saveCurrentScene } from '@/lib/document-store';
+import type { Scene, Stage } from '@/lib/types/stage';
+
+let stageCounter = 0;
+let stageId: string;
+
+function makeStage(id: string): Stage {
+  return { id, name: 'Recoverable', createdAt: 1, updatedAt: 1 };
+}
+
+function makeScene(id: string, stageId: string, title = id): Scene {
+  return {
+    id,
+    stageId,
+    type: 'text',
+    title,
+    order: 1,
+    content: { type: 'text', markdown: id },
+  } as unknown as Scene;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prepareMock.mockImplementation(async (_stageId: string, scenes: Scene[]) => scenes);
+  // Fresh id per test: deletion epochs are session-scoped module state.
+  stageCounter += 1;
+  stageId = `stage-agg-${stageCounter}`;
+  useStageStore.getState().clearStore();
+  useStageStore.setState({
+    stage: makeStage(stageId),
+    scenes: [makeScene('scene-1', stageId)],
+    currentSceneId: 'scene-1',
+    chats: [],
+    outlines: [],
+    generationComplete: false,
+  });
+});
+
+afterEach(() => {
+  useStageStore.getState().clearStore();
+  unmarkStageDeleted(stageId);
+});
+
+describe('failed-deletion recovery of direct aggregate saves', () => {
+  it('re-persists a fenced in-flight aggregate save after the deletion fails before removing the document', async () => {
+    // The aggregate save is mid-flight (parked in scene preparation, epoch
+    // already captured) when the deletion starts. Nothing about it is in the
+    // pending map or a flush round.
+    let releasePrepare!: () => void;
+    prepareMock.mockImplementationOnce(async (_stageId: string, scenes: Scene[]) => {
+      await new Promise<void>((resolve) => {
+        releasePrepare = resolve;
+      });
+      return scenes;
+    });
+    // The setGenerationComplete path: flag flips in memory, then a direct
+    // aggregate save carries it (completion barrier and scenes together).
+    useStageStore.setState({ generationComplete: true });
+    const inFlightSave = useStageStore.getState().saveToStorage();
+
+    // The deletion fails before deleteDocument removed anything; its failure
+    // path lifts the flag and runs the recovery re-mark.
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('delete failed'));
+    await expect(deleteStageData(stageId)).rejects.toThrow('delete failed');
+    expect(isStageDeleted(stageId)).toBe(false);
+
+    // The released save walks into the real epoch fence and drops.
+    releasePrepare();
+    await expect(inFlightSave).resolves.toBe(false);
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+
+    // Recovery: the re-marked aggregate flushes the CURRENT store state under
+    // the CURRENT epoch, so the fenced save's content becomes durable.
+    await flushStageSave();
+    expect(fakeStore.saveDocument).toHaveBeenCalledOnce();
+    const [savedDocument] = fakeStore.saveDocument.mock.calls[0]! as [
+      { stage: Stage; scenes: Scene[]; outline: { generationComplete?: boolean } },
+    ];
+    expect(savedDocument.stage.id).toBe(stageId);
+    expect(savedDocument.outline.generationComplete).toBe(true);
+    expect(savedDocument.scenes.map((scene) => scene.id)).toEqual(['scene-1']);
+    // The re-mark spans the whole aggregate: the cursor tail flushes too.
+    expect(saveCurrentScene).toHaveBeenCalledWith(stageId, 'scene-1');
+  });
+
+  it('re-persists an edit refused during the deletion window after the deletion fails', async () => {
+    // Edits inside the deletion window are refused by the scheduler and are
+    // in no snapshot; they live only in the store state. The full-aggregate
+    // re-mark recaptures that state, so they reach durability with it.
+    let rejectDelete!: (error: Error) => void;
+    fakeStore.deleteDocument.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectDelete = reject;
+        }),
+    );
+    const deletion = deleteStageData(stageId);
+    await vi.waitFor(() => expect(fakeStore.deleteDocument).toHaveBeenCalled());
+
+    useStageStore.getState().updateScene('scene-1', { title: 'edited during deletion' });
+
+    rejectDelete(new Error('delete failed'));
+    await expect(deletion).rejects.toThrow('delete failed');
+    expect(isStageDeleted(stageId)).toBe(false);
+
+    await flushStageSave();
+    expect(fakeStore.saveDocument).toHaveBeenCalledOnce();
+    const [savedDocument] = fakeStore.saveDocument.mock.calls[0]! as [{ scenes: Scene[] }];
+    expect(savedDocument.scenes[0]?.title).toBe('edited during deletion');
+  });
+
+  it('does not re-mark anything when the deletion succeeds (control)', async () => {
+    useStageStore.setState({ generationComplete: true });
+
+    await deleteStageData(stageId);
+
+    // Success path: the store is evicted, nothing is queued, and no later
+    // flush resurrects the deleted document.
+    expect(useStageStore.getState().stage).toBeNull();
+    expect(snapshotPendingStageChangesForDeletion(stageId)).toEqual([]);
+    await flushStageSave();
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(fakeStore.putStage).not.toHaveBeenCalled();
+    expect(fakeStore.putScene).not.toHaveBeenCalled();
+    expect(saveCurrentScene).not.toHaveBeenCalled();
+  });
+});

--- a/tests/store/stage-document-persistence.test.ts
+++ b/tests/store/stage-document-persistence.test.ts
@@ -15,8 +15,10 @@ vi.mock('@/lib/utils/stage-storage', () => ({
   loadStageData: vi.fn().mockResolvedValue(null),
 }));
 
-import { useStageStore } from '@/lib/store/stage';
+import { flushStageSave, useStageStore } from '@/lib/store/stage';
+import { saveStageDataIncremental } from '@/lib/utils/stage-storage';
 import { makeScene, type Scene, type Stage } from '@/lib/types/stage';
+import type { ChatSession } from '@/lib/types/chat';
 
 function makeStage(): Stage {
   return {
@@ -92,5 +94,44 @@ describe('stage document persistence', () => {
 
     expect(saved).toBe(false);
     expect(saveStageDataMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a fence-dropped save as not durable: false, no chatSnapshot rebind, pending kept', async () => {
+    // An epoch-stale drop is indistinguishable from success only if the
+    // storage layer hides it; with the explicit 'stale-dropped' status the
+    // store must skip every piece of success bookkeeping.
+    const scene = makeSlideScene('in-memory');
+    const chat: ChatSession = {
+      id: 'chat-1',
+      type: 'qa',
+      title: 'Chat',
+      status: 'completed',
+      messages: [],
+      config: { agentIds: [] },
+      toolCalls: [],
+      pendingToolCalls: [],
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    useStageStore.setState({ scenes: [scene], chats: [chat] });
+    // A queued edit a successful save would have cleared.
+    useStageStore.getState().setCurrentSceneId(scene.id);
+    const snapshotBefore = useStageStore.getState().chatSnapshot;
+    prepareScenesMock.mockResolvedValueOnce([scene]);
+    saveStageDataMock.mockResolvedValueOnce('stale-dropped');
+
+    const saved = await useStageStore.getState().saveToStorage();
+
+    expect(saved).toBe(false);
+    // The chatSnapshot must not rebind to a snapshot that never landed…
+    expect(useStageStore.getState().chatSnapshot).toBe(snapshotBefore);
+    // …and the queued dirt must survive: the next flush still carries it.
+    await flushStageSave();
+    expect(saveStageDataIncremental).toHaveBeenCalledWith(
+      'stage-1',
+      expect.arrayContaining([{ kind: 'currentScene' }]),
+      expect.anything(),
+      expect.any(Number),
+    );
   });
 });

--- a/tests/store/stage-document-persistence.test.ts
+++ b/tests/store/stage-document-persistence.test.ts
@@ -78,6 +78,7 @@ describe('stage document persistence', () => {
     expect(saveStageDataMock).toHaveBeenCalledWith(
       'stage-1',
       expect.objectContaining({ scenes: [persistedScene] }),
+      expect.any(Number),
     );
     expect(useStageStore.getState().scenes).toEqual([inMemoryScene]);
   });

--- a/tests/store/stage-generation-complete.test.ts
+++ b/tests/store/stage-generation-complete.test.ts
@@ -54,6 +54,7 @@ import {
   type StageSceneLoadToken,
 } from '@/lib/store/stage';
 import { applyHydratedClassroomFallbackScenes } from '@/lib/classroom/pbl-fallback-hydration';
+import { markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
 import type { Scene, Stage } from '@/lib/types/stage';
 import type { SceneOutline } from '@/lib/types/generation';
 
@@ -327,6 +328,27 @@ describe('generationComplete', () => {
   // The core regression: a completed deck must not resurrect a deleted slide.
   // On reload the orphaned outline (no matching scene) must NOT become a
   // generating placeholder, and the flag must round-trip.
+  it('does not land a load for a stage deleted during hydration (lock-free mid-cascade read)', async () => {
+    // Read-side mirror of the write fence: without Web Locks, loadStageData
+    // can read the document before the deletion cascade's deleteDocument
+    // lands. Landing that read would re-materialize a ghost classroom whose
+    // edits are refused; the load must re-check the flag before set().
+    loadStageDataMock.mockResolvedValue(makeStoredLoad('stage-1', 'scene-1'));
+    hydratePBLScenesFromRuntimeMock.mockImplementationOnce(
+      async (_stageId: string, scenes: Scene[]) => {
+        markStageDeleted('stage-1');
+        return scenes;
+      },
+    );
+    try {
+      await useStageStore.getState().loadFromStorage('stage-1', claimStageSceneLoadToken());
+      expect(useStageStore.getState().stage).toBeNull();
+      expect(useStageStore.getState().scenes).toEqual([]);
+    } finally {
+      unmarkStageDeleted('stage-1');
+    }
+  });
+
   it('drops generating placeholders on load when generation already completed', async () => {
     loadStageDataMock.mockResolvedValue({
       stage: makeStage(),

--- a/tests/store/stage-generation-complete.test.ts
+++ b/tests/store/stage-generation-complete.test.ts
@@ -194,6 +194,7 @@ describe('generationComplete', () => {
           generationComplete: false,
         }),
       }),
+      expect.any(Number),
     );
   });
 

--- a/tests/store/stage-incremental-persistence.test.ts
+++ b/tests/store/stage-incremental-persistence.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/lib/utils/stage-storage', () => ({
   loadStageData: vi.fn().mockResolvedValue(null),
 }));
 
-import { flushStageSave, useStageStore } from '@/lib/store/stage';
+import { flushStageSave, restorePendingStageChanges, useStageStore } from '@/lib/store/stage';
 import type { ChatSession } from '@/lib/types/chat';
 import type { Scene, Stage } from '@/lib/types/stage';
 
@@ -173,6 +173,61 @@ describe('incremental stage flush', () => {
       { kind: 'scene', sceneId: 'scene-2' },
     ]);
     await staleFlush;
+  });
+
+  it('skips the chatSnapshot rebind when an in-flight round is fenced, so restored chats still reach storage', async () => {
+    // A deletion fences a debounced flush round mid-flight ('stale-dropped').
+    // Treating that as success would rebind chatSnapshot to chats that never
+    // landed; after a failed deletion restores the chat descriptor, the retry
+    // would then see its own unsaved chats as the persisted baseline and
+    // storage-level no-op skips could silently swallow them. The rebind must
+    // be skipped so the retry carries the honest pre-fence baseline.
+    const chat: ChatSession = {
+      id: 'chat-1',
+      type: 'qa',
+      title: 'Fenced chat',
+      status: 'idle',
+      messages: [],
+      config: { agentIds: [] },
+      toolCalls: [],
+      pendingToolCalls: [],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    let releaseFirst!: (result: 'stale-dropped') => void;
+    incrementalSave.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+    useStageStore.getState().setChats([chat]);
+    const snapshotBefore = useStageStore.getState().chatSnapshot;
+
+    const fencedFlush = flushStageSave();
+    await vi.waitFor(() => expect(incrementalSave).toHaveBeenCalledOnce());
+    releaseFirst('stale-dropped');
+    await fencedFlush;
+
+    // No success bookkeeping: the baseline still records the chats as unsaved.
+    expect(useStageStore.getState().chatSnapshot).toBe(snapshotBefore);
+
+    // The deletion fails before removing the document; its failure path
+    // re-queues the discarded chat descriptor (deleteStageData's restore).
+    restorePendingStageChanges('stage-1', [{ kind: 'chats' }]);
+    incrementalSave.mockResolvedValueOnce({ failedChanges: [] });
+    await flushStageSave();
+
+    expect(incrementalSave).toHaveBeenCalledTimes(2);
+    expect(incrementalSave.mock.calls[1]![1]).toEqual([{ kind: 'chats' }]);
+    // The retry carried the honest baseline (the pre-fence snapshot), not the
+    // never-persisted chats…
+    expect(incrementalSave.mock.calls[1]![2]).toEqual(
+      expect.objectContaining({ chats: [chat], chatSnapshot: snapshotBefore }),
+    );
+    // …and only the verified write rebinds the snapshot.
+    expect(useStageStore.getState().chatSnapshot.sessions).toEqual([chat]);
+    expect(useStageStore.getState().chatSnapshot).not.toBe(snapshotBefore);
   });
 
   it('flushes old-document dirt when setStage switches documents', async () => {

--- a/tests/store/stage-incremental-persistence.test.ts
+++ b/tests/store/stage-incremental-persistence.test.ts
@@ -219,7 +219,11 @@ describe('incremental stage flush', () => {
     await flushStageSave();
 
     expect(incrementalSave).toHaveBeenCalledTimes(2);
-    expect(incrementalSave.mock.calls[1]![1]).toEqual([{ kind: 'chats' }]);
+    // The restore carries the chat descriptor plus the full-aggregate re-mark
+    // (untracked aggregate-save content has no descriptor of its own).
+    expect(incrementalSave.mock.calls[1]![1]).toEqual(
+      expect.arrayContaining([{ kind: 'chats' }, { kind: 'structure' }]),
+    );
     // The retry carried the honest baseline (the pre-fence snapshot), not the
     // never-persisted chats…
     expect(incrementalSave.mock.calls[1]![2]).toEqual(

--- a/tests/utils/stage-storage-deletion.test.ts
+++ b/tests/utils/stage-storage-deletion.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const {
+  clearStoreForDeletedStage,
   discardPendingStageChanges,
   snapshotPendingStageChangesForDeletion,
   restorePendingStageChanges,
@@ -48,6 +49,7 @@ const {
     transaction: vi.fn(async (_mode: string, _tables: unknown[], fn: () => Promise<void>) => fn()),
   };
   return {
+    clearStoreForDeletedStage: vi.fn(),
     discardPendingStageChanges: vi.fn(),
     snapshotPendingStageChangesForDeletion: vi.fn().mockReturnValue([]),
     restorePendingStageChanges: vi.fn(),
@@ -96,6 +98,7 @@ vi.mock('@/lib/pbl/v2/runtime/document-persistence', () => ({
   ),
 }));
 vi.mock('@/lib/store/stage', () => ({
+  clearStoreForDeletedStage,
   discardPendingStageChanges,
   snapshotPendingStageChangesForDeletion,
   restorePendingStageChanges,
@@ -108,7 +111,13 @@ import {
   type PendingChange,
   type StageStoreData,
 } from '@/lib/utils/stage-storage';
-import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
+import {
+  isStageDeleted,
+  isStageWriteStale,
+  markStageDeleted,
+  stageDeletionEpoch,
+  unmarkStageDeleted,
+} from '@/lib/utils/deleted-stages';
 import { saveCurrentScene } from '@/lib/document-store';
 import { saveChatSessions } from '@/lib/utils/chat-storage';
 import { withRuntimeStorageSharedLock } from '@/lib/utils/chat-storage-lock';
@@ -248,6 +257,122 @@ describe('saveStageDataIncremental vs deletion', () => {
   });
 });
 
+describe('deletion epochs (delete → restore straddles)', () => {
+  it('drops a round captured pre-delete even when a same-id restore lifted the deleted flag (incremental)', async () => {
+    // The core epoch invariant: a boolean tombstone cannot distinguish a
+    // pre-delete in-flight round from a post-restore edit once the restore
+    // lifts it. The epoch can — the delete bumped it, so the old capture is
+    // permanently stale and must not rebuild the restored document.
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        markStageDeleted(id); // delete wins the race while the round awaits
+        unmarkStageDeleted(id); // server-copy restore lifts the deleted flag
+        return callback(undefined, fakeStore);
+      },
+    );
+    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(fakeStore.putStage).not.toHaveBeenCalled();
+  });
+
+  it('drops a pre-delete aggregate save after a same-id restore', async () => {
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        markStageDeleted(id);
+        unmarkStageDeleted(id);
+        return callback(undefined, fakeStore);
+      },
+    );
+    await saveStageData(stageId, makeData(stageId));
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('drops the currentScene/chats tail of a pre-delete round after a restore', async () => {
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        markStageDeleted(id);
+        unmarkStageDeleted(id);
+        return callback(undefined, fakeStore);
+      },
+    );
+    const result = await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }, { kind: 'currentScene' }, { kind: 'chats' }],
+      makeData(stageId),
+    );
+    expect(result).toEqual({ failedChanges: [] });
+    expect(vi.mocked(saveCurrentScene)).not.toHaveBeenCalled();
+    expect(vi.mocked(saveChatSessions)).not.toHaveBeenCalled();
+  });
+
+  it('re-checks between the two tail writes: a delete during saveCurrentScene fences the chat write', async () => {
+    // No lock spans the tail. When a batch dirties both currentScene and
+    // chats, a delete can start while the first tail write is awaiting; the
+    // chat write must re-check independently instead of riding the earlier
+    // check.
+    vi.mocked(saveCurrentScene).mockImplementationOnce(async () => {
+      markStageDeleted(stageId);
+    });
+    const result = await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'currentScene' }, { kind: 'chats' }],
+      makeData(stageId),
+    );
+    expect(result).toEqual({ failedChanges: [] });
+    expect(vi.mocked(saveCurrentScene)).toHaveBeenCalledOnce();
+    expect(vi.mocked(saveChatSessions)).not.toHaveBeenCalled();
+  });
+
+  it('persists a write whose data was captured AFTER a delete → restore cycle (new epoch)', async () => {
+    // The counterpart invariant: the epoch fence must not overreach. Data
+    // captured after the restore observes the current epoch and lands.
+    markStageDeleted(stageId);
+    unmarkStageDeleted(stageId);
+    expect(stageDeletionEpoch(stageId)).toBe(1);
+    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    expect(fakeStore.saveDocument).toHaveBeenCalledOnce();
+  });
+
+  it('drops an explicitly stale captured epoch even while the stage is not deleted', async () => {
+    // The scheduler passes the epoch captured with its data snapshot; a
+    // mismatch alone (deleted flag already lifted) must drop the write.
+    const staleEpoch = stageDeletionEpoch(stageId);
+    markStageDeleted(stageId);
+    unmarkStageDeleted(stageId);
+    expect(isStageDeleted(stageId)).toBe(false);
+    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId), staleEpoch);
+    expect(mutateDocument).not.toHaveBeenCalled();
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+
+    await saveStageData(stageId, makeData(stageId), staleEpoch);
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('never rewinds the epoch: mark → unmark → mark keeps strictly increasing', () => {
+    expect(stageDeletionEpoch(stageId)).toBe(0);
+    markStageDeleted(stageId);
+    expect(stageDeletionEpoch(stageId)).toBe(1);
+    unmarkStageDeleted(stageId);
+    expect(stageDeletionEpoch(stageId)).toBe(1);
+    expect(isStageDeleted(stageId)).toBe(false);
+    markStageDeleted(stageId);
+    expect(stageDeletionEpoch(stageId)).toBe(2);
+    expect(isStageWriteStale(stageId, 1)).toBe(true);
+    unmarkStageDeleted(stageId);
+    expect(isStageWriteStale(stageId, 1)).toBe(true);
+    expect(isStageWriteStale(stageId, 2)).toBe(false);
+  });
+});
+
 describe('saveStageData vs deletion', () => {
   it('drops the aggregate save for a deleted stage', async () => {
     markStageDeleted(stageId);
@@ -310,11 +435,31 @@ describe('deleteStageData wiring', () => {
     expect(dbMock.stages.delete).toHaveBeenCalledWith(stageId);
   });
 
-  it('lifts the tombstone when the deletion fails before the document was removed', async () => {
+  it('evicts the warm in-memory store after a successful deletion', async () => {
+    // Without the eviction, a warm store keeps rendering the deleted
+    // classroom: loadFromStorage short-circuits on it, the server-restore
+    // path never runs, and every edit is silently dropped (back-button trap).
+    await deleteStageData(stageId);
+    expect(clearStoreForDeletedStage).toHaveBeenCalledExactlyOnceWith(stageId);
+  });
+
+  it('does not evict the store when the deletion fails', async () => {
     fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
     await expect(deleteStageData(stageId)).rejects.toThrow('locked');
-    // The stage still exists — later edits must persist normally again.
+    // The stage survives — the warm copy is still the live document.
+    expect(clearStoreForDeletedStage).not.toHaveBeenCalled();
+  });
+
+  it('lifts the deleted flag when the deletion fails before the document was removed, keeping the epoch bumped', async () => {
+    const epochBefore = stageDeletionEpoch(stageId);
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
+    await expect(deleteStageData(stageId)).rejects.toThrow('locked');
+    // The stage still exists — later edits must persist normally again…
     expect(isStageDeleted(stageId)).toBe(false);
+    // …but the epoch stays bumped: writes captured before the failed delete
+    // remain permanently stale (the restored dirt is re-queued as
+    // descriptors, so its flush re-captures under the current epoch).
+    expect(stageDeletionEpoch(stageId)).toBe(epochBefore + 1);
   });
 
   it('keeps the tombstone when the cascade fails after the document was removed', async () => {

--- a/tests/utils/stage-storage-deletion.test.ts
+++ b/tests/utils/stage-storage-deletion.test.ts
@@ -643,6 +643,88 @@ describe('deleteStageData wiring', () => {
     expect(mutateDocument).toHaveBeenCalledTimes(2);
   });
 
+  it('re-runs a fresh cascade for a joined delete when a same-id restore lands during the first cascade', async () => {
+    // The join is keyed on stage id, not document generation. When a restore
+    // recreates the document mid-cascade, the first cascade's success
+    // describes the PRE-restore document — a joined caller told "deleted"
+    // would watch the restored stage survive. The joined intent must run a
+    // fresh cascade against the restored document instead.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mutateDocument.mockImplementationOnce(
+      async (
+        _id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        await gate;
+        return callback(undefined, fakeStore);
+      },
+    );
+
+    const first = deleteStageData(stageId);
+    const second = deleteStageData(stageId);
+    await vi.waitFor(() => expect(mutateDocument).toHaveBeenCalledOnce());
+
+    // A server restore recreates the document and lifts the flag mid-cascade.
+    unmarkStageDeleted(stageId);
+    release();
+    await first;
+    await second;
+
+    // The joined caller ran (and reported) a second, full cascade.
+    expect(mutateDocument).toHaveBeenCalledTimes(2);
+    expect(fakeStore.deleteDocument).toHaveBeenCalledTimes(2);
+    expect(snapshotPendingStageChangesForDeletion).toHaveBeenCalledTimes(2);
+    expect(isStageDeleted(stageId)).toBe(true);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+  });
+
+  it('re-checks a joined delete exactly once: a restore during the re-run is reported as-is', async () => {
+    // The re-run must not recurse: a restore landing inside the re-run's own
+    // window is reported truthfully (stage no longer marked deleted) instead
+    // of spawning a third cascade — any later delete is a NEW call with its
+    // own single re-check, so repeated restore/delete races converge there.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mutateDocument
+      .mockImplementationOnce(
+        async (
+          _id: string,
+          callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+        ) => {
+          await gate;
+          return callback(undefined, fakeStore);
+        },
+      )
+      .mockImplementationOnce(
+        async (
+          id: string,
+          callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+        ) => {
+          // A second restore lands inside the re-run cascade's window.
+          unmarkStageDeleted(id);
+          return callback(undefined, fakeStore);
+        },
+      );
+
+    const first = deleteStageData(stageId);
+    const second = deleteStageData(stageId);
+    await vi.waitFor(() => expect(mutateDocument).toHaveBeenCalledOnce());
+    // The first restore triggers the joined caller's single re-run.
+    unmarkStageDeleted(stageId);
+    release();
+    await first;
+    await second;
+
+    expect(mutateDocument).toHaveBeenCalledTimes(2); // no third cascade
+    expect(isStageDeleted(stageId)).toBe(false); // the second restore stands
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+  });
+
   it('joined concurrent deletions share the first cascade failure', async () => {
     fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
     let release!: () => void;

--- a/tests/utils/stage-storage-deletion.test.ts
+++ b/tests/utils/stage-storage-deletion.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Deletion-vs-persistence fencing at the storage layer.
+ *
+ * The store-level tests cover snapshots that are dropped before they reach
+ * storage; these tests cover the last escape hatch: a write that already
+ * entered `saveStageData` / `saveStageDataIncremental` when the stage was
+ * deleted. Without the tombstone re-checks, `existing === undefined` after a
+ * delete routes the incremental path into a full save that rebuilds the
+ * deleted document from the in-memory snapshot.
+ */
+
+const { discardPendingStageChanges, mutateDocument, fakeStore, dbMock } = vi.hoisted(() => {
+  const fakeStore = {
+    saveDocument: vi.fn().mockResolvedValue(undefined),
+    putScene: vi.fn().mockResolvedValue(undefined),
+    putStage: vi.fn().mockResolvedValue(undefined),
+    deleteDocument: vi.fn().mockResolvedValue(undefined),
+  };
+  const generatedAgentsDelete = vi.fn().mockResolvedValue(0);
+  const scenesDelete = vi.fn().mockResolvedValue(0);
+  const dbMock = {
+    stages: { delete: vi.fn().mockResolvedValue(undefined) },
+    scenes: {
+      where: () => ({
+        equals: () => ({
+          toArray: vi.fn().mockResolvedValue([]),
+          delete: scenesDelete,
+        }),
+      }),
+    },
+    stageOutlines: { delete: vi.fn().mockResolvedValue(undefined) },
+    playbackState: { delete: vi.fn().mockResolvedValue(undefined) },
+    generatedAgents: {
+      where: () => ({
+        equals: () => ({ delete: generatedAgentsDelete }),
+      }),
+      _delete: generatedAgentsDelete,
+    },
+    transaction: vi.fn(async (_mode: string, _tables: unknown[], fn: () => Promise<void>) => fn()),
+  };
+  return {
+    discardPendingStageChanges: vi.fn(),
+    mutateDocument: vi.fn(),
+    fakeStore,
+    dbMock,
+  };
+});
+
+vi.mock('@/lib/document-store', () => ({
+  accessDocument: vi.fn(),
+  clearCurrentScene: vi.fn().mockResolvedValue(undefined),
+  getDocumentStore: vi.fn(),
+  getLegacyDocumentStore: vi.fn(),
+  loadCurrentScene: vi.fn().mockResolvedValue(null),
+  mutateDocument,
+  saveCurrentScene: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/utils/chat-storage', () => ({
+  ChatStorageLockUnavailableError: class ChatStorageLockUnavailableError extends Error {},
+  saveChatSessions: vi.fn().mockResolvedValue(undefined),
+  loadChatSessions: vi.fn().mockResolvedValue([]),
+  deleteChatSessions: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/utils/chat-storage-lock', () => ({
+  withRuntimeStorageSharedLock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withRuntimeStorageExclusiveLockUntilSettled: vi.fn(
+    async (fn: (release: (value: unknown) => void) => Promise<unknown>) => fn(() => undefined),
+  ),
+}));
+vi.mock('@/lib/utils/database', () => ({ db: dbMock }));
+vi.mock('@/lib/playback/cursor', () => ({ clearCursor: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@/lib/quiz/persistence', () => ({ clearAllForScene: vi.fn() }));
+vi.mock('@/lib/runtime/store', () => ({
+  beginStageRuntimeDeletionSafely: vi.fn(() => ({
+    completion: Promise.resolve(),
+    settlement: Promise.resolve(),
+  })),
+}));
+vi.mock('@/lib/pbl/v2/runtime/drain', () => ({
+  clearStageDrainWatermarks: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/pbl/v2/runtime/document-persistence', () => ({
+  preparePBLScenesForDocumentPersistence: vi.fn(
+    async (_stageId: string, scenes: unknown[]) => scenes,
+  ),
+}));
+vi.mock('@/lib/store/stage', () => ({ discardPendingStageChanges }));
+
+import {
+  deleteStageData,
+  saveStageData,
+  saveStageDataIncremental,
+  type StageStoreData,
+} from '@/lib/utils/stage-storage';
+import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
+
+let stageCounter = 0;
+let stageId: string;
+
+function makeData(id: string): StageStoreData {
+  return {
+    stage: { id, name: 'Doomed', createdAt: 1, updatedAt: 1 },
+    scenes: [],
+    currentSceneId: null,
+    chats: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Fresh id per test: the tombstone set is session-scoped module state.
+  stageCounter += 1;
+  stageId = `stage-del-${stageCounter}`;
+  // Default: the document is already gone (post-delete world).
+  mutateDocument.mockImplementation(
+    async (
+      _stageId: string,
+      callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+    ) => callback(undefined, fakeStore),
+  );
+});
+
+afterEach(() => {
+  unmarkStageDeleted(stageId);
+});
+
+describe('saveStageDataIncremental vs deletion', () => {
+  it('full-saves when the destination is missing and the stage is NOT deleted (pinned)', async () => {
+    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    expect(fakeStore.saveDocument).toHaveBeenCalledOnce();
+  });
+
+  it('drops the write instead of rebuilding a deleted document', async () => {
+    markStageDeleted(stageId);
+    const result = await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    expect(result).toEqual({ failedChanges: [] });
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(mutateDocument).not.toHaveBeenCalled();
+  });
+
+  it('re-checks the tombstone under the document lock (delete won the lock race)', async () => {
+    // The flush entered mutateDocument first; the delete completes while the
+    // flush waits for the per-stage lock. By the time the callback runs, the
+    // tombstone exists and the full-save fallback must not fire.
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        markStageDeleted(id);
+        return callback(undefined, fakeStore);
+      },
+    );
+    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(fakeStore.putStage).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveStageData vs deletion', () => {
+  it('drops the aggregate save for a deleted stage', async () => {
+    markStageDeleted(stageId);
+    const result = await saveStageData(stageId, makeData(stageId));
+    expect(result).toBeUndefined();
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(mutateDocument).not.toHaveBeenCalled();
+  });
+
+  it('re-checks the tombstone under the document lock', async () => {
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        markStageDeleted(id);
+        return callback(undefined, fakeStore);
+      },
+    );
+    await saveStageData(stageId, makeData(stageId));
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteStageData wiring', () => {
+  it('tombstones the stage BEFORE discarding pending work, then deletes', async () => {
+    discardPendingStageChanges.mockImplementationOnce((id: string) => {
+      // Ordering matters: an in-flight round survives the discard, so the
+      // tombstone must already be visible when the discard happens.
+      expect(isStageDeleted(id)).toBe(true);
+    });
+
+    await deleteStageData(stageId);
+
+    expect(discardPendingStageChanges).toHaveBeenCalledExactlyOnceWith(stageId);
+    expect(fakeStore.deleteDocument).toHaveBeenCalledExactlyOnceWith(stageId);
+    expect(isStageDeleted(stageId)).toBe(true);
+  });
+
+  it('clears the legacy roster-mirror rows for the deleted stage', async () => {
+    await deleteStageData(stageId);
+    expect(dbMock.generatedAgents._delete).toHaveBeenCalledOnce();
+  });
+
+  it('tolerates a mirror-row cleanup failure without failing the deletion', async () => {
+    dbMock.generatedAgents._delete.mockRejectedValueOnce(new Error('mirror gone wrong'));
+    await expect(deleteStageData(stageId)).resolves.toBeUndefined();
+    expect(dbMock.stages.delete).toHaveBeenCalledWith(stageId);
+  });
+
+  it('lifts the tombstone when the deletion fails before the document was removed', async () => {
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
+    await expect(deleteStageData(stageId)).rejects.toThrow('locked');
+    // The stage still exists — later edits must persist normally again.
+    expect(isStageDeleted(stageId)).toBe(false);
+  });
+
+  it('keeps the tombstone when the cascade fails after the document was removed', async () => {
+    dbMock.stageOutlines.delete.mockRejectedValueOnce(new Error('partial cascade'));
+    await expect(deleteStageData(stageId)).rejects.toThrow('partial cascade');
+    // The document is gone; dropping later writes is what prevents resurrection.
+    expect(isStageDeleted(stageId)).toBe(true);
+  });
+});

--- a/tests/utils/stage-storage-deletion.test.ts
+++ b/tests/utils/stage-storage-deletion.test.ts
@@ -11,7 +11,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * deleted document from the in-memory snapshot.
  */
 
-const { discardPendingStageChanges, mutateDocument, fakeStore, dbMock } = vi.hoisted(() => {
+const {
+  discardPendingStageChanges,
+  snapshotPendingStageChangesForDeletion,
+  restorePendingStageChanges,
+  mutateDocument,
+  fakeStore,
+  dbMock,
+} = vi.hoisted(() => {
   const fakeStore = {
     saveDocument: vi.fn().mockResolvedValue(undefined),
     putScene: vi.fn().mockResolvedValue(undefined),
@@ -42,6 +49,8 @@ const { discardPendingStageChanges, mutateDocument, fakeStore, dbMock } = vi.hoi
   };
   return {
     discardPendingStageChanges: vi.fn(),
+    snapshotPendingStageChangesForDeletion: vi.fn().mockReturnValue([]),
+    restorePendingStageChanges: vi.fn(),
     mutateDocument: vi.fn(),
     fakeStore,
     dbMock,
@@ -86,15 +95,25 @@ vi.mock('@/lib/pbl/v2/runtime/document-persistence', () => ({
     async (_stageId: string, scenes: unknown[]) => scenes,
   ),
 }));
-vi.mock('@/lib/store/stage', () => ({ discardPendingStageChanges }));
+vi.mock('@/lib/store/stage', () => ({
+  discardPendingStageChanges,
+  snapshotPendingStageChangesForDeletion,
+  restorePendingStageChanges,
+}));
 
 import {
   deleteStageData,
   saveStageData,
   saveStageDataIncremental,
+  type PendingChange,
   type StageStoreData,
 } from '@/lib/utils/stage-storage';
 import { isStageDeleted, markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
+import { saveCurrentScene } from '@/lib/document-store';
+import { saveChatSessions } from '@/lib/utils/chat-storage';
+import { withRuntimeStorageSharedLock } from '@/lib/utils/chat-storage-lock';
+import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
+import type { Scene } from '@/lib/types/stage';
 
 let stageCounter = 0;
 let stageId: string;
@@ -106,6 +125,17 @@ function makeData(id: string): StageStoreData {
     currentSceneId: null,
     chats: [],
   };
+}
+
+function makeScene(id: string, stageId: string): Scene {
+  return {
+    id,
+    stageId,
+    type: 'text',
+    title: id,
+    order: 1,
+    content: { type: 'text', markdown: id },
+  } as unknown as Scene;
 }
 
 beforeEach(() => {
@@ -157,6 +187,65 @@ describe('saveStageDataIncremental vs deletion', () => {
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(fakeStore.putStage).not.toHaveBeenCalled();
   });
+
+  it('re-checks immediately before the full-save write (lock-free fallback: delete lands during scene preparation)', async () => {
+    // Without Web Locks, mutateDocument degrades to running this callback
+    // lock-free: nothing serializes a delete against the awaits between the
+    // callback-entry check and the write. The write itself must re-check.
+    vi.mocked(preparePBLScenesForDocumentPersistence).mockImplementationOnce(
+      async (id: string, scenes: readonly Scene[]) => {
+        markStageDeleted(id);
+        return [...scenes];
+      },
+    );
+    await saveStageDataIncremental(stageId, [{ kind: 'structure' }], makeData(stageId));
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('re-checks immediately before each putScene on the incremental fast path', async () => {
+    // Lock-free existing is stale-non-null: the fast path stays incremental
+    // while a delete completes during preparation. No row may land.
+    mutateDocument.mockImplementationOnce(
+      async (
+        _stageId: string,
+        callback: (existing: unknown, store: typeof fakeStore) => Promise<unknown>,
+      ) => callback({ stage: makeData(stageId).stage, scenes: [], outline: undefined }, fakeStore),
+    );
+    vi.mocked(preparePBLScenesForDocumentPersistence).mockImplementationOnce(
+      async (id: string, scenes: readonly Scene[]) => {
+        markStageDeleted(id);
+        return [...scenes];
+      },
+    );
+    const data = { ...makeData(stageId), scenes: [makeScene('scene-1', stageId)] };
+    await saveStageDataIncremental(stageId, [{ kind: 'scene', sceneId: 'scene-1' }], data);
+    expect(fakeStore.putScene).not.toHaveBeenCalled();
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('drops the currentScene/chats tail when the delete wins during the document mutation', async () => {
+    // The tail writes run after mutateDocument returns; a delete that fenced
+    // the document write must also fence them, or the flush would resurrect
+    // the currentScene KV row and chat sessions the cascade just cleared.
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        markStageDeleted(id);
+        return callback(undefined, fakeStore);
+      },
+    );
+    const result = await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }, { kind: 'currentScene' }, { kind: 'chats' }],
+      makeData(stageId),
+    );
+    expect(result).toEqual({ failedChanges: [] });
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(vi.mocked(saveCurrentScene)).not.toHaveBeenCalled();
+    expect(vi.mocked(saveChatSessions)).not.toHaveBeenCalled();
+  });
 });
 
 describe('saveStageData vs deletion', () => {
@@ -180,6 +269,18 @@ describe('saveStageData vs deletion', () => {
     );
     await saveStageData(stageId, makeData(stageId));
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('re-checks immediately before the aggregate write (delete lands inside the runtime-lock window)', async () => {
+    vi.mocked(withRuntimeStorageSharedLock).mockImplementationOnce(
+      async (fn: () => Promise<unknown>) => {
+        markStageDeleted(stageId);
+        return fn();
+      },
+    );
+    await saveStageData(stageId, makeData(stageId));
+    expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+    expect(vi.mocked(saveCurrentScene)).not.toHaveBeenCalled();
   });
 });
 
@@ -220,6 +321,46 @@ describe('deleteStageData wiring', () => {
     dbMock.stageOutlines.delete.mockRejectedValueOnce(new Error('partial cascade'));
     await expect(deleteStageData(stageId)).rejects.toThrow('partial cascade');
     // The document is gone; dropping later writes is what prevents resurrection.
+    expect(isStageDeleted(stageId)).toBe(true);
+  });
+
+  it('snapshots the pending dirt BEFORE the tombstone exists', async () => {
+    snapshotPendingStageChangesForDeletion.mockImplementationOnce((id: string) => {
+      // The snapshot must see the pre-delete world: dirt queued now would be
+      // refused after the tombstone, so ordering is load-bearing.
+      expect(isStageDeleted(id)).toBe(false);
+      return [];
+    });
+    await deleteStageData(stageId);
+    expect(snapshotPendingStageChangesForDeletion).toHaveBeenCalledExactlyOnceWith(stageId);
+  });
+
+  it('restores the discarded dirt when the deletion fails before the document was removed', async () => {
+    const discarded: PendingChange[] = [{ kind: 'stage' }, { kind: 'scene', sceneId: 'scene-1' }];
+    snapshotPendingStageChangesForDeletion.mockReturnValueOnce(discarded);
+    restorePendingStageChanges.mockImplementationOnce((id: string) => {
+      // Ordering: the tombstone must already be lifted when the dirt is
+      // re-marked, or the restore itself would be refused.
+      expect(isStageDeleted(id)).toBe(false);
+    });
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
+
+    await expect(deleteStageData(stageId)).rejects.toThrow('locked');
+
+    // The edits the delete attempt discarded must reach durability again.
+    expect(restorePendingStageChanges).toHaveBeenCalledExactlyOnceWith(stageId, discarded);
+    expect(isStageDeleted(stageId)).toBe(false);
+  });
+
+  it('does not restore discarded dirt once the document is gone (tombstone stays)', async () => {
+    snapshotPendingStageChangesForDeletion.mockReturnValueOnce([
+      { kind: 'stage' },
+    ] satisfies PendingChange[]);
+    dbMock.stageOutlines.delete.mockRejectedValueOnce(new Error('partial cascade'));
+
+    await expect(deleteStageData(stageId)).rejects.toThrow('partial cascade');
+
+    expect(restorePendingStageChanges).not.toHaveBeenCalled();
     expect(isStageDeleted(stageId)).toBe(true);
   });
 });

--- a/tests/utils/stage-storage-deletion.test.ts
+++ b/tests/utils/stage-storage-deletion.test.ts
@@ -119,6 +119,7 @@ import {
   markStageDeleted,
   settleStageDeletionCascade,
   stageDeletionEpoch,
+  stageDeletionSettled,
   unmarkStageDeleted,
 } from '@/lib/utils/deleted-stages';
 import { saveCurrentScene } from '@/lib/document-store';
@@ -414,6 +415,45 @@ describe('deletion epochs (delete → restore straddles)', () => {
     expect(isStageDeleted(stageId)).toBe(true);
   });
 
+  it('keeps the cascade in flight until the LAST overlapping cascade settles (counter, not a bit)', () => {
+    markStageDeleted(stageId);
+    beginStageDeletionCascade(stageId);
+    beginStageDeletionCascade(stageId);
+    // The first settle must not expose the second, still-undecided cascade
+    // as settled — that would let the read side discard the warm state
+    // inside the second cascade's keep-window.
+    settleStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(true);
+    settleStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    // Extra settles never underflow into a phantom cascade.
+    settleStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    beginStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(true);
+    settleStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+  });
+
+  it('resolves the settlement promise only when the last cascade settles', async () => {
+    // Settled world: an awaiter is released immediately.
+    await expect(stageDeletionSettled(stageId)).resolves.toBeUndefined();
+
+    markStageDeleted(stageId);
+    beginStageDeletionCascade(stageId);
+    beginStageDeletionCascade(stageId);
+    let settled = false;
+    const waiter = stageDeletionSettled(stageId).then(() => {
+      settled = true;
+    });
+    settleStageDeletionCascade(stageId);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    settleStageDeletionCascade(stageId);
+    await waiter;
+    expect(settled).toBe(true);
+  });
+
   it('never rewinds the epoch: mark → unmark → mark keeps strictly increasing', () => {
     expect(stageDeletionEpoch(stageId)).toBe(0);
     markStageDeleted(stageId);
@@ -564,6 +604,116 @@ describe('deleteStageData wiring', () => {
     await expect(deleteStageData(stageId)).rejects.toThrow('partial cascade');
     // The document is gone; dropping later writes is what prevents resurrection.
     expect(isStageDeleted(stageId)).toBe(true);
+  });
+
+  it('single-flights concurrent deletions: a second call joins the first cascade', async () => {
+    // Overlapping cascades for the same stage would let the first settle
+    // clear the keep-window while the second is still undecided. The guard
+    // makes the second call share the first cascade (and its outcome).
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mutateDocument.mockImplementationOnce(
+      async (
+        _id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        await gate;
+        return callback(undefined, fakeStore);
+      },
+    );
+
+    const first = deleteStageData(stageId);
+    const second = deleteStageData(stageId);
+    await vi.waitFor(() => expect(mutateDocument).toHaveBeenCalledOnce());
+    expect(isStageDeletionInFlight(stageId)).toBe(true);
+
+    release();
+    await Promise.all([first, second]);
+
+    expect(mutateDocument).toHaveBeenCalledOnce();
+    expect(fakeStore.deleteDocument).toHaveBeenCalledExactlyOnceWith(stageId);
+    expect(snapshotPendingStageChangesForDeletion).toHaveBeenCalledOnce();
+    expect(clearStoreForDeletedStage).toHaveBeenCalledExactlyOnceWith(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+
+    // The single-flight entry is released: a LATER delete runs its own cascade.
+    await deleteStageData(stageId);
+    expect(mutateDocument).toHaveBeenCalledTimes(2);
+  });
+
+  it('joined concurrent deletions share the first cascade failure', async () => {
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mutateDocument.mockImplementationOnce(
+      async (
+        _id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        await gate;
+        return callback(undefined, fakeStore);
+      },
+    );
+
+    const first = deleteStageData(stageId);
+    const second = deleteStageData(stageId);
+    release();
+    await expect(first).rejects.toThrow('locked');
+    await expect(second).rejects.toThrow('locked');
+    // One cascade, one failure handling: the discarded dirt was restored
+    // exactly once (not once per caller).
+    expect(restorePendingStageChanges).toHaveBeenCalledExactlyOnceWith(stageId, []);
+    expect(isStageDeleted(stageId)).toBe(false);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+  });
+
+  it('holds the settlement promise open across the cascade and resolves it on success', async () => {
+    let midCascadeSettled: boolean | undefined;
+    let waiter: Promise<void> | undefined;
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        let resolved = false;
+        waiter = stageDeletionSettled(id).then(() => {
+          resolved = true;
+        });
+        await Promise.resolve();
+        midCascadeSettled = resolved;
+        return callback(undefined, fakeStore);
+      },
+    );
+
+    await deleteStageData(stageId);
+    await waiter;
+
+    expect(midCascadeSettled).toBe(false);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+  });
+
+  it('resolves the settlement promise when the deletion fails before removing the document', async () => {
+    let waiter: Promise<void> | undefined;
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        waiter = stageDeletionSettled(id);
+        return callback(undefined, fakeStore);
+      },
+    );
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
+
+    await expect(deleteStageData(stageId)).rejects.toThrow('locked');
+
+    // A failed cascade still settles (never rejects), releasing read-side
+    // waiters into the post-outcome flag state.
+    await expect(waiter).resolves.toBeUndefined();
   });
 
   it('snapshots the pending dirt BEFORE the tombstone exists', async () => {

--- a/tests/utils/stage-storage-deletion.test.ts
+++ b/tests/utils/stage-storage-deletion.test.ts
@@ -112,9 +112,12 @@ import {
   type StageStoreData,
 } from '@/lib/utils/stage-storage';
 import {
+  beginStageDeletionCascade,
   isStageDeleted,
+  isStageDeletionInFlight,
   isStageWriteStale,
   markStageDeleted,
+  settleStageDeletionCascade,
   stageDeletionEpoch,
   unmarkStageDeleted,
 } from '@/lib/utils/deleted-stages';
@@ -167,14 +170,24 @@ afterEach(() => {
 
 describe('saveStageDataIncremental vs deletion', () => {
   it('full-saves when the destination is missing and the stage is NOT deleted (pinned)', async () => {
-    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }],
+      makeData(stageId),
+      stageDeletionEpoch(stageId),
+    );
     expect(fakeStore.saveDocument).toHaveBeenCalledOnce();
   });
 
-  it('drops the write instead of rebuilding a deleted document', async () => {
+  it('drops the write instead of rebuilding a deleted document, reporting the drop', async () => {
     markStageDeleted(stageId);
-    const result = await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
-    expect(result).toEqual({ failedChanges: [] });
+    const result = await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }],
+      makeData(stageId),
+      stageDeletionEpoch(stageId),
+    );
+    expect(result).toBe('stale-dropped');
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(mutateDocument).not.toHaveBeenCalled();
   });
@@ -192,7 +205,12 @@ describe('saveStageDataIncremental vs deletion', () => {
         return callback(undefined, fakeStore);
       },
     );
-    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }],
+      makeData(stageId),
+      stageDeletionEpoch(stageId),
+    );
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(fakeStore.putStage).not.toHaveBeenCalled();
   });
@@ -207,7 +225,12 @@ describe('saveStageDataIncremental vs deletion', () => {
         return [...scenes];
       },
     );
-    await saveStageDataIncremental(stageId, [{ kind: 'structure' }], makeData(stageId));
+    await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'structure' }],
+      makeData(stageId),
+      stageDeletionEpoch(stageId),
+    );
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
   });
 
@@ -227,7 +250,12 @@ describe('saveStageDataIncremental vs deletion', () => {
       },
     );
     const data = { ...makeData(stageId), scenes: [makeScene('scene-1', stageId)] };
-    await saveStageDataIncremental(stageId, [{ kind: 'scene', sceneId: 'scene-1' }], data);
+    await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'scene', sceneId: 'scene-1' }],
+      data,
+      stageDeletionEpoch(stageId),
+    );
     expect(fakeStore.putScene).not.toHaveBeenCalled();
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
   });
@@ -249,8 +277,9 @@ describe('saveStageDataIncremental vs deletion', () => {
       stageId,
       [{ kind: 'stage' }, { kind: 'currentScene' }, { kind: 'chats' }],
       makeData(stageId),
+      stageDeletionEpoch(stageId),
     );
-    expect(result).toEqual({ failedChanges: [] });
+    expect(result).toBe('stale-dropped');
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(vi.mocked(saveCurrentScene)).not.toHaveBeenCalled();
     expect(vi.mocked(saveChatSessions)).not.toHaveBeenCalled();
@@ -273,7 +302,12 @@ describe('deletion epochs (delete → restore straddles)', () => {
         return callback(undefined, fakeStore);
       },
     );
-    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }],
+      makeData(stageId),
+      stageDeletionEpoch(stageId),
+    );
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(fakeStore.putStage).not.toHaveBeenCalled();
   });
@@ -289,7 +323,7 @@ describe('deletion epochs (delete → restore straddles)', () => {
         return callback(undefined, fakeStore);
       },
     );
-    await saveStageData(stageId, makeData(stageId));
+    await saveStageData(stageId, makeData(stageId), stageDeletionEpoch(stageId));
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
   });
 
@@ -308,8 +342,9 @@ describe('deletion epochs (delete → restore straddles)', () => {
       stageId,
       [{ kind: 'stage' }, { kind: 'currentScene' }, { kind: 'chats' }],
       makeData(stageId),
+      stageDeletionEpoch(stageId),
     );
-    expect(result).toEqual({ failedChanges: [] });
+    expect(result).toBe('stale-dropped');
     expect(vi.mocked(saveCurrentScene)).not.toHaveBeenCalled();
     expect(vi.mocked(saveChatSessions)).not.toHaveBeenCalled();
   });
@@ -326,8 +361,9 @@ describe('deletion epochs (delete → restore straddles)', () => {
       stageId,
       [{ kind: 'currentScene' }, { kind: 'chats' }],
       makeData(stageId),
+      stageDeletionEpoch(stageId),
     );
-    expect(result).toEqual({ failedChanges: [] });
+    expect(result).toBe('stale-dropped');
     expect(vi.mocked(saveCurrentScene)).toHaveBeenCalledOnce();
     expect(vi.mocked(saveChatSessions)).not.toHaveBeenCalled();
   });
@@ -338,7 +374,12 @@ describe('deletion epochs (delete → restore straddles)', () => {
     markStageDeleted(stageId);
     unmarkStageDeleted(stageId);
     expect(stageDeletionEpoch(stageId)).toBe(1);
-    await saveStageDataIncremental(stageId, [{ kind: 'stage' }], makeData(stageId));
+    await saveStageDataIncremental(
+      stageId,
+      [{ kind: 'stage' }],
+      makeData(stageId),
+      stageDeletionEpoch(stageId),
+    );
     expect(fakeStore.saveDocument).toHaveBeenCalledOnce();
   });
 
@@ -355,6 +396,22 @@ describe('deletion epochs (delete → restore straddles)', () => {
 
     await saveStageData(stageId, makeData(stageId), staleEpoch);
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('tracks cascade in-flight separately from the deleted flag (re-marks preserve it)', () => {
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    // Only deleteStageData begins a cascade; begin without a mark is a no-op.
+    beginStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    markStageDeleted(stageId);
+    beginStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(true);
+    // An import-rollback re-mark neither starts nor settles a cascade.
+    markStageDeleted(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(true);
+    settleStageDeletionCascade(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    expect(isStageDeleted(stageId)).toBe(true);
   });
 
   it('never rewinds the epoch: mark → unmark → mark keeps strictly increasing', () => {
@@ -374,10 +431,10 @@ describe('deletion epochs (delete → restore straddles)', () => {
 });
 
 describe('saveStageData vs deletion', () => {
-  it('drops the aggregate save for a deleted stage', async () => {
+  it('drops the aggregate save for a deleted stage, reporting the drop', async () => {
     markStageDeleted(stageId);
-    const result = await saveStageData(stageId, makeData(stageId));
-    expect(result).toBeUndefined();
+    const result = await saveStageData(stageId, makeData(stageId), stageDeletionEpoch(stageId));
+    expect(result).toBe('stale-dropped');
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(mutateDocument).not.toHaveBeenCalled();
   });
@@ -392,7 +449,7 @@ describe('saveStageData vs deletion', () => {
         return callback(undefined, fakeStore);
       },
     );
-    await saveStageData(stageId, makeData(stageId));
+    await saveStageData(stageId, makeData(stageId), stageDeletionEpoch(stageId));
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
   });
 
@@ -403,7 +460,7 @@ describe('saveStageData vs deletion', () => {
         return fn();
       },
     );
-    await saveStageData(stageId, makeData(stageId));
+    await saveStageData(stageId, makeData(stageId), stageDeletionEpoch(stageId));
     expect(fakeStore.saveDocument).not.toHaveBeenCalled();
     expect(vi.mocked(saveCurrentScene)).not.toHaveBeenCalled();
   });
@@ -448,6 +505,46 @@ describe('deleteStageData wiring', () => {
     await expect(deleteStageData(stageId)).rejects.toThrow('locked');
     // The stage survives — the warm copy is still the live document.
     expect(clearStoreForDeletedStage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the cascade in flight during the delete and settles before evicting', async () => {
+    mutateDocument.mockImplementationOnce(
+      async (
+        id: string,
+        callback: (existing: undefined, store: typeof fakeStore) => Promise<unknown>,
+      ) => {
+        // Mid-cascade the outcome is unknown: the read side must keep warm
+        // state instead of trusting the deleted flag as "document gone".
+        expect(isStageDeletionInFlight(id)).toBe(true);
+        return callback(undefined, fakeStore);
+      },
+    );
+    clearStoreForDeletedStage.mockImplementationOnce((id: string) => {
+      // Eviction runs against a settled, still-deleted world — exactly the
+      // state its own isStageDeleted guard expects.
+      expect(isStageDeletionInFlight(id)).toBe(false);
+      expect(isStageDeleted(id)).toBe(true);
+    });
+
+    await deleteStageData(stageId);
+
+    expect(clearStoreForDeletedStage).toHaveBeenCalledExactlyOnceWith(stageId);
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+  });
+
+  it('settles the cascade when the deletion fails before the document was removed', async () => {
+    fakeStore.deleteDocument.mockRejectedValueOnce(new Error('locked'));
+    await expect(deleteStageData(stageId)).rejects.toThrow('locked');
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    expect(isStageDeleted(stageId)).toBe(false);
+  });
+
+  it('settles the cascade when it fails after the document was removed', async () => {
+    dbMock.stageOutlines.delete.mockRejectedValueOnce(new Error('partial cascade'));
+    await expect(deleteStageData(stageId)).rejects.toThrow('partial cascade');
+    // Settled + still-deleted = the ghost may now be discarded by readers.
+    expect(isStageDeletionInFlight(stageId)).toBe(false);
+    expect(isStageDeleted(stageId)).toBe(true);
   });
 
   it('lifts the deleted flag when the deletion fails before the document was removed, keeping the epoch bumped', async () => {


### PR DESCRIPTION
# feat(roster): single-source the generated agent roster on the stage document

## Problem

The generated agent roster currently has a split-brain persistence model:

- The stage document carries `stage.generatedAgentConfigs`, but the actual **read authority** on classroom load is a device-local IndexedDB mirror (`db.generatedAgents`).
- Each agent's **voice binding** (`voiceDesign` / `voiceConfig`) exists *only* on the mirror. It never enters the document, so voices are silently lost whenever the mirror doesn't travel: opening a classroom on another device, server-side fallback hydration, export/import, and shared classrooms all come back voiceless.
- Roster edits persist through a bespoke `debouncedSaveAgents` bypass in the stage store — a second debounce next to the document persistence scheduler, with **no beforeunload / visibilitychange flush**, so an edit made right before closing the tab could be dropped even though the document scheduler already solves exactly this.
- Load-time hydration *wrote* the mirror from the document (and vice versa), so the two sources continuously overwrote each other depending on which path ran last.

## Change

Make the stage document the single source of truth for the roster; demote the mirror to a read-only migration source.

**Contract (`@openmaic/dsl`)**
- `GeneratedAgentConfig` gains optional `voiceConfig` / `voiceDesign`; `VoiceDesign` moves into the contract (the app re-exports it from `lib/audio/voice-design.ts`).
- `AgentVoiceConfig` is deliberately minimal: `{ providerId, voiceId }`. A speculative `modelId` field was dropped after auditing every roster producer (current and historical) and finding none that ever emitted it — contract fields are added only once a producer exists.
- Additive optional fields only — no change to the meaning of any existing field, so per the version policy in `version.ts` this is not a serialized-shape break for this codebase's tolerant structural validators: `DSL_VERSION` stays put and no migration step is added. The generated JSON Schema picks the fields up automatically (covered by a schema test); see Known limitations for what this means for consumers that pin the published schema artifact.

**Writes converge on the document**
- `debouncedSaveAgents` and its private `debounce` helper are deleted. `setStageAgents` now marks `{ kind: 'stage' }` on the shared persistence scheduler (the roster is simply part of the stage document) and performs only synchronous in-memory side effects: registry + selection mirrors.
- The selection mirror honors provenance (matching `restoreAgentSelection` semantics): a stage-derived selection tracks the roster wholesale; a user-set preset selection is not touched at all. A user-set **auto** selection is handled by intent: if it equaled the pre-edit full roster (the AgentBar auto toggle snapshots the whole roster, meaning "everyone"), it keeps tracking the roster wholesale so newly added agents join; a genuine subset is only narrowed — departed agents are dropped, newcomers are never auto-selected. If narrowing would leave an empty selection, the mirror falls back to the full roster and clears `agentSelectionIsUserSet`, mirroring `restoreAgentSelection`'s `length > 0` gate instead of running the classroom with zero agents.
- The registry's zustand `persist` now `partialize`s generated agents out of the localStorage snapshot, so the stage document is the roster's only durable home (the rehydration `merge` filter stays as defense in depth for pre-existing snapshots).
- `saveGeneratedAgents` (IndexedDB + registry) is replaced by a pure in-memory `applyGeneratedAgentsToRegistry(stageId, configs)`; voice warm-up stays as a fire-and-forget.
- Generation embeds the roster (voice included) on the stage before `saveToStorage`; import maps manifest agents straight into `document.stage.generatedAgentConfigs` inside the single atomic document commit; the classroom-load hydration paths no longer write the mirror at all.

**Reads follow the document**
- Classroom load hydrates the registry from the loaded stage's `generatedAgentConfigs`; export reads the stage roster directly (the previous DB-first/stage-fallback dual read is gone).

**Lazy migration (mirror kept, read-only)**
- On load, if the document's roster field is absent entirely, or an agent is missing its voice fields, the mirror is consulted: a missing roster is lifted whole, missing voice fields are backfilled by agent id (document fields always win). The merged result is committed onto the in-memory stage and marked dirty, so the next flush makes it durable — idempotent on subsequent loads. Absent (`undefined`) and explicitly empty (`[]`) rosters are deliberately not collapsed: only an absent field can mean "predates roster persistence" and trigger the full lift; a persisted `[]` is an authoritative empty roster and is never resurrected from the stale mirror (no writer produces `[]` today, but the read side no longer depends on that invariant).
- A fruitless probe is remembered per stage for the session, so classrooms whose producer never binds a voice (e.g. server-generated rosters) don't re-query the mirror on every load forever. Only a probe that **succeeded** and confirmed there is nothing to merge is memoized: a failed mirror read returns a distinct signal (`null`) and is retried on the next load, so a transient IndexedDB error cannot suppress migration for the rest of the session. A successful merge is not memoized either: if its flush fails, the next load retries until the document carries the voices. No persistent marker is introduced.
- Every landing point after an `await` re-checks the current load token and stage id, so switching classrooms mid-load can neither commit a stale roster nor leak it into the global agent registry.

**Deletion safety (deletion-generation model)**
- Stage deletion is fenced by a session-scoped, per-stage **deletion generation (epoch)** plus a deleted flag (`lib/utils/deleted-stages.ts`). `deleteStageData` marks the deletion — bumping the epoch — before removing anything, then discards the stage's queued persistence work. Every persistence path captures the epoch at the moment it captures the data it intends to write (flush-round snapshot, departing-stage snapshot, aggregate save entry) and re-checks `captured epoch == current && !deleted` immediately before each individual write (saveDocument / putScene / putStage / the currentScene and chats tail writes — the two tail writes re-check independently, since no lock spans the tail). Where Web Locks are unavailable the mutation callback is lock-free best-effort LWW, and the per-write re-checks shrink that window.
- A deleted id can legitimately come back, because deletion only removes client-side data: explicit document (re)creation points lift the deleted flag — restoring the server copy on a classroom revisit (`applyClassroomStageAndScenes`) and restoring a backup (`importDatabase`) — so edits after a same-session restore persist again. The epoch is deliberately **never rewound** by a restore: a pre-delete flush still in flight stays permanently stale and cannot overwrite the restored document, while post-restore edits capture the current epoch and persist normally. This is the distinction a boolean tombstone cannot express — after lifting one, pre-delete in-flight writes and post-restore edits were indistinguishable. In-flight flushes never lift the flag.
- Deleting a classroom evicts it from the warm in-memory store, and `loadFromStorage` treats a warm-but-deleted stage as not loaded (discarding the ghost), so navigating Back to a deleted classroom reaches the server-restore path instead of rendering a fully editable ghost from memory whose every edit is silently dropped. The warm-ghost handling is **settlement-driven**: the deletion cascade records an unsettled-cascade count (begun by `deleteStageData`, settled in its `finally`) plus a per-stage settlement promise, and a load that finds the warm stage mid-deletion **parks on that promise** instead of completing — completing early would expose a classroom whose edits are refused without being in the deletion's restore snapshot (silently lost on a failed delete), and whose route the success-path eviction would blank with nothing left to reload. Once settled, the parked load branches on the outcome: a failed delete lifted the flag and restored the pending dirt, so the warm state is kept as the live classroom; a successful delete falls through to a full cold load so the server-restore path recovers the route (the eviction deliberately does not claim a new load token, keeping the parked load current; a real navigation during the park is still caught by the usual token guard). `deleteStageData` is single-flight per stage — a concurrent second call joins the first cascade — and the in-flight state is a counter rather than a bit, so overlapping begin/settle pairs can never expose an undecided cascade as settled. The park cannot deadlock: a parked load holds no document lock, and the cascade never waits on a load. Eviction itself re-checks `isStageDeleted` at eviction time, so a same-id restore completing inside the cascade-tail window is never wiped, and the load path re-checks the deleted flag before landing hydrated data (the read-side mirror of the per-write re-checks), so a lock-free mid-cascade read cannot re-materialize the ghost.
- An epoch-fenced drop is **reported, not disguised**: `saveStageData` / `saveStageDataIncremental` return a distinct `'stale-dropped'` status instead of a success shape, and both store-side consumers react by skipping all success bookkeeping — `saveToStorage` performs no `chatSnapshot` rebind to a snapshot that never landed and no pending-dirt clearing, returning `false` to keep its "true means verified write" contract honest, and the debounced flush path propagates the status out of `persistDirtySnapshot` so the flush round skips its `chatSnapshot` rebind too (a falsely rebound baseline would let later chat saves no-op-skip chats that were never persisted and would corrupt cross-tab conflict detection; pending-map clearing keeps treating a drop as "nothing to retry", which is sound because restored descriptors mint fresh revisions). `capturedEpoch` is a required parameter on both storage entry points, so the type system enforces that the epoch is captured at the same instant as the data snapshot.
- A deletion that fails before the document is removed lifts the deleted flag — and restores the pending changes it discarded (snapshotted before the deletion was marked, including the in-flight flush round's dirt), so pre-delete edits still reach durability. The restore re-queues change descriptors; their flush re-captures the current store state under the current (bumped) epoch, so nothing replays a stale capture. Edits attempted during the deletion window itself are refused and are not part of the snapshot (documented; deletion runs from the home page, where the stage is not being edited).
- A failed backup import rolls back the deletion state it lifted: when the rolled-back document was deleted pre-import, the deletion is re-marked so an outstanding flush cannot recreate the absent document.
- Deleting a stage also clears its rows from the legacy roster mirror (best-effort; a deleted stage needs no migration source). The deletion state is per-tab by design; a sibling tab's scheduler is outside this fence (documented).

**Portability & import hardening**
- Classroom ZIP manifests now carry `voiceConfig` / `voiceDesign` per agent, so export → import preserves agent voices (up to id renaming).
- Manifest voice fields are structurally validated on import (manifests are parsed JSON from user-supplied ZIPs): a malformed `voiceConfig`/`voiceDesign` is dropped per field while the agent survives. On the registry side, `applyGeneratedAgentsToRegistry` validates `providerId` against the known TTS provider registry (built-ins + the `custom-tts-` namespace) instead of blindly casting; unknown providers are treated as "no bound voice". The provider lookups use own-property semantics (`Object.hasOwn`) rather than `in`/bare indexing, so prototype-chain keys (`toString`, `constructor`, …) can neither pass the whitelist nor resolve to `Object.prototype` members.

## Tests

- `tests/store/stage-agents.test.ts` rewritten for the scheduler-based model: document flush carries the roster (voice included), synchronous registry/selection mirroring, the selection-provenance matrix (stage-derived vs user-set × auto/preset, empty-intersection fallback, full-roster intent tracking newcomers, genuine subsets excluding them), scene advances never touch the registry, pending-discard on deletion, deletion fencing (queued-dirt fencing, refusal of new dirt, the departing-stage retry window — including a delete → restore straddle inside the retry window), failed-deletion dirt restore (snapshot includes the in-flight round; restore no-ops after a stage switch; the restored dirt flushes under the current epoch), and post-restore edits persisting under the new epoch.
- New `tests/utils/stage-storage-deletion.test.ts`: storage-layer deletion fencing — the missing-destination full-save is pinned for live stages and blocked for deleted ones (including the lock-race re-check and the lock-free per-write re-checks on both save paths), the incremental currentScene/chats tail is dropped after a mid-mutation delete (and the chat write re-checks independently after the currentScene write), plus the epoch invariants: a round captured pre-delete is dropped even after a same-id restore lifts the deleted flag (incremental, aggregate, and tail), an explicitly stale captured epoch is dropped while the stage is live, post-restore captures persist, mark → unmark → mark keeps the epoch strictly increasing, dropped writes report the distinct `'stale-dropped'` status, and the cascade in-flight state is tracked separately from the deleted flag (re-marks preserve it, overlapping cascades stay in flight until the last settle, and the settlement promise resolves only then). `deleteStageData` wiring: pre-deletion dirt snapshot, mark-before-discard ordering, warm-store eviction on success (and not on failure), eviction only after settlement (in flight during the cascade, settled — with the deleted flag intact — at eviction time and on both failure shapes), settlement-promise resolution on success and on failure, single-flight join of concurrent same-stage deletions (shared cascade and shared failure), mirror-row cleanup (and its failure tolerance), and deleted-flag lift + dirt restore (epoch kept bumped) vs. keep on failed deletions.
- `tests/classroom/load-classroom.test.ts`: existing supersede matrix retained; new coverage for document-first hydration, voice backfill + commit, full-roster lift (absent-field only; an explicitly persisted `[]` is authoritative and never resurrects stale mirror rows), idempotence, the stale-load / stage-id race gates, the fruitless-probe memo (skip on later loads, per-classroom scoping, no memo on successful merges, no memo on failed reads with retry on the next load), and the deletion lifecycle (explicit server-copy restore lifts it and edits persist again; unrestored deletions keep dropping writes; a deleted classroom still warm in the store is restored through the REAL `loadFromStorage` — the back-button path — and edits persist end-to-end afterwards, including a warm ghost with ZERO scenes (the ghost handling keys on stage identity, not scene count); a Back landing mid-cascade parks until the deletion settles, after which a failed delete keeps the warm classroom editable with the pending edits restored end-to-end, a successful delete completes through a cold load into the server restore, and a navigation that moved on during the park is never overwritten by the released load; the eviction refuses to wipe a classroom restored-and-unmarked during the cascade tail). `tests/store/stage-document-persistence.test.ts`: a fence-dropped save returns `false`, does not rebind `chatSnapshot`, and keeps the pending dirt. `tests/store/stage-incremental-persistence.test.ts`: a fenced in-flight flush round skips the `chatSnapshot` rebind, and restored chats flush afterwards against the honest pre-fence baseline. `tests/store/stage-generation-complete.test.ts`: a load whose stage is deleted during hydration does not land (read-side re-check).
- `tests/runtime/database-chat-cutover.test.ts`: a backup import lifts the deletion state of a recreated stage (epoch preserved), and a failed import that rolls the document back reinstates the deletion state it lifted.
- New `tests/lib/orchestration/apply-generated-agents.test.ts` for the registry apply: voice mapping, unknown/custom provider handling, prototype-chain provider keys dropped, cross-stage replacement — plus persistence exclusion (localStorage snapshot carries no generated agents; rehydration merge drops them as backstop).
- New `tests/audio/tts-provider-guard.test.ts`: own-property semantics of `isKnownTTSProviderId` / `getTTSProvider` / `getASRProvider` / `findVoiceDisplayName` against prototype-chain keys.
- `tests/export/classroom-zip.test.ts`: voice round-trip through the manifest, and structural sanitization of malformed manifest voice fields (per-field drop).
- `@openmaic/dsl` schema test: stage rosters with and without voice fields validate.

`pnpm check`, `pnpm lint`, `tsc --noEmit`, and the full vitest suites (root + `@openmaic/dsl`) are green.

## Known limitations / follow-ups

- The new voice fields are non-breaking for this codebase's tolerant TS validators, but they are **not** transparent to consumers that validate documents against a pinned copy of the published `stage.schema.json`: the generated schema sets `additionalProperties: false`, so an older schema artifact rejects any document carrying a voice field. Such cross-language consumers must upgrade their schema artifact in lockstep (a `DSL_VERSION` bump would not help them — an old schema rejects the new documents either way). Whether to drop `additionalProperties: false` from the generated schema for forward compatibility is a separate policy decision, left out of this PR.
- `validateStage` (structural-subset validator) has no `generatedAgentConfigs` branch yet; roster shape is enforced at the ingress points (import sanitization, registry provider whitelist) rather than at the document validator. Extending `validateStage` to cover the roster is left as a follow-up.
- The legacy mirror probe memo is session-scoped by design: a classroom with nothing to migrate costs at most one IndexedDB query per session.
- The deletion-generation state is per-tab: a sibling tab holding pending edits for the deleted stage still flushes through its own scheduler. Deletion vs. live editing in another tab is a cross-tab invalidation problem the per-tab scheduler never handled; documented at the deleted-stages module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
