### PR TITLE
refactor(dsl): name the default slide font instead of repeating it

### DIFF
--- a/app/eval/whiteboard/page.tsx
+++ b/app/eval/whiteboard/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { ScreenElement } from '@/components/slide-renderer/Editor/ScreenElement';
 import { SceneProvider } from '@/lib/contexts/scene-context';
 import { useStageStore } from '@/lib/store/stage';
-import type { PPTElement } from '@openmaic/dsl';
+import { DEFAULT_SLIDE_FONT, type PPTElement } from '@openmaic/dsl';
 
 const EVAL_STAGE_ID = '__eval_stage__';
 const EVAL_SCENE_ID = '__eval_scene__';
@@ -41,7 +41,7 @@ function WhiteboardCanvas() {
               backgroundColor: '#ffffff',
               themeColors: ['#5b9bd5'],
               fontColor: '#333333',
-              fontName: 'Microsoft YaHei',
+              fontName: DEFAULT_SLIDE_FONT,
             },
             elements: [],
           },
@@ -66,7 +66,7 @@ function WhiteboardCanvas() {
               backgroundColor: '#ffffff',
               themeColors: ['#5b9bd5'],
               fontColor: '#333333',
-              fontName: 'Microsoft YaHei',
+              fontName: DEFAULT_SLIDE_FONT,
             },
             elements: incoming,
           },

--- a/components/slide-renderer/Editor/ScreenElement.tsx
+++ b/components/slide-renderer/Editor/ScreenElement.tsx
@@ -14,6 +14,7 @@ import { BaseVideoElement } from '../components/element/VideoElement/BaseVideoEl
 import { BaseCodeElement } from '../components/element/CodeElement/BaseCodeElement';
 import { useSceneSelector } from '@/lib/contexts/scene-context';
 import type { SceneContent } from '@/lib/types/stage';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 interface ScreenElementProps {
   readonly elementInfo: PPTElement;
@@ -47,7 +48,7 @@ export function ScreenElement({ elementInfo, elementIndex, animate }: ScreenElem
       }
       return {
         fontColor: '#333333',
-        fontName: 'Microsoft YaHei',
+        fontName: DEFAULT_SLIDE_FONT,
       };
     },
   );

--- a/components/slide-renderer/components/element/ShapeElement/BaseShapeElement.tsx
+++ b/components/slide-renderer/components/element/ShapeElement/BaseShapeElement.tsx
@@ -7,6 +7,7 @@ import { useElementFlip } from '../hooks/useElementFlip';
 import { useElementFill } from '../hooks/useElementFill';
 import { GradientDefs } from './GradientDefs';
 import { PatternDefs } from './PatternDefs';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 export interface BaseShapeElementProps {
   elementInfo: PPTShapeElement;
@@ -24,7 +25,7 @@ export function BaseShapeElement({ elementInfo }: BaseShapeElementProps) {
   const text: ShapeText = elementInfo.text || {
     content: '',
     align: 'middle',
-    defaultFontName: 'Microsoft YaHei',
+    defaultFontName: DEFAULT_SLIDE_FONT,
     defaultColor: '#333333',
   };
 

--- a/lib/action/engine.ts
+++ b/lib/action/engine.ts
@@ -50,6 +50,7 @@ import {
 } from '@/lib/choreography';
 import katex from 'katex';
 import { createLogger } from '@/lib/logger';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 const log = createLogger('ActionEngine');
 
@@ -425,7 +426,7 @@ export class ActionEngine {
         width: action.width ?? 400,
         height: action.height ?? 100,
         rotate: 0,
-        defaultFontName: 'Microsoft YaHei',
+        defaultFontName: DEFAULT_SLIDE_FONT,
         defaultColor: action.color ?? '#333333',
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,

--- a/lib/agent/client/apply-regenerate.ts
+++ b/lib/agent/client/apply-regenerate.ts
@@ -12,13 +12,14 @@ import type { Action } from '@/lib/types/action';
 import type { Scene, ScenePatch, SceneContent, InteractiveContent } from '@/lib/types/stage';
 import type { GeneratedSlideContent } from '@/lib/types/generation';
 import { CURRENT_SLIDE_CONTENT_SCHEMA_VERSION } from '@/lib/edit/slide-schema';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 // Mirrors the default theme minted by createSceneWithActions for fresh slides.
 const DEFAULT_THEME = {
   backgroundColor: '#ffffff',
   themeColors: ['#5b9bd5', '#ed7d31', '#a5a5a5', '#ffc000', '#4472c4'],
   fontColor: '#333333',
-  fontName: 'Microsoft YaHei',
+  fontName: DEFAULT_SLIDE_FONT,
   outline: { color: '#d14424', width: 2, style: 'solid' },
   shadow: { h: 0, v: 0, blur: 10, color: '#000000' },
 };

--- a/lib/api/stage-api-defaults.ts
+++ b/lib/api/stage-api-defaults.ts
@@ -15,6 +15,7 @@ import type {
   InteractiveContent,
   PBLContent,
 } from '@/lib/types/stage';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 // ==================== Utility Functions ====================
 
@@ -53,7 +54,7 @@ export function createDefaultSlideContent(): SlideContent {
         backgroundColor: '#ffffff',
         themeColors: ['#5b9bd5', '#ed7d31', '#a5a5a5', '#ffc000', '#4472c4'],
         fontColor: '#333333',
-        fontName: 'Microsoft YaHei',
+        fontName: DEFAULT_SLIDE_FONT,
         outline: {
           color: '#d14424',
           width: 2,

--- a/lib/edit/slide-defaults.ts
+++ b/lib/edit/slide-defaults.ts
@@ -4,12 +4,13 @@ import type { Scene, SlideContent } from '@/lib/types/stage';
 import type { Action } from '@/lib/types/action';
 import { createElementIdMap } from '@/lib/utils/element';
 import { CURRENT_SLIDE_CONTENT_SCHEMA_VERSION } from '@/lib/edit/slide-schema';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 const DEFAULT_THEME: SlideTheme = {
   backgroundColor: '#ffffff',
   themeColors: ['#5b9bd5', '#ed7d31', '#a5a5a5', '#ffc000', '#4472c4'],
   fontColor: '#333333',
-  fontName: 'Microsoft YaHei',
+  fontName: DEFAULT_SLIDE_FONT,
   outline: { color: '#d14424', width: 2, style: 'solid' },
   shadow: { h: 0, v: 0, blur: 10, color: '#000000' },
 };

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -22,11 +22,12 @@ import { createLogger } from '@/lib/logger';
 import { inlineHtmlAssets, createAssetFetcher } from './inline-assets';
 import type { FetchAsset } from './inline-assets';
 import { createProxiedFetch } from './proxied-fetch';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 
 const log = createLogger('ExportPPTX');
 
 const DEFAULT_FONT_SIZE = 16;
-const DEFAULT_FONT_FAMILY = 'Microsoft YaHei';
+const DEFAULT_FONT_FAMILY = DEFAULT_SLIDE_FONT;
 
 // ── Color formatting ──
 

--- a/lib/generation/scene-builder.ts
+++ b/lib/generation/scene-builder.ts
@@ -22,6 +22,7 @@ import { generateSceneContent, generateSceneActions } from './scene-generator';
 import type { AgentInfo, SceneGenerationContext, AICallFn } from './pipeline-types';
 import { buildLanguageText } from './prompt-formatters';
 import { createLogger } from '@/lib/logger';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 const log = createLogger('Generation');
 
 /**
@@ -162,7 +163,7 @@ function buildCompleteSceneInner(
       backgroundColor: '#ffffff',
       themeColors: ['#5b9bd5', '#ed7d31', '#a5a5a5', '#ffc000', '#4472c4'],
       fontColor: '#333333',
-      fontName: 'Microsoft YaHei',
+      fontName: DEFAULT_SLIDE_FONT,
       outline: { color: '#d14424', width: 2, style: 'solid' },
       shadow: { h: 0, v: 0, blur: 10, color: '#000000' },
     };

--- a/lib/generation/scene-generator.ts
+++ b/lib/generation/scene-generator.ts
@@ -53,6 +53,7 @@ import type {
 } from './pipeline-types';
 import type { ThinkingConfig } from '@/lib/types/provider';
 import { createLogger } from '@/lib/logger';
+import { DEFAULT_SLIDE_FONT } from '@openmaic/dsl';
 const log = createLogger('Generation');
 
 const INTERACTIVE_WIDGET_ACTIONS = [
@@ -1830,7 +1831,7 @@ export function createSceneWithActions(
       backgroundColor: '#ffffff',
       themeColors: ['#5b9bd5', '#ed7d31', '#a5a5a5', '#ffc000', '#4472c4'],
       fontColor: '#333333',
-      fontName: 'Microsoft YaHei',
+      fontName: DEFAULT_SLIDE_FONT,
       outline: { color: '#d14424', width: 2, style: 'solid' },
       shadow: { h: 0, v: 0, blur: 10, color: '#000000' },
     };

--- a/packages/@openmaic/dsl/src/fonts.ts
+++ b/packages/@openmaic/dsl/src/fonts.ts
@@ -1,0 +1,53 @@
+/**
+ * Typography defaults for generated slide text.
+ */
+
+/**
+ * Typeface applied to slide text when a document does not name one.
+ *
+ * Every producer in the SDK family — the scene generator, the action engine,
+ * the editor defaults, the PPTX exporter, the DSL normalizer — needs the same
+ * answer to "what font when the document is silent?". Before this constant
+ * that answer was written out as a string literal in each of them, so the
+ * question had two dozen separate answers that only happened to agree.
+ *
+ * The value is unchanged: `Microsoft YaHei`, which ships with Windows and
+ * covers Simplified Chinese well.
+ *
+ * ## Why a deployment may need to retarget this
+ *
+ * The face is chosen for Chinese and its coverage stops there. Checked against
+ * `C:\Windows\Fonts\msyh.ttc` (fontTools `getBestCmap`), seven of eight sampled
+ * Vietnamese letters have no glyph:
+ *
+ * | code point | letter | in font |
+ * | ---------- | ------ | ------- |
+ * | U+1EBF     | ế      | no      |
+ * | U+1ED9     | ộ      | no      |
+ * | U+1EEF     | ữ      | no      |
+ * | U+1EA1     | ạ      | no      |
+ * | U+01B0     | ư      | no      |
+ * | U+01A1     | ơ      | no      |
+ * | U+1EB1     | ằ      | no      |
+ * | U+0111     | đ      | yes     |
+ *
+ * A missing glyph does not fail loudly. The browser silently substitutes
+ * another installed face for that one character, so a Vietnamese slide renders
+ * in two typefaces interleaved — weight and spacing shift mid-word. The PPTX
+ * exporter writes the face name into the OOXML and PowerPoint substitutes the
+ * same way. Latin-script languages with rich diacritics (Vietnamese) and every
+ * non-CJK script (Devanagari, Thai, Arabic, Korean) hit this.
+ *
+ * Retargeting is now an edit here rather than an audit of every producer. Two
+ * further constraints apply:
+ *
+ * - The `@default` annotations on `defaultFontName` in `slides.ts` must be
+ *   changed to match. They are JSDoc, so they cannot reference this constant;
+ *   they are compiled into the published JSON Schema, and the schema-lockstep
+ *   test in `test/normalize.test.ts` fails if the two disagree. Forgetting is
+ *   loud, not silent.
+ * - The name must be a single font family, not a CSS fallback list. The
+ *   renderer would accept a list, but the PPTX exporter passes this straight
+ *   through as an OOXML `fontFace`, where only one family name is valid.
+ */
+export const DEFAULT_SLIDE_FONT = 'Microsoft YaHei';

--- a/packages/@openmaic/dsl/src/index.ts
+++ b/packages/@openmaic/dsl/src/index.ts
@@ -24,6 +24,7 @@
  * consumers inject via `Scene`'s type parameters.
  */
 export * from './slides.js';
+export * from './fonts.js';
 export * from './guards.js';
 export * from './stage.js';
 export * from './action.js';

--- a/packages/@openmaic/dsl/src/normalize.ts
+++ b/packages/@openmaic/dsl/src/normalize.ts
@@ -54,6 +54,7 @@ import type {
 } from './slides.js';
 import type { Scene, SceneType, Stage } from './stage.js';
 import { isSlideContent } from './stage.js';
+import { DEFAULT_SLIDE_FONT } from './fonts.js';
 
 /**
  * The canonical static defaults for required element fields, and the single
@@ -67,7 +68,7 @@ import { isSlideContent } from './stage.js';
  */
 export const ELEMENT_DEFAULTS = {
   text: {
-    defaultFontName: 'Microsoft YaHei',
+    defaultFontName: DEFAULT_SLIDE_FONT,
     defaultColor: '#333333',
     content: '',
   },
@@ -80,7 +81,7 @@ export const ELEMENT_DEFAULTS = {
   },
   shapeText: {
     content: '',
-    defaultFontName: 'Microsoft YaHei',
+    defaultFontName: DEFAULT_SLIDE_FONT,
     defaultColor: '#333333',
     align: 'middle',
   },

--- a/packages/@openmaic/renderer/src/SlideElement.tsx
+++ b/packages/@openmaic/renderer/src/SlideElement.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, type ReactNode } from 'react';
 import {
+  DEFAULT_SLIDE_FONT,
   ElementTypes,
   type PPTElement,
   type PPTImageElement,
@@ -21,7 +22,7 @@ import { BaseCodeElement } from './elements/code/BaseCodeElement';
 
 const DEFAULT_THEME = {
   fontColor: '#333333',
-  fontName: 'Microsoft YaHei',
+  fontName: DEFAULT_SLIDE_FONT,
 } as const;
 
 export interface SlideElementProps {

--- a/packages/@openmaic/renderer/src/elements/shape/BaseShapeElement.tsx
+++ b/packages/@openmaic/renderer/src/elements/shape/BaseShapeElement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { PPTShapeElement, ShapeText } from '@openmaic/dsl';
+import { DEFAULT_SLIDE_FONT, type PPTShapeElement, type ShapeText } from '@openmaic/dsl';
 import { useElementOutline } from '../shared/useElementOutline';
 import { useElementShadow } from '../shared/useElementShadow';
 import { useElementFlip } from '../shared/useElementFlip';
@@ -98,7 +98,7 @@ export function BaseShapeElement({ elementInfo }: BaseShapeElementProps) {
   const text: ShapeText = elementInfo.text || {
     content: '',
     align: 'middle',
-    defaultFontName: 'Microsoft YaHei',
+    defaultFontName: DEFAULT_SLIDE_FONT,
     defaultColor: '#333333',
   };
 


### PR DESCRIPTION
## Problem

The typeface applied to slide text when a document names none is written as the string literal `'Microsoft YaHei'` in every producer independently:

| Package | Sites |
| --- | --- |
| `@openmaic/dsl` | `normalize.ts` (text + shapeText defaults) |
| `@openmaic/renderer` | `SlideElement.tsx`, `elements/shape/BaseShapeElement.tsx` |
| app | `lib/action/engine.ts`, `lib/agent/client/apply-regenerate.ts`, `lib/api/stage-api-defaults.ts`, `lib/edit/slide-defaults.ts`, `lib/export/use-export-pptx.ts`, `lib/generation/scene-builder.ts`, `lib/generation/scene-generator.ts`, `components/slide-renderer/Editor/ScreenElement.tsx`, `components/slide-renderer/components/element/ShapeElement/BaseShapeElement.tsx`, `app/eval/whiteboard/page.tsx` |

Fourteen copies across three packages and the app, each separately answering the same question.

## Change

Add `DEFAULT_SLIDE_FONT` to `@openmaic/dsl` and import it at every site.

The DSL is the right home: it already owns `ELEMENT_DEFAULTS`, it has no runtime dependencies, and both `@openmaic/renderer` and `@openmaic/importer` already depend on it — so no new edge is added to the dependency graph.

**No behaviour change.** The value stays `'Microsoft YaHei'`.

### Deliberately left as literals

- The `@default` JSDoc on `defaultFontName` in `slides.ts`. It is compiled into the published JSON Schema and cannot reference a constant. The lockstep test in `normalize.test.ts` already fails loudly if it drifts from `ELEMENT_DEFAULTS`, so this stays enforced rather than merely documented.
- Test assertions — a test should pin a concrete value, not restate the constant it is testing.
- Comments citing the name as an example of a legacy or CJK face (`text-format-bar.tsx`, `textSerializer.ts`).
- The CSS font stack in `eval/pbl-v2-planner/compare-html.ts`, which styles the eval report page rather than slide content.

## Why this is worth doing

The face is chosen for Simplified Chinese and its coverage stops there. Checked against `msyh.ttc` with fontTools `getBestCmap`, seven of eight sampled Vietnamese letters have no glyph:

| Code point | Letter | Present |
| --- | --- | --- |
| U+1EBF | ế | no |
| U+1ED9 | ộ | no |
| U+1EEF | ữ | no |
| U+1EA1 | ạ | no |
| U+01B0 | ư | no |
| U+01A1 | ơ | no |
| U+1EB1 | ằ | no |
| U+0111 | đ | yes |

A missing glyph does not fail loudly — the browser substitutes another installed face for that single character, so a Vietnamese slide renders in two typefaces interleaved and shifts weight and spacing mid-word. The PPTX exporter writes the face name into the OOXML and PowerPoint substitutes the same way. Every non-CJK script is affected, not just Vietnamese.

This PR does not change the default. It makes retargeting a deployment a single edit instead of an audit, and the constant's doc comment records the two constraints on doing so:

1. Update the matching `@default` annotations in `slides.ts` — the schema lockstep test enforces this.
2. Use a single family name, not a CSS fallback list: the renderer would accept a list, but the PPTX exporter passes the value through as an OOXML `fontFace` where only one family name is valid.

## Verification

- `tsc --noEmit` clean.
- `@openmaic/dsl` 190/190, `@openmaic/renderer` 242/242, `@openmaic/importer` 33/33 pass — including the schema-lockstep test that pins `ELEMENT_DEFAULTS` to the JSON Schema `default` annotations.
- Full app suite: 3373 passed / 28 failed. The same 28 fail on unmodified `main` in a full run (`tests/quiz/runtime.test.ts`, `tests/runtime/chat-storage.test.ts`, `tests/store/kv-persist.test.ts` — they pass in isolation, so they look like shared-IndexedDB/Web-Locks interference rather than anything this touches). Zero regressions introduced.
