### PR TITLE
refactor(media): share one stored-bytes resolver across export paths (#1007 part 3a)

### DIFF
--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -3,11 +3,10 @@ import type { ManifestAction } from './classroom-zip-types';
 import { db } from '@/lib/utils/database';
 import type { AudioFileRecord, MediaFileRecord } from '@/lib/utils/database';
 import type { Scene } from '@/lib/types/stage';
-import { isConcreteMediaAddress } from '@/lib/media/resolve-media-ref';
 import { resolveAudioBlob } from '@/lib/media/resolve-audio-bytes';
 import { fetchMediaUrl } from '@/lib/media/fetch-media-url';
 import { mapWithConcurrency } from '@/lib/media/convert-legacy-asset-refs';
-import { withAssetUrl } from '@/lib/media/use-asset-url';
+import { mediaRefFromRecordId, resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
 
 // ─── Export: Collect Media ─────────────────────────────────────
 
@@ -55,26 +54,15 @@ export async function collectAudioFiles(scenes: Scene[]): Promise<CollectedAudio
  * compatibility write then fails, the task records
  * `MEDIA_COMPATIBILITY_STORE_LAGGED` and the document deliberately keeps the
  * same reference. Rendering and the other export paths resolve the pool, so the
- * ZIP must too — otherwise it ships media the classroom no longer shows.
+ * ZIP must too -- otherwise it ships media the classroom no longer shows. The
+ * ZIP predates the `response.ok` validation the other export paths added and
+ * keeps that laxity, but a zero-byte pool answer is not usable bytes: the
+ * compatibility row stays the fallback rather than shipping an empty file.
  */
 async function pooledBytesForRef(ref: string): Promise<Blob | null> {
-  if (isConcreteMediaAddress(ref)) return null;
-  try {
-    return await withAssetUrl(ref, async (url) => {
-      if (!url) return null;
-      const blob = await fetch(url).then((response) => response.blob());
-      // Zero-byte pool answers are not usable bytes: the compatibility row
-      // stays the fallback rather than shipping an empty media file.
-      return blob.size > 0 ? blob : null;
-    });
-  } catch {
-    // The compatibility row remains the fallback when pool access fails.
-    return null;
-  }
-}
-
-function mediaRefFromRow(record: MediaFileRecord): string {
-  return record.id.includes(':') ? record.id.split(':').slice(1).join(':') : record.id;
+  return resolveStoredBytes(ref, {
+    fetchPolicy: { requireOk: false, requireNonEmpty: true },
+  });
 }
 
 export async function collectMediaFiles(stageId: string): Promise<CollectedMedia[]> {
@@ -88,11 +76,13 @@ export async function collectMediaFiles(stageId: string): Promise<CollectedMedia
   // deriving its rows from the document's speech actions instead of
   // enumerating the table.
   const supersededLegacyRefs = new Set(
-    records.map(mediaRefFromRow).filter((ref) => records.some((row) => row.placeholderRef === ref)),
+    records
+      .map((row) => mediaRefFromRecordId(row.id))
+      .filter((ref) => records.some((row) => row.placeholderRef === ref)),
   );
   const collected: CollectedMedia[] = [];
   for (const record of records) {
-    const elementId = mediaRefFromRow(record);
+    const elementId = mediaRefFromRecordId(record.id);
     if (supersededLegacyRefs.has(elementId)) continue;
     const ext = record.mimeType?.split('/')[1] || 'jpg';
     const pooled = await pooledBytesForRef(elementId);

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -22,8 +22,8 @@ import { createLogger } from '@/lib/logger';
 import { inlineHtmlAssets, createAssetFetcher } from './inline-assets';
 import type { FetchAsset } from './inline-assets';
 import { createProxiedFetch } from './proxied-fetch';
-import { db, mediaFileKey } from '@/lib/utils/database';
-import { withAssetUrl, type AssetUrlLeaseState } from '@/lib/media/use-asset-url';
+import type { AssetUrlLeaseState } from '@/lib/media/use-asset-url';
+import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
 import {
   MISSING_ASSET_LEASE,
   isConcreteMediaAddress,
@@ -370,15 +370,6 @@ function buildSpeakerNotes(scene: Scene): string {
   return parts.join('\n');
 }
 
-async function fetchBlob(url: string): Promise<Blob | null> {
-  try {
-    const response = await fetch(url);
-    return response.ok ? await response.blob() : null;
-  } catch {
-    return null;
-  }
-}
-
 async function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
@@ -413,40 +404,16 @@ export function exportMediaResolution(ref: string | undefined, stageId?: string)
 
 /** Resolve generated/allocated media without preventing the legacy source fetch fallback. */
 async function resolveStoredMediaBlob(ref: string, stageId?: string): Promise<Blob | null> {
-  const tasks = useMediaGenerationStore.getState().tasks;
-  const task =
-    tasks[ref] ??
-    Object.values(tasks).find(
-      (candidate) =>
-        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
-    );
-  const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
-  if (!isConcreteMediaAddress(ref)) {
-    try {
-      const pooled = await withAssetUrl(ref, async (url) => {
-        if (!url) return null;
-        const state = resolveMediaRef(ref, effectiveTask, { status: 'resolved', url });
-        const resolved = renderableMediaUrl(state);
-        return resolved ? fetchBlob(resolved) : null;
-      });
-      if (pooled) return pooled;
-    } catch {
-      // The compatibility row remains the fallback when pool access fails.
-    }
-  }
-  if (stageId) {
-    const record = await db.mediaFiles.get(mediaFileKey(stageId, ref)).catch(() => undefined);
-    if (record && !record.error && record.blob.size > 0) {
-      const state = resolveMediaRef(ref, effectiveTask, {
-        status: 'resolved',
-        url: 'dexie:media',
-      });
-      if (state.kind === 'url') return record.blob;
-    }
-  }
-  const state = resolveMediaRef(ref, effectiveTask, MISSING_ASSET_LEASE);
-  const resolved = renderableMediaUrl(state);
-  return resolved ? fetchBlob(resolved) : null;
+  // Pool first, then the Dexie compatibility row, then the task's resolved
+  // URL -- every level gated on the media-resolution state machine so an
+  // in-flight regeneration suppresses stale bytes.
+  return resolveStoredBytes(ref, {
+    stageId,
+    resolutionGating: true,
+    loadCompatRow: true,
+    taskUrlFallback: true,
+    fetchPolicy: { requireOk: true, requireNonEmpty: false },
+  });
 }
 
 // Exported for the round-trip integration test harness — the test wires its

--- a/lib/media/resolve-stored-bytes.ts
+++ b/lib/media/resolve-stored-bytes.ts
@@ -1,0 +1,180 @@
+import { db, mediaFileKey, type MediaFileRecord } from '@/lib/utils/database';
+import { useMediaGenerationStore } from '@/lib/store/media-generation';
+import { withAssetUrl } from './use-asset-url';
+import {
+  MISSING_ASSET_LEASE,
+  isConcreteMediaAddress,
+  renderableMediaUrl,
+  resolveMediaRef,
+  type MediaTaskState,
+} from './resolve-media-ref';
+
+/**
+ * Pool-first byte resolution for export paths, with the fallback chain every
+ * export surface shares.
+ *
+ * A same-id replacement commits the new bytes to the pool first; if the
+ * compatibility write then fails, the task records
+ * `MEDIA_COMPATIBILITY_STORE_LAGGED` and the document deliberately keeps the
+ * same reference. Rendering resolves the pool, so every export must too --
+ * otherwise it ships media the classroom no longer shows. The chain, in order:
+ *
+ * 1. The asset pool. An opaque ref's current bytes win whenever the pool
+ *    resolves them.
+ * 2. The Dexie compatibility row, optionally with its CDN URL (`ossKey`) as a
+ *    byte source when the local blob is empty -- a live-mode classroom whose
+ *    local blobs were LRU-evicted under storage pressure still exports a
+ *    self-contained archive.
+ * 3. The URL the media-resolution state machine resolves from the task, for
+ *    generated media whose bytes never reached either store.
+ *
+ * The three historical callers (classroom ZIP, PPTX, video) differ in which
+ * levels they run, how strictly they validate fetched bytes, and whether they
+ * gate acceptance on the media-resolution state machine. Those differences
+ * are load-bearing, so they are explicit options below rather than collapsed
+ * into one policy. Returns `null` when no level yields bytes; never throws.
+ */
+
+/** How strictly a fetched byte source is validated before it is accepted. */
+export interface StoredBytesFetchPolicy {
+  /** Reject a non-OK response instead of shipping the error body as bytes. */
+  readonly requireOk: boolean;
+  /** Reject an empty (0-byte) blob instead of shipping it. */
+  readonly requireNonEmpty: boolean;
+}
+
+export interface ResolveStoredBytesOptions {
+  /** Stage scope for the task lookup and the internal compatibility-row read. */
+  readonly stageId?: string;
+  /**
+   * Pre-loaded compatibility row. Its compound id authoritatively names the
+   * document ref, so a supplied row re-derives the ref every level resolves
+   * for. Rows carrying an `error` still name the ref but never supply bytes.
+   */
+  readonly record?: MediaFileRecord;
+  /**
+   * Read the compatibility row from Dexie by compound key when no `record`
+   * was supplied. A failed read is treated as a missing row.
+   */
+  readonly loadCompatRow?: boolean;
+  /** Allow the row's CDN URL (`ossKey`) as a byte source when its local blob is empty. */
+  readonly compatRowCdnFallback?: boolean;
+  /**
+   * Final level: fetch the URL the media-resolution state machine resolves
+   * from the ref's task, so generated media still exports when neither the
+   * pool nor the compatibility row holds its bytes.
+   */
+  readonly taskUrlFallback?: boolean;
+  /**
+   * Gate every level through the media-resolution state machine, keyed by the
+   * ref's current task: an in-flight regeneration then suppresses stale pool
+   * and compatibility bytes, so the export cannot ship media the classroom no
+   * longer shows. Off for callers that resolve the pool unconditionally.
+   */
+  readonly resolutionGating?: boolean;
+  /** Validation applied to every fetched byte source. */
+  readonly fetchPolicy: StoredBytesFetchPolicy;
+}
+
+/** The document ref a compatibility row's compound id (`stageId:ref`) names. */
+export function mediaRefFromRecordId(recordId: string): string {
+  return recordId.includes(':') ? recordId.split(':').slice(1).join(':') : recordId;
+}
+
+export async function resolveStoredBytes(
+  ref: string,
+  options: ResolveStoredBytesOptions,
+): Promise<Blob | null> {
+  const { stageId, fetchPolicy } = options;
+  const effectiveRef = options.record ? mediaRefFromRecordId(options.record.id) : ref;
+  const task = options.resolutionGating ? effectiveMediaTask(effectiveRef, stageId) : undefined;
+
+  const pooled = await pooledBytes(effectiveRef, task, options);
+  if (pooled) return pooled;
+
+  const record =
+    options.record ??
+    (options.loadCompatRow && stageId
+      ? await db.mediaFiles.get(mediaFileKey(stageId, effectiveRef)).catch(() => undefined)
+      : undefined);
+  if (record && !record.error) {
+    const stored = await compatRowBytes(record, options);
+    if (stored) {
+      // Without gating the task is undefined and the resolved lease always
+      // yields a URL, so this one check covers both caller shapes.
+      const state = resolveMediaRef(effectiveRef, task, {
+        status: 'resolved',
+        url: 'dexie:media',
+      });
+      if (state.kind === 'url') return stored;
+    }
+  }
+
+  if (options.taskUrlFallback) {
+    const state = resolveMediaRef(effectiveRef, task, MISSING_ASSET_LEASE);
+    const resolved = renderableMediaUrl(state);
+    return resolved ? fetchBytes(resolved, fetchPolicy) : null;
+  }
+  return null;
+}
+
+/**
+ * The pool level: a same-id replacement lands here first, so it answers
+ * before any stored row. Concrete addresses are network sources, not pool
+ * refs, and resolve to `null` immediately. Pool access failure is not fatal --
+ * the compatibility row remains the fallback.
+ */
+async function pooledBytes(
+  ref: string,
+  task: MediaTaskState | undefined,
+  options: ResolveStoredBytesOptions,
+): Promise<Blob | null> {
+  if (isConcreteMediaAddress(ref)) return null;
+  try {
+    return await withAssetUrl(ref, async (url) => {
+      if (!url) return null;
+      if (!options.resolutionGating) return fetchBytes(url, options.fetchPolicy);
+      const state = resolveMediaRef(ref, task, { status: 'resolved', url });
+      const resolved = renderableMediaUrl(state);
+      return resolved ? fetchBytes(resolved, options.fetchPolicy) : null;
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** The compatibility-row level: local blob first, then the CDN URL when enabled. */
+async function compatRowBytes(
+  record: MediaFileRecord,
+  options: ResolveStoredBytesOptions,
+): Promise<Blob | null> {
+  if (record.blob.size > 0) return record.blob;
+  if (!options.compatRowCdnFallback || !record.ossKey) return null;
+  return fetchBytes(record.ossKey, options.fetchPolicy);
+}
+
+async function fetchBytes(url: string, policy: StoredBytesFetchPolicy): Promise<Blob | null> {
+  try {
+    const response = await fetch(url);
+    if (policy.requireOk && !response.ok) return null;
+    const blob = await response.blob();
+    return policy.requireNonEmpty && blob.size === 0 ? null : blob;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The task governing a ref: keyed directly, or by the placeholder ref a
+ * completed allocation kept. A task from another stage never counts.
+ */
+function effectiveMediaTask(ref: string, stageId: string | undefined): MediaTaskState | undefined {
+  const tasks = useMediaGenerationStore.getState().tasks;
+  const task =
+    tasks[ref] ??
+    Object.values(tasks).find(
+      (candidate) =>
+        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
+    );
+  return task && (!stageId || task.stageId === stageId) ? task : undefined;
+}

--- a/lib/media/resolve-stored-bytes.ts
+++ b/lib/media/resolve-stored-bytes.ts
@@ -54,15 +54,23 @@ export interface ResolveStoredBytesOptions {
   readonly record?: MediaFileRecord;
   /**
    * Read the compatibility row from Dexie by compound key when no `record`
-   * was supplied. A failed read is treated as a missing row.
+   * was supplied. A failed read is treated as a missing row. Requires
+   * `stageId`: the row is keyed by `stageId:ref`, so with no stage this level
+   * is skipped entirely -- the same gate the pre-refactor callers applied.
    */
   readonly loadCompatRow?: boolean;
-  /** Allow the row's CDN URL (`ossKey`) as a byte source when its local blob is empty. */
+  /**
+   * Allow the row's CDN URL (`ossKey`) as a byte source when its local blob is
+   * empty. Applies to the compatibility level only, so it is inert unless a
+   * `record` was supplied or `loadCompatRow` found one.
+   */
   readonly compatRowCdnFallback?: boolean;
   /**
    * Final level: fetch the URL the media-resolution state machine resolves
    * from the ref's task, so generated media still exports when neither the
-   * pool nor the compatibility row holds its bytes.
+   * pool nor the compatibility row holds its bytes. Independent of
+   * `resolutionGating` -- the task is looked up for this level whether or not
+   * the earlier levels are gated.
    */
   readonly taskUrlFallback?: boolean;
   /**
@@ -87,9 +95,19 @@ export async function resolveStoredBytes(
 ): Promise<Blob | null> {
   const { stageId, fetchPolicy } = options;
   const effectiveRef = options.record ? mediaRefFromRecordId(options.record.id) : ref;
-  const task = options.resolutionGating ? effectiveMediaTask(effectiveRef, stageId) : undefined;
+  // Two independent concerns need the task: gating (which suppresses stale
+  // bytes) and the final URL fallback (which resolves the task's own address).
+  // Only the gating levels read it conditionally -- deriving it from
+  // `resolutionGating` alone would leave `taskUrlFallback` inert without it,
+  // which is not what the option promises and not what the pre-refactor
+  // callers did (their task lookup was unconditional).
+  const task =
+    options.resolutionGating || options.taskUrlFallback
+      ? effectiveMediaTask(effectiveRef, stageId)
+      : undefined;
+  const gate = options.resolutionGating ? task : undefined;
 
-  const pooled = await pooledBytes(effectiveRef, task, options);
+  const pooled = await pooledBytes(effectiveRef, gate, options);
   if (pooled) return pooled;
 
   const record =
@@ -100,9 +118,9 @@ export async function resolveStoredBytes(
   if (record && !record.error) {
     const stored = await compatRowBytes(record, options);
     if (stored) {
-      // Without gating the task is undefined and the resolved lease always
+      // Gating off means `gate` is undefined and the resolved lease always
       // yields a URL, so this one check covers both caller shapes.
-      const state = resolveMediaRef(effectiveRef, task, {
+      const state = resolveMediaRef(effectiveRef, gate, {
         status: 'resolved',
         url: 'dexie:media',
       });
@@ -148,7 +166,9 @@ async function compatRowBytes(
   record: MediaFileRecord,
   options: ResolveStoredBytesOptions,
 ): Promise<Blob | null> {
-  if (record.blob.size > 0) return record.blob;
+  // The blob is declared required, but the guard is the reason this function
+  // honors the module's "never throws" contract for a row that lost it.
+  if (record.blob && record.blob.size > 0) return record.blob;
   if (!options.compatRowCdnFallback || !record.ossKey) return null;
   return fetchBytes(record.ossKey, options.fetchPolicy);
 }

--- a/lib/media/resolve-stored-bytes.ts
+++ b/lib/media/resolve-stored-bytes.ts
@@ -106,17 +106,29 @@ export async function resolveStoredBytes(
       ? effectiveMediaTask(effectiveRef, stageId)
       : undefined;
   const gate = options.resolutionGating ? task : undefined;
+  // A SUPPLIED row's `error` verdict is taken here, before the pool is
+  // awaited, because that is where the pre-refactor caller took it: the row is
+  // a live object, so deciding after the await would let an `error` set (or
+  // cleared) while the pool lookup is pending change the answer. A row this
+  // function loads itself is judged when it is read, after the pool miss --
+  // also as before, since that read did not exist until then.
+  const suppliedRow = options.record && !options.record.error ? options.record : undefined;
 
   const pooled = await pooledBytes(effectiveRef, gate, options);
   if (pooled) return pooled;
 
-  const record =
-    options.record ??
-    (options.loadCompatRow && stageId
+  const record = options.record
+    ? suppliedRow
+    : options.loadCompatRow && stageId
       ? await db.mediaFiles.get(mediaFileKey(stageId, effectiveRef)).catch(() => undefined)
-      : undefined);
-  if (record && !record.error) {
-    const stored = await compatRowBytes(record, options);
+      : undefined;
+  // `suppliedRow` already carries the pre-await verdict, so it is NOT
+  // re-examined here -- re-reading `error` off the live object is exactly the
+  // late decision this snapshot exists to avoid. A row loaded above is judged
+  // now, when it was read.
+  const usableRow = options.record ? suppliedRow : record && !record.error ? record : undefined;
+  if (usableRow) {
+    const stored = await compatRowBytes(usableRow, options);
     if (stored) {
       // Gating off means `gate` is undefined and the resolved lease always
       // yields a URL, so this one check covers both caller shapes.

--- a/lib/video-export-app/collect.ts
+++ b/lib/video-export-app/collect.ts
@@ -28,14 +28,14 @@ import { isMediaPlaceholder } from '@/lib/store/media-generation';
 import type { MediaFileRecord } from '@/lib/utils/database';
 import type { VideoTimelineRecords } from './timeline-deps';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
-import { withAssetUrl, type AssetUrlLeaseState } from '@/lib/media/use-asset-url';
+import type { AssetUrlLeaseState } from '@/lib/media/use-asset-url';
 import {
   MISSING_ASSET_LEASE,
-  isConcreteMediaAddress,
   renderableMediaUrl,
   resolveMediaRef,
   type MediaTaskState,
 } from '@/lib/media/resolve-media-ref';
+import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
 import { slideMediaReferenceSlots } from '@/lib/media/slide-media-slots';
 import { resolveVideoMediaForElement } from '@/lib/media/media-task-resolution';
 
@@ -147,10 +147,6 @@ async function resolveBytes(
   }
 }
 
-function mediaRefFromRecordId(recordId: string): string {
-  return recordId.includes(':') ? recordId.split(':').slice(1).join(':') : recordId;
-}
-
 export function resolveVideoExportMediaBinding(
   ref: string | undefined,
   task: MediaTaskState | undefined,
@@ -161,47 +157,25 @@ export function resolveVideoExportMediaBinding(
   return { resolution, src: renderableMediaUrl(resolution) ?? '' };
 }
 
+/**
+ * Resolve one media asset's bytes: pool first, then the Dexie compatibility
+ * row (with its CDN `ossKey` as a byte source when the local blob is empty),
+ * then the task's resolved URL -- every level gated on the media-resolution
+ * state machine so an in-flight regeneration suppresses stale bytes.
+ */
 async function resolveMediaBytesWithFallback(
   assetId: string,
   record: MediaFileRecord | undefined,
   stageId?: string,
 ): Promise<Blob | null> {
-  const usableRecord = record && !record.error ? record : undefined;
-  const ref = record ? mediaRefFromRecordId(record.id) : assetId;
-  const tasks = useMediaGenerationStore.getState().tasks;
-  const task =
-    tasks[ref] ??
-    Object.values(tasks).find(
-      (candidate) =>
-        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
-    );
-  const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
-  if (!isConcreteMediaAddress(ref)) {
-    try {
-      const pooled = await withAssetUrl(ref, async (url) => {
-        if (!url) return null;
-        const binding = resolveVideoExportMediaBinding(ref, effectiveTask, {
-          status: 'resolved',
-          url,
-        });
-        return binding.src ? resolveBytes(undefined, binding.src) : null;
-      });
-      if (pooled) return pooled;
-    } catch {
-      // The compatibility record remains the fallback when pool access fails.
-    }
-  }
-  const stored = await resolveBytes(usableRecord?.blob, usableRecord?.ossKey);
-  if (stored) {
-    const state = resolveVideoExportMediaBinding(ref, effectiveTask, {
-      status: 'resolved',
-      url: 'dexie:media',
-    }).resolution;
-    if (state.kind === 'url') return stored;
-  }
-
-  const resolved = resolveVideoExportMediaBinding(ref, effectiveTask).src;
-  return resolved ? resolveBytes(undefined, resolved) : null;
+  return resolveStoredBytes(assetId, {
+    stageId,
+    record,
+    resolutionGating: true,
+    compatRowCdnFallback: true,
+    taskUrlFallback: true,
+    fetchPolicy: { requireOk: true, requireNonEmpty: true },
+  });
 }
 
 /** The generated-image ref an element points at, when it is an unresolved placeholder. */

--- a/tests/export/classroom-zip-pool-first.test.ts
+++ b/tests/export/classroom-zip-pool-first.test.ts
@@ -106,6 +106,35 @@ describe('classroom ZIP media collection', () => {
     expect(await collected[0].record.blob.text()).toBe('row-bytes');
   });
 
+  /**
+   * The ZIP predates the `response.ok` validation the other export paths
+   * added, and keeps that laxity: a non-OK response carrying a body is still
+   * shipped. Pinned here because the shared resolver expresses it as an option
+   * (`requireOk: false`) that would otherwise be tightenable without a failure.
+   */
+  it('ships a non-OK pool response body, as the ZIP always has', async () => {
+    const ref = 'ast_pool_error_body';
+    mocks.rows.push({
+      id: `stage-1:${ref}`,
+      stageId: 'stage-1',
+      blob: new Blob(['row-bytes'], { type: 'image/png' }),
+      mimeType: 'image/png',
+    });
+    const poolUrl = 'blob:pool-error';
+    mocks.poolResolve.mockResolvedValue(poolUrl);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        if (input === poolUrl) return new Response(new Blob(['error-body']), { status: 404 });
+        throw new Error(`Unexpected fetch: ${input}`);
+      }),
+    );
+
+    const collected = await collectMediaFiles('stage-1');
+
+    expect(await collected[0].record.blob.text()).toBe('error-body');
+  });
+
   it('leaves legacy placeholder rows on their stored bytes', async () => {
     mocks.rows.push({
       id: 'stage-1:gen_img_1',

--- a/tests/media/resolve-stored-bytes-equivalence.test.ts
+++ b/tests/media/resolve-stored-bytes-equivalence.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Frozen-base differential harness for the shared stored-bytes resolver.
+ *
+ * The three export paths this branch collapses into `resolveStoredBytes` are
+ * reproduced below **verbatim** as they stand at commit `e1578083` — the merge
+ * base this branch was cut from, and (at the time of writing) still identical
+ * to `main`, since no commit between the two touched these functions:
+ *
+ * - `pooledBytesForRef`            — `lib/export/classroom-zip-utils.ts`
+ * - `resolveStoredMediaBlob` + `fetchBlob`
+ *                                  — `lib/export/use-export-pptx.ts`
+ * - `resolveMediaBytesWithFallback` + `resolveBytes` + `mediaRefFromRecordId`
+ *                                  — `lib/video-export-app/collect.ts`
+ *
+ * Each frozen implementation is driven side by side with the current helper
+ * under the option set its call site now passes, over the matrix declared at
+ * the bottom of this file. For every combination the harness compares:
+ *
+ * - the outcome — returned bytes, `null`, or a thrown error and its type;
+ * - **blob identity** — whether the answer is the caller's own row blob by
+ *   reference, or freshly fetched bytes;
+ * - the ordered sequence of lease acquisitions, Dexie reads, and fetches,
+ *   **including their arguments**.
+ *
+ * Absolute microtask offsets are deliberately NOT compared. Extracting the
+ * pool level into its own async function moves later operations one or two
+ * ticks, which the PR description states; the harness asserts that the
+ * sequence, the arguments, and the results are unchanged, which is what a
+ * caller can observe.
+ *
+ * Exactly one divergence is permitted, and it is asserted to occur exactly
+ * where it is documented and nowhere else: a PPTX compatibility row whose
+ * `blob` is missing threw a `TypeError` out of the frozen implementation and
+ * falls through to the next byte source in the current one.
+ *
+ * Scope, so this file is not mistaken for total coverage: it drives the three
+ * real call sites and only those. Option combinations no call site uses --
+ * `taskUrlFallback` without `resolutionGating`, most obviously -- are outside
+ * it by construction and are covered by the targeted cases in
+ * `resolve-stored-bytes.test.ts`. A change that is unobservable under all
+ * three call sites' options (leaking the task into the gate, for instance)
+ * does not red this file, and should not: it is unobservable in production
+ * too. Nor does this file cover state that mutates mid-await; the supplied
+ * row's `error` verdict timing is pinned by its own tests.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mediaGet: vi.fn(),
+  withAssetUrl: vi.fn(),
+  getState: vi.fn(),
+  calls: [] as string[],
+}));
+
+vi.mock('@/lib/utils/database', () => ({
+  db: { mediaFiles: { get: mocks.mediaGet } },
+  mediaFileKey: (stageId: string, ref: string) => `${stageId}:${ref}`,
+}));
+
+vi.mock('@/lib/media/use-asset-url', () => ({ withAssetUrl: mocks.withAssetUrl }));
+
+vi.mock('@/lib/store/media-generation', () => ({
+  useMediaGenerationStore: { getState: mocks.getState },
+}));
+
+import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
+import { db, mediaFileKey, type MediaFileRecord } from '@/lib/utils/database';
+import { withAssetUrl } from '@/lib/media/use-asset-url';
+import type { AssetUrlLeaseState } from '@/lib/media/use-asset-url';
+import { useMediaGenerationStore } from '@/lib/store/media-generation';
+import {
+  MISSING_ASSET_LEASE,
+  isConcreteMediaAddress,
+  renderableMediaUrl,
+  resolveMediaRef,
+  type MediaTaskState,
+} from '@/lib/media/resolve-media-ref';
+
+// ─── Frozen @ e1578083 — lib/export/classroom-zip-utils.ts ──────────────────
+
+async function frozenZip(ref: string): Promise<Blob | null> {
+  if (isConcreteMediaAddress(ref)) return null;
+  try {
+    return await withAssetUrl(ref, async (url) => {
+      if (!url) return null;
+      const blob = await fetch(url).then((response) => response.blob());
+      return blob.size > 0 ? blob : null;
+    });
+  } catch {
+    return null;
+  }
+}
+
+// ─── Frozen @ e1578083 — lib/export/use-export-pptx.ts ──────────────────────
+
+async function frozenFetchBlob(url: string): Promise<Blob | null> {
+  try {
+    const response = await fetch(url);
+    return response.ok ? await response.blob() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function frozenPptx(ref: string, stageId?: string): Promise<Blob | null> {
+  const tasks = useMediaGenerationStore.getState().tasks;
+  const task =
+    tasks[ref] ??
+    Object.values(tasks).find(
+      (candidate) =>
+        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
+    );
+  const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
+  if (!isConcreteMediaAddress(ref)) {
+    try {
+      const pooled = await withAssetUrl(ref, async (url) => {
+        if (!url) return null;
+        const state = resolveMediaRef(ref, effectiveTask, { status: 'resolved', url });
+        const resolved = renderableMediaUrl(state);
+        return resolved ? frozenFetchBlob(resolved) : null;
+      });
+      if (pooled) return pooled;
+    } catch {
+      // The compatibility row remains the fallback when pool access fails.
+    }
+  }
+  if (stageId) {
+    const record = await db.mediaFiles.get(mediaFileKey(stageId, ref)).catch(() => undefined);
+    if (record && !record.error && record.blob.size > 0) {
+      const state = resolveMediaRef(ref, effectiveTask, {
+        status: 'resolved',
+        url: 'dexie:media',
+      });
+      if (state.kind === 'url') return record.blob;
+    }
+  }
+  const state = resolveMediaRef(ref, effectiveTask, MISSING_ASSET_LEASE);
+  const resolved = renderableMediaUrl(state);
+  return resolved ? frozenFetchBlob(resolved) : null;
+}
+
+// ─── Frozen @ e1578083 — lib/video-export-app/collect.ts ────────────────────
+
+async function frozenResolveBytes(
+  blob: Blob | undefined,
+  ossKey: string | undefined,
+): Promise<Blob | null> {
+  if (blob && blob.size > 0) return blob;
+  if (!ossKey) return null;
+  try {
+    const res = await fetch(ossKey);
+    if (!res.ok) return null;
+    const fetched = await res.blob();
+    return fetched.size > 0 ? fetched : null;
+  } catch {
+    return null;
+  }
+}
+
+function frozenMediaRefFromRecordId(recordId: string): string {
+  return recordId.includes(':') ? recordId.split(':').slice(1).join(':') : recordId;
+}
+
+function frozenBinding(
+  ref: string | undefined,
+  task: MediaTaskState | undefined,
+  lease: AssetUrlLeaseState = MISSING_ASSET_LEASE,
+) {
+  const resolution = resolveMediaRef(ref, task, lease);
+  return { resolution, src: renderableMediaUrl(resolution) ?? '' };
+}
+
+async function frozenVideo(
+  assetId: string,
+  record: MediaFileRecord | undefined,
+  stageId?: string,
+): Promise<Blob | null> {
+  const usableRecord = record && !record.error ? record : undefined;
+  const ref = record ? frozenMediaRefFromRecordId(record.id) : assetId;
+  const tasks = useMediaGenerationStore.getState().tasks;
+  const task =
+    tasks[ref] ??
+    Object.values(tasks).find(
+      (candidate) =>
+        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
+    );
+  const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
+  if (!isConcreteMediaAddress(ref)) {
+    try {
+      const pooled = await withAssetUrl(ref, async (url) => {
+        if (!url) return null;
+        const binding = frozenBinding(ref, effectiveTask, { status: 'resolved', url });
+        return binding.src ? frozenResolveBytes(undefined, binding.src) : null;
+      });
+      if (pooled) return pooled;
+    } catch {
+      // The compatibility record remains the fallback when pool access fails.
+    }
+  }
+  const stored = await frozenResolveBytes(usableRecord?.blob, usableRecord?.ossKey);
+  if (stored) {
+    const state = frozenBinding(ref, effectiveTask, {
+      status: 'resolved',
+      url: 'dexie:media',
+    }).resolution;
+    if (state.kind === 'url') return stored;
+  }
+  const resolved = frozenBinding(ref, effectiveTask).src;
+  return resolved ? frozenResolveBytes(undefined, resolved) : null;
+}
+
+// ─── Matrix ─────────────────────────────────────────────────────────────────
+
+const REFS = [
+  'ast_opaque_1',
+  'gen_img_1',
+  'https://cdn.example.com/remote.png',
+  'blob:local-object',
+  'data:image/png;base64,AAAA',
+  'nested/path/file.png',
+] as const;
+
+type TaskCase = { name: string; tasks: Record<string, Record<string, unknown>> };
+
+const taskCases = (ref: string): TaskCase[] => [
+  { name: 'no-task', tasks: {} },
+  {
+    name: 'done-with-url',
+    tasks: {
+      [ref]: { status: 'done', objectUrl: 'https://cdn.example.com/task.png', stageId: 'stage-1' },
+    },
+  },
+  { name: 'done-no-url', tasks: { [ref]: { status: 'done', stageId: 'stage-1' } } },
+  { name: 'generating', tasks: { [ref]: { status: 'generating', stageId: 'stage-1' } } },
+  { name: 'pending', tasks: { [ref]: { status: 'pending', stageId: 'stage-1' } } },
+  {
+    name: 'failed-retryable',
+    tasks: {
+      [ref]: {
+        status: 'failed',
+        errorCode: 'TRANSIENT',
+        objectUrl: 'https://cdn.example.com/last.png',
+        stageId: 'stage-1',
+      },
+    },
+  },
+  {
+    name: 'failed-sensitive',
+    tasks: { [ref]: { status: 'failed', errorCode: 'CONTENT_SENSITIVE', stageId: 'stage-1' } },
+  },
+  {
+    name: 'other-stage',
+    tasks: {
+      [ref]: { status: 'done', objectUrl: 'https://cdn.example.com/other.png', stageId: 'stage-9' },
+    },
+  },
+  {
+    name: 'placeholder-ref-match',
+    tasks: {
+      unrelated_key: {
+        status: 'done',
+        objectUrl: 'https://cdn.example.com/ph.png',
+        placeholderRef: ref,
+        stageId: 'stage-1',
+      },
+    },
+  },
+];
+
+const POOL_CASES = ['url', 'miss', 'throw'] as const;
+const FETCH_CASES = ['ok', 'not-ok', 'empty', 'throw'] as const;
+
+type RecordCase = { name: string; make: () => MediaFileRecord | undefined };
+
+const recordCases: RecordCase[] = [
+  { name: 'absent', make: () => undefined },
+  {
+    name: 'ok',
+    make: () =>
+      ({ id: 'stage-1:ast_opaque_1', blob: new Blob(['row']) }) as unknown as MediaFileRecord,
+  },
+  {
+    name: 'errored',
+    make: () =>
+      ({
+        id: 'stage-1:ast_opaque_1',
+        blob: new Blob(['row']),
+        error: 'FAILED',
+      }) as unknown as MediaFileRecord,
+  },
+  {
+    name: 'empty-blob',
+    make: () => ({ id: 'stage-1:ast_opaque_1', blob: new Blob([]) }) as unknown as MediaFileRecord,
+  },
+  {
+    name: 'empty-blob-with-oss',
+    make: () =>
+      ({
+        id: 'stage-1:ast_opaque_1',
+        blob: new Blob([]),
+        ossKey: 'https://cdn.example.com/oss.png',
+      }) as unknown as MediaFileRecord,
+  },
+  {
+    name: 'blobless-with-oss',
+    make: () =>
+      ({
+        id: 'stage-1:ast_opaque_1',
+        ossKey: 'https://cdn.example.com/oss.png',
+      }) as unknown as MediaFileRecord,
+  },
+  {
+    name: 'non-compound-id',
+    make: () => ({ id: 'ast_opaque_1', blob: new Blob(['row']) }) as unknown as MediaFileRecord,
+  },
+];
+
+const STAGES = ['stage-1', undefined] as const;
+
+// ─── Recording rig ──────────────────────────────────────────────────────────
+
+interface Outcome {
+  kind: 'bytes' | 'null' | 'throw';
+  text?: string;
+  thrown?: string;
+  /** Whether the answer is the caller's own row blob by reference. */
+  identity?: 'row-blob' | 'fresh';
+  calls: string[];
+}
+
+function arm(pool: string, fetchMode: string, tasks: Record<string, unknown>) {
+  mocks.calls.length = 0;
+  mocks.getState.mockReturnValue({ tasks });
+  mocks.withAssetUrl.mockImplementation(
+    async (ref: string, use: (url: string | null) => Promise<Blob | null>) => {
+      mocks.calls.push(`lease:${ref}`);
+      if (pool === 'throw') throw new Error('pool unavailable');
+      return use(pool === 'url' ? `blob:pool-${ref}` : null);
+    },
+  );
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      mocks.calls.push(`fetch:${url}`);
+      if (fetchMode === 'throw') throw new Error('network');
+      if (fetchMode === 'empty') return new Response(new Blob([]));
+      if (fetchMode === 'not-ok') return new Response(new Blob(['err']), { status: 404 });
+      return new Response(new Blob(['bytes']));
+    }),
+  );
+}
+
+async function capture(run: () => Promise<Blob | null>, row?: MediaFileRecord): Promise<Outcome> {
+  try {
+    const result = await run();
+    if (!result) return { kind: 'null', calls: [...mocks.calls] };
+    return {
+      kind: 'bytes',
+      text: await result.text(),
+      identity: row && result === row.blob ? 'row-blob' : 'fresh',
+      calls: [...mocks.calls],
+    };
+  } catch (error) {
+    return { kind: 'throw', thrown: (error as Error).constructor.name, calls: [...mocks.calls] };
+  }
+}
+
+describe('frozen-base differential harness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mediaGet.mockResolvedValue(undefined);
+  });
+
+  it('classroom ZIP: the shared resolver reproduces the frozen implementation', async () => {
+    let compared = 0;
+    for (const ref of REFS)
+      for (const task of taskCases(ref))
+        for (const pool of POOL_CASES)
+          for (const fetchMode of FETCH_CASES) {
+            arm(pool, fetchMode, task.tasks);
+            const before = await capture(() => frozenZip(ref));
+            arm(pool, fetchMode, task.tasks);
+            const after = await capture(() =>
+              resolveStoredBytes(ref, {
+                fetchPolicy: { requireOk: false, requireNonEmpty: true },
+              }),
+            );
+            expect(after, `ZIP ${ref} ${task.name} pool=${pool} fetch=${fetchMode}`).toEqual(
+              before,
+            );
+            compared++;
+          }
+    expect(compared).toBe(REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length);
+  });
+
+  it('PPTX: the shared resolver reproduces the frozen implementation', async () => {
+    const divergences: string[] = [];
+    let compared = 0;
+    for (const ref of REFS)
+      for (const task of taskCases(ref))
+        for (const pool of POOL_CASES)
+          for (const fetchMode of FETCH_CASES)
+            for (const row of recordCases)
+              for (const stageId of STAGES) {
+                const label = `PPTX ${ref} ${task.name} pool=${pool} fetch=${fetchMode} row=${row.name} stage=${stageId}`;
+                const loaded = row.make();
+                arm(pool, fetchMode, task.tasks);
+                mocks.mediaGet.mockImplementation(async (key: string) => {
+                  mocks.calls.push(`dexie:${key}`);
+                  return loaded;
+                });
+                const before = await capture(() => frozenPptx(ref, stageId), loaded);
+                arm(pool, fetchMode, task.tasks);
+                mocks.mediaGet.mockImplementation(async (key: string) => {
+                  mocks.calls.push(`dexie:${key}`);
+                  return loaded;
+                });
+                const after = await capture(
+                  () =>
+                    resolveStoredBytes(ref, {
+                      stageId,
+                      resolutionGating: true,
+                      loadCompatRow: true,
+                      taskUrlFallback: true,
+                      fetchPolicy: { requireOk: true, requireNonEmpty: false },
+                    }),
+                  loaded,
+                );
+                compared++;
+                if (before.kind === 'throw') {
+                  // The single documented divergence.
+                  divergences.push(label);
+                  expect(before.thrown, label).toBe('TypeError');
+                  expect(row.name, label).toBe('blobless-with-oss');
+                  expect(stageId, label).toBe('stage-1');
+                  expect(after.kind, label).not.toBe('throw');
+                  continue;
+                }
+                expect(after, label).toEqual(before);
+              }
+    expect(compared).toBe(
+      REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length * recordCases.length * STAGES.length,
+    );
+    // Divergences occur only for the blob-less row with a stage -- and for
+    // every such combination that actually reaches the row. The frozen PPTX
+    // path returns pooled bytes before it ever reads the row, so those
+    // combinations never touch the unguarded `record.blob.size`: pool `url`,
+    // one of the two non-concrete refs, a fetch outcome the frozen `fetchBlob`
+    // accepts (`ok` and `empty` alike -- it checks only `response.ok`), and any
+    // task state that still resolves to a URL, which is all of them except
+    // `generating` and `pending`.
+    const bloblessStaged = REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length;
+    const pooledBeforeRow = 2 * 1 * 2 * 7;
+    expect(divergences.length).toBe(bloblessStaged - pooledBeforeRow);
+  });
+
+  it('video export: the shared resolver reproduces the frozen implementation', async () => {
+    let compared = 0;
+    for (const ref of REFS)
+      for (const task of taskCases(ref))
+        for (const pool of POOL_CASES)
+          for (const fetchMode of FETCH_CASES)
+            for (const row of recordCases)
+              for (const stageId of STAGES) {
+                const label = `VIDEO ${ref} ${task.name} pool=${pool} fetch=${fetchMode} row=${row.name} stage=${stageId}`;
+                const supplied = row.make();
+                arm(pool, fetchMode, task.tasks);
+                const before = await capture(() => frozenVideo(ref, supplied, stageId), supplied);
+                arm(pool, fetchMode, task.tasks);
+                const after = await capture(
+                  () =>
+                    resolveStoredBytes(ref, {
+                      stageId,
+                      record: supplied,
+                      resolutionGating: true,
+                      compatRowCdnFallback: true,
+                      taskUrlFallback: true,
+                      fetchPolicy: { requireOk: true, requireNonEmpty: true },
+                    }),
+                  supplied,
+                );
+                expect(after, label).toEqual(before);
+                compared++;
+              }
+    expect(compared).toBe(
+      REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length * recordCases.length * STAGES.length,
+    );
+  });
+});

--- a/tests/media/resolve-stored-bytes-equivalence.test.ts
+++ b/tests/media/resolve-stored-bytes-equivalence.test.ts
@@ -139,6 +139,45 @@ async function frozenPptx(ref: string, stageId?: string): Promise<Blob | null> {
   return resolved ? frozenFetchBlob(resolved) : null;
 }
 
+// NOT part of the frozen set: this is `frozenPptx` plus exactly the documented
+// blob-presence guard, used to pin the current behavior at that divergence.
+async function frozenPptxRepaired(ref: string, stageId?: string): Promise<Blob | null> {
+  const tasks = useMediaGenerationStore.getState().tasks;
+  const task =
+    tasks[ref] ??
+    Object.values(tasks).find(
+      (candidate) =>
+        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
+    );
+  const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
+  if (!isConcreteMediaAddress(ref)) {
+    try {
+      const pooled = await withAssetUrl(ref, async (url) => {
+        if (!url) return null;
+        const state = resolveMediaRef(ref, effectiveTask, { status: 'resolved', url });
+        const resolved = renderableMediaUrl(state);
+        return resolved ? frozenFetchBlob(resolved) : null;
+      });
+      if (pooled) return pooled;
+    } catch {
+      // The compatibility row remains the fallback when pool access fails.
+    }
+  }
+  if (stageId) {
+    const record = await db.mediaFiles.get(mediaFileKey(stageId, ref)).catch(() => undefined);
+    if (record && !record.error && record.blob && record.blob.size > 0) {
+      const state = resolveMediaRef(ref, effectiveTask, {
+        status: 'resolved',
+        url: 'dexie:media',
+      });
+      if (state.kind === 'url') return record.blob;
+    }
+  }
+  const state = resolveMediaRef(ref, effectiveTask, MISSING_ASSET_LEASE);
+  const resolved = renderableMediaUrl(state);
+  return resolved ? frozenFetchBlob(resolved) : null;
+}
+
 // ─── Frozen @ e1578083 — lib/video-export-app/collect.ts ────────────────────
 
 async function frozenResolveBytes(
@@ -213,6 +252,7 @@ async function frozenVideo(
 
 const REFS = [
   'ast_opaque_1',
+  'ast_opaque_1:variant',
   'gen_img_1',
   'https://cdn.example.com/remote.png',
   'blob:local-object',
@@ -270,48 +310,48 @@ const taskCases = (ref: string): TaskCase[] => [
 const POOL_CASES = ['url', 'miss', 'throw'] as const;
 const FETCH_CASES = ['ok', 'not-ok', 'empty', 'throw'] as const;
 
-type RecordCase = { name: string; make: () => MediaFileRecord | undefined };
+type RecordCase = { name: string; make: (ref: string) => MediaFileRecord | undefined };
 
 const recordCases: RecordCase[] = [
   { name: 'absent', make: () => undefined },
   {
     name: 'ok',
-    make: () =>
-      ({ id: 'stage-1:ast_opaque_1', blob: new Blob(['row']) }) as unknown as MediaFileRecord,
+    make: (ref) =>
+      ({ id: `stage-1:${ref}`, blob: new Blob(['row']) }) as unknown as MediaFileRecord,
   },
   {
     name: 'errored',
-    make: () =>
+    make: (ref) =>
       ({
-        id: 'stage-1:ast_opaque_1',
+        id: `stage-1:${ref}`,
         blob: new Blob(['row']),
         error: 'FAILED',
       }) as unknown as MediaFileRecord,
   },
   {
     name: 'empty-blob',
-    make: () => ({ id: 'stage-1:ast_opaque_1', blob: new Blob([]) }) as unknown as MediaFileRecord,
+    make: (ref) => ({ id: `stage-1:${ref}`, blob: new Blob([]) }) as unknown as MediaFileRecord,
   },
   {
     name: 'empty-blob-with-oss',
-    make: () =>
+    make: (ref) =>
       ({
-        id: 'stage-1:ast_opaque_1',
+        id: `stage-1:${ref}`,
         blob: new Blob([]),
         ossKey: 'https://cdn.example.com/oss.png',
       }) as unknown as MediaFileRecord,
   },
   {
     name: 'blobless-with-oss',
-    make: () =>
+    make: (ref) =>
       ({
-        id: 'stage-1:ast_opaque_1',
+        id: `stage-1:${ref}`,
         ossKey: 'https://cdn.example.com/oss.png',
       }) as unknown as MediaFileRecord,
   },
   {
     name: 'non-compound-id',
-    make: () => ({ id: 'ast_opaque_1', blob: new Blob(['row']) }) as unknown as MediaFileRecord,
+    make: (ref) => ({ id: ref, blob: new Blob(['row']) }) as unknown as MediaFileRecord,
   },
 ];
 
@@ -403,7 +443,7 @@ describe('frozen-base differential harness', () => {
             for (const row of recordCases)
               for (const stageId of STAGES) {
                 const label = `PPTX ${ref} ${task.name} pool=${pool} fetch=${fetchMode} row=${row.name} stage=${stageId}`;
-                const loaded = row.make();
+                const loaded = row.make(ref);
                 arm(pool, fetchMode, task.tasks);
                 mocks.mediaGet.mockImplementation(async (key: string) => {
                   mocks.calls.push(`dexie:${key}`);
@@ -433,6 +473,13 @@ describe('frozen-base differential harness', () => {
                   expect(before.thrown, label).toBe('TypeError');
                   expect(row.name, label).toBe('blobless-with-oss');
                   expect(stageId, label).toBe('stage-1');
+                  arm(pool, fetchMode, task.tasks);
+                  mocks.mediaGet.mockImplementation(async (key: string) => {
+                    mocks.calls.push(`dexie:${key}`);
+                    return loaded;
+                  });
+                  const repaired = await capture(() => frozenPptxRepaired(ref, stageId), loaded);
+                  expect(after, label).toEqual(repaired);
                   expect(after.kind, label).not.toBe('throw');
                   continue;
                 }
@@ -445,12 +492,13 @@ describe('frozen-base differential harness', () => {
     // every such combination that actually reaches the row. The frozen PPTX
     // path returns pooled bytes before it ever reads the row, so those
     // combinations never touch the unguarded `record.blob.size`: pool `url`,
-    // one of the two non-concrete refs, a fetch outcome the frozen `fetchBlob`
+    // one of the three non-concrete refs, a fetch outcome the frozen `fetchBlob`
     // accepts (`ok` and `empty` alike -- it checks only `response.ok`), and any
     // task state that still resolves to a URL, which is all of them except
-    // `generating` and `pending`.
+    // `generating` and `pending`. There are three non-concrete refs now: both
+    // opaque base refs and the opaque ref carrying an additional colon.
     const bloblessStaged = REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length;
-    const pooledBeforeRow = 2 * 1 * 2 * 7;
+    const pooledBeforeRow = 3 * 1 * 2 * 7;
     expect(divergences.length).toBe(bloblessStaged - pooledBeforeRow);
   });
 
@@ -463,7 +511,7 @@ describe('frozen-base differential harness', () => {
             for (const row of recordCases)
               for (const stageId of STAGES) {
                 const label = `VIDEO ${ref} ${task.name} pool=${pool} fetch=${fetchMode} row=${row.name} stage=${stageId}`;
-                const supplied = row.make();
+                const supplied = row.make(ref);
                 arm(pool, fetchMode, task.tasks);
                 const before = await capture(() => frozenVideo(ref, supplied, stageId), supplied);
                 arm(pool, fetchMode, task.tasks);

--- a/tests/media/resolve-stored-bytes.test.ts
+++ b/tests/media/resolve-stored-bytes.test.ts
@@ -152,4 +152,168 @@ describe('shared stored-bytes resolution', () => {
     expect(await bytes?.text()).toBe('row-bytes');
     expect(mocks.mediaGet).toHaveBeenCalledWith('stage-1:ast_img_1');
   });
+
+  /**
+   * Gating's headline promise is that an in-flight regeneration suppresses
+   * stale bytes at EVERY level, not only at the final one -- otherwise an
+   * export ships media the classroom no longer shows.
+   */
+  it('suppresses stale pool and row bytes while a regeneration is in flight', async () => {
+    mocks.getState.mockReturnValue({
+      tasks: { ast_img_1: { status: 'generating', stageId: 'stage-1' } },
+    });
+    mocks.withAssetUrl.mockImplementation(
+      async (_ref: string, use: (url: string | null) => Promise<Blob | null>) =>
+        use('blob:pool-stale'),
+    );
+    mocks.mediaGet.mockResolvedValue({
+      id: 'stage-1:ast_img_1',
+      blob: new Blob(['row-stale']),
+    } as MediaFileRecord);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['stale']))),
+    );
+
+    expect(
+      await resolveStoredBytes('ast_img_1', {
+        stageId: 'stage-1',
+        loadCompatRow: true,
+        resolutionGating: true,
+        fetchPolicy: STRICT,
+      }),
+    ).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Documents the pool level's unconditional branch: with gating off the
+   * caller gets pool bytes even while a regeneration is in flight. This one is
+   * NOT a regression sentinel for the task/gate separation -- the pool level
+   * branches on the option, never on the gate, so it survives that mutation.
+   * The compatibility-row case below is the discriminator.
+   */
+  it('accepts pool bytes with gating off even while a task is generating', async () => {
+    mocks.getState.mockReturnValue({ tasks: { ast_img_1: { status: 'generating' } } });
+    mocks.withAssetUrl.mockImplementation(
+      async (_ref: string, use: (url: string | null) => Promise<Blob | null>) =>
+        use('blob:pool-current'),
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['pool-bytes']))),
+    );
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      taskUrlFallback: true,
+      resolutionGating: false,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('pool-bytes');
+  });
+
+  /**
+   * The discriminating case for keeping `gate` separate from `task`: the
+   * compatibility level's acceptance check is the only place the gate is read
+   * once the pool has been consulted, so a task leaking into it would suppress
+   * a row the caller asked for unconditionally.
+   */
+  it('accepts the compatibility row with gating off while a task is generating', async () => {
+    mocks.getState.mockReturnValue({
+      tasks: { ast_img_1: { status: 'generating', stageId: 'stage-1' } },
+    });
+    mocks.mediaGet.mockResolvedValue({
+      id: 'stage-1:ast_img_1',
+      blob: new Blob(['row-bytes']),
+    } as MediaFileRecord);
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      stageId: 'stage-1',
+      loadCompatRow: true,
+      taskUrlFallback: true,
+      resolutionGating: false,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('row-bytes');
+  });
+
+  /** A row evicted under storage pressure keeps its CDN copy as the byte source. */
+  it('falls through a zero-length row blob to the CDN source', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['cdn-bytes']))),
+    );
+
+    const record = {
+      id: 'stage-1:ast_img_1',
+      blob: new Blob([]),
+      ossKey: 'https://cdn.example.com/evicted.png',
+    } as unknown as MediaFileRecord;
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      stageId: 'stage-1',
+      record,
+      compatRowCdnFallback: true,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('cdn-bytes');
+    expect(fetch).toHaveBeenCalledWith('https://cdn.example.com/evicted.png');
+  });
+
+  /** The CDN level stays unreachable for a caller that did not enable it. */
+  it('never reaches the CDN source when the fallback is off', async () => {
+    mocks.getState.mockReturnValue({
+      tasks: {
+        ast_img_1: {
+          status: 'done',
+          objectUrl: 'https://cdn.example.com/task.png',
+          stageId: 'stage-1',
+        },
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['task-bytes']))),
+    );
+
+    const record = {
+      id: 'stage-1:ast_img_1',
+      blob: new Blob([]),
+      ossKey: 'https://cdn.example.com/evicted.png',
+    } as unknown as MediaFileRecord;
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      stageId: 'stage-1',
+      record,
+      taskUrlFallback: true,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('task-bytes');
+    expect(fetch).not.toHaveBeenCalledWith('https://cdn.example.com/evicted.png');
+  });
+
+  /**
+   * A supplied row's compound id authoritatively names the document ref, so
+   * every level must resolve for that ref rather than the one the caller
+   * happened to pass.
+   */
+  it("derives the effective ref from a supplied row's compound id", async () => {
+    const record = {
+      id: 'stage-1:gen_img_7',
+      blob: new Blob(['row-bytes']),
+    } as unknown as MediaFileRecord;
+
+    const bytes = await resolveStoredBytes('caller-supplied-ref', {
+      stageId: 'stage-1',
+      record,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('row-bytes');
+    expect(mocks.withAssetUrl).toHaveBeenCalledWith('gen_img_7', expect.any(Function));
+  });
 });

--- a/tests/media/resolve-stored-bytes.test.ts
+++ b/tests/media/resolve-stored-bytes.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mediaGet: vi.fn(),
+  withAssetUrl: vi.fn(),
+  getState: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/database', () => ({
+  db: { mediaFiles: { get: mocks.mediaGet } },
+  mediaFileKey: (stageId: string, ref: string) => `${stageId}:${ref}`,
+}));
+
+vi.mock('@/lib/media/use-asset-url', () => ({
+  withAssetUrl: mocks.withAssetUrl,
+}));
+
+vi.mock('@/lib/store/media-generation', () => ({
+  useMediaGenerationStore: { getState: mocks.getState },
+}));
+
+import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
+import type { MediaFileRecord } from '@/lib/utils/database';
+
+const STRICT = { requireOk: true, requireNonEmpty: true } as const;
+
+describe('shared stored-bytes resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Pool miss by default: every test below exercises a later level.
+    mocks.withAssetUrl.mockImplementation(
+      async (_ref: string, use: (url: string | null) => Promise<Blob | null>) => use(null),
+    );
+    mocks.mediaGet.mockResolvedValue(undefined);
+    mocks.getState.mockReturnValue({ tasks: {} });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  /**
+   * The task is what the final level resolves its address from. Deriving the
+   * lookup from `resolutionGating` alone made `taskUrlFallback` inert without
+   * it -- the option would be accepted and then decide nothing.
+   */
+  it('resolves the task URL fallback with gating off', async () => {
+    mocks.getState.mockReturnValue({
+      tasks: { ast_img_1: { status: 'done', objectUrl: 'https://cdn.example.com/generated.png' } },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['generated']))),
+    );
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      taskUrlFallback: true,
+      resolutionGating: false,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('generated');
+    expect(fetch).toHaveBeenCalledWith('https://cdn.example.com/generated.png');
+  });
+
+  /** Gating still suppresses stale bytes while a regeneration is in flight. */
+  it('keeps gating independent of the fallback lookup', async () => {
+    mocks.getState.mockReturnValue({
+      tasks: {
+        ast_img_1: { status: 'generating', objectUrl: 'https://cdn.example.com/stale.png' },
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['stale']))),
+    );
+
+    expect(
+      await resolveStoredBytes('ast_img_1', {
+        taskUrlFallback: true,
+        resolutionGating: true,
+        fetchPolicy: STRICT,
+      }),
+    ).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The module promises it never throws. A row that lost its blob must fall
+   * through to the next byte source, the way the pre-refactor video path did.
+   */
+  it('falls through a compatibility row whose blob is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['cdn-bytes']))),
+    );
+
+    const record = {
+      id: 'stage-1:ast_img_1',
+      blob: undefined,
+      ossKey: 'https://cdn.example.com/evicted.png',
+    } as unknown as MediaFileRecord;
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      stageId: 'stage-1',
+      record,
+      compatRowCdnFallback: true,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('cdn-bytes');
+  });
+
+  it('returns null rather than throwing when a blob-less row has no CDN source', async () => {
+    const record = { id: 'stage-1:ast_img_1', blob: undefined } as unknown as MediaFileRecord;
+
+    await expect(
+      resolveStoredBytes('ast_img_1', {
+        stageId: 'stage-1',
+        record,
+        compatRowCdnFallback: true,
+        fetchPolicy: STRICT,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  /**
+   * The compatibility row is keyed `stageId:ref`, so the level is unreachable
+   * without a stage. Pinned so the documented dependency cannot drift into a
+   * silent lookup against a wrong key.
+   */
+  it('skips the compatibility level when loadCompatRow has no stage', async () => {
+    expect(
+      await resolveStoredBytes('ast_img_1', {
+        loadCompatRow: true,
+        fetchPolicy: STRICT,
+      }),
+    ).toBeNull();
+    expect(mocks.mediaGet).not.toHaveBeenCalled();
+  });
+
+  it('reads the compatibility row by compound key once a stage is supplied', async () => {
+    mocks.mediaGet.mockResolvedValue({
+      id: 'stage-1:ast_img_1',
+      blob: new Blob(['row-bytes']),
+    } as MediaFileRecord);
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      stageId: 'stage-1',
+      loadCompatRow: true,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('row-bytes');
+    expect(mocks.mediaGet).toHaveBeenCalledWith('stage-1:ast_img_1');
+  });
+});

--- a/tests/media/resolve-stored-bytes.test.ts
+++ b/tests/media/resolve-stored-bytes.test.ts
@@ -316,4 +316,54 @@ describe('shared stored-bytes resolution', () => {
     expect(await bytes?.text()).toBe('row-bytes');
     expect(mocks.withAssetUrl).toHaveBeenCalledWith('gen_img_7', expect.any(Function));
   });
+
+  /**
+   * The pre-refactor video path decided whether a SUPPLIED row was usable
+   * before it awaited the pool. The row is a live object, so taking that
+   * verdict after the await would let an `error` landing mid-lookup change
+   * which bytes the export ships.
+   */
+  it("takes a supplied row's error verdict before the pool lookup", async () => {
+    const record = {
+      id: 'stage-1:ast_img_1',
+      blob: new Blob(['row-bytes']),
+    } as unknown as MediaFileRecord;
+    mocks.withAssetUrl.mockImplementation(
+      async (_ref: string, use: (url: string | null) => Promise<Blob | null>) => {
+        (record as { error?: string }).error = 'MEDIA_TASK_FAILED';
+        return use(null);
+      },
+    );
+
+    const bytes = await resolveStoredBytes('ast_img_1', {
+      stageId: 'stage-1',
+      record,
+      fetchPolicy: STRICT,
+    });
+
+    expect(await bytes?.text()).toBe('row-bytes');
+  });
+
+  /** The same snapshot in the other direction: a clear mid-lookup is ignored too. */
+  it('keeps an errored supplied row excluded when the flag clears mid-lookup', async () => {
+    const record = {
+      id: 'stage-1:ast_img_1',
+      blob: new Blob(['row-bytes']),
+      error: 'MEDIA_TASK_FAILED',
+    } as unknown as MediaFileRecord;
+    mocks.withAssetUrl.mockImplementation(
+      async (_ref: string, use: (url: string | null) => Promise<Blob | null>) => {
+        delete (record as { error?: string }).error;
+        return use(null);
+      },
+    );
+
+    expect(
+      await resolveStoredBytes('ast_img_1', {
+        stageId: 'stage-1',
+        record,
+        fetchPolicy: STRICT,
+      }),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
First PR of the #1007 part 3 (export convergence) line, now that part 2(c) (#1101) is on `main`.

Three export paths (classroom ZIP, PPTX, video export) each re-implemented the same byte-resolution fallback chain — pool → Dexie compatibility row → task/CDN URL — with subtle per-path differences. This replaces them with one shared helper, `lib/media/resolve-stored-bytes.ts`.

The genuine divergences between the three implementations are preserved as explicit options rather than silently unified:

- **Fetch strictness** (ZIP accepts any response status but rejects zero-byte answers, PPTX requires `response.ok`, video requires both) → `fetchPolicy`.
- **Regeneration gating** (PPTX/video suppress stale bytes through `resolveMediaRef` while a regeneration is in flight; ZIP did not) → `resolutionGating`.
- **Fallback levels** (ZIP pool-only; PPTX adds the task URL; video adds the `ossKey` CDN fetch) → `loadCompatRow` / `compatRowCdnFallback` / `taskUrlFallback`.
- **Dexie row source** (read internally by compound key vs. pre-loaded by the caller) → `loadCompatRow` vs `record`.

Replaced: ZIP's `pooledBytesForRef`, PPTX's `resolveStoredMediaBlob`, video export's `resolveMediaBytesWithFallback`, plus two duplicate `mediaRefFromRecordId` helpers. Call sites keep their old local signatures through thin wrappers, so no calling code changed shape.

## Behavior preservation, and the one divergence

The three call sites resolve the same bytes from the same inputs as before. That is not an assertion you have to take on trust: `tests/media/resolve-stored-bytes-equivalence.test.ts` reproduces the three pre-refactor implementations verbatim as they stand at the merge base and drives them side by side with the current helper under each call site's real option set, over a declared matrix (ref shapes × task states × pool outcomes × fetch outcomes × record shapes × stage scoping), comparing returned bytes, thrown error types, blob identity by reference, and the ordered lease / Dexie / fetch sequences including their arguments. Run it with `pnpm exec vitest run tests/media/resolve-stored-bytes-equivalence.test.ts`. One divergence, deliberate:

**A compatibility row with no `blob` no longer throws.** On `main` the PPTX path evaluated `record.blob.size` unguarded, so such a row rejected the whole PPTX export with a `TypeError`; the shared helper guards it and falls through to the next byte source. This restores the guard `main`'s video path already had (`blob && blob.size > 0`) and is what makes the module's documented "never throws" contract true. No writer in the repo can currently produce that row shape — success rows, failed rows (an empty placeholder blob), classroom import, and the conversion mirror all populate `blob` — so the divergence is unreachable in practice, but it is a divergence and not worth hiding.

One further note for reviewers weighing "pure refactor": the extraction introduces async-function boundaries the inline chains did not have — one at the pool level, and a second at the compatibility level for the PPTX shape, whose row check used to be inline. Every operation after them therefore starts one or two microtasks later than it did on `main`. The order, the count, and the identity of the operations themselves are unchanged, and every value whose observation point mattered — the effective ref, the task, and a supplied row's `error` verdict — is taken before the boundaries. What that leaves is a scheduling difference: a microtask that mutated a row in place, or committed a Dexie write, in exactly that window would be observed by one version and not the other. No writer in the repo does that — every `mediaFiles` writer replaces the record rather than mutating a held reference — so the difference has no trigger today, but it is a difference and not a proof of equivalence.

## Rebase across #1101

Two hunks needed a decision rather than a replay, both where #1101's later hardening landed in the same lines:

- The ZIP's pool fetch maps to `{ requireOk: false, requireNonEmpty: true }`. The branch predated #1101's zero-byte rejection, so a verbatim replay would have restored shipping empty media files. Now pinned by a test that reddens if `requireOk` is tightened.
- `collectMediaFiles` keeps #1101's skip of a legacy row superseded by its allocated-id mirror, expressed through the shared `mediaRefFromRecordId` so the local duplicate goes away with the others.

## Review

Six cross-vendor review rounds (Codex and DeepSeek, each reviewing the same diff independently, findings merged by consensus).

- **Round 1** — an option surface that promised more than the code did: `taskUrlFallback` was inert without `resolutionGating`, and an unguarded `record.blob` broke the module's "never throws" contract. Both fixed.
- **Round 2** — no behavior defects; every finding was a test that would still pass with the behavior broken. Six mutation-verified cases close them.
- **Round 3** — no behavior defects. Its findings were the `blob` divergence documented above and an overstated mutation claim in a commit message.
- **Round 4** — the one real defect the earlier level-by-level rounds missed: the extraction moved a supplied row's `error` verdict past the pool await, so an `error` landing mid-lookup changed which bytes shipped. Fixed, with both directions pinned.
- **Round 5** — no new code defect. One reviewer enumerated every read in the helper against its pre-refactor observation point and could not falsify the sweep; the other confirmed the fix and raised only commit-message accuracy.
- **Round 6** — no new code defect and no undocumented divergence from either reviewer; one reviewer independently confirmed the two divergences stated above are the complete set. Remaining findings were documentary and are folded in.

Refs #1007
