### PR TITLE
fix(agents): bind generated agents to a voice of the matching gender

### DIFF
--- a/app/api/generate/agent-profiles/route.ts
+++ b/app/api/generate/agent-profiles/route.ts
@@ -29,6 +29,7 @@ interface RequestBody {
     voiceId: string;
     voiceName: string;
     voiceLanguage?: string;
+    voiceGender?: 'male' | 'female' | 'neutral';
   }>;
 }
 
@@ -96,6 +97,7 @@ export async function POST(req: NextRequest) {
               id: `${v.providerId}::${v.voiceId}`,
               name: v.voiceName,
               language: v.voiceLanguage || 'unknown',
+              gender: v.voiceGender || 'unknown',
             })),
           )
         : '';
@@ -103,7 +105,13 @@ export async function POST(req: NextRequest) {
     const voicePrompt = voiceListStr
       ? `- Each agent should be assigned a voice that matches their persona from this list: ${voiceListStr}
   - Prefer a voice whose language matches the course language directive
-  - Pick a voice that suits the agent's personality and role (e.g. authoritative voice for teacher, lively voice for energetic student)
+  - The voice's "gender" MUST match the gender implied by the agent's name and by
+    the "identity" of its voiceDesign. A female-named agent must not get a voice
+    whose gender is "male", and vice versa. Voice display names may be in a
+    language you are not generating in — trust the "gender" field, not the name.
+  - Within the voices of the right gender, pick one that suits the agent's
+    personality and role (e.g. authoritative voice for teacher, lively voice for
+    energetic student)
   - Try to use different voices for each agent`
       : '';
 
@@ -129,6 +137,10 @@ Requirements:
   - Use the "path" value as the avatar field in the output
 - Each agent must be assigned one color from this list: ${JSON.stringify(AGENT_COLOR_PALETTE)}
   - Each agent must have a different color
+- Each agent needs a "gender" field — always one of the literal English values
+  "male", "female" or "neutral" — consistent with the agent's name. This is a
+  machine field: it stays in English even when names and personas follow the
+  language directive, and it is what binds the agent to a matching voice.
 - Each agent needs a "voiceDesign" object describing their VOCAL identity (not personality), written following the language directive and consistent with the persona, as three short comma-free phrases:
   - "identity": gender + age + role (e.g. "middle-aged male teacher")
   - "texture": pitch + vocal quality (e.g. "warm low-pitched slightly husky")
@@ -142,6 +154,7 @@ Return a JSON object with this exact structure:
       "name": "string",
       "role": "teacher" | "assistant" | "student",
       "persona": "string (2-3 sentences)",
+      "gender": "male" | "female" | "neutral",
       "voiceDesign": { "identity": "string", "texture": "string", "delivery": "string" },
       "avatar": "string (from available list)",
       "color": "string (hex color from palette)",
@@ -175,6 +188,7 @@ Return a JSON object with this exact structure:
         avatar: string;
         color: string;
         priority: number;
+        gender?: string;
         voice?: string;
         voiceDesign?: unknown;
       }>;
@@ -219,6 +233,11 @@ Return a JSON object with this exact structure:
       }
 
       const voiceDesign = normalizeVoiceDesign(agent.voiceDesign);
+      const rawGender = typeof agent.gender === 'string' ? agent.gender.trim().toLowerCase() : '';
+      const gender =
+        rawGender === 'male' || rawGender === 'female' || rawGender === 'neutral'
+          ? (rawGender as 'male' | 'female' | 'neutral')
+          : undefined;
 
       return {
         id: `gen-${nanoid(8)}`,
@@ -229,6 +248,7 @@ Return a JSON object with this exact structure:
         color: agent.color || AGENT_COLOR_PALETTE[index % AGENT_COLOR_PALETTE.length],
         priority:
           agent.priority ?? (agent.role === 'teacher' ? 10 : agent.role === 'assistant' ? 7 : 5),
+        ...(gender ? { gender } : {}),
         ...(voiceConfig ? { voiceConfig } : {}),
         ...(voiceDesign ? { voiceDesign } : {}),
       };

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -840,6 +840,11 @@ function GenerationPreviewContent() {
                 voiceId: v.id,
                 voiceName: v.name,
                 voiceLanguage: v.language,
+                // Without this the model has to infer gender from the id and
+                // display name, and several catalogues (MiniMax) name their
+                // voices in Chinese — so a female agent regularly got a male
+                // voice. The registry knows; pass it on.
+                voiceGender: v.gender,
               })),
             );
           };

--- a/lib/audio/voice-resolver.ts
+++ b/lib/audio/voice-resolver.ts
@@ -1,4 +1,4 @@
-import type { TTSProviderId } from '@/lib/audio/types';
+import type { TTSProviderId, TTSVoiceInfo } from '@/lib/audio/types';
 import { isCustomTTSProvider } from '@/lib/audio/types';
 import type { AgentConfig } from '@/lib/orchestration/registry/types';
 import { TTS_PROVIDERS } from '@/lib/audio/constants';
@@ -46,6 +46,29 @@ export type AgentVoiceOverrides = Record<string, AgentVoiceOverride>;
  * 3. If the list is empty, return null — the caller must skip TTS rather than
  *    silently falling back to browser-native (#665 symptom 4).
  */
+/**
+ * The gender an agent's voice should have.
+ *
+ * Prefers the profile's explicit `gender` field, which the generator emits with
+ * literal English values regardless of the course language. Falls back to
+ * parsing `voiceDesign.identity` for profiles generated before that field
+ * existed; that prose follows the course language, so the match is
+ * English-only and best-effort. Ambiguous or absent information returns
+ * undefined, which leaves the caller on its previous behaviour.
+ */
+export function inferAgentGender(agent: AgentConfig): 'male' | 'female' | undefined {
+  if (agent.gender === 'male' || agent.gender === 'female') return agent.gender;
+  if (agent.gender === 'neutral') return undefined;
+
+  const identity = agent.voiceDesign?.identity;
+  if (!identity) return undefined;
+  const text = identity.toLowerCase();
+  const female = /\b(female|woman|women|girl|lady)\b/.test(text);
+  const male = /\b(male|man|men|boy|gentleman)\b/.test(text);
+  if (female === male) return undefined;
+  return female ? 'female' : 'male';
+}
+
 export function resolveAgentVoice(
   agent: AgentConfig,
   agentIndex: number,
@@ -77,12 +100,22 @@ export function resolveAgentVoice(
   }
 
   // Fallback: deterministic pick among enabled providers (canonical order).
+  // Round-robin by index alone regularly gave a female-named agent a male
+  // voice, so narrow the pool to voices whose gender matches the one the
+  // generated voiceDesign states before indexing into it. Rotation is kept —
+  // the index still spreads agents across the matching voices — and a pool
+  // with no gender information behaves exactly as before.
   if (enabledProviders.length > 0) {
     const first = enabledProviders[0];
     if (first.voices.length > 0) {
+      const wanted = inferAgentGender(agent);
+      const pool = wanted
+        ? first.voices.filter((v) => v.gender === wanted || v.gender === 'neutral')
+        : [];
+      const voices = pool.length > 0 ? pool : first.voices;
       return {
         providerId: first.providerId,
-        voiceId: first.voices[agentIndex % first.voices.length].id,
+        voiceId: voices[agentIndex % voices.length].id,
       };
     }
   }
@@ -115,13 +148,13 @@ export function getServerVoiceList(
 export interface ModelVoiceGroup {
   modelId: string;
   modelName: string;
-  voices: Array<{ id: string; name: string; language?: string }>;
+  voices: Array<{ id: string; name: string; language?: string; gender?: TTSVoiceInfo['gender'] }>;
 }
 
 export interface ProviderWithVoices {
   providerId: TTSProviderId;
   providerName: string;
-  voices: Array<{ id: string; name: string; language?: string }>;
+  voices: Array<{ id: string; name: string; language?: string; gender?: TTSVoiceInfo['gender'] }>;
   modelGroups: ModelVoiceGroup[]; // voices grouped by model
 }
 
@@ -172,6 +205,7 @@ export function getEnabledProvidersWithVoices(
           id: v.id,
           name: v.name,
           language: v.language,
+          gender: v.gender,
         })),
         ...(providerId === VOXCPM_TTS_PROVIDER_ID
           ? visibleVoxCPMProfiles.map((profile) => ({

--- a/lib/orchestration/registry/types.ts
+++ b/lib/orchestration/registry/types.ts
@@ -15,6 +15,8 @@ export interface AgentConfig {
   color: string; // UI theme color (hex)
   allowedActions: string[]; // Action types this agent can use
   priority: number; // Priority for director selection (1-10)
+  /** Vocal gender of the agent, used to bind it to a matching voice. */
+  gender?: 'male' | 'female' | 'neutral';
   voiceConfig?: { providerId: TTSProviderId; modelId?: string; voiceId: string }; // Per-agent TTS voice selection
   voiceDesign?: VoiceDesign; // 3-layer vocal descriptor for auto voice (provider-neutral)
 
@@ -37,6 +39,8 @@ export interface AgentTemplate {
   color: string;
   allowedActions: string[];
   priority: number;
+  /** Vocal gender of the agent, used to bind it to a matching voice. */
+  gender?: 'male' | 'female' | 'neutral';
   voiceConfig?: { providerId: TTSProviderId; modelId?: string; voiceId: string }; // Per-agent TTS voice selection
   voiceDesign?: VoiceDesign; // 3-layer vocal descriptor for auto voice (provider-neutral)
 

--- a/tests/audio/voice-resolver-gender.test.ts
+++ b/tests/audio/voice-resolver-gender.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The deterministic fallback (no override, no voiceConfig) narrows the pool to
+ * voices whose gender matches the agent before indexing into it.
+ *
+ * The fixture is ordered so that plain index round-robin returns a voice of the
+ * WRONG gender: every assertion here fails if the gender filter is removed.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
+import {
+  resolveAgentVoice,
+  inferAgentGender,
+  type ProviderWithVoices,
+} from '@/lib/audio/voice-resolver';
+
+const provider: ProviderWithVoices = {
+  providerId: 'minimax-tts',
+  providerName: 'MiniMax TTS',
+  voices: [
+    { id: 'male-a', name: '精英青年', gender: 'male' },
+    { id: 'female-b', name: '少女音色', gender: 'female' },
+    { id: 'male-c', name: '温润男声', gender: 'male' },
+    { id: 'neutral-d', name: 'Neutral', gender: 'neutral' },
+  ],
+  modelGroups: [],
+};
+
+const agent = (over: Partial<AgentConfig>) => ({ id: 'gen-1', ...over }) as AgentConfig;
+
+describe('resolveAgentVoice — gender-aware fallback', () => {
+  it('gives a female agent at index 0 a female voice, not the first voice in the list', () => {
+    const resolved = resolveAgentVoice(agent({ gender: 'female' }), 0, [provider]);
+    // Index round-robin would return 'male-a'.
+    expect(resolved).toEqual({ providerId: 'minimax-tts', voiceId: 'female-b' });
+  });
+
+  it('gives a male agent at index 1 a male voice, not the second voice in the list', () => {
+    const resolved = resolveAgentVoice(agent({ gender: 'male' }), 1, [provider]);
+    // Index round-robin would return 'female-b'; the male+neutral pool is
+    // [male-a, male-c, neutral-d] and index 1 lands on 'male-c'.
+    expect(resolved).toEqual({ providerId: 'minimax-tts', voiceId: 'male-c' });
+  });
+
+  it('still rotates across the matching voices as the index advances', () => {
+    const first = resolveAgentVoice(agent({ gender: 'female' }), 0, [provider]);
+    const second = resolveAgentVoice(agent({ gender: 'female' }), 1, [provider]);
+    expect(first?.voiceId).toBe('female-b');
+    expect(second?.voiceId).toBe('neutral-d');
+  });
+
+  it('keeps the plain index behaviour when the agent has no gender information', () => {
+    const resolved = resolveAgentVoice(agent({}), 1, [provider]);
+    expect(resolved).toEqual({ providerId: 'minimax-tts', voiceId: 'female-b' });
+  });
+
+  it('falls back to the full list when no voice matches the wanted gender', () => {
+    const maleOnly: ProviderWithVoices = {
+      ...provider,
+      voices: [{ id: 'male-a', name: '精英青年', gender: 'male' }],
+    };
+    const resolved = resolveAgentVoice(agent({ gender: 'female' }), 0, [maleOnly]);
+    expect(resolved).toEqual({ providerId: 'minimax-tts', voiceId: 'male-a' });
+  });
+
+  it('leaves a gender-less catalogue on the plain index behaviour', () => {
+    const unlabelled: ProviderWithVoices = {
+      ...provider,
+      voices: [
+        { id: 'v0', name: 'V0' },
+        { id: 'v1', name: 'V1' },
+      ],
+    };
+    const resolved = resolveAgentVoice(agent({ gender: 'female' }), 1, [unlabelled]);
+    expect(resolved).toEqual({ providerId: 'minimax-tts', voiceId: 'v1' });
+  });
+});
+
+describe('inferAgentGender', () => {
+  it('prefers the explicit field over the voiceDesign prose', () => {
+    expect(
+      inferAgentGender(
+        agent({
+          gender: 'female',
+          voiceDesign: { identity: 'middle-aged male teacher', texture: '', delivery: '' },
+        }),
+      ),
+    ).toBe('female');
+  });
+
+  it('reads the English voiceDesign identity when there is no explicit field', () => {
+    expect(
+      inferAgentGender(
+        agent({
+          voiceDesign: { identity: 'middle-aged female teacher', texture: '', delivery: '' },
+        }),
+      ),
+    ).toBe('female');
+  });
+
+  it('does not read "male" out of "female"', () => {
+    expect(
+      inferAgentGender(
+        agent({ voiceDesign: { identity: 'young female student', texture: '', delivery: '' } }),
+      ),
+    ).toBe('female');
+  });
+
+  it('returns undefined for neutral, ambiguous, or absent information', () => {
+    expect(inferAgentGender(agent({ gender: 'neutral' }))).toBeUndefined();
+    expect(
+      inferAgentGender(
+        agent({ voiceDesign: { identity: 'a male or female voice', texture: '', delivery: '' } }),
+      ),
+    ).toBeUndefined();
+    expect(inferAgentGender(agent({}))).toBeUndefined();
+  });
+
+  it('returns undefined for a non-English identity rather than guessing', () => {
+    // The generator writes voiceDesign in the course language; this is exactly
+    // why the explicit `gender` field exists.
+    expect(
+      inferAgentGender(
+        agent({ voiceDesign: { identity: 'professora de meia-idade', texture: '', delivery: '' } }),
+      ),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Generated agents were regularly given a voice of the wrong gender — a female-named teacher speaking with a male voice. This passes the registry's voice `gender` through to the profile generator, has the generator emit an explicit per-agent `gender`, and uses it to narrow the deterministic fallback pool.

## Related Issues

Closes #1084

## Changes

- `app/generation-preview/page.tsx`: include `voiceGender` in the voice list sent to `/api/generate/agent-profiles` (the registry had it; the payload dropped it).
- `app/api/generate/agent-profiles/route.ts`: expose each voice's `gender` to the model and require it to match the agent; ask for an explicit `gender` per agent in literal English values (`male`/`female`/`neutral`) so it survives the language directive; validate and pass it through.
- `lib/orchestration/registry/types.ts`: `gender` on the agent config.
- `lib/audio/voice-resolver.ts`: `inferAgentGender()`; the fallback now filters to matching (and `neutral`) voices before indexing, keeping the existing rotation.
- `tests/audio/voice-resolver-gender.test.ts`: new.

Existing behaviour is preserved where there is no gender information: an agent without one, or a catalogue whose voices carry none, still gets the plain index pick, and a pool with no match falls back to the full list.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Configure MiniMax TTS (its voice display names are Chinese) and generate a classroom in a non-Chinese language.
2. Inspect the generated agents' assigned voices against their names.

### What you personally verified

**End to end, on a live instance** (MiniMax `MiniMax-M3` + MiniMax TTS, course in European Portuguese). Called `/api/generate/agent-profiles` with five MiniMax voices whose display names are Chinese and whose genders differ, and checked every returned agent:

```
OK  Professora Lúcia   gender=female   voice=Chinese (Mandarin)_Warm_Girl   (voice is female)
OK  Tiago              gender=male     voice=male-qn-jingying               (voice is male)
OK  Sofia              gender=female   voice=female-shaonv                  (voice is female)
OK  Mateus             gender=male     voice=Chinese (Mandarin)_Gentleman   (voice is male)
```

4/4 consistent, with Portuguese names and Chinese voice names — the case that used to fail.

**Mutation-checked the fallback.** The new fixture is ordered so plain index round-robin returns the wrong gender. Removing the gender filter turns exactly the three tests that assert the new behaviour red, and leaves the three that pin the unchanged behaviour green:

```
× gives a female agent at index 0 a female voice, not the first voice in the list
× gives a male agent at index 1 a male voice, not the second voice in the list
× still rotates across the matching voices as the index advances
✓ keeps the plain index behaviour when the agent has no gender information
✓ falls back to the full list when no voice matches the wanted gender
✓ leaves a gender-less catalogue on the plain index behaviour
Tests  3 failed | 8 passed (11)
```

**Regression.** `tests/audio/` — 26 files, 160 tests, all passing. Full `tests/` suite on this branch matches the baseline on a clean `main` checkout: the only failures are the 16 pre-existing ones in `tests/ci/publish-openmaic-skill.test.ts`, which fail identically without this change. `prettier --check` and `eslint` clean; `tsc --noEmit` reports 0 errors outside `packages/@openmaic/*/test/**` (pre-existing, environment-related).

What I did **not** verify: providers other than MiniMax TTS (the change is provider-agnostic and reads only the registry's `gender`, but I only exercised MiniMax against a live API), and I did not touch the separate issue that `voiceDesign` is ignored for every non-VoxCPM provider — see point 2 of #1084, which this PR deliberately leaves open.

### Evidence

See the agent table and the mutation output above.
