### PR TITLE
fix(agent): harden shared Pi transport contracts

### DIFF
--- a/lib/agent/runtime/build-agent.ts
+++ b/lib/agent/runtime/build-agent.ts
@@ -20,6 +20,7 @@ import {
 import type { Api, Model } from '@earendil-works/pi-ai';
 import { makeAllowlistGate } from './allowlist';
 import { makeQuotaHook } from './quota';
+import { hasLengthToolCallProvenance } from './stream-fn';
 import { V0_ALLOWLIST } from '../tools/registry';
 
 // pi needs *a* model object on state; the injected StreamFn ignores it and uses
@@ -59,7 +60,7 @@ export interface BuildAgentOptions {
 
 export function buildAgent(opts: BuildAgentOptions): Agent {
   const quotaHook = makeQuotaHook({ remaining: () => Number.MAX_SAFE_INTEGER });
-  return new Agent({
+  const agent = new Agent({
     streamFn: opts.streamFn,
     transformContext: opts.transformContext,
     convertToLlm: opts.convertToLlm,
@@ -74,16 +75,50 @@ export function buildAgent(opts: BuildAgentOptions): Agent {
     },
     beforeToolCall: makeAllowlistGate(opts.allowedToolNames ?? V0_ALLOWLIST),
     afterToolCall: async (context, signal) => {
-      const quotaResult = await quotaHook(context);
-      const requestResult = await opts.afterToolCall?.(context, signal);
-      if (!quotaResult && !requestResult) return undefined;
+      const markerIsError =
+        typeof context.result === 'object' &&
+        context.result !== null &&
+        Object.prototype.hasOwnProperty.call(context.result, 'isError') &&
+        (context.result as { isError?: unknown }).isError === true;
+      const baseIsError = context.isError || markerIsError;
+      const normalizedContext = baseIsError ? { ...context, isError: true } : context;
+      const quotaResult = await quotaHook(normalizedContext);
+      const requestResult = await opts.afterToolCall?.(normalizedContext, signal);
+      if (!quotaResult && !requestResult && !baseIsError) return undefined;
       return {
         ...quotaResult,
         ...requestResult,
+        isError: baseIsError || quotaResult?.isError === true || requestResult?.isError === true,
         terminate: quotaResult?.terminate === true || requestResult?.terminate === true,
       };
     },
   });
+
+  let terminalBarrierActive = false;
+  agent.subscribe((event) => {
+    if (
+      event.type === 'turn_end' &&
+      event.message.role === 'assistant' &&
+      event.message.stopReason === 'length' &&
+      hasLengthToolCallProvenance(event.message)
+    ) {
+      terminalBarrierActive = true;
+      agent.clearAllQueues();
+    } else if (event.type === 'agent_end') {
+      terminalBarrierActive = false;
+    }
+  });
+
+  const steer = agent.steer.bind(agent);
+  agent.steer = (message) => {
+    if (!terminalBarrierActive) steer(message);
+  };
+  const followUp = agent.followUp.bind(agent);
+  agent.followUp = (message) => {
+    if (!terminalBarrierActive) followUp(message);
+  };
+
+  return agent;
 }
 
 export function buildSystemPrompt(scene?: { id: string; title: string }): string {

--- a/lib/agent/runtime/stream-fn.ts
+++ b/lib/agent/runtime/stream-fn.ts
@@ -28,6 +28,8 @@ import {
   jsonSchema,
   stepCountIs,
   tool as aiTool,
+  type FinishReason,
+  type LanguageModelUsage,
   type LanguageModel,
   type ModelMessage,
   type ToolSet,
@@ -51,6 +53,7 @@ class LocalAssistantEventStream {
   private queue: AssistantMessageEvent[] = [];
   private waiting: ((r: IteratorResult<AssistantMessageEvent>) => void)[] = [];
   private done = false;
+  private started = false;
   private resolveFinal!: (m: AssistantMessage) => void;
   private finalPromise: Promise<AssistantMessage>;
 
@@ -62,6 +65,7 @@ class LocalAssistantEventStream {
 
   push(event: AssistantMessageEvent): void {
     if (this.done) return;
+    if (event.type === 'start') this.started = true;
     if (event.type === 'done') {
       this.done = true;
       this.resolveFinal(event.message);
@@ -72,6 +76,23 @@ class LocalAssistantEventStream {
     const waiter = this.waiting.shift();
     if (waiter) waiter({ value: event, done: false });
     else this.queue.push(event);
+  }
+
+  fail(error: unknown): void {
+    if (this.done) return;
+    const message: AssistantMessage = {
+      role: 'assistant',
+      content: [],
+      api: 'unknown' as AssistantMessage['api'],
+      provider: 'unknown' as AssistantMessage['provider'],
+      model: 'maic-connector',
+      usage: { ...EMPTY_USAGE },
+      stopReason: 'error',
+      errorMessage: errorMessage(error, 'LLM stream error'),
+      timestamp: Date.now(),
+    };
+    if (!this.started) this.push({ type: 'start', partial: message });
+    this.push({ type: 'error', reason: 'error', error: message });
   }
 
   async *[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
@@ -103,6 +124,17 @@ const EMPTY_USAGE = {
   totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+const lengthToolCallMessages = new WeakSet<AssistantMessage>();
+
+/**
+ * Identity-only provenance for the one terminal condition that needs the
+ * shared Agent queue barrier. This deliberately does not add a message field
+ * or any serializable transport metadata.
+ */
+export function hasLengthToolCallProvenance(message: AssistantMessage): boolean {
+  return lengthToolCallMessages.has(message);
+}
 
 export interface CallLlmStreamFnOptions {
   /** Resolved Vercel AI SDK model instance (from resolveModelFromRequest). */
@@ -211,7 +243,7 @@ export function createPartMapper(
 export function createCallLlmStreamFn(opts: CallLlmStreamFnOptions): StreamFn {
   return ((_piModel, context: PiContext, streamOptions?: SimpleStreamOptions) => {
     const stream = new LocalAssistantEventStream();
-    void pump(stream, context, opts, streamOptions);
+    void pump(stream, context, opts, streamOptions).catch((error) => stream.fail(error));
     return stream as unknown as AssistantMessageEventStream;
   }) as StreamFn;
 }
@@ -233,42 +265,14 @@ async function pump(
     timestamp: Date.now(),
   };
 
-  try {
-    const requestedMaxTokens = streamOptions?.maxTokens;
-    const maxOutputTokens =
-      opts.maxOutputTokens && requestedMaxTokens
-        ? Math.min(opts.maxOutputTokens, requestedMaxTokens)
-        : (requestedMaxTokens ?? opts.maxOutputTokens);
-    const result = streamLLM(
-      {
-        model: opts.languageModel,
-        system: context.systemPrompt,
-        messages: toModelMessages(context.messages, {
-          includeReasoning:
-            typeof opts.languageModel !== 'string' &&
-            opts.languageModel.provider === 'kimi.chat' &&
-            opts.languageModel.modelId === 'kimi-k3',
-        }),
-        tools: toAiTools(context.tools ?? []),
-        toolChoice: 'auto',
-        // pi's loop owns multi-step; one LLM turn per streamFn call.
-        stopWhen: stepCountIs(1),
-        maxOutputTokens,
-        abortSignal: opts.abortSignal ?? streamOptions?.signal,
-      },
-      opts.source ?? 'maic-agent',
-      opts.thinkingConfig,
-    );
+  stream.push({ type: 'start', partial });
 
-    stream.push({ type: 'start', partial });
+  const mapper = createPartMapper(partial, (event) => stream.push(event));
+  let settled = false;
+  let cleanupAbortListeners = () => {};
 
-    const mapper = createPartMapper(partial, (event) => stream.push(event));
-    for await (const part of result.fullStream as AsyncIterable<Record<string, unknown>>) {
-      mapper.handle(part);
-    }
-    mapper.finalize();
-
-    const usage = normalizeUsage(await result.usage);
+  const setUsage = (rawUsage: LanguageModelUsage | undefined): void => {
+    const usage = normalizeUsage(rawUsage);
     // AI SDK inputTokens includes cached input. Pi stores cached classes
     // separately, so subtract them before calculating its total.
     const uncachedInput = Math.max(
@@ -284,15 +288,186 @@ async function pump(
         uncachedInput + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreationTokens,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     };
+  };
 
-    const hasToolCall = partial.content.some((c) => (c as ToolCall).type === 'toolCall');
-    partial.stopReason = hasToolCall ? 'toolUse' : 'stop';
-    stream.push({ type: 'done', reason: hasToolCall ? 'toolUse' : 'stop', message: partial });
+  const removeExecutableToolCalls = (): void => {
+    partial.content = partial.content.filter((content) => content.type !== 'toolCall');
+  };
+
+  const settleError = (reason: 'error' | 'aborted', error: unknown): boolean => {
+    if (settled) return false;
+    settled = true;
+    mapper.finalize();
+    removeExecutableToolCalls();
+    partial.stopReason = reason;
+    partial.errorMessage = errorMessage(
+      error,
+      reason === 'aborted' ? 'Operation aborted' : 'LLM stream error',
+    );
+    cleanupAbortListeners();
+    stream.push({ type: 'error', reason, error: partial });
+    return true;
+  };
+
+  const settleFinish = (
+    finishReason: FinishReason | undefined,
+    totalUsage: LanguageModelUsage | undefined,
+  ): boolean => {
+    if (settled) return false;
+
+    const hasToolCall = partial.content.some((content) => content.type === 'toolCall');
+    mapper.finalize();
+    setUsage(totalUsage);
+
+    switch (finishReason) {
+      case 'length':
+        settled = true;
+        if (hasToolCall) lengthToolCallMessages.add(partial);
+        removeExecutableToolCalls();
+        partial.stopReason = 'length';
+        cleanupAbortListeners();
+        stream.push({ type: 'done', reason: 'length', message: partial });
+        return true;
+      case 'content-filter':
+      case 'error':
+      case 'other':
+        return settleError('error', `LLM stream finished with ${finishReason}`);
+      case 'tool-calls':
+        if (!hasToolCall) {
+          return settleError(
+            'error',
+            'LLM stream reported tool-calls without a complete parsed tool call',
+          );
+        }
+        settled = true;
+        partial.stopReason = 'toolUse';
+        cleanupAbortListeners();
+        stream.push({ type: 'done', reason: 'toolUse', message: partial });
+        return true;
+      case 'stop':
+        settled = true;
+        partial.stopReason = hasToolCall ? 'toolUse' : 'stop';
+        cleanupAbortListeners();
+        stream.push({
+          type: 'done',
+          reason: hasToolCall ? 'toolUse' : 'stop',
+          message: partial,
+        });
+        return true;
+      default:
+        return settleError('error', 'LLM stream finished with an invalid finish reason');
+    }
+  };
+
+  try {
+    const abortSources = [opts.abortSignal, streamOptions?.signal].filter(
+      (signal): signal is AbortSignal => signal !== undefined,
+    );
+    const preAborted = abortSources.find((signal) => signal.aborted);
+    if (preAborted) {
+      settleError('aborted', preAborted.reason);
+      return;
+    }
+
+    const combinedAbort = combineAbortSignals(abortSources);
+    const onAbort = () => {
+      settleError('aborted', combinedAbort.signal?.reason);
+    };
+    combinedAbort.signal?.addEventListener('abort', onAbort, { once: true });
+    cleanupAbortListeners = () => {
+      combinedAbort.signal?.removeEventListener('abort', onAbort);
+      combinedAbort.cleanup();
+    };
+    // Close the race between the pre-check and listener installation.
+    if (combinedAbort.signal?.aborted) {
+      settleError('aborted', combinedAbort.signal.reason);
+      return;
+    }
+
+    const requestedMaxTokens = streamOptions?.maxTokens;
+    const maxOutputTokens =
+      opts.maxOutputTokens && requestedMaxTokens
+        ? Math.min(opts.maxOutputTokens, requestedMaxTokens)
+        : (requestedMaxTokens ?? opts.maxOutputTokens);
+    const result = await streamLLM(
+      {
+        model: opts.languageModel,
+        system: context.systemPrompt,
+        messages: toModelMessages(context.messages, {
+          includeReasoning:
+            typeof opts.languageModel !== 'string' &&
+            opts.languageModel.provider === 'kimi.chat' &&
+            opts.languageModel.modelId === 'kimi-k3',
+        }),
+        tools: toAiTools(context.tools ?? []),
+        toolChoice: 'auto',
+        // pi's loop owns multi-step; one LLM turn per streamFn call.
+        stopWhen: stepCountIs(1),
+        maxOutputTokens,
+        abortSignal: combinedAbort.signal,
+      },
+      opts.source ?? 'maic-agent',
+      opts.thinkingConfig,
+    );
+
+    for await (const part of result.fullStream as AsyncIterable<Record<string, unknown>>) {
+      if (settled) break;
+      if (part.type === 'finish') {
+        settleFinish(
+          part.finishReason as FinishReason | undefined,
+          part.totalUsage as LanguageModelUsage | undefined,
+        );
+        break;
+      }
+      if (part.type === 'abort') {
+        settleError('aborted', part.reason);
+        break;
+      }
+      if (part.type === 'error') {
+        settleError('error', part.error);
+        break;
+      }
+      mapper.handle(part);
+    }
+    if (!settled) settleError('error', 'LLM stream ended without a terminal event');
   } catch (err) {
-    partial.stopReason = 'error';
-    partial.errorMessage = err instanceof Error ? err.message : String(err);
-    stream.push({ type: 'error', reason: 'error', error: partial });
+    settleError('error', err);
+  } finally {
+    cleanupAbortListeners();
   }
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === 'string' && error.trim()) return error;
+  return fallback;
+}
+
+function combineAbortSignals(signals: AbortSignal[]): {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+} {
+  if (signals.length === 0) return { signal: undefined, cleanup: () => {} };
+
+  const controller = new AbortController();
+  const listeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  for (const signal of signals) {
+    const listener = () => {
+      if (!controller.signal.aborted) controller.abort(signal.reason);
+    };
+    listeners.push({ signal, listener });
+    signal.addEventListener('abort', listener, { once: true });
+    if (signal.aborted) listener();
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const { signal, listener } of listeners) {
+        signal.removeEventListener('abort', listener);
+      }
+    },
+  };
 }
 
 /** pi Message[] -> AI SDK ModelMessage[]. */
@@ -341,7 +516,7 @@ export function toModelMessages(
             type: 'tool-result',
             toolCallId: m.toolCallId,
             toolName: m.toolName,
-            output: { type: 'text', value: text },
+            output: { type: m.isError ? 'error-text' : 'text', value: text },
           },
         ],
       } as unknown as ModelMessage);

--- a/tests/lib/agent/runtime/build-agent-runtime.test.ts
+++ b/tests/lib/agent/runtime/build-agent-runtime.test.ts
@@ -1,0 +1,382 @@
+import type { AgentMessage, AgentTool } from '@earendil-works/pi-agent-core';
+import { Type } from 'typebox';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
+
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+import { buildAgent } from '@/lib/agent/runtime/build-agent';
+import { createCallLlmStreamFn, hasLengthToolCallProvenance } from '@/lib/agent/runtime/stream-fn';
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+
+function finish(finishReason: string) {
+  return { type: 'finish', finishReason, totalUsage: ZERO_USAGE };
+}
+
+function toolCall(args: unknown = { value: 1 }) {
+  return {
+    type: 'tool-call',
+    toolCallId: 'call-1',
+    toolName: 'demo',
+    input: args,
+  };
+}
+
+function resultFrom(parts: Array<Record<string, unknown>>) {
+  return {
+    fullStream: (async function* () {
+      for (const part of parts) yield part;
+    })(),
+    usage: new Promise(() => {}),
+  };
+}
+
+function useResponses(responses: Array<Array<Record<string, unknown>>>) {
+  mocks.streamLLM.mockImplementation(() => {
+    const parts = responses.shift();
+    return resultFrom(
+      parts ?? [{ type: 'text-delta', text: 'unexpected transport' }, finish('stop')],
+    );
+  });
+}
+
+function userMessage(text: string): AgentMessage {
+  return { role: 'user', content: [{ type: 'text', text }], timestamp: Date.now() };
+}
+
+function makeTool(
+  execute: AgentTool<typeof DemoParams>['execute'] = async () => ({
+    content: [{ type: 'text', text: 'ok' }],
+    details: { source: 'tool' },
+  }),
+): AgentTool<typeof DemoParams> {
+  return {
+    name: 'demo',
+    label: 'Demo',
+    description: 'Test tool',
+    parameters: DemoParams,
+    execute,
+  };
+}
+
+const DemoParams = Type.Object({ value: Type.Number() });
+
+function makeAgent(options: {
+  tool?: AgentTool<typeof DemoParams>;
+  afterToolCall?: Parameters<typeof buildAgent>[0]['afterToolCall'];
+  allowedToolNames?: ReadonlySet<string>;
+}) {
+  return buildAgent({
+    streamFn: createCallLlmStreamFn({ languageModel: {} as never }),
+    systemPrompt: 'system',
+    tools: [options.tool ?? makeTool()],
+    allowedToolNames: options.allowedToolNames ?? new Set(['demo']),
+    afterToolCall: options.afterToolCall,
+  });
+}
+
+function transportMessages(index: number) {
+  const params = mocks.streamLLM.mock.calls[index]?.[0] as { messages?: unknown[] } | undefined;
+  return params?.messages ?? [];
+}
+
+function toolOutputType(index: number): unknown {
+  const toolMessage = transportMessages(index).find(
+    (message) => (message as { role?: string }).role === 'tool',
+  ) as { content?: Array<{ output?: { type?: string } }> } | undefined;
+  return toolMessage?.content?.[0]?.output?.type;
+}
+
+describe('buildAgent shared transport lifecycle', () => {
+  beforeEach(() => mocks.streamLLM.mockReset());
+
+  it('executes an ordinary toolUse once and continues through the same Agent loop', async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'tool success' }],
+      details: { source: 'tool' },
+    }));
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'complete' }, finish('stop')],
+    ]);
+    const agent = makeAgent({ tool: makeTool(execute) });
+
+    await agent.prompt('start');
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(toolOutputType(1)).toBe('text');
+  });
+
+  it('makes length plus parsed toolCall terminal and side-effect-free', async () => {
+    let actionCount = 0;
+    const execute = vi.fn(async () => {
+      actionCount += 1;
+      return {
+        content: [{ type: 'text' as const, text: 'must not run' }],
+        details: {},
+      };
+    });
+    const allowlistHas = vi.fn(() => true);
+    const allowedToolNames = { has: allowlistHas } as unknown as ReadonlySet<string>;
+    const afterToolCall = vi.fn();
+    useResponses([[toolCall(), finish('length')]]);
+    const agent = makeAgent({ tool: makeTool(execute), afterToolCall, allowedToolNames });
+
+    await agent.prompt('start');
+
+    const final = agent.state.messages.at(-1);
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(1);
+    expect(allowlistHas).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    expect(afterToolCall).not.toHaveBeenCalled();
+    expect(actionCount).toBe(0);
+    expect(final?.role).toBe('assistant');
+    if (final?.role !== 'assistant') throw new Error('expected assistant message');
+    expect(final.stopReason).toBe('length');
+    expect(final.content.some((content) => content.type === 'toolCall')).toBe(false);
+    expect(hasLengthToolCallProvenance(final)).toBe(true);
+    expect(JSON.stringify(final)).not.toContain('provenance');
+  });
+
+  it('clears undrained queues and silently suppresses terminal-window queue calls', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mocks.streamLLM.mockReturnValue({
+      fullStream: (async function* () {
+        await gate;
+        yield toolCall();
+        yield finish('length');
+      })(),
+      usage: new Promise(() => {}),
+    });
+    const agent = makeAgent({});
+    agent.followUp(userMessage('pre-run follow-up'));
+    agent.subscribe((event) => {
+      if (event.type !== 'turn_end') return;
+      expect(() => agent.steer(userMessage('listener steering'))).not.toThrow();
+      expect(() => agent.followUp(userMessage('listener follow-up'))).not.toThrow();
+    });
+
+    const prompt = agent.prompt('start');
+    await vi.waitFor(() => expect(mocks.streamLLM).toHaveBeenCalledTimes(1));
+    agent.steer(userMessage('streaming steering'));
+    agent.followUp(userMessage('streaming follow-up'));
+    release();
+    await prompt;
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(1);
+    expect(agent.hasQueuedMessages()).toBe(false);
+  });
+
+  it('keeps pre-run steering that Pi drains into the initial provider request', async () => {
+    useResponses([[toolCall(), finish('length')]]);
+    const agent = makeAgent({});
+    agent.steer(userMessage('pre-run steering'));
+
+    await agent.prompt('start');
+
+    const userText = transportMessages(0)
+      .filter((message) => (message as { role?: string }).role === 'user')
+      .map((message) => JSON.stringify(message))
+      .join(' ');
+    expect(userText).toContain('start');
+    expect(userText).toContain('pre-run steering');
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves existing queue semantics for plain length', async () => {
+    useResponses([
+      [{ type: 'text-delta', text: 'truncated' }, finish('length')],
+      [{ type: 'text-delta', text: 'follow-up complete' }, finish('stop')],
+    ]);
+    const agent = makeAgent({});
+    agent.followUp(userMessage('queued follow-up'));
+
+    await agent.prompt('start');
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    const firstAssistant = agent.state.messages.find(
+      (message) => message.role === 'assistant' && message.stopReason === 'length',
+    );
+    expect(firstAssistant?.role).toBe('assistant');
+    if (firstAssistant?.role !== 'assistant') throw new Error('expected assistant message');
+    expect(hasLengthToolCallProvenance(firstAssistant)).toBe(false);
+  });
+
+  it('restores queue methods after agent_end for the next independent run', async () => {
+    useResponses([
+      [toolCall(), finish('length')],
+      [{ type: 'text-delta', text: 'next run' }, finish('stop')],
+    ]);
+    const agent = makeAgent({});
+
+    await agent.prompt('start');
+    agent.followUp(userMessage('after agent end'));
+    expect(agent.hasQueuedMessages()).toBe(true);
+    await agent.continue();
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(agent.hasQueuedMessages()).toBe(false);
+  });
+
+  it('normalizes only an own boolean isError true before caller hooks', async () => {
+    const details = { source: 'existing-tool' };
+    const execute = vi.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'existing failure' }],
+      details,
+      isError: true,
+    }));
+    const afterToolCall = vi.fn((context: { isError: boolean }) => {
+      expect(context.isError).toBe(true);
+      return { isError: false };
+    });
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'acknowledged' }, finish('stop')],
+    ]);
+    const agent = makeAgent({
+      tool: makeTool(execute as never),
+      afterToolCall: afterToolCall as never,
+    });
+
+    await agent.prompt('start');
+
+    const toolResult = agent.state.messages.find((message) => message.role === 'toolResult');
+    expect(afterToolCall).toHaveBeenCalledTimes(1);
+    expect(toolResult).toMatchObject({
+      role: 'toolResult',
+      isError: true,
+      content: [{ type: 'text', text: 'existing failure' }],
+      details,
+    });
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(toolOutputType(1)).toBe('error-text');
+  });
+
+  it.each([
+    {
+      name: 'inherited marker',
+      makeResult: () =>
+        Object.assign(Object.create({ isError: true }), {
+          content: [{ type: 'text' as const, text: 'not an error' }],
+          details: {},
+        }),
+    },
+    {
+      name: 'nested marker',
+      makeResult: () => ({
+        content: [{ type: 'text' as const, text: 'not an error' }],
+        details: { isError: true },
+      }),
+    },
+    {
+      name: 'truthy string marker',
+      makeResult: () => ({
+        content: [{ type: 'text' as const, text: 'not an error' }],
+        details: {},
+        isError: 'true',
+      }),
+    },
+    {
+      name: 'numeric marker',
+      makeResult: () => ({
+        content: [{ type: 'text' as const, text: 'not an error' }],
+        details: {},
+        isError: 1,
+      }),
+    },
+    {
+      name: 'own boolean false marker',
+      makeResult: () => ({
+        content: [{ type: 'text' as const, text: 'not an error' }],
+        details: {},
+        isError: false,
+      }),
+    },
+    {
+      name: 'error-like text',
+      makeResult: () => ({
+        content: [{ type: 'text' as const, text: 'ERROR: looks bad' }],
+        details: {},
+      }),
+    },
+  ])('does not infer failure from $name', async ({ makeResult }) => {
+    const observed: boolean[] = [];
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'complete' }, finish('stop')],
+    ]);
+    const agent = makeAgent({
+      tool: makeTool(vi.fn(async () => makeResult()) as never),
+      afterToolCall: (context) => {
+        observed.push(context.isError);
+        return undefined;
+      },
+    });
+
+    await agent.prompt('start');
+
+    expect(observed).toEqual([false]);
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(toolOutputType(1)).toBe('text');
+  });
+
+  it('keeps caller error promotion monotonic for an ordinary success', async () => {
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'complete' }, finish('stop')],
+    ]);
+    const agent = makeAgent({ afterToolCall: () => ({ isError: true }) });
+
+    await agent.prompt('start');
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(toolOutputType(1)).toBe('error-text');
+  });
+
+  it.each(['handler throw', 'schema rejection', 'hook throw'] as const)(
+    'encodes Pi-recognized failure from %s as error-text',
+    async (caseName) => {
+      const execute =
+        caseName === 'handler throw'
+          ? vi.fn(async () => {
+              throw new Error('handler failed');
+            })
+          : vi.fn(async () => ({
+              content: [{ type: 'text' as const, text: 'ok' }],
+              details: {},
+            }));
+      useResponses([
+        [
+          toolCall(caseName === 'schema rejection' ? { value: 'bad' } : undefined),
+          finish('tool-calls'),
+        ],
+        [{ type: 'text-delta', text: 'complete' }, finish('stop')],
+      ]);
+      const agent = makeAgent({
+        tool: makeTool(execute as never),
+        afterToolCall:
+          caseName === 'hook throw'
+            ? () => {
+                throw new Error('hook failed');
+              }
+            : undefined,
+      });
+
+      await agent.prompt('start');
+
+      if (caseName === 'schema rejection') expect(execute).not.toHaveBeenCalled();
+      expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+      expect(toolOutputType(1)).toBe('error-text');
+    },
+  );
+});

--- a/tests/lib/agent/runtime/director-transport-consumer.test.ts
+++ b/tests/lib/agent/runtime/director-transport-consumer.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
+import type { StatelessChatRequest, StatelessEvent } from '@/lib/types/chat';
+
+const mocks = vi.hoisted(() => ({
+  streamLLM: vi.fn(),
+  injectOwnErrorWithOkStatus: false,
+}));
+
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+vi.mock('@/lib/chat/pi/tools/read-scene', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/chat/pi/tools/read-scene')>();
+  return {
+    ...actual,
+    buildReadSceneTool: vi.fn((options: Parameters<typeof actual.buildReadSceneTool>[0]) => {
+      const tool = actual.buildReadSceneTool(options);
+      const execute = tool.execute.bind(tool);
+      return {
+        ...tool,
+        execute: async (...args: Parameters<typeof tool.execute>) => {
+          if (!mocks.injectOwnErrorWithOkStatus) return execute(...args);
+          return {
+            content: [{ type: 'text' as const, text: 'Synthetic own-marker failure.' }],
+            details: {
+              status: 'ok' as const,
+              sceneId: 'synthetic-marker',
+              source: 'request_start_snapshot' as const,
+              truncated: false as const,
+            },
+            isError: true,
+          };
+        },
+      };
+    }),
+  };
+});
+
+import { runPiDirectorLoop } from '@/lib/chat/pi/director-loop';
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+const resolvedModel = { provider: 'test.provider', modelId: 'director-model' };
+const teacher: AgentConfig = {
+  id: 'teacher-1',
+  name: 'Teacher',
+  role: 'teacher',
+  persona: 'Teach clearly.',
+  avatar: '',
+  color: '#3366ff',
+  allowedActions: [],
+  priority: 10,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  isDefault: true,
+};
+
+function finish(finishReason: string) {
+  return { type: 'finish', finishReason, totalUsage: ZERO_USAGE };
+}
+
+function resultFrom(parts: Array<Record<string, unknown>>) {
+  return {
+    fullStream: (async function* () {
+      for (const part of parts) yield part;
+    })(),
+    usage: new Promise(() => {}),
+  };
+}
+
+function makeBody(): StatelessChatRequest {
+  return {
+    messages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Read the missing scene.' }],
+      },
+    ],
+    storeState: {
+      stage: { id: 'stage-1', name: 'Transport test', createdAt: 1, updatedAt: 2 },
+      outlines: [],
+      scenes: [],
+      currentSceneId: null,
+      mode: 'autonomous',
+      whiteboardOpen: false,
+    },
+    config: { agentIds: [teacher.id], agentConfigs: [teacher] },
+    apiKey: '',
+  } as StatelessChatRequest;
+}
+
+function toolOutput(callIndex: number): { type?: string; value?: string } | undefined {
+  const params = mocks.streamLLM.mock.calls[callIndex]?.[0] as
+    | { messages?: Array<Record<string, unknown>> }
+    | undefined;
+  const toolMessage = params?.messages?.find((message) => message.role === 'tool') as
+    | { content?: Array<{ output?: { type?: string; value?: string } }> }
+    | undefined;
+  return toolMessage?.content?.[0]?.output;
+}
+
+describe('Director shared Pi transport consumer', () => {
+  beforeEach(() => {
+    mocks.streamLLM.mockReset();
+    mocks.injectOwnErrorWithOkStatus = false;
+  });
+
+  it('uses the resolved chat model and traces a normalized evidence failure unchanged', async () => {
+    mocks.streamLLM
+      .mockReturnValueOnce(
+        resultFrom([
+          {
+            type: 'tool-call',
+            toolCallId: 'director-read',
+            toolName: 'read_scene',
+            input: { sceneId: 'missing-scene' },
+          },
+          finish('tool-calls'),
+        ]),
+      )
+      .mockReturnValueOnce(
+        resultFrom([
+          { type: 'text-delta', text: 'The requested scene does not exist.' },
+          finish('stop'),
+        ]),
+      );
+    const events: StatelessEvent[] = [];
+    const abortController = new AbortController();
+
+    await runPiDirectorLoop({
+      body: makeBody(),
+      agentConfigs: [teacher],
+      send: async (event) => {
+        events.push(event);
+      },
+      languageModel: resolvedModel as never,
+      thinkingConfig: { mode: 'disabled', enabled: false },
+      maxOutputTokens: 640,
+      abortSignal: abortController.signal,
+      signal: abortController.signal,
+      maxAgentTurns: 2,
+      maxActionsPerAgent: 1,
+      enableWhiteboardTools: false,
+      enableWebSearch: false,
+    });
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(mocks.streamLLM.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ model: resolvedModel, maxOutputTokens: 640 }),
+    );
+    expect(mocks.streamLLM.mock.calls[0]?.[1]).toBe('pi-chat-director');
+    expect(toolOutput(1)).toEqual({
+      type: 'error-text',
+      value: expect.stringContaining('was not found in the request-start course snapshot'),
+    });
+
+    const done = events.find((event) => event.type === 'done');
+    expect(done?.type).toBe('done');
+    if (done?.type !== 'done') throw new Error('expected done event');
+    expect(done.data.directorToolTrace).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        toolName: 'read_scene',
+        args: { sceneId: 'missing-scene' },
+        isError: true,
+        resultPreview: expect.stringContaining('was not found'),
+        details: {
+          status: 'not_found',
+          sceneId: 'missing-scene',
+          source: 'request_start_snapshot',
+          truncated: false,
+        },
+      }),
+    ]);
+  });
+
+  it('sees own-marker normalization before the Director evidence fallback', async () => {
+    mocks.injectOwnErrorWithOkStatus = true;
+    mocks.streamLLM
+      .mockReturnValueOnce(
+        resultFrom([
+          {
+            type: 'tool-call',
+            toolCallId: 'director-marker',
+            toolName: 'read_scene',
+            input: { sceneId: 'synthetic-marker' },
+          },
+          finish('tool-calls'),
+        ]),
+      )
+      .mockReturnValueOnce(
+        resultFrom([{ type: 'text-delta', text: 'Failure acknowledged.' }, finish('stop')]),
+      );
+    const events: StatelessEvent[] = [];
+    const abortController = new AbortController();
+
+    await runPiDirectorLoop({
+      body: makeBody(),
+      agentConfigs: [teacher],
+      send: async (event) => {
+        events.push(event);
+      },
+      languageModel: resolvedModel as never,
+      thinkingConfig: { mode: 'disabled', enabled: false },
+      maxOutputTokens: 640,
+      abortSignal: abortController.signal,
+      signal: abortController.signal,
+      maxAgentTurns: 2,
+      maxActionsPerAgent: 1,
+      enableWhiteboardTools: false,
+      enableWebSearch: false,
+    });
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(toolOutput(1)).toEqual({
+      type: 'error-text',
+      value: 'Synthetic own-marker failure.',
+    });
+
+    const done = events.find((event) => event.type === 'done');
+    expect(done?.type).toBe('done');
+    if (done?.type !== 'done') throw new Error('expected done event');
+    expect(done.data.directorToolTrace).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        toolName: 'read_scene',
+        args: { sceneId: 'synthetic-marker' },
+        isError: true,
+        resultPreview: 'Synthetic own-marker failure.',
+        details: {
+          status: 'ok',
+          sceneId: 'synthetic-marker',
+          source: 'request_start_snapshot',
+          truncated: false,
+        },
+      }),
+    ]);
+  });
+});

--- a/tests/lib/agent/runtime/editor-transport-consumer.test.ts
+++ b/tests/lib/agent/runtime/editor-transport-consumer.test.ts
@@ -1,0 +1,180 @@
+import type { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolveModelFromRequest: vi.fn(),
+  streamLLM: vi.fn(),
+  callLLM: vi.fn(),
+}));
+
+vi.mock('@/lib/server/resolve-model', () => ({
+  resolveModelFromRequest: mocks.resolveModelFromRequest,
+}));
+
+vi.mock('@/lib/ai/llm', () => ({
+  streamLLM: mocks.streamLLM,
+  callLLM: mocks.callLLM,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { POST } from '@/app/api/agent/edit/route';
+
+const EDITOR_FLAG = 'NEXT_PUBLIC_MAIC_EDITOR_ENABLED';
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+const resolvedModel = { provider: 'test.provider', modelId: 'editor-model' };
+let originalEditorFlag: string | undefined;
+
+function finish(finishReason: string) {
+  return { type: 'finish', finishReason, totalUsage: ZERO_USAGE };
+}
+
+function resultFrom(parts: Array<Record<string, unknown>>) {
+  return {
+    fullStream: (async function* () {
+      for (const part of parts) yield part;
+    })(),
+    usage: new Promise(() => {}),
+  };
+}
+
+function makeRequest(): NextRequest {
+  return new Request('http://localhost/api/agent/edit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: 'Read the current slide.',
+      scene: { id: 'missing-scene', title: 'Missing' },
+      sceneContextMap: {},
+    }),
+  }) as unknown as NextRequest;
+}
+
+async function readSseEvents(response: Response): Promise<Array<Record<string, unknown>>> {
+  const body = await response.text();
+  return body
+    .split('\n\n')
+    .filter((chunk) => chunk.startsWith('data: '))
+    .map((chunk) => JSON.parse(chunk.slice('data: '.length)) as Record<string, unknown>);
+}
+
+function toolOutputType(callIndex: number): unknown {
+  const params = mocks.streamLLM.mock.calls[callIndex]?.[0] as
+    | { messages?: Array<Record<string, unknown>> }
+    | undefined;
+  const toolMessage = params?.messages?.find((message) => message.role === 'tool') as
+    | { content?: Array<{ output?: { type?: string } }> }
+    | undefined;
+  return toolMessage?.content?.[0]?.output?.type;
+}
+
+describe('Editor shared Pi transport consumer', () => {
+  beforeEach(() => {
+    originalEditorFlag = process.env[EDITOR_FLAG];
+    process.env[EDITOR_FLAG] = 'true';
+    mocks.resolveModelFromRequest.mockReset();
+    mocks.streamLLM.mockReset();
+    mocks.callLLM.mockReset();
+    mocks.resolveModelFromRequest.mockResolvedValue({
+      model: resolvedModel,
+      modelInfo: { outputWindow: 512 },
+      modelString: 'test:editor-model',
+      providerId: 'test',
+      modelId: 'editor-model',
+      apiKey: '',
+      thinkingConfig: { mode: 'disabled', enabled: false },
+    });
+  });
+
+  afterEach(() => {
+    if (originalEditorFlag === undefined) delete process.env[EDITOR_FLAG];
+    else process.env[EDITOR_FLAG] = originalEditorFlag;
+  });
+
+  it('uses the resolved maic-agent model and carries a strict tool failure as error-text', async () => {
+    mocks.streamLLM
+      .mockReturnValueOnce(
+        resultFrom([
+          {
+            type: 'tool-call',
+            toolCallId: 'editor-read',
+            toolName: 'read_scene_content',
+            input: { sceneId: 'missing-scene' },
+          },
+          finish('tool-calls'),
+        ]),
+      )
+      .mockReturnValueOnce(
+        resultFrom([{ type: 'text-delta', text: 'The scene is unavailable.' }, finish('stop')]),
+      );
+
+    const response = await POST(makeRequest());
+    const events = await readSseEvents(response);
+
+    expect(response.status).toBe(200);
+    expect(mocks.resolveModelFromRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveModelFromRequest.mock.calls[0]?.[2]).toBe('maic-agent');
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    expect(mocks.streamLLM.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ model: resolvedModel, maxOutputTokens: 512 }),
+    );
+    expect(mocks.streamLLM.mock.calls[0]?.[1]).toBe('maic-agent');
+    expect(toolOutputType(1)).toBe('error-text');
+    expect(mocks.callLLM).not.toHaveBeenCalled();
+
+    const toolEnd = events.find((event) => event.type === 'tool_execution_end') as
+      | { isError?: boolean; result?: { content?: unknown; details?: unknown } }
+      | undefined;
+    expect(toolEnd).toMatchObject({
+      isError: true,
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: expect.stringContaining('scene context not found'),
+          },
+        ],
+        details: {
+          sceneId: 'missing-scene',
+          title: '',
+          type: '',
+        },
+      },
+    });
+  });
+
+  it('propagates response cancellation into the active OpenMAIC transport', async () => {
+    let transportSignal: AbortSignal | undefined;
+    mocks.streamLLM.mockImplementation((params: { abortSignal?: AbortSignal }) => {
+      transportSignal = params.abortSignal;
+      return {
+        fullStream: (async function* () {
+          if (!transportSignal?.aborted) {
+            await new Promise<void>((resolve) =>
+              transportSignal?.addEventListener('abort', () => resolve(), { once: true }),
+            );
+          }
+          yield { type: 'abort', reason: 'editor response cancelled' };
+        })(),
+        usage: new Promise(() => {}),
+      };
+    });
+
+    const response = await POST(makeRequest());
+    await vi.waitFor(() => expect(mocks.streamLLM).toHaveBeenCalledTimes(1));
+    await response.body?.cancel();
+
+    expect(transportSignal?.aborted).toBe(true);
+  });
+});

--- a/tests/lib/agent/runtime/legacy-child-transport-consumer.test.ts
+++ b/tests/lib/agent/runtime/legacy-child-transport-consumer.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfig } from '@/lib/orchestration/registry/types';
+import type { AgentTurnSummary } from '@/lib/orchestration/types';
+import type { StatelessChatRequest, StatelessEvent } from '@/lib/types/chat';
+
+const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
+
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+import { buildCallAgentTool } from '@/lib/chat/pi/tools/call-agent';
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+const resolvedModel = { provider: 'test.provider', modelId: 'child-model' };
+const teacher: AgentConfig = {
+  id: 'teacher-1',
+  name: 'Teacher',
+  role: 'teacher',
+  persona: 'Teach clearly.',
+  avatar: '',
+  color: '#3366ff',
+  allowedActions: ['wb_open'],
+  priority: 10,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  isDefault: true,
+};
+
+function finish(finishReason: string) {
+  return { type: 'finish', finishReason, totalUsage: ZERO_USAGE };
+}
+
+function parsedToolCall() {
+  return {
+    type: 'tool-call',
+    toolCallId: 'unexpected-pi-tool',
+    toolName: 'unexpected_tool',
+    input: {},
+  };
+}
+
+function resultFrom(parts: Array<Record<string, unknown>>) {
+  return {
+    fullStream: (async function* () {
+      for (const part of parts) yield part;
+    })(),
+    usage: new Promise(() => {}),
+  };
+}
+
+function makeBody(): StatelessChatRequest {
+  return {
+    messages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Open the whiteboard.' }],
+      },
+    ],
+    storeState: {
+      stage: {
+        id: 'stage-1',
+        name: 'Transport test',
+        createdAt: 1,
+        updatedAt: 2,
+        whiteboard: [],
+      },
+      outlines: [],
+      scenes: [
+        {
+          id: 'scene-1',
+          stageId: 'stage-1',
+          title: 'Lesson',
+          order: 1,
+          type: 'slide',
+          content: { type: 'slide', canvas: { elements: [] } as never },
+        },
+      ],
+      currentSceneId: 'scene-1',
+      mode: 'autonomous',
+      whiteboardOpen: false,
+    },
+    config: { agentIds: [teacher.id], agentConfigs: [teacher] },
+    apiKey: '',
+  } as StatelessChatRequest;
+}
+
+function makeHarness() {
+  const events: StatelessEvent[] = [];
+  const summaries: AgentTurnSummary[] = [];
+  const onActionDone = vi.fn();
+  const abortController = new AbortController();
+  const tool = buildCallAgentTool({
+    body: makeBody(),
+    agentConfigs: [teacher],
+    send: async (event) => {
+      events.push(event);
+    },
+    languageModel: resolvedModel as never,
+    onAgentDone: (summary) => summaries.push(summary),
+    onActionDone,
+    thinkingConfig: { mode: 'disabled', enabled: false },
+    maxOutputTokens: 384,
+    abortSignal: abortController.signal,
+    maxAgentTurns: 3,
+    getAgentTurnCount: () => summaries.length,
+    getAgentResponses: () => summaries,
+    getWhiteboardLedger: () => [],
+    maxActionsPerAgent: 2,
+    enableWhiteboardTools: true,
+  });
+  return { events, summaries, onActionDone, tool };
+}
+
+async function execute(harness: ReturnType<typeof makeHarness>) {
+  return harness.tool.execute('delegate-1', {
+    agentId: teacher.id,
+    instruction: 'Teach briefly.',
+  });
+}
+
+function actionOutput(text = 'I opened the board.') {
+  return JSON.stringify([
+    { type: 'action', name: 'wb_open', params: {} },
+    { type: 'text', content: text },
+  ]);
+}
+
+describe('Legacy Pi Child shared transport consumer', () => {
+  beforeEach(() => mocks.streamLLM.mockReset());
+
+  it('makes length plus a parsed Pi tool call terminal without action or continuation', async () => {
+    mocks.streamLLM.mockReturnValue(resultFrom([parsedToolCall(), finish('length')]));
+    const harness = makeHarness();
+
+    await execute(harness);
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(1);
+    expect(mocks.streamLLM.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ model: resolvedModel, maxOutputTokens: 384 }),
+    );
+    expect(mocks.streamLLM.mock.calls[0]?.[1]).toBe('pi-chat-child');
+    expect(harness.onActionDone).not.toHaveBeenCalled();
+    expect(harness.events.filter((event) => event.type === 'action')).toEqual([]);
+    expect(harness.summaries).toEqual([
+      expect.objectContaining({ agentId: teacher.id, actionCount: 0, contentPreview: '' }),
+    ]);
+  });
+
+  it('preserves ordinary streamed-text action accounting through the real shared loop', async () => {
+    mocks.streamLLM.mockReturnValue(
+      resultFrom([{ type: 'text-delta', text: actionOutput() }, finish('stop')]),
+    );
+    const harness = makeHarness();
+
+    const result = await execute(harness);
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(1);
+    expect(harness.events.filter((event) => event.type === 'action')).toEqual([
+      expect.objectContaining({ data: expect.objectContaining({ actionName: 'wb_open' }) }),
+    ]);
+    expect(harness.onActionDone).toHaveBeenCalledTimes(1);
+    expect(harness.summaries).toEqual([
+      expect.objectContaining({
+        agentId: teacher.id,
+        actionCount: 1,
+        contentPreview: 'I opened the board.',
+      }),
+    ]);
+    expect(result.details).toEqual(
+      expect.objectContaining({ text: 'I opened the board.', actionWarnings: [] }),
+    );
+  });
+
+  it('does not roll back a streamed Legacy action seen before length plus parsed toolCall', async () => {
+    mocks.streamLLM.mockReturnValue(
+      resultFrom([
+        { type: 'text-delta', text: actionOutput('Action arrived before truncation.') },
+        parsedToolCall(),
+        finish('length'),
+      ]),
+    );
+    const harness = makeHarness();
+
+    await execute(harness);
+
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(1);
+    expect(harness.onActionDone).toHaveBeenCalledTimes(1);
+    expect(harness.events.filter((event) => event.type === 'action')).toHaveLength(1);
+    expect(harness.summaries).toEqual([
+      expect.objectContaining({
+        agentId: teacher.id,
+        actionCount: 1,
+        contentPreview: 'Action arrived before truncation.',
+      }),
+    ]);
+  });
+});

--- a/tests/lib/agent/runtime/stream-fn-contract.test.ts
+++ b/tests/lib/agent/runtime/stream-fn-contract.test.ts
@@ -1,0 +1,305 @@
+import type { AssistantMessageEvent, SimpleStreamOptions } from '@earendil-works/pi-ai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
+
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+import { createCallLlmStreamFn, hasLengthToolCallProvenance } from '@/lib/agent/runtime/stream-fn';
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+
+function finish(finishReason: unknown) {
+  return { type: 'finish', finishReason, totalUsage: ZERO_USAGE };
+}
+
+function toolCall() {
+  return {
+    type: 'tool-call',
+    toolCallId: 'call-1',
+    toolName: 'demo',
+    input: { value: 1 },
+  };
+}
+
+function resultFrom(parts: Array<Record<string, unknown>>) {
+  return {
+    fullStream: (async function* () {
+      for (const part of parts) yield part;
+    })(),
+    usage: new Promise(() => {}),
+  };
+}
+
+async function collect(
+  parts: Array<Record<string, unknown>>,
+  options: { outerSignal?: AbortSignal; streamOptions?: SimpleStreamOptions } = {},
+) {
+  mocks.streamLLM.mockReturnValue(resultFrom(parts));
+  const streamFn = createCallLlmStreamFn({
+    languageModel: {} as never,
+    abortSignal: options.outerSignal,
+  });
+  const stream = await streamFn(
+    {} as never,
+    { systemPrompt: 'system', messages: [], tools: [] },
+    options.streamOptions,
+  );
+  const events: AssistantMessageEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return { events, message: await stream.result() };
+}
+
+describe('createCallLlmStreamFn terminal contract', () => {
+  beforeEach(() => mocks.streamLLM.mockReset());
+
+  it.each([
+    { name: 'plain stop', reason: 'stop', withTool: false, stopReason: 'stop', event: 'done' },
+    {
+      name: 'stop upgraded by a parsed tool call',
+      reason: 'stop',
+      withTool: true,
+      stopReason: 'toolUse',
+      event: 'done',
+    },
+    {
+      name: 'tool-calls with a parsed tool call',
+      reason: 'tool-calls',
+      withTool: true,
+      stopReason: 'toolUse',
+      event: 'done',
+    },
+    {
+      name: 'tool-calls without a parsed tool call',
+      reason: 'tool-calls',
+      withTool: false,
+      stopReason: 'error',
+      event: 'error',
+    },
+    {
+      name: 'plain length',
+      reason: 'length',
+      withTool: false,
+      stopReason: 'length',
+      event: 'done',
+    },
+    {
+      name: 'length with a parsed tool call',
+      reason: 'length',
+      withTool: true,
+      stopReason: 'length',
+      event: 'done',
+    },
+    {
+      name: 'content filter',
+      reason: 'content-filter',
+      withTool: true,
+      stopReason: 'error',
+      event: 'error',
+    },
+    {
+      name: 'provider error finish',
+      reason: 'error',
+      withTool: true,
+      stopReason: 'error',
+      event: 'error',
+    },
+    {
+      name: 'other finish',
+      reason: 'other',
+      withTool: true,
+      stopReason: 'error',
+      event: 'error',
+    },
+    {
+      name: 'malformed finish',
+      reason: 'future-reason',
+      withTool: true,
+      stopReason: 'error',
+      event: 'error',
+    },
+  ])('$name maps deterministically', async ({ reason, withTool, stopReason, event }) => {
+    const parts = [
+      { type: 'text-delta', text: 'visible' },
+      ...(withTool ? [toolCall()] : []),
+      finish(reason),
+    ];
+
+    const { events, message } = await collect(parts);
+    const terminal = events.filter(
+      (candidate) => candidate.type === 'done' || candidate.type === 'error',
+    );
+
+    expect(events[0]?.type).toBe('start');
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0]?.type).toBe(event);
+    if (terminal[0]?.type === 'done') expect(terminal[0].message).toBe(message);
+    if (terminal[0]?.type === 'error') expect(terminal[0].error).toBe(message);
+    expect(message.stopReason).toBe(stopReason);
+    if (event === 'error') expect(message.errorMessage?.length).toBeGreaterThan(0);
+
+    const finalToolCalls = message.content.filter((content) => content.type === 'toolCall');
+    const toolCallsRemain = stopReason === 'toolUse';
+    expect(finalToolCalls).toHaveLength(toolCallsRemain ? 1 : 0);
+    expect(hasLengthToolCallProvenance(message)).toBe(reason === 'length' && withTool);
+  });
+
+  it('uses only the top-level finish part as finish authority', async () => {
+    const { message } = await collect([
+      { type: 'finish-step', finishReason: 'length' },
+      { type: 'text-delta', text: 'answer' },
+      finish('stop'),
+    ]);
+
+    expect(message.stopReason).toBe('stop');
+  });
+
+  it('fails closed when fullStream ends without a terminal part', async () => {
+    const { events, message } = await collect([{ type: 'text-delta', text: 'partial' }]);
+
+    expect(events.at(-1)?.type).toBe('error');
+    expect(message.stopReason).toBe('error');
+    expect(message.errorMessage).toContain('without a terminal event');
+  });
+
+  it('maps top-level abort and error parts to the Pi error channel', async () => {
+    const aborted = await collect([{ type: 'abort', reason: 'provider cancelled' }]);
+    const failed = await collect([{ type: 'error', error: new Error('provider failed') }]);
+
+    expect(aborted.message).toMatchObject({
+      stopReason: 'aborted',
+      errorMessage: 'provider cancelled',
+    });
+    expect(aborted.events.at(-1)).toMatchObject({ type: 'error', reason: 'aborted' });
+    expect(failed.message).toMatchObject({ stopReason: 'error', errorMessage: 'provider failed' });
+    expect(failed.events.at(-1)).toMatchObject({ type: 'error', reason: 'error' });
+  });
+
+  it('returns a protocol stream when provider stream setup fails', async () => {
+    mocks.streamLLM.mockReturnValue({
+      fullStream: (async function* () {
+        throw new Error('request setup failed');
+      })(),
+      usage: new Promise(() => {}),
+    });
+    const streamFn = createCallLlmStreamFn({ languageModel: {} as never });
+
+    let returned: ReturnType<typeof streamFn> | undefined;
+    expect(() => {
+      returned = streamFn({} as never, { systemPrompt: 'system', messages: [], tools: [] }, {});
+    }).not.toThrow();
+    const stream = await returned!;
+    const events: AssistantMessageEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    // Keep the result assertion separate from stream iteration so a request
+    // setup exception can only be observed through the Pi protocol.
+    const finalMessage = await stream.result();
+
+    expect(events.map((event) => event.type)).toEqual(['start', 'error']);
+    expect(finalMessage).toMatchObject({
+      stopReason: 'error',
+      errorMessage: 'request setup failed',
+    });
+  });
+
+  it.each(['outer', 'run'] as const)('pre-aborted %s signal prevents transport', async (owner) => {
+    const outer = new AbortController();
+    const run = new AbortController();
+    (owner === 'outer' ? outer : run).abort(`${owner} cancelled`);
+
+    const { events, message } = await collect([], {
+      outerSignal: outer.signal,
+      streamOptions: { signal: run.signal },
+    });
+
+    expect(mocks.streamLLM).not.toHaveBeenCalled();
+    expect(events.map((event) => event.type)).toEqual(['start', 'error']);
+    expect(message).toMatchObject({ stopReason: 'aborted', errorMessage: `${owner} cancelled` });
+  });
+
+  it.each(['outer', 'run'] as const)(
+    'combines cancellation ownership and settles when the %s signal wins',
+    async (owner) => {
+      const outer = new AbortController();
+      const run = new AbortController();
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let transportSignal: AbortSignal | undefined;
+      mocks.streamLLM.mockImplementation((...args: unknown[]) => {
+        const params = args[0] as { abortSignal?: AbortSignal };
+        transportSignal = params?.abortSignal;
+        return {
+          fullStream: (async function* () {
+            await gate;
+            yield finish('stop');
+          })(),
+          usage: new Promise(() => {}),
+        };
+      });
+      const streamFn = createCallLlmStreamFn({
+        languageModel: {} as never,
+        abortSignal: outer.signal,
+      });
+      const stream = await streamFn(
+        {} as never,
+        { systemPrompt: 'system', messages: [], tools: [] },
+        { signal: run.signal },
+      );
+      const eventsPromise = (async () => {
+        const events: AssistantMessageEvent[] = [];
+        for await (const event of stream) events.push(event);
+        return events;
+      })();
+
+      (owner === 'outer' ? outer : run).abort(`${owner} cancelled`);
+      const message = await stream.result();
+      release();
+      const events = await eventsPromise;
+
+      expect(transportSignal).not.toBe(outer.signal);
+      expect(transportSignal).not.toBe(run.signal);
+      expect(transportSignal?.aborted).toBe(true);
+      expect(message).toMatchObject({ stopReason: 'aborted', errorMessage: `${owner} cancelled` });
+      expect(events.filter((event) => event.type === 'error')).toHaveLength(1);
+    },
+  );
+
+  it('keeps a captured provider finish when a late abort arrives', async () => {
+    const outer = new AbortController();
+    const { events, message } = await collect(
+      [{ type: 'text-delta', text: 'done' }, finish('stop'), { type: 'error', error: 'late' }],
+      { outerSignal: outer.signal },
+    );
+
+    outer.abort('too late');
+
+    expect(message.stopReason).toBe('stop');
+    expect(events.filter((event) => event.type === 'done' || event.type === 'error')).toHaveLength(
+      1,
+    );
+    expect(events.at(-1)?.type).toBe('done');
+  });
+
+  it('keeps a captured provider error when a late abort arrives', async () => {
+    const run = new AbortController();
+    const { events, message } = await collect(
+      [{ type: 'error', error: new Error('provider failed') }, finish('stop')],
+      { streamOptions: { signal: run.signal } },
+    );
+
+    run.abort('too late');
+
+    expect(message).toMatchObject({ stopReason: 'error', errorMessage: 'provider failed' });
+    expect(events.filter((event) => event.type === 'done' || event.type === 'error')).toHaveLength(
+      1,
+    );
+    expect(events.at(-1)?.type).toBe('error');
+  });
+});

--- a/tests/lib/agent/runtime/stream-fn-usage.test.ts
+++ b/tests/lib/agent/runtime/stream-fn-usage.test.ts
@@ -13,12 +13,19 @@ describe('createCallLlmStreamFn usage', () => {
     mocks.streamLLM.mockReturnValue({
       fullStream: (async function* () {
         yield { type: 'text-delta', text: 'answer' };
+        yield {
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: {
+            inputTokens: 120,
+            outputTokens: 30,
+            inputTokenDetails: { cacheReadTokens: 10, cacheWriteTokens: 5 },
+          },
+        };
       })(),
-      usage: Promise.resolve({
-        inputTokens: 120,
-        outputTokens: 30,
-        inputTokenDetails: { cacheReadTokens: 10, cacheWriteTokens: 5 },
-      }),
+      // The adapter deliberately takes terminal usage from fullStream.finish,
+      // not from a separately resolving result promise.
+      usage: new Promise(() => {}),
     });
     const streamFn = createCallLlmStreamFn({ languageModel: {} as never });
 

--- a/tests/lib/agent/runtime/stream-fn.test.ts
+++ b/tests/lib/agent/runtime/stream-fn.test.ts
@@ -248,4 +248,22 @@ describe('toModelMessages', () => {
     expect(content[0].toolName).toBe('myTool');
     expect(content[0].output).toEqual({ type: 'text', value: 'result text' });
   });
+
+  it('encodes failed toolResult content as AI SDK error-text', () => {
+    const messages: PiMessage[] = [
+      {
+        role: 'toolResult',
+        toolCallId: 'call-error',
+        toolName: 'myTool',
+        content: [{ type: 'text', text: 'failure detail' }],
+        isError: true,
+        timestamp: 0,
+      },
+    ];
+
+    const result = toModelMessages(messages);
+    const content = (result[0] as { content: Array<Record<string, unknown>> }).content;
+
+    expect(content[0].output).toEqual({ type: 'error-text', value: 'failure detail' });
+  });
 });


### PR DESCRIPTION
## Summary

This PR lands the Shared Pi Transport Correctness prerequisite approved in #1049.

It fixes the shared protocol adapter and Agent harness used by the Editor, Director, and Legacy Pi Child before Native Child + Spotlight is implemented.

OpenMAIC remains the sole provider and model-resolution authority:

```text
OpenMAIC model resolution
→ callLLM / streamLLM
→ OpenMAIC AI SDK stream
→ shared Pi transport adapter
→ Pi Agent loop and tool execution
```

Pi remains the execution harness, not a second provider layer.

## What changed

### Transport settlement and cancellation

The shared adapter now:

- maps top-level AI SDK `finish`, `abort`, and `error` outcomes deterministically;
- uses first-wins, exactly-once terminal settlement;
- fails closed on malformed or missing terminal events;
- returns a valid Pi event stream for provider/runtime failures instead of throwing;
- composes caller/request cancellation with the Pi per-run signal;
- prevents `streamLLM` from starting when either signal is already aborted;
- prevents late aborts from overwriting an already captured provider terminal result.

### Failed tool-result encoding

Pi tool results now map into the next AI SDK payload as:

```text
isError=false → text
isError=true  → error-text
```

The shared harness also normalizes the existing OpenMAIC compatibility marker only when the resolved result has its own `isError` property whose value is exactly boolean `true`.

Normalization happens before quota and caller hooks. Error state is monotonic, while original content, details, and existing termination semantics are preserved.

### `length + parsed toolCall` safety boundary

A parsed tool call from a truncated provider response is terminal and side-effect-free in the shared Pi tool path:

- executable tool-call content is removed before Pi execution;
- handler, before/after hooks, and action accounting are not entered;
- no continuation provider transport starts;
- undrained steering/follow-up queues are cleared only for this exact condition;
- queue calls during the terminal window are silent no-ops;
- normal queue behavior is restored after `agent_end`.

Plain `length` retains the existing Pi queue semantics.

The adapter and harness coordinate through module-local, identity-only `WeakSet<AssistantMessage>` provenance. Nothing is added to messages, transcripts, provider metadata, or durable state.

## Consumer regressions

Targeted tests exercise the real shared adapter, `buildAgent`, and Pi Agent loop for all current production consumers:

- **Editor** preserves `resolveModelFromRequest(..., "maic-agent")`, uses the resolved OpenMAIC model, propagates response cancellation, preserves strict failure content/details, and sends `error-text` continuation.
- **Director** uses the caller-resolved model, observes normalized failure state before its caller hook, preserves trace content/details, and continues through `error-text`.
- **Legacy Pi Child** inherits the Director-resolved model, does not execute shared Pi tool calls after `length`, preserves existing streamed-text action accounting, and does not claim rollback for actions already executed before the final finish reason arrives.

## Scope

Production changes are limited to:

- `lib/agent/runtime/stream-fn.ts`
- `lib/agent/runtime/build-agent.ts`

This PR does not add or modify:

- Native Child or the `legacy | native` selector;
- Spotlight or Native Web Search;
- whiteboard RuntimeStore behavior;
- Browser ACK/receipt behavior;
- provider/model resolution;
- retry, fallback, replay, or telemetry;
- dependencies or lockfiles.

## Independent cross-review

The implementation was independently reviewed by:

- the continuity Codex reviewer familiar with the #1049 architecture history;
- a separate Codex reviewer without relying on that prior continuity;
- Claude as an additional independent cross-check.

The reviews covered both the production implementation and consumer-level test closure. Confirmed findings were resolved, including missing consumer regressions, explicit zero-count proof for `length + parsed toolCall`, and a Director test false positive that could mask normalization ordering.

The final targeted test-closure review passed with no remaining production or test blockers.

## Validation

- targeted runtime and consumer regressions: 21 files / 167 tests passed;
- full unit suite: 431 files / 4,492 tests passed;
- skipped by repository configuration: 3 files / 53 tests;
- TypeScript: passed;
- Prettier: passed;
- ESLint: passed with 0 errors;
- `git diff --check`: passed.

GitHub CI remains the merge gate.

## Delivery order

```text
PR1 RuntimeStore foundation — merged
→ this Shared Pi Transport prerequisite
→ PR2 Native Child + Spotlight
```

PR2 will start from an updated `main` only after this prerequisite is reviewed and merged.
