### PR TITLE
fix(editor): add npm provenance metadata

### DIFF
--- a/packages/@openmaic/editor/package.json
+++ b/packages/@openmaic/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/editor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Composable slide editing core, React surface, and UI for OpenMAIC.",
   "type": "module",
   "main": "./dist/core/index.js",
@@ -28,6 +28,11 @@
     "README.md",
     "LICENSE"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/THU-MAIC/OpenMAIC",
+    "directory": "packages/@openmaic/editor"
+  },
   "scripts": {
     "build": "rm -rf dist && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
     "test": "vitest run",

--- a/tests/packages/editor-manifest.test.ts
+++ b/tests/packages/editor-manifest.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const editorPackage = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL('../../packages/@openmaic/editor/package.json', import.meta.url)),
+    'utf8',
+  ),
+) as {
+  repository?: { type?: string; url?: string; directory?: string };
+  version?: string;
+};
+
+describe('@openmaic/editor publish manifest', () => {
+  it('declares provenance repository metadata at the next release version', () => {
+    expect(editorPackage.version).toBe('0.0.2');
+    expect(editorPackage.repository).toEqual({
+      type: 'git',
+      url: 'https://github.com/THU-MAIC/OpenMAIC',
+      directory: 'packages/@openmaic/editor',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add repository metadata required by npm provenance validation
- bump `@openmaic/editor` to `0.0.2` for the retry release
- add a manifest regression test

## Verification
- `pnpm exec vitest run tests/packages/editor-manifest.test.ts`
- `node scripts/check-package-version-bumps.mjs origin/main`
- `pnpm exec prettier --check packages/@openmaic/editor/package.json tests/packages/editor-manifest.test.ts`
- `git diff --check`