### PR TITLE
Publish validated package tarballs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,23 @@ jobs:
       # rewrites one; catching it here means a stale generated file is a pull
       # request failure instead of a release failure.
       #
-      # Against HEAD, not the index: a bare `git diff` compares the worktree to
-      # the index, so anything the install staged would be invisible to it.
+      # Against GITHUB_SHA, not the index or HEAD: a bare `git diff` misses
+      # staged changes, while install code can create a commit and move HEAD.
+      # This check exists precisely because code ran before it, so its reference
+      # point must be something that code cannot move. Disabling replacement
+      # objects also prevents a local replace ref from redirecting the commit.
       - name: Verify the install did not rewrite tracked package files
         run: |
           set -euo pipefail
-          if ! git diff --quiet HEAD -- packages/@openmaic; then
+          actual_head="$(git --no-replace-objects rev-parse HEAD)"
+          if [ "$actual_head" != "$GITHUB_SHA" ]; then
+            echo "::error::HEAD moved from $GITHUB_SHA to $actual_head during installation."
+            exit 1
+          fi
+          if ! git --no-replace-objects diff --quiet "$GITHUB_SHA" -- packages/@openmaic; then
             echo "::error::Installing rewrote tracked files under packages/@openmaic."
             echo "Regenerate them and commit the result."
-            git --no-pager diff --stat HEAD -- packages/@openmaic
+            git --no-replace-objects --no-pager diff --stat "$GITHUB_SHA" -- packages/@openmaic
             exit 1
           fi
           echo "Tracked package files match the commit under test."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
 
       # The tarball smoke test proves this about the bytes that would actually
-      # be published, but it packs and installs four packages, so it runs only
-      # on the release path. This is the cheap source-level form, here so that a
+      # be published, but it installs four package tarballs, so it runs only on
+      # the release path. This is the cheap source-level form, here so that a
       # pull request restoring `workspace:*` fails at review time rather than at
       # release time, after a version number has already been spent.
       - name: Internal dependency ranges

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -334,12 +334,9 @@ jobs:
           set -euo pipefail
           # Anchor the validated digests in this shell before any repository
           # script runs with the npm token. A child process can alter files,
-          # but it cannot rewrite its parent shell's associative array.
+          # but it cannot rewrite its parent shell's scalar.
           node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
-          declare -A trusted_digests
-          while read -r digest filename; do
-            trusted_digests["$filename"]="$digest"
-          done < "$RELEASE_ARTIFACTS/SHA256SUMS"
+          trusted_digests="$(< "$RELEASE_ARTIFACTS/SHA256SUMS")"
 
           node scripts/check-package-version-bumps.mjs --release
           for pkg in dsl storage renderer importer; do
@@ -355,7 +352,10 @@ jobs:
             fi
             filename="openmaic-$pkg-$version.tgz"
             tarball="$RELEASE_ARTIFACTS/$filename"
-            expected_digest="${trusted_digests[$filename]:-}"
+            expected_digest="$(
+              printf '%s\n' "$trusted_digests" | awk -v filename="$filename" \
+                '$2 == filename { print $1 }'
+            )"
             if [ -z "$expected_digest" ]; then
               echo "::error::$filename has no validated SHA-256 digest."
               exit 1

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -148,9 +148,10 @@ jobs:
           fi
           echo "Tracked repository files match the commit being released."
 
-      # Seal the checked build before any repository test code runs. The tests
-      # below may mutate the worktree, but the tarballs they smoke-test and the
-      # publish job receives are already fixed at this point.
+      # Seal the checked build before any repository test code runs. Uploading
+      # immediately after packing makes the publish input immutable before the
+      # tests or smoke test can write to their local copies. `needs: validate`
+      # still prevents publication unless every later validation step passes.
       #
       # Pack each package exactly once. pnpm resolves workspace:^ in the packed
       # manifest, while the config form suppresses prepack and prepare (pnpm
@@ -168,6 +169,22 @@ jobs:
             echo "::endgroup::"
           done
           node scripts/verify-package-artifacts.mjs --write "$RELEASE_ARTIFACTS"
+
+      - name: Verify freshly packed release artifacts
+        env:
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
+        run: node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
+
+      # actions/upload-artifact v4 artifacts cannot be modified after upload.
+      # Tests below keep using the same local tarballs, while `publish` receives
+      # this already-uploaded snapshot only after the whole validate job passes.
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: openmaic-package-tarballs-${{ github.sha }}
+          path: ${{ runner.temp }}/openmaic-package-tarballs
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
 
       # storage runs separately, under the json reporter, so that the run leaves
       # a record of WHICH suites executed. STORAGE_PG_CONTRACT_REQUIRED only
@@ -199,19 +216,6 @@ jobs:
         env:
           RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
         run: pnpm test:package-tarballs -- "$RELEASE_ARTIFACTS"
-
-      - name: Verify and upload the validated artifacts
-        env:
-          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
-        run: node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: openmaic-package-tarballs-${{ github.sha }}
-          path: ${{ runner.temp }}/openmaic-package-tarballs
-          if-no-files-found: error
-          overwrite: true
-          retention-days: 7
 
   # The only job that can reach NPM_TOKEN. It is separate so the environment,
   # and therefore the token, is never attached to a run that is merely
@@ -335,8 +339,8 @@ jobs:
           # Anchor the validated digests in this shell before any repository
           # script runs with the npm token. A child process can alter files,
           # but it cannot rewrite its parent shell's scalar.
-          node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
           trusted_digests="$(< "$RELEASE_ARTIFACTS/SHA256SUMS")"
+          node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
 
           node scripts/check-package-version-bumps.mjs --release
           for pkg in dsl storage renderer importer; do

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,6 +58,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # A full commit SHA is the only immutable GitHub Action reference. Version
+  # comments beside each pin keep the selected release human-readable.
   # SECURITY BOUNDARY: package installation, builds and packing happen only in
   # `validate`, before any job can read NPM_TOKEN. `publish` receives immutable
   # tarballs and verifies their digests before giving those exact files to npm.
@@ -92,13 +94,13 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -146,6 +148,27 @@ jobs:
           fi
           echo "Tracked repository files match the commit being released."
 
+      # Seal the checked build before any repository test code runs. The tests
+      # below may mutate the worktree, but the tarballs they smoke-test and the
+      # publish job receives are already fixed at this point.
+      #
+      # Pack each package exactly once. pnpm resolves workspace:^ in the packed
+      # manifest, while the config form suppresses prepack and prepare (pnpm
+      # pack does not accept --ignore-scripts).
+      - name: Pack release artifacts and record digests
+        env:
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
+        run: |
+          set -euo pipefail
+          mkdir "$RELEASE_ARTIFACTS"
+          for pkg in dsl storage renderer importer; do
+            echo "::group::@openmaic/$pkg"
+            ( cd "packages/@openmaic/$pkg" \
+              && pnpm pack --config.ignore-scripts=true --pack-destination "$RELEASE_ARTIFACTS" )
+            echo "::endgroup::"
+          done
+          node scripts/verify-package-artifacts.mjs --write "$RELEASE_ARTIFACTS"
+
       # storage runs separately, under the json reporter, so that the run leaves
       # a record of WHICH suites executed. STORAGE_PG_CONTRACT_REQUIRED only
       # protects against a missing database: it is a `throw` inside the test
@@ -172,23 +195,6 @@ jobs:
             --baseline "$STORAGE_PG_BASELINE"
           pnpm --filter "@openmaic/dsl" --filter "@openmaic/storage" --filter "@openmaic/renderer" run typecheck
 
-      # Pack each package exactly once. pnpm resolves workspace:^ in the packed
-      # manifest, while the config form suppresses prepack and prepare (pnpm
-      # pack does not accept --ignore-scripts).
-      - name: Pack release artifacts and record digests
-        env:
-          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
-        run: |
-          set -euo pipefail
-          mkdir "$RELEASE_ARTIFACTS"
-          for pkg in dsl storage renderer importer; do
-            echo "::group::@openmaic/$pkg"
-            ( cd "packages/@openmaic/$pkg" \
-              && pnpm pack --config.ignore-scripts=true --pack-destination "$RELEASE_ARTIFACTS" )
-            echo "::endgroup::"
-          done
-          node scripts/verify-package-artifacts.mjs --write "$RELEASE_ARTIFACTS"
-
       - name: Smoke-test publishable tarballs
         env:
           RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
@@ -199,11 +205,12 @@ jobs:
           RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
         run: node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: openmaic-package-tarballs-${{ github.sha }}
           path: ${{ runner.temp }}/openmaic-package-tarballs
           if-no-files-found: error
+          overwrite: true
           retention-days: 7
 
   # The only job that can reach NPM_TOKEN. It is separate so the environment,
@@ -219,7 +226,7 @@ jobs:
       actions: read # required to read this commit's CI conclusion
       id-token: write # required for npm provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # The first-parent check needs real history.
           fetch-depth: 0
@@ -227,13 +234,13 @@ jobs:
           # remains isolated in the `mark` job.
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Download validated package tarballs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: openmaic-package-tarballs-${{ github.sha }}
           path: ${{ runner.temp }}/openmaic-package-tarballs
@@ -325,6 +332,15 @@ jobs:
           RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
         run: |
           set -euo pipefail
+          # Anchor the validated digests in this shell before any repository
+          # script runs with the npm token. A child process can alter files,
+          # but it cannot rewrite its parent shell's associative array.
+          node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
+          declare -A trusted_digests
+          while read -r digest filename; do
+            trusted_digests["$filename"]="$digest"
+          done < "$RELEASE_ARTIFACTS/SHA256SUMS"
+
           node scripts/check-package-version-bumps.mjs --release
           for pkg in dsl storage renderer importer; do
             name="@openmaic/$pkg"
@@ -337,7 +353,22 @@ jobs:
               echo "Skipping $name@$version: already on the registry."
               continue
             fi
-            tarball="$RELEASE_ARTIFACTS/openmaic-$pkg-$version.tgz"
+            filename="openmaic-$pkg-$version.tgz"
+            tarball="$RELEASE_ARTIFACTS/$filename"
+            expected_digest="${trusted_digests[$filename]:-}"
+            if [ -z "$expected_digest" ]; then
+              echo "::error::$filename has no validated SHA-256 digest."
+              exit 1
+            fi
+            if ! actual_digest="$(sha256sum "$tarball" | awk '{print $1}')"; then
+              echo "::error::Could not re-verify $filename immediately before publication."
+              exit 1
+            fi
+            if [ "$actual_digest" != "$expected_digest" ]; then
+              echo "::error::$filename failed its pre-publish SHA-256 re-check."
+              exit 1
+            fi
+            echo "Re-verified $filename immediately before publication."
             # npm accepts a tarball package-spec and attaches provenance to the
             # supplied bytes. --ignore-scripts also prevents publish lifecycle
             # scripts from executing in the token-bearing job.
@@ -361,12 +392,12 @@ jobs:
     permissions:
       contents: write # required to push the release marker tags
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,6 +58,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # SECURITY BOUNDARY: package installation, builds and packing happen only in
+  # `validate`, before any job can read NPM_TOKEN. `publish` receives immutable
+  # tarballs and verifies their digests before giving those exact files to npm.
+  # This structurally removes build-code tampering with the git index, validated
+  # bytes differing from published bytes, and build code rewriting enforcement
+  # scripts before the token-bearing step uses them: the token-bearing job runs
+  # neither install nor build code.
+
   # Everything that does not need the token, so it can run from any ref and a
   # dry run stays useful to contributors.
   validate:
@@ -127,16 +135,16 @@ jobs:
       # reports clean and the rewritten bytes are packed and published. `git
       # diff HEAD` compares against the commit being released, which is the
       # thing this step actually claims.
-      - name: Verify the build did not rewrite tracked package files
+      - name: Verify the build did not rewrite tracked files
         run: |
           set -euo pipefail
-          if ! git diff --quiet HEAD -- packages/@openmaic; then
-            echo "::error::The build modified tracked files under packages/@openmaic."
+          if ! git diff --quiet HEAD; then
+            echo "::error::The build modified tracked repository files."
             echo "Regenerate them and commit the result before releasing."
-            git --no-pager diff --stat HEAD -- packages/@openmaic
+            git --no-pager diff --stat HEAD
             exit 1
           fi
-          echo "Tracked package files match the commit being released."
+          echo "Tracked repository files match the commit being released."
 
       # storage runs separately, under the json reporter, so that the run leaves
       # a record of WHICH suites executed. STORAGE_PG_CONTRACT_REQUIRED only
@@ -164,20 +172,39 @@ jobs:
             --baseline "$STORAGE_PG_BASELINE"
           pnpm --filter "@openmaic/dsl" --filter "@openmaic/storage" --filter "@openmaic/renderer" run typecheck
 
-      # `--config.ignore-scripts=true` mirrors the publish step's
-      # `--ignore-scripts`. Inspecting a tarball built with lifecycle scripts
-      # while publishing one built without them means this step describes a
-      # tarball the registry never receives.
-      - name: Inspect tarball contents (dry-run pack)
+      # Pack each package exactly once. pnpm resolves workspace:^ in the packed
+      # manifest, while the config form suppresses prepack and prepare (pnpm
+      # pack does not accept --ignore-scripts).
+      - name: Pack release artifacts and record digests
+        env:
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
         run: |
+          set -euo pipefail
+          mkdir "$RELEASE_ARTIFACTS"
           for pkg in dsl storage renderer importer; do
             echo "::group::@openmaic/$pkg"
-            ( cd "packages/@openmaic/$pkg" && pnpm pack --dry-run --config.ignore-scripts=true )
+            ( cd "packages/@openmaic/$pkg" \
+              && pnpm pack --config.ignore-scripts=true --pack-destination "$RELEASE_ARTIFACTS" )
             echo "::endgroup::"
           done
+          node scripts/verify-package-artifacts.mjs --write "$RELEASE_ARTIFACTS"
 
       - name: Smoke-test publishable tarballs
-        run: pnpm test:package-tarballs
+        env:
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
+        run: pnpm test:package-tarballs -- "$RELEASE_ARTIFACTS"
+
+      - name: Verify and upload the validated artifacts
+        env:
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
+        run: node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openmaic-package-tarballs-${{ github.sha }}
+          path: ${{ runner.temp }}/openmaic-package-tarballs
+          if-no-files-found: error
+          retention-days: 7
 
   # The only job that can reach NPM_TOKEN. It is separate so the environment,
   # and therefore the token, is never attached to a run that is merely
@@ -196,19 +223,25 @@ jobs:
         with:
           # The first-parent check needs real history.
           fetch-depth: 0
-          # This job installs dependencies and builds the packages, so it
-          # executes third-party code while holding NPM_TOKEN. It must not also
-          # hold a git credential that could push repository refs; writing the
-          # release markers is a separate job that runs no package code.
+          # Publishing holds no repository credential. Writing release markers
+          # remains isolated in the `mark` job.
           persist-credentials: false
-
-      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      - name: Download validated package tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: openmaic-package-tarballs-${{ github.sha }}
+          path: ${{ runner.temp }}/openmaic-package-tarballs
+
+      - name: Verify validated package tarballs
+        run: node scripts/verify-package-artifacts.mjs "$RELEASE_ARTIFACTS"
+        env:
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
 
       # The environment's branch rule is the real boundary; this is defence in
       # depth, and it catches the case the rule cannot see. First-parent only:
@@ -265,33 +298,15 @@ jobs:
             sleep 30
           done
 
-      # Recomputed here rather than carried over from `validate`: this job must
-      # decide what to publish from the tree it is actually publishing.
-      - name: Plan the release
-        run: node scripts/check-package-version-bumps.mjs --release
-        env:
-          RELEASE_PLAN_PATH: ${{ runner.temp }}/release-plan.json
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build @openmaic packages
-        run: >-
-          pnpm -r
-          --filter "@openmaic/dsl"
-          --filter "@openmaic/storage"
-          --filter "@openmaic/renderer"
-          --filter "@openmaic/importer"
-          run build
-
-      # As in `validate`, and for the same reason: against HEAD, so that a
-      # rewrite the build staged cannot pass as a clean worktree. This is the
-      # copy that guards the bytes actually being published.
-      - name: Verify the build did not rewrite tracked package files
+      # No install or build runs in this job. This whole-tree check is defence
+      # in depth that the checked-out enforcement scripts still match HEAD
+      # before NPM_TOKEN is exposed to the registry preflight and publication.
+      - name: Verify the release checkout is unchanged
         run: |
           set -euo pipefail
-          if ! git diff --quiet HEAD -- packages/@openmaic; then
-            echo "::error::The build modified tracked files under packages/@openmaic."
-            git --no-pager diff --stat HEAD -- packages/@openmaic
+          if ! git diff --quiet HEAD; then
+            echo "::error::Tracked repository files differ from the release commit."
+            git --no-pager diff --stat HEAD
             exit 1
           fi
 
@@ -300,13 +315,17 @@ jobs:
       # it; per-package publishing makes an ordinary re-run pick up exactly
       # where it stopped, because a version already on the registry is no
       # longer in the plan.
-      - name: Publish to npm
+      # The registry preflight is deliberately in this token-bearing step,
+      # immediately before the sequential loop, to minimize the race window.
+      - name: Registry preflight and publish validated tarballs
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
           RELEASE_PLAN_PATH: ${{ runner.temp }}/release-plan.json
+          RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
         run: |
           set -euo pipefail
+          node scripts/check-package-version-bumps.mjs --release
           for pkg in dsl storage renderer importer; do
             name="@openmaic/$pkg"
             version="$(node -p "require('./packages/@openmaic/$pkg/package.json').version")"
@@ -318,11 +337,11 @@ jobs:
               echo "Skipping $name@$version: already on the registry."
               continue
             fi
-            # --ignore-scripts: every package's prepublishOnly reruns the build,
-            # which would delete and regenerate the dist that was just verified,
-            # so npm could receive bytes nothing checked.
-            ( cd "packages/@openmaic/$pkg" \
-              && pnpm publish --access public --provenance --no-git-checks --ignore-scripts )
+            tarball="$RELEASE_ARTIFACTS/openmaic-$pkg-$version.tgz"
+            # npm accepts a tarball package-spec and attaches provenance to the
+            # supplied bytes. --ignore-scripts also prevents publish lifecycle
+            # scripts from executing in the token-bearing job.
+            npm publish "$tarball" --access public --provenance --ignore-scripts
             echo "Published $name@$version."
           done
 
@@ -345,6 +364,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -353,6 +373,7 @@ jobs:
       - name: Write missing release markers
         env:
           GIT_COMMIT: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           for pkg in dsl storage renderer importer; do
@@ -372,7 +393,8 @@ jobs:
               fi
               continue
             fi
-            if git tag "$tag" "$GIT_COMMIT" && git push origin "refs/tags/$tag"; then
+            if gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$tag" -f sha="$GIT_COMMIT" >/dev/null; then
               echo "Marked $tag at $GIT_COMMIT."
             else
               echo "::warning::Could not write the release marker $tag; $name@$version is published."

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -130,20 +130,24 @@ jobs:
       # copies are stale, the build rewrites them here and the registry would
       # receive content that is not in the commit being released.
       #
-      # Compare against HEAD, not the index. A bare `git diff` compares the
-      # worktree to the index, so anything the build staged is invisible to it:
-      # the steps above run third-party package code, which needs no credential
-      # to rewrite a tracked file and `git add` it, after which the bare form
-      # reports clean and the rewritten bytes are packed and published. `git
-      # diff HEAD` compares against the commit being released, which is the
-      # thing this step actually claims.
+      # Compare against GITHUB_SHA, not the index or HEAD. A bare `git diff`
+      # misses staged changes, while build code can create a commit and move
+      # HEAD. This check exists precisely because build code ran before it, so
+      # its reference point must be something that code cannot move. Disabling
+      # replacement objects also prevents a local replace ref from redirecting
+      # the commit comparison.
       - name: Verify the build did not rewrite tracked files
         run: |
           set -euo pipefail
-          if ! git diff --quiet HEAD; then
+          actual_head="$(git --no-replace-objects rev-parse HEAD)"
+          if [ "$actual_head" != "$GITHUB_SHA" ]; then
+            echo "::error::HEAD moved from $GITHUB_SHA to $actual_head during the build."
+            exit 1
+          fi
+          if ! git --no-replace-objects diff --quiet "$GITHUB_SHA"; then
             echo "::error::The build modified tracked repository files."
             echo "Regenerate them and commit the result before releasing."
-            git --no-pager diff --stat HEAD
+            git --no-replace-objects --no-pager diff --stat "$GITHUB_SHA"
             exit 1
           fi
           echo "Tracked repository files match the commit being released."
@@ -212,6 +216,13 @@ jobs:
             --baseline "$STORAGE_PG_BASELINE"
           pnpm --filter "@openmaic/dsl" --filter "@openmaic/storage" --filter "@openmaic/renderer" run typecheck
 
+      # KNOWN LIMITATION: this smoke test reads the writable local directory,
+      # not the uploaded snapshot. Because upload already happened, a test
+      # process can replace a poisoned local tarball with a valid one and make
+      # this pass while `publish` downloads the poisoned snapshot, whose own
+      # SHA256SUMS can still be internally consistent. This cannot be closed
+      # while packing, uploading, and testing share one job and filesystem;
+      # closing it requires a separate packing-only job that runs no tests.
       - name: Smoke-test publishable tarballs
         env:
           RELEASE_ARTIFACTS: ${{ runner.temp }}/openmaic-package-tarballs
@@ -310,14 +321,21 @@ jobs:
           done
 
       # No install or build runs in this job. This whole-tree check is defence
-      # in depth that the checked-out enforcement scripts still match HEAD
-      # before NPM_TOKEN is exposed to the registry preflight and publication.
+      # in depth after repository code has run. It exists precisely because
+      # code ran before it, so its reference point must be GITHUB_SHA, which
+      # that code cannot move, rather than HEAD, which it can. Disabling
+      # replacement objects prevents local indirection during the comparison.
       - name: Verify the release checkout is unchanged
         run: |
           set -euo pipefail
-          if ! git diff --quiet HEAD; then
+          actual_head="$(git --no-replace-objects rev-parse HEAD)"
+          if [ "$actual_head" != "$GITHUB_SHA" ]; then
+            echo "::error::HEAD moved from $GITHUB_SHA to $actual_head before publication."
+            exit 1
+          fi
+          if ! git --no-replace-objects diff --quiet "$GITHUB_SHA"; then
             echo "::error::Tracked repository files differ from the release commit."
-            git --no-pager diff --stat HEAD
+            git --no-replace-objects --no-pager diff --stat "$GITHUB_SHA"
             exit 1
           fi
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -352,8 +352,8 @@ jobs:
   # plan alone could never do, because a version already on the registry is
   # excluded from it.
   #
-  # Tag pushes use GITHUB_TOKEN credentials, and GitHub does not start new
-  # workflow runs from GITHUB_TOKEN pushes.
+  # Tags are created through the GitHub API with GITHUB_TOKEN, and GitHub does
+  # not start new workflow runs from GITHUB_TOKEN writes.
   mark:
     name: Mark released versions
     needs: publish

--- a/scripts/check-internal-dependency-ranges.mjs
+++ b/scripts/check-internal-dependency-ranges.mjs
@@ -28,7 +28,7 @@ import {
  *
  * WHERE THIS RUNS. `scripts/smoke-test-package-tarballs.mjs` proves the same
  * thing about the tarball that would actually be published, which is the
- * stronger claim — but it packs and installs four packages, so it runs only on
+ * stronger claim — but it installs four package tarballs, so it runs only on
  * the release path. This is the cheap source-level form, in `ci.yml`, so that a
  * pull request reintroducing an exact pin fails at review time rather than at
  * release time, after a version number has already been spent.

--- a/scripts/smoke-test-package-tarballs.mjs
+++ b/scripts/smoke-test-package-tarballs.mjs
@@ -7,11 +7,14 @@ import { fileURLToPath } from 'node:url';
 import { INTERNAL_DEPENDENTS, OPENMAIC_PACKAGES, readManifest } from './openmaic-packages.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const artifactDirectoryArgument = process.argv[2];
+const args = process.argv.slice(2);
+if (args[0] === '--') args.shift();
+const artifactDirectoryArgument = args[0];
 assert(
   artifactDirectoryArgument,
   'Usage: node smoke-test-package-tarballs.mjs <artifact-directory>',
 );
+assert.equal(args.length, 1, 'Unexpected command-line arguments');
 const artifactDirectory = resolve(root, artifactDirectoryArgument);
 const temporaryDirectory = mkdtempSync(join(tmpdir(), 'openmaic-package-smoke-'));
 

--- a/scripts/smoke-test-package-tarballs.mjs
+++ b/scripts/smoke-test-package-tarballs.mjs
@@ -4,11 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  INTERNAL_DEPENDENTS,
-  OPENMAIC_PACKAGES,
-  readManifest,
-} from './openmaic-packages.mjs';
+import { INTERNAL_DEPENDENTS, OPENMAIC_PACKAGES, readManifest } from './openmaic-packages.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const artifactDirectoryArgument = process.argv[2];

--- a/scripts/smoke-test-package-tarballs.mjs
+++ b/scripts/smoke-test-package-tarballs.mjs
@@ -1,12 +1,22 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { INTERNAL_DEPENDENTS, OPENMAIC_PACKAGES } from './openmaic-packages.mjs';
+import {
+  INTERNAL_DEPENDENTS,
+  OPENMAIC_PACKAGES,
+  readManifest,
+} from './openmaic-packages.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const artifactDirectoryArgument = process.argv[2];
+assert(
+  artifactDirectoryArgument,
+  'Usage: node smoke-test-package-tarballs.mjs <artifact-directory>',
+);
+const artifactDirectory = resolve(root, artifactDirectoryArgument);
 const temporaryDirectory = mkdtempSync(join(tmpdir(), 'openmaic-package-smoke-'));
 
 function run(command, args, options = {}) {
@@ -15,30 +25,6 @@ function run(command, args, options = {}) {
     encoding: 'utf8',
     stdio: options.stdio ?? 'inherit',
   });
-}
-
-function pack(name) {
-  const packageDirectory = join(root, 'packages', '@openmaic', name);
-  // `--config.ignore-scripts=true` because the publish step runs
-  // `pnpm publish --ignore-scripts`. Packing WITH lifecycle scripts while
-  // publishing without them means this smoke test inspects a different tarball
-  // than the one that reaches the registry: a `prepack` that rewrote the
-  // manifest — committing `workspace:*` alongside a `prepack` that turns it
-  // into `workspace:^`, say — would satisfy every assertion below and then not
-  // run at publish time, so the exact pin would ship anyway. Validation and
-  // publication must have identical lifecycle semantics, or validation proves
-  // nothing about what is published.
-  run('pnpm', ['pack', '--config.ignore-scripts=true', '--pack-destination', temporaryDirectory], {
-    cwd: packageDirectory,
-    stdio: 'pipe',
-  });
-  const prefix = `openmaic-${name}-`;
-  const tarball = readdirSync(temporaryDirectory).find(
-    (entry) => entry.startsWith(prefix) && entry.endsWith('.tgz'),
-  );
-  assert(tarball, `pnpm pack did not produce a tarball for @openmaic/${name}`);
-  console.log(`Packed @openmaic/${name}.`);
-  return join(temporaryDirectory, tarball);
 }
 
 /** The manifest as the registry will see it, read out of the tarball itself. */
@@ -99,15 +85,22 @@ function assertDeduplicableDslRange(name, manifest, dslVersion, ownedPackages) {
 try {
   const packageNames = OPENMAIC_PACKAGES;
   const localPackages = new Set(packageNames.map((name) => `@openmaic/${name}`));
+  const tarballs = Object.fromEntries(
+    packageNames.map((name) => {
+      const { version } = readManifest(name);
+      return [name, join(artifactDirectory, `openmaic-${name}-${version}.tgz`)];
+    }),
+  );
+  const packedManifests = Object.fromEntries(
+    packageNames.map((name) => [name, packedManifest(tarballs[name])]),
+  );
   // The smoke program executes the renderer root, whose optional chart and
   // highlighting peers are imported by that entry. Other optional peers remain
   // optional unless the smoke program starts executing their owning entry.
   const installOptionalPeersFor = new Set(['renderer']);
   const peerDependencies = {};
   for (const name of packageNames) {
-    const manifest = JSON.parse(
-      readFileSync(join(root, 'packages/@openmaic', name, 'package.json'), 'utf8'),
-    );
+    const manifest = packedManifests[name];
     for (const [peer, range] of Object.entries(manifest.peerDependencies ?? {})) {
       if (localPackages.has(peer)) continue;
       const isOptional = manifest.peerDependenciesMeta?.[peer]?.optional === true;
@@ -122,11 +115,9 @@ try {
       peerDependencies[peer] = range;
     }
   }
-  const tarballs = Object.fromEntries(packageNames.map((name) => [name, pack(name)]));
-
-  const dslVersion = packedManifest(tarballs.dsl).version;
+  const dslVersion = packedManifests.dsl.version;
   for (const name of Object.keys(INTERNAL_DEPENDENTS)) {
-    assertDeduplicableDslRange(name, packedManifest(tarballs[name]), dslVersion, localPackages);
+    assertDeduplicableDslRange(name, packedManifests[name], dslVersion, localPackages);
   }
 
   const consumerDirectory = join(temporaryDirectory, 'consumer');
@@ -188,7 +179,7 @@ for (const subpath of [
   );
   run('node', ['smoke.mjs'], { cwd: consumerDirectory });
 
-  console.log('Packed @openmaic package imports passed.');
+  console.log('Validated @openmaic package tarball imports passed.');
 } finally {
   rmSync(temporaryDirectory, { recursive: true, force: true });
 }

--- a/scripts/verify-package-artifacts.mjs
+++ b/scripts/verify-package-artifacts.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { OPENMAIC_PACKAGES, readManifest } from './openmaic-packages.mjs';
+
+const DIGESTS_FILE = 'SHA256SUMS';
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function expectedArtifacts() {
+  return OPENMAIC_PACKAGES.map((shortName) => {
+    const manifest = readManifest(shortName);
+    return {
+      shortName,
+      name: `@openmaic/${shortName}`,
+      version: manifest.version,
+      filename: `openmaic-${shortName}-${manifest.version}.tgz`,
+    };
+  });
+}
+
+function sha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function readPackedManifest(path) {
+  return JSON.parse(execFileSync('tar', ['-xzOf', path, 'package/package.json'], { encoding: 'utf8' }));
+}
+
+function assertArtifactSet(directory, expected, includeDigests) {
+  const expectedNames = new Set(expected.map(({ filename }) => filename));
+  if (includeDigests) expectedNames.add(DIGESTS_FILE);
+
+  const entries = readdirSync(directory, { withFileTypes: true });
+  assert.deepEqual(
+    entries.map(({ name }) => name).sort(),
+    [...expectedNames].sort(),
+    `Release artifact directory must contain exactly ${[...expectedNames].sort().join(', ')}`,
+  );
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    assert(entry.isFile() && !lstatSync(path).isSymbolicLink(), `${entry.name} must be a regular file`);
+  }
+
+  for (const artifact of expected) {
+    const manifest = readPackedManifest(join(directory, artifact.filename));
+    assert.equal(manifest.name, artifact.name, `${artifact.filename} contains package ${manifest.name}`);
+    assert.equal(
+      manifest.version,
+      artifact.version,
+      `${artifact.filename} contains version ${manifest.version}`,
+    );
+  }
+}
+
+function writeDigests(directory, expected) {
+  assertArtifactSet(directory, expected, false);
+  const contents = expected
+    .map(({ filename }) => `${sha256(join(directory, filename))}  ${filename}`)
+    .join('\n');
+  writeFileSync(join(directory, DIGESTS_FILE), `${contents}\n`);
+  console.log(`Recorded SHA-256 digests for ${expected.length} package tarballs.`);
+}
+
+function verifyDigests(directory, expected) {
+  assertArtifactSet(directory, expected, true);
+  const lines = readFileSync(join(directory, DIGESTS_FILE), 'utf8').trimEnd().split('\n');
+  const recorded = new Map();
+
+  for (const line of lines) {
+    const match = /^([0-9a-f]{64})  ([^/]+\.tgz)$/.exec(line);
+    assert(match, `Invalid ${DIGESTS_FILE} entry: ${JSON.stringify(line)}`);
+    assert(!recorded.has(match[2]), `${DIGESTS_FILE} lists ${match[2]} more than once`);
+    recorded.set(match[2], match[1]);
+  }
+
+  assert.deepEqual(
+    [...recorded.keys()].sort(),
+    expected.map(({ filename }) => filename).sort(),
+    `${DIGESTS_FILE} must list every allowed package tarball exactly once`,
+  );
+
+  for (const { filename } of expected) {
+    assert.equal(sha256(join(directory, filename)), recorded.get(filename), `${filename} failed SHA-256 verification`);
+  }
+  console.log(`Verified SHA-256 digests for ${expected.length} package tarballs.`);
+}
+
+const args = process.argv.slice(2);
+const write = args[0] === '--write';
+const directoryArgument = args[write ? 1 : 0];
+assert(directoryArgument, `Usage: node ${basename(process.argv[1])} [--write] <artifact-directory>`);
+assert.equal(args.length, write ? 2 : 1, 'Unexpected command-line arguments');
+
+const directory = resolve(root, directoryArgument);
+const expected = expectedArtifacts();
+if (write) writeDigests(directory, expected);
+else verifyDigests(directory, expected);

--- a/scripts/verify-package-artifacts.mjs
+++ b/scripts/verify-package-artifacts.mjs
@@ -26,7 +26,9 @@ function sha256(path) {
 }
 
 function readPackedManifest(path) {
-  return JSON.parse(execFileSync('tar', ['-xzOf', path, 'package/package.json'], { encoding: 'utf8' }));
+  return JSON.parse(
+    execFileSync('tar', ['-xzOf', path, 'package/package.json'], { encoding: 'utf8' }),
+  );
 }
 
 function assertArtifactSet(directory, expected, includeDigests) {
@@ -41,12 +43,19 @@ function assertArtifactSet(directory, expected, includeDigests) {
   );
   for (const entry of entries) {
     const path = join(directory, entry.name);
-    assert(entry.isFile() && !lstatSync(path).isSymbolicLink(), `${entry.name} must be a regular file`);
+    assert(
+      entry.isFile() && !lstatSync(path).isSymbolicLink(),
+      `${entry.name} must be a regular file`,
+    );
   }
 
   for (const artifact of expected) {
     const manifest = readPackedManifest(join(directory, artifact.filename));
-    assert.equal(manifest.name, artifact.name, `${artifact.filename} contains package ${manifest.name}`);
+    assert.equal(
+      manifest.name,
+      artifact.name,
+      `${artifact.filename} contains package ${manifest.name}`,
+    );
     assert.equal(
       manifest.version,
       artifact.version,
@@ -83,7 +92,11 @@ function verifyDigests(directory, expected) {
   );
 
   for (const { filename } of expected) {
-    assert.equal(sha256(join(directory, filename)), recorded.get(filename), `${filename} failed SHA-256 verification`);
+    assert.equal(
+      sha256(join(directory, filename)),
+      recorded.get(filename),
+      `${filename} failed SHA-256 verification`,
+    );
   }
   console.log(`Verified SHA-256 digests for ${expected.length} package tarballs.`);
 }
@@ -91,7 +104,10 @@ function verifyDigests(directory, expected) {
 const args = process.argv.slice(2);
 const write = args[0] === '--write';
 const directoryArgument = args[write ? 1 : 0];
-assert(directoryArgument, `Usage: node ${basename(process.argv[1])} [--write] <artifact-directory>`);
+assert(
+  directoryArgument,
+  `Usage: node ${basename(process.argv[1])} [--write] <artifact-directory>`,
+);
 assert.equal(args.length, write ? 2 : 1, 'Unexpected command-line arguments');
 
 const directory = resolve(root, directoryArgument);


### PR DESCRIPTION
## Summary

- Pack each of the four allowlisted `@openmaic/*` packages exactly once in `validate` with lifecycle scripts disabled, record SHA-256 digests, smoke-test those exact tarballs, verify them again, and upload them as one workflow artifact.
- Download the artifact in `publish`, fail closed unless it contains exactly the four expected name/version tarballs plus `SHA256SUMS`, re-verify every digest, and publish those exact `.tgz` files sequentially with `npm publish <tarball>`.
- Remove pnpm setup, dependency installation, and package builds from `publish`. Keep the registry preflight in the token-bearing job immediately before the sequential publish loop.
- Anchor post-install/build whole-tree integrity checks to immutable `GITHUB_SHA`, reject a locally moved `HEAD`, and disable Git replacement objects during commit resolution and comparison. The equivalent package-scoped CI install check uses the same protection.
- Keep provenance enabled. npm documents tarballs as accepted `npm publish` package specs and `--provenance` as applying to the publish; npm 11.16 also derives the provenance subject digest from the supplied tarball bytes. A local dry run accepted the prebuilt tarball. See [npm publish](https://docs.npmjs.com/cli/publish/) and [Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements/).
- Disable persisted checkout credentials in all three jobs. The marker job remains the sole `contents: write` holder and creates tags through the GitHub API without installing or building anything.

## Security impact

This structurally removes three findings that depended on the token-bearing publish job running install and build code:

- build code tampering with the git index;
- validated bytes differing from published bytes; and
- build code rewriting enforcement scripts before the token-bearing step uses them.

The publish job now runs no install or build command and sends only digest-verified artifacts from `validate` to npm.

The integrity checks no longer trust local `HEAD`. These checks exist because repository and build code run before them; that code can create a commit and move `HEAD` without any GitHub credential. The runner-provided `GITHUB_SHA` is the immutable release reference, and `--no-replace-objects` prevents a local replacement ref from redirecting the comparison.

## Known limitation

The smoke test reads the writable local tarball directory, not the uploaded snapshot. Because upload happens first, a test process can replace a poisoned tarball locally with a valid one after upload; the smoke test can then pass against the replacement while `publish` downloads and publishes the poisoned uploaded snapshot, whose own `SHA256SUMS` remains internally consistent.

This cannot be closed while packing, uploading, and testing all run in one job with a writable filesystem. Closing it requires a separate packing-only job that runs no tests. That structural change is not attempted here.

## Scope

This implements item 1 of #1021. It does not attempt the retry semantics in item 2 or the broader registry-race changes in item 3. The existing registry preflight is only placed immediately before publication, as requested, to reduce its current race window.

Part of #1021

## Verification

- Node 22.22.0 and pnpm 10.28.0.
- `pnpm install --frozen-lockfile`: passed across 7 workspace projects; the lockfile was current, dependencies were already up to date, and postinstall completed.
- `pnpm check`: 0 formatting mismatches.
- `pnpm lint`: 0 errors, 15 existing warnings.
- `pnpm exec tsc --noEmit`: passed.
- Four package suites with `VITEST_MAX_WORKERS=4`: 58 files passed, 2 skipped; 1,125 tests passed, 59 skipped.
  - dsl: 6 files, 196 tests passed.
  - storage without PostgreSQL requirement: 16 files passed, 2 skipped; 654 tests passed, 59 skipped.
  - renderer: 25 files, 242 tests passed.
  - importer: 11 files, 33 tests passed.
- PostgreSQL-required storage rerun: 18 files and 713 tests passed. Both contract files ran (32 and 27 cases), and the baseline audit observed positive insert deltas in all 5 owned tables: 24, 51, 24, 36, and 30.
- Gate scripts passed explicitly: vendored importer assertion, i18n alignment (9 locales), internal dependency ranges (3 dependents), package allowlist (4 packages and every workflow enumeration), package version diff plus serialized-format rule, release registry preflight (0 packages currently planned), PostgreSQL contract audit, exact-tarball smoke test, and artifact digest verification (4 tarballs).
- Workflow audit: 4 YAML files parsed; all 38 `run` blocks passed `bash -n`.
- Release invariant audit: 3 jobs with explicit permissions; 3 checkouts with `persist-credentials: false`; 1 `contents: write` holder and 1 tag writer, both `mark`; 9 action uses pinned to full 40-hex SHAs; `publish` has 0 install commands, 0 build commands, and 0 contents scope; upload precedes both test steps; both whole-tree checks use `GITHUB_SHA`, assert `HEAD` equality, and disable replacement objects.
- The remaining release invariants were rechecked: release environment, digest anchoring before repository scripts, per-package digest verification immediately before each sequential publish, registry preflight immediately before the loop, `--provenance`, first-parent membership with the `grep -cx`/SIGPIPE safeguard, exact-SHA CI lookup keyed by `ci.yml` and `event=push`, PostgreSQL baseline/delta audit, repository-wide concurrency, and no tag trigger.
- Fault injection at commit `34d271c1e53154ad4f4d56034ebc5b3de720fb50`: the ordinary clean tree passed with exit 0. A local commit moved `HEAD` to `475e556e289273e60561f887021722a865c0cf5a`; the guard printed `HEAD moved from ... to ... during the build` and failed with exit 1.
