### PR TITLE
fix(build): make the dist clean step work on Windows

### DIFF
--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -20,8 +20,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json && node scripts/gen-schema.mjs",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json && node scripts/gen-schema.mjs",
     "build:schema": "node scripts/gen-schema.mjs",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/@openmaic/editor/package.json
+++ b/packages/@openmaic/editor/package.json
@@ -34,7 +34,7 @@
     "directory": "packages/@openmaic/editor"
   },
   "scripts": {
-    "build": "rm -rf dist && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm run build"

--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -22,8 +22,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",

--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -20,8 +20,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean:dist": "rimraf dist",
-    "build": "rm -rf dist && rollup -c && tsc --emitDeclarationOnly",
+    "clean:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && rollup -c && tsc --emitDeclarationOnly",
     "dev": "rollup -c -w",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "test": "vitest run",

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -35,10 +35,10 @@
     "font-licenses"
   ],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "genfonts": "node scripts/generate-fonts-css.mjs",
     "gen-katex-fonts": "node scripts/generate-katex-fonts.mjs",
-    "build": "node scripts/generate-fonts-css.mjs && node scripts/generate-katex-fonts.mjs && rm -rf dist && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
+    "build": "node scripts/generate-fonts-css.mjs && node scripts/generate-katex-fonts.mjs && node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
     "dev": "rollup -c -w",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -67,8 +67,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Fixes #973.

## Problem

`pnpm install` aborts on Windows during the root `postinstall`. The workspace build scripts clean their output with `rm -rf dist`, which cmd.exe does not provide, so the chain dies at the first package:

```
> @openmaic/dsl@0.8.0 build
> rm -rf dist && tsc -p tsconfig.json && node scripts/gen-schema.mjs
'rm' is not recognized as an internal or external command, operable program or batch file.
 ELIFECYCLE  Command failed with exit code 1.
```

## Fix

Replace the clean step with:

```
node -e "require('fs').rmSync('dist',{recursive:true,force:true})"
```

`fs.rmSync` has been available since Node 14.14 and this repo already requires `>= 20.9`, so **no new dependency is introduced** and the behaviour is identical on POSIX. I chose this over adding `rimraf` because these packages are published as tarballs and a devDependency would be one more thing to keep in sync across six of them.

## Scope is wider than the issue reports

The issue lists four packages. Two more use `rm -rf dist` as well:

| Package | Scripts | In the issue? |
| --- | --- | --- |
| `@openmaic/dsl` | `clean`, `build` | yes |
| `@openmaic/editor` | `build` | **no** |
| `@openmaic/generation` | `clean`, `build` | **no** |
| `@openmaic/importer` | `clean:dist`, `build` | yes |
| `@openmaic/renderer` | `clean`, `build` | yes |
| `@openmaic/storage` | `clean`, `build` | yes |

The issue also notes that `@openmaic/importer`'s `clean:dist` calls `rimraf`. That is worse than a portability problem: `rimraf` is not declared as a dependency anywhere in the repo, so the script could not run on any platform. It now uses the same node call as the others.

11 replacements across 6 files, no logic change.

## Verification

Windows 11, pnpm 10.28.0, Node 24.16.0.

- Before: `pnpm install` fails at `@openmaic/dsl`, reproduced verbatim as quoted above.
- After: `pnpm install` completes with exit code 0 in 1m28s, and the postinstall chain builds all eight workspace packages including `@openmaic/editor`, which previously was never reached.
- With the packages finally built, `tsc --noEmit` drops from **724 errors to 4** — every remaining one is a stale `.next/types/validator.ts` artifact unrelated to this change.
- `pnpm-lock.yaml` is untouched.

I did not have a Linux box to hand for this branch, so POSIX behaviour rests on `fs.rmSync` being equivalent to `rm -rf` rather than on a local run; CI will exercise that path.
