### PR TITLE
fix(asr): drop region subtag before calling the transcription API

### DIFF
--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -304,6 +304,16 @@ function getOptionalBearerAuthHeaders(apiKey?: string): Record<string, string> {
 /**
  * OpenAI Whisper implementation (using Vercel AI SDK)
  */
+/**
+ * Reduce a language setting to the ISO-639-1 code the OpenAI-compatible
+ * transcription API expects. `auto` (and anything empty) means "detect".
+ */
+function toISO6391(language: string | undefined): string | undefined {
+  if (!language || language === 'auto') return undefined;
+  const base = language.split('-')[0]?.trim().toLowerCase();
+  return base || undefined;
+}
+
 async function transcribeOpenAIWhisper(
   config: ASRModelConfig,
   audioBuffer: Buffer | Blob,
@@ -330,7 +340,12 @@ async function transcribeOpenAIWhisper(
       audio: audioData,
       providerOptions: {
         openai: {
-          language: config.language === 'auto' ? undefined : config.language,
+          // The transcription API takes ISO-639-1, but `asrLanguage` is a single
+          // global setting shared with browser-native ASR, whose catalogue is
+          // region-tagged (pt-BR, pt-PT, zh-CN...). Carrying such a value over
+          // to this provider fails the whole request with
+          // "unsupported language: pt-BR", so drop the region subtag.
+          language: toISO6391(config.language),
         },
       },
     });


### PR DESCRIPTION
## Summary

`openai-whisper` transcription fails outright when the ASR language setting carries a region subtag (`pt-BR`, `pt-PT`, `zh-CN`, ...). This reduces the value to the ISO-639-1 code the API expects.

## Related Issues

Closes #1082

## Changes

- `lib/audio/asr-providers.ts`: new `toISO6391()` helper; `transcribeOpenAIWhisper` sends the base subtag instead of the raw setting. `auto` still maps to `undefined` (detect).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Configure `ASR_OPENAI_API_KEY` / `ASR_OPENAI_BASE_URL` against any OpenAI-compatible transcription endpoint.
2. `POST /api/transcription` with `language=pt-BR` and an audio file.

Before: `500`, and the server logs `AI_APICallError: unsupported language: pt-BR`. After: `200` with the transcription.

### What you personally verified

On a live instance backed by Groq's OpenAI-compatible endpoint (`whisper-large-v3-turbo`), same audio file in all three cases:

- `language=pt` — worked before and after (this is why the bug is invisible when testing the API directly with a bare code).
- `language=pt-BR` — **before:** upstream 400 `unsupported language: pt-BR`; **after:** `{"success":true,"text":" A fotossintese transforma a luz solar em energia química."}`.
- `language=pt-PT` — **after:** same successful transcription.

I also confirmed the source of the mismatch: `browser-native` is the only ASR provider whose `supportedLanguages` are region-tagged (`pt-BR`, `pt-PT`), while `openai-whisper`, `qwen-asr`, `qwen3-asr-flash` and `azure-asr` all list bare `pt` — and `asrLanguage` is a single global setting shared across them.

What I did **not** verify: the Azure and Qwen ASR paths (untouched by this change, and they build their own request), and whether any OpenAI-compatible provider actually wants a region-tagged code (I found none documented; the API reference specifies ISO-639-1).

### Evidence

```
# before
[ERROR] [Transcription] Transcription failed [provider=openai-whisper, model=whisper-large-v3-turbo]: AI_APICallError: unsupported language: pt-BR

# after
$ curl -F 'audio=@fala.mp3' -F 'providerId=openai-whisper' -F 'modelId=whisper-large-v3-turbo' -F 'language=pt-BR' .../api/transcription
{"success":true,"text":" A fotossintese transforma a luz solar em energia química."}
HTTP=200
```
