### PR TITLE
fix(interactive): load micropip before generated Pyodide imports

### DIFF
--- a/lib/prompts/templates/code-content/system.md
+++ b/lib/prompts/templates/code-content/system.md
@@ -59,6 +59,20 @@ If user code needs packages like numpy, load them during initialization:
 await pyodide.loadPackage(['numpy']);
 ```
 
+`micropip` is included in the Pyodide distribution but is **not loaded by
+default**. Before Python executes `import micropip`, JavaScript MUST load it:
+
+```javascript
+await pyodide.loadPackage('micropip');
+await pyodide.runPythonAsync(`
+    import micropip
+    await micropip.install('package-name')
+`);
+```
+
+Never call `import micropip` first; that aborts initialization with
+`ModuleNotFoundError`.
+
 ### 4. Wait for Pyodide Initialization
 
 - Disable the run button until Pyodide is fully loaded

--- a/lib/utils/iframe.ts
+++ b/lib/utils/iframe.ts
@@ -99,6 +99,118 @@ const ERROR_CAPTURE_SHIM = `<script data-iframe-error-shim>
 </script>`;
 
 /**
+ * Repair a common LLM-authored Pyodide bootstrap bug.
+ *
+ * `micropip` ships with the Pyodide distribution but is not loaded into the
+ * runtime by `loadPyodide()` itself. Generated widgets sometimes immediately
+ * execute `import micropip`, which aborts their whole initialization with
+ * `ModuleNotFoundError`. When that exact mismatch is present, insert the
+ * documented `loadPackage('micropip')` call after the assigned loader promise.
+ *
+ * This is intentionally narrow: unrelated HTML is untouched, already-correct
+ * widgets stay byte-for-byte stable, and pages whose loader result is not
+ * assigned are left for the runtime-error reporter instead of being guessed at.
+ */
+function patchMissingMicropipLoad(html: string): string {
+  if (!/\b(?:import\s+micropip|from\s+micropip\s+import)\b/.test(html)) return html;
+  if (/\.loadPackage\s*\(\s*(?:['"]micropip['"]|\[[^\]]*['"]micropip['"][^\]]*\])/.test(html)) {
+    return html;
+  }
+
+  const loader = /\b([A-Za-z_$][\w$]*)\s*=\s*await\s+loadPyodide\s*\(/.exec(html);
+  if (!loader || loader.index === undefined) return html;
+
+  const variable = loader[1];
+  const openParen = html.indexOf('(', loader.index);
+  if (openParen === -1) return html;
+
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+  let blockComment = false;
+  let lineComment = false;
+  let closeParen = -1;
+
+  for (let index = openParen; index < html.length; index += 1) {
+    const char = html[index];
+    const next = html[index + 1];
+
+    if (lineComment) {
+      if (char === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = '';
+      }
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '(') depth += 1;
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        closeParen = index;
+        break;
+      }
+    }
+  }
+
+  if (closeParen === -1) return html;
+
+  let insertAt = closeParen + 1;
+  let crossedLineBreak = false;
+  while (insertAt < html.length && /[ \t\r\n]/.test(html[insertAt])) {
+    if (html[insertAt] === '\n' || html[insertAt] === '\r') crossedLineBreak = true;
+    insertAt += 1;
+  }
+
+  // A property-access token means the result is still part of a chain such as
+  // `loadPyodide().then(...)`; inserting in the middle would corrupt the script.
+  if (html[insertAt] === '.' || html[insertAt] === '?' || html[insertAt] === '[') return html;
+
+  if (html[insertAt] === ';') insertAt += 1;
+  else if (
+    insertAt < html.length &&
+    !crossedLineBreak &&
+    html[insertAt] !== '}' &&
+    html[insertAt] !== '<'
+  ) {
+    return html;
+  }
+
+  const lineStart = html.lastIndexOf('\n', loader.index) + 1;
+  const indentation = html.slice(lineStart, loader.index).match(/^[ \t]*/)?.[0] ?? '';
+  const loadStatement = `\n${indentation}await ${variable}.loadPackage('micropip');`;
+
+  return html.slice(0, insertAt) + loadStatement + html.slice(insertAt);
+}
+
+/**
  * Patch embedded HTML to display correctly inside an iframe.
  *
  * Injects a runtime-error capture shim + a storage shim (so sandboxed pages that
@@ -108,6 +220,7 @@ const ERROR_CAPTURE_SHIM = `<script data-iframe-error-shim>
  * it also observes the storage shim).
  */
 export function patchHtmlForIframe(html: string): string {
+  const runtimePatchedHtml = patchMissingMicropipLoad(html);
   const iframeCss = `<style data-iframe-patch>
   html, body {
     width: 100%;
@@ -125,21 +238,29 @@ export function patchHtmlForIframe(html: string): string {
   const injection = '\n' + ERROR_CAPTURE_SHIM + '\n' + STORAGE_SHIM + '\n' + iframeCss;
 
   // Insert right after <head> or at the start of the document
-  const headIdx = html.indexOf('<head>');
+  const headIdx = runtimePatchedHtml.indexOf('<head>');
   if (headIdx !== -1) {
     const insertPos = headIdx + 6; // after <head>
-    return html.substring(0, insertPos) + injection + html.substring(insertPos);
+    return (
+      runtimePatchedHtml.substring(0, insertPos) +
+      injection +
+      runtimePatchedHtml.substring(insertPos)
+    );
   }
 
-  const headWithAttrs = html.indexOf('<head ');
+  const headWithAttrs = runtimePatchedHtml.indexOf('<head ');
   if (headWithAttrs !== -1) {
-    const closeAngle = html.indexOf('>', headWithAttrs);
+    const closeAngle = runtimePatchedHtml.indexOf('>', headWithAttrs);
     if (closeAngle !== -1) {
       const insertPos = closeAngle + 1;
-      return html.substring(0, insertPos) + injection + html.substring(insertPos);
+      return (
+        runtimePatchedHtml.substring(0, insertPos) +
+        injection +
+        runtimePatchedHtml.substring(insertPos)
+      );
     }
   }
 
   // Fallback: prepend
-  return injection + html;
+  return injection + runtimePatchedHtml;
 }

--- a/tests/lib/utils/iframe.test.ts
+++ b/tests/lib/utils/iframe.test.ts
@@ -133,4 +133,55 @@ describe('patchHtmlForIframe', () => {
     handlers.message({ data: { foo: 1 } });
     expect(posts).toHaveLength(4);
   });
+
+  it('loads micropip before generated Python bootstrap code imports it', () => {
+    const html = `<html><head></head><body><script>
+      async function initPyodide() {
+        pyodide = await loadPyodide({
+          indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.26.4/full/'
+        });
+        await pyodide.runPythonAsync(\`
+          import micropip
+          await micropip.install('requests')
+        \`);
+      }
+    </script></body></html>`;
+
+    const out = patchHtmlForIframe(html);
+    const loadIndex = out.indexOf("await pyodide.loadPackage('micropip');");
+    const importIndex = out.indexOf('import micropip');
+
+    expect(loadIndex).toBeGreaterThan(-1);
+    expect(loadIndex).toBeLessThan(importIndex);
+  });
+
+  it('does not duplicate an existing micropip package load', () => {
+    const html = `<script>
+      const runtime = await loadPyodide();
+      await runtime.loadPackage(['numpy', 'micropip']);
+      await runtime.runPythonAsync('import micropip');
+    </script>`;
+
+    const out = patchHtmlForIframe(html);
+    expect(out.match(/loadPackage\s*\(\s*\[['"]?/g)).toHaveLength(1);
+    expect(out).not.toContain("await runtime.loadPackage('micropip');");
+  });
+
+  it('does not modify a chained loadPyodide expression', () => {
+    const html = `<script>
+      const runtime = await loadPyodide().then((loaded) => loaded);
+      await runtime.runPythonAsync('import micropip');
+    </script>`;
+
+    const out = patchHtmlForIframe(html);
+    expect(out).toContain('loadPyodide().then((loaded) => loaded)');
+    expect(out).not.toContain("await runtime.loadPackage('micropip');");
+  });
+
+  it('leaves non-Pyodide interactive HTML free of micropip repair code', () => {
+    const out = patchHtmlForIframe(
+      '<html><head></head><body><script>window.answer = 42;</script></body></html>',
+    );
+    expect(out).not.toContain("loadPackage('micropip')");
+  });
 });


### PR DESCRIPTION
## Summary

Fix generated interactive Python widgets that fail during initialization when their bootstrap code imports `micropip` before loading the package.

The generator prompt now emits the documented package-loading order, while a narrow render-time fallback also recovers already-generated classrooms. This PR was developed with AI assistance, then manually reviewed, refined, and tested by the contributor.

## Related Issues

Fixes #1008

## Changes

- Require `pyodide.loadPackage('micropip')` before generated Python executes `import micropip`
- Repair existing generated HTML only when it imports `micropip` without already loading it
- Leave unrelated HTML, existing package arrays, and chained `loadPyodide()` expressions unchanged
- Add regression coverage for missing, existing, unrelated, and unsupported bootstrap patterns

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Verification

### Steps to reproduce / test

1. Render generated interactive HTML that assigns the result of `await loadPyodide(...)`.
2. Have the generated bootstrap immediately execute `import micropip`.
3. Confirm the iframe patch inserts `await <runtime>.loadPackage('micropip')` before the import.
4. Confirm already-correct and unsupported bootstrap patterns are not modified.

### What you personally verified

- Reproduced `ModuleNotFoundError: No module named 'micropip'` in a real OpenMAIC-generated classroom
- Confirmed the same saved classroom reports `Python 环境就绪` and enables the Run button after the fix
- AI self-review identified and added guards for package arrays and chained loader expressions
- `pnpm exec vitest run tests/lib/utils/iframe.test.ts` — 11 tests passed
- Targeted Prettier check — passed
- `pnpm lint` — 0 errors (17 pre-existing warnings outside this change)
- `pnpm exec tsc --noEmit` — passed
- `pnpm build` — passed, including the Next.js production build and TypeScript phase

The repository-wide Prettier check reports the existing Windows CRLF checkout as formatting differences across the repository. The three changed files pass a targeted Prettier check; Linux CI completed the authoritative full-repository check successfully.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally and against the affected generated classroom
- [ ] Screenshots / recordings attached (no visual design change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
