### PR TITLE
feat(dsl): unify media asset reference types (#1007 part 2, step a)

### DIFF
--- a/lib/agent/tools/edit-elements-gate.ts
+++ b/lib/agent/tools/edit-elements-gate.ts
@@ -223,7 +223,7 @@ function decodeRefName(ref: string): string | null {
 
 assertGateSchemaSource(schemaDefinitions);
 
-export function resolveSchema(schema: JsonSchema, seen = new Set<string>()): JsonSchema {
+function resolveSchema(schema: JsonSchema, seen = new Set<string>()): JsonSchema {
   if (!schema.$ref) return schema;
   const name = decodeRefName(schema.$ref);
   if (!name || seen.has(name)) return schema;

--- a/lib/agent/tools/edit-elements-gate.ts
+++ b/lib/agent/tools/edit-elements-gate.ts
@@ -223,7 +223,7 @@ function decodeRefName(ref: string): string | null {
 
 assertGateSchemaSource(schemaDefinitions);
 
-function resolveSchema(schema: JsonSchema, seen = new Set<string>()): JsonSchema {
+export function resolveSchema(schema: JsonSchema, seen = new Set<string>()): JsonSchema {
   if (!schema.$ref) return schema;
   const name = decodeRefName(schema.$ref);
   if (!name || seen.has(name)) return schema;

--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -44,6 +44,7 @@ export interface DocumentMigrationDeps {
   kv?: KVStore;
   legacyStore?: LegacyDocumentStore;
   lockManager?: LockManager | null;
+  migrateDsl?: (document: unknown) => unknown;
   /** The mutation callback acquires the runtime shared epoch before writing. */
   storageSharedLockHeld?: boolean;
 }
@@ -172,6 +173,20 @@ function assertValidDestination(stageId: string, document: AppDocument): void {
   }
 }
 
+/**
+ * Migrate a document forward to the current DSL version, leaving the opaque,
+ * app-owned `outline` untouched. The outline is not DSL-shaped, so migrations
+ * must never see it — splitting it out here makes the "outline is not migrated"
+ * contract literally true and stops a future migration transform from silently
+ * dropping the snapshot while rebuilding the aggregate. Throws (via `migrate`)
+ * if the document's version has no path up the ladder.
+ *
+ * Scenes (including an app-widened union) *do* stay inside the migrated core:
+ * the DSL owns the scene contract, so its migrations are the authority on scene
+ * shape and are expected to key on `scene.type` and pass app kinds through
+ * untouched. This is the deliberate asymmetry with `outline`, which the DSL owns
+ * no contract for at all.
+ */
 export function migrateDocumentForVerification(
   document: AppDocument,
   migrateDsl: (document: unknown) => unknown = migrate,
@@ -181,9 +196,13 @@ export function migrateDocumentForVerification(
   return outline === undefined ? migrated : { ...migrated, outline };
 }
 
-function assertMigrationVerified(expected: AppDocument, actual: AppDocument): void {
+function assertMigrationVerified(
+  expected: AppDocument,
+  actual: AppDocument,
+  migrateDsl: (document: unknown) => unknown = migrate,
+): void {
   assertValidDestination(expected.stage.id, actual);
-  const migratedExpected = migrateDocumentForVerification(expected);
+  const migratedExpected = migrateDocumentForVerification(expected, migrateDsl);
   const strip = (document: AppDocument) => ({
     stage: document.stage,
     scenes: [...document.scenes].sort((a, b) => a.order - b.order),
@@ -257,7 +276,7 @@ async function migrateLocked(
         const markerKey = `${MARKER_PREFIX}${stageId}`;
         if (!(await kv.get<MigrationMarker>(markerKey, 'device'))) {
           try {
-            assertMigrationVerified(canonicalize(snapshot), existing);
+            assertMigrationVerified(canonicalize(snapshot), existing, deps.migrateDsl);
           } catch (error) {
             log.warn(
               `Legacy snapshot diverges from authoritative destination for stage ${stageId}; migration marker was not written`,
@@ -280,7 +299,7 @@ async function migrateLocked(
     await store.saveDocument(expected);
     const actual = await store.loadDocument(stageId);
     if (!actual) throw new Error(`Legacy migration lost document ${JSON.stringify(stageId)}`);
-    assertMigrationVerified(expected, actual);
+    assertMigrationVerified(expected, actual, deps.migrateDsl);
 
     await finishMigrationMetadata(snapshot, resolveKv(deps));
     return { document: actual, readOnlyLegacy: false };

--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -186,6 +186,8 @@ function assertValidDestination(stageId: string, document: AppDocument): void {
  * shape and are expected to key on `scene.type` and pass app kinds through
  * untouched. This is the deliberate asymmetry with `outline`, which the DSL owns
  * no contract for at all.
+ * This mirrors `@openmaic/storage`'s private `migrateDocument` in
+ * `document/browser.ts`; changes must be kept in sync.
  */
 export function migrateDocumentForVerification(
   document: AppDocument,

--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -1,4 +1,4 @@
-import { DSL_VERSION } from '@openmaic/dsl';
+import { DSL_VERSION, migrate } from '@openmaic/dsl';
 import { BrowserKVStore, type DocumentStore, type KVStore } from '@openmaic/storage';
 import isEqual from 'lodash/isEqual';
 
@@ -172,15 +172,28 @@ function assertValidDestination(stageId: string, document: AppDocument): void {
   }
 }
 
+export function migrateDocumentForVerification(
+  document: AppDocument,
+  migrateDsl: (document: unknown) => unknown = migrate,
+): AppDocument {
+  const { outline, ...core } = document;
+  const migrated = migrateDsl(core) as AppDocument;
+  return outline === undefined ? migrated : { ...migrated, outline };
+}
+
 function assertMigrationVerified(expected: AppDocument, actual: AppDocument): void {
   assertValidDestination(expected.stage.id, actual);
+  const migratedExpected = migrateDocumentForVerification(expected);
   const strip = (document: AppDocument) => ({
     stage: document.stage,
     scenes: [...document.scenes].sort((a, b) => a.order - b.order),
     outline: document.outline,
   });
   if (
-    !isEqual(omitUndefinedObjectMembers(strip(actual)), omitUndefinedObjectMembers(strip(expected)))
+    !isEqual(
+      omitUndefinedObjectMembers(strip(actual)),
+      omitUndefinedObjectMembers(strip(migratedExpected)),
+    )
   ) {
     throw new Error(
       `Legacy migration verification failed for document ${JSON.stringify(expected.stage.id)}`,

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/dsl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The MAIC slide DSL: the pure, dependency-free contract (types + JSON Schema + validators + version/migration helpers) that @openmaic/renderer and @openmaic/importer both depend on.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/dsl/src/action.ts
+++ b/packages/@openmaic/dsl/src/action.ts
@@ -15,6 +15,8 @@
  * No runtime dependencies. Pure types + plain data constants only.
  */
 
+import type { AssetRef } from './storage.js';
+
 // ==================== Base ====================
 
 export interface ActionBase {
@@ -45,8 +47,14 @@ export interface LaserAction extends ActionBase {
 export interface SpeechAction extends ActionBase {
   type: 'speech';
   text: string;
-  audioId?: string;
-  audioUrl?: string; // Server-generated TTS audio URL
+  /** An asset reference for narration audio. */
+  audioId?: AssetRef;
+  /**
+   * @deprecated Transitional. A server-provided playback URL. Removed together with the
+   * byte-ingestion step of #1007 part 2, which rewrites speech references to allocated asset ids;
+   * new writers should not add it.
+   */
+  audioUrl?: string;
   voice?: string;
   speed?: number; // default 1.0
 }

--- a/packages/@openmaic/dsl/src/action.ts
+++ b/packages/@openmaic/dsl/src/action.ts
@@ -50,9 +50,9 @@ export interface SpeechAction extends ActionBase {
   /** An asset reference for narration audio. */
   audioId?: AssetRef;
   /**
-   * @deprecated Transitional. A server-provided playback URL. Removed together with the
-   * byte-ingestion step of #1007 part 2, which rewrites speech references to allocated asset ids;
-   * new writers should not add it.
+   * Deprecated: A transitional server-provided playback URL. Use `audioId` instead. Removed
+   * together with the byte-ingestion step of #1007 part 2, which rewrites speech references to
+   * allocated asset ids; new writers should not add it.
    */
   audioUrl?: string;
   voice?: string;

--- a/packages/@openmaic/dsl/src/action.ts
+++ b/packages/@openmaic/dsl/src/action.ts
@@ -47,7 +47,11 @@ export interface LaserAction extends ActionBase {
 export interface SpeechAction extends ActionBase {
   type: 'speech';
   text: string;
-  /** An asset reference for narration audio. */
+  /**
+   * An asset reference for narration audio. Legacy documents and TTS paths also store TTS-derived
+   * ids here; such values are foreign to the asset pool and are addressed by later delivery-plan
+   * steps.
+   */
   audioId?: AssetRef;
   /**
    * Deprecated: A transitional server-provided playback URL. Use `audioId` instead. Removed

--- a/packages/@openmaic/dsl/src/slides.ts
+++ b/packages/@openmaic/dsl/src/slides.ts
@@ -334,9 +334,9 @@ export interface PPTImageElement extends PPTBaseElement {
   /** @default true */
   fixedRatio: boolean;
   /**
-   * An asset reference. Import and render paths also store concrete URLs here today; those values
-   * are foreign refs to the asset pool and are drained when reference conversion lands (delivery
-   * plan part 2).
+   * An asset reference. Legacy documents and import/render paths also store placeholder ids or
+   * concrete URLs here; such values are foreign to the asset pool and are addressed by later
+   * delivery-plan steps.
    */
   src: AssetRef;
   outline?: PPTElementOutline;
@@ -743,8 +743,10 @@ export interface PPTVideoElement extends PPTBaseElement {
    */
   src?: AssetRef;
   /**
-   * An asset reference for the generated video. Merging `src` and `mediaRef` is deliberately out
-   * of scope for this type-unification step.
+   * An asset reference for generated video. Legacy documents and generation paths also store
+   * generated-video placeholder ids here; such values are foreign to the asset pool and are
+   * addressed by later delivery-plan steps. Merging `src` and `mediaRef` is deliberately out of
+   * scope for this type-unification step.
    */
   mediaRef?: AssetRef;
   autoplay: boolean;

--- a/packages/@openmaic/dsl/src/slides.ts
+++ b/packages/@openmaic/dsl/src/slides.ts
@@ -334,9 +334,9 @@ export interface PPTImageElement extends PPTBaseElement {
   /** @default true */
   fixedRatio: boolean;
   /**
-   * An asset reference. Import and render paths historically also store concrete URLs here; those
-   * values are foreign refs to the asset pool and are drained when reference conversion lands
-   * (delivery plan part 2).
+   * An asset reference. Import and render paths also store concrete URLs here today; those values
+   * are foreign refs to the asset pool and are drained when reference conversion lands (delivery
+   * plan part 2).
    */
   src: AssetRef;
   outline?: PPTElementOutline;
@@ -735,9 +735,17 @@ export interface PPTLatexElement extends PPTBaseElement {
  */
 export interface PPTVideoElement extends PPTBaseElement {
   type: 'video';
-  /** Concrete URL produced by rendering or import; merging is deferred to delivery plan part 3. */
+  /**
+   * An asset reference. Legacy documents and render/import paths also store placeholder ids or
+   * concrete URLs here; such values are foreign to the asset pool and are addressed by later
+   * delivery-plan steps. Merging `src` and `mediaRef` is deliberately out of scope for this
+   * type-unification step.
+   */
   src?: AssetRef;
-  /** An asset reference; merging with `src` is deferred to delivery plan part 3. */
+  /**
+   * An asset reference for the generated video. Merging `src` and `mediaRef` is deliberately out
+   * of scope for this type-unification step.
+   */
   mediaRef?: AssetRef;
   autoplay: boolean;
   poster?: string;

--- a/packages/@openmaic/dsl/src/slides.ts
+++ b/packages/@openmaic/dsl/src/slides.ts
@@ -16,6 +16,8 @@
  * Pure types only — no runtime imports, no React/pptx/echarts.
  */
 
+import type { AssetRef } from './storage.js';
+
 /**
  * Regular (not `const`) enum on purpose: consumers compile with
  * `isolatedModules`, under which importing an ambient `const enum` across the
@@ -331,7 +333,12 @@ export interface PPTImageElement extends PPTBaseElement {
   type: 'image';
   /** @default true */
   fixedRatio: boolean;
-  src: string;
+  /**
+   * An asset reference. Import and render paths historically also store concrete URLs here; those
+   * values are foreign refs to the asset pool and are drained when reference conversion lands
+   * (delivery plan part 2).
+   */
+  src: AssetRef;
   outline?: PPTElementOutline;
   filters?: ImageElementFilters;
   clip?: ImageElementClip;
@@ -728,8 +735,10 @@ export interface PPTLatexElement extends PPTBaseElement {
  */
 export interface PPTVideoElement extends PPTBaseElement {
   type: 'video';
-  src?: string;
-  mediaRef?: string;
+  /** Concrete URL produced by rendering or import; merging is deferred to delivery plan part 3. */
+  src?: AssetRef;
+  /** An asset reference; merging with `src` is deferred to delivery plan part 3. */
+  mediaRef?: AssetRef;
   autoplay: boolean;
   poster?: string;
   ext?: string;

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -18,7 +18,7 @@ type GeneratedSchema = {
     string,
     {
       type?: string;
-      properties?: Record<string, { deprecated?: boolean }>;
+      properties?: Record<string, Record<string, unknown>>;
     }
   >;
 };
@@ -32,13 +32,18 @@ describe('generated JSON Schema — asset references', () => {
     expect((schema as GeneratedSchema).definitions.AssetRef).toMatchObject({ type: 'string' });
   });
 
-  it('emits a valid deprecated keyword for SpeechAction.audioUrl', () => {
-    const audioUrl = (schemas.Action as GeneratedSchema).definitions.SpeechAction.properties
-      ?.audioUrl;
-    expect(audioUrl).toBeDefined();
-    expect(audioUrl?.deprecated === undefined || typeof audioUrl.deprecated === 'boolean').toBe(
-      true,
-    );
+  it.each(Object.entries(schemas))('%s emits only boolean deprecated keywords', (root, schema) => {
+    for (const [definitionName, definition] of Object.entries(
+      (schema as GeneratedSchema).definitions,
+    )) {
+      for (const [propertyName, property] of Object.entries(definition.properties ?? {})) {
+        if (!Object.prototype.hasOwnProperty.call(property, 'deprecated')) continue;
+        const path = `${root}.definitions.${definitionName}.properties.${propertyName}.deprecated`;
+        expect(typeof property.deprecated, `${path} = ${JSON.stringify(property.deprecated)}`).toBe(
+          'boolean',
+        );
+      }
+    }
   });
 });
 

--- a/packages/@openmaic/dsl/test/schema.test.ts
+++ b/packages/@openmaic/dsl/test/schema.test.ts
@@ -13,9 +13,34 @@ const schemas = {
   SerializedScene: generateSchema('SerializedScene'),
 } as const;
 
+type GeneratedSchema = {
+  definitions: Record<
+    string,
+    {
+      type?: string;
+      properties?: Record<string, { deprecated?: boolean }>;
+    }
+  >;
+};
+
 function validator(root: keyof typeof schemas) {
   return new Ajv({ allErrors: true, strict: false }).compile(schemas[root]);
 }
+
+describe('generated JSON Schema — asset references', () => {
+  it.each(Object.entries(schemas))('%s defines AssetRef as a string', (_root, schema) => {
+    expect((schema as GeneratedSchema).definitions.AssetRef).toMatchObject({ type: 'string' });
+  });
+
+  it('emits a valid deprecated keyword for SpeechAction.audioUrl', () => {
+    const audioUrl = (schemas.Action as GeneratedSchema).definitions.SpeechAction.properties
+      ?.audioUrl;
+    expect(audioUrl).toBeDefined();
+    expect(audioUrl?.deprecated === undefined || typeof audioUrl.deprecated === 'boolean').toBe(
+      true,
+    );
+  });
+});
 
 describe('generated JSON Schema — Stage', () => {
   const v = validator('Stage');

--- a/tests/document-store/migration.test.ts
+++ b/tests/document-store/migration.test.ts
@@ -223,6 +223,29 @@ describe('legacy document migration', () => {
     });
   });
 
+  test('uses the injected DSL migration to verify a fresh destination', async () => {
+    const migrateDsl = vi.fn((value: unknown) => ({
+      ...(value as AppDocument),
+      dslVersion: DSL_VERSION,
+    }));
+
+    await expect(
+      accessDocument('stage-1', {
+        store: store(),
+        kv: new MemoryKv(),
+        legacyStore: legacy(snapshot()),
+        lockManager: lockManager(),
+        migrateDsl,
+      }),
+    ).resolves.toMatchObject({
+      document: { dslVersion: DSL_VERSION, stage: { id: 'stage-1' } },
+      readOnlyLegacy: false,
+    });
+
+    expect(migrateDsl).toHaveBeenCalledOnce();
+    expect(migrateDsl.mock.calls[0]![0]).toMatchObject({ stage: { id: 'stage-1' } });
+  });
+
   test('uses the injected DSL migration to verify an existing destination', async () => {
     const documentStore = store();
     const kv = new MemoryKv();

--- a/tests/document-store/migration.test.ts
+++ b/tests/document-store/migration.test.ts
@@ -223,23 +223,44 @@ describe('legacy document migration', () => {
     });
   });
 
-  test('verifies a legacy Dexie snapshot without throwing', async () => {
-    const idb = new IDBFactory();
+  test('uses the injected DSL migration to verify an existing destination', async () => {
+    const documentStore = store();
+    const kv = new MemoryKv();
+    const destination: AppDocument = {
+      dslVersion: DSL_VERSION,
+      stage: { id: 'stage-1', name: 'Migrated', createdAt: 100, updatedAt: 200 },
+      scenes: [],
+      outline: {
+        outlines: [],
+        generationComplete: true,
+        createdAt: 100,
+        updatedAt: 200,
+      },
+    };
+    await documentStore.saveDocument(destination);
+    const migrateDsl = vi.fn((value: unknown) => {
+      const candidate = value as AppDocument;
+      return {
+        ...candidate,
+        dslVersion: DSL_VERSION,
+        stage: { ...candidate.stage, name: 'Migrated' },
+        scenes: [],
+      };
+    });
 
     await expect(
       accessDocument('stage-1', {
-        store: store(idb),
-        kv: new MemoryKv(),
-        legacyStore: await indexedLegacyStore(idb, snapshot()),
+        store: documentStore,
+        kv,
+        legacyStore: legacy(snapshot()),
         lockManager: lockManager(),
+        migrateDsl,
       }),
-    ).resolves.toMatchObject({
-      document: {
-        dslVersion: DSL_VERSION,
-        stage: { id: 'stage-1' },
-        outline: { generationComplete: true },
-      },
-      readOnlyLegacy: false,
+    ).resolves.toMatchObject({ document: destination, readOnlyLegacy: false });
+
+    expect(migrateDsl).toHaveBeenCalledOnce();
+    expect(await kv.get('document-migration:stage-1', 'device')).toMatchObject({
+      sourceUpdatedAt: 200,
     });
   });
 

--- a/tests/document-store/migration.test.ts
+++ b/tests/document-store/migration.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import {
   accessDocument,
+  migrateDocumentForVerification,
   type LegacyDocumentSnapshot,
   type LegacyDocumentStore,
 } from '@/lib/document-store/migration';
@@ -157,6 +158,34 @@ function store(idb = new IDBFactory()): DocumentStore<AppScene> {
 }
 
 describe('legacy document migration', () => {
+  test('keeps the opaque outline outside the migration verification baseline', () => {
+    const outline = {
+      outlines: [],
+      generationComplete: true,
+      createdAt: 100,
+      updatedAt: 200,
+    };
+    const document: AppDocument = {
+      dslVersion: DSL_VERSION,
+      stage: { id: 'stage-1', name: 'Legacy', createdAt: 100, updatedAt: 200 },
+      scenes: [],
+      outline,
+    };
+    const migrateDsl = vi.fn((value: unknown) => {
+      const candidate = value as AppDocument;
+      return 'outline' in candidate
+        ? { ...candidate, stage: { ...candidate.stage, name: 'Corrupted' } }
+        : candidate;
+    });
+
+    const migrated = migrateDocumentForVerification(document, migrateDsl);
+
+    expect(migrateDsl).toHaveBeenCalledOnce();
+    expect(migrateDsl.mock.calls[0]![0]).not.toHaveProperty('outline');
+    expect(migrated).toEqual(document);
+    expect(migrated.outline).toBe(outline);
+  });
+
   test('returns null when neither store has a document', async () => {
     await expect(
       accessDocument('missing', {
@@ -191,6 +220,26 @@ describe('legacy document migration', () => {
     });
     expect(await kv.get('document-migration:stage-1', 'device')).toMatchObject({
       sourceUpdatedAt: 200,
+    });
+  });
+
+  test('verifies a legacy Dexie snapshot without throwing', async () => {
+    const idb = new IDBFactory();
+
+    await expect(
+      accessDocument('stage-1', {
+        store: store(idb),
+        kv: new MemoryKv(),
+        legacyStore: await indexedLegacyStore(idb, snapshot()),
+        lockManager: lockManager(),
+      }),
+    ).resolves.toMatchObject({
+      document: {
+        dslVersion: DSL_VERSION,
+        stage: { id: 'stage-1' },
+        outline: { generationComplete: true },
+      },
+      readOnlyLegacy: false,
     });
   });
 

--- a/tests/lib/agent/tools/edit-elements-gate.test.ts
+++ b/tests/lib/agent/tools/edit-elements-gate.test.ts
@@ -9,9 +9,9 @@ import {
   getEditablePropSchema,
   mapProposalsToEditIntents,
   normalizeRotate,
-  resolveSchema,
-  type JsonSchema,
+  validateJsonSchemaSubset,
   type ElementInventoryItem,
+  type JsonSchema,
 } from '@/lib/agent/tools/edit-elements-gate';
 import type { PPTElement } from '@openmaic/dsl';
 
@@ -700,7 +700,10 @@ describe('edit-elements-gate', () => {
     ] as const) {
       const propertySchema = definitions[definition]?.properties?.[property];
       expect(propertySchema, `${definition}.${property} should exist`).toBeDefined();
-      expect(resolveSchema(propertySchema ?? {}).type).toBe('string');
+      expect(validateJsonSchemaSubset('asset-ref', propertySchema ?? {}, property)).toBeNull();
+      expect(validateJsonSchemaSubset(1, propertySchema ?? {}, property)).toBe(
+        `${property} must be string`,
+      );
     }
   });
 

--- a/tests/lib/agent/tools/edit-elements-gate.test.ts
+++ b/tests/lib/agent/tools/edit-elements-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as editElementsGate from '@/lib/agent/tools/edit-elements-gate';
+import sceneSchemaJson from '@openmaic/dsl/schema/scene.schema.json';
 import {
   ALLOWED_EDIT_PROPS,
   buildElementInventory,
@@ -8,6 +9,8 @@ import {
   getEditablePropSchema,
   mapProposalsToEditIntents,
   normalizeRotate,
+  resolveSchema,
+  type JsonSchema,
   type ElementInventoryItem,
 } from '@/lib/agent/tools/edit-elements-gate';
 import type { PPTElement } from '@openmaic/dsl';
@@ -683,6 +686,22 @@ describe('edit-elements-gate', () => {
 
     expect(getEditablePropSchema('text', 'notARealProp')).toBeNull();
     expect(getEditablePropSchema('shape', 'notARealProp')).toBeNull();
+  });
+
+  it('resolves asset-reference property indirection to strings', () => {
+    const definitions = (sceneSchemaJson as { definitions: Record<string, JsonSchema> })
+      .definitions;
+
+    for (const [definition, property] of [
+      ['PPTImageElement', 'src'],
+      ['PPTVideoElement', 'src'],
+      ['PPTVideoElement', 'mediaRef'],
+      ['SpeechAction', 'audioId'],
+    ] as const) {
+      const propertySchema = definitions[definition]?.properties?.[property];
+      expect(propertySchema, `${definition}.${property} should exist`).toBeDefined();
+      expect(resolveSchema(propertySchema ?? {}).type).toBe('string');
+    }
   });
 
   it('keeps layered policy on top of schema-derived object validation', () => {


### PR DESCRIPTION
Step (a) of #1007's delivery plan part 2 — type unification with **zero behavior change**, per the RFC's sequenced-removal amendment.

## What lands

- `PPTImageElement.src`, `PPTVideoElement.src`/`mediaRef`, and `SpeechAction.audioId` take the `AssetRef` type (a string alias — no runtime or downstream type impact; root and per-package `tsc` verified clean). Each field's docstring states uniformly what it holds today: placeholder/derived ids and concrete URLs are foreign values to the asset pool, addressed by later delivery-plan steps.
- `SpeechAction.audioUrl` **stays**, deprecated in prose (replacement: `audioId`). Per the amended RFC, its removal ships together with the byte-ingestion step (part 2 step c) — a pure migration can neither ingest bytes nor decide the co-presence case, where a server-issued `audioId` may be a dangling reference whose only live handle is the URL beside it. The `@deprecated` tag form is deliberately avoided: `ts-json-schema-generator` emits it as a string-typed `deprecated` key, which is invalid against JSON Schema 2019-09+ meta-schemas; a schema test now asserts no property in any generated root carries a non-boolean `deprecated`.
- Legacy migration verification hardening (`lib/document-store/migration.ts`): the comparison baseline now runs through the DSL migration ladder with the app-owned `outline` stripped and re-attached, mirroring the document store's own read path — so the first real ladder step (part 2 step c) cannot break legacy Dexie verification. The DSL migrate is an injectable seam in `DocumentMigrationDeps`, and both call sites are pinned by injection tests (mutation-verified: reverting the wiring fails a test).
- A pin that the agent edit gate still resolves the new `$ref` indirection for the three fields to `string`, so a future schema-generation change degrades loudly.

`@openmaic/dsl` 0.6.0 → 0.6.1 (docstrings and a type alias; no value domain narrows — patch per the pre-1.0 policy). `DSL_VERSION` is untouched.

Steps (b) write paths and (c) reference conversion + `audioUrl` removal + `DSL_VERSION` bump follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)