### PR TITLE
fix(i18n): translate ASR provider names in the generation toolbar

### DIFF
--- a/components/generation/media-popover.tsx
+++ b/components/generation/media-popover.tsx
@@ -24,6 +24,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/hooks/use-i18n';
+import { resolveASRProviderName } from '@/lib/audio/provider-display';
 import { useSettingsStore } from '@/lib/store/settings';
 import { IMAGE_PROVIDERS } from '@/lib/media/image-providers';
 import { VIDEO_PROVIDERS } from '@/lib/media/video-providers';
@@ -191,7 +192,9 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
       if (!cfgOk(asrProvidersConfig, p.id, p.requiresApiKey)) continue;
       groups.push({
         groupId: p.id,
-        groupName: p.name,
+        // `p.name` is the registry label, which is Chinese for several
+        // providers; resolve it the way the settings dialog does.
+        groupName: resolveASRProviderName(p.id, t, p.name),
         groupIcon: p.icon,
         available: true,
         items: getASRSupportedLanguages(p.id).map((l) => ({
@@ -216,7 +219,7 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
     }
 
     return groups;
-  }, [asrProvidersConfig, cfgOk]);
+  }, [asrProvidersConfig, cfgOk, t]);
 
   // Auto-select first enabled tab on open
   const handleOpenChange = (isOpen: boolean) => {

--- a/components/settings/index.tsx
+++ b/components/settings/index.tsx
@@ -62,6 +62,7 @@ import { ModelEditDialog } from './model-edit-dialog';
 import { AddProviderDialog, type NewProviderData } from './add-provider-dialog';
 import { AddAudioProviderDialog, type NewAudioProviderData } from './add-audio-provider-dialog';
 import { isCustomTTSProvider, isCustomASRProvider } from '@/lib/audio/types';
+import { resolveASRProviderName, resolveTTSProviderName } from '@/lib/audio/provider-display';
 import type { SettingsSection, EditingModel } from '@/lib/types/settings';
 
 // ─── Provider List Column (reusable) ───
@@ -133,24 +134,14 @@ function ProviderListColumn<T extends string>({
 }
 
 // ─── Helper: get TTS/ASR provider display name ───
+// The id→i18n-key tables live in lib/audio/provider-display so the generation
+// toolbar resolves provider names the same way this dialog does.
 function getTTSProviderName(providerId: TTSProviderId, t: (key: string) => string): string {
   if (isCustomTTSProvider(providerId)) {
     const cfg = useSettingsStore.getState().ttsProvidersConfig[providerId];
     return cfg?.customName || providerId;
   }
-  const names: Record<string, string> = {
-    'openai-tts': t('settings.providerOpenAITTS'),
-    'azure-tts': t('settings.providerAzureTTS'),
-    'glm-tts': t('settings.providerGLMTTS'),
-    'qwen-tts': t('settings.providerQwenTTS'),
-    'voxcpm-tts': t('settings.providerVoxCPMTTS'),
-    'doubao-tts': t('settings.providerDoubaoTTS'),
-    'elevenlabs-tts': t('settings.providerElevenLabsTTS'),
-    'minimax-tts': t('settings.providerMiniMaxTTS'),
-    'lemonade-tts': t('settings.providerLemonadeTTS'),
-    'browser-native-tts': t('settings.providerBrowserNativeTTS'),
-  };
-  return names[providerId] || providerId;
+  return resolveTTSProviderName(providerId, t);
 }
 
 function getASRProviderName(providerId: ASRProviderId, t: (key: string) => string): string {
@@ -158,14 +149,7 @@ function getASRProviderName(providerId: ASRProviderId, t: (key: string) => strin
     const cfg = useSettingsStore.getState().asrProvidersConfig[providerId];
     return cfg?.customName || providerId;
   }
-  const names: Record<string, string> = {
-    'openai-whisper': t('settings.providerOpenAIWhisper'),
-    'browser-native': t('settings.providerBrowserNative'),
-    'qwen-asr': t('settings.providerQwenASR'),
-    'azure-asr': t('settings.providerAzureASR'),
-    'lemonade-asr': t('settings.providerLemonadeASR'),
-  };
-  return names[providerId] || providerId;
+  return resolveASRProviderName(providerId, t);
 }
 
 // ─── Image/Video provider name helpers ───

--- a/lib/audio/provider-display.ts
+++ b/lib/audio/provider-display.ts
@@ -1,0 +1,59 @@
+/**
+ * Localized display names for the built-in audio providers.
+ *
+ * The `name` field in `ASR_PROVIDERS` / `TTS_PROVIDERS` is a registry label, not
+ * a UI string: several are written in Chinese (`浏览器原生 ASR (Web Speech API)`,
+ * `Qwen ASR (阿里云百炼)`). Rendering it directly leaks Chinese into every other
+ * locale, so any surface that shows a provider to the user must resolve the
+ * name through i18n instead.
+ *
+ * Kept here rather than in a component so the settings dialog and the
+ * generation toolbar cannot drift apart on what a provider is called.
+ */
+
+import type { ASRProviderId, TTSProviderId } from './types';
+
+const ASR_PROVIDER_NAME_KEYS: Record<string, string> = {
+  'openai-whisper': 'settings.providerOpenAIWhisper',
+  'browser-native': 'settings.providerBrowserNative',
+  'qwen-asr': 'settings.providerQwenASR',
+  'azure-asr': 'settings.providerAzureASR',
+  'lemonade-asr': 'settings.providerLemonadeASR',
+};
+
+const TTS_PROVIDER_NAME_KEYS: Record<string, string> = {
+  'openai-tts': 'settings.providerOpenAITTS',
+  'azure-tts': 'settings.providerAzureTTS',
+  'glm-tts': 'settings.providerGLMTTS',
+  'qwen-tts': 'settings.providerQwenTTS',
+  'voxcpm-tts': 'settings.providerVoxCPMTTS',
+  'doubao-tts': 'settings.providerDoubaoTTS',
+  'elevenlabs-tts': 'settings.providerElevenLabsTTS',
+  'minimax-tts': 'settings.providerMiniMaxTTS',
+  'lemonade-tts': 'settings.providerLemonadeTTS',
+  'browser-native-tts': 'settings.providerBrowserNativeTTS',
+};
+
+/**
+ * Translate a built-in ASR provider's name. Unknown ids (custom providers,
+ * which carry their own user-supplied name) fall back to `fallback`, then to
+ * the id, so a caller never renders an empty label.
+ */
+export function resolveASRProviderName(
+  providerId: ASRProviderId | string,
+  t: (key: string) => string,
+  fallback?: string,
+): string {
+  const key = ASR_PROVIDER_NAME_KEYS[providerId];
+  return key ? t(key) : fallback || providerId;
+}
+
+/** TTS counterpart of {@link resolveASRProviderName}. */
+export function resolveTTSProviderName(
+  providerId: TTSProviderId | string,
+  t: (key: string) => string,
+  fallback?: string,
+): string {
+  const key = TTS_PROVIDER_NAME_KEYS[providerId];
+  return key ? t(key) : fallback || providerId;
+}


### PR DESCRIPTION
## The bug

The ASR provider dropdown in the media popover renders `p.name` straight from the `ASR_PROVIDERS` registry:

```ts
for (const p of Object.values(ASR_PROVIDERS)) {
  groups.push({ groupId: p.id, groupName: p.name, ... });
}
```

`name` there is a registry label, not a UI string, and several entries are written in Chinese:

| id | registry `name` |
| --- | --- |
| `browser-native` | `浏览器原生 ASR (Web Speech API)` |
| `qwen-asr` | `Qwen ASR (阿里云百炼)` |

So a user on any non-Chinese locale gets Chinese in the toolbar. The settings dialog shows the same providers correctly, because it resolves through `t('settings.providerBrowserNative')` — the translations already exist in every locale file; the toolbar simply never used them.

Screenshot from a Vietnamese UI, before this change — everything is Vietnamese except the provider itself:

> **Nhận dạng giọng nói** — `浏览器原生 ASR (Web Speech API)`

## The change

The id→i18n-key tables move to `lib/audio/provider-display.ts`, and both the settings dialog and the toolbar resolve names through it, so the two surfaces cannot drift apart again.

- The settings dialog keeps its own handling of custom providers, which carry a user-supplied `customName` rather than an i18n key.
- TTS is included in the shared module for symmetry — `doubao-tts` (`豆包 TTS 2.0（火山引擎）`) and `qwen-tts` have the same problem — though the popover's TTS tab is currently a toggle with no provider list.
- Image and video groups in the same popover also render `p.name`, but those registry labels are already English, so no user-visible string changes. Left alone to keep this focused; happy to fold them in if you would rather have it uniform.

## Verification

- `npx tsc --noEmit` reports nothing in `components/` or `lib/audio/`.
- `npx vitest run tests/store tests/prompts` — 342 passed.
- Prettier passes on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)