### PR TITLE
refactor(pbl): consume the contract's PBL project types (#1061)

### DIFF
--- a/lib/pbl/legacy/read.ts
+++ b/lib/pbl/legacy/read.ts
@@ -56,6 +56,7 @@ interface LegacyPBLChatMessage {
 }
 
 export interface PBLProjectConfig {
+  [key: string]: unknown;
   projectInfo: LegacyPBLProjectInfo;
   agents: LegacyPBLAgent[];
   issueboard: {

--- a/lib/pbl/v2/types.ts
+++ b/lib/pbl/v2/types.ts
@@ -40,21 +40,7 @@ export type PBLEvaluationKind = 'task' | 'milestone' | 'final';
  *  `record_closing_check` tool before `advance_micro_task` is allowed. */
 export type PBLClosingQuality = 'weak' | 'ok' | 'strong';
 
-// Contract PBL tree nodes deliberately tolerate unknown stored fields via an
-// index signature. Remove only that signature before replacing known nested
-// properties, so the app surface remains as precise as it was before the
-// contract extraction.
-type WithoutIndexSignature<T> = {
-  [K in keyof T as string extends K
-    ? never
-    : number extends K
-      ? never
-      : symbol extends K
-        ? never
-        : K]: T[K];
-};
-
-type RuntimeOverlay<Base, Overlay> = Omit<WithoutIndexSignature<Base>, keyof Overlay> & Overlay;
+type RuntimeOverlay<Base, Overlay> = Omit<Base, keyof Overlay> & Overlay;
 
 /** Set by Instructor when advancing a task via `advance_micro_task`.
  *  Never shown to the learner — internal teaching record. */

--- a/lib/pbl/v2/types.ts
+++ b/lib/pbl/v2/types.ts
@@ -1,93 +1,60 @@
 /**
- * PBL v2 — Project Schema
+ * PBL v2 — contract design types plus the app runtime overlay.
  *
- * Replaces v1's role-selection + read-only issueboard + @question/@judge
- * model with a single-Instructor guided flow (Hero → Workspace → Completion).
- *
- * Legacy v1 project data is supported only through the read-only adapter in
- * `../legacy/read.ts`; new generation and persistence use this v2 model.
- *
- * The product ships a single Instructor. The multi-agent chat-thread
- * structure is kept generic so additional roles can be introduced later
- * with their own design, but no other role type exists today.
+ * The persisted design/skeleton belongs to `@openmaic/dsl`. This barrel keeps
+ * the established app-facing names while adding learner/runtime state to the
+ * nested contract shapes that carry it.
  */
+import type {
+  PBLMicrotask as ContractPBLMicrotask,
+  PBLMilestone as ContractPBLMilestone,
+  PBLProject as ContractPBLProject,
+  PBLProficiency,
+  PBLRoleType,
+  PBLThreadSeat as ContractPBLThreadSeat,
+} from '@openmaic/dsl';
 import type { SceneOutline } from '@/lib/types/generation';
 
-// ---------------------------------------------------------------------------
-// Enums (string-literal unions; no runtime enum cost)
-// ---------------------------------------------------------------------------
-
-/** Project lifecycle status. */
-export type PBLProjectStatus = 'designing' | 'review' | 'active' | 'completed' | 'archived';
-
-/** Milestone lifecycle. The LOCKED→ACTIVE transition is gated by the
- *  learner clicking "Continue" on a milestone handover card (see
- *  `PBLHandover`). */
-export type PBLMilestoneStatus = 'locked' | 'active' | 'completed';
-
-export type PBLMicrotaskStatus = 'todo' | 'in_progress' | 'completed' | 'skipped';
-
-/** Role types. `user` is the implicit learner (a message/event actor, never
- *  created as a role record). The product currently ships a single Instructor;
- *  `evaluator` / `mentor` / `collaborator` are reserved role kinds. Tools are
- *  NOT roles — roles/agents call tools, recorded as runtime events.
- *  `simulator` is the in-scene role-play character voice and `system` is
- *  neutral scene narration (旁白) — neither a character nor the Instructor;
- *  both ONLY appear on scenario projects (`project.scenario` set) as message
- *  `roleType`s for rendering, NOT `roles[]` records. Normal projects never
- *  produce a `simulator` or `system` message. */
-export type PBLRoleType =
-  | 'user'
-  | 'instructor'
-  | 'evaluator'
-  | 'mentor'
-  | 'collaborator'
-  | 'simulator'
-  | 'system';
-
-/** Self-reported skill tier; drives Instructor's three-tier guidance.
- *  Empty string means "not yet set" — Planner refuses to leave the
- *  initial phase without it (in v1 standalone; in v2 the value is
- *  derived from outline context, not asked from the user). */
-export type PBLProficiency = '' | 'beginner' | 'intermediate' | 'advanced';
+export type {
+  PBLProject,
+  PBLRole,
+  PBLDocument,
+  PBLScenarioConfig,
+  PBLScenarioCharacter,
+  PBLSceneVisual,
+  PBLThreadSeat,
+  PBLProjectStatus,
+  PBLMilestoneStatus,
+  PBLMicrotaskStatus,
+  PBLRoleType,
+  PBLProficiency,
+  PBLAssignee,
+  PBLUiPhase,
+} from '@openmaic/dsl';
 
 export type PBLSubmissionKind = 'text' | 'file' | 'link';
 
 export type PBLEvaluationKind = 'task' | 'milestone' | 'final';
 
-/** Who is responsible for a microtask. The AI-collaborator option was
- *  removed from the product, so every microtask is learner-owned. Kept
- *  as a named type (rather than inlining `'user'`) so the field stays
- *  self-documenting and a future re-introduction is a one-line change. */
-export type PBLAssignee = 'user';
-
 /** Closing-check answer quality. Recorded by Instructor via the
  *  `record_closing_check` tool before `advance_micro_task` is allowed. */
 export type PBLClosingQuality = 'weak' | 'ok' | 'strong';
 
-/** UI state machine for the in-scene PBL flow. */
-export type PBLUiPhase = 'hero' | 'generating' | 'workspace' | 'completed';
+// Contract PBL tree nodes deliberately tolerate unknown stored fields via an
+// index signature. Remove only that signature before replacing known nested
+// properties, so the app surface remains as precise as it was before the
+// contract extraction.
+type WithoutIndexSignature<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K]: T[K];
+};
 
-// ---------------------------------------------------------------------------
-// Core types
-// ---------------------------------------------------------------------------
-
-/** A participant in the project. The Instructor is always present; the
- *  learner ("user") is implicit and has no role record. */
-export interface PBLRole {
-  id: string;
-  type: PBLRoleType;
-  name: string;
-  /** SHORT, learner-facing introduction shown as a hover tooltip on the
-   *  instructor's avatar. Written TO the learner, in the project language.
-   *  Curated to be meaningful/reassuring — must NOT expose internal mechanics
-   *  (history, tools, evaluation/scoring, task-advancing). Optional: when
-   *  absent the avatar hover falls back to showing the role name. */
-  description?: string;
-  /** Internal persona/voice that drives the agent's behaviour. NOT shown to
-   *  the learner. */
-  systemPrompt?: string;
-}
+type RuntimeOverlay<Base, Overlay> = Omit<WithoutIndexSignature<Base>, keyof Overlay> & Overlay;
 
 /** Set by Instructor when advancing a task via `advance_micro_task`.
  *  Never shown to the learner — internal teaching record. */
@@ -124,196 +91,29 @@ export interface PBLEngagementSummary {
   closingQuality?: PBLClosingQuality;
 }
 
-/** A single actionable step within a milestone. */
-export interface PBLMicrotask {
-  id: string;
-  title: string;
-  description?: string;
-  status: PBLMicrotaskStatus;
-  /** Always "user" — the learner does this task. */
-  assignee: PBLAssignee;
-  hints: string[];
-  order: number;
-  /** Internal teaching record from `advance_micro_task`. */
-  internalAssessment?: PBLInternalAssessment;
-  completionReason?: string;
-  /** Engagement summary cached on completion. */
-  engagement?: PBLEngagementSummary;
-  /** SCENARIO ONLY (design-time). Per-beat advance criteria for a SCENE
-   *  beat. Normal microtasks / prep / wrapup leave this undefined and
-   *  rely on the milestone-level gate. */
-  completionCriteria?: string;
-  /** SCENARIO ONLY (design-time, B1′). The CONCRETE, OBSERVABLE in-scene
-   *  action the learner must say or do for THIS beat to count as done — the
-   *  scenario equivalent of a "deliverable" (e.g. "下注、加注或弃牌" /
-   *  "对对方的感受做出共情回应"). Authored in plain scene terms, NOT a
-   *  teaching goal. The advance detector uses this (falling back to
-   *  `completionCriteria`) so off-topic / small-talk turns do NOT advance.
-   *  Undefined = fall back to `completionCriteria`. */
-  successWhen?: string;
-  /** SCENARIO ONLY (design-time, B1′). What the character PRIVATELY wants
-   *  this beat (their in-scene drive, e.g. "试探对方是否在虚张声势"). Fed to
-   *  the Simulator so the character pursues a goal in character — NEVER
-   *  narrated, evaluated, or coached. Undefined = no explicit drive. */
-  characterObjective?: string;
-  /** SCENARIO ONLY (design-time, B1′). The single skill this beat practises
-   *  (e.g. "底池赔率判断" / "积极倾听"). Consumed by the final evaluator's
-   *  per-act goal scaffold and surfaced in the completion page's per-act
-   *  review; never spoken by the character. Undefined = none. */
-  skillFocus?: string;
-  /** SCENARIO ONLY (design-time). Neutral system narration shown when
-   *  this SCENE beat is entered (e.g. "you walk into a quiet café").
-   *  Rendered as a `'system'` message — NOT a character, NOT the
-   *  Instructor. Undefined = no narration. */
-  narration?: string;
-  /** SCENARIO ONLY (design-time). Learner-facing brief for the right-side
-   *  "current task" panel — what this beat is about and WHY it matters, in
-   *  the learner's own framing. May give orientation / things to think about,
-   *  but NEVER names the exact action or answer (that is the hidden
-   *  `successWhen`) and NEVER spoils a `characterObjective` fact. This is a
-   *  PURE DISPLAY field: it is NOT fed to the character/narrator (so it can
-   *  carry light teaching framing without polluting the role-play), unlike
-   *  `description` which is the character's established-fact source. When
-   *  absent, the panel falls back to `description`. */
-  learnerBrief?: string;
-}
+/** Contract microtask plus learner-owned runtime state. */
+export type PBLMicrotask = RuntimeOverlay<
+  ContractPBLMicrotask,
+  {
+    /** Internal teaching record from `advance_micro_task`. */
+    internalAssessment?: PBLInternalAssessment;
+    completionReason?: string;
+    /** Engagement summary cached on completion. */
+    engagement?: PBLEngagementSummary;
+  }
+>;
 
-/** A learning document or reference material attached to a milestone. */
-export interface PBLDocument {
-  id: string;
-  title: string;
-  content: string;
-  docType: 'markdown' | 'reference' | 'starter_file';
-}
-
-/** A major phase of the project.
- *
- * The three "script" fields — `briefing`, `completionCriteria`,
- * `debrief` — are the Planner's hand-off to the Instructor. The
- * Instructor reads them off the milestone like a script: what to set
- * up, what counts as done, how to wrap.
- */
-export interface PBLMilestone {
-  id: string;
-  title: string;
-  description?: string;
-  status: PBLMilestoneStatus;
-  order: number;
-  microtasks: PBLMicrotask[];
-  /** Legacy / future resource slot. Current generators do not author this. */
-  documents?: PBLDocument[];
-  /** Short intro: why this milestone exists, what to expect. */
-  briefing?: string;
-  /** How to tell the learner is done. */
-  completionCriteria?: string;
-  /** What to say when wrapping up. */
-  debrief?: string;
-  /** Optional, authored by the Planner ONLY for the 1-2 stages that
-   *  carry the project's core knowledge. When present, the Instructor
-   *  runs a one-time integrative reverse-question about the whole
-   *  stage's core concept before the stage is allowed to seal (see
-   *  the milestone evidence gate in `agents/instructor.ts`). Leaving
-   *  it undefined means "no stage-level synthesis check" — most
-   *  stages. This is the deterministic knob that keeps stage-level
-   *  reverse-questions from being asked on every stage (too many) or
-   *  never (too few). */
-  synthesisCheck?: {
-    /** Short description of the core concept the integrative question
-     *  should probe (e.g. "为什么循环能避免重复代码"). */
-    coreConcept: string;
-  };
-  /** Same idea as `PBLMicrotask.internalAssessment` — Instructor sets
-   *  this when auto-completing the milestone via `advance_micro_task`
-   *  on the last task. */
-  internalAssessment?: PBLInternalAssessment;
-  /** SCENARIO ONLY (design-time). This milestone's role in the fixed
-   *  three-stage scenario skeleton:
-   *    - 'prep'   = first stage; Instructor introduces the concrete
-   *                 premise + cast (no assessment, confirm-to-advance).
-   *    - 'roleplay' = immersive role-play stage driven by the Simulator
-   *                 (the cast in `project.scenario.characters`); there
-   *                 may be MORE THAN ONE consecutive roleplay stage.
-   *    - 'wrapup' = last stage; Instructor gives light, data-driven
-   *                 feedback (detailed report lives on the completion page).
-   *  Normal milestones leave this undefined and run the standard
-   *  Instructor flow. (Named 'roleplay' — NOT 'scene' — to avoid
-   *  collision with OpenMAIC's top-level "scene" type.) */
-  scenarioStage?: 'prep' | 'roleplay' | 'wrapup';
-}
-
-/** SCENARIO ONLY. One character in the role-play cast. Authored at
- *  design time (Planner) and frozen into the packaged project. The
- *  character is data on `project.scenario`, NOT a `roles[]` record. */
-export interface PBLScenarioCharacter {
-  id: string;
-  name: string;
-  /** Persona: stable identity / relationship to the learner /
-   *  personality / speaking style — injected into the Simulator system
-   *  prompt. */
-  persona: string;
-  /** SCENARIO ONLY (design-time). This character's CONCRETE current
-   *  circumstance / role in the scenario that the learner walks into —
-   *  e.g. "just went through a breakup, low mood, says they're fine but
-   *  aren't"; in a game: "sits at the under-the-gun position, plays
-   *  tight". Distinct from `persona` (stable identity). Pinned at design
-   *  time and introduced by the Instructor in the prep stage — the
-   *  learner never has to guess it. */
-  situation?: string;
-  /** Hard safety boundaries (what the character must never say/do). */
-  boundaries?: string;
-  /** Avatar asset path or style seed; rendered distinct from the
-   *  Instructor avatar. */
-  avatar?: string;
-  /** Optional design-time opening line so the packaged scene is
-   *  reproducible; if absent the Simulator generates one at runtime. */
-  openingLine?: string;
-}
-
-/** SCENARIO ONLY (design-time). ONE project-wide scene visual for the
- *  role-play entrance animation + banner. Authored by the Planner from an
- *  understanding of ALL roleplay stages, so it fits the whole project (not a
- *  guessed/enumerated category). Rendered deterministically; EVERY field is
- *  optional and sanitized at render time, so a missing / malformed value can
- *  never break the view. Purely cosmetic — never gates logic. */
-export interface PBLSceneVisual {
-  /** A short, project-wide scene phrase that fits every roleplay stage
-   *  (e.g. "深夜，各自房间隔着手机聊到天亮" / "决赛辩论赛场" / "牌桌现金局"). */
-  caption?: string;
-  /** Background gradient top colour (hex, e.g. "#3a2740"). */
-  bg1?: string;
-  /** Background gradient bottom colour (hex). */
-  bg2?: string;
-  /** Accent colour for glows / motifs (hex). */
-  accent?: string;
-  /** 2–4 emoji that evoke the shared setting (e.g. ["📱","🌙","🛏️"]). */
-  motifs?: string[];
-}
-
-/** SCENARIO ONLY. Presence of `project.scenario` is the single gate
- *  that marks a project as a role-play scenario project. Absent on all
- *  normal projects (the baseline). Authored at design time and frozen
- *  into the packaged project. */
-export interface PBLScenarioConfig {
-  /** The overall premise / situation (what is going on). Introduced by
-   *  the Instructor in the prep stage. */
-  setting: string;
-  /** SCENARIO ONLY (design-time). The project-wide scene visual (entrance
-   *  animation + banner backdrop), authored by the Planner to fit all
-   *  roleplay stages. Cosmetic; absent → a neutral fallback is rendered. */
-  sceneVisual?: PBLSceneVisual;
-  /** What the learner is practicing (used by wrapup / completion page). */
-  goal?: string;
-  /** SCENARIO ONLY (design-time). Rules / structure the learner must be
-   *  told before the scene (games / interviews / debates etc.). Omit for
-   *  free-form emotional scenarios. Introduced by the Instructor in prep. */
-  rules?: string;
-  /** SCENARIO ONLY (design-time). The learner's OWN role / position in
-   *  the scenario — e.g. "you are their close friend" / "you are the 5th
-   *  player, on the button". Introduced by the Instructor in prep. */
-  learnerRole?: string;
-  /** The cast (1..N; first showcase ships a single character). */
-  characters: PBLScenarioCharacter[];
-}
+/** Contract milestone with runtime-aware microtasks and assessment state. */
+export type PBLMilestone = RuntimeOverlay<
+  ContractPBLMilestone,
+  {
+    microtasks: PBLMicrotask[];
+    /** Same idea as `PBLMicrotask.internalAssessment` — Instructor sets
+     *  this when auto-completing the milestone via `advance_micro_task`
+     *  on the last task. */
+    internalAssessment?: PBLInternalAssessment;
+  }
+>;
 
 /** A piece of learner-produced work attached to a microtask. */
 export interface PBLSubmission {
@@ -692,16 +492,16 @@ export interface PBLChatMessage {
   characterId?: string;
 }
 
-/** Per-agent chat thread. Currently only the Instructor thread is
- *  populated. */
-export interface PBLAgentThread {
-  /** Matches `PBLRole.id`. */
-  agentId: string;
-  messages: PBLChatMessage[];
-  /** When messages exceed a threshold, the older half is folded into
-   *  a summary string so the context window stays bounded. */
-  earlierSummary?: string;
-}
+/** Contract thread seat plus app-owned typed message history. */
+export type PBLAgentThread = RuntimeOverlay<
+  ContractPBLThreadSeat,
+  {
+    messages: PBLChatMessage[];
+    /** When messages exceed a threshold, the older half is folded into
+     *  a summary string so the context window stays bounded. */
+    earlierSummary?: string;
+  }
+>;
 
 // ---------------------------------------------------------------------------
 // Milestone handover
@@ -745,146 +545,27 @@ export interface PBLPendingTaskCompletion {
 // ---------------------------------------------------------------------------
 
 /**
- * The v2 PBL project model. Lives at `scene.content.projectV2`.
- *
- * Key differences from the legacy v1 project shape:
- *  - Replaces "issueboard" with structured Milestones + Microtasks
- *  - Replaces the role-selection Landing with Hero → Workspace →
- *    Completion flow
- *  - Single Instructor agent (the `roles` / `threads` arrays are kept
- *    generic so additional roles could be introduced later)
- *  - First-class evaluations (task / milestone / final) with
- *    structured fields
- *  - First-class engagement analytics
- *  - Submission objects (paste-text / upload / link)
- *  - Milestone gating (LOCKED→ACTIVE explicit user gate via
- *    `pendingHandover`)
- *
- * Only the Instructor is wired: `roles` contains exactly one Instructor
- * record and `threads` contains its single thread.
+ * Contract design/skeleton with app-owned learner and runtime state overlaid
+ * onto the nested arrays. The property replacement is essential: intersecting
+ * only the two top-level project types would leave contract microtasks and
+ * thread messages untyped at app call sites.
  */
-export interface PBLProjectV2 {
-  /** UI state machine for the in-scene PBL flow. */
-  uiPhase: PBLUiPhase;
-
-  // --- Project metadata --------------------------------------------------
-
-  title: string;
-  description: string;
-  /** What the learner wants to LEARN (distinct from `description` =
-   *  what they will BUILD). Derived from outline context in v2 (in v1
-   *  standalone this was captured by Planner's intent-convergence
-   *  phase, which we drop in v2). */
-  learningObjective?: string;
-  /** Learner-facing "what you'll gain" statements shown on the Hero —
-   *  3-5 concise, readable phrases for the abilities / awareness /
-   *  knowledge the learner BUILDS by working through the project. These
-   *  describe what the learner takes away (capabilities exercised), NOT
-   *  the final deliverable/result the project produces (that is
-   *  `description`). Authored by the Planner in the project language,
-   *  typically by expanding each terse outline `targetSkills` entry into
-   *  a readable competency. Distinct from `learningObjective`, the single
-   *  internal skill sentence used by prompts. Optional only for backward
-   *  compatibility with projects packaged before this field existed
-   *  (legacy v1→v2 upgrades); new Planner runs always populate it. */
-  gains?: string[];
-  /** Skill tier — kept in sync with `proficiencyAssessment.tier` for
-   *  legacy consumers (planner prompt, tier-guidance block, dev
-   *  logs). The full adaptive state lives in `proficiencyAssessment`. */
-  proficiency: PBLProficiency;
-  /** Adaptive proficiency state — pre-play initial assessment + the
-   *  in-PBL EWMA-updated score. Drives Instructor's tier guidance.
-   *  See `lib/pbl/v2/operations/kernel/proficiency.ts` for the algorithm. */
-  proficiencyAssessment?: PBLProficiencyAssessment;
-  /** ISO 639 language code from outline language inference.
-   *  BCP-47 fallback locale for deterministic platform text (e.g.
-   *  syntheticPlatformOpener). For CONTENT language, prefer
-   *  `languageDirective` — it carries the classroom's full language
-   *  policy (e.g. "中文为主，英文技术术语保留原文") and is the
-   *  authoritative source for Planner / Instructor / Evaluator. */
-  language: string;
-  /** Classroom-level content-language policy. Set by the Planner from
-   *  `courseContext.languageDirective`. When present, it overrides
-   *  `language` as the content-language rule. It may be a simple locale
-   *  ("zh-CN") or a nuanced directive ("中文为主，英文技术术语保留原文").
-   *  When undefined (legacy projects), `language` is the fallback. */
-  languageDirective?: string;
-  /** Free-form tags (e.g. ["python", "data-analysis"]). */
-  tags: string[];
-
-  /** SCENARIO ONLY. Role-play scenario configuration. Presence of this
-   *  field is the single gate that marks the project as a scenario
-   *  project; absent on all normal projects. Authored at design time
-   *  (Planner) and frozen into the packaged project. */
-  scenario?: PBLScenarioConfig;
-
-  /** Packaged-format version. Absent = baseline (current). Reserved for
-   *  future migrations once the project package format is frozen. */
-  schemaVersion?: number;
-
-  // --- Lifecycle ---------------------------------------------------------
-
-  status: PBLProjectStatus;
-
-  // --- Structure ---------------------------------------------------------
-
-  /** Multi-agent participants. Stage A only populates the Instructor
-   *  (one record with `type === 'instructor'`). The schema supports
-   *  any number of additional agents for follow-up PRs. */
-  roles: PBLRole[];
-
-  milestones: PBLMilestone[];
-
-  /** Learner deliverables attached to microtasks. */
-  submissions: PBLSubmission[];
-
-  /** Instructor's structured feedback at task / milestone / final
-   *  levels. */
-  evaluations: PBLEvaluation[];
-
-  // --- Runtime state -----------------------------------------------------
-
-  /** Per-agent chat threads. Stage A only contains an Instructor
-   *  thread. */
-  threads: PBLAgentThread[];
-
-  /** Append-only event ledger (ring-buffer capped; see analytics
-   *  module for the cap). */
-  engagementEvents: PBLEngagementEvent[];
-
-  /** Append-only runtime fact ledger. This is intentionally broader than
-   *  engagement analytics: it records actor actions such as messages, tool
-   *  calls, submissions, evaluations and state changes. It remains optional
-   *  for old v2 projects; future runtime-split work can make it required. */
-  runtimeEvents?: PBLRuntimeEvent[];
-
-  /** Monotonically incremented by resetProjectProgress, never derived from
-   *  the bounded runtime event ring buffer. */
-  runtimeResetEpoch?: number;
-
-  /** Cross-milestone hand-off state. Present after Instructor
-   *  completes a milestone's last microtask, until the learner clicks
-   *  Continue. */
-  pendingHandover?: PBLHandover;
-
-  /** Task-level manual-completion state. Present after a microtask has
-   *  reached B point; the task remains active until the learner clicks
-   *  the sidebar "Done" button. */
-  pendingTaskCompletion?: PBLPendingTaskCompletion;
-
-  /** Transient client-only payload for the first Workspace greeting.
-   *  The Hero computes the prior-quiz snapshot immediately before
-   *  launch, then the Chat consumes and clears this field before it
-   *  starts `/api/pbl/v2/open-task`. It should not remain on persisted
-   *  project state after that first request begins. */
-  pendingOpenTaskPriorQuizResults?: PriorQuizResult[];
-
-  // --- Timestamps --------------------------------------------------------
-
-  /** ISO timestamps. */
-  createdAt: string;
-  updatedAt: string;
-}
+export type PBLProjectV2 = RuntimeOverlay<
+  ContractPBLProject,
+  {
+    milestones: PBLMilestone[];
+    submissions: PBLSubmission[];
+    evaluations: PBLEvaluation[];
+    threads: PBLAgentThread[];
+    engagementEvents: PBLEngagementEvent[];
+    proficiencyAssessment?: PBLProficiencyAssessment;
+    runtimeEvents?: PBLRuntimeEvent[];
+    runtimeResetEpoch?: number;
+    pendingHandover?: PBLHandover;
+    pendingTaskCompletion?: PBLPendingTaskCompletion;
+    pendingOpenTaskPriorQuizResults?: PriorQuizResult[];
+  }
+>;
 
 // ---------------------------------------------------------------------------
 // Planner input (consumed by PR 2)

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -2,16 +2,16 @@
 //
 // The universal lesson skeleton (Stage / Scene / SceneContent / Whiteboard /
 // VideoManifest / SlideContent / QuizContent / …) now lives in `@openmaic/dsl` and
-// is re-exported below. `Scene` is generic there: the contract owns only the
-// structure + the slide/quiz content kinds, while the playback `Action` set and
-// the richer feature content (interactive widgets, PBL) are app-side and get
-// composed in here.
+// is re-exported below. `Scene` is generic there: the contract owns the
+// structure and all four persisted content kinds, while richer interactive
+// widget payloads and PBL learner/runtime state are composed in here.
 //
 // `Scene` is re-exported as an alias of the app's fully-instantiated
 // `Scene<Action, AppSceneContent>`, so existing `import { Scene }` callers keep
 // the same semantics (actions are `Action[]`, content spans all four kinds).
 import type {
   InteractiveContent as DslInteractiveContent,
+  PBLContent as DslPBLContent,
   Scene as DslScene,
   SceneContent as DslSceneContent,
 } from '@openmaic/dsl';
@@ -45,10 +45,9 @@ export { isSlideContent, isQuizContent } from '@openmaic/dsl';
 // `QuizQuestionType` from `@/lib/types/stage`.
 export type QuizQuestionType = import('@openmaic/dsl').QuizQuestion['type'];
 
-// The contract's `SceneContent` is the universal subset (slide | quiz). Reach it
-// under a distinct name; the app's own `SceneContent` (declared below) is the
-// full four-way union so existing `switch (content.type)` call sites keep all
-// four cases.
+// The contract's compatibility-default `SceneContent` is slide | quiz. Reach it
+// under a distinct name; the contract-owned interactive and PBL shapes are
+// widened below before composing the app's full four-way union.
 export type { SceneContent as SceneContentBase } from '@openmaic/dsl';
 
 // The raw, generic contract Scene is reachable under a distinct name for
@@ -66,21 +65,19 @@ export type InteractiveContent = DslInteractiveContent<WidgetConfig>;
 /**
  * PBL content - Project-based learning.
  *
- * App-level feature surface: kept here rather than in `@openmaic/dsl` because it
- * supports v2 projects and read-only legacy v1 project data.
+ * The contract records the stored field names and opaque legacy configuration;
+ * the app retains its read-only typed view of that record and widens
+ * `projectV2` with learner/runtime state.
  */
-export interface PBLContent {
-  type: 'pbl';
-  /** Read-only data retained on scenes stored before the PBL v2 cutover. */
-  projectConfig?: PBLProjectConfig;
-  /** PBL v2 project payload used by the web-PBL runtime. */
+export type PBLContent = DslPBLContent & {
+  projectConfig?: PBLProjectConfig & Record<string, unknown>;
   projectV2?: PBLProjectV2;
-}
+};
 
 /**
  * The app's full scene-content union: the contract's universal kinds plus the
- * app-only feature kinds. This is what `@/lib/types/stage` callers have always
- * known as `SceneContent` (all four cases).
+ * app-widened feature kinds. This is what `@/lib/types/stage` callers have
+ * always known as `SceneContent` (all four cases).
  */
 export type AppSceneContent = DslSceneContent | InteractiveContent | PBLContent;
 

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/dsl",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The MAIC slide DSL: the pure, dependency-free contract (types + JSON Schema + validators + version/migration helpers) that @openmaic/renderer and @openmaic/importer both depend on.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/dsl/scripts/gen-schema.mjs
+++ b/packages/@openmaic/dsl/scripts/gen-schema.mjs
@@ -18,6 +18,11 @@ export const ROOTS = {
   Action: 'action.schema.json',
 };
 
+// Historical stored PBL documents may carry app-owned runtime fields on these
+// contract nodes. Keep their TypeScript interfaces precise for consumers, then
+// open exactly these JSON Schema definitions for backward-compatible reads.
+const OPEN_PBL_DEFINITIONS = ['PBLProject', 'PBLMilestone', 'PBLMicrotask', 'PBLThreadSeat'];
+
 // One generator over the whole tsconfig program, built lazily and reused for
 // every root — parses/type-builds the program once instead of per type.
 // `createSchema(typeName)` still walks from each root, so each schema only
@@ -40,7 +45,11 @@ function getGenerator() {
 /** Generate the JSON Schema object for one root type (in-memory). */
 export function generateSchema(typeName) {
   if (!(typeName in ROOTS)) throw new Error(`unknown schema root: ${typeName}`);
-  return getGenerator().createSchema(typeName);
+  const schema = getGenerator().createSchema(typeName);
+  for (const name of OPEN_PBL_DEFINITIONS) {
+    if (schema.definitions?.[name]) schema.definitions[name].additionalProperties = true;
+  }
+  return schema;
 }
 
 function main() {

--- a/packages/@openmaic/dsl/src/pbl.ts
+++ b/packages/@openmaic/dsl/src/pbl.ts
@@ -28,7 +28,7 @@ export interface PBLRole {
  * fields; the contract tolerates unknown members on the project tree for that
  * reason and does not interpret them.
  */
-export interface PBLMicrotask extends Record<string, unknown> {
+export interface PBLMicrotask {
   id: string;
   title: string;
   description?: string;
@@ -58,7 +58,7 @@ export interface PBLDocument {
  * fields; the contract tolerates unknown members on the project tree for that
  * reason and does not interpret them.
  */
-export interface PBLMilestone extends Record<string, unknown> {
+export interface PBLMilestone {
   id: string;
   title: string;
   description?: string;
@@ -108,7 +108,7 @@ export interface PBLScenarioConfig {
  * strip may carry app runtime fields; the contract tolerates unknown members on
  * the project tree for that reason and does not interpret them.
  */
-export interface PBLThreadSeat extends Record<string, unknown> {
+export interface PBLThreadSeat {
   agentId: string;
   messages: unknown[];
 }
@@ -119,7 +119,7 @@ export interface PBLThreadSeat extends Record<string, unknown> {
  * runtime fields; the contract tolerates unknown members on the project tree
  * for that reason and does not interpret them.
  */
-export interface PBLProject extends Record<string, unknown> {
+export interface PBLProject {
   /** Seeded to the canonical `hero` value in stored documents. */
   uiPhase: PBLUiPhase;
   title: string;

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -15,10 +15,10 @@ import type { Stage, Scene } from '@openmaic/dsl';
  * The minimal scene shape the store itself depends on — the fields it uses to
  * normalize (`stageId` + `id` are the compound row key), order (`order`), and
  * integrity-check scenes. The DSL `Scene` satisfies it. The store is generic
- * over the concrete scene type so an app can persist its own widened scene union
- * (interactive / pbl / …) — content the DSL does not own — by supplying a
- * matching {@link SceneValidator}. Everything below `SceneLike` is opaque to the
- * store and rides along verbatim.
+ * over the concrete scene type so an app can persist widened payloads for the
+ * contract's interactive / pbl kinds by supplying a matching
+ * {@link SceneValidator}. Everything below `SceneLike` is opaque to the store
+ * and rides along verbatim.
  */
 export interface SceneLike {
   id: string;
@@ -27,10 +27,10 @@ export interface SceneLike {
 }
 
 /**
- * Validate a scene at the write boundary. Defaults to the DSL `validateScene`
- * (which owns the universal `slide` / `quiz` kinds); an app that widens `Scene`
- * with its own content kinds injects a validator that also accepts those, so the
- * gate stays fail-loud for the app's shapes rather than silently rejecting them.
+ * Validate a scene at the write boundary. Defaults to the DSL `validateScene`,
+ * which owns all four persisted content kinds. An app that widens their payloads
+ * injects its own validator so the gate applies the app's compatibility policy
+ * instead of rejecting its richer or historical shapes.
  */
 export type SceneValidator = (
   scene: unknown,

--- a/tests/document-store/persistence.test.ts
+++ b/tests/document-store/persistence.test.ts
@@ -1,4 +1,8 @@
-import { validateScene, type WidgetConfigBase } from '@openmaic/dsl';
+import {
+  validateScene,
+  type PBLContent as ContractPBLContent,
+  type WidgetConfigBase,
+} from '@openmaic/dsl';
 import type { DocumentStore } from '@openmaic/storage';
 import { describe, expect, test, vi } from 'vitest';
 import { IDBFactory } from 'fake-indexeddb';
@@ -13,7 +17,7 @@ import type { AppDocument } from '@/lib/document-store/persistence-types';
 import { validateAppScene, validateAppStage } from '@/lib/document-store/validators';
 import { upgradeLegacyPBLConfigToProjectV2 } from '@/lib/pbl/legacy/read';
 import type { SceneOutline } from '@/lib/types/generation';
-import type { AppScene, InteractiveContent } from '@/lib/types/stage';
+import type { AppScene, InteractiveContent, PBLContent } from '@/lib/types/stage';
 import type { SimulationConfig } from '@/lib/types/widgets';
 import type { SceneRecord, StageOutlinesRecord, StageRecord } from '@/lib/utils/database';
 import { legacyPBLSceneFixture } from '@/tests/fixtures/pbl-v1-scene';
@@ -300,6 +304,12 @@ describe('app document validators', () => {
     expect(validateAppScene(legacyPBLSceneFixture)).toEqual({ valid: true });
   });
 
+  test('keeps a historical projectConfig-only scene inside the write-validator matrix', () => {
+    const historicalScene = structuredClone(legacyPBLSceneFixture);
+    expect(historicalScene.content).not.toHaveProperty('projectV2');
+    expect(validateAppScene(historicalScene)).toEqual({ valid: true });
+  });
+
   test('accepts PBL content with an empty legacy projectConfig object', () => {
     expect(
       validateAppScene({
@@ -441,6 +451,11 @@ describe('app document validators', () => {
 });
 
 type Assert<T extends true> = T;
+
+test('app PBLContent remains assignable to the contract PBLContent', () => {
+  const assignable: Assert<PBLContent extends ContractPBLContent ? true : false> = true;
+  expect(assignable).toBe(true);
+});
 
 test('SimulationConfig satisfies the contract widget config base', () => {
   const assignable: Assert<SimulationConfig extends WidgetConfigBase ? true : false> = true;

--- a/tests/document-store/persistence.test.ts
+++ b/tests/document-store/persistence.test.ts
@@ -15,7 +15,7 @@ import {
 import { getDocumentStore } from '@/lib/document-store/store';
 import type { AppDocument } from '@/lib/document-store/persistence-types';
 import { validateAppScene, validateAppStage } from '@/lib/document-store/validators';
-import { upgradeLegacyPBLConfigToProjectV2 } from '@/lib/pbl/legacy/read';
+import { upgradeLegacyPBLConfigToProjectV2, type PBLProjectConfig } from '@/lib/pbl/legacy/read';
 import type { SceneOutline } from '@/lib/types/generation';
 import type { AppScene, InteractiveContent, PBLContent } from '@/lib/types/stage';
 import type { SimulationConfig } from '@/lib/types/widgets';
@@ -451,6 +451,12 @@ describe('app document validators', () => {
 });
 
 type Assert<T extends true> = T;
+
+test('typed legacy PBL config remains assignable to app PBLContent', () => {
+  type LegacyPBLContent = { type: 'pbl'; projectConfig: PBLProjectConfig };
+  const assignable: Assert<LegacyPBLContent extends PBLContent ? true : false> = true;
+  expect(assignable).toBe(true);
+});
 
 test('app PBLContent remains assignable to the contract PBLContent', () => {
   const assignable: Assert<PBLContent extends ContractPBLContent ? true : false> = true;

--- a/tests/pbl/v2/types.test.ts
+++ b/tests/pbl/v2/types.test.ts
@@ -13,6 +13,7 @@
  *      `PBLProjectConfig` from v2 `PBLProjectV2`.
  */
 import { describe, it, expect } from 'vitest';
+import { isPBLProject, type PBLProject } from '@openmaic/dsl';
 import {
   hasPBLProjectV2Containers,
   isRunnablePBLProjectV2,
@@ -28,6 +29,58 @@ import {
   type PBLHandover,
   type PBLRuntimeEvent,
 } from '@/lib/pbl/v2/types';
+
+const canonicalStoredDesignTemplate = {
+  uiPhase: 'hero',
+  title: 'Neighborhood biodiversity survey',
+  description: 'Create a field guide from local observations.',
+  learningObjective: 'Practice observation, classification, and evidence-based writing.',
+  gains: ['Record observations consistently', 'Classify organisms from evidence'],
+  proficiency: 'beginner',
+  language: 'en-US',
+  languageDirective: 'Reply in English.',
+  tags: ['biology', 'fieldwork'],
+  status: 'active',
+  roles: [
+    {
+      id: 'role-instructor',
+      type: 'instructor',
+      name: 'Field Guide',
+      description: 'Helps you turn observations into a clear field guide.',
+    },
+  ],
+  milestones: [
+    {
+      id: 'milestone-observe',
+      title: 'Observe the site',
+      status: 'active',
+      order: 0,
+      briefing: 'Start with a repeatable observation method.',
+      completionCriteria: 'Three observations use the same recording format.',
+      microtasks: [
+        {
+          id: 'microtask-record',
+          title: 'Record three organisms',
+          status: 'todo',
+          assignee: 'user',
+          hints: ['Note location, visible traits, and behavior.'],
+          order: 0,
+        },
+      ],
+    },
+  ],
+  submissions: [],
+  evaluations: [],
+  threads: [{ agentId: 'role-instructor', messages: [] }],
+  engagementEvents: [],
+  createdAt: '2026-08-09T08:00:00.000Z',
+  updatedAt: '2026-08-09T08:00:00.000Z',
+} satisfies PBLProjectV2;
+
+const canonicalContractProject: PBLProject = canonicalStoredDesignTemplate;
+
+type Assert<T extends true> = T;
+const appProjectSatisfiesContract: Assert<PBLProjectV2 extends PBLProject ? true : false> = true;
 
 // A fully-populated reference value covering every optional field so
 // drift in any nested shape is caught.
@@ -192,6 +245,11 @@ function makeFullProject(): PBLProjectV2 {
 }
 
 describe('PBL v2 — types', () => {
+  it('keeps a canonical stored design template assignable to app and contract types', () => {
+    expect(appProjectSatisfiesContract).toBe(true);
+    expect(isPBLProject(canonicalContractProject)).toBe(true);
+  });
+
   it('JSON round-trip is loss-free on a fully populated project', () => {
     const project = makeFullProject();
     const serialized = JSON.stringify(project);

--- a/tests/pbl/v2/types.test.ts
+++ b/tests/pbl/v2/types.test.ts
@@ -81,6 +81,27 @@ const canonicalContractProject: PBLProject = canonicalStoredDesignTemplate;
 
 type Assert<T extends true> = T;
 const appProjectSatisfiesContract: Assert<PBLProjectV2 extends PBLProject ? true : false> = true;
+const projectHasTitle: Assert<'title' extends keyof PBLProjectV2 ? true : false> = true;
+const projectHasStatus: Assert<'status' extends keyof PBLProjectV2 ? true : false> = true;
+const projectHasRoles: Assert<'roles' extends keyof PBLProjectV2 ? true : false> = true;
+const projectHasCreatedAt: Assert<'createdAt' extends keyof PBLProjectV2 ? true : false> = true;
+const projectHasRuntimeEvents: Assert<'runtimeEvents' extends keyof PBLProjectV2 ? true : false> =
+  true;
+
+const { title: _omittedTitle, ...projectWithoutTitle } = canonicalStoredDesignTemplate;
+// @ts-expect-error title is required by the contract-backed app type.
+const projectMissingTitle: PBLProjectV2 = { ...projectWithoutTitle };
+
+// @ts-expect-error id is required by the contract-backed app microtask type.
+const microtaskMissingId: PBLMicrotask = {
+  title: 'Record three organisms',
+  status: 'todo',
+  assignee: 'user',
+  hints: [],
+  order: 0,
+};
+void projectMissingTitle;
+void microtaskMissingId;
 
 // A fully-populated reference value covering every optional field so
 // drift in any nested shape is caught.
@@ -247,6 +268,11 @@ function makeFullProject(): PBLProjectV2 {
 describe('PBL v2 — types', () => {
   it('keeps a canonical stored design template assignable to app and contract types', () => {
     expect(appProjectSatisfiesContract).toBe(true);
+    expect(projectHasTitle).toBe(true);
+    expect(projectHasStatus).toBe(true);
+    expect(projectHasRoles).toBe(true);
+    expect(projectHasCreatedAt).toBe(true);
+    expect(projectHasRuntimeEvents).toBe(true);
     expect(isPBLProject(canonicalContractProject)).toBe(true);
   });
 


### PR DESCRIPTION
Third and final PR for #1061 (after #1070/#1073, sequenced behind #1060/#1069). `lib/pbl/v2/types.ts` becomes a barrel over `@openmaic/dsl` plus an app-side runtime overlay; no importer changes anywhere.

- **Composition**: `PBLProjectV2 = RuntimeOverlay<contract PBLProject, app overlay>` applied recursively (microtasks, milestones, thread seats), so the app's hydrated shape keeps its exact structure while the contract owns the design-time definition. Type assertions pin app → contract assignability and a canonical stored design template satisfies both.
- **`PBLContent`** widens the contract's with the app-hydrated `projectV2`.
- **Write validator untouched by construction**: `lib/document-store/validators.ts` is byte-identical to base (same SHA-256) — no new field enforcement over stored shapes; the contract validator stays strict for external consumers only.
- **Storage**: comment-only correction of the stale "owns the universal slide/quiz kinds" docs; patch bump `0.2.2 → 0.2.3`, no code changes.

Verification (Node 22): dsl 220 / generation 87 / storage 659 package tests · PBL+classroom+document-store 857 · **full app suite 4,173 passing** · root tsc (the 72+175 importer surfaces compile unchanged) · check/lint · version-bump gate.

Closes #1061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)