### PR TITLE
fix(i18n): load every Inter subset so non-Latin text keeps the UI font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,11 @@
 }
 
 :root {
+  /* Inter is loaded from @fontsource in app/layout.tsx, which declares one
+     @font-face per unicode subset. Previously this came from next/font wrapping
+     a single latin-only file, which left Cyrillic and Vietnamese text to OS
+     fallback fonts. */
+  --font-sans: 'Inter Variable', ui-sans-serif, system-ui, sans-serif;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import localFont from 'next/font/local';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
 import './globals.css';
@@ -13,11 +12,20 @@ import { ServerProvidersInit } from '@/components/server-providers-init';
 import { StorageHealthNotice } from '@/components/storage-health-notice';
 import { AccessCodeGuard } from '@/components/access-code-guard';
 
-const inter = localFont({
-  src: '../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2',
-  variable: '--font-sans',
-  weight: '100 900',
-});
+// The UI font is loaded from @fontsource's stylesheet rather than next/font,
+// because only the stylesheet carries the per-subset `unicode-range`
+// declarations. Pointing next/font at `inter-latin-wght-normal.woff2` loaded
+// exactly one subset, so every character outside Latin — Cyrillic for ru-RU,
+// tone-marked letters for vi-VN — fell back to an arbitrary OS font and
+// rendered in a different typeface mid-word.
+//
+// Declaring the other subset files as sibling faces of the same family does not
+// fix it either: faces with identical descriptors and no `unicode-range` do not
+// fall through per glyph, so the browser simply picks one.
+//
+// `--font-sans` moves to globals.css since the family no longer comes from
+// next/font's generated class.
+import '@fontsource-variable/inter';
 
 export const metadata: Metadata = {
   title: 'OpenMAIC',
@@ -31,7 +39,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={inter.variable} suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
         suppressHydrationWarning


### PR DESCRIPTION
## The bug

`app/layout.tsx` loads the UI font through `next/font/local`, pointed at a single file:

```ts
const inter = localFont({
  src: '../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2',
  ...
});
```

That is the **latin** subset only. `@fontsource-variable/inter` ships seven:

```
inter-cyrillic-ext  inter-cyrillic  inter-greek-ext  inter-greek
inter-latin-ext     inter-latin     inter-vietnamese
```

The per-subset `unicode-range` declarations live in the package's stylesheet, which was never imported — so nothing requested the other six. Any character outside the Latin range falls back to an arbitrary OS font and renders with different shapes, weight and metrics than the text around it, frequently mid-word.

## Who this affects today

This is not hypothetical or limited to new locales:

- **`ru-RU`** is Cyrillic. `inter-cyrillic-wght-normal.woff2` was never loaded, so Russian has been rendering in a fallback font.
- **`pt-BR`** and **`es-MX`** lose the accented characters that live in `latin-ext`.

## Why not just add the other files to `next/font`

Because it does not work. Faces sharing a family with identical descriptors and no `unicode-range` are not tried per glyph — the browser resolves to one face and stops. `next/font/local` has no way to express `unicode-range`, so the fix has to come from the stylesheet that already declares it correctly.

## The change

- Import `@fontsource-variable/inter` (the stylesheet, with all seven `unicode-range` blocks) instead of wrapping one file in `next/font/local`.
- Move `--font-sans` into `globals.css`, since the family no longer comes from next/font's generated class.

**The typeface does not change.** It is still Inter, now with the subsets that were already sitting in `node_modules`.

## Verification

- `npx tsc --noEmit` reports nothing in `app/`.
- Prettier passes on both touched files.
- Rendered a page of Vietnamese and Russian text before and after: before, accented and Cyrillic glyphs visibly differ in weight and spacing from neighbouring Latin ones; after, the whole string is one typeface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)