### PR TITLE
fix(importer): handle custom shapes without paths

### DIFF
--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/importer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A javascript tool for parsing .pptx file",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-/* eslint-disable no-console */
 import {
   parse as parsePptxDefault,
   type Shape,
@@ -984,14 +982,14 @@ export async function transformParsedToSlides(
               element.path = el.path;
               element.viewBox = [originWidth, originHeight];
             }
-            if (el.shapType === 'custom') {
-              if (el.path!.indexOf('NaN') !== -1) {
+            if (el.shapType === 'custom' && el.path) {
+              if (el.path.indexOf('NaN') !== -1) {
                 if (element.width === 0) element.width = 0.1;
                 if (element.height === 0) element.height = 0.1;
-                element.path = el.path!.replace(/NaN/g, '0');
+                element.path = el.path.replace(/NaN/g, '0');
               } else {
                 element.special = true;
-                element.path = el.path!;
+                element.path = el.path;
               }
               const { maxX, maxY } = getSvgPathRange(element.path);
               element.viewBox = [maxX || originWidth, maxY || originHeight];

--- a/packages/@openmaic/importer/test/normalizeImportedSlides.test.ts
+++ b/packages/@openmaic/importer/test/normalizeImportedSlides.test.ts
@@ -108,4 +108,49 @@ describe('parsedToSlides · normalize boundary', () => {
     expect(shape.type).toBe('shape');
     expect((shape as { fill?: string }).fill).toBe('');
   });
+
+  it('keeps importing when a custom shape has no generated path', async () => {
+    const json = {
+      size: { width: 960, height: 540 },
+      themeColors: [],
+      slides: [
+        {
+          fill: { type: 'color', value: '#ffffff' },
+          note: '',
+          layoutElements: [],
+          elements: [
+            {
+              type: 'shape',
+              shapType: 'custom',
+              left: 100,
+              top: 100,
+              width: 200,
+              height: 120,
+              name: 'custom shape without path',
+              order: 1,
+              rotate: 0,
+              content: '<div></div>',
+              borderWidth: 0,
+              borderColor: '#000000',
+              borderType: 'solid',
+              borderStrokeDasharray: '0',
+              vAlign: 'mid',
+              isFlipH: false,
+              isFlipV: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const slides = await parsedToSlides(json as unknown as Parameters<typeof parsedToSlides>[0]);
+
+    expect(slides).toHaveLength(1);
+    expect(slides[0].elements).toHaveLength(1);
+    expect(slides[0].elements[0]).toMatchObject({
+      type: 'shape',
+      width: 200 * (96 / 72),
+      height: 120 * (96 / 72),
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- guard custom shape path handling when the parser cannot generate a path
- add regression coverage for custom shapes without generated paths
- bump @openmaic/importer to 0.1.1 for npm publishing

## Verification
- pnpm --filter @openmaic/importer test
- pnpm --filter @openmaic/importer build
- pnpm exec eslint packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts packages/@openmaic/importer/test/normalizeImportedSlides.test.ts
- pnpm exec tsc --noEmit --pretty false