### PR TITLE
fix(render-service): keep the entrypoint LF so the image starts on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Shell scripts must keep LF endings even when checked out on Windows.
+#
+# With Git's default `core.autocrlf=true` on Windows, docker-entrypoint.sh is
+# rewritten to CRLF at checkout. COPY-ing it into a Linux image then leaves the
+# shebang reading `#!/bin/sh\r`, so the kernel looks for an interpreter whose
+# name ends in a carriage return and the container exits immediately with
+# `exec /usr/local/bin/docker-entrypoint.sh: no such file or directory` —
+# a message that points at the script rather than at the interpreter.
+*.sh text eol=lf

--- a/render-service/Dockerfile
+++ b/render-service/Dockerfile
@@ -45,7 +45,13 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --chown=render:render package.json tsconfig.json ./
 COPY --chown=render:render src ./src
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+# Strip CR before chmod. .gitattributes keeps this file LF on fresh checkouts,
+# but clones made before that landed still hold a CRLF copy, and the resulting
+# `#!/bin/sh\r` shebang fails at container start with a message that blames the
+# script instead of the interpreter. Normalizing here makes the build
+# independent of how the tree was checked out.
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh \
+    && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV PORT=9000 \
     PRODUCER_TMP_PROJECT_DIR=/tmp/openmaic-renders


### PR DESCRIPTION
## The bug

Building `render-service` from a Windows clone produces an image that dies at startup:

```
exec /usr/local/bin/docker-entrypoint.sh: no such file or directory
```

The file is there, and it is executable. The missing thing is the *interpreter*.

Git's default `core.autocrlf=true` on Windows rewrites `docker-entrypoint.sh` to CRLF at checkout. Copied into the Linux image, its shebang becomes `#!/bin/sh\r`, and the kernel goes looking for an interpreter whose name ends in a carriage return. The error names the script rather than the interpreter, which sends you hunting for a path or permissions problem that does not exist.

```console
$ file render-service/docker-entrypoint.sh
POSIX shell script, ... with CRLF line terminators

$ head -1 render-service/docker-entrypoint.sh | od -c
0000000   #   !   /   b   i   n   /   s   h  \r  \n
```

## The change

Two parts, covering different cases:

**`.gitattributes`** — marks `*.sh` as `text eol=lf`, so fresh checkouts are no longer rewritten. This is the root-cause fix and also covers `render-service/scripts/egress-smoke.sh`, which has the same exposure.

**Dockerfile** — strips CR before `chmod`. `.gitattributes` does nothing for clones that already hold a CRLF copy, and renormalizing an existing tree is a manual step most people will not know to run. Stripping in the build makes the image independent of how the tree was checked out.

## Verification

Built from a CRLF checkout on Windows (Docker Desktop, WSL2 backend) and started the container:

```console
$ docker run -d -p 9001:9000 --cap-add=NET_ADMIN openmaic-render:pr-test
$ curl http://localhost:9001/health
{"ok":true}
```

Before the change the same tree produced a container that restart-looped on the exec error.

## Unrelated note for the docs

Not changed here, but worth flagging: the service refuses to start without `CAP_NET_ADMIN` (`egress lockdown requested but iptables rules failed to apply ... Refusing to start unisolated`). That is the right call, but `docker run` outside the compose profile needs `--cap-add=NET_ADMIN` and the README does not mention it. Happy to add a line if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)