### PR TITLE
feat(llm): fall back to another model when one is out of quota

### DIFF
--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -36,6 +36,7 @@ import type {
 import { apiError } from '@/lib/server/api-response';
 import { createLogger } from '@/lib/logger';
 import { resolveModelFromRequest } from '@/lib/server/resolve-model';
+import { isCapacityError, nextFallbackModel } from '@/lib/server/model-fallback';
 import { sortDocumentImagesForVision } from '@/lib/document/bundle';
 import { resolveVocationalActive } from '@/lib/config/feature-flags';
 const log = createLogger('Outlines Stream');
@@ -311,6 +312,13 @@ export async function POST(req: NextRequest) {
     };
     requirementSnippet = requirements?.requirement?.substring(0, 60);
 
+    // The UI locale is the default teaching-language signal. Without it a
+    // language-neutral requirement ("ok", "go", a bare topic) leaves the model
+    // to infer the language from the reference document, so a Vietnamese
+    // teacher uploading an English PDF gets an English course. An explicit
+    // request in the requirement text still wins — see the prompt's decision
+    // rules — this only fills the gap when the requirement carries no signal.
+
     // Build user profile string for language inference context
     const userProfileText =
       requirements.userNickname || requirements.userBio
@@ -423,7 +431,19 @@ export async function POST(req: NextRequest) {
         try {
           startHeartbeat();
 
-          const streamParams = visionImages?.length
+          // `streamText` does not reject the text stream on an upstream
+          // failure — it ends the stream and reports through `onError`. A 429
+          // therefore arrives as a zero-length response rather than a throw,
+          // so the catch below never sees it and only the empty-result branch
+          // does. Capture it to tell "the model refused us" apart from "the
+          // model answered with nothing usable".
+          let streamError: unknown;
+
+          // `let`, not `const`: a quota rejection re-points this at the next
+          // model in MODEL_FALLBACKS before the next attempt. Outlines are the
+          // first step of a lecture, so one exhausted model here fails the
+          // whole generation.
+          let streamParams = visionImages?.length
             ? {
                 model: languageModel,
                 system: prompts.system,
@@ -437,6 +457,9 @@ export async function POST(req: NextRequest) {
                 // Tear down the upstream LLM request when the client disconnects,
                 // instead of letting it run to completion for a dead connection.
                 abortSignal: req.signal,
+                onError: ({ error }: { error: unknown }) => {
+                  streamError = error;
+                },
               }
             : {
                 model: languageModel,
@@ -444,7 +467,33 @@ export async function POST(req: NextRequest) {
                 prompt: prompts.user,
                 maxOutputTokens: modelInfo?.outputWindow,
                 abortSignal: req.signal,
+                onError: ({ error }: { error: unknown }) => {
+                  streamError = error;
+                },
               };
+
+          const triedModels = new Set<string>();
+
+          /**
+           * Re-point `streamParams` at the next model when `error` says the
+           * current one has no capacity. Returns whether a swap happened, so
+           * the caller can grant the new model a fresh attempt budget.
+           */
+          const swapToFallbackModel = async (error: unknown): Promise<boolean> => {
+            if (!isCapacityError(error)) return false;
+            if (triedModels.size === 0 && resolvedModelString) {
+              triedModels.add(resolvedModelString);
+            }
+            const next = await nextFallbackModel(triedModels);
+            if (!next) {
+              log.warn('Outlines: out of capacity and no fallback model left.');
+              return false;
+            }
+            log.warn(`Outlines: model out of capacity; falling back to ${next.modelString}.`);
+            streamParams = { ...streamParams, model: next.model };
+            streamError = undefined;
+            return true;
+          };
 
           let parsedOutlines: SceneOutline[] = [];
           let languageDirective: string | null = null;
@@ -553,6 +602,14 @@ export async function POST(req: NextRequest) {
                 `Outlines attempt ${attempt} diagnostics: textLen=${fullText.length}, outlines=${parsedOutlines.length}, languageDirective=${languageDirective ? 'yes' : 'no'}, preview=${JSON.stringify(fullText.slice(0, 240))}`,
               );
 
+              // The empty response was a refusal, not a bad answer: re-sending
+              // to the same model repeats it. Spend the next attempt elsewhere.
+              const swapped = await swapToFallbackModel(streamError);
+              if (swapped) {
+                attempt = 0;
+                continue;
+              }
+
               if (attempt <= MAX_STREAM_RETRIES) {
                 log.warn(
                   `Empty outlines (attempt ${attempt}/${MAX_STREAM_RETRIES + 1}), retrying...`,
@@ -576,6 +633,13 @@ export async function POST(req: NextRequest) {
               log.warn(
                 `Outlines stream error detail (attempt ${attempt}/${MAX_STREAM_RETRIES + 1}): ${lastError}`,
               );
+
+              // A 429 that did surface as a throw gets the same treatment as
+              // one that arrived silently through `onError`.
+              if (await swapToFallbackModel(error ?? streamError)) {
+                attempt = 0;
+                continue;
+              }
 
               if (attempt <= MAX_STREAM_RETRIES) {
                 log.warn(

--- a/lib/ai/llm.ts
+++ b/lib/ai/llm.ts
@@ -134,6 +134,14 @@ function getModelProviderId(params: GenerateTextParams | StreamTextParams): stri
 }
 
 /**
+ * `provider:model` for logs and for marking a model as already tried. Matches
+ * the form used by `MODEL_FALLBACKS` / `DEFAULT_MODEL`, so the two compare.
+ */
+function getModelString(params: GenerateTextParams | StreamTextParams): string {
+  return `${getModelProviderId(params) ?? 'unknown'}:${getModelId(params)}`;
+}
+
+/**
  * Map a unified ThinkingConfig to provider-specific providerOptions.
  */
 function buildThinkingProviderOptions(
@@ -335,11 +343,19 @@ export async function callLLM<T extends GenerateTextParams>(
   let lastResult: GenerateTextResult<any, any> | undefined;
   let lastError: unknown;
 
+  // A quota rejection is not retryable against the same model, so the loop can
+  // re-point itself at the next model in MODEL_FALLBACKS instead of spending
+  // its remaining attempts on a 429 that will not clear. `activeParams` is what
+  // actually gets sent; `params` stays untouched so usage is still attributed
+  // per model and the caller's object is not mutated.
+  let activeParams: GenerateTextParams = params;
+  const triedModels = new Set<string>();
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       // Resolve effective thinking config: per-call > global env > undefined
       const effectiveThinking = thinking ?? getGlobalThinkingConfig();
-      const injectedParams = injectProviderOptions(params, effectiveThinking);
+      const injectedParams = injectProviderOptions(activeParams, effectiveThinking);
 
       // Wrap in thinkingContext so the custom fetch wrapper in providers.ts
       // can read the config and inject vendor-specific body params for
@@ -357,7 +373,9 @@ export async function callLLM<T extends GenerateTextParams>(
       // every earlier step would go unaccounted. `totalUsage` aggregates across
       // steps and equals `usage` for a single-step call. Mirrors streamLLM,
       // which already prefers the aggregate.
-      recordUsageSafe(result.totalUsage ?? result.usage, buildUsageMeta(params, source));
+      // Attributed to `activeParams`, not `params`: after a fallback swap the
+      // call was served by a different model and the usage ledger must say so.
+      recordUsageSafe(result.totalUsage ?? result.usage, buildUsageMeta(activeParams, source));
 
       // Validate result (only when retries are configured)
       if (validate && !validate(result.text)) {
@@ -371,6 +389,27 @@ export async function callLLM<T extends GenerateTextParams>(
       return result;
     } catch (error) {
       lastError = error;
+
+      // Out of capacity on this model: another attempt against it would fail
+      // the same way, so move to the next model in the chain and give it a
+      // fresh attempt budget. Imported lazily to keep this module free of a
+      // static dependency on server-only provider config.
+      const { isCapacityError, isFallbackEligible, nextFallbackModel } = await import(
+        '@/lib/server/model-fallback'
+      );
+      if (isCapacityError(error) && isFallbackEligible(source)) {
+        if (triedModels.size === 0) triedModels.add(getModelString(activeParams));
+        const next = await nextFallbackModel(triedModels);
+        if (next) {
+          log.warn(
+            `[${source}] ${getModelString(activeParams)} is out of capacity; falling back to ${next.modelString}.`,
+          );
+          activeParams = { ...activeParams, model: next.model };
+          attempt = 0; // the new model has not been tried yet
+          continue;
+        }
+        log.warn(`[${source}] Out of capacity and no fallback model left.`);
+      }
 
       if (attempt < maxAttempts) {
         log.warn(`[${source}] Call failed (attempt ${attempt}/${maxAttempts}), retrying...`, error);

--- a/lib/server/model-fallback.ts
+++ b/lib/server/model-fallback.ts
@@ -1,0 +1,135 @@
+/**
+ * Move a call to the next model when the current one is out of quota.
+ *
+ * A free-tier key meters each model separately and per day, so the model a
+ * stage is routed to is the first to run dry while its siblings still have
+ * headroom. The retry that already exists in `callLLM` and in the outlines
+ * route does not help: it re-sends to the *same* exhausted model and burns its
+ * attempts on an error that cannot clear within the call. That is what a
+ * generation failure looks like in the log — three attempts, three 429s, then
+ * "LLM returned empty response".
+ *
+ * This module supplies the missing piece: a chain of models to walk when, and
+ * only when, the failure is a quota or rate-limit rejection. Any other error
+ * (a bad prompt, a malformed schema, a network fault) still fails where it
+ * happened, because retrying it elsewhere would only hide the real cause and
+ * spend a second model's quota to do so.
+ *
+ * Configure with `MODEL_FALLBACKS`, either JSON or comma-separated:
+ *
+ *     MODEL_FALLBACKS='["google:gemini-3.6-flash","google:gemini-3.5-flash-lite"]'
+ *     MODEL_FALLBACKS=google:gemini-3.6-flash,google:gemini-3.5-flash-lite
+ *
+ * Unset means the previous behaviour, unchanged: no failover.
+ */
+
+import { createLogger } from '@/lib/logger';
+import { resolveModel } from '@/lib/server/resolve-model';
+import type { LanguageModel } from 'ai';
+
+const log = createLogger('ModelFallback');
+
+/** Model strings to try, in order, after a quota rejection. */
+export function getFallbackChain(): string[] {
+  const raw = process.env.MODEL_FALLBACKS?.trim();
+  if (!raw) return [];
+
+  if (raw.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        log.warn('MODEL_FALLBACKS must be a JSON array of model strings; ignored.');
+        return [];
+      }
+      return parsed.filter((v): v is string => typeof v === 'string' && v.includes(':'));
+    } catch {
+      log.warn('MODEL_FALLBACKS is not valid JSON; ignored.');
+      return [];
+    }
+  }
+
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.includes(':'));
+}
+
+/**
+ * Whether an error means "this model has no capacity for you right now".
+ *
+ * Covers the shapes the AI SDK produces: a bare `APICallError` with a status
+ * code, and a `RetryError` that wraps the last one after its own backoff gave
+ * up. Google reports daily free-tier exhaustion as 429 / RESOURCE_EXHAUSTED;
+ * 503 is a transient server overload rather than a quota fact, but it is worth
+ * moving on from too — the alternative is stalling on one busy model while
+ * another is idle.
+ */
+export function isCapacityError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let node: unknown = error;
+
+  for (let depth = 0; node && depth < 5; depth++) {
+    if (seen.has(node)) break;
+    seen.add(node);
+
+    const e = node as { statusCode?: number; message?: string; lastError?: unknown; cause?: unknown };
+    if (e.statusCode === 429 || e.statusCode === 503) return true;
+    if (
+      typeof e.message === 'string' &&
+      /\b429\b|\b503\b|exceeded your current quota|RESOURCE_EXHAUSTED|rate.?limit|overloaded|high demand/i.test(
+        e.message,
+      )
+    ) {
+      return true;
+    }
+
+    node = e.lastError ?? e.cause;
+  }
+
+  return false;
+}
+
+/**
+ * Call sources that must never fail over.
+ *
+ * Failover is right when the caller wants *an answer* and any capable model
+ * will do. It is wrong when the caller wants to know something *about a
+ * particular model* — `verify-model` sends a probe to the exact model a user
+ * typed in and reports whether it works. Quietly answering from a different
+ * model would make it report a dead or mis-keyed model as healthy, which is
+ * worse than the failure it was asked to detect.
+ */
+const NO_FALLBACK_SOURCES = new Set(['verify-model']);
+
+/** Whether a call made under this source label may switch models. */
+export function isFallbackEligible(source: string): boolean {
+  return !NO_FALLBACK_SOURCES.has(source);
+}
+
+export interface FallbackModel {
+  model: LanguageModel;
+  modelString: string;
+}
+
+/**
+ * Build the next untried model in the chain, or `null` when the chain is spent.
+ *
+ * `tried` is mutated to record every candidate handed out, so a caller looping
+ * over failures cannot be served the same model twice and cannot loop forever.
+ * Pass the model that just failed in `tried` before the first call.
+ */
+export async function nextFallbackModel(tried: Set<string>): Promise<FallbackModel | null> {
+  for (const candidate of getFallbackChain()) {
+    if (tried.has(candidate)) continue;
+    tried.add(candidate);
+    try {
+      const resolved = await resolveModel({ modelString: candidate });
+      return { model: resolved.model, modelString: candidate };
+    } catch (err) {
+      // A chain entry naming a provider with no key configured is a config
+      // mistake, not a reason to abandon the remaining candidates.
+      log.warn(`Fallback model "${candidate}" could not be resolved; skipping.`, err);
+    }
+  }
+  return null;
+}

--- a/tests/server/model-fallback.test.ts
+++ b/tests/server/model-fallback.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  getFallbackChain,
+  isCapacityError,
+  isFallbackEligible,
+  nextFallbackModel,
+} from '@/lib/server/model-fallback';
+
+const resolveModel = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/server/resolve-model', () => ({ resolveModel }));
+
+const ORIGINAL = process.env.MODEL_FALLBACKS;
+
+beforeEach(() => {
+  resolveModel.mockReset();
+  resolveModel.mockImplementation(async ({ modelString }: { modelString: string }) => ({
+    model: { provider: 'google', modelId: modelString.split(':')[1] },
+  }));
+});
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.MODEL_FALLBACKS;
+  else process.env.MODEL_FALLBACKS = ORIGINAL;
+});
+
+describe('getFallbackChain', () => {
+  it('reads a JSON array', () => {
+    process.env.MODEL_FALLBACKS = '["google:a","google:b"]';
+    expect(getFallbackChain()).toEqual(['google:a', 'google:b']);
+  });
+
+  it('reads a comma-separated list, trimming spaces', () => {
+    process.env.MODEL_FALLBACKS = ' google:a , google:b ';
+    expect(getFallbackChain()).toEqual(['google:a', 'google:b']);
+  });
+
+  it('is empty when unset, so the feature is opt-in', () => {
+    delete process.env.MODEL_FALLBACKS;
+    expect(getFallbackChain()).toEqual([]);
+  });
+
+  it('ignores malformed JSON instead of throwing at call time', () => {
+    process.env.MODEL_FALLBACKS = '["google:a"';
+    expect(getFallbackChain()).toEqual([]);
+  });
+
+  it('drops entries with no provider prefix', () => {
+    process.env.MODEL_FALLBACKS = 'google:a,gemini-3.6-flash,google:b';
+    expect(getFallbackChain()).toEqual(['google:a', 'google:b']);
+  });
+});
+
+describe('isCapacityError', () => {
+  it('matches a bare 429', () => {
+    expect(isCapacityError({ statusCode: 429 })).toBe(true);
+  });
+
+  it('matches the quota message Google actually returns', () => {
+    expect(
+      isCapacityError(new Error('You exceeded your current quota, please check your plan')),
+    ).toBe(true);
+  });
+
+  it('matches a 503 overload, which stalls just as hard', () => {
+    expect(isCapacityError({ statusCode: 503 })).toBe(true);
+  });
+
+  it('unwraps the AI SDK RetryError that hides the real status', () => {
+    expect(isCapacityError({ message: 'Failed after 3 attempts', lastError: { statusCode: 429 } })).toBe(
+      true,
+    );
+  });
+
+  it('follows a `cause` chain too', () => {
+    expect(isCapacityError({ message: 'wrapped', cause: { statusCode: 429 } })).toBe(true);
+  });
+
+  // The point of the guard: an ordinary failure must fail where it happened
+  // rather than spending a second model's quota to produce the same error.
+  it('does not match an ordinary error', () => {
+    expect(isCapacityError(new Error('Expected exactly 1 teacher, got 2'))).toBe(false);
+  });
+
+  it('does not match auth or bad-request failures', () => {
+    expect(isCapacityError({ statusCode: 401 })).toBe(false);
+    expect(isCapacityError({ statusCode: 400, message: 'invalid schema' })).toBe(false);
+  });
+
+  it('terminates on a self-referential cause chain', () => {
+    const loop: { message: string; cause?: unknown } = { message: 'x' };
+    loop.cause = loop;
+    expect(isCapacityError(loop)).toBe(false);
+  });
+});
+
+describe('isFallbackEligible', () => {
+  // Falling back here would report the user's dead or mis-keyed model as
+  // healthy, because a different model answered the probe.
+  it('refuses to fail over a model verification probe', () => {
+    expect(isFallbackEligible('verify-model')).toBe(false);
+  });
+
+  it('allows ordinary generation sources', () => {
+    for (const source of ['scene-content', 'scene-actions', 'quiz-grade', 'pbl-chat']) {
+      expect(isFallbackEligible(source)).toBe(true);
+    }
+  });
+});
+
+describe('nextFallbackModel', () => {
+  it('walks the chain in order and never repeats a model', async () => {
+    process.env.MODEL_FALLBACKS = 'google:a,google:b';
+    const tried = new Set<string>();
+
+    expect((await nextFallbackModel(tried))?.modelString).toBe('google:a');
+    expect((await nextFallbackModel(tried))?.modelString).toBe('google:b');
+    expect(await nextFallbackModel(tried)).toBeNull();
+  });
+
+  it('skips a model the caller already used', async () => {
+    process.env.MODEL_FALLBACKS = 'google:a,google:b';
+    const tried = new Set(['google:a']);
+
+    expect((await nextFallbackModel(tried))?.modelString).toBe('google:b');
+  });
+
+  it('skips an unresolvable entry rather than abandoning the rest', async () => {
+    process.env.MODEL_FALLBACKS = 'google:broken,google:b';
+    resolveModel.mockImplementation(async ({ modelString }: { modelString: string }) => {
+      if (modelString === 'google:broken') throw new Error('no API key configured');
+      return { model: { provider: 'google', modelId: 'b' } };
+    });
+
+    expect((await nextFallbackModel(new Set()))?.modelString).toBe('google:b');
+  });
+
+  it('returns null when nothing is configured', async () => {
+    delete process.env.MODEL_FALLBACKS;
+    expect(await nextFallbackModel(new Set())).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

A free-tier key meters **each model separately, per day**. The model a stage is routed to runs dry while its siblings still have headroom.

The existing retry does not help — it re-sends to the *same* exhausted model, spending its attempts on an error that cannot clear within the call:

```
[Scene Content API] Scene content generation failed
  [scene="…", model=google:gemini-3-flash-preview]
  AI_APICallError: You exceeded your current quota
…
[Outlines Stream] Outline generation failed after 3 attempts: LLM returned empty response
```

Outlines are the first step of a lecture, so one exhausted model there fails the whole generation.

## Change

An opt-in chain to walk when, and only when, the failure is a capacity rejection:

```env
MODEL_FALLBACKS=google:gemini-3.6-flash,google:gemini-3.5-flash-lite,google:gemini-3.1-flash-lite
```

Unset means the previous behaviour, unchanged. Wired into `callLLM` (which covers scene content, scene actions, agent profiles, quiz grading, web search) and into the outlines route.

Only 429/503 triggers it. Any other failure still fails where it happened — retrying a bad prompt or a malformed schema elsewhere would hide the real cause and spend a second model's quota to reproduce the same error.

### Two details worth flagging

**`verify-model` is excluded.** It probes the exact model a user typed in and reports whether it works. Answering from a different model would report a dead or mis-keyed model as healthy — worse than the failure it was asked to detect. There is a test pinning this.

**The outlines route needed `onError`, not just a catch.** `streamText` does not reject its text stream on an upstream failure; it ends the stream and reports through the callback. A 429 therefore arrives as a zero-length response and the catch never sees it. My first attempt type-checked, passed review by eye, and did nothing at runtime — it took testing against a real exhausted key to find.

Usage is attributed to the model that actually served the call, not the one originally selected.

## Verification

- 19 unit tests, including: an ordinary error does **not** switch models; auth and bad-request failures do not; a self-referential `cause` chain terminates; the chain never hands out the same model twice; an unresolvable entry is skipped rather than abandoning the rest.
- `tsc --noEmit` clean.
- **End to end against a genuinely exhausted key.** Pointed the primary at a model that was actually out of quota; the call fell through two models and produced outlines on the third:

```
Outlines: model out of capacity; falling back to google:gemini-3.6-flash.
Outlines: model out of capacity; falling back to google:gemini-3.5-flash-lite.
→ HTTP 200, 7440 bytes
```

## Scope note

`streamLLM` itself is untouched — it returns the stream synchronously and has no retry loop, so failover there would need a different shape. The outlines route is handled because it owns its own attempt loop. Happy to extend if you would like it broader.
