### PR TITLE
fix(slide-renderer): keep arrowheads visible when toggling thumbnails…

### DIFF
--- a/components/slide-renderer/components/element/LineElement/BaseLineElement.tsx
+++ b/components/slide-renderer/components/element/LineElement/BaseLineElement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect, useId } from 'react';
 import type { PPTLineElement } from '@openmaic/dsl';
 import { getLineElementPath } from '@/lib/utils/element';
 import { useElementShadow } from '../hooks/useElementShadow';
@@ -22,6 +22,7 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
   const { shadowStyle } = useElementShadow(elementInfo.shadow);
   const pathRef = useRef<SVGPathElement>(null);
   const [drawComplete, setDrawComplete] = useState(!animate);
+  const markerId = `${elementInfo.id}-${useId().replaceAll(':', '')}`;
 
   const svgWidth = useMemo(() => {
     const width = Math.abs(elementInfo.start[0] - elementInfo.end[0]);
@@ -104,7 +105,7 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
           <defs>
             {elementInfo.points[0] && (
               <LinePointMarker
-                id={elementInfo.id}
+                id={markerId}
                 position="start"
                 type={elementInfo.points[0]}
                 color={elementInfo.color}
@@ -113,7 +114,7 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
             )}
             {elementInfo.points[1] && (
               <LinePointMarker
-                id={elementInfo.id}
+                id={markerId}
                 position="end"
                 type={elementInfo.points[1]}
                 color={elementInfo.color}
@@ -130,12 +131,12 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
             fill="none"
             markerStart={
               drawComplete && elementInfo.points[0]
-                ? `url(#${elementInfo.id}-${elementInfo.points[0]}-start)`
+                ? `url(#${markerId}-${elementInfo.points[0]}-start)`
                 : ''
             }
             markerEnd={
               drawComplete && elementInfo.points[1]
-                ? `url(#${elementInfo.id}-${elementInfo.points[1]}-end)`
+                ? `url(#${markerId}-${elementInfo.points[1]}-end)`
                 : ''
             }
           />

--- a/components/slide-renderer/components/element/LineElement/index.tsx
+++ b/components/slide-renderer/components/element/LineElement/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import type { PPTLineElement } from '@openmaic/dsl';
 import { getLineElementPath } from '@/lib/utils/element';
 import { useElementShadow } from '../hooks/useElementShadow';
@@ -19,6 +19,7 @@ export interface LineElementProps {
  */
 export function LineElement({ elementInfo, selectElement }: LineElementProps) {
   const { shadowStyle } = useElementShadow(elementInfo.shadow);
+  const markerId = `${elementInfo.id}-${useId().replaceAll(':', '')}`;
 
   const handleSelectElement = (e: React.MouseEvent | React.TouchEvent) => {
     if (elementInfo.lock) return;
@@ -79,7 +80,7 @@ export function LineElement({ elementInfo, selectElement }: LineElementProps) {
           <defs>
             {elementInfo.points[0] && (
               <LinePointMarker
-                id={elementInfo.id}
+                id={markerId}
                 position="start"
                 type={elementInfo.points[0]}
                 color={elementInfo.color}
@@ -88,7 +89,7 @@ export function LineElement({ elementInfo, selectElement }: LineElementProps) {
             )}
             {elementInfo.points[1] && (
               <LinePointMarker
-                id={elementInfo.id}
+                id={markerId}
                 position="end"
                 type={elementInfo.points[1]}
                 color={elementInfo.color}
@@ -105,10 +106,10 @@ export function LineElement({ elementInfo, selectElement }: LineElementProps) {
             strokeDasharray={lineDashArray}
             fill="none"
             markerStart={
-              elementInfo.points[0] ? `url(#${elementInfo.id}-${elementInfo.points[0]}-start)` : ''
+              elementInfo.points[0] ? `url(#${markerId}-${elementInfo.points[0]}-start)` : ''
             }
             markerEnd={
-              elementInfo.points[1] ? `url(#${elementInfo.id}-${elementInfo.points[1]}-end)` : ''
+              elementInfo.points[1] ? `url(#${markerId}-${elementInfo.points[1]}-end)` : ''
             }
           />
           {/* Invisible wider path for easier clicking */}

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/renderer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React component for rendering PPTist-style Slide JSON, extracted from OpenMAIC.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/renderer/src/elements/line/BaseLineElement.tsx
+++ b/packages/@openmaic/renderer/src/elements/line/BaseLineElement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect, useId } from 'react';
 import type { PPTLineElement } from '@openmaic/dsl';
 import { getLineElementPath } from '../../utils/element';
 import { useElementShadow } from '../shared/useElementShadow';
@@ -17,6 +17,7 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
   const { shadowStyle } = useElementShadow(elementInfo.shadow);
   const pathRef = useRef<SVGPathElement>(null);
   const [drawComplete, setDrawComplete] = useState(!animate);
+  const markerId = `${elementInfo.id}-${useId().replaceAll(':', '')}`;
 
   const svgWidth = useMemo(() => {
     const width = Math.abs(elementInfo.start[0] - elementInfo.end[0]);
@@ -94,7 +95,7 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
           <defs>
             {elementInfo.points[0] && (
               <LinePointMarker
-                id={elementInfo.id}
+                id={markerId}
                 position="start"
                 type={elementInfo.points[0]}
                 color={elementInfo.color}
@@ -103,7 +104,7 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
             )}
             {elementInfo.points[1] && (
               <LinePointMarker
-                id={elementInfo.id}
+                id={markerId}
                 position="end"
                 type={elementInfo.points[1]}
                 color={elementInfo.color}
@@ -120,12 +121,12 @@ export function BaseLineElement({ elementInfo, animate }: BaseLineElementProps) 
             fill="none"
             markerStart={
               drawComplete && elementInfo.points[0]
-                ? `url(#${elementInfo.id}-${elementInfo.points[0]}-start)`
+                ? `url(#${markerId}-${elementInfo.points[0]}-start)`
                 : ''
             }
             markerEnd={
               drawComplete && elementInfo.points[1]
-                ? `url(#${elementInfo.id}-${elementInfo.points[1]}-end)`
+                ? `url(#${markerId}-${elementInfo.points[1]}-end)`
                 : ''
             }
           />

--- a/packages/@openmaic/renderer/test/elements/BaseLineElement.test.tsx
+++ b/packages/@openmaic/renderer/test/elements/BaseLineElement.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import type { PPTLineElement } from '@openmaic/dsl';
+import { describe, expect, it } from 'vitest';
+
+import { BaseLineElement } from '../../src/elements/line/BaseLineElement';
+
+const line = {
+  id: 'shared-line',
+  type: 'line',
+  left: 0,
+  top: 0,
+  start: [0, 0],
+  end: [120, 40],
+  width: 4,
+  style: 'solid',
+  color: '#123456',
+  points: ['arrow', 'arrow'],
+} as PPTLineElement;
+
+function markerReferences(svg: SVGSVGElement): string[] {
+  const path = svg.querySelector(':scope > path');
+  return ['marker-start', 'marker-end'].map((attribute) => {
+    const reference = path?.getAttribute(attribute);
+    expect(reference).toMatch(/^url\(#.+\)$/);
+    return reference!.slice(5, -1);
+  });
+}
+
+describe('BaseLineElement marker ids', () => {
+  it('keeps marker references local to each render instance and stable while scaling', () => {
+    const { container, rerender } = render(
+      <div style={{ transform: 'scale(1)' }}>
+        <BaseLineElement elementInfo={line} animate={false} />
+        <BaseLineElement elementInfo={line} animate={false} />
+      </div>,
+    );
+
+    const before = Array.from(container.querySelectorAll('svg')).map((svg) => {
+      const references = markerReferences(svg);
+      const ownMarkerIds = Array.from(svg.querySelectorAll('marker'), (marker) => marker.id);
+
+      expect(references).toEqual(ownMarkerIds);
+      return references;
+    });
+
+    expect(new Set(before.flat()).size).toBe(4);
+
+    rerender(
+      <div style={{ transform: 'scale(1.75)' }}>
+        <BaseLineElement elementInfo={line} animate={false} />
+        <BaseLineElement elementInfo={line} animate={false} />
+      </div>,
+    );
+
+    const after = Array.from(container.querySelectorAll('svg')).map(markerReferences);
+    expect(after).toEqual(before);
+    expect((container.firstElementChild as HTMLElement).style.transform).toBe('scale(1.75)');
+  });
+});


### PR DESCRIPTION
## Summary

Fix an issue where line arrowheads disappear when the thumbnail panel is hidden or the course presentation enters fullscreen mode.

Arrowheads are rendered using SVG markers. Previously, each marker ID was derived only from the course element ID. When the same line element was rendered simultaneously in the main canvas and a thumbnail, both SVGs created markers with identical DOM IDs.

Hiding the thumbnail panel or entering fullscreen changes which SVG elements are mounted and their order in the DOM. This could cause the main canvas line to reference a marker belonging to another SVG that had been hidden or removed. The line would remain visible, but its arrowhead would disappear.

Each line render instance now receives a unique marker ID, ensuring that every line references the marker defined within its own SVG.

## Related Issues

N/A

## Changes

- Generate a unique SVG marker ID for each line render instance.
- Keep each line’s `marker-start` and `marker-end` references scoped to markers defined within its own SVG.
- Apply the fix consistently to:
  - course playback and read-only rendering;
  - the slide editor;
  - the standalone `@openmaic/renderer` package.
- Add regression tests covering:
  - simultaneous rendering of the same line in multiple locations;
  - unique marker IDs across render instances;
  - correct marker references for each SVG;
  - stable marker references after rerendering.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open a course containing a line with an arrowhead.
2. Confirm that the line appears in both the main canvas and the thumbnail panel.
3. Hide the thumbnail panel and verify that the arrowhead remains visible on the main canvas.
4. Enter fullscreen mode and verify that the arrowhead remains visible.
5. Exit fullscreen and show the thumbnail panel again.
6. Confirm that all arrowheads remain visible throughout these transitions.

### What you personally verified

- All 243 `@openmaic/renderer` tests pass.
- Renderer package type checking passes.
- Project-wide TypeScript type checking passes.
- ESLint and Prettier checks pass for the changed files.
- `git diff --check` passes.
- Playwright tests were not required or run.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Verified through component regression tests
- [ ] Screenshots or recordings attached

## Checklist

- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [x] I have added or updated tests as needed
- [x] My changes do not introduce new warnings