### PR TITLE
feat(dsl): standardize the asset manifest and converge the export paths (#1007 part 3)

### DIFF
--- a/lib/export/classroom-zip-types.ts
+++ b/lib/export/classroom-zip-types.ts
@@ -136,7 +136,7 @@ export type ManifestAction = Omit<Action, 'audioId'> & {
 
 export interface MediaIndexEntry {
   type: 'audio' | 'image' | 'generated';
-  /** Original document ref for audio; ZIP paths and refs are separate namespaces. */
+  /** Original document ref; ZIP paths and refs are separate namespaces. */
   sourceRef?: string;
   mimeType?: string;
   format?: string;

--- a/lib/export/classroom-zip-types.ts
+++ b/lib/export/classroom-zip-types.ts
@@ -136,6 +136,8 @@ export type ManifestAction = Omit<Action, 'audioId'> & {
 
 export interface MediaIndexEntry {
   type: 'audio' | 'image' | 'generated';
+  /** Original document ref for audio; ZIP paths and refs are separate namespaces. */
+  sourceRef?: string;
   mimeType?: string;
   format?: string;
   duration?: number;

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -216,11 +216,14 @@ export function rewriteAudioRefsToIds(
   return actions.map((action) => {
     if (action.type === 'speech' && 'audioRef' in action) {
       const { audioRef, ...rest } = action;
-      const mapped = audioRef
-        ? audioRefMap instanceof Map
-          ? audioRefMap.get(audioRef)
-          : (audioRefMap as Readonly<Record<string, unknown>>)[audioRef]
-        : undefined;
+      const mapped =
+        typeof audioRef === 'string'
+          ? audioRefMap instanceof Map
+            ? audioRefMap.get(audioRef)
+            : Object.hasOwn(audioRefMap, audioRef)
+              ? (audioRefMap as Readonly<Record<string, unknown>>)[audioRef]
+              : undefined
+          : undefined;
       const audioId = typeof mapped === 'string' ? mapped : undefined;
       return {
         ...rest,

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -1,17 +1,19 @@
 import type { Action, DiscussionAction, SpeechAction } from '@/lib/types/action';
 import type { ManifestAction } from './classroom-zip-types';
-import { db } from '@/lib/utils/database';
+import { db, mediaFileKey } from '@/lib/utils/database';
+import type { AssetManifestEntry } from '@openmaic/dsl';
 import type { AudioFileRecord, MediaFileRecord } from '@/lib/utils/database';
 import type { Scene } from '@/lib/types/stage';
 import { resolveAudioBlob } from '@/lib/media/resolve-audio-bytes';
 import { fetchMediaUrl } from '@/lib/media/fetch-media-url';
 import { mapWithConcurrency } from '@/lib/media/convert-legacy-asset-refs';
-import { mediaRefFromRecordId, resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
+import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
 
 // ─── Export: Collect Media ─────────────────────────────────────
 
 export interface CollectedAudio {
   zipPath: string;
+  sourceRef: string;
   record: AudioFileRecord;
 }
 
@@ -21,30 +23,30 @@ export interface CollectedMedia {
   elementId: string;
 }
 
-export async function collectAudioFiles(scenes: Scene[]): Promise<CollectedAudio[]> {
-  const audioIds = new Set<string>();
-  for (const scene of scenes) {
-    for (const action of scene.actions ?? []) {
-      if (action.type === 'speech' && (action as SpeechAction).audioId) {
-        audioIds.add((action as SpeechAction).audioId!);
-      }
-    }
-  }
+/**
+ * Collect the bytes of every audio entry selected by the classroom export.
+ * That set includes speech narration and reconstructable slide-audio refs, so
+ * no table scan runs here and an orphan audio row cannot ride into the archive.
+ * Bytes come only from the shared resolver (pool-first, with the
+ * compatibility-row fallback inside it); the row read here supplies the
+ * archive's format/duration/voice metadata.
+ */
+export async function collectAudioFiles(
+  entries: readonly AssetManifestEntry[],
+): Promise<CollectedAudio[]> {
   const collected: CollectedAudio[] = [];
-  for (const audioId of audioIds) {
-    const record = await db.audioFiles.get(audioId);
+  for (const entry of entries) {
+    const audioId = entry.ref;
     // The pool answers first: after a stable-id regeneration whose mirror write
     // failed, the row holds the superseded narration.
     const blob = await resolveAudioBlob(audioId);
     // A row with no usable bytes -- an evicted row (empty blob, no pool
-    // resolve) -- must not ship an empty audio file. It produces no zip
-    // path, so the URL rescue in collectLegacyAudioForExport sees the id as
-    // missing and fetches the live co-present URL instead.
-    if (blob && blob.size > 0) {
-      const ext = record?.format || 'mp3';
-      const resolved = (record ? { ...record, blob } : { id: audioId, blob }) as AudioFileRecord;
-      collected.push({ zipPath: `audio/${audioId}.${ext}`, record: resolved });
-    }
+    // resolve) -- must not ship an empty audio file.
+    if (!blob || blob.size === 0) continue;
+    const record = await db.audioFiles.get(audioId);
+    const ext = record?.format || 'mp3';
+    const resolved = (record ? { ...record, blob } : { id: audioId, blob }) as AudioFileRecord;
+    collected.push({ zipPath: `audio/${audioId}.${ext}`, sourceRef: entry.ref, record: resolved });
   }
   return collected;
 }
@@ -65,32 +67,43 @@ async function pooledBytesForRef(ref: string): Promise<Blob | null> {
   });
 }
 
-export async function collectMediaFiles(stageId: string): Promise<CollectedMedia[]> {
-  const records = await db.mediaFiles.where('stageId').equals(stageId).toArray();
-  // A converted asset exists as two rows: the legacy row (keyed by the
-  // original gen_* placeholder) and the allocated-id compatibility mirror
-  // (placeholderRef retained). The document now references the mirror, so the
-  // ZIP must ship each logical asset once -- the mirror -- and skip the legacy
-  // row it mirrors: importing the archive would otherwise materialize an
-  // unreferenced duplicate and inflate the round trip. Audio avoids this by
-  // deriving its rows from the document's speech actions instead of
-  // enumerating the table.
-  const supersededLegacyRefs = new Set(
-    records
-      .map((row) => mediaRefFromRecordId(row.id))
-      .filter((ref) => records.some((row) => row.placeholderRef === ref)),
-  );
+/**
+ * Collect the bytes of every media entry (image/video/poster/background) in
+ * the asset manifest. Only referenced assets are archived: the pre-manifest
+ * implementation scanned the whole `mediaFiles` table for the stage, which
+ * swept rows no document element still references into the ZIP. A referenced
+ * asset whose bytes exist only in the pool (its compatibility row was never
+ * written or has been pruned) is still collected, with a synthesized record.
+ */
+export async function collectMediaFiles(
+  stageId: string,
+  entries: readonly AssetManifestEntry[],
+): Promise<CollectedMedia[]> {
   const collected: CollectedMedia[] = [];
-  for (const record of records) {
-    const elementId = mediaRefFromRecordId(record.id);
-    if (supersededLegacyRefs.has(elementId)) continue;
-    const ext = record.mimeType?.split('/')[1] || 'jpg';
-    const pooled = await pooledBytesForRef(elementId);
-    collected.push({
-      zipPath: `media/${elementId}.${ext}`,
-      record: pooled ? { ...record, blob: pooled } : record,
-      elementId,
-    });
+  for (const entry of entries) {
+    const ref = entry.ref;
+    const record = await db.mediaFiles.get(mediaFileKey(stageId, ref)).catch(() => undefined);
+    const pooled = await pooledBytesForRef(ref);
+    // Referenced but with bytes nowhere (pending generation, pruned): the
+    // archive simply lacks the file, as it did when no row existed.
+    if (!record && !pooled) continue;
+    const effective: MediaFileRecord = record
+      ? pooled
+        ? { ...record, blob: pooled }
+        : record
+      : {
+          id: mediaFileKey(stageId, ref),
+          stageId,
+          type: pooled!.type.startsWith('video/') ? 'video' : 'image',
+          blob: pooled!,
+          mimeType: pooled!.type,
+          size: pooled!.size,
+          prompt: '',
+          params: '',
+          createdAt: 0,
+        };
+    const ext = effective.mimeType?.split('/')[1] || 'jpg';
+    collected.push({ zipPath: `media/${ref}.${ext}`, record: effective, elementId: ref });
   }
   return collected;
 }
@@ -202,41 +215,20 @@ interface RewriteManifestActionOptions {
   fallbackDiscussionAgentIndex?: number;
 }
 
-/**
- * Speech references that would dangle in the exported ZIP: an audioId with no
- * archive row and no recovered fallback. A legacy audioUrl that WAS recovered
- * travels under its own zip path (`actionsToManifest` maps the action to it),
- * so the same narration must not also be flagged missing under a phantom
- * `audio/${audioId}.mp3` path.
- */
-export function collectMissingAudioRefs(
-  scenes: readonly Scene[],
-  audioIdToPath: Map<string, string>,
-  audioUrlToPath: Map<string, string>,
-): Array<{ audioId: string; missingPath: string }> {
-  const missing: Array<{ audioId: string; missingPath: string }> = [];
-  for (const scene of scenes) {
-    for (const action of scene.actions ?? []) {
-      if (action.type !== 'speech') continue;
-      const speech = action as SpeechAction & { audioUrl?: string };
-      const audioId = speech.audioId;
-      if (!audioId || audioIdToPath.has(audioId)) continue;
-      if (speech.audioUrl && audioUrlToPath.has(speech.audioUrl)) continue;
-      missing.push({ audioId, missingPath: `audio/${audioId}.mp3` });
-    }
-  }
-  return missing;
-}
-
 export function rewriteAudioRefsToIds(
   actions: ManifestAction[],
-  audioRefMap: Record<string, string>,
+  audioRefMap: ReadonlyMap<string, unknown> | Readonly<Record<string, unknown>>,
   options: RewriteManifestActionOptions = {},
 ): Action[] {
   return actions.map((action) => {
     if (action.type === 'speech' && 'audioRef' in action) {
       const { audioRef, ...rest } = action;
-      const audioId = audioRef ? audioRefMap[audioRef] : undefined;
+      const mapped = audioRef
+        ? audioRefMap instanceof Map
+          ? audioRefMap.get(audioRef)
+          : (audioRefMap as Readonly<Record<string, unknown>>)[audioRef]
+        : undefined;
+      const audioId = typeof mapped === 'string' ? mapped : undefined;
       return {
         ...rest,
         ...(audioId ? { audioId } : {}),

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -19,17 +19,129 @@ export interface CollectedAudio {
 
 export interface CollectedMedia {
   zipPath: string;
+  posterZipPath: string;
   sourceRef: string;
   record: MediaFileRecord;
   elementId: string;
 }
 
-export function audioArchivePath(index: number, extension: string): string {
-  return `audio/audio-${index + 1}.${extension}`;
+const AUDIO_ARCHIVE_EXTENSIONS = new Set([
+  'aac',
+  'flac',
+  'm4a',
+  'mp3',
+  'mp4',
+  'mpeg',
+  'ogg',
+  'opus',
+  'wav',
+  'webm',
+]);
+const MEDIA_ARCHIVE_EXTENSIONS = new Set([
+  'avif',
+  'gif',
+  'jpeg',
+  'jpg',
+  'm4v',
+  'mov',
+  'mp4',
+  'ogv',
+  'png',
+  'svg',
+  'webm',
+  'webp',
+]);
+
+const MIME_ARCHIVE_EXTENSIONS: Readonly<Record<string, string>> = {
+  'audio/aac': 'aac',
+  'audio/flac': 'flac',
+  'audio/mp4': 'mp4',
+  'audio/mpeg': 'mpeg',
+  'audio/ogg': 'ogg',
+  'audio/opus': 'opus',
+  'audio/wav': 'wav',
+  'audio/webm': 'webm',
+  'audio/x-m4a': 'm4a',
+  'audio/x-wav': 'wav',
+  'image/avif': 'avif',
+  'image/gif': 'gif',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/svg+xml': 'svg',
+  'image/webp': 'webp',
+  'video/mp4': 'mp4',
+  'video/ogg': 'ogv',
+  'video/quicktime': 'mov',
+  'video/webm': 'webm',
+  'video/x-m4v': 'm4v',
+};
+
+/**
+ * Accept only one allowlisted filename suffix. Slashes, backslashes, dot
+ * segments, parameters, and unknown values all fall back instead of entering
+ * an archive path.
+ */
+function canonicalArchiveExtension(
+  extension: string | undefined,
+  allowed: ReadonlySet<string>,
+  fallback: string,
+): string {
+  if (typeof extension !== 'string' || !/^[a-z0-9]+$/i.test(extension)) return fallback;
+  const canonical = extension.toLowerCase();
+  return allowed.has(canonical) ? canonical : fallback;
 }
 
-export function mediaArchivePath(index: number, extension: string): string {
-  return `media/asset-${index + 1}.${extension}`;
+function extensionFromMimeType(mimeType: string | undefined): string | undefined {
+  if (typeof mimeType !== 'string' || mimeType !== mimeType.toLowerCase()) return undefined;
+  return MIME_ARCHIVE_EXTENSIONS[mimeType];
+}
+
+function canonicalAudioExtension(format: string | undefined): string {
+  return canonicalArchiveExtension(format, AUDIO_ARCHIVE_EXTENSIONS, 'mp3');
+}
+
+function canonicalAudioMimeExtension(mimeType: string | undefined): string {
+  return canonicalArchiveExtension(
+    extensionFromMimeType(mimeType),
+    AUDIO_ARCHIVE_EXTENSIONS,
+    'mp3',
+  );
+}
+
+function canonicalMediaExtension(mimeType: string | undefined, fallback: 'jpg' | 'mp4'): string {
+  return canonicalArchiveExtension(
+    extensionFromMimeType(mimeType),
+    MEDIA_ARCHIVE_EXTENSIONS,
+    fallback,
+  );
+}
+
+export function audioArchivePath(index: number, extension: string | undefined): string {
+  return `audio/audio-${index + 1}.${canonicalArchiveExtension(
+    extension,
+    AUDIO_ARCHIVE_EXTENSIONS,
+    'mp3',
+  )}`;
+}
+
+export function legacyAudioArchivePath(index: number, extension: string | undefined): string {
+  return `audio/legacy-${index + 1}.${canonicalArchiveExtension(
+    extension,
+    AUDIO_ARCHIVE_EXTENSIONS,
+    'mp3',
+  )}`;
+}
+
+export function mediaArchivePath(index: number, extension: string | undefined): string {
+  return `media/asset-${index + 1}.${canonicalArchiveExtension(
+    extension,
+    MEDIA_ARCHIVE_EXTENSIONS,
+    'jpg',
+  )}`;
+}
+
+export function mediaPosterArchivePath(index: number): string {
+  return `media/asset-${index + 1}.poster.jpg`;
 }
 
 /**
@@ -54,8 +166,10 @@ export async function collectAudioFiles(
     // resolve) -- must not ship an empty audio file.
     if (!blob || blob.size === 0) continue;
     const record = await db.audioFiles.get(audioId);
-    const ext = record?.format || 'mp3';
-    const resolved = (record ? { ...record, blob } : { id: audioId, blob }) as AudioFileRecord;
+    const ext = canonicalAudioExtension(record?.format);
+    const resolved = (
+      record ? { ...record, blob, format: ext } : { id: audioId, blob, format: ext }
+    ) as AudioFileRecord;
     collected.push({
       zipPath: audioArchivePath(index, ext),
       sourceRef: entry.ref,
@@ -108,9 +222,13 @@ export async function collectMediaFiles(
           params: '',
           createdAt: 0,
         };
-    const ext = effective.mimeType?.split('/')[1] || 'jpg';
+    const ext = canonicalMediaExtension(
+      effective.mimeType,
+      effective.type === 'video' ? 'mp4' : 'jpg',
+    );
     collected.push({
       zipPath: mediaArchivePath(index, ext),
+      posterZipPath: mediaPosterArchivePath(index),
       sourceRef: entry.ref,
       record: effective,
       elementId: ref,
@@ -170,8 +288,8 @@ export async function collectLegacyAudioForExport(
   });
   for (const { url, blob } of fetched) {
     if (!blob) continue;
-    const format = blob.type.split('/')[1] || 'mp3';
-    const zipPath = `audio/legacy-${blobs.length + 1}.${format}`;
+    const format = canonicalAudioMimeExtension(blob.type);
+    const zipPath = legacyAudioArchivePath(blobs.length, format);
     audioUrlToPath.set(url, zipPath);
     blobs.push({ zipPath, blob, format });
   }

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -238,11 +238,18 @@ export interface LegacyAudioBlob {
   blob: Blob;
   format: string;
   mimeType: string;
+  /** The legacy URL the narration was fetched from — its natural source ref. */
+  sourceRef: string;
 }
 
 /** Exact media-index metadata serialized for one fetched legacy narration asset. */
 export function legacyAudioMediaIndexEntry(file: LegacyAudioBlob): MediaIndexEntry {
-  return { type: 'audio', format: file.format, mimeType: file.mimeType };
+  return {
+    type: 'audio',
+    sourceRef: file.sourceRef,
+    format: file.format,
+    mimeType: file.mimeType,
+  };
 }
 
 /**
@@ -291,7 +298,7 @@ export async function collectLegacyAudioForExport(
     const format = canonical.extension;
     const zipPath = legacyAudioArchivePath(blobs.length, format);
     audioUrlToPath.set(url, zipPath);
-    blobs.push({ zipPath, blob, format, mimeType: canonical.mimeType });
+    blobs.push({ zipPath, blob, format, mimeType: canonical.mimeType, sourceRef: url });
   }
   return { audioUrlToPath, blobs };
 }

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -8,6 +8,7 @@ import { resolveAudioBlob } from '@/lib/media/resolve-audio-bytes';
 import { fetchMediaUrl } from '@/lib/media/fetch-media-url';
 import { mapWithConcurrency } from '@/lib/media/convert-legacy-asset-refs';
 import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
+import { canonicalArchiveMedia } from '@/lib/video-export/archive-media';
 
 // ─── Export: Collect Media ─────────────────────────────────────
 
@@ -52,30 +53,6 @@ const MEDIA_ARCHIVE_EXTENSIONS = new Set([
   'webp',
 ]);
 
-const MIME_ARCHIVE_EXTENSIONS: Readonly<Record<string, string>> = {
-  'audio/aac': 'aac',
-  'audio/flac': 'flac',
-  'audio/mp4': 'mp4',
-  'audio/mpeg': 'mpeg',
-  'audio/ogg': 'ogg',
-  'audio/opus': 'opus',
-  'audio/wav': 'wav',
-  'audio/webm': 'webm',
-  'audio/x-m4a': 'm4a',
-  'audio/x-wav': 'wav',
-  'image/avif': 'avif',
-  'image/gif': 'gif',
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/svg+xml': 'svg',
-  'image/webp': 'webp',
-  'video/mp4': 'mp4',
-  'video/ogg': 'ogv',
-  'video/quicktime': 'mov',
-  'video/webm': 'webm',
-  'video/x-m4v': 'm4v',
-};
-
 /**
  * Accept only one allowlisted filename suffix. Slashes, backslashes, dot
  * segments, parameters, and unknown values all fall back instead of entering
@@ -89,31 +66,6 @@ function canonicalArchiveExtension(
   if (typeof extension !== 'string' || !/^[a-z0-9]+$/i.test(extension)) return fallback;
   const canonical = extension.toLowerCase();
   return allowed.has(canonical) ? canonical : fallback;
-}
-
-function extensionFromMimeType(mimeType: string | undefined): string | undefined {
-  if (typeof mimeType !== 'string' || mimeType !== mimeType.toLowerCase()) return undefined;
-  return MIME_ARCHIVE_EXTENSIONS[mimeType];
-}
-
-function canonicalAudioExtension(format: string | undefined): string {
-  return canonicalArchiveExtension(format, AUDIO_ARCHIVE_EXTENSIONS, 'mp3');
-}
-
-function canonicalAudioMimeExtension(mimeType: string | undefined): string {
-  return canonicalArchiveExtension(
-    extensionFromMimeType(mimeType),
-    AUDIO_ARCHIVE_EXTENSIONS,
-    'mp3',
-  );
-}
-
-function canonicalMediaExtension(mimeType: string | undefined, fallback: 'jpg' | 'mp4'): string {
-  return canonicalArchiveExtension(
-    extensionFromMimeType(mimeType),
-    MEDIA_ARCHIVE_EXTENSIONS,
-    fallback,
-  );
 }
 
 export function audioArchivePath(index: number, extension: string | undefined): string {
@@ -141,7 +93,8 @@ export function mediaArchivePath(index: number, extension: string | undefined): 
 }
 
 export function mediaPosterArchivePath(index: number): string {
-  return `media/asset-${index + 1}.poster.jpg`;
+  const { extension } = canonicalArchiveMedia('image', {});
+  return `media/asset-${index + 1}.poster.${extension}`;
 }
 
 /**
@@ -166,7 +119,7 @@ export async function collectAudioFiles(
     // resolve) -- must not ship an empty audio file.
     if (!blob || blob.size === 0) continue;
     const record = await db.audioFiles.get(audioId);
-    const ext = canonicalAudioExtension(record?.format);
+    const { extension: ext } = canonicalArchiveMedia('audio', { extension: record?.format });
     const resolved = (
       record ? { ...record, blob, format: ext } : { id: audioId, blob, format: ext }
     ) as AudioFileRecord;
@@ -222,15 +175,14 @@ export async function collectMediaFiles(
           params: '',
           createdAt: 0,
         };
-    const ext = canonicalMediaExtension(
-      effective.mimeType,
-      effective.type === 'video' ? 'mp4' : 'jpg',
-    );
+    const kind: MediaFileRecord['type'] = effective.type === 'video' ? 'video' : 'image';
+    const canonical = canonicalArchiveMedia(kind, { mimeType: effective.mimeType });
+    const normalized = { ...effective, type: kind, mimeType: canonical.mimeType };
     collected.push({
-      zipPath: mediaArchivePath(index, ext),
+      zipPath: mediaArchivePath(index, canonical.extension),
       posterZipPath: mediaPosterArchivePath(index),
       sourceRef: entry.ref,
-      record: effective,
+      record: normalized,
       elementId: ref,
     });
   }
@@ -288,7 +240,7 @@ export async function collectLegacyAudioForExport(
   });
   for (const { url, blob } of fetched) {
     if (!blob) continue;
-    const format = canonicalAudioMimeExtension(blob.type);
+    const { extension: format } = canonicalArchiveMedia('audio', { mimeType: blob.type });
     const zipPath = legacyAudioArchivePath(blobs.length, format);
     audioUrlToPath.set(url, zipPath);
     blobs.push({ zipPath, blob, format });

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -37,8 +37,9 @@ export async function collectAudioFiles(
   const collected: CollectedAudio[] = [];
   for (const entry of entries) {
     const audioId = entry.ref;
-    // The pool answers first: after a stable-id regeneration whose mirror write
-    // failed, the row holds the superseded narration.
+    // The pool answers first: after a stable-id regeneration whose mirror
+    // write failed, the row holds the superseded narration. A ref whose bytes
+    // resolve nowhere ships nothing; the caller marks it missing.
     const blob = await resolveAudioBlob(audioId);
     // A row with no usable bytes -- an evicted row (empty blob, no pool
     // resolve) -- must not ship an empty audio file.
@@ -52,28 +53,19 @@ export async function collectAudioFiles(
 }
 
 /**
- * A same-id replacement commits the new bytes to the pool first; if the
- * compatibility write then fails, the task records
- * `MEDIA_COMPATIBILITY_STORE_LAGGED` and the document deliberately keeps the
- * same reference. Rendering and the other export paths resolve the pool, so the
- * ZIP must too -- otherwise it ships media the classroom no longer shows. The
- * ZIP predates the `response.ok` validation the other export paths added and
- * keeps that laxity, but a zero-byte pool answer is not usable bytes: the
- * compatibility row stays the fallback rather than shipping an empty file.
- */
-async function pooledBytesForRef(ref: string): Promise<Blob | null> {
-  return resolveStoredBytes(ref, {
-    fetchPolicy: { requireOk: false, requireNonEmpty: true },
-  });
-}
-
-/**
  * Collect the bytes of every media entry (image/video/poster/background) in
  * the asset manifest. Only referenced assets are archived: the pre-manifest
  * implementation scanned the whole `mediaFiles` table for the stage, which
- * swept rows no document element still references into the ZIP. A referenced
- * asset whose bytes exist only in the pool (its compatibility row was never
- * written or has been pruned) is still collected, with a synthesized record.
+ * swept rows no document element still references into the ZIP.
+ *
+ * Bytes come from the shared resolver, pool-first with the supplied
+ * compatibility record's blob as its legacy row-fallback level -- so a
+ * same-id replacement whose mirror write lagged
+ * (MEDIA_COMPATIBILITY_STORE_LAGGED) ships what the classroom renders, and a
+ * referenced asset whose bytes exist only in the pool is collected with a
+ * synthesized record. A failed row (error set, empty placeholder blob) yields
+ * no bytes and ships no empty file. The ZIP predates the response validation
+ * the other export paths added, so it keeps its historical lax fetch policy.
  */
 export async function collectMediaFiles(
   stageId: string,
@@ -83,21 +75,22 @@ export async function collectMediaFiles(
   for (const entry of entries) {
     const ref = entry.ref;
     const record = await db.mediaFiles.get(mediaFileKey(stageId, ref)).catch(() => undefined);
-    const pooled = await pooledBytesForRef(ref);
-    // Referenced but with bytes nowhere (pending generation, pruned): the
-    // archive simply lacks the file, as it did when no row existed.
-    if (!record && !pooled) continue;
+    const blob = await resolveStoredBytes(ref, {
+      record,
+      fetchPolicy: { requireOk: false, requireNonEmpty: true },
+    });
+    // Referenced but with bytes nowhere (pending generation, pruned, failed):
+    // the archive simply lacks the file, as it did when no row existed.
+    if (!blob) continue;
     const effective: MediaFileRecord = record
-      ? pooled
-        ? { ...record, blob: pooled }
-        : record
+      ? { ...record, blob }
       : {
           id: mediaFileKey(stageId, ref),
           stageId,
-          type: pooled!.type.startsWith('video/') ? 'video' : 'image',
-          blob: pooled!,
-          mimeType: pooled!.type,
-          size: pooled!.size,
+          type: blob.type.startsWith('video/') ? 'video' : 'image',
+          blob,
+          mimeType: blob.type,
+          size: blob.size,
           prompt: '',
           params: '',
           createdAt: 0,

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -19,8 +19,17 @@ export interface CollectedAudio {
 
 export interface CollectedMedia {
   zipPath: string;
+  sourceRef: string;
   record: MediaFileRecord;
   elementId: string;
+}
+
+export function audioArchivePath(index: number, extension: string): string {
+  return `audio/audio-${index + 1}.${extension}`;
+}
+
+export function mediaArchivePath(index: number, extension: string): string {
+  return `media/asset-${index + 1}.${extension}`;
 }
 
 /**
@@ -35,7 +44,7 @@ export async function collectAudioFiles(
   entries: readonly AssetManifestEntry[],
 ): Promise<CollectedAudio[]> {
   const collected: CollectedAudio[] = [];
-  for (const entry of entries) {
+  for (const [index, entry] of entries.entries()) {
     const audioId = entry.ref;
     // The pool answers first: after a stable-id regeneration whose mirror
     // write failed, the row holds the superseded narration. A ref whose bytes
@@ -47,7 +56,11 @@ export async function collectAudioFiles(
     const record = await db.audioFiles.get(audioId);
     const ext = record?.format || 'mp3';
     const resolved = (record ? { ...record, blob } : { id: audioId, blob }) as AudioFileRecord;
-    collected.push({ zipPath: `audio/${audioId}.${ext}`, sourceRef: entry.ref, record: resolved });
+    collected.push({
+      zipPath: audioArchivePath(index, ext),
+      sourceRef: entry.ref,
+      record: resolved,
+    });
   }
   return collected;
 }
@@ -72,7 +85,7 @@ export async function collectMediaFiles(
   entries: readonly AssetManifestEntry[],
 ): Promise<CollectedMedia[]> {
   const collected: CollectedMedia[] = [];
-  for (const entry of entries) {
+  for (const [index, entry] of entries.entries()) {
     const ref = entry.ref;
     const record = await db.mediaFiles.get(mediaFileKey(stageId, ref)).catch(() => undefined);
     const blob = await resolveStoredBytes(ref, {
@@ -96,7 +109,12 @@ export async function collectMediaFiles(
           createdAt: 0,
         };
     const ext = effective.mimeType?.split('/')[1] || 'jpg';
-    collected.push({ zipPath: `media/${ref}.${ext}`, record: effective, elementId: ref });
+    collected.push({
+      zipPath: mediaArchivePath(index, ext),
+      sourceRef: entry.ref,
+      record: effective,
+      elementId: ref,
+    });
   }
   return collected;
 }

--- a/lib/export/classroom-zip-utils.ts
+++ b/lib/export/classroom-zip-utils.ts
@@ -1,5 +1,5 @@
 import type { Action, DiscussionAction, SpeechAction } from '@/lib/types/action';
-import type { ManifestAction } from './classroom-zip-types';
+import type { ManifestAction, MediaIndexEntry } from './classroom-zip-types';
 import { db, mediaFileKey } from '@/lib/utils/database';
 import type { AssetManifestEntry } from '@openmaic/dsl';
 import type { AudioFileRecord, MediaFileRecord } from '@/lib/utils/database';
@@ -16,6 +16,8 @@ export interface CollectedAudio {
   zipPath: string;
   sourceRef: string;
   record: AudioFileRecord;
+  /** Canonical serialized MIME paired with `record.format` and `zipPath`. */
+  mimeType: string;
 }
 
 export interface CollectedMedia {
@@ -24,6 +26,29 @@ export interface CollectedMedia {
   sourceRef: string;
   record: MediaFileRecord;
   elementId: string;
+}
+
+/** Exact media-index metadata serialized for one collected narration asset. */
+export function collectedAudioMediaIndexEntry(file: CollectedAudio): MediaIndexEntry {
+  return {
+    type: 'audio',
+    sourceRef: file.sourceRef,
+    format: file.record.format,
+    mimeType: file.mimeType,
+    duration: file.record.duration,
+    voice: file.record.voice,
+  };
+}
+
+/** Exact media-index metadata serialized for one collected generated-media asset. */
+export function collectedMediaIndexEntry(file: CollectedMedia): MediaIndexEntry {
+  return {
+    type: 'generated',
+    sourceRef: file.sourceRef,
+    mimeType: file.record.mimeType,
+    size: file.record.size,
+    prompt: file.record.prompt,
+  };
 }
 
 const AUDIO_ARCHIVE_EXTENSIONS = new Set([
@@ -57,6 +82,13 @@ const MEDIA_ARCHIVE_EXTENSIONS = new Set([
  * Accept only one allowlisted filename suffix. Slashes, backslashes, dot
  * segments, parameters, and unknown values all fall back instead of entering
  * an archive path.
+ *
+ * Contract boundary: archive paths, extensions, and serialized MIME metadata
+ * are a mutually coherent, canonical function of authoritative kind metadata.
+ * This code does not inspect or transcode bytes and therefore does not promise
+ * that those labels describe the payload. A byte/kind mismatch is already-
+ * corrupt store state outside the export contract; runtime and renderer
+ * consumers likewise trust the kind metadata.
  */
 function canonicalArchiveExtension(
   extension: string | undefined,
@@ -92,8 +124,12 @@ export function mediaArchivePath(index: number, extension: string | undefined): 
   )}`;
 }
 
+export function mediaPosterArchiveMetadata() {
+  return canonicalArchiveMedia('image', {});
+}
+
 export function mediaPosterArchivePath(index: number): string {
-  const { extension } = canonicalArchiveMedia('image', {});
+  const { extension } = mediaPosterArchiveMetadata();
   return `media/asset-${index + 1}.poster.${extension}`;
 }
 
@@ -119,7 +155,8 @@ export async function collectAudioFiles(
     // resolve) -- must not ship an empty audio file.
     if (!blob || blob.size === 0) continue;
     const record = await db.audioFiles.get(audioId);
-    const { extension: ext } = canonicalArchiveMedia('audio', { extension: record?.format });
+    const canonical = canonicalArchiveMedia('audio', { extension: record?.format });
+    const ext = canonical.extension;
     const resolved = (
       record ? { ...record, blob, format: ext } : { id: audioId, blob, format: ext }
     ) as AudioFileRecord;
@@ -127,6 +164,7 @@ export async function collectAudioFiles(
       zipPath: audioArchivePath(index, ext),
       sourceRef: entry.ref,
       record: resolved,
+      mimeType: canonical.mimeType,
     });
   }
   return collected;
@@ -175,6 +213,9 @@ export async function collectMediaFiles(
           params: '',
           createdAt: 0,
         };
+    // The record kind is authoritative. Canonicalization makes the archive path
+    // and serialized MIME agree with it; it intentionally does not sniff or
+    // transcode `blob`, whose bytes may expose already-corrupt store state.
     const kind: MediaFileRecord['type'] = effective.type === 'video' ? 'video' : 'image';
     const canonical = canonicalArchiveMedia(kind, { mimeType: effective.mimeType });
     const normalized = { ...effective, type: kind, mimeType: canonical.mimeType };
@@ -196,6 +237,12 @@ export interface LegacyAudioBlob {
   zipPath: string;
   blob: Blob;
   format: string;
+  mimeType: string;
+}
+
+/** Exact media-index metadata serialized for one fetched legacy narration asset. */
+export function legacyAudioMediaIndexEntry(file: LegacyAudioBlob): MediaIndexEntry {
+  return { type: 'audio', format: file.format, mimeType: file.mimeType };
 }
 
 /**
@@ -240,10 +287,11 @@ export async function collectLegacyAudioForExport(
   });
   for (const { url, blob } of fetched) {
     if (!blob) continue;
-    const { extension: format } = canonicalArchiveMedia('audio', { mimeType: blob.type });
+    const canonical = canonicalArchiveMedia('audio', { mimeType: blob.type });
+    const format = canonical.extension;
     const zipPath = legacyAudioArchivePath(blobs.length, format);
     audioUrlToPath.set(url, zipPath);
-    blobs.push({ zipPath, blob, format });
+    blobs.push({ zipPath, blob, format, mimeType: canonical.mimeType });
   }
   return { audioUrlToPath, blobs };
 }

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -239,27 +239,33 @@ export async function buildClassroomExportZip(
     );
 
     // 8. Build mediaIndex
-    const mediaIndex: Record<string, MediaIndexEntry> = {};
+    const mediaIndexEntries: Array<[string, MediaIndexEntry]> = [];
 
     for (const af of audioFiles) {
-      mediaIndex[af.zipPath] = {
-        type: 'audio',
-        sourceRef: af.sourceRef,
-        format: af.record.format,
-        duration: af.record.duration,
-        voice: af.record.voice,
-      };
+      mediaIndexEntries.push([
+        af.zipPath,
+        {
+          type: 'audio',
+          sourceRef: af.sourceRef,
+          format: af.record.format,
+          duration: af.record.duration,
+          voice: af.record.voice,
+        },
+      ]);
     }
     for (const legacy of legacyAudioBlobs) {
-      mediaIndex[legacy.zipPath] = { type: 'audio', format: legacy.format };
+      mediaIndexEntries.push([legacy.zipPath, { type: 'audio', format: legacy.format }]);
     }
     for (const mf of mediaFiles) {
-      mediaIndex[mf.zipPath] = {
-        type: 'generated',
-        mimeType: mf.record.mimeType,
-        size: mf.record.size,
-        prompt: mf.record.prompt,
-      };
+      mediaIndexEntries.push([
+        mf.zipPath,
+        {
+          type: 'generated',
+          mimeType: mf.record.mimeType,
+          size: mf.record.size,
+          prompt: mf.record.prompt,
+        },
+      ]);
     }
 
     // Referenced audio whose bytes resolved nowhere is reported as missing.
@@ -267,13 +273,17 @@ export async function buildClassroomExportZip(
     // is handled by collectLegacyAudioForExport above.
     for (const entry of audioEntries) {
       if (!audioIdToPath.has(entry.ref)) {
-        mediaIndex[`audio/${entry.ref}.mp3`] = {
-          type: 'audio',
-          sourceRef: entry.ref,
-          missing: true,
-        };
+        mediaIndexEntries.push([
+          `audio/${entry.ref}.mp3`,
+          {
+            type: 'audio',
+            sourceRef: entry.ref,
+            missing: true,
+          },
+        ]);
       }
     }
+    const mediaIndex = Object.fromEntries(mediaIndexEntries);
 
     // 9. Assemble manifest
     const manifest: ClassroomManifest = {

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -20,9 +20,9 @@ import {
   collectMediaFiles,
   actionsToManifest,
   collectLegacyAudioForExport,
-  collectMissingAudioRefs,
 } from './classroom-zip-utils';
 import { createLogger } from '@/lib/logger';
+import { buildStageAssetManifest } from '@/lib/media/asset-manifest';
 import {
   inlineHtmlAssets,
   createAssetFetcher,
@@ -156,12 +156,22 @@ export async function buildClassroomExportZip(
     // the in-memory stage already carries any lazily migrated voice fields).
     const agentConfigs = exportStage.generatedAgentConfigs ?? stage.generatedAgentConfigs ?? [];
 
-    // 4. Collect audio files from the converted scenes: their speech actions
-    // name the allocated ids, whose compatibility rows the conversion wrote.
-    const audioFiles = await collectAudioFiles(exportScenes);
+    // 4. Enumerate exactly the references in the converted export snapshot.
+    // Both collectors take their reference sets from this manifest, so orphan
+    // compatibility rows do not ride into the archive.
+    // Classroom ZIP v1 has never serialized Stage.whiteboard. Exclude those
+    // refs here: archiving their bytes would create an unreconstructable,
+    // permanently orphaned payload on import. Scene whiteboards remain part of
+    // the portable manifest and are still collected.
+    const assetManifest = await buildStageAssetManifest(exportStage, exportScenes, stage.id, {
+      includeStageWhiteboard: false,
+    });
+    const audioEntries = assetManifest.entries.filter((entry) => entry.kind === 'audio');
+    const mediaEntries = assetManifest.entries.filter((entry) => entry.kind !== 'audio');
 
-    // 5. Collect media files (generated images/videos)
-    const mediaFiles = await collectMediaFiles(stage.id);
+    // 5. Collect referenced audio and generated media.
+    const audioFiles = await collectAudioFiles(audioEntries);
+    const mediaFiles = await collectMediaFiles(stage.id, mediaEntries);
 
     // 6. Build audioId → zipPath mapping for manifest
     const audioIdToPath = new Map<string, string>();
@@ -234,6 +244,7 @@ export async function buildClassroomExportZip(
     for (const af of audioFiles) {
       mediaIndex[af.zipPath] = {
         type: 'audio',
+        sourceRef: af.sourceRef,
         format: af.record.format,
         duration: af.record.duration,
         voice: af.record.voice,
@@ -251,14 +262,17 @@ export async function buildClassroomExportZip(
       };
     }
 
-    // Check for missing audio references. A legacy audioUrl recovered by
-    // the pass above travels under its own zip path, so it is not missing.
-    for (const { missingPath } of collectMissingAudioRefs(
-      exportScenes,
-      audioIdToPath,
-      audioUrlToPath,
-    )) {
-      mediaIndex[missingPath] = { type: 'audio', missing: true };
+    // Referenced audio whose bytes resolved nowhere is reported as missing.
+    // Legacy audioUrl-only narration is outside the standardized manifest and
+    // is handled by collectLegacyAudioForExport above.
+    for (const entry of audioEntries) {
+      if (!audioIdToPath.has(entry.ref)) {
+        mediaIndex[`audio/${entry.ref}.mp3`] = {
+          type: 'audio',
+          sourceRef: entry.ref,
+          missing: true,
+        };
+      }
     }
 
     // 9. Assemble manifest

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -310,7 +310,7 @@ export async function buildClassroomExportZip(
     for (const mf of mediaFiles) {
       zip.file(mf.zipPath, mf.record.blob);
       if (mf.record.poster) {
-        zip.file(mf.zipPath.replace(/\.\w+$/, '.poster.jpg'), mf.record.poster);
+        zip.file(mf.posterZipPath, mf.record.poster);
       }
     }
 

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -17,10 +17,13 @@ import {
 } from './classroom-zip-types';
 import {
   collectAudioFiles,
+  collectedAudioMediaIndexEntry,
+  collectedMediaIndexEntry,
   collectMediaFiles,
   actionsToManifest,
   audioArchivePath,
   collectLegacyAudioForExport,
+  legacyAudioMediaIndexEntry,
 } from './classroom-zip-utils';
 import { createLogger } from '@/lib/logger';
 import { buildStageAssetManifest } from '@/lib/media/asset-manifest';
@@ -243,31 +246,13 @@ export async function buildClassroomExportZip(
     const mediaIndexEntries: Array<[string, MediaIndexEntry]> = [];
 
     for (const af of audioFiles) {
-      mediaIndexEntries.push([
-        af.zipPath,
-        {
-          type: 'audio',
-          sourceRef: af.sourceRef,
-          format: af.record.format,
-          duration: af.record.duration,
-          voice: af.record.voice,
-        },
-      ]);
+      mediaIndexEntries.push([af.zipPath, collectedAudioMediaIndexEntry(af)]);
     }
     for (const legacy of legacyAudioBlobs) {
-      mediaIndexEntries.push([legacy.zipPath, { type: 'audio', format: legacy.format }]);
+      mediaIndexEntries.push([legacy.zipPath, legacyAudioMediaIndexEntry(legacy)]);
     }
     for (const mf of mediaFiles) {
-      mediaIndexEntries.push([
-        mf.zipPath,
-        {
-          type: 'generated',
-          sourceRef: mf.sourceRef,
-          mimeType: mf.record.mimeType,
-          size: mf.record.size,
-          prompt: mf.record.prompt,
-        },
-      ]);
+      mediaIndexEntries.push([mf.zipPath, collectedMediaIndexEntry(mf)]);
     }
 
     // Referenced audio whose bytes resolved nowhere is reported as missing.

--- a/lib/export/use-export-classroom.ts
+++ b/lib/export/use-export-classroom.ts
@@ -19,6 +19,7 @@ import {
   collectAudioFiles,
   collectMediaFiles,
   actionsToManifest,
+  audioArchivePath,
   collectLegacyAudioForExport,
 } from './classroom-zip-utils';
 import { createLogger } from '@/lib/logger';
@@ -261,6 +262,7 @@ export async function buildClassroomExportZip(
         mf.zipPath,
         {
           type: 'generated',
+          sourceRef: mf.sourceRef,
           mimeType: mf.record.mimeType,
           size: mf.record.size,
           prompt: mf.record.prompt,
@@ -271,10 +273,10 @@ export async function buildClassroomExportZip(
     // Referenced audio whose bytes resolved nowhere is reported as missing.
     // Legacy audioUrl-only narration is outside the standardized manifest and
     // is handled by collectLegacyAudioForExport above.
-    for (const entry of audioEntries) {
+    for (const [index, entry] of audioEntries.entries()) {
       if (!audioIdToPath.has(entry.ref)) {
         mediaIndexEntries.push([
-          `audio/${entry.ref}.mp3`,
+          audioArchivePath(index, 'mp3'),
           {
             type: 'audio',
             sourceRef: entry.ref,

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -31,7 +31,7 @@ import {
   resolveMediaRef,
   type MediaTaskState,
 } from '@/lib/media/resolve-media-ref';
-import { resolveVideoMediaForElement } from '@/lib/media/media-task-resolution';
+import { lookupMediaTask, resolveVideoMediaForElement } from '@/lib/media/media-task-resolution';
 
 const log = createLogger('ExportPPTX');
 
@@ -416,22 +416,9 @@ async function resolvePptxEmbeddableSrc(
     });
     if (stored) return blobToDataUrl(stored);
   }
-  const effectiveTask = task ?? lookupMediaTask(ref, stageId);
-  return renderableMediaUrl(resolvePptxMediaBinding(ref, effectiveTask).resolution) ?? '';
-}
-
-/** The media task governing a ref in this stage, when the caller did not supply one. */
-function lookupMediaTask(ref: string, stageId?: string): MediaTaskState | undefined {
-  // A concrete address is a network source, not a task key.
-  if (isConcreteMediaAddress(ref)) return undefined;
   const tasks = useMediaGenerationStore.getState().tasks;
-  const task =
-    tasks[ref] ??
-    Object.values(tasks).find(
-      (candidate) =>
-        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
-    );
-  return task && (!stageId || task.stageId === stageId) ? task : undefined;
+  const effectiveTask = task ?? lookupMediaTask(tasks, ref, stageId);
+  return renderableMediaUrl(resolvePptxMediaBinding(ref, effectiveTask).resolution) ?? '';
 }
 
 // Exported for the round-trip integration test harness — the test wires its

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -450,6 +450,22 @@ export function derivePptxMediaReferenceSet(slides: readonly Slide[]): ReadonlyS
 }
 
 /**
+ * The manifest-guard predicate: is this ref foreign to the PPTX document's
+ * asset manifest, with no task ownership that would legitimate it? A generated
+ * task may supply concrete runtime URLs (its objectUrl, or the poster of an
+ * element without one) that are runtime metadata rather than document refs;
+ * every other ref the layout resolves must come from the manifest. Exported so
+ * the guard's foreign-ref rejection stays directly testable.
+ */
+export function isPptxManifestForeignRef(
+  ref: string | undefined,
+  manifestRefs: ReadonlySet<string>,
+  task: MediaTaskState | undefined,
+): boolean {
+  return !!ref && !manifestRefs.has(ref) && task?.objectUrl !== ref;
+}
+
+/**
  * Pin the manifest and layout walks together. Element iteration remains
  * necessary for coordinates, z-order and video binding selection; it may not
  * introduce or omit a media role relative to the manifest.
@@ -498,7 +514,7 @@ export async function buildPptxBlob(
     // A generated task may supply a concrete poster URL that is runtime
     // metadata rather than a document ref. Preserve that established fallback;
     // every document-owned ref must still come from the manifest.
-    if (ref && !manifestRefs.has(ref) && task?.objectUrl !== ref) {
+    if (isPptxManifestForeignRef(ref, manifestRefs, task)) {
       throw new Error(`PPTX layout attempted to resolve a ref outside the asset manifest: ${ref}`);
     }
     return resolvePptxEmbeddableSrc(ref, task, stageId);

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -1038,11 +1038,7 @@ export async function buildPptxBlob(
               )
             : undefined;
         const sourceRef = videoBinding?.sourceRef ?? el.src;
-        const resolvedSrc = await resolvePptxEmbeddableSrc(
-          sourceRef,
-          videoBinding?.task,
-          stageId,
-        );
+        const resolvedSrc = await resolvePptxEmbeddableSrc(sourceRef, videoBinding?.task, stageId);
 
         if (!resolvedSrc) continue;
 

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -8,7 +8,7 @@ import { toast } from 'sonner';
 
 import { useStageStore } from '@/lib/store';
 import { useCanvasStore } from '@/lib/store/canvas';
-import { useMediaGenerationStore, isMediaPlaceholder } from '@/lib/store/media-generation';
+import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import type { Slide, PPTElementOutline, PPTElementShadow, PPTElementLink } from '@openmaic/dsl';
 import type { Scene, SlideContent } from '@/lib/types/stage';
@@ -389,31 +389,49 @@ export function resolvePptxMediaBinding(
   return { resolution, src: renderableMediaUrl(resolution) ?? '' };
 }
 
-export function exportMediaResolution(ref: string | undefined, stageId?: string) {
-  const tasks = useMediaGenerationStore.getState().tasks;
-  const task = ref
-    ? (tasks[ref] ??
-      Object.values(tasks).find(
-        (candidate) =>
-          candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
-      ))
-    : undefined;
-  const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
-  return resolvePptxMediaBinding(ref, effectiveTask).resolution;
+/**
+ * Resolve one media ref to an embeddable PPTX source through the shared
+ * resolver, so no export-element branch carries its own fallback chain.
+ *
+ * An opaque ref (allocated id or legacy placeholder) resolves pool-first via
+ * {@link resolveStoredBytes} -- then the compatibility row, then the task's
+ * resolved URL, every level gated on the media-resolution state machine -- and
+ * embeds as a data URL. A concrete address resolves to itself through the
+ * state machine and keeps the caller's legacy fetch path. Returns '' when no
+ * level yields a renderable source; the caller skips the element.
+ */
+async function resolvePptxEmbeddableSrc(
+  ref: string | undefined,
+  task: MediaTaskState | undefined,
+  stageId?: string,
+): Promise<string> {
+  if (!ref) return '';
+  if (!isConcreteMediaAddress(ref)) {
+    const stored = await resolveStoredBytes(ref, {
+      stageId,
+      resolutionGating: true,
+      loadCompatRow: true,
+      taskUrlFallback: true,
+      fetchPolicy: { requireOk: true, requireNonEmpty: false },
+    });
+    if (stored) return blobToDataUrl(stored);
+  }
+  const effectiveTask = task ?? lookupMediaTask(ref, stageId);
+  return renderableMediaUrl(resolvePptxMediaBinding(ref, effectiveTask).resolution) ?? '';
 }
 
-/** Resolve generated/allocated media without preventing the legacy source fetch fallback. */
-async function resolveStoredMediaBlob(ref: string, stageId?: string): Promise<Blob | null> {
-  // Pool first, then the Dexie compatibility row, then the task's resolved
-  // URL -- every level gated on the media-resolution state machine so an
-  // in-flight regeneration suppresses stale bytes.
-  return resolveStoredBytes(ref, {
-    stageId,
-    resolutionGating: true,
-    loadCompatRow: true,
-    taskUrlFallback: true,
-    fetchPolicy: { requireOk: true, requireNonEmpty: false },
-  });
+/** The media task governing a ref in this stage, when the caller did not supply one. */
+function lookupMediaTask(ref: string, stageId?: string): MediaTaskState | undefined {
+  // A concrete address is a network source, not a task key.
+  if (isConcreteMediaAddress(ref)) return undefined;
+  const tasks = useMediaGenerationStore.getState().tasks;
+  const task =
+    tasks[ref] ??
+    Object.values(tasks).find(
+      (candidate) =>
+        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
+    );
+  return task && (!stageId || task.stageId === stageId) ? task : undefined;
 }
 
 // Exported for the round-trip integration test harness — the test wires its
@@ -451,11 +469,7 @@ export async function buildPptxBlob(
     if (slide.background) {
       const bg = slide.background;
       if (bg.type === 'image' && bg.image) {
-        let resolvedSrc = renderableMediaUrl(exportMediaResolution(bg.image.src, stageId));
-        if (!resolvedSrc) {
-          const stored = await resolveStoredMediaBlob(bg.image.src, stageId);
-          if (stored) resolvedSrc = await blobToDataUrl(stored);
-        }
+        const resolvedSrc = await resolvePptxEmbeddableSrc(bg.image.src, undefined, stageId);
         if (!resolvedSrc) {
           // Missing generated backgrounds stay empty instead of leaking an opaque ref to pptxgen.
         } else if (isSVGImage(resolvedSrc)) {
@@ -536,12 +550,9 @@ export async function buildPptxBlob(
 
       // ── IMAGE ──
       else if (el.type === 'image') {
-        // Resolve placeholder src → actual image data
-        let resolvedSrc = renderableMediaUrl(exportMediaResolution(el.src, stageId));
-        if (isMediaPlaceholder(el.src)) {
-          const stored = await resolveStoredMediaBlob(el.src, stageId);
-          if (stored) resolvedSrc = await blobToDataUrl(stored);
-        }
+        // Resolve the src through the shared stored-bytes resolver (opaque
+        // refs embed as data URLs; concrete addresses keep the fetch below).
+        let resolvedSrc = await resolvePptxEmbeddableSrc(el.src, undefined, stageId);
         if (!resolvedSrc) continue;
 
         // Fetch and convert to base64 for embedding in PPTX
@@ -1027,19 +1038,11 @@ export async function buildPptxBlob(
               )
             : undefined;
         const sourceRef = videoBinding?.sourceRef ?? el.src;
-        let resolvedSrc = renderableMediaUrl(
-          videoBinding
-            ? resolvePptxMediaBinding(sourceRef, videoBinding.task).resolution
-            : exportMediaResolution(sourceRef, stageId),
+        const resolvedSrc = await resolvePptxEmbeddableSrc(
+          sourceRef,
+          videoBinding?.task,
+          stageId,
         );
-        const mediaLookupKey =
-          sourceRef && !isConcreteMediaAddress(sourceRef) && isMediaPlaceholder(sourceRef)
-            ? sourceRef
-            : undefined;
-        if (mediaLookupKey) {
-          const stored = await resolveStoredMediaBlob(mediaLookupKey, stageId);
-          if (stored) resolvedSrc = await blobToDataUrl(stored);
-        }
 
         if (!resolvedSrc) continue;
 
@@ -1075,27 +1078,27 @@ export async function buildPptxBlob(
           if (el.type === 'video') {
             let coverBase64: string | undefined;
 
-            // 1. Try poster from element or media generation store
-            let posterUrl = videoBinding?.posterRef;
-            let posterBlob = posterUrl ? await resolveStoredMediaBlob(posterUrl, stageId) : null;
-            if (posterUrl && !posterBlob) {
-              posterUrl = renderableMediaUrl(
-                resolvePptxMediaBinding(posterUrl, videoBinding?.posterTask).resolution,
-              );
-            }
-            if (posterBlob) {
-              coverBase64 = await blobToDataUrl(posterBlob);
-            } else if (posterUrl) {
-              try {
-                const posterResp = await fetch(posterUrl);
-                if (!posterResp.ok) {
-                  log.warn(`Failed to fetch poster (HTTP ${posterResp.status}), skipping`);
-                } else {
-                  posterBlob = await posterResp.blob();
-                  coverBase64 = await blobToDataUrl(posterBlob);
+            // 1. Try the poster the element (or its generation task) names,
+            // resolved through the same shared chain as the media itself.
+            const posterSrc = await resolvePptxEmbeddableSrc(
+              videoBinding?.posterRef,
+              videoBinding?.posterTask,
+              stageId,
+            );
+            if (posterSrc) {
+              if (isBase64Image(posterSrc)) {
+                coverBase64 = posterSrc;
+              } else {
+                try {
+                  const posterResp = await fetch(posterSrc);
+                  if (!posterResp.ok) {
+                    log.warn(`Failed to fetch poster (HTTP ${posterResp.status}), skipping`);
+                  } else {
+                    coverBase64 = await blobToDataUrl(await posterResp.blob());
+                  }
+                } catch {
+                  // Poster fetch failed, fall through to video frame capture
                 }
-              } catch {
-                // Poster fetch failed, fall through to video frame capture
               }
             }
 

--- a/lib/export/use-export-pptx.ts
+++ b/lib/export/use-export-pptx.ts
@@ -10,7 +10,14 @@ import { useStageStore } from '@/lib/store';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import { useI18n } from '@/lib/hooks/use-i18n';
-import type { Slide, PPTElementOutline, PPTElementShadow, PPTElementLink } from '@openmaic/dsl';
+import {
+  enumerateAssetManifest,
+  slideMediaSlotDescriptors,
+  type Slide,
+  type PPTElementOutline,
+  type PPTElementShadow,
+  type PPTElementLink,
+} from '@openmaic/dsl';
 import type { Scene, SlideContent } from '@/lib/types/stage';
 import type { SpeechAction } from '@/lib/types/action';
 import { getElementRange, getLineElementPath, getTableSubThemeColor } from '@/lib/utils/element';
@@ -421,6 +428,53 @@ async function resolvePptxEmbeddableSrc(
   return renderableMediaUrl(resolvePptxMediaBinding(ref, effectiveTask).resolution) ?? '';
 }
 
+/**
+ * Derive the document-wide candidate set for PPTX media resolution through the
+ * standard manifest. The PPTX document is the ordered slide list it renders;
+ * speaker-note actions and non-rendered whiteboards are intentionally outside
+ * this media scope.
+ */
+export function derivePptxMediaReferenceSet(slides: readonly Slide[]): ReadonlySet<string> {
+  const scenes = slides.map(
+    (slide, index) =>
+      ({
+        id: `pptx-slide-${index}`,
+        stageId: 'pptx-export',
+        type: 'slide',
+        title: '',
+        order: index,
+        content: { type: 'slide', canvas: slide },
+      }) as Scene,
+  );
+  return new Set(enumerateAssetManifest({ stage: {}, scenes }).entries.map(({ ref }) => ref));
+}
+
+/**
+ * Pin the manifest and layout walks together. Element iteration remains
+ * necessary for coordinates, z-order and video binding selection; it may not
+ * introduce or omit a media role relative to the manifest.
+ */
+export function assertPptxMediaReferenceParity(
+  slides: readonly Slide[],
+  manifestRefs: ReadonlySet<string>,
+): void {
+  const layoutRefs = new Set<string>();
+  for (const slide of slides) {
+    for (const slot of slideMediaSlotDescriptors(slide)) {
+      if (slot.ref) layoutRefs.add(slot.ref);
+    }
+  }
+  const missingFromLayout = [...manifestRefs].filter((ref) => !layoutRefs.has(ref));
+  const missingFromManifest = [...layoutRefs].filter((ref) => !manifestRefs.has(ref));
+  if (missingFromLayout.length > 0 || missingFromManifest.length > 0) {
+    throw new Error(
+      `PPTX media manifest/layout mismatch: ` +
+        `manifest-only=${JSON.stringify(missingFromLayout)}, ` +
+        `layout-only=${JSON.stringify(missingFromManifest)}`,
+    );
+  }
+}
+
 // Exported for the round-trip integration test harness — the test wires its
 // own slides + ratios in and inspects the resulting PPTX bytes via JSZip.
 // The hook below is still the only intended runtime caller.
@@ -435,6 +489,20 @@ export async function buildPptxBlob(
 ): Promise<Blob> {
   const pptx = new pptxgen();
   const documentElements = slides.flatMap((slide) => slide.elements);
+  const manifestRefs = derivePptxMediaReferenceSet(slides);
+  assertPptxMediaReferenceParity(slides, manifestRefs);
+  const resolveManifestMedia = (
+    ref: string | undefined,
+    task: MediaTaskState | undefined,
+  ): Promise<string> => {
+    // A generated task may supply a concrete poster URL that is runtime
+    // metadata rather than a document ref. Preserve that established fallback;
+    // every document-owned ref must still come from the manifest.
+    if (ref && !manifestRefs.has(ref) && task?.objectUrl !== ref) {
+      throw new Error(`PPTX layout attempted to resolve a ref outside the asset manifest: ${ref}`);
+    }
+    return resolvePptxEmbeddableSrc(ref, task, stageId);
+  };
 
   // Set layout based on aspect ratio
   if (viewportRatio === 0.625) pptx.layout = 'LAYOUT_16x10';
@@ -456,7 +524,7 @@ export async function buildPptxBlob(
     if (slide.background) {
       const bg = slide.background;
       if (bg.type === 'image' && bg.image) {
-        const resolvedSrc = await resolvePptxEmbeddableSrc(bg.image.src, undefined, stageId);
+        const resolvedSrc = await resolveManifestMedia(bg.image.src, undefined);
         if (!resolvedSrc) {
           // Missing generated backgrounds stay empty instead of leaking an opaque ref to pptxgen.
         } else if (isSVGImage(resolvedSrc)) {
@@ -539,7 +607,7 @@ export async function buildPptxBlob(
       else if (el.type === 'image') {
         // Resolve the src through the shared stored-bytes resolver (opaque
         // refs embed as data URLs; concrete addresses keep the fetch below).
-        let resolvedSrc = await resolvePptxEmbeddableSrc(el.src, undefined, stageId);
+        let resolvedSrc = await resolveManifestMedia(el.src, undefined);
         if (!resolvedSrc) continue;
 
         // Fetch and convert to base64 for embedding in PPTX
@@ -1025,7 +1093,7 @@ export async function buildPptxBlob(
               )
             : undefined;
         const sourceRef = videoBinding?.sourceRef ?? el.src;
-        const resolvedSrc = await resolvePptxEmbeddableSrc(sourceRef, videoBinding?.task, stageId);
+        const resolvedSrc = await resolveManifestMedia(sourceRef, videoBinding?.task);
 
         if (!resolvedSrc) continue;
 
@@ -1063,10 +1131,9 @@ export async function buildPptxBlob(
 
             // 1. Try the poster the element (or its generation task) names,
             // resolved through the same shared chain as the media itself.
-            const posterSrc = await resolvePptxEmbeddableSrc(
+            const posterSrc = await resolveManifestMedia(
               videoBinding?.posterRef,
               videoBinding?.posterTask,
-              stageId,
             );
             if (posterSrc) {
               if (isBase64Image(posterSrc)) {

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -256,7 +256,10 @@ export async function materializeImportedMedia(
     const zipEntry = zip.file(zipPath);
     if (!zipEntry) continue;
     const blob = await zipEntry.async('blob');
-    const oldRef = mediaRefFromZipPath(zipPath, meta.mimeType);
+    const oldRef =
+      typeof meta.sourceRef === 'string'
+        ? meta.sourceRef
+        : mediaRefFromZipPath(zipPath, meta.mimeType);
     const mimeType = meta.mimeType || 'image/jpeg';
     const type = mimeType.startsWith('video/') ? 'video' : 'image';
     const posterEntry =

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -25,9 +25,9 @@ import type { Stage } from '@/lib/types/stage';
 const log = createLogger('ImportClassroom');
 
 export interface ImportedMediaMappings {
-  refToNewId: Record<string, string>;
-  posterRefToNewId: Record<string, string>;
-  posterByMediaRef: Record<string, string>;
+  readonly refToNewId: ReadonlyMap<string, string>;
+  readonly posterRefToNewId: ReadonlyMap<string, string>;
+  readonly posterByMediaRef: ReadonlyMap<string, string>;
 }
 
 export interface ImportedAudioMappings {
@@ -39,12 +39,17 @@ type ImportedRefMapping = ReadonlyMap<string, unknown> | Readonly<Record<string,
 
 function mappedString(mapping: ImportedRefMapping, key: string): string | undefined {
   const value =
-    mapping instanceof Map ? mapping.get(key) : (mapping as Readonly<Record<string, unknown>>)[key];
+    mapping instanceof Map
+      ? mapping.get(key)
+      : Object.hasOwn(mapping, key)
+        ? (mapping as Readonly<Record<string, unknown>>)[key]
+        : undefined;
   return typeof value === 'string' ? value : undefined;
 }
 
-function rewriteImportedMediaRef(value: string, mapped: string | undefined): string | undefined {
+function rewriteImportedMediaRef(value: unknown, mapped: string | undefined): string | undefined {
   if (mapped) return mapped;
+  if (typeof value !== 'string') return undefined;
   if (isConcreteMediaAddress(value) || isGeneratedMediaPlaceholder(value)) return value;
   return undefined;
 }
@@ -108,7 +113,7 @@ export function rewriteImportedSlideMediaRefs(
             src:
               rewriteImportedMediaRef(
                 slide.background.image.src,
-                mappings.refToNewId[slide.background.image.src],
+                mappedString(mappings.refToNewId, slide.background.image.src),
               ) ?? '',
           },
         }
@@ -118,7 +123,9 @@ export function rewriteImportedSlideMediaRefs(
     background,
     elements: slide.elements.map((element) => {
       if (element.type === 'image') {
-        const src = rewriteImportedMediaRef(element.src, mappings.refToNewId[element.src]) ?? '';
+        const src =
+          rewriteImportedMediaRef(element.src, mappedString(mappings.refToNewId, element.src)) ??
+          '';
         return src === element.src ? element : { ...element, src };
       }
       if (element.type === 'audio') {
@@ -129,17 +136,22 @@ export function rewriteImportedSlideMediaRefs(
       if (element.type !== 'video') return element;
       const oldMediaRef = element.mediaRef || element.src || '';
       const src = element.src
-        ? (rewriteImportedMediaRef(element.src, mappings.refToNewId[element.src]) ?? '')
+        ? (rewriteImportedMediaRef(element.src, mappedString(mappings.refToNewId, element.src)) ??
+          '')
         : undefined;
       const mediaRef = element.mediaRef
-        ? rewriteImportedMediaRef(element.mediaRef, mappings.refToNewId[element.mediaRef])
+        ? rewriteImportedMediaRef(
+            element.mediaRef,
+            mappedString(mappings.refToNewId, element.mediaRef),
+          )
         : undefined;
       const poster = element.poster
         ? rewriteImportedMediaRef(
             element.poster,
-            mappings.posterRefToNewId[element.poster] ?? mappings.refToNewId[element.poster],
+            mappedString(mappings.posterRefToNewId, element.poster) ??
+              mappedString(mappings.refToNewId, element.poster),
           )
-        : mappings.posterByMediaRef[oldMediaRef];
+        : mappedString(mappings.posterByMediaRef, oldMediaRef);
       const rewritten = { ...element, ...(src !== undefined ? { src } : {}) };
       if (mediaRef) rewritten.mediaRef = mediaRef;
       else delete rewritten.mediaRef;
@@ -157,7 +169,7 @@ export function rewriteImportedVideoManifest(
   if (!manifest) return manifest;
   return Object.fromEntries(
     Object.entries(manifest).flatMap(([ref, entry]) => {
-      const rewritten = rewriteImportedMediaRef(ref, mappings.refToNewId[ref]);
+      const rewritten = rewriteImportedMediaRef(ref, mappedString(mappings.refToNewId, ref));
       return rewritten ? [[rewritten, entry] as const] : [];
     }),
   );
@@ -195,7 +207,7 @@ export async function materializeImportedAudio(
     const relativePath = zipPath.startsWith('audio/') ? zipPath.slice('audio/'.length) : zipPath;
     const formatSuffix = meta.format ? `.${meta.format}` : undefined;
     const sourceRef =
-      meta.sourceRef ??
+      (typeof meta.sourceRef === 'string' ? meta.sourceRef : undefined) ??
       (formatSuffix && relativePath.endsWith(formatSuffix)
         ? relativePath.slice(0, -formatSuffix.length)
         : relativePath.replace(/\.[^/.]+$/, ''));
@@ -222,10 +234,13 @@ export async function materializeImportedMedia(
   createdAt: number,
   allocatedIds: string[] = [],
 ): Promise<ImportedMediaMappings> {
+  const refToNewId = new Map<string, string>();
+  const posterRefToNewId = new Map<string, string>();
+  const posterByMediaRef = new Map<string, string>();
   const mappings: ImportedMediaMappings = {
-    refToNewId: {},
-    posterRefToNewId: {},
-    posterByMediaRef: {},
+    refToNewId,
+    posterRefToNewId,
+    posterByMediaRef,
   };
 
   const imported: Array<{
@@ -253,7 +268,7 @@ export async function materializeImportedMedia(
       prompt: meta.prompt,
     });
     allocatedIds.push(assetId);
-    mappings.refToNewId[oldRef] = assetId;
+    refToNewId.set(oldRef, assetId);
 
     await db.mediaFiles.put({
       id: mediaFileKey(stageId, assetId),
@@ -277,8 +292,8 @@ export async function materializeImportedMedia(
     if (entry.type !== 'video' || !entry.posterBlob) continue;
     const oldPosterRefs = posterRefsForMedia(manifest, entry.oldRef);
     let posterAssetId = oldPosterRefs
-      .map((oldPosterRef) => mappings.refToNewId[oldPosterRef])
-      .find(Boolean);
+      .map((oldPosterRef) => mappedString(mappings.refToNewId, oldPosterRef))
+      .find((value): value is string => typeof value === 'string');
     if (!posterAssetId) {
       posterAssetId = await putAsset(entry.posterBlob, {
         contentType: entry.posterBlob.type || 'image/jpeg',
@@ -298,9 +313,9 @@ export async function materializeImportedMedia(
         createdAt,
       });
     }
-    mappings.posterByMediaRef[entry.oldRef] = posterAssetId;
+    posterByMediaRef.set(entry.oldRef, posterAssetId);
     for (const oldPosterRef of oldPosterRefs) {
-      mappings.posterRefToNewId[oldPosterRef] = posterAssetId;
+      posterRefToNewId.set(oldPosterRef, posterAssetId);
     }
   }
   return mappings;

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -467,7 +467,11 @@ export function useImportClassroom(onSuccess?: (importedStageId: string) => void
               mScene.content.type === 'slide'
                 ? {
                     ...mScene.content,
-                    canvas: rewriteImportedSlideMediaRefs(mScene.content.canvas, mediaMappings),
+                    canvas: rewriteImportedSlideMediaRefs(
+                      mScene.content.canvas,
+                      mediaMappings,
+                      audioMappings.sourceRefToId,
+                    ),
                   }
                 : mScene.content;
             return canonicalizeLegacyScene({
@@ -478,7 +482,7 @@ export function useImportClassroom(onSuccess?: (importedStageId: string) => void
               content,
               actions,
               whiteboards: mScene.whiteboards?.map((slide) =>
-                rewriteImportedSlideMediaRefs(slide, mediaMappings),
+                rewriteImportedSlideMediaRefs(slide, mediaMappings, audioMappings.sourceRefToId),
               ),
               multiAgent,
               createdAt: now,

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -11,6 +11,7 @@ import {
   agentConfigFromManifest,
   type ClassroomManifest,
   type ManifestScene,
+  type MediaIndexEntry,
 } from '@/lib/export/classroom-zip-types';
 import { rewriteAudioRefsToIds } from '@/lib/export/classroom-zip-utils';
 import { createLogger } from '@/lib/logger';
@@ -33,6 +34,14 @@ export interface ImportedMediaMappings {
 export interface ImportedAudioMappings {
   readonly pathToId: ReadonlyMap<string, string>;
   readonly sourceRefToId: ReadonlyMap<string, string>;
+}
+
+/** Content type the importer writes for serialized narration metadata. */
+export function importedAudioContentType(
+  meta: Pick<MediaIndexEntry, 'mimeType' | 'format'>,
+  blobType: string,
+): string {
+  return meta.mimeType || blobType || `audio/${meta.format || 'mp3'}`;
 }
 
 type ImportedRefMapping = ReadonlyMap<string, unknown> | Readonly<Record<string, unknown>>;
@@ -197,7 +206,7 @@ export async function materializeImportedAudio(
     if (!zipEntry) continue;
     const blob = await zipEntry.async('blob');
     const assetId = await putAsset(blob, {
-      contentType: blob.type || `audio/${meta.format || 'mp3'}`,
+      contentType: importedAudioContentType(meta, blob.type),
       mediaType: 'audio',
       duration: meta.duration,
       voice: meta.voice,

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -261,7 +261,7 @@ export async function materializeImportedMedia(
         ? meta.sourceRef
         : mediaRefFromZipPath(zipPath, meta.mimeType);
     const mimeType = meta.mimeType || 'image/jpeg';
-    const type = mimeType.startsWith('video/') ? 'video' : 'image';
+    const type = importedMediaKind(mimeType);
     const posterEntry =
       type === 'video' ? zip.file(siblingPosterZipPath(zipPath, meta.mimeType)) : null;
     const posterBlob = posterEntry ? await posterEntry.async('blob') : undefined;
@@ -322,6 +322,11 @@ export async function materializeImportedMedia(
     }
   }
   return mappings;
+}
+
+/** Classification used for imported generated media after export normalization. */
+export function importedMediaKind(mimeType: string): 'image' | 'video' {
+  return mimeType.startsWith('video/') ? 'video' : 'image';
 }
 
 export type ImportPhase =

--- a/lib/import/use-import-classroom.ts
+++ b/lib/import/use-import-classroom.ts
@@ -30,6 +30,19 @@ export interface ImportedMediaMappings {
   posterByMediaRef: Record<string, string>;
 }
 
+export interface ImportedAudioMappings {
+  readonly pathToId: ReadonlyMap<string, string>;
+  readonly sourceRefToId: ReadonlyMap<string, string>;
+}
+
+type ImportedRefMapping = ReadonlyMap<string, unknown> | Readonly<Record<string, unknown>>;
+
+function mappedString(mapping: ImportedRefMapping, key: string): string | undefined {
+  const value =
+    mapping instanceof Map ? mapping.get(key) : (mapping as Readonly<Record<string, unknown>>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
 function rewriteImportedMediaRef(value: string, mapped: string | undefined): string | undefined {
   if (mapped) return mapped;
   if (isConcreteMediaAddress(value) || isGeneratedMediaPlaceholder(value)) return value;
@@ -84,6 +97,7 @@ function posterRefsForMedia(manifest: ClassroomManifest, mediaRef: string): stri
 export function rewriteImportedSlideMediaRefs(
   slide: Slide,
   mappings: ImportedMediaMappings,
+  audioRefToNewId: ImportedRefMapping = new Map(),
 ): Slide {
   const background =
     slide.background?.type === 'image' && slide.background.image
@@ -105,6 +119,11 @@ export function rewriteImportedSlideMediaRefs(
     elements: slide.elements.map((element) => {
       if (element.type === 'image') {
         const src = rewriteImportedMediaRef(element.src, mappings.refToNewId[element.src]) ?? '';
+        return src === element.src ? element : { ...element, src };
+      }
+      if (element.type === 'audio') {
+        const src =
+          rewriteImportedMediaRef(element.src, mappedString(audioRefToNewId, element.src)) ?? '';
         return src === element.src ? element : { ...element, src };
       }
       if (element.type !== 'video') return element;
@@ -151,9 +170,16 @@ export async function materializeImportedAudio(
   stageId: string,
   createdAt: number,
   allocatedIds: string[] = [],
-): Promise<Record<string, string>> {
-  const mappings: Record<string, string> = {};
-  for (const [zipPath, meta] of Object.entries(manifest.mediaIndex ?? {})) {
+): Promise<ImportedAudioMappings> {
+  const pathToId = new Map<string, string>();
+  const sourceRefToId = new Map<string, string>();
+  // Sorting makes malformed duplicate-sourceRef handling independent of JSON
+  // object insertion order: the lexicographically first ZIP path owns the
+  // source-ref alias, while every genuine ZIP path remains addressable.
+  const entries = Object.entries(manifest.mediaIndex ?? {}).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  for (const [zipPath, meta] of entries) {
     if (meta.type !== 'audio' || meta.missing) continue;
     const zipEntry = zip.file(zipPath);
     if (!zipEntry) continue;
@@ -165,7 +191,15 @@ export async function materializeImportedAudio(
       voice: meta.voice,
     });
     allocatedIds.push(assetId);
-    mappings[zipPath] = assetId;
+    pathToId.set(zipPath, assetId);
+    const relativePath = zipPath.startsWith('audio/') ? zipPath.slice('audio/'.length) : zipPath;
+    const formatSuffix = meta.format ? `.${meta.format}` : undefined;
+    const sourceRef =
+      meta.sourceRef ??
+      (formatSuffix && relativePath.endsWith(formatSuffix)
+        ? relativePath.slice(0, -formatSuffix.length)
+        : relativePath.replace(/\.[^/.]+$/, ''));
+    if (!sourceRefToId.has(sourceRef)) sourceRefToId.set(sourceRef, assetId);
     const record: AudioFileRecord = {
       id: assetId,
       stageId,
@@ -177,7 +211,7 @@ export async function materializeImportedAudio(
     };
     await db.audioFiles.put(record);
   }
-  return mappings;
+  return { pathToId, sourceRefToId };
 }
 
 /** Allocate imported media into the browser-global pool and mirror it to Dexie. */
@@ -362,7 +396,7 @@ export function useImportClassroom(onSuccess?: (importedStageId: string) => void
         setPhase('writingMedia');
         toast.loading(t('import.writingMedia'), { id: toastId });
 
-        const audioRefToNewId = await materializeImportedAudio(
+        const audioMappings = await materializeImportedAudio(
           zip,
           manifest,
           newStageId,
@@ -414,7 +448,7 @@ export function useImportClassroom(onSuccess?: (importedStageId: string) => void
           scenes: manifest.scenes.map((mScene: ManifestScene, index: number) => {
             const newSceneId = nanoid();
             const actions = mScene.actions
-              ? rewriteAudioRefsToIds(mScene.actions, audioRefToNewId, {
+              ? rewriteAudioRefsToIds(mScene.actions, audioMappings.pathToId, {
                   agentIds: newAgentIds,
                   fallbackDiscussionAgentIndex,
                 })

--- a/lib/media/asset-manifest.ts
+++ b/lib/media/asset-manifest.ts
@@ -1,0 +1,68 @@
+import {
+  enumerateAssetManifest,
+  type AssetKind,
+  type AssetManifest,
+  type AssetManifestMetadata,
+} from '@openmaic/dsl';
+import type { Scene, Stage } from '@/lib/types/stage';
+import { db, mediaFileKey, type AudioFileRecord, type MediaFileRecord } from '@/lib/utils/database';
+
+/**
+ * The stage document's asset manifest with the metadata the compatibility
+ * rows carry, ready for export paths to consume.
+ *
+ * The enumeration itself is the pure dsl one: the manifest is exactly the set
+ * of references the document touches, so a media/audio row nothing references
+ * (an orphan left behind by an edit or a failed regeneration) can no longer
+ * ride along into an archive. These row reads enrich the manifest metadata.
+ * At the classroom ZIP call site, media collection reads the compatibility
+ * record again and supplies its blob to the shared resolver as the legacy
+ * fallback after a pool miss; PPTX and video resolve bytes through their own
+ * accurately documented compatibility-row paths.
+ */
+export async function buildStageAssetManifest(
+  stage: Pick<Stage, 'whiteboard' | 'videoManifest'>,
+  scenes: readonly Scene[],
+  stageId: string,
+  options: { readonly includeStageWhiteboard?: boolean } = {},
+): Promise<AssetManifest> {
+  const manifestStage =
+    options.includeStageWhiteboard === false ? { ...stage, whiteboard: undefined } : stage;
+  const skeleton = enumerateAssetManifest({ stage: manifestStage, scenes });
+
+  const mediaRows = new Map<string, MediaFileRecord>();
+  const audioRows = new Map<string, AudioFileRecord>();
+  await Promise.all(
+    skeleton.entries.map(async (entry) => {
+      if (entry.kind === 'audio') {
+        const row = await db.audioFiles.get(entry.ref).catch(() => undefined);
+        if (row) audioRows.set(entry.ref, row);
+      } else {
+        const row = await db.mediaFiles.get(mediaFileKey(stageId, entry.ref)).catch(() => undefined);
+        if (row) mediaRows.set(entry.ref, row);
+      }
+    }),
+  );
+
+  const metadata = (ref: string, kind: AssetKind): AssetManifestMetadata | undefined => {
+    if (kind === 'audio') {
+      const row = audioRows.get(ref);
+      if (!row) return undefined;
+      return {
+        byteSize: row.blob?.size || undefined,
+        mimeType: row.blob?.type || undefined,
+        durationSeconds: row.duration,
+        voice: row.voice,
+      };
+    }
+    const row = mediaRows.get(ref);
+    if (!row) return undefined;
+    return {
+      byteSize: row.size,
+      mimeType: row.mimeType || undefined,
+      prompt: row.prompt || undefined,
+    };
+  };
+
+  return enumerateAssetManifest({ stage: manifestStage, scenes }, { metadata });
+}

--- a/lib/media/asset-manifest.ts
+++ b/lib/media/asset-manifest.ts
@@ -38,7 +38,9 @@ export async function buildStageAssetManifest(
         const row = await db.audioFiles.get(entry.ref).catch(() => undefined);
         if (row) audioRows.set(entry.ref, row);
       } else {
-        const row = await db.mediaFiles.get(mediaFileKey(stageId, entry.ref)).catch(() => undefined);
+        const row = await db.mediaFiles
+          .get(mediaFileKey(stageId, entry.ref))
+          .catch(() => undefined);
         if (row) mediaRows.set(entry.ref, row);
       }
     }),

--- a/lib/media/collect-stage-asset-refs.ts
+++ b/lib/media/collect-stage-asset-refs.ts
@@ -1,4 +1,4 @@
-import type { Slide } from '@openmaic/dsl';
+import { enumerateAssetManifest, type Slide } from '@openmaic/dsl';
 import { getDocumentStore } from '@/lib/document-store';
 import { createLogger } from '@/lib/logger';
 import type { Scene, Stage } from '@/lib/types/stage';
@@ -27,6 +27,7 @@ export interface StageAudioRow {
 
 export interface StageAssetRefs {
   readonly imageSrc: ReadonlySet<string>;
+  readonly slideAudioSrc: ReadonlySet<string>;
   readonly videoSrc: ReadonlySet<string>;
   readonly videoMediaRef: ReadonlySet<string>;
   readonly poster: ReadonlySet<string>;
@@ -88,6 +89,7 @@ export function collectStageAssetRefs(
   },
 ): StageAssetRefs {
   const imageSrc = new Set<string>();
+  const slideAudioSrc = new Set<string>();
   const videoSrc = new Set<string>();
   const videoMediaRef = new Set<string>();
   const poster = new Set<string>();
@@ -97,23 +99,9 @@ export function collectStageAssetRefs(
   const speechAudioId = new Set<string>();
   const videoManifestKey = new Set<string>();
   const referenced = new Set<string>();
-  const ownerKeysByRef = new Map<string, Set<string>>();
-
-  const own = (ref: string | undefined, ownerKey: string) => {
-    if (!ref) return;
-    referenced.add(ref);
-    let owners = ownerKeysByRef.get(ref);
-    if (!owners) {
-      owners = new Set<string>();
-      ownerKeysByRef.set(ref, owners);
-    }
-    owners.add(ownerKey);
-  };
-
   const visitSlide = (
     slide: Pick<Slide, 'id' | 'elements' | 'background'>,
     scope: 'scene' | 'stage-whiteboard' | 'scene-whiteboard',
-    scopeId: string,
   ) => {
     for (const slot of slideMediaReferenceSlots(slide)) {
       const ref = slot.read();
@@ -125,15 +113,13 @@ export function collectStageAssetRefs(
             ? sceneWhiteboard
             : undefined;
 
-      const ownerKey = slot.element
-        ? `${scope}:${scopeId}:${slot.element.id || slot.elementIndex}`
-        : `${scope}:${scopeId}:background`;
       if (slot.kind === 'background-image') addValue(backgroundImage, ref);
       else if (slot.kind === 'image-src') addValue(imageSrc, ref);
+      else if (slot.kind === 'audio-src') addValue(slideAudioSrc, ref);
       else if (slot.kind === 'video-src') addValue(videoSrc, ref);
       else if (slot.kind === 'video-media-ref') addValue(videoMediaRef, ref);
       else addValue(poster, ref);
-      own(ref, slot.kind === 'video-poster' ? `${ownerKey}:poster` : ownerKey);
+      referenced.add(ref);
       whiteboardCategory?.add(ref);
     }
   };
@@ -141,22 +127,22 @@ export function collectStageAssetRefs(
   if (document) {
     for (let index = 0; index < (document.stage.whiteboard ?? []).length; index += 1) {
       const slide = document.stage.whiteboard![index];
-      visitSlide(slide, 'stage-whiteboard', slide.id || String(index));
+      visitSlide(slide, 'stage-whiteboard');
     }
 
     for (const scene of document.scenes) {
       if (scene.content.type === 'slide') {
-        visitSlide(scene.content.canvas, 'scene', scene.id);
+        visitSlide(scene.content.canvas, 'scene');
       }
       for (let index = 0; index < (scene.whiteboards ?? []).length; index += 1) {
         const slide = scene.whiteboards![index];
-        visitSlide(slide, 'scene-whiteboard', `${scene.id}:${slide.id || index}`);
+        visitSlide(slide, 'scene-whiteboard');
       }
       for (let index = 0; index < (scene.actions ?? []).length; index += 1) {
         const action = scene.actions![index];
         if (action.type !== 'speech' || !action.audioId) continue;
         speechAudioId.add(action.audioId);
-        own(action.audioId, `speech:${scene.id}:${action.id || index}`);
+        referenced.add(action.audioId);
       }
     }
 
@@ -181,12 +167,16 @@ export function collectStageAssetRefs(
   const audioOrphans = new Set([...audioRow].filter((ref) => !documentRefs.has(ref)));
   const all = new Set([...documentRefs, ...mediaRow, ...audioRow]);
   const poolOwned = new Set([...mediaRow, ...audioRow]);
-  const referenceCounts = new Map(
-    [...ownerKeysByRef].map(([ref, owners]) => [ref, owners.size] as const),
-  );
+  // Consume the DSL's position-keyed ownership accounting directly. Keeping
+  // one implementation prevents user-controlled duplicate scene/slide/
+  // element/action ids from collapsing distinct owners here.
+  const referenceCounts = document
+    ? new Map(enumerateAssetManifest(document).referenceCounts)
+    : new Map<string, number>();
 
   return {
     imageSrc,
+    slideAudioSrc,
     videoSrc,
     videoMediaRef,
     poster,

--- a/lib/media/convert-legacy-asset-refs.ts
+++ b/lib/media/convert-legacy-asset-refs.ts
@@ -577,6 +577,10 @@ export async function convertDocumentAssetRefs(
     const rewrites: Array<{ index: number; assetId: string }> = [];
     const removals: number[] = [];
     for (let index = 0; index < slots.length; index += 1) {
+      // Slide-audio refs use the audio compatibility store and metadata path;
+      // the dedicated pass below routes them through the same conversion as
+      // speech narration instead of misclassifying them as image/video media.
+      if (slots[index].kind === 'audio-src') continue;
       const ref = slots[index].read();
       if (isGeneratedMediaPlaceholder(ref)) {
         const assetId = await allocateMediaRef(ref);
@@ -826,10 +830,39 @@ export async function convertDocumentAssetRefs(
     return action;
   };
 
+  const convertSlideAudio = async <T extends SlideLike>(slide: T): Promise<T> => {
+    const sourceSlots = [...slideMediaReferenceSlots(slide)];
+    const rewrites: Array<{ index: number; ref: string | undefined }> = [];
+    for (let index = 0; index < sourceSlots.length; index += 1) {
+      const slot = sourceSlots[index];
+      if (slot.kind !== 'audio-src') continue;
+      const ref = slot.read();
+      if (!ref) continue;
+      const transportUrl = isClassroomMediaUrl(ref);
+      const pseudoAction = {
+        id: `slide-audio:${index}`,
+        type: 'speech',
+        text: '',
+        ...(transportUrl ? { audioUrl: ref } : { audioId: ref }),
+      } as unknown as Action;
+      const converted = (await convertSpeechAction(pseudoAction)) as LegacySpeechAction;
+      const convertedRef = converted.audioId ?? converted.audioUrl;
+      if (convertedRef !== ref) rewrites.push({ index, ref: convertedRef });
+    }
+    if (rewrites.length === 0) return slide;
+    const clone = structuredClone(slide);
+    const cloneSlots = [...slideMediaReferenceSlots(clone)];
+    for (const rewrite of rewrites) cloneSlots[rewrite.index].write(rewrite.ref);
+    return clone;
+  };
+
+  const convertAllSlideRefs = async <T extends SlideLike>(slide: T): Promise<T> =>
+    convertSlideAudio(await convertSlide(slide));
+
   const stage = document.stage;
   let whiteboard = stage.whiteboard;
   if (whiteboard) {
-    const converted = await Promise.all(whiteboard.map((slide) => convertSlide(slide)));
+    const converted = await Promise.all(whiteboard.map((slide) => convertAllSlideRefs(slide)));
     if (converted.some((slide, index) => slide !== whiteboard![index])) {
       whiteboard = converted;
     }
@@ -839,7 +872,7 @@ export async function convertDocumentAssetRefs(
   for (const scene of document.scenes) {
     let nextScene = scene;
     if (scene.content.type === 'slide') {
-      const canvas = await convertSlide(scene.content.canvas);
+      const canvas = await convertAllSlideRefs(scene.content.canvas);
       if (canvas !== scene.content.canvas) {
         // Rebuild through makeScene so the discriminated union stays bound:
         // a plain spread cannot prove the canvas lands on the slide member.
@@ -850,7 +883,9 @@ export async function convertDocumentAssetRefs(
       }
     }
     if (scene.whiteboards) {
-      const converted = await Promise.all(scene.whiteboards.map((slide) => convertSlide(slide)));
+      const converted = await Promise.all(
+        scene.whiteboards.map((slide) => convertAllSlideRefs(slide)),
+      );
       if (converted.some((slide, index) => slide !== scene.whiteboards![index])) {
         nextScene = { ...nextScene, whiteboards: converted };
       }

--- a/lib/media/convert-legacy-asset-refs.ts
+++ b/lib/media/convert-legacy-asset-refs.ts
@@ -923,19 +923,19 @@ export async function convertDocumentAssetRefs(
   let videoManifest = stage.videoManifest;
   if (videoManifest) {
     let manifestChanged = false;
-    const nextManifest: typeof videoManifest = {};
+    const nextManifestEntries: Array<[string, (typeof videoManifest)[string]]> = [];
     for (const [key, entry] of Object.entries(videoManifest)) {
       if (isGeneratedMediaPlaceholder(key)) {
         const assetId = await allocateMediaRef(key);
         if (assetId) {
-          nextManifest[assetId] = entry;
+          nextManifestEntries.push([assetId, entry]);
           manifestChanged = true;
           continue;
         }
       } else if (isClassroomMediaUrl(key)) {
         const outcome = await allocateUrlMediaRef(key);
         if (outcome.kind === 'allocated') {
-          nextManifest[outcome.assetId] = entry;
+          nextManifestEntries.push([outcome.assetId, entry]);
           manifestChanged = true;
           continue;
         }
@@ -946,10 +946,10 @@ export async function convertDocumentAssetRefs(
         }
         report.kept += 1;
       }
-      nextManifest[key] = entry;
+      nextManifestEntries.push([key, entry]);
     }
     if (manifestChanged) {
-      videoManifest = nextManifest;
+      videoManifest = Object.fromEntries(nextManifestEntries);
       changed = true;
     }
   }

--- a/lib/media/convert-legacy-asset-refs.ts
+++ b/lib/media/convert-legacy-asset-refs.ts
@@ -88,9 +88,10 @@ export interface LegacyAssetConversionDeps {
   /**
    * Write the post-conversion Dexie compatibility copy of a media row, keyed
    * by the ref the document now names. Without it the export/import
-   * round-trip breaks: collectMediaFiles derives ZIP references from row
-   * keys, so a converted document would point at media the export only knows
-   * by the old placeholder. Same double-write discipline as the audio path.
+   * round-trip breaks: collectMediaFiles reads rows by the compound key of
+   * the refs the asset manifest enumerates, so a converted document would
+   * point at media the export only knows by the old placeholder. Same
+   * double-write discipline as the audio path.
    */
   putMediaRecord(stageId: string, ref: string, record: MediaFileRecord): Promise<void>;
   /** Write the post-conversion Dexie compatibility copy of an audio row. */
@@ -497,10 +498,11 @@ export async function convertDocumentAssetRefs(
         // a mirror-write failure.
         assertContinuing();
         // Mirror the row under the allocated id, like the audio path and the
-        // generation write path: collectMediaFiles derives export references
-        // from row keys, so without the copy an exported manifest would name
-        // media the ZIP only knows by the old placeholder. The original ref
-        // stays on placeholderRef for reload reconciliation.
+        // generation write path: collectMediaFiles reads rows by the compound
+        // key of the refs the asset manifest enumerates, so without the copy
+        // an exported manifest would name media the ZIP only knows by the old
+        // placeholder. The original ref stays on placeholderRef for reload
+        // reconciliation.
         await resolvedDeps.putMediaRecord(stageId, assetId, {
           ...record,
           placeholderRef: record.placeholderRef ?? ref,

--- a/lib/media/media-task-resolution.ts
+++ b/lib/media/media-task-resolution.ts
@@ -28,6 +28,34 @@ export interface VideoMediaTaskResolution<T extends MediaTaskLookupEntry> {
 
 type MediaTaskMatch<T extends MediaTaskLookupEntry> = readonly [key: string, task: T];
 
+/**
+ * Look up a media task without allowing inherited Object.prototype members to
+ * masquerade as direct hits. The placeholder fallback supports tasks that
+ * were re-keyed to an allocated asset id while retaining their document ref.
+ */
+export function lookupMediaTask<T extends MediaTaskLookupEntry>(
+  tasks: Readonly<Record<string, T>>,
+  ref: string | undefined,
+  stageId?: string,
+  placeholderFallback = true,
+): T | undefined {
+  if (!ref) return undefined;
+  // Own-property direct hit: AssetRef is an unconstrained string, so a ref can
+  // legitimately be "__proto__" or "constructor"; an inherited Object.prototype
+  // member must neither masquerade as a task nor shadow the placeholder
+  // fallback below.
+  const direct = Object.hasOwn(tasks, ref) ? tasks[ref] : undefined;
+  const task =
+    direct ??
+    (placeholderFallback
+      ? Object.values(tasks).find(
+          (candidate) =>
+            candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
+        )
+      : undefined);
+  return task && (!stageId || task.stageId === stageId) ? task : undefined;
+}
+
 /** Shared lookup for non-element media such as slide backgrounds. */
 export function resolveMediaTaskForRef<T extends MediaTaskLookupEntry>(
   tasks: Readonly<Record<string, T>>,
@@ -36,13 +64,8 @@ export function resolveMediaTaskForRef<T extends MediaTaskLookupEntry>(
   targetElementId?: string,
 ): T | undefined {
   if (!ref || !stageId || isConcreteMediaAddress(ref)) return undefined;
-  const targeted = targetElementId ? tasks[targetElementId] : undefined;
-  if (targeted?.stageId === stageId) return targeted;
-  const direct = tasks[ref];
-  if (direct?.stageId === stageId) return direct;
-  return Object.values(tasks).find(
-    (candidate) => candidate.stageId === stageId && candidate.placeholderRef === ref,
-  );
+  const targeted = lookupMediaTask(tasks, targetElementId, stageId, false);
+  return targeted ?? lookupMediaTask(tasks, ref, stageId);
 }
 
 export function mediaTaskRefForElement(element: PPTElement): string | undefined {
@@ -66,15 +89,14 @@ function matchMediaTaskForElement<T extends MediaTaskLookupEntry>(
   const ref = mediaTaskRefForElement(element);
   if (!ref || !stageId) return undefined;
 
-  const targeted = tasks[element.id];
-  if (targeted?.stageId === stageId) return [element.id, targeted];
+  const targeted = lookupMediaTask(tasks, element.id, stageId, false);
+  if (targeted) return [element.id, targeted];
 
-  const exact = tasks[ref];
-  if (exact) return exact.stageId === stageId ? [ref, exact] : undefined;
-
-  return Object.entries(tasks).find(
-    ([, candidate]) => candidate.stageId === stageId && candidate.placeholderRef === ref,
-  );
+  const task = lookupMediaTask(tasks, ref, stageId);
+  if (!task) return undefined;
+  if (Object.hasOwn(tasks, ref) && tasks[ref] === task) return [ref, task];
+  const fallbackKey = Object.entries(tasks).find(([, candidate]) => candidate === task)?.[0];
+  return fallbackKey ? [fallbackKey, task] : undefined;
 }
 
 /** Shared task lookup used by direct elements and resolved-slide consumers. */

--- a/lib/media/media-task-resolution.ts
+++ b/lib/media/media-task-resolution.ts
@@ -131,8 +131,15 @@ export function resolveVideoMediaForElement<T extends MediaTaskLookupEntry>(
     ? undefined
     : resolveMediaTaskForElement(effectiveTasks, element, stageId);
   const posterRef = element.poster ?? task?.poster;
+  // A task-owned poster is carried as a binding whenever it is the effective
+  // poster. An element with no poster of its own falls back to the task's
+  // generated poster URL, so that URL must travel with a task binding for the
+  // manifest guard's task-ownership exemption to admit it; an opaque element
+  // poster ref keeps the task's runtime poster URL as its bytes fallback. A
+  // concrete explicit element poster stays element-owned and never borrows the
+  // task binding.
   const posterTask =
-    element.poster && !isConcreteMediaAddress(element.poster) && task?.poster
+    task?.poster && (!element.poster || !isConcreteMediaAddress(element.poster))
       ? ({ ...task, objectUrl: task.poster } as T & { readonly objectUrl: string })
       : undefined;
 

--- a/lib/media/resolve-stored-bytes.ts
+++ b/lib/media/resolve-stored-bytes.ts
@@ -1,6 +1,7 @@
 import { db, mediaFileKey, type MediaFileRecord } from '@/lib/utils/database';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import { withAssetUrl } from './use-asset-url';
+import { lookupMediaTask } from './media-task-resolution';
 import {
   MISSING_ASSET_LEASE,
   isConcreteMediaAddress,
@@ -202,11 +203,5 @@ async function fetchBytes(url: string, policy: StoredBytesFetchPolicy): Promise<
  */
 function effectiveMediaTask(ref: string, stageId: string | undefined): MediaTaskState | undefined {
   const tasks = useMediaGenerationStore.getState().tasks;
-  const task =
-    tasks[ref] ??
-    Object.values(tasks).find(
-      (candidate) =>
-        candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
-    );
-  return task && (!stageId || task.stageId === stageId) ? task : undefined;
+  return lookupMediaTask(tasks, ref, stageId);
 }

--- a/lib/media/slide-media-slots.ts
+++ b/lib/media/slide-media-slots.ts
@@ -1,15 +1,16 @@
-import type { PPTImageElement, PPTVideoElement, Slide } from '@openmaic/dsl';
+import type { PPTAudioElement, PPTImageElement, PPTVideoElement, Slide } from '@openmaic/dsl';
 
 export type SlideMediaReferenceKind =
   | 'background-image'
   | 'image-src'
+  | 'audio-src'
   | 'video-src'
   | 'video-media-ref'
   | 'video-poster';
 
 export interface SlideMediaReferenceSlot {
   readonly kind: SlideMediaReferenceKind;
-  readonly element?: PPTImageElement | PPTVideoElement;
+  readonly element?: PPTImageElement | PPTVideoElement | PPTAudioElement;
   readonly elementIndex?: number;
   readonly read: () => string | undefined;
   readonly write: (value: string | undefined) => void;
@@ -42,6 +43,10 @@ export function* slideMediaReferenceSlots(
       yield elementSlot('image-src', element, elementIndex, 'src');
       continue;
     }
+    if (element.type === 'audio') {
+      yield elementSlot('audio-src', element, elementIndex, 'src');
+      continue;
+    }
     if (element.type !== 'video') continue;
     yield elementSlot('video-src', element, elementIndex, 'src');
     yield elementSlot('video-media-ref', element, elementIndex, 'mediaRef');
@@ -50,7 +55,7 @@ export function* slideMediaReferenceSlots(
 }
 
 function elementSlot<
-  T extends PPTImageElement | PPTVideoElement,
+  T extends PPTImageElement | PPTVideoElement | PPTAudioElement,
   K extends Extract<keyof T, 'src' | 'mediaRef' | 'poster'>,
 >(
   kind: SlideMediaReferenceKind,

--- a/lib/media/slide-media-slots.ts
+++ b/lib/media/slide-media-slots.ts
@@ -1,12 +1,14 @@
-import type { PPTAudioElement, PPTImageElement, PPTVideoElement, Slide } from '@openmaic/dsl';
+import {
+  slideMediaSlotDescriptors,
+  type PPTAudioElement,
+  type PPTImageElement,
+  type PPTVideoElement,
+  type Slide,
+  type SlideMediaSlotKind,
+  type SlideMediaSlotProperty,
+} from '@openmaic/dsl';
 
-export type SlideMediaReferenceKind =
-  | 'background-image'
-  | 'image-src'
-  | 'audio-src'
-  | 'video-src'
-  | 'video-media-ref'
-  | 'video-poster';
+export type SlideMediaReferenceKind = SlideMediaSlotKind;
 
 export interface SlideMediaReferenceSlot {
   readonly kind: SlideMediaReferenceKind;
@@ -26,51 +28,44 @@ export interface SlideMediaReferenceSlot {
 export function* slideMediaReferenceSlots(
   slide: Pick<Slide, 'background' | 'elements'>,
 ): Generator<SlideMediaReferenceSlot> {
-  const background = slide.background?.type === 'image' ? slide.background.image : undefined;
-  if (background) {
-    yield {
-      kind: 'background-image',
-      read: () => background.src,
-      write: (value) => {
-        background.src = value ?? '';
-      },
-    };
-  }
-
-  for (let elementIndex = 0; elementIndex < slide.elements.length; elementIndex += 1) {
-    const element = slide.elements[elementIndex];
-    if (element.type === 'image') {
-      yield elementSlot('image-src', element, elementIndex, 'src');
+  for (const descriptor of slideMediaSlotDescriptors(slide)) {
+    if (descriptor.elementIndex === undefined) {
+      const background = slide.background?.type === 'image' ? slide.background.image : undefined;
+      if (!background) continue;
+      yield {
+        kind: descriptor.kind,
+        read: () => background.src,
+        write: (value) => {
+          background.src = value ?? '';
+        },
+      };
       continue;
     }
-    if (element.type === 'audio') {
-      yield elementSlot('audio-src', element, elementIndex, 'src');
-      continue;
-    }
-    if (element.type !== 'video') continue;
-    yield elementSlot('video-src', element, elementIndex, 'src');
-    yield elementSlot('video-media-ref', element, elementIndex, 'mediaRef');
-    yield elementSlot('video-poster', element, elementIndex, 'poster');
+    const element = slide.elements[descriptor.elementIndex];
+    yield elementSlot(
+      descriptor.kind,
+      element as PPTImageElement | PPTVideoElement | PPTAudioElement,
+      descriptor.elementIndex,
+      descriptor.property,
+    );
   }
 }
 
-function elementSlot<
-  T extends PPTImageElement | PPTVideoElement | PPTAudioElement,
-  K extends Extract<keyof T, 'src' | 'mediaRef' | 'poster'>,
->(
+function elementSlot(
   kind: SlideMediaReferenceKind,
-  element: T,
+  element: PPTImageElement | PPTVideoElement | PPTAudioElement,
   elementIndex: number,
-  key: K,
+  key: SlideMediaSlotProperty,
 ): SlideMediaReferenceSlot {
+  const mediaProperties = element as unknown as Partial<Record<SlideMediaSlotProperty, string>>;
   return {
     kind,
     element,
     elementIndex,
-    read: () => element[key] as string | undefined,
+    read: () => mediaProperties[key],
     write: (value) => {
-      if (value === undefined && key !== 'src') delete element[key];
-      else element[key] = (value ?? '') as T[K];
+      if (value === undefined && key !== 'src') delete mediaProperties[key];
+      else mediaProperties[key] = value ?? '';
     },
   };
 }

--- a/lib/video-export-app/collect.ts
+++ b/lib/video-export-app/collect.ts
@@ -37,7 +37,7 @@ import {
 } from '@/lib/media/resolve-media-ref';
 import { resolveStoredBytes } from '@/lib/media/resolve-stored-bytes';
 import { slideMediaReferenceSlots } from '@/lib/media/slide-media-slots';
-import { resolveVideoMediaForElement } from '@/lib/media/media-task-resolution';
+import { lookupMediaTask, resolveVideoMediaForElement } from '@/lib/media/media-task-resolution';
 
 export interface CollectOptions {
   /** Slide-snapshot render width in px (frame height follows the slide ratio). Default 1920. */
@@ -218,14 +218,7 @@ async function resolveGeneratedMedia(
       backgroundSlot.write(url);
     } else {
       const tasks = useMediaGenerationStore.getState().tasks;
-      const task =
-        tasks[backgroundRef] ??
-        Object.values(tasks).find(
-          (candidate) =>
-            candidate.placeholderRef === backgroundRef &&
-            (!stageId || candidate.stageId === stageId),
-        );
-      const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
+      const effectiveTask = lookupMediaTask(tasks, backgroundRef, stageId);
       if (!renderableMediaUrl(resolveMediaRef(backgroundRef, effectiveTask))) {
         backgroundSlot.write('');
       }
@@ -267,13 +260,7 @@ async function resolveGeneratedMedia(
     const record = mediaByElementId.get(ref);
     const bytes = await resolveMediaBytesWithFallback(ref, record, stageId);
     if (!bytes) {
-      const task =
-        tasks[ref] ??
-        Object.values(tasks).find(
-          (candidate) =>
-            candidate.placeholderRef === ref && (!stageId || candidate.stageId === stageId),
-        );
-      const effectiveTask = task && (!stageId || task.stageId === stageId) ? task : undefined;
+      const effectiveTask = lookupMediaTask(tasks, ref, stageId);
       if (!renderableMediaUrl(resolveMediaRef(ref, effectiveTask))) element.src = '';
       continue;
     }

--- a/lib/video-export-app/timeline-deps.ts
+++ b/lib/video-export-app/timeline-deps.ts
@@ -34,9 +34,10 @@ import type {
   TimingProbe,
 } from '@/lib/video-export';
 import type { Scene, SlideContent } from '@/lib/types/stage';
+import { enumerateAssetManifest } from '@openmaic/dsl';
 import { isMediaPlaceholder } from '@/lib/store/media-generation';
 import { measureSlideElementGeometry, type MeasuredGeometry } from '@openmaic/renderer/snapshot';
-import { db, type AudioFileRecord, type MediaFileRecord } from '@/lib/utils/database';
+import { db, mediaFileKey, type AudioFileRecord, type MediaFileRecord } from '@/lib/utils/database';
 import {
   emptyPreparedInteractiveHtmlSet,
   prepareInteractiveHtmlScenes,
@@ -222,6 +223,15 @@ export async function createVideoTimelineDeps(input: {
     ? emptyPreparedInteractiveHtmlSet()
     : await prepareInteractiveHtmlScenes(scenes);
 
+  // The standardized asset manifest names exactly the media references this
+  // document holds. Video compilation consumes audio only through speech
+  // actions, so narration ids come from the speech pairs below; slide-audio
+  // elements are renderable document assets but never timeline audio clips.
+  // The media load no longer scans the table -- a row no document reference
+  // names (an orphan) was never reachable through the scene-scoped bridge
+  // anyway, and now is not even read.
+  const assetManifest = enumerateAssetManifest({ stage, scenes });
+
   // Audio: load only the records referenced by speech actions.
   const speechPairs: Array<{ audioId?: string; audioUrl?: string }> = [];
   for (const scene of scenes) {
@@ -234,10 +244,7 @@ export async function createVideoTimelineDeps(input: {
       });
     }
   }
-  const audioIds = new Set<string>();
-  for (const pair of speechPairs) {
-    if (pair.audioId) audioIds.add(pair.audioId);
-  }
+  const audioIds = new Set(speechPairs.flatMap((pair) => (pair.audioId ? [pair.audioId] : [])));
   const audioById = new Map<string, AudioFileRecord>();
   for (const audioId of audioIds) {
     const record = await db.audioFiles.get(audioId);
@@ -291,14 +298,14 @@ export async function createVideoTimelineDeps(input: {
     if (ms !== null) audioDurationMsByAudioId.set(audioId, ms);
   });
 
-  // Media: all generated media for this stage, keyed by media ref (`gen_vid_…` /
-  // `gen_img_…` — the stored `stageId:` prefix stripped), NOT the slide element
-  // id that `play_video` actions target.
-  const mediaRecords = await db.mediaFiles.where('stageId').equals(stage.id).toArray();
+  // Media: the records of every media ref the manifest names, keyed by that
+  // ref (`gen_vid_…` / allocated id -- the stored `stageId:` prefix stripped),
+  // NOT the slide element id that `play_video` actions target.
   const mediaByElementId = new Map<string, MediaFileRecord>();
-  for (const record of mediaRecords) {
-    const elementId = record.id.includes(':') ? record.id.split(':').slice(1).join(':') : record.id;
-    mediaByElementId.set(elementId, record);
+  for (const entry of assetManifest.entries) {
+    if (entry.kind === 'audio') continue;
+    const record = await db.mediaFiles.get(mediaFileKey(stage.id, entry.ref)).catch(() => undefined);
+    if (record) mediaByElementId.set(entry.ref, record);
   }
 
   // Bridge slide element `.id` → media ref, so a `play_video`/media lookup by the

--- a/lib/video-export-app/timeline-deps.ts
+++ b/lib/video-export-app/timeline-deps.ts
@@ -33,7 +33,7 @@ import type {
   InteractiveHtmlSource,
   TimingProbe,
 } from '@/lib/video-export';
-import type { Scene, SlideContent } from '@/lib/types/stage';
+import type { Scene, SlideContent, Stage } from '@/lib/types/stage';
 import { enumerateAssetManifest } from '@openmaic/dsl';
 import { isMediaPlaceholder } from '@/lib/store/media-generation';
 import { measureSlideElementGeometry, type MeasuredGeometry } from '@openmaic/renderer/snapshot';
@@ -203,7 +203,7 @@ function probeAudioDurationMs(blob: Blob): Promise<number | null> {
  * compiler's sync `videoDurationMs` is a table lookup.
  */
 export async function createVideoTimelineDeps(input: {
-  stage: { id: string };
+  stage: Pick<Stage, 'id' | 'whiteboard' | 'videoManifest'>;
   scenes: Scene[];
   /**
    * Skip the off-screen content-box geometry measurement (an off-screen React
@@ -311,7 +311,9 @@ export async function createVideoTimelineDeps(input: {
   const mediaByElementId = new Map<string, MediaFileRecord>();
   for (const entry of assetManifest.entries) {
     if (entry.kind === 'audio') continue;
-    const record = await db.mediaFiles.get(mediaFileKey(stage.id, entry.ref)).catch(() => undefined);
+    const record = await db.mediaFiles
+      .get(mediaFileKey(stage.id, entry.ref))
+      .catch(() => undefined);
     if (record) mediaByElementId.set(entry.ref, record);
   }
 

--- a/lib/video-export-app/timeline-deps.ts
+++ b/lib/video-export-app/timeline-deps.ts
@@ -244,13 +244,16 @@ export async function createVideoTimelineDeps(input: {
       });
     }
   }
-  const speechAudioRefs = new Set(
-    speechPairs.flatMap((pair) => (pair.audioId ? [pair.audioId] : [])),
+  const manifestAudioRefs = new Set(
+    assetManifest.entries.filter((entry) => entry.kind === 'audio').map((entry) => entry.ref),
   );
+  // The manifest gates membership, but speech traversal remains the ordering
+  // source. Slide-audio slots can make the same ref appear earlier in manifest
+  // order even though the timeline first consumes a different narration.
   const audioIds = new Set(
-    assetManifest.entries
-      .filter((entry) => entry.kind === 'audio' && speechAudioRefs.has(entry.ref))
-      .map((entry) => entry.ref),
+    speechPairs.flatMap((pair) =>
+      pair.audioId && manifestAudioRefs.has(pair.audioId) ? [pair.audioId] : [],
+    ),
   );
   const audioById = new Map<string, AudioFileRecord>();
   for (const audioId of audioIds) {

--- a/lib/video-export-app/timeline-deps.ts
+++ b/lib/video-export-app/timeline-deps.ts
@@ -244,7 +244,14 @@ export async function createVideoTimelineDeps(input: {
       });
     }
   }
-  const audioIds = new Set(speechPairs.flatMap((pair) => (pair.audioId ? [pair.audioId] : [])));
+  const speechAudioRefs = new Set(
+    speechPairs.flatMap((pair) => (pair.audioId ? [pair.audioId] : [])),
+  );
+  const audioIds = new Set(
+    assetManifest.entries
+      .filter((entry) => entry.kind === 'audio' && speechAudioRefs.has(entry.ref))
+      .map((entry) => entry.ref),
+  );
   const audioById = new Map<string, AudioFileRecord>();
   for (const audioId of audioIds) {
     // Bytes come only from the shared resolver: pool-first, so a stable-id

--- a/lib/video-export-app/timeline-deps.ts
+++ b/lib/video-export-app/timeline-deps.ts
@@ -247,12 +247,19 @@ export async function createVideoTimelineDeps(input: {
   const audioIds = new Set(speechPairs.flatMap((pair) => (pair.audioId ? [pair.audioId] : [])));
   const audioById = new Map<string, AudioFileRecord>();
   for (const audioId of audioIds) {
+    // Bytes come only from the shared resolver: pool-first, so a stable-id
+    // regeneration whose mirror write failed (the row then holds the
+    // superseded narration) still exports what the classroom plays; the row's
+    // own blob is the resolver's legacy fallback. The row read here supplies
+    // duration/format/ossKey metadata for the compiler's sync lookups.
     const record = await db.audioFiles.get(audioId);
-    // A stable-id regeneration whose mirror write failed leaves the row on the
-    // superseded narration, so the pool answers first here too.
     const blob = await resolveAudioBlob(audioId);
-    if (record) audioById.set(audioId, blob ? { ...record, blob } : record);
-    else if (blob) audioById.set(audioId, { id: audioId, blob } as AudioFileRecord);
+    if (blob)
+      audioById.set(
+        audioId,
+        record ? { ...record, blob } : ({ id: audioId, blob } as AudioFileRecord),
+      );
+    else if (record) audioById.set(audioId, record);
   }
   // An unconverted document can carry narration only as a legacy URL: the
   // playback paths fall back to it, and the export must too, or a playable

--- a/lib/video-export/archive-media.ts
+++ b/lib/video-export/archive-media.ts
@@ -71,6 +71,11 @@ const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
  * Normalize untrusted archive metadata against the authoritative media kind.
  * The returned extension and MIME are one inseparable pair: a valid hint must
  * belong to the kind's allowlist, and every other value falls back by kind.
+ *
+ * This is label coherence, not byte validation. Exporters deliberately neither
+ * inspect nor transcode payload bytes; like runtime and renderer consumers, they
+ * trust the authoritative kind metadata. Bytes that do not match that kind are
+ * already-corrupt store state outside the archive/export contract.
  */
 export function canonicalArchiveMedia(
   kind: ArchiveMediaKind,

--- a/lib/video-export/archive-media.ts
+++ b/lib/video-export/archive-media.ts
@@ -1,0 +1,98 @@
+export type ArchiveMediaKind = 'image' | 'video' | 'audio';
+
+export interface ArchiveMediaDescriptor {
+  extension: string;
+  mimeType: string;
+}
+
+const DEFAULT_BY_KIND: Readonly<Record<ArchiveMediaKind, ArchiveMediaDescriptor>> = {
+  image: { extension: 'jpg', mimeType: 'image/jpeg' },
+  video: { extension: 'mp4', mimeType: 'video/mp4' },
+  audio: { extension: 'mp3', mimeType: 'audio/mpeg' },
+};
+
+const MIME_BY_EXTENSION: Readonly<Record<ArchiveMediaKind, Readonly<Record<string, string>>>> = {
+  image: {
+    avif: 'image/avif',
+    gif: 'image/gif',
+    jpeg: 'image/jpeg',
+    jpg: 'image/jpeg',
+    png: 'image/png',
+    svg: 'image/svg+xml',
+    webp: 'image/webp',
+  },
+  video: {
+    m4v: 'video/x-m4v',
+    mov: 'video/quicktime',
+    mp4: 'video/mp4',
+    ogv: 'video/ogg',
+    webm: 'video/webm',
+  },
+  audio: {
+    aac: 'audio/aac',
+    flac: 'audio/flac',
+    m4a: 'audio/x-m4a',
+    mp3: 'audio/mpeg',
+    mp4: 'audio/mp4',
+    mpeg: 'audio/mpeg',
+    ogg: 'audio/ogg',
+    opus: 'audio/opus',
+    wav: 'audio/wav',
+    webm: 'audio/webm',
+  },
+};
+
+const EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  'audio/aac': 'aac',
+  'audio/flac': 'flac',
+  'audio/mp3': 'mp3',
+  'audio/mp4': 'mp4',
+  'audio/mpeg': 'mpeg',
+  'audio/ogg': 'ogg',
+  'audio/opus': 'opus',
+  'audio/wav': 'wav',
+  'audio/webm': 'webm',
+  'audio/x-m4a': 'm4a',
+  'audio/x-wav': 'wav',
+  'image/avif': 'avif',
+  'image/gif': 'gif',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/svg+xml': 'svg',
+  'image/webp': 'webp',
+  'video/mp4': 'mp4',
+  'video/ogg': 'ogv',
+  'video/quicktime': 'mov',
+  'video/webm': 'webm',
+  'video/x-m4v': 'm4v',
+};
+
+/**
+ * Normalize untrusted archive metadata against the authoritative media kind.
+ * The returned extension and MIME are one inseparable pair: a valid hint must
+ * belong to the kind's allowlist, and every other value falls back by kind.
+ */
+export function canonicalArchiveMedia(
+  kind: ArchiveMediaKind,
+  input: { mimeType?: string; extension?: string },
+): ArchiveMediaDescriptor {
+  const allowed = MIME_BY_EXTENSION[kind];
+  let extension: string | undefined;
+
+  if (typeof input.extension === 'string' && /^[a-z0-9]+$/i.test(input.extension)) {
+    const candidate = input.extension.toLowerCase();
+    if (allowed[candidate]) extension = candidate;
+  }
+
+  if (
+    !extension &&
+    typeof input.mimeType === 'string' &&
+    input.mimeType === input.mimeType.toLowerCase()
+  ) {
+    const candidate = EXTENSION_BY_MIME[input.mimeType];
+    if (candidate && allowed[candidate]) extension = candidate;
+  }
+
+  if (!extension) return DEFAULT_BY_KIND[kind];
+  return { extension, mimeType: allowed[extension] };
+}

--- a/lib/video-export/passes/assets.ts
+++ b/lib/video-export/passes/assets.ts
@@ -8,8 +8,10 @@
  * the browser-side implementation in the next phase (P1d); {@link AssetSource}
  * supplies just enough metadata (id, mime/format, presence) to build the plan.
  *
- * Deduplication is by `assetId`: the first reference owns the path, later
- * references reuse it and carry `dedupOf`. A referenced-but-absent asset is kept
+ * Deduplication is by (`assetId`, `kind`): the first same-kind reference owns
+ * the path, later same-kind references reuse it and carry `dedupOf`. A ref may
+ * legitimately identify both narration audio and video media, so ownership must
+ * not cross the kind boundary. A referenced-but-absent asset is kept
  * in the plan as `present: false` with a `skipped-media` diagnostic, so the
  * report shows the gap instead of hiding it.
  *
@@ -54,16 +56,17 @@ export function canonicalAssetExtension(kind: ArchiveMediaKind, meta: AssetMeta)
 class AssetPlanner {
   readonly entries: AssetPlanEntry[] = [];
   private readonly usedPaths = new Map<string, number>();
-  /** assetId → the first (owner) entry, whose path + presence every later ref inherits. */
-  private readonly owner = new Map<string, AssetPlanEntry>();
+  /** kind → assetId → first owner, whose path + presence later same-kind refs inherit. */
+  private readonly owners = new Map<AssetKind, Map<string, AssetPlanEntry>>();
 
   /**
    * Plan one asset reference. Returns the path it maps to and the *authoritative*
-   * presence for its `assetId`.
+   * presence for its (`assetId`, `kind`) identity.
    *
-   * Presence is a property of the asset id, not of an individual reference: the
-   * first reference to an id decides it, and every later reference (and the
-   * caller's segment) inherits that value. This keeps the plan internally
+   * Presence is a property of the kind-scoped asset id, not of an individual
+   * reference: the first reference to an id within one kind decides it, and every
+   * later same-kind reference (and the caller's segment) inherits that value.
+   * This keeps the plan internally
    * consistent even if an {@link AssetSource} returns inconsistent `present` for
    * the same id — otherwise a dedup entry could claim a different presence than
    * its owner.
@@ -74,7 +77,8 @@ class AssetPlanner {
     desiredPath: string,
     present: boolean,
   ): { path: string; present: boolean } {
-    const existing = this.owner.get(assetId);
+    const ownersForKind = this.owners.get(kind);
+    const existing = ownersForKind?.get(assetId);
     if (existing) {
       this.entries.push({
         assetId,
@@ -87,7 +91,8 @@ class AssetPlanner {
     }
     const path = this.unique(desiredPath);
     const entry: AssetPlanEntry = { assetId, kind, path, present };
-    this.owner.set(assetId, entry);
+    if (ownersForKind) ownersForKind.set(assetId, entry);
+    else this.owners.set(kind, new Map([[assetId, entry]]));
     this.entries.push(entry);
     return { path, present };
   }

--- a/lib/video-export/passes/assets.ts
+++ b/lib/video-export/passes/assets.ts
@@ -21,6 +21,7 @@
 import type { SpeechAction } from '@openmaic/dsl';
 import type { AssetSource, AssetMeta, CompilerScene } from '../deps';
 import type { AssetKind, AssetPlan, AssetPlanEntry, Diagnostic, VideoTimelineScene } from '../ir';
+import { canonicalArchiveMedia, type ArchiveMediaKind } from '../archive-media';
 
 export interface AssetsResult {
   scenes: VideoTimelineScene[];
@@ -41,42 +42,12 @@ export function sanitizeFilenamePart(value: string): string {
   return normalized.slice(0, 80) || 'scene';
 }
 
-/**
- * File extension for an asset from its `format`/`mimeType`, falling back per
- * kind. The result is sanitized to a bare, traversal-free extension token
- * (alphanumeric, lowercased) so a hostile `format` such as `../../escape` cannot
- * steer the planned zip path outside its directory — the ZIP-writing stage
- * receives only safe extensions.
- */
-function extension(meta: AssetMeta, fallback: string): string {
-  const raw = extensionRaw(meta, fallback);
-  const safe = raw
-    .toLowerCase()
-    .replace(/^\.+/, '')
-    .replace(/[^a-z0-9]/g, '');
-  return safe || fallback;
-}
-
-/** The unsanitized extension candidate from `format` / `mimeType` / fallback. */
-function extensionRaw(meta: AssetMeta, fallback: string): string {
-  if (meta.format) return meta.format.replace(/^\./, '');
-  const mime = meta.mimeType;
-  if (mime) {
-    const known: Record<string, string> = {
-      'audio/mpeg': 'mp3',
-      'audio/mp3': 'mp3',
-      'audio/wav': 'wav',
-      'audio/webm': 'weba',
-      'image/png': 'png',
-      'image/jpeg': 'jpg',
-      'video/mp4': 'mp4',
-      'video/webm': 'webm',
-    };
-    if (known[mime]) return known[mime];
-    const sub = mime.split('/')[1];
-    if (sub) return sub;
-  }
-  return fallback;
+/** Kind-scoped extension used by every audio/video path planned by this pass. */
+export function canonicalAssetExtension(kind: ArchiveMediaKind, meta: AssetMeta): string {
+  return canonicalArchiveMedia(kind, {
+    extension: meta.format,
+    mimeType: meta.mimeType,
+  }).extension;
 }
 
 /** Planner state: tracks used paths (for collision suffixes) and asset dedup. */
@@ -184,7 +155,7 @@ export function planAssets(
       const { path, present } = planner.plan(
         meta.id,
         'audio',
-        `audio/${sceneSlug}/speech-${String(speechSeq).padStart(3, '0')}.${extension(meta, 'mp3')}`,
+        `audio/${sceneSlug}/speech-${String(speechSeq).padStart(3, '0')}.${canonicalAssetExtension('audio', meta)}`,
         meta.present,
       );
       if (!present) {
@@ -232,7 +203,7 @@ export function planAssets(
       const { path, present } = planner.plan(
         meta.id,
         'video',
-        `media/${sanitizeFilenamePart(seg.elementId)}.${extension(meta, 'mp4')}`,
+        `media/${sanitizeFilenamePart(seg.elementId)}.${canonicalAssetExtension('video', meta)}`,
         meta.present,
       );
       if (!present) {

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -31,6 +31,7 @@ nothing.
 | `validate.ts` | Pure, zero-dep structural validators — `validateStage` / `validateScene` / `validateAction` returning an error-collecting `ValidationResult`. |
 | `normalize.ts` | Pure, zero-dep defaulters — `normalizeElement` / `normalizeSlide` / `normalizeScene` / `normalizeStage` and the canonical `ELEMENT_DEFAULTS`. Fills required-field defaults, derives geometry, fails loud on malformed input; the repair counterpart to `validate*`. `normalizeSlideWith({ onInvalid: 'drop', onDropped })` builds a map-safe `normalizeSlide` variant so producers normalizing wild-world input (imported decks, model output) can degrade per element instead of failing the document; `normalizeSlide` itself stays unary (`slides.map(normalizeSlide)` keeps working). |
 | `asset-manifest.ts` | Pure document asset enumeration: `enumerateAssetManifest`, `AssetManifest`, entry kinds and optional caller-supplied metadata enrichment. |
+| `slide-media-slots.ts` | Canonical read-only role descriptors for every media-bearing slide slot. |
 | `version.ts`  | Serialized-contract version + migration registry: `DSL_VERSION`, the `DSL_MIGRATIONS` ladder, and the pure `migrate` / `dslVersionOf` / `needsMigration` runner. |
 
 ```ts

--- a/packages/@openmaic/dsl/README.md
+++ b/packages/@openmaic/dsl/README.md
@@ -30,12 +30,52 @@ nothing.
 | `guards.ts`   | Pure discriminant type-guards (`isTextElement`, …) and `PPT_ELEMENT_TYPES`. |
 | `validate.ts` | Pure, zero-dep structural validators — `validateStage` / `validateScene` / `validateAction` returning an error-collecting `ValidationResult`. |
 | `normalize.ts` | Pure, zero-dep defaulters — `normalizeElement` / `normalizeSlide` / `normalizeScene` / `normalizeStage` and the canonical `ELEMENT_DEFAULTS`. Fills required-field defaults, derives geometry, fails loud on malformed input; the repair counterpart to `validate*`. `normalizeSlideWith({ onInvalid: 'drop', onDropped })` builds a map-safe `normalizeSlide` variant so producers normalizing wild-world input (imported decks, model output) can degrade per element instead of failing the document; `normalizeSlide` itself stays unary (`slides.map(normalizeSlide)` keeps working). |
+| `asset-manifest.ts` | Pure document asset enumeration: `enumerateAssetManifest`, `AssetManifest`, entry kinds and optional caller-supplied metadata enrichment. |
 | `version.ts`  | Serialized-contract version + migration registry: `DSL_VERSION`, the `DSL_MIGRATIONS` ladder, and the pure `migrate` / `dslVersionOf` / `needsMigration` runner. |
 
 ```ts
 import type { Slide, PPTElement, Action } from '@openmaic/dsl';
 import { isTextElement, DSL_VERSION, SYNC_ACTIONS } from '@openmaic/dsl';
 ```
+
+## Asset manifest (0.10)
+
+`enumerateAssetManifest(document, options?)` is the standard, IO-free answer to
+which asset references a stage document touches. It walks stage whiteboards,
+scene canvases, scene whiteboards, speech actions, and video-manifest keys. It
+recognizes slide backgrounds; image, audio, and video sources; video
+`mediaRef`s and posters; and speech `audioId`s.
+
+```ts
+import {
+  enumerateAssetManifest,
+  type AssetManifest,
+  type AssetManifestMetadata,
+} from '@openmaic/dsl';
+
+const manifest: AssetManifest = enumerateAssetManifest(document, {
+  metadata(ref, kind): AssetManifestMetadata | undefined {
+    return metadataAlreadyKnownByTheCaller(ref, kind);
+  },
+});
+```
+
+`manifest.entries` contains one entry per distinct `(ref, kind)` pair in
+first-occurrence document order. If one ref appears in several roles, each role
+gets its own entry; the first occurrence of each pair fixes its deterministic
+ordering slot without losing ownership information.
+Optional metadata (`byteSize`, `mimeType`, `durationSeconds`, `voice`, and
+`prompt`) is copied from the callback once per distinct `(ref, kind)` pair. The enumerator
+itself performs no IO and never mutates the document. The callback is an
+explicit caller boundary: it may consult caller-owned state, but it must not
+mutate the document.
+
+`manifest.referenceCounts` counts logical owners, not raw slots. A video
+element using the same ref in both `src` and `mediaRef` is one owner; its poster
+is separate. Owner keys use traversal positions rather than user-controlled
+scene, slide, element, or action IDs, so duplicate IDs do not collapse distinct
+owners. Consumers deciding whether bytes may be replaced in place should use
+these counts instead of rebuilding an ID-keyed walk.
 
 ## Runtime layer (schema + validators + normalizers)
 

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/dsl",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "The MAIC slide DSL: the pure, dependency-free contract (types + JSON Schema + validators + version/migration helpers) that @openmaic/renderer and @openmaic/importer both depend on.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/dsl/src/asset-manifest.ts
+++ b/packages/@openmaic/dsl/src/asset-manifest.ts
@@ -23,6 +23,7 @@
  */
 import type { Action } from './action.js';
 import type { Slide } from './slides.js';
+import { slideMediaSlotDescriptors, type SlideMediaSlotKind } from './slide-media-slots.js';
 import { isSlideContent, type Scene, type SceneType, type Stage } from './stage.js';
 
 /** The role a referenced asset plays in the document. */
@@ -91,59 +92,6 @@ export interface EnumerateAssetManifestOptions {
   readonly metadata?: (ref: string, kind: AssetKind) => AssetManifestMetadata | undefined;
 }
 
-type SlideMediaSlotKind =
-  | 'background-image'
-  | 'image-src'
-  | 'video-src'
-  | 'video-media-ref'
-  | 'video-poster'
-  | 'audio-src';
-
-interface SlideMediaSlot {
-  readonly kind: SlideMediaSlotKind;
-  /** The owning element; absent for the slide background. */
-  readonly elementIndex?: number;
-  readonly ref: string;
-}
-
-/**
- * Yield the non-empty media references of one slide with their roles. This is
- * the read-only package counterpart of the app's mutable
- * `slideMediaReferenceSlots`; both cover background, image, audio, and all
- * video reference roles. It stays local so this package remains free of app
- * imports. Optional video slots contribute nothing when empty.
- */
-function* slideMediaSlots(
-  slide: Pick<Slide, 'background' | 'elements'>,
-): Generator<SlideMediaSlot> {
-  const background = slide.background?.type === 'image' ? slide.background.image : undefined;
-  if (background?.src) {
-    yield { kind: 'background-image', ref: background.src };
-  }
-
-  for (let elementIndex = 0; elementIndex < slide.elements.length; elementIndex += 1) {
-    const element = slide.elements[elementIndex];
-    if (element.type === 'image') {
-      if (element.src) yield { kind: 'image-src', elementIndex, ref: element.src };
-      continue;
-    }
-    if (element.type === 'audio') {
-      // Slide audio elements carry their own src; a manifest that skips them
-      // cannot archive their bytes.
-      if (element.src) yield { kind: 'audio-src', elementIndex, ref: element.src };
-      continue;
-    }
-    if (element.type !== 'video') continue;
-    if (element.src) yield { kind: 'video-src', elementIndex, ref: element.src };
-    if (element.mediaRef) {
-      yield { kind: 'video-media-ref', elementIndex, ref: element.mediaRef };
-    }
-    if (element.poster) {
-      yield { kind: 'video-poster', elementIndex, ref: element.poster };
-    }
-  }
-}
-
 function manifestKind(slotKind: SlideMediaSlotKind): AssetKind {
   switch (slotKind) {
     case 'background-image':
@@ -196,7 +144,8 @@ export function enumerateAssetManifest(
   };
 
   const visitSlide = (slide: Pick<Slide, 'background' | 'elements'>, scopeKey: string) => {
-    for (const slot of slideMediaSlots(slide)) {
+    for (const slot of slideMediaSlotDescriptors(slide)) {
+      if (!slot.ref) continue;
       // Structural positions, rather than user-controlled ids, make owners
       // collision-free even for documents whose scene or element ids repeat.
       const ownerKey =

--- a/packages/@openmaic/dsl/src/asset-manifest.ts
+++ b/packages/@openmaic/dsl/src/asset-manifest.ts
@@ -1,0 +1,266 @@
+/**
+ * Asset manifest — the standardized answer to "which assets does this document
+ * reference?".
+ *
+ * ZIP and video export used to re-derive that set independently, and the ZIP
+ * even derived it from a full scan of the local media tables, which swept
+ * unreferenced rows into the archive. They now consume this enumeration; PPTX
+ * walks slide elements directly but shares the same resolver and resolution
+ * semantics. The manifest is the set of references a document *touches*,
+ * classified by role, with optional per-asset metadata layered on by the caller.
+ *
+ * An entry's `ref` is the reference exactly as the document holds it -- an
+ * allocated asset id, a legacy placeholder, or a concrete URL. The enumeration
+ * is deliberately not a content hash and not a resolution result: it is the
+ * id-based reference set, so two exports of an unchanged document produce the
+ * same manifest, and a reference whose bytes live nowhere still appears (it is
+ * referenced; whether bytes resolve is a separate question each export answers
+ * through its own resolver).
+ *
+ * The enumeration itself is pure and IO-free over the document: no DOM or
+ * storage imports. Optional metadata enrichment is a caller-supplied callback;
+ * it may perform caller-controlled work but must not mutate the document.
+ */
+import type { Action } from './action.js';
+import type { Slide } from './slides.js';
+import { isSlideContent, type Scene, type SceneType, type Stage } from './stage.js';
+
+/** The role a referenced asset plays in the document. */
+export type AssetKind = 'image' | 'video' | 'audio' | 'poster' | 'background';
+
+/**
+ * Provenance and byte metadata an export can attach to a manifest entry.
+ *
+ * Every field is optional: the enumeration is over the document, and a
+ * referenced asset may have no stored record to read metadata from (bytes
+ * pending, pruned, or never written locally). `durationSeconds` is seconds to
+ * match the TTS-time duration the audio records already store.
+ */
+export interface AssetManifestMetadata {
+  /** Size of the stored bytes, when known. */
+  readonly byteSize?: number;
+  /** MIME type of the stored bytes, e.g. `image/png`. */
+  readonly mimeType?: string;
+  /** Playback duration in seconds, for audio/video assets that recorded one. */
+  readonly durationSeconds?: number;
+  /** Voice the narration was synthesized with, for speech audio. */
+  readonly voice?: string;
+  /** Generation prompt the asset was produced from, for generated media. */
+  readonly prompt?: string;
+}
+
+/**
+ * One manifest entry: a reference the document touches, the role it plays
+ * there, and whatever metadata the caller could supply for it.
+ */
+export interface AssetManifestEntry extends AssetManifestMetadata {
+  /** The reference exactly as the document holds it. */
+  readonly ref: string;
+  readonly kind: AssetKind;
+}
+
+export interface AssetManifest {
+  /**
+   * One entry per distinct (reference, kind) pair, in document order (stage
+   * whiteboard, then each scene's canvas, whiteboards and speech actions, then
+   * the stage's video-manifest keys). The first occurrence of each pair keeps
+   * its ordering slot.
+   */
+  readonly entries: readonly AssetManifestEntry[];
+  /**
+   * Logical owners per reference. An owner is the element, background, or
+   * speech action holding the reference, so a video element repeating one ref
+   * in both `src` and `mediaRef` counts once while its poster counts
+   * separately -- the same accounting duplication-safe byte replacement uses.
+   */
+  readonly referenceCounts: ReadonlyMap<string, number>;
+}
+
+/** The document slice the enumeration reads: a stage plus its scenes. */
+export interface AssetManifestDocument {
+  readonly stage: Pick<Stage, 'whiteboard' | 'videoManifest'>;
+  readonly scenes: readonly Scene<Action, { type: SceneType }>[];
+}
+
+export interface EnumerateAssetManifestOptions {
+  /**
+   * Supply per-asset metadata. Called once per distinct (reference, kind) pair;
+   * return `undefined` when nothing is known. Only defined values are copied
+   * onto the entry.
+   */
+  readonly metadata?: (ref: string, kind: AssetKind) => AssetManifestMetadata | undefined;
+}
+
+type SlideMediaSlotKind =
+  | 'background-image'
+  | 'image-src'
+  | 'video-src'
+  | 'video-media-ref'
+  | 'video-poster';
+
+interface SlideMediaSlot {
+  readonly kind: SlideMediaSlotKind;
+  /** The owning element; absent for the slide background. */
+  readonly elementIndex?: number;
+  readonly ref: string;
+}
+
+/**
+ * Yield the non-empty media references of one slide with their roles. This is
+ * the read-only package counterpart of the app's mutable
+ * `slideMediaReferenceSlots`; both cover background, image, audio, and all
+ * video reference roles. It stays local so this package remains free of app
+ * imports. Optional video slots contribute nothing when empty.
+ */
+function* slideMediaSlots(
+  slide: Pick<Slide, 'background' | 'elements'>,
+): Generator<SlideMediaSlot> {
+  const background = slide.background?.type === 'image' ? slide.background.image : undefined;
+  if (background?.src) {
+    yield { kind: 'background-image', ref: background.src };
+  }
+
+  for (let elementIndex = 0; elementIndex < slide.elements.length; elementIndex += 1) {
+    const element = slide.elements[elementIndex];
+    if (element.type === 'image') {
+      if (element.src) yield { kind: 'image-src', elementIndex, ref: element.src };
+      continue;
+    }
+    if (element.type !== 'video') continue;
+    if (element.src) yield { kind: 'video-src', elementIndex, ref: element.src };
+    if (element.mediaRef) {
+      yield { kind: 'video-media-ref', elementIndex, ref: element.mediaRef };
+    }
+    if (element.poster) {
+      yield { kind: 'video-poster', elementIndex, ref: element.poster };
+    }
+  }
+}
+
+function manifestKind(slotKind: SlideMediaSlotKind): AssetKind {
+  switch (slotKind) {
+    case 'background-image':
+      return 'background';
+    case 'image-src':
+      return 'image';
+    case 'video-src':
+    case 'video-media-ref':
+      return 'video';
+    case 'video-poster':
+      return 'poster';
+  }
+}
+
+/**
+ * Enumerate the asset manifest of one document.
+ *
+ * The traversal order is the document's own: stage whiteboard slides first,
+ * then scenes in order (canvas, whiteboards, speech actions), then the stage's
+ * video-manifest keys. That order is what makes `entries` deterministic for a
+ * fixed document, which the serialized views built on top (the ZIP
+ * `mediaIndex`) rely on.
+ */
+export function enumerateAssetManifest(
+  document: AssetManifestDocument,
+  options: EnumerateAssetManifestOptions = {},
+): AssetManifest {
+  const kindsByRef = new Map<string, Set<AssetKind>>();
+  const orderedPairs: Array<{ ref: string; kind: AssetKind }> = [];
+  const ownerKeysByRef = new Map<string, Set<string>>();
+
+  const record = (ref: string, kind: AssetKind, ownerKey: string) => {
+    let kinds = kindsByRef.get(ref);
+    if (!kinds) {
+      kinds = new Set<AssetKind>();
+      kindsByRef.set(ref, kinds);
+    }
+    if (!kinds.has(kind)) {
+      kinds.add(kind);
+      orderedPairs.push({ ref, kind });
+    }
+    let owners = ownerKeysByRef.get(ref);
+    if (!owners) {
+      owners = new Set<string>();
+      ownerKeysByRef.set(ref, owners);
+    }
+    owners.add(ownerKey);
+  };
+
+  const visitSlide = (slide: Pick<Slide, 'background' | 'elements'>, scopeKey: string) => {
+    for (const slot of slideMediaSlots(slide)) {
+      // Structural positions, rather than user-controlled ids, make owners
+      // collision-free even for documents whose scene or element ids repeat.
+      const ownerKey =
+        slot.elementIndex !== undefined
+          ? `${scopeKey}:element:${slot.elementIndex}`
+          : `${scopeKey}:background`;
+      record(
+        slot.ref,
+        manifestKind(slot.kind),
+        slot.kind === 'video-poster' ? `${ownerKey}:poster` : ownerKey,
+      );
+    }
+  };
+
+  const stage = document.stage;
+  for (let index = 0; index < (stage.whiteboard ?? []).length; index += 1) {
+    const slide = stage.whiteboard![index];
+    visitSlide(slide, `stage-whiteboard:${index}`);
+  }
+
+  for (let sceneIndex = 0; sceneIndex < document.scenes.length; sceneIndex += 1) {
+    const scene = document.scenes[sceneIndex];
+    if (isSlideContent(scene.content)) {
+      visitSlide(scene.content.canvas, `scene:${sceneIndex}:canvas`);
+    }
+    for (let index = 0; index < (scene.whiteboards ?? []).length; index += 1) {
+      const slide = scene.whiteboards![index];
+      visitSlide(slide, `scene:${sceneIndex}:whiteboard:${index}`);
+    }
+    for (let index = 0; index < (scene.actions ?? []).length; index += 1) {
+      const action = scene.actions![index];
+      if (action.type !== 'speech' || !action.audioId) continue;
+      record(action.audioId, 'audio', `scene:${sceneIndex}:speech:${index}`);
+    }
+  }
+
+  // The video manifest names generated stage-level videos by the mediaRef a
+  // PPTVideoElement would carry; each key is a referenced video asset. It is
+  // an index over that asset, not another byte owner: replacement ownership
+  // remains the element/background/action accounting described above. A
+  // manifest-only ref is therefore enumerated but has no provable owner and
+  // correctly cannot qualify for in-place replacement.
+  for (const ref of Object.keys(stage.videoManifest ?? {})) {
+    let kinds = kindsByRef.get(ref);
+    if (!kinds) {
+      kinds = new Set<AssetKind>();
+      kindsByRef.set(ref, kinds);
+    }
+    if (!kinds.has('video')) {
+      kinds.add('video');
+      orderedPairs.push({ ref, kind: 'video' });
+    }
+  }
+
+  const entries: AssetManifestEntry[] = [];
+  for (const { ref, kind } of orderedPairs) {
+    const metadata = options.metadata?.(ref, kind);
+    entries.push({
+      ref,
+      kind,
+      ...(metadata?.byteSize !== undefined ? { byteSize: metadata.byteSize } : {}),
+      ...(metadata?.mimeType !== undefined ? { mimeType: metadata.mimeType } : {}),
+      ...(metadata?.durationSeconds !== undefined
+        ? { durationSeconds: metadata.durationSeconds }
+        : {}),
+      ...(metadata?.voice !== undefined ? { voice: metadata.voice } : {}),
+      ...(metadata?.prompt !== undefined ? { prompt: metadata.prompt } : {}),
+    });
+  }
+
+  const referenceCounts = new Map(
+    [...ownerKeysByRef].map(([ref, owners]) => [ref, owners.size] as const),
+  );
+
+  return { entries, referenceCounts };
+}

--- a/packages/@openmaic/dsl/src/asset-manifest.ts
+++ b/packages/@openmaic/dsl/src/asset-manifest.ts
@@ -2,11 +2,10 @@
  * Asset manifest — the standardized answer to "which assets does this document
  * reference?".
  *
- * ZIP and video export used to re-derive that set independently, and the ZIP
- * even derived it from a full scan of the local media tables, which swept
- * unreferenced rows into the archive. They now consume this enumeration; PPTX
- * walks slide elements directly but shares the same resolver and resolution
- * semantics. The manifest is the set of references a document *touches*,
+ * ZIP, PPTX, and video export used to re-derive that set independently, and
+ * the ZIP even derived it from a full scan of the local media tables, which
+ * swept unreferenced rows into the archive. They now consume this enumeration.
+ * The manifest is the set of references a document *touches*,
  * classified by role, with optional per-asset metadata layered on by the caller.
  *
  * An entry's `ref` is the reference exactly as the document holds it -- an

--- a/packages/@openmaic/dsl/src/asset-manifest.ts
+++ b/packages/@openmaic/dsl/src/asset-manifest.ts
@@ -96,7 +96,8 @@ type SlideMediaSlotKind =
   | 'image-src'
   | 'video-src'
   | 'video-media-ref'
-  | 'video-poster';
+  | 'video-poster'
+  | 'audio-src';
 
 interface SlideMediaSlot {
   readonly kind: SlideMediaSlotKind;
@@ -126,6 +127,12 @@ function* slideMediaSlots(
       if (element.src) yield { kind: 'image-src', elementIndex, ref: element.src };
       continue;
     }
+    if (element.type === 'audio') {
+      // Slide audio elements carry their own src; a manifest that skips them
+      // cannot archive their bytes.
+      if (element.src) yield { kind: 'audio-src', elementIndex, ref: element.src };
+      continue;
+    }
     if (element.type !== 'video') continue;
     if (element.src) yield { kind: 'video-src', elementIndex, ref: element.src };
     if (element.mediaRef) {
@@ -148,6 +155,8 @@ function manifestKind(slotKind: SlideMediaSlotKind): AssetKind {
       return 'video';
     case 'video-poster':
       return 'poster';
+    case 'audio-src':
+      return 'audio';
   }
 }
 

--- a/packages/@openmaic/dsl/src/index.ts
+++ b/packages/@openmaic/dsl/src/index.ts
@@ -32,4 +32,5 @@ export * from './validate.js';
 export * from './normalize.js';
 export * from './version.js';
 export * from './storage.js';
+export * from './asset-manifest.js';
 export * from './runtime.js';

--- a/packages/@openmaic/dsl/src/index.ts
+++ b/packages/@openmaic/dsl/src/index.ts
@@ -33,4 +33,5 @@ export * from './normalize.js';
 export * from './version.js';
 export * from './storage.js';
 export * from './asset-manifest.js';
+export * from './slide-media-slots.js';
 export * from './runtime.js';

--- a/packages/@openmaic/dsl/src/slide-media-slots.ts
+++ b/packages/@openmaic/dsl/src/slide-media-slots.ts
@@ -1,0 +1,57 @@
+import type { Slide } from './slides.js';
+
+/** Every media-bearing property the slide DSL assigns a semantic role. */
+export type SlideMediaSlotKind =
+  | 'background-image'
+  | 'image-src'
+  | 'audio-src'
+  | 'video-src'
+  | 'video-media-ref'
+  | 'video-poster';
+
+export type SlideMediaSlotProperty = 'src' | 'mediaRef' | 'poster';
+
+/**
+ * A read-only description of one media slot in a slide.
+ *
+ * `elementIndex` is absent only for the image background. Optional properties
+ * are described even when empty so consumers that write slots and consumers
+ * that only enumerate populated refs share exactly the same role definition.
+ */
+export interface SlideMediaSlotDescriptor {
+  readonly kind: SlideMediaSlotKind;
+  readonly elementIndex?: number;
+  readonly property: SlideMediaSlotProperty;
+  readonly ref: string | undefined;
+}
+
+/** Yield the canonical media-slot classification for one slide. */
+export function* slideMediaSlotDescriptors(
+  slide: Pick<Slide, 'background' | 'elements'>,
+): Generator<SlideMediaSlotDescriptor> {
+  const background = slide.background?.type === 'image' ? slide.background.image : undefined;
+  if (background) {
+    yield { kind: 'background-image', property: 'src', ref: background.src };
+  }
+
+  for (let elementIndex = 0; elementIndex < slide.elements.length; elementIndex += 1) {
+    const element = slide.elements[elementIndex];
+    if (element.type === 'image') {
+      yield { kind: 'image-src', elementIndex, property: 'src', ref: element.src };
+      continue;
+    }
+    if (element.type === 'audio') {
+      yield { kind: 'audio-src', elementIndex, property: 'src', ref: element.src };
+      continue;
+    }
+    if (element.type !== 'video') continue;
+    yield { kind: 'video-src', elementIndex, property: 'src', ref: element.src };
+    yield {
+      kind: 'video-media-ref',
+      elementIndex,
+      property: 'mediaRef',
+      ref: element.mediaRef,
+    };
+    yield { kind: 'video-poster', elementIndex, property: 'poster', ref: element.poster };
+  }
+}

--- a/packages/@openmaic/dsl/src/storage.ts
+++ b/packages/@openmaic/dsl/src/storage.ts
@@ -7,8 +7,11 @@
  * indirection is what keeps a document portable: a raw URL would bake in a
  * particular provider and an expiry assumption, so it cannot travel with the
  * document to another runtime. `@openmaic/renderer` already consumes resolved
- * URLs via its media slots; `@openmaic/exporter` will consume the set of refs a
- * document touches as its asset manifest.
+ * URLs via its media slots; the set of refs a document touches, with per-asset
+ * metadata, is enumerated as its asset manifest by `./asset-manifest.ts`.
+ * ZIP and video consume that enumeration; PPTX walks slide elements directly
+ * while sharing the same resolver and resolution semantics. The reserved
+ * future `@openmaic/exporter` package can build on the same contract.
  *
  * The DSL owns only the minimal `put` / `resolve` / `remove` interface.
  * Concrete backends — IndexedDB + object URLs in the browser, object storage /

--- a/packages/@openmaic/dsl/test/asset-manifest.test.ts
+++ b/packages/@openmaic/dsl/test/asset-manifest.test.ts
@@ -55,6 +55,7 @@ describe('enumerateAssetManifest — reference categories', () => {
           slideWith(
             [
               imageElement('img-1', 'ast_image'),
+              { id: 'aud-1', type: 'audio', src: 'ast_slide_audio' } as Slide['elements'][number],
               videoElement('vid-1', {
                 src: 'ast_video_src',
                 mediaRef: 'ast_video_ref',
@@ -86,6 +87,7 @@ describe('enumerateAssetManifest — reference categories', () => {
         ['ast_stage_wb', 'image'],
         ['ast_background', 'background'],
         ['ast_image', 'image'],
+        ['ast_slide_audio', 'audio'],
         ['ast_video_src', 'video'],
         ['ast_video_ref', 'video'],
         ['ast_poster', 'poster'],

--- a/packages/@openmaic/dsl/test/asset-manifest.test.ts
+++ b/packages/@openmaic/dsl/test/asset-manifest.test.ts
@@ -192,9 +192,7 @@ describe('enumerateAssetManifest — reference counts', () => {
     const document = documentWith([
       slideScene(
         'scene-1',
-        slideWith([
-          videoElement('vid-1', { src: 'ast_v', mediaRef: 'ast_v', poster: 'ast_p' }),
-        ]),
+        slideWith([videoElement('vid-1', { src: 'ast_v', mediaRef: 'ast_v', poster: 'ast_p' })]),
       ),
     ]);
 
@@ -280,7 +278,9 @@ describe('enumerateAssetManifest — metadata', () => {
   });
 
   it('leaves entries metadata-free when no lookup is supplied', () => {
-    const document = documentWith([slideScene('scene-1', slideWith([imageElement('i1', 'ast_img')]))]);
+    const document = documentWith([
+      slideScene('scene-1', slideWith([imageElement('i1', 'ast_img')])),
+    ]);
 
     expect(enumerateAssetManifest(document).entries).toEqual([{ ref: 'ast_img', kind: 'image' }]);
   });

--- a/packages/@openmaic/dsl/test/asset-manifest.test.ts
+++ b/packages/@openmaic/dsl/test/asset-manifest.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enumerateAssetManifest,
+  type AssetManifestDocument,
+  type Scene,
+  type Slide,
+  type Stage,
+} from '@openmaic/dsl';
+
+/** A minimal slide carrier: only the slots the enumeration reads. */
+function slideWith(elements: Slide['elements'], background?: Slide['background']): Slide {
+  return { id: 'slide-1', elements, ...(background ? { background } : {}) } as Slide;
+}
+
+function imageElement(id: string, src: string): Slide['elements'][number] {
+  return { id, type: 'image', src } as Slide['elements'][number];
+}
+
+function videoElement(
+  id: string,
+  fields: { src?: string; mediaRef?: string; poster?: string },
+): Slide['elements'][number] {
+  return { id, type: 'video', autoplay: false, ...fields } as Slide['elements'][number];
+}
+
+function slideScene(
+  id: string,
+  canvas: Slide,
+  extra: Partial<Scene> = {},
+): AssetManifestDocument['scenes'][number] {
+  return {
+    id,
+    stageId: 'stage-1',
+    title: id,
+    order: 0,
+    type: 'slide',
+    content: { type: 'slide', canvas },
+    ...extra,
+  } as AssetManifestDocument['scenes'][number];
+}
+
+function documentWith(
+  scenes: AssetManifestDocument['scenes'],
+  stage: Partial<Pick<Stage, 'whiteboard' | 'videoManifest'>> = {},
+): AssetManifestDocument {
+  return { stage: stage as AssetManifestDocument['stage'], scenes };
+}
+
+describe('enumerateAssetManifest — reference categories', () => {
+  it('enumerates every reference category with its kind', () => {
+    const document = documentWith(
+      [
+        slideScene(
+          'scene-1',
+          slideWith(
+            [
+              imageElement('img-1', 'ast_image'),
+              videoElement('vid-1', {
+                src: 'ast_video_src',
+                mediaRef: 'ast_video_ref',
+                poster: 'ast_poster',
+              }),
+            ],
+            { type: 'image', image: { src: 'ast_background', size: 'cover' } },
+          ),
+          {
+            whiteboards: [slideWith([imageElement('wb-img', 'ast_scene_wb')])],
+            actions: [
+              { id: 'a1', type: 'speech', text: 'hi', audioId: 'ast_narration' },
+              { id: 'a2', type: 'spotlight', elementId: 'img-1' },
+            ] as Scene['actions'],
+          },
+        ),
+      ],
+      {
+        whiteboard: [slideWith([imageElement('stage-wb-img', 'ast_stage_wb')])],
+        videoManifest: { ast_manifest_video: { type: 'video', prompt: 'trailer' } },
+      },
+    );
+
+    const manifest = enumerateAssetManifest(document);
+    const kindByRef = new Map(manifest.entries.map((entry) => [entry.ref, entry.kind]));
+
+    expect(kindByRef).toEqual(
+      new Map([
+        ['ast_stage_wb', 'image'],
+        ['ast_background', 'background'],
+        ['ast_image', 'image'],
+        ['ast_video_src', 'video'],
+        ['ast_video_ref', 'video'],
+        ['ast_poster', 'poster'],
+        ['ast_scene_wb', 'image'],
+        ['ast_narration', 'audio'],
+        ['ast_manifest_video', 'video'],
+      ]),
+    );
+  });
+
+  it('skips empty slots and non-speech actions', () => {
+    const document = documentWith([
+      slideScene(
+        'scene-1',
+        slideWith([
+          videoElement('vid-1', {}),
+          { id: 't1', type: 'text', content: 'hello' } as Slide['elements'][number],
+        ]),
+        { actions: [{ id: 'a1', type: 'speech', text: 'no audio yet' }] as Scene['actions'] },
+      ),
+    ]);
+
+    expect(enumerateAssetManifest(document).entries).toEqual([]);
+  });
+
+  it('enumerates legacy placeholder refs and concrete URLs verbatim', () => {
+    // The manifest is the reference set the document touches, not a resolution
+    // result: legacy placeholders and concrete URLs both appear, and the
+    // export paths decide which of them resolve to archivable bytes.
+    const document = documentWith([
+      slideScene(
+        'scene-1',
+        slideWith([
+          imageElement('img-1', 'gen_img_1'),
+          imageElement('img-2', 'https://cdn.example/photo.jpg'),
+        ]),
+      ),
+    ]);
+
+    const refs = enumerateAssetManifest(document).entries.map((entry) => entry.ref);
+    expect(refs).toEqual(['gen_img_1', 'https://cdn.example/photo.jpg']);
+  });
+});
+
+describe('enumerateAssetManifest — orphan exclusion and dedup', () => {
+  it('contains exactly the document references -- a ref the document drops disappears', () => {
+    // Orphan exclusion is structural: the enumeration reads the document, not
+    // any storage table, so a stored row nothing references can never appear.
+    const withRef = documentWith([slideScene('scene-1', slideWith([imageElement('i', 'ast_a')]))]);
+    const withoutRef = documentWith([slideScene('scene-1', slideWith([]))]);
+
+    expect(enumerateAssetManifest(withRef).entries.map((entry) => entry.ref)).toEqual(['ast_a']);
+    expect(enumerateAssetManifest(withoutRef).entries).toEqual([]);
+  });
+
+  it('keeps one entry for repeated occurrences of the same ref and kind', () => {
+    const document = documentWith(
+      [
+        slideScene('scene-1', slideWith([imageElement('i1', 'ast_shared')])),
+        slideScene('scene-2', slideWith([imageElement('i2', 'ast_shared')])),
+      ],
+      { whiteboard: [slideWith([imageElement('i3', 'ast_shared')])] },
+    );
+
+    const entries = enumerateAssetManifest(document).entries;
+    expect(entries.filter((entry) => entry.ref === 'ast_shared')).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ ref: 'ast_shared', kind: 'image' });
+  });
+
+  it('keeps one entry per ref and kind when a structurally valid ref spans roles', () => {
+    const document = documentWith([
+      slideScene('scene-1', slideWith([imageElement('i1', 'ast_cross_kind')]), {
+        actions: [
+          { id: 'a1', type: 'speech', text: 'shared', audioId: 'ast_cross_kind' },
+        ] as Scene['actions'],
+      }),
+    ]);
+
+    expect(enumerateAssetManifest(document).entries).toEqual([
+      { ref: 'ast_cross_kind', kind: 'image' },
+      { ref: 'ast_cross_kind', kind: 'audio' },
+    ]);
+  });
+
+  it('orders entries in document order', () => {
+    const document = documentWith(
+      [
+        slideScene('scene-1', slideWith([imageElement('i1', 'ast_b')])),
+        slideScene('scene-2', slideWith([imageElement('i2', 'ast_c')])),
+      ],
+      { whiteboard: [slideWith([imageElement('i3', 'ast_a')])] },
+    );
+
+    expect(enumerateAssetManifest(document).entries.map((entry) => entry.ref)).toEqual([
+      'ast_a',
+      'ast_b',
+      'ast_c',
+    ]);
+  });
+});
+
+describe('enumerateAssetManifest — reference counts', () => {
+  it('counts a video element once for src+mediaRef but its poster separately', () => {
+    const document = documentWith([
+      slideScene(
+        'scene-1',
+        slideWith([
+          videoElement('vid-1', { src: 'ast_v', mediaRef: 'ast_v', poster: 'ast_p' }),
+        ]),
+      ),
+    ]);
+
+    const { referenceCounts } = enumerateAssetManifest(document);
+    expect(referenceCounts.get('ast_v')).toBe(1);
+    expect(referenceCounts.get('ast_p')).toBe(1);
+  });
+
+  it('counts every owning element across scopes', () => {
+    const document = documentWith(
+      [
+        slideScene('scene-1', slideWith([imageElement('i1', 'ast_img')])),
+        slideScene('scene-2', slideWith([imageElement('i2', 'ast_img')])),
+      ],
+      { whiteboard: [slideWith([imageElement('i3', 'ast_img')])] },
+    );
+
+    expect(enumerateAssetManifest(document).referenceCounts.get('ast_img')).toBe(3);
+  });
+
+  it('does not collapse owners when scene and element ids repeat', () => {
+    const document = documentWith([
+      slideScene('duplicate-scene', slideWith([imageElement('duplicate-element', 'ast_img')])),
+      slideScene('duplicate-scene', slideWith([imageElement('duplicate-element', 'ast_img')])),
+    ]);
+
+    expect(enumerateAssetManifest(document).referenceCounts.get('ast_img')).toBe(2);
+  });
+
+  it('enumerates video-manifest refs without counting the index as another owner', () => {
+    const document = documentWith(
+      [slideScene('scene-1', slideWith([videoElement('vid-1', { mediaRef: 'ast_video' })]))],
+      {
+        videoManifest: {
+          ast_video: { type: 'video', prompt: 'inserted' },
+          ast_manifest_only: { type: 'video', prompt: 'not inserted yet' },
+        },
+      },
+    );
+
+    const manifest = enumerateAssetManifest(document);
+    expect(manifest.entries.map((entry) => entry.ref)).toEqual(['ast_video', 'ast_manifest_only']);
+    expect(manifest.referenceCounts.get('ast_video')).toBe(1);
+    expect(manifest.referenceCounts.has('ast_manifest_only')).toBe(false);
+  });
+});
+
+describe('enumerateAssetManifest — metadata', () => {
+  it('propagates metadata from the injected lookup, omitting unknown fields', () => {
+    const document = documentWith([
+      slideScene('scene-1', slideWith([imageElement('i1', 'ast_img')]), {
+        actions: [
+          { id: 'a1', type: 'speech', text: 'hi', audioId: 'ast_audio' },
+        ] as Scene['actions'],
+      }),
+    ]);
+
+    const manifest = enumerateAssetManifest(document, {
+      metadata: (ref, kind) =>
+        kind === 'audio'
+          ? { durationSeconds: 2.5, voice: 'alloy', mimeType: 'audio/mpeg' }
+          : ref === 'ast_img'
+            ? { byteSize: 1024, mimeType: 'image/png', prompt: 'a diagram' }
+            : undefined,
+    });
+
+    expect(manifest.entries).toEqual([
+      {
+        ref: 'ast_img',
+        kind: 'image',
+        byteSize: 1024,
+        mimeType: 'image/png',
+        prompt: 'a diagram',
+      },
+      {
+        ref: 'ast_audio',
+        kind: 'audio',
+        durationSeconds: 2.5,
+        voice: 'alloy',
+        mimeType: 'audio/mpeg',
+      },
+    ]);
+  });
+
+  it('leaves entries metadata-free when no lookup is supplied', () => {
+    const document = documentWith([slideScene('scene-1', slideWith([imageElement('i1', 'ast_img')]))]);
+
+    expect(enumerateAssetManifest(document).entries).toEqual([{ ref: 'ast_img', kind: 'image' }]);
+  });
+});

--- a/tests/classroom/restored-video-resolution.test.ts
+++ b/tests/classroom/restored-video-resolution.test.ts
@@ -112,6 +112,21 @@ describe('restored classroom video resolution', () => {
     expect(binding.task).toMatchObject({ status: 'done', placeholderRef: legacyRef });
   });
 
+  it('carries the task poster binding when the element has no explicit poster', () => {
+    const task = {
+      ...lookupTask('done'),
+      objectUrl: 'blob:video',
+      poster: 'blob:generated-poster',
+    };
+
+    const binding = resolveVideoMediaForElement({ [legacyRef]: task }, videoElement(), stageId);
+
+    // The task-owned poster URL is the effective poster, and it travels with a
+    // task binding so the manifest guard's task-ownership exemption admits it.
+    expect(binding.posterRef).toBe('blob:generated-poster');
+    expect(binding.posterTask).toEqual({ ...task, objectUrl: 'blob:generated-poster' });
+  });
+
   it('keeps a concrete explicit poster ahead of a completed task poster', () => {
     const element = {
       ...videoElement(),

--- a/tests/export/archive-media-coherence-matrix.test.ts
+++ b/tests/export/archive-media-coherence-matrix.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AssetManifestEntry } from '@openmaic/dsl';
+import type { Scene } from '@/lib/types/stage';
+import type { ArchiveMediaKind } from '@/lib/video-export/archive-media';
+import type { AssetMeta } from '@/lib/video-export';
+
+const mocks = vi.hoisted(() => ({
+  audioRows: new Map<string, { id: string; blob: Blob; format: string }>(),
+  mediaRows: new Map<
+    string,
+    {
+      id: string;
+      stageId: string;
+      type: 'image' | 'video';
+      blob: Blob;
+      mimeType: string;
+      size: number;
+      prompt: string;
+      params: string;
+      createdAt: number;
+      poster?: Blob;
+    }
+  >(),
+  resolveAudioBlob: vi.fn(),
+  resolveStoredBytes: vi.fn(),
+  fetchMediaUrl: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/database', () => ({
+  mediaFileKey: (stageId: string, ref: string) => `${stageId}:${ref}`,
+  db: {
+    audioFiles: { get: async (id: string) => mocks.audioRows.get(id) },
+    mediaFiles: { get: async (id: string) => mocks.mediaRows.get(id) },
+  },
+}));
+vi.mock('@/lib/media/resolve-audio-bytes', () => ({
+  resolveAudioBlob: (...args: unknown[]) => mocks.resolveAudioBlob(...args),
+}));
+vi.mock('@/lib/media/resolve-stored-bytes', () => ({
+  resolveStoredBytes: (...args: unknown[]) => mocks.resolveStoredBytes(...args),
+}));
+vi.mock('@/lib/media/fetch-media-url', () => ({
+  fetchMediaUrl: (...args: unknown[]) => mocks.fetchMediaUrl(...args),
+}));
+vi.mock('@/lib/media/convert-legacy-asset-refs', () => ({
+  mapWithConcurrency: async <T, R>(
+    items: T[],
+    _limit: number,
+    fn: (item: T, index: number) => Promise<R>,
+  ) => Promise.all(items.map(fn)),
+}));
+
+import {
+  collectAudioFiles,
+  collectLegacyAudioForExport,
+  collectMediaFiles,
+  mediaPosterArchivePath,
+} from '@/lib/export/classroom-zip-utils';
+import { importedMediaKind } from '@/lib/import/use-import-classroom';
+import {
+  buildTimeline,
+  buildTimelineOptions,
+  normalizeScenes,
+  planAssets,
+} from '@/lib/video-export';
+import { playVideo, slide, speech, stubAssets, stubProbe } from '../video-export/helpers';
+
+interface MetadataCase {
+  name: string;
+  value(kind: ArchiveMediaKind): { mimeType: string; extension: string };
+}
+
+const metadataCases: MetadataCase[] = [
+  {
+    name: 'valid',
+    value: (kind) =>
+      ({
+        image: { mimeType: 'image/png', extension: 'png' },
+        video: { mimeType: 'video/webm', extension: 'webm' },
+        audio: { mimeType: 'audio/wav', extension: 'wav' },
+      })[kind],
+  },
+  { name: 'empty', value: () => ({ mimeType: '', extension: '' }) },
+  {
+    name: 'application/octet-stream',
+    value: () => ({ mimeType: 'application/octet-stream', extension: 'application/octet-stream' }),
+  },
+  {
+    name: 'contradictory allowlisted',
+    value: (kind) =>
+      kind === 'image'
+        ? { mimeType: 'video/mp4', extension: 'mp4' }
+        : { mimeType: 'image/jpeg', extension: 'jpg' },
+  },
+  {
+    name: 'non-allowlisted',
+    value: (kind) =>
+      ({
+        image: { mimeType: 'image/tiff', extension: 'tiff' },
+        video: { mimeType: 'video/x-matroska', extension: 'mkv' },
+        audio: { mimeType: 'audio/aiff', extension: 'aiff' },
+      })[kind],
+  },
+  { name: 'uppercase compound', value: () => ({ mimeType: 'TAR.GZ', extension: 'TAR.GZ' }) },
+];
+
+const expectedByKind = {
+  image: { fallbackExtension: 'jpg', fallbackMime: 'image/jpeg', validExtension: 'png' },
+  video: { fallbackExtension: 'mp4', fallbackMime: 'video/mp4', validExtension: 'webm' },
+  audio: { fallbackExtension: 'mp3', fallbackMime: 'audio/mpeg', validExtension: 'wav' },
+} as const;
+
+const entry = (ref: string, kind: AssetManifestEntry['kind']): AssetManifestEntry => ({
+  ref,
+  kind,
+});
+
+function legacyScene(url: string): Scene {
+  return slide('legacy', [speech('speech', 'Narration', { audioUrl: url })]) as unknown as Scene;
+}
+
+function plannedPath(kind: 'audio' | 'video', meta: AssetMeta): string {
+  const scene =
+    kind === 'audio'
+      ? slide('scene', [speech('speech', 'Narration')])
+      : slide('scene', [playVideo('play', 'clip')]);
+  const source = normalizeScenes([scene]).scenes;
+  const timeline = buildTimeline(source, buildTimelineOptions(stubProbe({}, { play: 1_000 })));
+  const assets = kind === 'audio' ? stubAssets({ speech: meta }) : stubAssets({}, { clip: meta });
+  const result = planAssets(source, timeline.scenes, assets);
+  const planned = result.plan.entries.find((item) => item.kind === kind);
+  if (!planned) throw new Error(`Missing ${kind} plan entry`);
+  return planned.path;
+}
+
+afterEach(() => {
+  mocks.audioRows.clear();
+  mocks.mediaRows.clear();
+  vi.clearAllMocks();
+});
+
+describe('archive media coherence coverage matrix', () => {
+  it.each(metadataCases)(
+    'makes every archive surface canonical for $name metadata',
+    async ({ name, value }) => {
+      for (const kind of ['image', 'video', 'audio'] as const) {
+        const input = value(kind);
+        const expected = expectedByKind[kind];
+        const extension = name === 'valid' ? expected.validExtension : expected.fallbackExtension;
+
+        if (kind === 'image' || kind === 'video') {
+          const ref = `${kind}-${name}`;
+          const blob = new Blob([kind], { type: input.mimeType });
+          mocks.mediaRows.set(`stage:${ref}`, {
+            id: `stage:${ref}`,
+            stageId: 'stage',
+            type: kind,
+            blob,
+            mimeType: input.mimeType,
+            size: blob.size,
+            prompt: '',
+            params: '',
+            createdAt: 0,
+            ...(kind === 'video' ? { poster: new Blob(['poster'], { type: input.mimeType }) } : {}),
+          });
+          mocks.resolveStoredBytes.mockResolvedValueOnce(blob);
+
+          const [collected] = await collectMediaFiles('stage', [entry(ref, kind)]);
+          expect(collected.zipPath).toBe(`media/asset-1.${extension}`);
+          expect(collected.record.mimeType).toBe(
+            name === 'valid' ? input.mimeType : expected.fallbackMime,
+          );
+          expect(importedMediaKind(collected.record.mimeType)).toBe(kind);
+
+          if (kind === 'video') {
+            expect(collected.posterZipPath).toBe(mediaPosterArchivePath(0));
+            expect(collected.posterZipPath).toBe('media/asset-1.poster.jpg');
+            expect(importedMediaKind('image/jpeg')).toBe('image');
+          }
+        }
+
+        if (kind === 'audio') {
+          const ref = `audio-${name}`;
+          const blob = new Blob(['audio'], { type: input.mimeType });
+          mocks.audioRows.set(ref, { id: ref, blob, format: input.extension });
+          mocks.resolveAudioBlob.mockResolvedValueOnce(blob);
+
+          const [collected] = await collectAudioFiles([entry(ref, 'audio')]);
+          expect(collected.zipPath).toBe(`audio/audio-1.${extension}`);
+          expect(collected.record.format).toBe(extension);
+
+          const url = `https://example.test/${encodeURIComponent(name)}`;
+          mocks.fetchMediaUrl.mockResolvedValueOnce(new Response(blob, { status: 200 }));
+          const legacy = await collectLegacyAudioForExport([legacyScene(url)], new Map());
+          expect(legacy.blobs[0]?.zipPath).toBe(`audio/legacy-1.${extension}`);
+          expect(legacy.blobs[0]?.format).toBe(extension);
+        }
+
+        if (kind === 'audio' || kind === 'video') {
+          const path = plannedPath(kind, {
+            id: `${kind}-${name}`,
+            present: true,
+            mimeType: input.mimeType,
+            format: input.extension,
+          });
+          expect(path.endsWith(`.${extension}`)).toBe(true);
+        }
+      }
+    },
+  );
+});

--- a/tests/export/archive-media-coherence-matrix.test.ts
+++ b/tests/export/archive-media-coherence-matrix.test.ts
@@ -1,8 +1,21 @@
+/**
+ * Contract coverage: 6 metadata cases × 7 archive surfaces = 42 cells.
+ * Each classroom surface follows every end-to-end link it supports: canonical
+ * path, serialized metadata, and import-side kind/content-type coherence. The
+ * two planner surfaces additionally pin the exact path and kind metadata.
+ *
+ * The boundary is intentional: kind metadata is authoritative. Export does not
+ * inspect or transcode payload bytes, so this matrix validates coherent labels,
+ * not whether already-stored bytes match them. A byte/kind mismatch is corrupt
+ * store state outside the export contract, just as it is for runtime/renderers.
+ */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AssetManifestEntry } from '@openmaic/dsl';
+import type { MediaIndexEntry } from '@/lib/export/classroom-zip-types';
 import type { Scene } from '@/lib/types/stage';
-import type { ArchiveMediaKind } from '@/lib/video-export/archive-media';
+import { canonicalArchiveMedia, type ArchiveMediaKind } from '@/lib/video-export/archive-media';
 import type { AssetMeta } from '@/lib/video-export';
+import type { AssetPlanEntry } from '@/lib/video-export/ir';
 
 const mocks = vi.hoisted(() => ({
   audioRows: new Map<string, { id: string; blob: Blob; format: string }>(),
@@ -52,11 +65,15 @@ vi.mock('@/lib/media/convert-legacy-asset-refs', () => ({
 
 import {
   collectAudioFiles,
+  collectedAudioMediaIndexEntry,
+  collectedMediaIndexEntry,
   collectLegacyAudioForExport,
   collectMediaFiles,
+  mediaPosterArchiveMetadata,
   mediaPosterArchivePath,
+  legacyAudioMediaIndexEntry,
 } from '@/lib/export/classroom-zip-utils';
-import { importedMediaKind } from '@/lib/import/use-import-classroom';
+import { importedAudioContentType, importedMediaKind } from '@/lib/import/use-import-classroom';
 import {
   buildTimeline,
   buildTimelineOptions,
@@ -119,7 +136,7 @@ function legacyScene(url: string): Scene {
   return slide('legacy', [speech('speech', 'Narration', { audioUrl: url })]) as unknown as Scene;
 }
 
-function plannedPath(kind: 'audio' | 'video', meta: AssetMeta): string {
+function plannedEntry(kind: 'audio' | 'video', meta: AssetMeta): AssetPlanEntry {
   const scene =
     kind === 'audio'
       ? slide('scene', [speech('speech', 'Narration')])
@@ -130,7 +147,24 @@ function plannedPath(kind: 'audio' | 'video', meta: AssetMeta): string {
   const result = planAssets(source, timeline.scenes, assets);
   const planned = result.plan.entries.find((item) => item.kind === kind);
   if (!planned) throw new Error(`Missing ${kind} plan entry`);
-  return planned.path;
+  return planned;
+}
+
+function expectImportedMediaMetadata(mimeType: string, kind: 'image' | 'video'): void {
+  // materializeImportedMedia forwards the serialized MIME as pool contentType
+  // and derives mediaType through importedMediaKind.
+  expect(mimeType.startsWith(`${kind}/`)).toBe(true);
+  expect(importedMediaKind(mimeType)).toBe(kind);
+}
+
+function expectImportedAudioMetadata(metadata: MediaIndexEntry): void {
+  expect(metadata.type).toBe('audio');
+  expect(metadata.mimeType?.startsWith('audio/')).toBe(true);
+  expect(importedAudioContentType(metadata, '')).toBe(metadata.mimeType);
+  expect(canonicalArchiveMedia('audio', { extension: metadata.format })).toEqual({
+    extension: metadata.format,
+    mimeType: metadata.mimeType,
+  });
 }
 
 afterEach(() => {
@@ -143,6 +177,7 @@ describe('archive media coherence coverage matrix', () => {
   it.each(metadataCases)(
     'makes every archive surface canonical for $name metadata',
     async ({ name, value }) => {
+      let assertedCells = 0;
       for (const kind of ['image', 'video', 'audio'] as const) {
         const input = value(kind);
         const expected = expectedByKind[kind];
@@ -167,15 +202,20 @@ describe('archive media coherence coverage matrix', () => {
 
           const [collected] = await collectMediaFiles('stage', [entry(ref, kind)]);
           expect(collected.zipPath).toBe(`media/asset-1.${extension}`);
-          expect(collected.record.mimeType).toBe(
-            name === 'valid' ? input.mimeType : expected.fallbackMime,
-          );
-          expect(importedMediaKind(collected.record.mimeType)).toBe(kind);
+          const serializedMime = name === 'valid' ? input.mimeType : expected.fallbackMime;
+          const serialized = collectedMediaIndexEntry(collected);
+          expect(serialized.mimeType).toBe(serializedMime);
+          expectImportedMediaMetadata(serialized.mimeType!, kind);
+          assertedCells += 1;
 
           if (kind === 'video') {
+            const posterMetadata = mediaPosterArchiveMetadata();
             expect(collected.posterZipPath).toBe(mediaPosterArchivePath(0));
-            expect(collected.posterZipPath).toBe('media/asset-1.poster.jpg');
-            expect(importedMediaKind('image/jpeg')).toBe('image');
+            expect(collected.posterZipPath).toBe(
+              `media/asset-1.poster.${posterMetadata.extension}`,
+            );
+            expectImportedMediaMetadata(posterMetadata.mimeType, 'image');
+            assertedCells += 1;
           }
         }
 
@@ -188,24 +228,85 @@ describe('archive media coherence coverage matrix', () => {
           const [collected] = await collectAudioFiles([entry(ref, 'audio')]);
           expect(collected.zipPath).toBe(`audio/audio-1.${extension}`);
           expect(collected.record.format).toBe(extension);
+          expect(collected.mimeType).toBe(
+            name === 'valid' ? input.mimeType : expected.fallbackMime,
+          );
+          expectImportedAudioMetadata(collectedAudioMediaIndexEntry(collected));
+          assertedCells += 1;
 
           const url = `https://example.test/${encodeURIComponent(name)}`;
           mocks.fetchMediaUrl.mockResolvedValueOnce(new Response(blob, { status: 200 }));
           const legacy = await collectLegacyAudioForExport([legacyScene(url)], new Map());
           expect(legacy.blobs[0]?.zipPath).toBe(`audio/legacy-1.${extension}`);
           expect(legacy.blobs[0]?.format).toBe(extension);
+          expect(legacy.blobs[0]?.mimeType).toBe(
+            name === 'valid' ? input.mimeType : expected.fallbackMime,
+          );
+          expectImportedAudioMetadata(legacyAudioMediaIndexEntry(legacy.blobs[0]!));
+          assertedCells += 1;
         }
 
         if (kind === 'audio' || kind === 'video') {
-          const path = plannedPath(kind, {
+          const planned = plannedEntry(kind, {
             id: `${kind}-${name}`,
             present: true,
             mimeType: input.mimeType,
             format: input.extension,
           });
-          expect(path.endsWith(`.${extension}`)).toBe(true);
+          expect(planned).toMatchObject({
+            assetId: `${kind}-${name}`,
+            kind,
+            path:
+              kind === 'audio'
+                ? `audio/001-scene/speech-001.${extension}`
+                : `media/clip.${extension}`,
+            present: true,
+          });
+          expect(
+            canonicalArchiveMedia(kind, {
+              extension: input.extension,
+              mimeType: input.mimeType,
+            }),
+          ).toEqual({
+            extension,
+            mimeType: name === 'valid' ? input.mimeType : expected.fallbackMime,
+          });
+          assertedCells += 1;
         }
       }
+      expect(assertedCells).toBe(7);
     },
   );
+
+  it('trusts authoritative kind labels without inspecting or transcoding mismatched bytes', async () => {
+    // Boundary pin: this record is deliberately corrupt. Its authoritative kind
+    // says video while its payload was produced with image metadata. The export
+    // contract promises deterministic video labels, no crash, unchanged bytes,
+    // and import classification from serialized metadata -- never byte sniffing.
+    const ref = 'mismatched-video-record';
+    const imageBytes = new Blob(['actually-image-labelled'], { type: 'image/png' });
+    mocks.mediaRows.set(`stage:${ref}`, {
+      id: `stage:${ref}`,
+      stageId: 'stage',
+      type: 'video',
+      blob: imageBytes,
+      mimeType: 'image/png',
+      size: imageBytes.size,
+      prompt: '',
+      params: '',
+      createdAt: 0,
+    });
+    mocks.resolveStoredBytes.mockResolvedValueOnce(imageBytes);
+
+    const [collected] = await collectMediaFiles('stage', [entry(ref, 'video')]);
+
+    expect(collected.zipPath).toBe('media/asset-1.mp4');
+    expect(collected.record.type).toBe('video');
+    expect(collected.record.mimeType).toBe('video/mp4');
+    expect(collected.record.blob).toBe(imageBytes);
+    expect(collected.record.blob.type).toBe('image/png');
+    expect(await collected.record.blob.text()).toBe('actually-image-labelled');
+    const serialized = collectedMediaIndexEntry(collected);
+    expectImportedMediaMetadata(serialized.mimeType!, 'video');
+  });
 });

--- a/tests/export/archive-media-coherence-matrix.test.ts
+++ b/tests/export/archive-media-coherence-matrix.test.ts
@@ -242,7 +242,12 @@ describe('archive media coherence coverage matrix', () => {
           expect(legacy.blobs[0]?.mimeType).toBe(
             name === 'valid' ? input.mimeType : expected.fallbackMime,
           );
-          expectImportedAudioMetadata(legacyAudioMediaIndexEntry(legacy.blobs[0]!));
+          // Legacy narration carries the URL it was fetched from as its source
+          // ref, so every audio surface preserves an explicit original ref.
+          expect(legacy.blobs[0]?.sourceRef).toBe(url);
+          const serializedLegacy = legacyAudioMediaIndexEntry(legacy.blobs[0]!);
+          expect(serializedLegacy.sourceRef).toBe(url);
+          expectImportedAudioMetadata(serializedLegacy);
           assertedCells += 1;
         }
 

--- a/tests/export/classroom-zip-legacy-audio.test.ts
+++ b/tests/export/classroom-zip-legacy-audio.test.ts
@@ -29,6 +29,7 @@ import {
   actionsToManifest,
   collectAudioFiles,
   collectLegacyAudioForExport,
+  legacyAudioMediaIndexEntry,
 } from '@/lib/export/classroom-zip-utils';
 import type { Scene } from '@/lib/types/stage';
 
@@ -63,6 +64,15 @@ describe('legacy audio URL export', () => {
     expect(blobs).toHaveLength(1);
     expect(blobs[0]?.zipPath).toBe('audio/legacy-1.mpeg');
     expect(await blobs[0]?.blob.text()).toBe('narration-bytes');
+    // The legacy URL itself is the natural source ref and travels with the
+    // fetched asset into the serialized media index.
+    expect(blobs[0]?.sourceRef).toBe(url);
+    expect(legacyAudioMediaIndexEntry(blobs[0]!)).toMatchObject({
+      type: 'audio',
+      sourceRef: url,
+      format: 'mpeg',
+      mimeType: 'audio/mpeg',
+    });
 
     const manifest = actionsToManifest(
       scenes[0].actions as never,

--- a/tests/export/classroom-zip-legacy-audio.test.ts
+++ b/tests/export/classroom-zip-legacy-audio.test.ts
@@ -29,7 +29,6 @@ import {
   actionsToManifest,
   collectAudioFiles,
   collectLegacyAudioForExport,
-  collectMissingAudioRefs,
 } from '@/lib/export/classroom-zip-utils';
 import type { Scene } from '@/lib/types/stage';
 
@@ -109,65 +108,6 @@ describe('legacy audio URL export', () => {
     expect(manifest[0]).not.toHaveProperty('audioUrl');
   });
 
-  it('does not flag a recovered legacy audioUrl as missing (the archive carries it)', async () => {
-    // Finding: the missing-audio pass checked only audioIdToPath, so a
-    // dangling audioId whose audioUrl WAS recovered produced a valid
-    // recovered entry PLUS a false missing:true entry for the same narration.
-    const url = 'https://server.example.com/audio/recovered.mp3';
-    fetchMediaUrlMock.mockResolvedValue(
-      new Response(new Blob(['narration-bytes'], { type: 'audio/mpeg' }), { status: 200 }),
-    );
-    const action = {
-      id: 'a1',
-      type: 'speech',
-      text: 'Hi',
-      audioId: 'tts_dangling',
-      audioUrl: url,
-    };
-    const scenes = [sceneWithSpeech([action])];
-
-    const { audioUrlToPath } = await collectLegacyAudioForExport(scenes, new Map());
-
-    expect(collectMissingAudioRefs(scenes, new Map(), audioUrlToPath)).toEqual([]);
-  });
-
-  it('flags a dangling audioId whose legacy URL could not be recovered', async () => {
-    const url = 'https://server.example.com/audio/gone.mp3';
-    fetchMediaUrlMock.mockResolvedValue(new Response(null, { status: 404 }));
-    const action = {
-      id: 'a1',
-      type: 'speech',
-      text: 'Hi',
-      audioId: 'tts_dangling',
-      audioUrl: url,
-    };
-    const scenes = [sceneWithSpeech([action])];
-
-    const { audioUrlToPath } = await collectLegacyAudioForExport(scenes, new Map());
-
-    expect(collectMissingAudioRefs(scenes, new Map(), audioUrlToPath)).toEqual([
-      { audioId: 'tts_dangling', missingPath: 'audio/tts_dangling.mp3' },
-    ]);
-  });
-
-  it('flags a bare dangling audioId with no legacy URL', () => {
-    const action = { id: 'a1', type: 'speech', text: 'Hi', audioId: 'tts_bare' };
-    const scenes = [sceneWithSpeech([action])];
-
-    expect(collectMissingAudioRefs(scenes, new Map(), new Map())).toEqual([
-      { audioId: 'tts_bare', missingPath: 'audio/tts_bare.mp3' },
-    ]);
-  });
-
-  it('skips an audioId that already has bytes in the archive', () => {
-    const action = { id: 'a1', type: 'speech', text: 'Hi', audioId: 'ast_have' };
-    const scenes = [sceneWithSpeech([action])];
-
-    expect(
-      collectMissingAudioRefs(scenes, new Map([['ast_have', 'audio/ast_have.mp3']]), new Map()),
-    ).toEqual([]);
-  });
-
   it('an evicted row with no usable bytes produces no zip path, so the live URL is rescued', async () => {
     // Finding: collectAudioFiles included a row whenever `record` was
     // truthy, even when its blob was empty and the pool resolve came back
@@ -193,19 +133,17 @@ describe('legacy audio URL export', () => {
     const scenes = [sceneWithSpeech([action])];
 
     // No empty audio entry is collected for the evicted row...
-    const collected = await collectAudioFiles(scenes);
+    const collected = await collectAudioFiles([{ ref: audioId, kind: 'audio' }]);
     expect(collected).toHaveLength(0);
 
     // ...so the id is missing from the archive map and the URL rescue
     // fetches the live narration instead of being skipped.
     const audioIdToPath = new Map(collected.map((c) => [c.record.id, c.zipPath]));
-    const { audioUrlToPath, blobs } = await collectLegacyAudioForExport(scenes, audioIdToPath);
+    const { blobs } = await collectLegacyAudioForExport(scenes, audioIdToPath);
     expect(fetchMediaUrlMock).toHaveBeenCalledWith(url, 15_000);
     expect(blobs).toHaveLength(1);
     expect(blobs[0]?.zipPath).toBe('audio/legacy-1.mpeg');
     expect(await blobs[0]?.blob.text()).toBe('url-bytes');
-    // The rescued narration is not flagged missing under a phantom path.
-    expect(collectMissingAudioRefs(scenes, audioIdToPath, audioUrlToPath)).toEqual([]);
   });
 
   it('a row with usable row bytes still ships even when the pool resolve is empty', async () => {
@@ -222,9 +160,8 @@ describe('legacy audio URL export', () => {
       createdAt: 1,
     });
     resolveAudioBlobMock.mockResolvedValue(new Blob(['row-bytes'], { type: 'audio/mpeg' }));
-    const scenes = [sceneWithSpeech([{ id: 'a1', type: 'speech', text: 'Hi', audioId }])];
 
-    const collected = await collectAudioFiles(scenes);
+    const collected = await collectAudioFiles([{ ref: audioId, kind: 'audio' }]);
 
     expect(collected).toHaveLength(1);
     expect(collected[0]?.zipPath).toBe(`audio/${audioId}.mp3`);

--- a/tests/export/classroom-zip-legacy-audio.test.ts
+++ b/tests/export/classroom-zip-legacy-audio.test.ts
@@ -193,4 +193,44 @@ describe('legacy audio URL export', () => {
     expect(new Set(collected.map(({ zipPath }) => zipPath)).size).toBe(refs.length);
     expect(collected.map(({ sourceRef }) => sourceRef)).toEqual(refs);
   });
+
+  it.each(['/../../evil', 'png/../x', '', undefined])(
+    're-exports imported audio format %s under a safe canonical path',
+    async (format) => {
+      const audioId = 'ast_imported_audio';
+      const { db } = await import('@/lib/utils/database');
+      (db.audioFiles.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: audioId,
+        stageId: 'stage-1',
+        blob: new Blob(['imported']),
+        format,
+        createdAt: 1,
+      });
+      resolveAudioBlobMock.mockResolvedValue(new Blob(['imported']));
+
+      const collected = await collectAudioFiles([{ ref: audioId, kind: 'audio' }]);
+
+      expect(collected[0]?.zipPath).toBe('audio/audio-1.mp3');
+      expect(collected[0]?.record.format).toBe('mp3');
+      expect(collected[0]?.zipPath).not.toMatch(/(?:\.\.|\\)/);
+    },
+  );
+
+  it.each(['audio//../../evil', 'audio/png/../x', ''])(
+    'uses the canonical fallback for malformed legacy narration MIME %s',
+    async (mimeType) => {
+      const url = 'https://server.example.com/audio/imported';
+      fetchMediaUrlMock.mockResolvedValue(
+        new Response(new Blob(['narration-bytes'], { type: mimeType }), { status: 200 }),
+      );
+
+      const { blobs } = await collectLegacyAudioForExport(
+        [sceneWithSpeech([{ id: 'a1', type: 'speech', text: 'Hi', audioUrl: url }])],
+        new Map(),
+      );
+
+      expect(blobs[0]?.zipPath).toBe('audio/legacy-1.mp3');
+      expect(blobs[0]?.format).toBe('mp3');
+    },
+  );
 });

--- a/tests/export/classroom-zip-legacy-audio.test.ts
+++ b/tests/export/classroom-zip-legacy-audio.test.ts
@@ -164,7 +164,33 @@ describe('legacy audio URL export', () => {
     const collected = await collectAudioFiles([{ ref: audioId, kind: 'audio' }]);
 
     expect(collected).toHaveLength(1);
-    expect(collected[0]?.zipPath).toBe(`audio/${audioId}.mp3`);
+    expect(collected[0]?.zipPath).toBe('audio/audio-1.mp3');
     expect(await collected[0]?.record.blob.text()).toBe('row-bytes');
+  });
+
+  it('assigns distinct safe paths without interpolating adversarial audio refs', async () => {
+    const refs = ['../evil', 'a/b', 'a/../collision', 'collision'];
+    const { db } = await import('@/lib/utils/database');
+    (db.audioFiles.get as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => ({
+      id,
+      stageId: 'stage-1',
+      blob: new Blob([id], { type: 'audio/mpeg' }),
+      format: 'mp3',
+      createdAt: 1,
+    }));
+    resolveAudioBlobMock.mockImplementation(
+      async (id: string) => new Blob([id], { type: 'audio/mpeg' }),
+    );
+
+    const collected = await collectAudioFiles(refs.map((ref) => ({ ref, kind: 'audio' })));
+
+    expect(collected.map(({ zipPath }) => zipPath)).toEqual([
+      'audio/audio-1.mp3',
+      'audio/audio-2.mp3',
+      'audio/audio-3.mp3',
+      'audio/audio-4.mp3',
+    ]);
+    expect(new Set(collected.map(({ zipPath }) => zipPath)).size).toBe(refs.length);
+    expect(collected.map(({ sourceRef }) => sourceRef)).toEqual(refs);
   });
 });

--- a/tests/export/classroom-zip-pool-first.test.ts
+++ b/tests/export/classroom-zip-pool-first.test.ts
@@ -1,25 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AssetManifestEntry } from '@openmaic/dsl';
 
 const mocks = vi.hoisted(() => ({
-  rows: [] as Array<{
-    id: string;
-    stageId: string;
-    blob: Blob;
-    mimeType?: string;
-    placeholderRef?: string;
-  }>,
+  rows: new Map<string, { id: string; stageId: string; blob: Blob; mimeType?: string }>(),
   poolResolve: vi.fn(),
   poolRelease: vi.fn(),
 }));
 
 vi.mock('@/lib/utils/database', () => ({
+  mediaFileKey: (stageId: string, ref: string) => `${stageId}:${ref}`,
   db: {
     mediaFiles: {
-      where: () => ({
-        equals: (stageId: string) => ({
-          toArray: async () => mocks.rows.filter((row) => row.stageId === stageId),
-        }),
-      }),
+      get: async (id: string) => mocks.rows.get(id),
     },
     audioFiles: { get: vi.fn() },
   },
@@ -31,9 +23,16 @@ vi.mock('@/lib/media/asset-pool', () => ({
 
 import { collectMediaFiles } from '@/lib/export/classroom-zip-utils';
 
+const entry = (ref: string): AssetManifestEntry => ({ ref, kind: 'image' });
+
+function seedRow(ref: string, blob: Blob, stageId = 'stage-1') {
+  const id = `${stageId}:${ref}`;
+  mocks.rows.set(id, { id, stageId, blob, mimeType: blob.type || 'image/png' });
+}
+
 describe('classroom ZIP media collection', () => {
   afterEach(() => {
-    mocks.rows.length = 0;
+    mocks.rows.clear();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
@@ -45,12 +44,7 @@ describe('classroom ZIP media collection', () => {
    */
   it('prefers pool bytes over a lagging compatibility row', async () => {
     const ref = 'ast_replaced_media';
-    mocks.rows.push({
-      id: `stage-1:${ref}`,
-      stageId: 'stage-1',
-      blob: new Blob(['stale-row-bytes'], { type: 'image/png' }),
-      mimeType: 'image/png',
-    });
+    seedRow(ref, new Blob(['stale-row-bytes'], { type: 'image/png' }));
     const poolUrl = 'blob:pool-current';
     mocks.poolResolve.mockResolvedValue(poolUrl);
     vi.stubGlobal(
@@ -61,7 +55,7 @@ describe('classroom ZIP media collection', () => {
       }),
     );
 
-    const collected = await collectMediaFiles('stage-1');
+    const collected = await collectMediaFiles('stage-1', [entry(ref)]);
 
     expect(collected).toHaveLength(1);
     expect(await collected[0].record.blob.text()).toBe('pool-current-bytes');
@@ -70,27 +64,17 @@ describe('classroom ZIP media collection', () => {
 
   it('falls back to the compatibility row when the pool misses', async () => {
     const ref = 'ast_pool_missing';
-    mocks.rows.push({
-      id: `stage-1:${ref}`,
-      stageId: 'stage-1',
-      blob: new Blob(['row-bytes'], { type: 'image/png' }),
-      mimeType: 'image/png',
-    });
+    seedRow(ref, new Blob(['row-bytes'], { type: 'image/png' }));
     mocks.poolResolve.mockResolvedValue(null);
 
-    const collected = await collectMediaFiles('stage-1');
+    const collected = await collectMediaFiles('stage-1', [entry(ref)]);
 
     expect(await collected[0].record.blob.text()).toBe('row-bytes');
   });
 
   it('treats a zero-byte pooled answer as a miss and ships the compatibility row', async () => {
     const ref = 'ast_pool_empty';
-    mocks.rows.push({
-      id: `stage-1:${ref}`,
-      stageId: 'stage-1',
-      blob: new Blob(['row-bytes'], { type: 'image/png' }),
-      mimeType: 'image/png',
-    });
+    seedRow(ref, new Blob(['row-bytes'], { type: 'image/png' }));
     const poolUrl = 'blob:pool-empty';
     mocks.poolResolve.mockResolvedValue(poolUrl);
     vi.stubGlobal(
@@ -101,7 +85,7 @@ describe('classroom ZIP media collection', () => {
       }),
     );
 
-    const collected = await collectMediaFiles('stage-1');
+    const collected = await collectMediaFiles('stage-1', [entry(ref)]);
 
     expect(await collected[0].record.blob.text()).toBe('row-bytes');
   });
@@ -109,17 +93,11 @@ describe('classroom ZIP media collection', () => {
   /**
    * The ZIP predates the `response.ok` validation the other export paths
    * added, and keeps that laxity: a non-OK response carrying a body is still
-   * shipped. Pinned here because the shared resolver expresses it as an option
-   * (`requireOk: false`) that would otherwise be tightenable without a failure.
+   * shipped. The shared resolver expresses this through `requireOk: false`.
    */
   it('ships a non-OK pool response body, as the ZIP always has', async () => {
     const ref = 'ast_pool_error_body';
-    mocks.rows.push({
-      id: `stage-1:${ref}`,
-      stageId: 'stage-1',
-      blob: new Blob(['row-bytes'], { type: 'image/png' }),
-      mimeType: 'image/png',
-    });
+    seedRow(ref, new Blob(['row-bytes'], { type: 'image/png' }));
     const poolUrl = 'blob:pool-error';
     mocks.poolResolve.mockResolvedValue(poolUrl);
     vi.stubGlobal(
@@ -130,61 +108,64 @@ describe('classroom ZIP media collection', () => {
       }),
     );
 
-    const collected = await collectMediaFiles('stage-1');
+    const collected = await collectMediaFiles('stage-1', [entry(ref)]);
 
     expect(await collected[0].record.blob.text()).toBe('error-body');
   });
 
   it('leaves legacy placeholder rows on their stored bytes', async () => {
-    mocks.rows.push({
-      id: 'stage-1:gen_img_1',
-      stageId: 'stage-1',
-      blob: new Blob(['legacy-bytes'], { type: 'image/png' }),
-      mimeType: 'image/png',
-    });
+    seedRow('gen_img_1', new Blob(['legacy-bytes'], { type: 'image/png' }));
     mocks.poolResolve.mockResolvedValue(null);
 
-    const collected = await collectMediaFiles('stage-1');
+    const collected = await collectMediaFiles('stage-1', [entry('gen_img_1')]);
 
     expect(await collected[0].record.blob.text()).toBe('legacy-bytes');
     expect(collected[0].zipPath).toBe('media/gen_img_1.png');
   });
 
-  it('ships each converted logical asset once, preferring the allocated-id mirror', async () => {
-    // A converted asset exists as two rows: the legacy gen_* row and the
-    // allocated-id compatibility mirror (placeholderRef retained). The ZIP
-    // must carry the mirror -- the document now references it -- and skip the
-    // legacy row, or importing the archive would materialize an unreferenced
-    // duplicate. Unconverted siblings keep their legacy rows.
-    mocks.rows.push(
-      {
-        id: 'stage-1:gen_img_1',
-        stageId: 'stage-1',
-        blob: new Blob(['legacy-bytes'], { type: 'image/png' }),
-        mimeType: 'image/png',
-      },
-      {
-        id: 'stage-1:ast_converted_1',
-        stageId: 'stage-1',
-        blob: new Blob(['mirror-bytes'], { type: 'image/png' }),
-        mimeType: 'image/png',
-        placeholderRef: 'gen_img_1',
-      },
-      {
-        id: 'stage-1:gen_vid_1',
-        stageId: 'stage-1',
-        blob: new Blob(['video-bytes'], { type: 'video/mp4' }),
-        mimeType: 'video/mp4',
-      },
+  it('collects a referenced asset whose bytes exist only in the pool', async () => {
+    // No compatibility row (never written, or pruned): the pre-manifest scan
+    // could not see this asset at all, but the document references it and the
+    // pool resolves it, so the archive must carry it.
+    const ref = 'ast_pool_only';
+    const poolUrl = 'blob:pool-only';
+    mocks.poolResolve.mockResolvedValue(poolUrl);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        if (input === poolUrl) {
+          return new Response(new Blob(['pool-only-bytes'], { type: 'image/webp' }));
+        }
+        throw new Error(`Unexpected fetch: ${input}`);
+      }),
     );
+
+    const collected = await collectMediaFiles('stage-1', [entry(ref)]);
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0].zipPath).toBe(`media/${ref}.webp`);
+    expect(await collected[0].record.blob.text()).toBe('pool-only-bytes');
+  });
+
+  it('skips a referenced asset whose bytes resolve nowhere', async () => {
     mocks.poolResolve.mockResolvedValue(null);
 
-    const collected = await collectMediaFiles('stage-1');
+    const collected = await collectMediaFiles('stage-1', [entry('ast_nowhere')]);
 
-    expect(collected.map((entry) => entry.zipPath).sort()).toEqual([
-      'media/ast_converted_1.png',
-      'media/gen_vid_1.mp4',
-    ]);
-    expect(await collected[0].record.blob.text()).toBe('mirror-bytes');
+    expect(collected).toEqual([]);
+  });
+
+  it('never collects rows the manifest does not name (orphan exclusion)', async () => {
+    // The pre-manifest implementation scanned the whole table for the stage,
+    // so this orphan row would have ridden into the archive. The manifest
+    // drives collection now: a row no document reference names stays out.
+    seedRow('ast_orphan', new Blob(['orphan-bytes'], { type: 'image/png' }));
+    seedRow('ast_referenced', new Blob(['referenced-bytes'], { type: 'image/png' }));
+    mocks.poolResolve.mockResolvedValue(null);
+
+    const collected = await collectMediaFiles('stage-1', [entry('ast_referenced')]);
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0].elementId).toBe('ast_referenced');
   });
 });

--- a/tests/export/classroom-zip-pool-first.test.ts
+++ b/tests/export/classroom-zip-pool-first.test.ts
@@ -120,7 +120,7 @@ describe('classroom ZIP media collection', () => {
     const collected = await collectMediaFiles('stage-1', [entry('gen_img_1')]);
 
     expect(await collected[0].record.blob.text()).toBe('legacy-bytes');
-    expect(collected[0].zipPath).toBe('media/gen_img_1.png');
+    expect(collected[0].zipPath).toBe('media/asset-1.png');
   });
 
   it('collects a referenced asset whose bytes exist only in the pool', async () => {
@@ -143,7 +143,7 @@ describe('classroom ZIP media collection', () => {
     const collected = await collectMediaFiles('stage-1', [entry(ref)]);
 
     expect(collected).toHaveLength(1);
-    expect(collected[0].zipPath).toBe(`media/${ref}.webp`);
+    expect(collected[0].zipPath).toBe('media/asset-1.webp');
     expect(await collected[0].record.blob.text()).toBe('pool-only-bytes');
   });
 
@@ -167,5 +167,23 @@ describe('classroom ZIP media collection', () => {
 
     expect(collected).toHaveLength(1);
     expect(collected[0].elementId).toBe('ast_referenced');
+  });
+
+  it('assigns distinct safe paths without interpolating adversarial source refs', async () => {
+    const refs = ['../evil', 'a/b', 'a/../collision', 'collision'];
+    for (const ref of refs) seedRow(ref, new Blob([ref], { type: 'image/png' }));
+    mocks.poolResolve.mockResolvedValue(null);
+
+    const collected = await collectMediaFiles('stage-1', refs.map(entry));
+
+    expect(collected.map(({ zipPath }) => zipPath)).toEqual([
+      'media/asset-1.png',
+      'media/asset-2.png',
+      'media/asset-3.png',
+      'media/asset-4.png',
+    ]);
+    expect(new Set(collected.map(({ zipPath }) => zipPath)).size).toBe(refs.length);
+    expect(collected.map(({ sourceRef }) => sourceRef)).toEqual(refs);
+    expect(collected.every(({ zipPath }) => !zipPath.includes('..'))).toBe(true);
   });
 });

--- a/tests/export/classroom-zip-pool-first.test.ts
+++ b/tests/export/classroom-zip-pool-first.test.ts
@@ -21,7 +21,13 @@ vi.mock('@/lib/media/asset-pool', () => ({
   getAssetPool: () => ({ resolve: mocks.poolResolve, release: mocks.poolRelease }),
 }));
 
-import { collectMediaFiles } from '@/lib/export/classroom-zip-utils';
+import {
+  audioArchivePath,
+  collectMediaFiles,
+  legacyAudioArchivePath,
+  mediaArchivePath,
+  mediaPosterArchivePath,
+} from '@/lib/export/classroom-zip-utils';
 
 const entry = (ref: string): AssetManifestEntry => ({ ref, kind: 'image' });
 
@@ -185,5 +191,33 @@ describe('classroom ZIP media collection', () => {
     expect(new Set(collected.map(({ zipPath }) => zipPath)).size).toBe(refs.length);
     expect(collected.map(({ sourceRef }) => sourceRef)).toEqual(refs);
     expect(collected.every(({ zipPath }) => !zipPath.includes('..'))).toBe(true);
+  });
+
+  it.each(['/../../evil', 'png/../x', '', undefined])(
+    'canonicalizes the untrusted archive extension %s at every path generator',
+    (extension) => {
+      expect(audioArchivePath(0, extension)).toBe('audio/audio-1.mp3');
+      expect(legacyAudioArchivePath(0, extension)).toBe('audio/legacy-1.mp3');
+      expect(mediaArchivePath(0, extension)).toBe('media/asset-1.jpg');
+      expect(mediaPosterArchivePath(0)).toBe('media/asset-1.poster.jpg');
+    },
+  );
+
+  it.each([
+    ['image//../../evil', 'media/asset-1.jpg'],
+    ['image/png/../x', 'media/asset-1.jpg'],
+    ['', 'media/asset-1.jpg'],
+    [undefined, 'media/asset-1.jpg'],
+  ])('re-exports imported media MIME %s under a safe canonical path', async (mimeType, path) => {
+    const ref = 'ast_imported_media';
+    seedRow(ref, new Blob(['imported']), 'stage-1');
+    mocks.rows.get(`stage-1:${ref}`)!.mimeType = mimeType;
+    mocks.poolResolve.mockResolvedValue(null);
+
+    const collected = await collectMediaFiles('stage-1', [entry(ref)]);
+
+    expect(collected[0]?.zipPath).toBe(path);
+    expect(collected[0]?.posterZipPath).toBe('media/asset-1.poster.jpg');
+    expect(collected[0]?.zipPath).not.toMatch(/(?:\.\.|\\)/);
   });
 });

--- a/tests/export/export-classroom-conversion.test.ts
+++ b/tests/export/export-classroom-conversion.test.ts
@@ -297,6 +297,78 @@ describe('classroom ZIP export conversion snapshot', () => {
     expect(importedActions[0]).toMatchObject({ audioId: importedAudioId });
   });
 
+  it('round-trips pool-backed slide audio through the classroom ZIP', async () => {
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { BrowserDocumentStore } = await import('@openmaic/storage');
+    const { buildClassroomExportZip } = await import('@/lib/export/use-export-classroom');
+    const { materializeImportedAudio, rewriteImportedSlideMediaRefs } =
+      await import('@/lib/import/use-import-classroom');
+    const { DSL_VERSION } = await import('@openmaic/dsl');
+    const pool = getAssetPool();
+    const sourceAudioId = await pool.put(new Blob(['slide-audio-bytes'], { type: 'audio/mpeg' }), {
+      contentType: 'audio/mpeg',
+      mediaType: 'audio',
+    });
+    const slide = {
+      id: 'slide-1',
+      elements: [{ id: 'audio-1', type: 'audio', src: sourceAudioId }],
+    };
+    const scene = {
+      id: 'scene-1',
+      stageId: 'stage-1',
+      type: 'slide',
+      title: 'Scene',
+      order: 0,
+      content: { type: 'slide', canvas: slide },
+    };
+    const stage = { id: 'stage-1', name: 'Course', createdAt: 100, updatedAt: 200 };
+    const store = new BrowserDocumentStore({
+      indexedDB: globalThis.indexedDB as unknown as IDBFactory,
+      dbName: 'maic-documents',
+      validateScene: () => ({ valid: true }),
+    });
+    await store.saveDocument({
+      dslVersion: DSL_VERSION,
+      stage,
+      scenes: [scene],
+    } as never);
+
+    const { zip } = await buildClassroomExportZip(stage as Stage, [scene] as Scene[], {
+      store,
+      kv: new MemoryKv(),
+      legacyStore: { read: async () => null, listStages: async () => [] },
+      lockManager: lockManager(),
+    });
+    const zipData = await JSZip.loadAsync(zip);
+    const manifest = JSON.parse(
+      await zipData.file('manifest.json')!.async('string'),
+    ) as ClassroomManifest;
+    const audioPath = `audio/${sourceAudioId}.mp3`;
+    expect(zipData.file(audioPath)).toBeDefined();
+    expect(await zipData.file(audioPath)!.async('string')).toBe('slide-audio-bytes');
+    expect(manifest.mediaIndex?.[audioPath]).toMatchObject({ type: 'audio' });
+
+    const audioMappings = await materializeImportedAudio(
+      zipData,
+      manifest,
+      'imported-1',
+      Date.now(),
+    );
+    const exportedContent = manifest.scenes[0].content;
+    expect(exportedContent.type).toBe('slide');
+    if (exportedContent.type !== 'slide') throw new Error('expected exported slide content');
+    const importedSlide = rewriteImportedSlideMediaRefs(
+      exportedContent.canvas,
+      { refToNewId: {}, posterRefToNewId: {}, posterByMediaRef: {} },
+      audioMappings.sourceRefToId,
+    );
+    const importedAudioId = audioMappings.sourceRefToId.get(sourceAudioId);
+    expect(importedAudioId).toMatch(/^ast_/);
+    expect(importedAudioId).not.toBe(sourceAudioId);
+    expect(importedSlide.elements[0]).toMatchObject({ type: 'audio', src: importedAudioId });
+    expect(await pool.exists?.(importedAudioId as never)).toBe(true);
+  });
+
   it('does not archive stage-whiteboard bytes the classroom format cannot reconstruct', async () => {
     const { getAssetPool } = await import('@/lib/media/asset-pool');
     const { BrowserDocumentStore } = await import('@openmaic/storage');

--- a/tests/export/export-classroom-conversion.test.ts
+++ b/tests/export/export-classroom-conversion.test.ts
@@ -188,13 +188,158 @@ describe('classroom ZIP export conversion snapshot', () => {
       importedAllocations,
     );
     const importedMediaId = mediaMappings.refToNewId[exportedSrc];
-    const importedAudioId = audioMappings[exportedAudioRef!];
+    const importedAudioId = audioMappings.pathToId.get(exportedAudioRef!);
     expect(importedMediaId).toMatch(/^ast_/);
     expect(importedAudioId).toMatch(/^ast_/);
     expect(await pool.exists?.(importedMediaId as never)).toBe(true);
     expect(await pool.exists?.(importedAudioId as never)).toBe(true);
     expect(await db.mediaFiles.get(`imported-1:${importedMediaId}`)).toBeDefined();
-    expect(await db.audioFiles.get(importedAudioId)).toBeDefined();
+    expect(await db.audioFiles.get(importedAudioId!)).toBeDefined();
+  });
+
+  it('round-trips one opaque ref independently as image media and speech audio', async () => {
+    const { db } = await import('@/lib/utils/database');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { BrowserDocumentStore } = await import('@openmaic/storage');
+    const { buildClassroomExportZip } = await import('@/lib/export/use-export-classroom');
+    const { materializeImportedAudio, materializeImportedMedia, rewriteImportedSlideMediaRefs } =
+      await import('@/lib/import/use-import-classroom');
+    const { rewriteAudioRefsToIds } = await import('@/lib/export/classroom-zip-utils');
+    const { DSL_VERSION } = await import('@openmaic/dsl');
+    const pool = getAssetPool();
+    const sharedRef = await pool.put(new Blob(['shared-bytes'], { type: 'image/png' }), {
+      contentType: 'image/png',
+      mediaType: 'image',
+    });
+    const slide = {
+      id: 'slide-1',
+      elements: [{ id: 'image-1', type: 'image', src: sharedRef }],
+    };
+    const scene = {
+      id: 'scene-1',
+      stageId: 'stage-1',
+      type: 'slide',
+      title: 'Scene',
+      order: 0,
+      content: { type: 'slide', canvas: slide },
+      actions: [{ id: 'speech-1', type: 'speech', text: 'Shared', audioId: sharedRef }],
+    };
+    const stage = { id: 'stage-1', name: 'Course', createdAt: 100, updatedAt: 200 };
+    const store = new BrowserDocumentStore({
+      indexedDB: globalThis.indexedDB as unknown as IDBFactory,
+      dbName: 'maic-documents',
+      validateScene: () => ({ valid: true }),
+    });
+    await store.saveDocument({ dslVersion: DSL_VERSION, stage, scenes: [scene] } as never);
+    await db.mediaFiles.put({
+      id: `stage-1:${sharedRef}`,
+      stageId: 'stage-1',
+      type: 'image',
+      blob: new Blob(['image-row'], { type: 'image/png' }),
+      mimeType: 'image/png',
+      size: 9,
+      prompt: '',
+      params: '',
+      createdAt: 1,
+    });
+    await db.audioFiles.put({
+      id: sharedRef,
+      stageId: 'stage-1',
+      blob: new Blob(['audio-row'], { type: 'audio/mpeg' }),
+      format: 'mp3',
+      duration: 1,
+      createdAt: 1,
+    });
+
+    const { zip } = await buildClassroomExportZip(stage as Stage, [scene] as Scene[], {
+      store,
+      kv: new MemoryKv(),
+      legacyStore: { read: async () => null, listStages: async () => [] },
+      lockManager: lockManager(),
+    });
+    const zipData = await JSZip.loadAsync(zip);
+    const manifest = JSON.parse(
+      await zipData.file('manifest.json')!.async('string'),
+    ) as ClassroomManifest;
+    const mediaPath = `media/${sharedRef}.png`;
+    const audioPath = `audio/${sharedRef}.mp3`;
+    expect(zipData.file(mediaPath)).toBeDefined();
+    expect(zipData.file(audioPath)).toBeDefined();
+    expect(manifest.mediaIndex?.[mediaPath]).toMatchObject({ type: 'generated' });
+    expect(manifest.mediaIndex?.[audioPath]).toMatchObject({ type: 'audio' });
+    expect(manifest.scenes[0].actions?.[0]).toMatchObject({ audioRef: audioPath });
+
+    const audioMappings = await materializeImportedAudio(
+      zipData,
+      manifest,
+      'imported-cross-kind',
+      Date.now(),
+    );
+    const mediaMappings = await materializeImportedMedia(
+      zipData,
+      manifest,
+      'imported-cross-kind',
+      Date.now(),
+    );
+    const exportedContent = manifest.scenes[0].content;
+    if (exportedContent.type !== 'slide') throw new Error('expected slide content');
+    const importedSlide = rewriteImportedSlideMediaRefs(exportedContent.canvas, mediaMappings);
+    const importedActions = rewriteAudioRefsToIds(
+      manifest.scenes[0].actions ?? [],
+      audioMappings.pathToId,
+    );
+    const importedMediaId = mediaMappings.refToNewId[sharedRef];
+    const importedAudioId = audioMappings.pathToId.get(audioPath);
+    expect(importedMediaId).toMatch(/^ast_/);
+    expect(importedAudioId).toMatch(/^ast_/);
+    expect(importedMediaId).not.toBe(importedAudioId);
+    expect(importedSlide.elements[0]).toMatchObject({ src: importedMediaId });
+    expect(importedActions[0]).toMatchObject({ audioId: importedAudioId });
+  });
+
+  it('does not archive stage-whiteboard bytes the classroom format cannot reconstruct', async () => {
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { BrowserDocumentStore } = await import('@openmaic/storage');
+    const { buildClassroomExportZip } = await import('@/lib/export/use-export-classroom');
+    const { DSL_VERSION } = await import('@openmaic/dsl');
+    const pool = getAssetPool();
+    const whiteboardAssetId = await pool.put(
+      new Blob(['stage-whiteboard-bytes'], { type: 'image/png' }),
+      { contentType: 'image/png', mediaType: 'image' },
+    );
+    const stage = {
+      id: 'stage-1',
+      name: 'Course',
+      createdAt: 100,
+      updatedAt: 200,
+      whiteboard: [
+        {
+          id: 'stage-whiteboard',
+          elements: [{ id: 'whiteboard-image', type: 'image', src: whiteboardAssetId }],
+        },
+      ],
+    };
+    const store = new BrowserDocumentStore({
+      indexedDB: globalThis.indexedDB as unknown as IDBFactory,
+      dbName: 'maic-documents',
+      validateScene: () => ({ valid: true }),
+    });
+    await store.saveDocument({ dslVersion: DSL_VERSION, stage, scenes: [] } as never);
+
+    const { zip } = await buildClassroomExportZip(stage as Stage, [], {
+      store,
+      kv: new MemoryKv(),
+      legacyStore: { read: async () => null, listStages: async () => [] },
+      lockManager: lockManager(),
+    });
+    const zipData = await JSZip.loadAsync(zip);
+    const manifest = JSON.parse(
+      await zipData.file('manifest.json')!.async('string'),
+    ) as ClassroomManifest;
+
+    expect(manifest.stage).not.toHaveProperty('whiteboard');
+    expect(manifest.mediaIndex).not.toHaveProperty(`media/${whiteboardAssetId}.png`);
+    expect(zipData.file(`media/${whiteboardAssetId}.png`)).toBeNull();
   });
 
   it('keeps unsaved scene edits while converting their references', async () => {

--- a/tests/export/export-classroom-conversion.test.ts
+++ b/tests/export/export-classroom-conversion.test.ts
@@ -161,13 +161,16 @@ describe('classroom ZIP export conversion snapshot', () => {
     const exportedAudioRef = manifest.scenes[0].actions?.[0]?.audioRef;
     expect(exportedSrc).toBe(durableCanvas.elements[0].src);
     expect(exportedSrc).toMatch(/^ast_/);
-    expect(exportedAudioRef).toBe(`audio/${durableAction?.audioId}.mp3`);
+    expect(exportedAudioRef).toBe('audio/audio-1.mp3');
 
     // The archive carries the media under exactly the manifest's references,
     // and the mediaIndex covers them (no dangling handles).
-    expect(zipData.file(`media/${exportedSrc}.png`)).toBeDefined();
+    expect(zipData.file('media/asset-1.png')).toBeDefined();
     expect(zipData.file(exportedAudioRef!)).toBeDefined();
-    expect(manifest.mediaIndex?.[`media/${exportedSrc}.png`]).toMatchObject({ type: 'generated' });
+    expect(manifest.mediaIndex?.['media/asset-1.png']).toMatchObject({
+      type: 'generated',
+      sourceRef: exportedSrc,
+    });
     expect(manifest.mediaIndex?.[exportedAudioRef!]).toMatchObject({ type: 'audio' });
 
     // Round-trip: importing the ZIP materializes every entry into fresh
@@ -261,12 +264,18 @@ describe('classroom ZIP export conversion snapshot', () => {
     const manifest = JSON.parse(
       await zipData.file('manifest.json')!.async('string'),
     ) as ClassroomManifest;
-    const mediaPath = `media/${sharedRef}.png`;
-    const audioPath = `audio/${sharedRef}.mp3`;
+    const mediaPath = 'media/asset-1.png';
+    const audioPath = 'audio/audio-1.mp3';
     expect(zipData.file(mediaPath)).toBeDefined();
     expect(zipData.file(audioPath)).toBeDefined();
-    expect(manifest.mediaIndex?.[mediaPath]).toMatchObject({ type: 'generated' });
-    expect(manifest.mediaIndex?.[audioPath]).toMatchObject({ type: 'audio' });
+    expect(manifest.mediaIndex?.[mediaPath]).toMatchObject({
+      type: 'generated',
+      sourceRef: sharedRef,
+    });
+    expect(manifest.mediaIndex?.[audioPath]).toMatchObject({
+      type: 'audio',
+      sourceRef: sharedRef,
+    });
     expect(manifest.scenes[0].actions?.[0]).toMatchObject({ audioRef: audioPath });
 
     const audioMappings = await materializeImportedAudio(
@@ -343,7 +352,7 @@ describe('classroom ZIP export conversion snapshot', () => {
     const manifest = JSON.parse(
       await zipData.file('manifest.json')!.async('string'),
     ) as ClassroomManifest;
-    const audioPath = `audio/${sourceAudioId}.mp3`;
+    const audioPath = 'audio/audio-1.mp3';
     expect(zipData.file(audioPath)).toBeDefined();
     expect(await zipData.file(audioPath)!.async('string')).toBe('slide-audio-bytes');
     expect(manifest.mediaIndex?.[audioPath]).toMatchObject({ type: 'audio' });
@@ -410,8 +419,9 @@ describe('classroom ZIP export conversion snapshot', () => {
     ) as ClassroomManifest;
 
     expect(manifest.stage).not.toHaveProperty('whiteboard');
-    expect(manifest.mediaIndex).not.toHaveProperty(`media/${whiteboardAssetId}.png`);
-    expect(zipData.file(`media/${whiteboardAssetId}.png`)).toBeNull();
+    expect(Object.values(manifest.mediaIndex)).not.toContainEqual(
+      expect.objectContaining({ sourceRef: whiteboardAssetId }),
+    );
   });
 
   it('keeps unsaved scene edits while converting their references', async () => {
@@ -476,7 +486,7 @@ describe('classroom ZIP export conversion snapshot', () => {
     expect(manifest.scenes[0].title).toBe('Edited title');
     const exportedSrc = manifest.scenes[0].content.canvas.elements[0].src;
     expect(exportedSrc).toMatch(/^ast_/);
-    expect(zipData.file(`media/${exportedSrc}.png`)).toBeDefined();
+    expect(zipData.file('media/asset-1.png')).toBeDefined();
   });
 
   it('a successful export leaves no new pool entries or mirror rows behind', async () => {
@@ -600,7 +610,7 @@ describe('classroom ZIP export conversion snapshot', () => {
     };
     const exportedNewSrc = manifest.scenes[0].content.canvas.elements[1].src;
     expect(exportedNewSrc).toMatch(/^ast_/);
-    expect(zipData.file(`media/${exportedNewSrc}.png`)).toBeDefined();
+    expect(zipData.file('media/asset-1.png')).toBeDefined();
 
     // ...but its pool entry and compatibility mirror row were rolled back
     // once the ZIP captured the bytes: the durable document never referenced

--- a/tests/export/export-classroom-conversion.test.ts
+++ b/tests/export/export-classroom-conversion.test.ts
@@ -187,7 +187,7 @@ describe('classroom ZIP export conversion snapshot', () => {
       Date.now(),
       importedAllocations,
     );
-    const importedMediaId = mediaMappings.refToNewId[exportedSrc];
+    const importedMediaId = mediaMappings.refToNewId.get(exportedSrc);
     const importedAudioId = audioMappings.pathToId.get(exportedAudioRef!);
     expect(importedMediaId).toMatch(/^ast_/);
     expect(importedAudioId).toMatch(/^ast_/);
@@ -288,7 +288,7 @@ describe('classroom ZIP export conversion snapshot', () => {
       manifest.scenes[0].actions ?? [],
       audioMappings.pathToId,
     );
-    const importedMediaId = mediaMappings.refToNewId[sharedRef];
+    const importedMediaId = mediaMappings.refToNewId.get(sharedRef);
     const importedAudioId = audioMappings.pathToId.get(audioPath);
     expect(importedMediaId).toMatch(/^ast_/);
     expect(importedAudioId).toMatch(/^ast_/);
@@ -359,7 +359,7 @@ describe('classroom ZIP export conversion snapshot', () => {
     if (exportedContent.type !== 'slide') throw new Error('expected exported slide content');
     const importedSlide = rewriteImportedSlideMediaRefs(
       exportedContent.canvas,
-      { refToNewId: {}, posterRefToNewId: {}, posterByMediaRef: {} },
+      { refToNewId: new Map(), posterRefToNewId: new Map(), posterByMediaRef: new Map() },
       audioMappings.sourceRefToId,
     );
     const importedAudioId = audioMappings.sourceRefToId.get(sourceAudioId);

--- a/tests/export/pptx-media-fallback.test.ts
+++ b/tests/export/pptx-media-fallback.test.ts
@@ -22,6 +22,7 @@ import {
   assertPptxMediaReferenceParity,
   buildPptxBlob,
   derivePptxMediaReferenceSet,
+  isPptxManifestForeignRef,
 } from '@/lib/export/use-export-pptx';
 import { lookupMediaTask } from '@/lib/media/media-task-resolution';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
@@ -270,6 +271,99 @@ describe('PPTX media fallback chains', () => {
 
     expect(media.some((bytes) => Buffer.from(bytes).equals(Buffer.from(PNG_BYTES)))).toBe(true);
     expect(mocks.mediaGet).toHaveBeenCalledWith('stage-1:ast_poster');
+  });
+
+  it('embeds a task-provided poster when the video element has no explicit poster', async () => {
+    const videoUrl = 'https://cdn.example/task-video.mp4';
+    const posterUrl = 'https://cdn.example/task-poster.jpg';
+    const videoBytes = new TextEncoder().encode('task-video-bytes');
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.startsWith('data:')) {
+        const [meta, b64] = url.slice(5).split(',');
+        return new Response(new Blob([Buffer.from(b64, 'base64')], { type: meta.split(';')[0] }));
+      }
+      if (url === videoUrl) return new Response(new Blob([videoBytes], { type: 'video/mp4' }));
+      if (url === posterUrl) return new Response(new Blob([PNG_BYTES], { type: 'image/jpeg' }));
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    useMediaGenerationStore.setState({
+      tasks: {
+        ast_video_task: {
+          elementId: 'ast_video_task',
+          placeholderRef: 'gen_vid_1',
+          objectUrl: videoUrl,
+          poster: posterUrl,
+          type: 'video',
+          status: 'done',
+          prompt: 'Clip',
+          params: {},
+          retryCount: 0,
+          stageId: 'stage-1',
+        },
+      },
+    });
+    const slide = baseSlide({
+      id: 'video-1',
+      type: 'video',
+      src: 'gen_vid_1',
+      mediaRef: 'gen_vid_1',
+      left: 0,
+      top: 0,
+      width: 640,
+      height: 360,
+      rotate: 0,
+    });
+
+    const blob = await buildPptxBlob([slide], [sceneFor(slide)], 0.5625, 1000, 100, 1, 'stage-1');
+    const media = await pptxMediaBytes(blob);
+
+    // The runtime poster fallback reaches the export: the task-owned poster URL
+    // is fetched (not rejected by the manifest guard) and embedded as the cover.
+    expect(fetchSpy).toHaveBeenCalledWith(posterUrl);
+    expect(media.some((bytes) => Buffer.from(bytes).equals(Buffer.from(videoBytes)))).toBe(true);
+    expect(media.some((bytes) => Buffer.from(bytes).equals(Buffer.from(PNG_BYTES)))).toBe(true);
+  });
+
+  it('still rejects a genuinely unrelated poster URL that no task owns', () => {
+    // The guard's task-ownership exemption is narrow: it admits exactly the
+    // URL the bound task owns. A genuinely foreign URL — neither a document
+    // ref nor the task's own objectUrl — must still be rejected, so the fix
+    // cannot grow into a blanket runtime-URL bypass.
+    const slide = baseSlide({
+      id: 'video-1',
+      type: 'video',
+      src: 'gen_vid_1',
+      mediaRef: 'gen_vid_1',
+      left: 0,
+      top: 0,
+      width: 640,
+      height: 360,
+      rotate: 0,
+    });
+    const manifestRefs = derivePptxMediaReferenceSet([slide]);
+    const unrelatedPoster = 'https://unrelated.example/poster.jpg';
+    const videoUrl = 'https://cdn.example/task-video.mp4';
+
+    // Rejected: not a document ref, and the task owns only the video URL.
+    expect(isPptxManifestForeignRef(unrelatedPoster, manifestRefs, undefined)).toBe(true);
+    expect(
+      isPptxManifestForeignRef(unrelatedPoster, manifestRefs, {
+        status: 'done',
+        objectUrl: videoUrl,
+        retryCount: 0,
+      }),
+    ).toBe(true);
+
+    // Admitted: the task-owned poster URL (the fix's exemption) and document refs.
+    expect(
+      isPptxManifestForeignRef(unrelatedPoster, manifestRefs, {
+        status: 'done',
+        objectUrl: unrelatedPoster,
+        retryCount: 0,
+      }),
+    ).toBe(false);
+    expect(isPptxManifestForeignRef('gen_vid_1', manifestRefs, undefined)).toBe(false);
   });
 
   it('embeds an allocated slide background from its Dexie row', async () => {

--- a/tests/export/pptx-media-fallback.test.ts
+++ b/tests/export/pptx-media-fallback.test.ts
@@ -18,7 +18,11 @@ vi.mock('@/lib/media/asset-pool', () => ({
   getAssetPool: () => ({ resolve: mocks.poolResolve, release: mocks.poolRelease }),
 }));
 
-import { buildPptxBlob } from '@/lib/export/use-export-pptx';
+import {
+  assertPptxMediaReferenceParity,
+  buildPptxBlob,
+  derivePptxMediaReferenceSet,
+} from '@/lib/export/use-export-pptx';
 import { lookupMediaTask } from '@/lib/media/media-task-resolution';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 
@@ -89,6 +93,39 @@ describe('PPTX media fallback chains', () => {
   });
 
   afterEach(() => vi.unstubAllGlobals());
+
+  it('derives the complete layout media set from the manifest with exact walker parity', () => {
+    const slide = {
+      ...baseSlide({}),
+      background: { type: 'image', image: { src: 'background' } },
+      elements: [
+        { id: 'image', type: 'image', src: 'image' },
+        {
+          id: 'video',
+          type: 'video',
+          src: 'video-src',
+          mediaRef: 'video-ref',
+          poster: 'poster',
+        },
+        { id: 'audio', type: 'audio', src: 'audio' },
+      ],
+    } as unknown as Slide;
+
+    const manifestRefs = derivePptxMediaReferenceSet([slide]);
+
+    expect([...manifestRefs]).toEqual([
+      'background',
+      'image',
+      'video-src',
+      'video-ref',
+      'poster',
+      'audio',
+    ]);
+    expect(() => assertPptxMediaReferenceParity([slide], manifestRefs)).not.toThrow();
+    expect(() =>
+      assertPptxMediaReferenceParity([slide], new Set([...manifestRefs, 'manifest-only'])),
+    ).toThrow(/manifest-only/);
+  });
 
   it.each(['__proto__', 'constructor'])(
     'uses only an own task for the adversarial media ref %s',

--- a/tests/export/pptx-media-fallback.test.ts
+++ b/tests/export/pptx-media-fallback.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/lib/media/asset-pool', () => ({
 }));
 
 import { buildPptxBlob } from '@/lib/export/use-export-pptx';
+import { lookupMediaTask } from '@/lib/media/media-task-resolution';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 
 const PNG_BASE64 =
@@ -88,6 +89,72 @@ describe('PPTX media fallback chains', () => {
   });
 
   afterEach(() => vi.unstubAllGlobals());
+
+  it.each(['__proto__', 'constructor'])(
+    'uses only an own task for the adversarial media ref %s',
+    (ref) => {
+      expect(lookupMediaTask({}, ref)).toBeUndefined();
+      const task = {
+        elementId: ref,
+        type: 'image',
+        status: 'done',
+        prompt: ref,
+        params: {},
+        retryCount: 0,
+        stageId: 'stage-1',
+      } as const;
+      useMediaGenerationStore.setState({ tasks: Object.fromEntries([[ref, task]]) });
+
+      expect(lookupMediaTask(useMediaGenerationStore.getState().tasks, ref, 'stage-1')).toBe(task);
+    },
+  );
+
+  it.each(['__proto__', 'constructor'])(
+    'embeds task URL bytes for a re-keyed adversarial placeholder ref %s',
+    async (ref) => {
+      const taskUrl = `https://task.test/${encodeURIComponent(ref)}.png`;
+      const fetchSpy = vi.fn(async (url: string) =>
+        url === taskUrl
+          ? new Response(new Blob([PNG_BYTES], { type: 'image/png' }))
+          : new Response(null, { status: 404 }),
+      );
+      vi.stubGlobal('fetch', fetchSpy);
+      useMediaGenerationStore.setState({
+        tasks: {
+          [`ast_rekeyed_${ref}`]: {
+            elementId: `ast_rekeyed_${ref}`,
+            placeholderRef: ref,
+            objectUrl: taskUrl,
+            type: 'image',
+            status: 'done',
+            prompt: ref,
+            params: {},
+            retryCount: 0,
+            stageId: 'stage-1',
+          },
+        },
+      });
+      const slide = baseSlide({
+        id: 'image-1',
+        type: 'image',
+        src: ref,
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        rotate: 0,
+        fixedRatio: true,
+      });
+
+      const blob = await buildPptxBlob([slide], [sceneFor(slide)], 0.5625, 1000, 100, 1, 'stage-1');
+      const media = await pptxMediaBytes(blob);
+
+      expect(mocks.poolResolve).toHaveBeenCalledWith(ref);
+      expect(mocks.mediaGet).toHaveBeenCalledWith(`stage-1:${ref}`);
+      expect(fetchSpy).toHaveBeenCalledWith(taskUrl);
+      expect(media.some((bytes) => Buffer.from(bytes).equals(Buffer.from(PNG_BYTES)))).toBe(true);
+    },
+  );
 
   it('embeds a concrete video src when its opaque mediaRef cannot be resolved', async () => {
     const videoBytes = new TextEncoder().encode('direct-video-bytes');

--- a/tests/import/import-media-assets.test.ts
+++ b/tests/import/import-media-assets.test.ts
@@ -416,14 +416,154 @@ describe('classroom import media allocation', () => {
       allocations,
     );
 
-    expect(mappings[missingPath]).toBeUndefined();
-    expect(mappings[presentPath]).toMatch(/^ast_/);
+    expect(mappings.pathToId.get(missingPath)).toBeUndefined();
+    expect(mappings.pathToId.get(presentPath)).toMatch(/^ast_/);
     expect(put).toHaveBeenCalledTimes(1);
-    expect(allocations).toEqual([mappings[presentPath]]);
+    expect(allocations).toEqual([mappings.pathToId.get(presentPath)]);
     expect(mocks.audioPut).toHaveBeenCalledWith(
-      expect.objectContaining({ id: mappings[presentPath], stageId: 'imported-stage' }),
+      expect.objectContaining({
+        id: mappings.pathToId.get(presentPath),
+        stageId: 'imported-stage',
+      }),
     );
   });
+
+  it.each([
+    ['short ref first', ['audio/foo.mp3', 'audio/audio/foo.mp3.mp3']],
+    ['nested ref first', ['audio/audio/foo.mp3.mp3', 'audio/foo.mp3']],
+  ])('keeps ZIP paths and source refs in separate audio namespaces: %s', async (_case, paths) => {
+    const zip = new JSZip();
+    zip.file('audio/foo.mp3', 'short-ref-bytes');
+    zip.file('audio/audio/foo.mp3.mp3', 'nested-ref-bytes');
+    const mediaIndex = Object.fromEntries(
+      paths.map((path) => [
+        path,
+        {
+          type: 'audio' as const,
+          format: 'mp3',
+          sourceRef: path === 'audio/foo.mp3' ? 'foo' : 'audio/foo.mp3',
+        },
+      ]),
+    );
+    const manifest = {
+      formatVersion: 1,
+      exportedAt: new Date(0).toISOString(),
+      appVersion: 'test',
+      stage: { name: 'Imported', createdAt: 1, updatedAt: 1 },
+      agents: [],
+      scenes: [],
+      mediaIndex,
+    } as unknown as ClassroomManifest;
+
+    const mappings = await materializeImportedAudio(zip, manifest, 'imported-stage', 2);
+
+    expect(await poolText(mappings.pathToId.get('audio/foo.mp3')!)).toBe('short-ref-bytes');
+    expect(await poolText(mappings.pathToId.get('audio/audio/foo.mp3.mp3')!)).toBe(
+      'nested-ref-bytes',
+    );
+    expect(mappings.sourceRefToId.get('foo')).toBe(mappings.pathToId.get('audio/foo.mp3'));
+    expect(mappings.sourceRefToId.get('audio/foo.mp3')).toBe(
+      mappings.pathToId.get('audio/audio/foo.mp3.mp3'),
+    );
+  });
+
+  it.each([
+    ['lexical path first', ['audio/a.mp3', 'audio/z.mp3']],
+    ['lexical path last', ['audio/z.mp3', 'audio/a.mp3']],
+  ])(
+    'resolves duplicate audio source refs by ZIP path deterministically: %s',
+    async (_case, paths) => {
+      const zip = new JSZip();
+      zip.file('audio/a.mp3', 'lexical-winner');
+      zip.file('audio/z.mp3', 'later-path');
+      const manifest = {
+        formatVersion: 1,
+        exportedAt: new Date(0).toISOString(),
+        appVersion: 'test',
+        stage: { name: 'Imported', createdAt: 1, updatedAt: 1 },
+        agents: [],
+        scenes: [],
+        mediaIndex: Object.fromEntries(
+          paths.map((path) => [path, { type: 'audio', format: 'mp3', sourceRef: 'duplicate' }]),
+        ),
+      } as unknown as ClassroomManifest;
+
+      const mappings = await materializeImportedAudio(zip, manifest, 'imported-stage', 2);
+
+      expect(mappings.sourceRefToId.get('duplicate')).toBe(mappings.pathToId.get('audio/a.mp3'));
+      expect(await poolText(mappings.sourceRefToId.get('duplicate')!)).toBe('lexical-winner');
+    },
+  );
+
+  it('maps prototype-named aliases as strings without crossing path and source namespaces', async () => {
+    const zip = new JSZip();
+    const cases = [
+      ['audio/proto.mp3', '__proto__', 'proto-bytes'],
+      ['audio/ctor.mp3', 'constructor', 'constructor-bytes'],
+      ['audio/collision.mp3', 'audio/proto.mp3', 'collision-bytes'],
+    ] as const;
+    for (const [path, , bytes] of cases) zip.file(path, bytes);
+    const manifest = {
+      formatVersion: 1,
+      exportedAt: new Date(0).toISOString(),
+      appVersion: 'test',
+      stage: { name: 'Imported', createdAt: 1, updatedAt: 1 },
+      agents: [],
+      scenes: [],
+      mediaIndex: Object.fromEntries(
+        cases.map(([path, sourceRef]) => [path, { type: 'audio', format: 'mp3', sourceRef }]),
+      ),
+    } as unknown as ClassroomManifest;
+
+    const mappings = await materializeImportedAudio(zip, manifest, 'imported-stage', 2);
+
+    for (const [path, sourceRef, bytes] of cases) {
+      const pathId = mappings.pathToId.get(path);
+      const sourceId = mappings.sourceRefToId.get(sourceRef);
+      expect(typeof pathId).toBe('string');
+      expect(typeof sourceId).toBe('string');
+      expect(sourceId).toBe(pathId);
+      expect(await poolText(sourceId!)).toBe(bytes);
+    }
+    expect(mappings.sourceRefToId.get('audio/proto.mp3')).not.toBe(
+      mappings.pathToId.get('audio/proto.mp3'),
+    );
+  });
+
+  it.each([
+    ['forward', ['audio/z.mp3', 'audio/ä.mp3', 'audio/Ω.mp3']],
+    ['reverse', ['audio/Ω.mp3', 'audio/ä.mp3', 'audio/z.mp3']],
+  ])(
+    'uses locale-independent code-unit order for a three-way source alias: %s',
+    async (_case, paths) => {
+      const zip = new JSZip();
+      zip.file('audio/z.mp3', 'code-unit-winner');
+      zip.file('audio/ä.mp3', 'latin-diacritic');
+      zip.file('audio/Ω.mp3', 'greek');
+      const manifest = {
+        formatVersion: 1,
+        exportedAt: new Date(0).toISOString(),
+        appVersion: 'test',
+        stage: { name: 'Imported', createdAt: 1, updatedAt: 1 },
+        agents: [],
+        scenes: [],
+        mediaIndex: Object.fromEntries(
+          paths.map((path) => [path, { type: 'audio', format: 'mp3', sourceRef: 'duplicate' }]),
+        ),
+      } as unknown as ClassroomManifest;
+
+      const localeCompare = vi.spyOn(String.prototype, 'localeCompare').mockImplementation(() => {
+        throw new Error('host locale must not participate in alias ordering');
+      });
+      const mappings = await materializeImportedAudio(zip, manifest, 'imported-stage', 2).finally(
+        () => localeCompare.mockRestore(),
+      );
+      const winner = mappings.sourceRefToId.get('duplicate');
+
+      expect(winner).toBe(mappings.pathToId.get('audio/z.mp3'));
+      expect(await poolText(winner!)).toBe('code-unit-winner');
+    },
+  );
 
   it('re-derives nested refs with parameterized MIME metadata intact', () => {
     expect(mediaRefFromZipPath('media/nested/course/ref.svg', 'image/svg+xml; charset=utf-8')).toBe(

--- a/tests/import/import-media-assets.test.ts
+++ b/tests/import/import-media-assets.test.ts
@@ -33,6 +33,7 @@ import {
   rewriteImportedSlideMediaRefs,
   rewriteImportedVideoManifest,
 } from '@/lib/import/use-import-classroom';
+import { rewriteAudioRefsToIds } from '@/lib/export/classroom-zip-utils';
 
 describe('classroom import media allocation', () => {
   let pool: BrowserAssetStore;
@@ -71,6 +72,94 @@ describe('classroom import media allocation', () => {
       await pool.release(ref);
     }
   }
+
+  it('round-trips adversarial refs through safe media and audio archive paths', async () => {
+    const refs = ['../evil', 'a/b', 'a/../collision', 'collision'];
+    const mediaPaths = refs.map((_, index) => `media/asset-${index + 1}.png`);
+    const audioPaths = refs.map((_, index) => `audio/audio-${index + 1}.mp3`);
+    const zip = new JSZip();
+    for (const [index, path] of mediaPaths.entries()) zip.file(path, `media-${refs[index]}`);
+    for (const [index, path] of audioPaths.entries()) zip.file(path, `audio-${refs[index]}`);
+
+    const slide = {
+      id: 'adversarial-slide',
+      background: { type: 'image', image: { src: refs[3] } },
+      elements: [
+        { id: 'image', type: 'image', src: refs[0] },
+        { id: 'video', type: 'video', src: refs[1], mediaRef: refs[1], poster: refs[2] },
+        ...refs.map((ref, index) => ({ id: `audio-${index}`, type: 'audio', src: ref })),
+      ],
+    } as unknown as Slide;
+    const manifest = {
+      formatVersion: 1,
+      exportedAt: new Date(0).toISOString(),
+      appVersion: 'test',
+      stage: { name: 'Imported', createdAt: 1, updatedAt: 1 },
+      agents: [],
+      scenes: [
+        {
+          type: 'slide',
+          title: 'Adversarial refs',
+          order: 0,
+          content: { type: 'slide', canvas: slide },
+          actions: refs.map((_, index) => ({
+            id: `speech-${index}`,
+            type: 'speech' as const,
+            text: `Speech ${index}`,
+            audioRef: audioPaths[index],
+          })),
+        },
+      ],
+      mediaIndex: Object.fromEntries([
+        ...mediaPaths.map((path, index) => [
+          path,
+          {
+            type: 'generated' as const,
+            sourceRef: refs[index],
+            mimeType: index === 1 ? 'video/mp4' : 'image/png',
+          },
+        ]),
+        ...audioPaths.map((path, index) => [
+          path,
+          { type: 'audio' as const, sourceRef: refs[index], format: 'mp3' },
+        ]),
+      ]),
+    } satisfies ClassroomManifest;
+
+    const mediaMappings = await materializeImportedMedia(zip, manifest, 'safe-stage', 2);
+    const audioMappings = await materializeImportedAudio(zip, manifest, 'safe-stage', 2);
+    const rewritten = rewriteImportedSlideMediaRefs(
+      slide,
+      mediaMappings,
+      audioMappings.sourceRefToId,
+    );
+    const rewrittenActions = rewriteAudioRefsToIds(
+      manifest.scenes[0].actions ?? [],
+      audioMappings.pathToId,
+    );
+    const mediaIds = refs.map((ref) => mediaMappings.refToNewId.get(ref));
+    const audioIds = refs.map((ref) => audioMappings.sourceRefToId.get(ref));
+
+    expect(new Set(mediaIds).size).toBe(refs.length);
+    expect(new Set(audioIds).size).toBe(refs.length);
+    expect(rewritten.background).toMatchObject({ image: { src: mediaIds[3] } });
+    expect(rewritten.elements[0]).toMatchObject({ src: mediaIds[0] });
+    expect(rewritten.elements[1]).toMatchObject({
+      src: mediaIds[1],
+      mediaRef: mediaIds[1],
+      poster: mediaIds[2],
+    });
+    refs.forEach((_, index) => {
+      expect(rewritten.elements[index + 2]).toMatchObject({ src: audioIds[index] });
+      expect(rewrittenActions[index]).toMatchObject({ audioId: audioIds[index] });
+    });
+    await Promise.all(
+      refs.map(async (ref, index) => {
+        expect(await poolText(mediaIds[index]!)).toBe(`media-${ref}`);
+        expect(await poolText(audioIds[index]!)).toBe(`audio-${ref}`);
+      }),
+    );
+  });
 
   it('re-mints colliding video and poster refs without changing the source assets', async () => {
     const sourceVideoId = await pool.put(new Blob(['source-video'], { type: 'video/mp4' }));

--- a/tests/import/import-media-assets.test.ts
+++ b/tests/import/import-media-assets.test.ts
@@ -151,8 +151,8 @@ describe('classroom import media allocation', () => {
     );
     const importedSlide = rewriteImportedSlideMediaRefs(slide, mappings);
     const importedManifest = rewriteImportedVideoManifest(manifest.stage.videoManifest, mappings);
-    const newVideoId = mappings.refToNewId[sourceVideoId];
-    const newPosterId = mappings.refToNewId[sourcePosterId];
+    const newVideoId = mappings.refToNewId.get(sourceVideoId)!;
+    const newPosterId = mappings.refToNewId.get(sourcePosterId)!;
 
     expect(newVideoId).not.toBe(sourceVideoId);
     expect(newPosterId).not.toBe(sourcePosterId);
@@ -206,6 +206,150 @@ describe('classroom import media allocation', () => {
     });
   });
 
+  it.each(['__proto__', 'constructor'])(
+    'round-trips the adversarial media ref %s through every generated-media alias map',
+    async (adversarialRef) => {
+      const zip = new JSZip();
+      const videoRef = adversarialRef;
+      const indexedPosterRef = `${adversarialRef}-indexed-poster`;
+      const videoPath = `media/${videoRef}.mp4`;
+      const indexedPosterPath = `media/${indexedPosterRef}.jpg`;
+      zip.file(videoPath, `video-${adversarialRef}`);
+      zip.file(videoPath.replace(/\.mp4$/, '.poster.jpg'), `sibling-${adversarialRef}`);
+      zip.file(indexedPosterPath, `poster-${adversarialRef}`);
+
+      const slide = {
+        id: `slide-${adversarialRef}`,
+        elements: [
+          {
+            id: `video-${adversarialRef}`,
+            type: 'video',
+            src: videoRef,
+            mediaRef: videoRef,
+            poster: indexedPosterRef,
+          },
+        ],
+      } as unknown as Slide;
+      const manifest = {
+        formatVersion: 1,
+        exportedAt: new Date(0).toISOString(),
+        appVersion: 'test',
+        stage: {
+          name: 'Imported',
+          createdAt: 1,
+          updatedAt: 1,
+          videoManifest: Object.fromEntries([
+            [videoRef, { type: 'video', prompt: adversarialRef }],
+          ]),
+        },
+        agents: [],
+        scenes: [
+          {
+            type: 'slide',
+            title: 'Scene',
+            order: 0,
+            content: { type: 'slide', canvas: slide },
+          },
+        ],
+        mediaIndex: Object.fromEntries([
+          [videoPath, { type: 'generated', mimeType: 'video/mp4' }],
+          [indexedPosterPath, { type: 'generated', mimeType: 'image/jpeg' }],
+        ]),
+      } satisfies ClassroomManifest;
+
+      const mappings = await materializeImportedMedia(zip, manifest, 'imported-stage', 2);
+      const rewrittenSlide = rewriteImportedSlideMediaRefs(slide, mappings);
+      const rewrittenManifest = rewriteImportedVideoManifest(
+        manifest.stage.videoManifest,
+        mappings,
+      );
+      const rewrittenVideo = rewrittenSlide.elements[0] as {
+        src: unknown;
+        mediaRef?: unknown;
+        poster?: unknown;
+      };
+
+      expect(typeof rewrittenVideo.src).toBe('string');
+      const rewrittenSrc = rewrittenVideo.src as string;
+      expect(rewrittenSrc).toBe(mappings.refToNewId.get(videoRef));
+      expect(rewrittenVideo.mediaRef).toBe(mappings.refToNewId.get(videoRef));
+      expect(rewrittenVideo.poster).toBe(mappings.posterRefToNewId.get(indexedPosterRef));
+      expect(mappings.posterByMediaRef.get(videoRef)).toBe(rewrittenVideo.poster);
+      expect(Object.keys(rewrittenManifest ?? {})).toEqual([rewrittenSrc]);
+      expect(await poolText(rewrittenSrc)).toBe(`video-${adversarialRef}`);
+      expect(await poolText(rewrittenVideo.poster as string)).toBe(`poster-${adversarialRef}`);
+
+      const posterZip = new JSZip();
+      const safeVideoRef = `safe-video-${adversarialRef}`;
+      const safeVideoPath = `media/${safeVideoRef}.mp4`;
+      const adversarialPosterPath = `media/${adversarialRef}.jpg`;
+      posterZip.file(safeVideoPath, `safe-video-${adversarialRef}`);
+      posterZip.file(safeVideoPath.replace(/\.mp4$/, '.poster.jpg'), `sibling-${adversarialRef}`);
+      posterZip.file(adversarialPosterPath, `adversarial-poster-${adversarialRef}`);
+      const posterSlide = {
+        id: `poster-slide-${adversarialRef}`,
+        elements: [
+          {
+            id: `poster-video-${adversarialRef}`,
+            type: 'video',
+            src: safeVideoRef,
+            mediaRef: safeVideoRef,
+            poster: adversarialRef,
+          },
+        ],
+      } as unknown as Slide;
+      const posterManifest = {
+        ...manifest,
+        stage: { ...manifest.stage, videoManifest: undefined },
+        scenes: [
+          {
+            type: 'slide',
+            title: 'Poster scene',
+            order: 0,
+            content: { type: 'slide', canvas: posterSlide },
+          },
+        ],
+        mediaIndex: Object.fromEntries([
+          [safeVideoPath, { type: 'generated', mimeType: 'video/mp4' }],
+          [adversarialPosterPath, { type: 'generated', mimeType: 'image/jpeg' }],
+        ]),
+      } satisfies ClassroomManifest;
+      const posterMappings = await materializeImportedMedia(
+        posterZip,
+        posterManifest,
+        'poster-stage',
+        3,
+      );
+      const rewrittenPosterVideo = rewriteImportedSlideMediaRefs(posterSlide, posterMappings)
+        .elements[0] as { poster?: unknown };
+
+      expect(rewrittenPosterVideo.poster).toBe(posterMappings.refToNewId.get(adversarialRef));
+      expect(rewrittenPosterVideo.poster).toBe(posterMappings.posterRefToNewId.get(adversarialRef));
+      expect(typeof rewrittenPosterVideo.poster).toBe('string');
+      expect(await poolText(rewrittenPosterVideo.poster as string)).toBe(
+        `adversarial-poster-${adversarialRef}`,
+      );
+    },
+  );
+
+  it('rejects non-string alias values before they reach imported media slots', () => {
+    const invalidMappings = {
+      refToNewId: new Map<string, unknown>([['source-image', { polluted: true }]]),
+      posterRefToNewId: new Map<string, unknown>(),
+      posterByMediaRef: new Map<string, unknown>(),
+    } as unknown as Parameters<typeof rewriteImportedSlideMediaRefs>[1];
+
+    const rewritten = rewriteImportedSlideMediaRefs(
+      {
+        id: 'invalid-alias',
+        elements: [{ id: 'image', type: 'image', src: 'source-image' }],
+      } as unknown as Slide,
+      invalidMappings,
+    );
+
+    expect(rewritten.elements[0]).toMatchObject({ src: '' });
+  });
+
   it('clears opaque unmapped refs while preserving mapped, generated, and concrete refs', () => {
     const rewritten = rewriteImportedSlideMediaRefs(
       {
@@ -242,9 +386,9 @@ describe('classroom import media allocation', () => {
         ],
       } as unknown as Slide,
       {
-        refToNewId: { 'source-image': 'ast_new_image' },
-        posterRefToNewId: {},
-        posterByMediaRef: {},
+        refToNewId: new Map([['source-image', 'ast_new_image']]),
+        posterRefToNewId: new Map(),
+        posterByMediaRef: new Map(),
       },
     );
 
@@ -272,9 +416,9 @@ describe('classroom import media allocation', () => {
           gen_vid_waiting: { type: 'video', prompt: 'generated' },
         },
         {
-          refToNewId: {},
-          posterRefToNewId: {},
-          posterByMediaRef: {},
+          refToNewId: new Map(),
+          posterRefToNewId: new Map(),
+          posterByMediaRef: new Map(),
         },
       ),
     ).toEqual({
@@ -304,7 +448,7 @@ describe('classroom import media allocation', () => {
             },
           ],
         } as unknown as Slide,
-        { refToNewId: {}, posterRefToNewId: {}, posterByMediaRef: {} },
+        { refToNewId: new Map(), posterRefToNewId: new Map(), posterByMediaRef: new Map() },
       );
 
       expect(rewritten.background).toMatchObject({ type: 'image', image: { src: address } });
@@ -340,12 +484,12 @@ describe('classroom import media allocation', () => {
         ],
       } as unknown as Slide,
       {
-        refToNewId: {
-          'source-video': 'ast_new_video',
-          'source-poster': 'ast_new_poster',
-        },
-        posterRefToNewId: {},
-        posterByMediaRef: {},
+        refToNewId: new Map([
+          ['source-video', 'ast_new_video'],
+          ['source-poster', 'ast_new_poster'],
+        ]),
+        posterRefToNewId: new Map(),
+        posterByMediaRef: new Map(),
       },
     );
 
@@ -378,9 +522,9 @@ describe('classroom import media allocation', () => {
           elements: [],
         } as unknown as Slide,
         {
-          refToNewId: mapping,
-          posterRefToNewId: {},
-          posterByMediaRef: {},
+          refToNewId: new Map(Object.entries(mapping)),
+          posterRefToNewId: new Map(),
+          posterByMediaRef: new Map(),
         },
       );
 

--- a/tests/media/assert-stage-asset-ownership.ts
+++ b/tests/media/assert-stage-asset-ownership.ts
@@ -27,7 +27,7 @@ export async function expectDocumentAssetOwnership({
   );
 
   for (const ref of allocated) {
-    const isAudio = refs.speechAudioId.has(ref);
+    const isAudio = refs.speechAudioId.has(ref) || refs.slideAudioSrc.has(ref);
     const compatibilityId = isAudio ? ref : `${document.stage.id}:${ref}`;
     expect(
       isAudio ? audioRowIds.has(compatibilityId) : mediaRowIds.has(compatibilityId),

--- a/tests/media/asset-manifest.test.ts
+++ b/tests/media/asset-manifest.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * buildStageAssetManifest layers compatibility-row metadata onto the pure dsl
+ * enumeration. These tests pin the join semantics: metadata attaches by ref,
+ * rows nothing references never appear (orphan exclusion at the metadata
+ * layer), and refs without rows stay metadata-free rather than missing.
+ */
+const mocks = vi.hoisted(() => ({
+  mediaRows: new Map<string, Record<string, unknown>>(),
+  audioRows: new Map<string, Record<string, unknown>>(),
+}));
+
+vi.mock('@/lib/utils/database', () => ({
+  mediaFileKey: (stageId: string, ref: string) => `${stageId}:${ref}`,
+  db: {
+    mediaFiles: { get: async (id: string) => mocks.mediaRows.get(id) },
+    audioFiles: { get: async (id: string) => mocks.audioRows.get(id) },
+  },
+}));
+
+import { buildStageAssetManifest } from '@/lib/media/asset-manifest';
+import type { Scene, Stage } from '@/lib/types/stage';
+
+const STAGE_ID = 'stage-1';
+
+function sceneWithImage(ref: string): Scene {
+  return {
+    id: 'scene-1',
+    stageId: STAGE_ID,
+    title: 'Scene',
+    order: 0,
+    type: 'slide',
+    content: {
+      type: 'slide',
+      canvas: { id: 'slide-1', elements: [{ id: 'img-1', type: 'image', src: ref }] },
+    },
+    actions: [{ id: 'a1', type: 'speech', text: 'hi', audioId: 'ast_narration' }],
+  } as unknown as Scene;
+}
+
+const stage = { id: STAGE_ID } as Stage;
+
+afterEach(() => {
+  mocks.mediaRows.clear();
+  mocks.audioRows.clear();
+});
+
+describe('buildStageAssetManifest', () => {
+  it('attaches row metadata to the enumerated refs', async () => {
+    mocks.mediaRows.set(`${STAGE_ID}:ast_image`, {
+      id: `${STAGE_ID}:ast_image`,
+      stageId: STAGE_ID,
+      type: 'image',
+      blob: new Blob(['x']),
+      mimeType: 'image/png',
+      size: 2048,
+      prompt: 'a diagram',
+    });
+    mocks.audioRows.set('ast_narration', {
+      id: 'ast_narration',
+      blob: new Blob(['aa'], { type: 'audio/mpeg' }),
+      format: 'mp3',
+      duration: 2.5,
+      voice: 'alloy',
+    });
+
+    const manifest = await buildStageAssetManifest(stage, [sceneWithImage('ast_image')], STAGE_ID);
+
+    expect(manifest.entries).toEqual([
+      { ref: 'ast_image', kind: 'image', byteSize: 2048, mimeType: 'image/png', prompt: 'a diagram' },
+      {
+        ref: 'ast_narration',
+        kind: 'audio',
+        byteSize: 2,
+        mimeType: 'audio/mpeg',
+        durationSeconds: 2.5,
+        voice: 'alloy',
+      },
+    ]);
+    expect(manifest.referenceCounts.get('ast_image')).toBe(1);
+    expect(manifest.referenceCounts.get('ast_narration')).toBe(1);
+  });
+
+  it('excludes orphan rows and keeps row-less refs metadata-free', async () => {
+    // Rows exist for refs the document does not name; the manifest must not
+    // surface them. The referenced asset has no row and keeps only ref+kind.
+    mocks.mediaRows.set(`${STAGE_ID}:ast_orphan`, {
+      id: `${STAGE_ID}:ast_orphan`,
+      stageId: STAGE_ID,
+      mimeType: 'image/png',
+      size: 10,
+    });
+
+    const manifest = await buildStageAssetManifest(
+      stage,
+      [sceneWithImage('ast_rowless')],
+      STAGE_ID,
+    );
+
+    expect(manifest.entries.map((entry) => entry.ref)).toEqual(['ast_rowless', 'ast_narration']);
+    expect(manifest.entries[0]).toEqual({ ref: 'ast_rowless', kind: 'image' });
+  });
+});

--- a/tests/media/asset-manifest.test.ts
+++ b/tests/media/asset-manifest.test.ts
@@ -68,7 +68,13 @@ describe('buildStageAssetManifest', () => {
     const manifest = await buildStageAssetManifest(stage, [sceneWithImage('ast_image')], STAGE_ID);
 
     expect(manifest.entries).toEqual([
-      { ref: 'ast_image', kind: 'image', byteSize: 2048, mimeType: 'image/png', prompt: 'a diagram' },
+      {
+        ref: 'ast_image',
+        kind: 'image',
+        byteSize: 2048,
+        mimeType: 'image/png',
+        prompt: 'a diagram',
+      },
       {
         ref: 'ast_narration',
         kind: 'audio',

--- a/tests/media/convert-legacy-asset-refs.test.ts
+++ b/tests/media/convert-legacy-asset-refs.test.ts
@@ -581,6 +581,33 @@ describe('classroom media URL conversion', () => {
     expect(containsClassroomMediaUrls(result.document)).toBe(true);
   });
 
+  test('a changed video manifest preserves adversarial ref keys through the conversion commit', async () => {
+    const { urlFetches, deps } = makeHarness();
+    const deadKey = 'https://server.example.com/api/classroom-media/c1/videos/dead.mp4';
+    urlFetches.set(deadKey, { kind: 'dead' });
+    const entries = [
+      ['__proto__', { prompt: 'proto' }],
+      ['constructor', { prompt: 'constructor' }],
+      [deadKey, { prompt: 'drop' }],
+    ] as const;
+    const doc = document({
+      stage: stage({
+        videoManifest: Object.fromEntries(entries) as unknown as Stage['videoManifest'],
+      }),
+    });
+
+    const result = await convertDocumentAssetRefs(doc, deps);
+
+    expect(result.changed).toBe(true);
+    expect(Object.keys(result.document.stage.videoManifest ?? {})).toEqual([
+      '__proto__',
+      'constructor',
+    ]);
+    expect(Object.hasOwn(result.document.stage.videoManifest ?? {}, '__proto__')).toBe(true);
+    expect(result.document.stage.videoManifest?.['__proto__']).toEqual({ prompt: 'proto' });
+    expect(result.document.stage.videoManifest?.constructor).toEqual({ prompt: 'constructor' });
+  });
+
   test('a transiently unavailable classroom media URL keeps the legacy slot untouched', async () => {
     const { pool, deps } = makeHarness();
     const doc = document({

--- a/tests/media/media-task-resolution.test.ts
+++ b/tests/media/media-task-resolution.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { lookupMediaTask, type MediaTaskLookupEntry } from '@/lib/media/media-task-resolution';
+
+function task(
+  elementId: string,
+  placeholderRef?: string,
+  stageId = 'stage-1',
+): MediaTaskLookupEntry & { elementId: string } {
+  return {
+    elementId,
+    placeholderRef,
+    stageId,
+    type: 'image',
+    status: 'done',
+  };
+}
+
+describe('lookupMediaTask', () => {
+  it.each(['__proto__', 'constructor'])(
+    'does not accept inherited Object.prototype member %s as a direct task',
+    (ref) => {
+      expect(lookupMediaTask({}, ref, 'stage-1')).toBeUndefined();
+    },
+  );
+
+  it('returns an own direct task for a normal ref', () => {
+    const direct = task('ast_direct');
+
+    expect(lookupMediaTask({ ast_direct: direct }, 'ast_direct', 'stage-1')).toBe(direct);
+  });
+
+  it.each(['__proto__', 'constructor', 'gen_img_1'])(
+    'falls back to a re-keyed task whose placeholderRef is %s',
+    (ref) => {
+      const rekeyed = task('ast_rekeyed', ref);
+
+      expect(lookupMediaTask({ ast_rekeyed: rekeyed }, ref, 'stage-1')).toBe(rekeyed);
+    },
+  );
+});

--- a/tests/media/prove-exclusive-ownership.test.ts
+++ b/tests/media/prove-exclusive-ownership.test.ts
@@ -117,6 +117,17 @@ describe('exclusive asset ownership', () => {
     expect(exclusive).toBe(false);
   });
 
+  it('is not exclusive when duplicate user-controlled ids hide a second owner', async () => {
+    const duplicateOwners = documentWithOneOwner('stage-1');
+    duplicateOwners.scenes.push(structuredClone(duplicateOwners.scenes[0]));
+    mocks.loadDocument.mockResolvedValue(duplicateOwners);
+
+    const { exclusive, activePersistedRefs } = await proveExclusiveAssetOwnership(ASSET, 'stage-1');
+
+    expect(activePersistedRefs?.referenceCounts.get(ASSET)).toBe(2);
+    expect(exclusive).toBe(false);
+  });
+
   /**
    * A probe that could not be carried out proves nothing, so it must not be
    * read as "nobody else is editing".

--- a/tests/media/reclamation-matrix.test.ts
+++ b/tests/media/reclamation-matrix.test.ts
@@ -163,6 +163,25 @@ function documentWithImage(id: string, ref: string): StageAssetDocument {
   } as unknown as StageAssetDocument;
 }
 
+function documentWithSlideAudio(id: string, ref: string): StageAssetDocument {
+  return {
+    stage: { id, name: id, createdAt: 1, updatedAt: 1 },
+    scenes: [
+      {
+        id: `${id}-scene`,
+        stageId: id,
+        type: 'slide',
+        title: id,
+        order: 1,
+        content: {
+          type: 'slide',
+          canvas: slide(`${id}-slide`, [{ id: `${id}-audio`, type: 'audio', src: ref }]),
+        },
+      },
+    ],
+  } as unknown as StageAssetDocument;
+}
+
 function documentWithManifestRef(id: string, ref: string): StageAssetDocument {
   return {
     stage: {
@@ -343,6 +362,33 @@ describe('stage asset reference and reclamation matrix', () => {
     expect(mocks.removeAsset).not.toHaveBeenCalledWith(sharedRef);
     expect(mocks.mediaRows).toEqual([]);
     expect(await resolveImageBytes(survivingDocument)).toBe('shared-surviving-bytes');
+  });
+
+  it('preserves a shared ref referenced by a surviving slide-audio element', async () => {
+    const sharedRef = 'ast_cross_role_alias';
+    const deletedStageId = 'stage-deleted';
+    const deletedDocument = documentWithImage(deletedStageId, sharedRef);
+    const survivingDocument = documentWithSlideAudio('stage-surviving', sharedRef);
+    mocks.mediaRows.splice(0, mocks.mediaRows.length, {
+      id: `${deletedStageId}:${sharedRef}`,
+      stageId: deletedStageId,
+    });
+    mocks.audioRows.splice(0, mocks.audioRows.length);
+    mocks.poolBytes.set(sharedRef, new Blob(['shared-surviving-bytes']));
+    mocks.documents.set(deletedDocument.stage.id, deletedDocument);
+    mocks.documents.set(survivingDocument.stage.id, survivingDocument);
+    const inventory = await loadStageAssetInventory(deletedDocument);
+    const plan = buildStageAssetReclamationPlan(
+      deletedStageId,
+      inventory.refs,
+      inventory.mediaRows,
+      inventory.audioRows,
+    );
+    mocks.documents.delete(deletedStageId);
+
+    await executeStageAssetReclamation(plan, null);
+
+    expect(mocks.removeAsset).not.toHaveBeenCalledWith(sharedRef);
   });
 
   it('preserves the compatibility row of an audio ref a surviving document shares', async () => {

--- a/tests/media/resolve-stored-bytes-equivalence.test.ts
+++ b/tests/media/resolve-stored-bytes-equivalence.test.ts
@@ -2,9 +2,9 @@
  * Frozen-base differential harness for the shared stored-bytes resolver.
  *
  * The three export paths this branch collapses into `resolveStoredBytes` are
- * reproduced below **verbatim** as they stand at commit `e1578083` — the merge
- * base this branch was cut from, and (at the time of writing) still identical
- * to `main`, since no commit between the two touched these functions:
+ * reproduced below **verbatim** from their pre-#1116 implementations as of
+ * commit `e1578083`. They are preserved as the differential evidence for the
+ * shared resolver. This branch now sits on post-#1116 main at `1a151c4a`:
  *
  * - `pooledBytesForRef`            — `lib/export/classroom-zip-utils.ts`
  * - `resolveStoredMediaBlob` + `fetchBlob`
@@ -28,20 +28,33 @@
  * sequence, the arguments, and the results are unchanged, which is what a
  * caller can observe.
  *
- * Exactly one divergence is permitted, and it is asserted to occur exactly
- * where it is documented and nowhere else: a PPTX compatibility row whose
- * `blob` is missing threw a `TypeError` out of the frozen implementation and
- * falls through to the next byte source in the current one.
+ * Two precisely counted divergence classes are permitted:
  *
- * Scope, so this file is not mistaken for total coverage: it drives the three
- * real call sites and only those. Option combinations no call site uses --
- * `taskUrlFallback` without `resolutionGating`, most obviously -- are outside
- * it by construction and are covered by the targeted cases in
- * `resolve-stored-bytes.test.ts`. A change that is unobservable under all
- * three call sites' options (leaking the task into the gate, for instance)
- * does not red this file, and should not: it is unobservable in production
- * too. Nor does this file cover state that mutates mid-await; the supplied
- * row's `error` verdict timing is pinned by its own tests.
+ * - ZIP now passes its preloaded metadata row into the helper, moving the
+ *   compatibility-blob fallback that the historical caller performed after
+ *   `pooledBytesForRef` into the shared resolver. Thus, at this helper
+ *   boundary, a usable supplied row answers after a pool miss. This is a
+ *   relocation, not an archive behavior change; failed and empty rows are
+ *   deliberately excluded by the new call site.
+ * - A PPTX compatibility row whose `blob` is missing threw a `TypeError` out
+ *   of the frozen implementation and falls through to the next byte source in
+ *   the current one.
+ *
+ * Scope, so this file is not mistaken for total coverage: it drives the
+ * current option sets of the three real call sites and only those. Call-site
+ * behavior is additionally covered by the targeted export, video-export, and
+ * resolver suites; no separate caller-level differential machinery is
+ * duplicated here. ZIP's section includes the preloaded row
+ * matrix because that caller now passes `record`; it deliberately omits
+ * `stageId`, gating, CDN fallback, and task fallback because ZIP passes none of
+ * them. Option combinations no call site uses -- `taskUrlFallback` without
+ * `resolutionGating`, most obviously -- are outside it by construction and
+ * are covered by the targeted cases in `resolve-stored-bytes.test.ts`. A
+ * change that is unobservable under all three call sites' options (leaking the
+ * task into the gate, for instance) does not red this file, and should not: it
+ * is unobservable in production too. Nor does this file cover state that
+ * mutates mid-await; the supplied row's `error` verdict timing is pinned by
+ * its own tests.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -355,6 +368,10 @@ const recordCases: RecordCase[] = [
   },
 ];
 
+// ZIP loads by mediaFileKey(stageId, ref), so unlike the generic resolver and
+// video sections it cannot supply a non-compound compatibility-row id.
+const zipRecordCases = recordCases.filter((row) => row.name !== 'non-compound-id');
+
 const STAGES = ['stage-1', undefined] as const;
 
 // ─── Recording rig ──────────────────────────────────────────────────────────
@@ -412,25 +429,55 @@ describe('frozen-base differential harness', () => {
   });
 
   it('classroom ZIP: the shared resolver reproduces the frozen implementation', async () => {
+    const divergences: string[] = [];
     let compared = 0;
     for (const ref of REFS)
       for (const task of taskCases(ref))
         for (const pool of POOL_CASES)
-          for (const fetchMode of FETCH_CASES) {
-            arm(pool, fetchMode, task.tasks);
-            const before = await capture(() => frozenZip(ref));
-            arm(pool, fetchMode, task.tasks);
-            const after = await capture(() =>
-              resolveStoredBytes(ref, {
-                fetchPolicy: { requireOk: false, requireNonEmpty: true },
-              }),
-            );
-            expect(after, `ZIP ${ref} ${task.name} pool=${pool} fetch=${fetchMode}`).toEqual(
-              before,
-            );
-            compared++;
-          }
-    expect(compared).toBe(REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length);
+          for (const fetchMode of FETCH_CASES)
+            for (const row of zipRecordCases) {
+              const label = `ZIP ${ref} ${task.name} pool=${pool} fetch=${fetchMode} row=${row.name}`;
+              const supplied = row.make(ref);
+              arm(pool, fetchMode, task.tasks);
+              const before = await capture(() => frozenZip(ref), supplied);
+              arm(pool, fetchMode, task.tasks);
+              const after = await capture(
+                () =>
+                  resolveStoredBytes(ref, {
+                    record: supplied,
+                    fetchPolicy: { requireOk: false, requireNonEmpty: true },
+                  }),
+                supplied,
+              );
+              compared++;
+              if (before.kind === 'null' && after.kind === 'bytes') {
+                // The compatibility fallback moved from the ZIP caller into
+                // the resolver. Only a usable, non-empty row may account for
+                // this helper-boundary divergence.
+                divergences.push(label);
+                expect(row.name, label).toBe('ok');
+                expect(after.identity, label).toBe('row-blob');
+                expect(after.calls, label).toEqual(before.calls);
+                continue;
+              }
+              expect(after, label).toEqual(before);
+            }
+    expect(compared).toBe(
+      REFS.length * 9 * POOL_CASES.length * FETCH_CASES.length * zipRecordCases.length,
+    );
+    // Every concrete ref bypasses the pool and reaches the supplied row. For
+    // each opaque ref, the row is reached on pool miss/throw (8 fetch-mode
+    // combinations), plus pool URL with the two rejected fetch outcomes
+    // (empty/throw). Exactly one ZIP row case carries usable non-empty bytes.
+    const concreteRefs = REFS.filter(isConcreteMediaAddress).length;
+    const opaqueRefs = REFS.length - concreteRefs;
+    const rowReachingOpaqueCases =
+      (POOL_CASES.length - 1) * FETCH_CASES.length + 1 * (FETCH_CASES.length - 2);
+    expect(divergences.length).toBe(
+      (concreteRefs * POOL_CASES.length * FETCH_CASES.length +
+        opaqueRefs * rowReachingOpaqueCases) *
+        9,
+    );
   });
 
   it('PPTX: the shared resolver reproduces the frozen implementation', async () => {

--- a/tests/media/slide-media-slots.test.ts
+++ b/tests/media/slide-media-slots.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { slideMediaSlotDescriptors, type Slide } from '@openmaic/dsl';
+import { slideMediaReferenceSlots } from '@/lib/media/slide-media-slots';
+
+describe('slide media slot parity', () => {
+  it('keeps the app walker aligned with the canonical DSL role descriptors', () => {
+    const slide = {
+      id: 'roles',
+      background: { type: 'image', image: { src: 'background' } },
+      elements: [
+        { id: 'image', type: 'image', src: 'image' },
+        {
+          id: 'video',
+          type: 'video',
+          src: 'video-src',
+          mediaRef: 'video-ref',
+          poster: 'video-poster',
+        },
+        { id: 'audio', type: 'audio', src: 'audio' },
+      ],
+    } as unknown as Slide;
+
+    const canonical = [...slideMediaSlotDescriptors(slide)].map(({ kind, elementIndex, ref }) => ({
+      kind,
+      elementIndex,
+      ref,
+    }));
+    const app = [...slideMediaReferenceSlots(slide)].map(({ kind, elementIndex, read }) => ({
+      kind,
+      elementIndex,
+      ref: read(),
+    }));
+
+    expect(app).toEqual(canonical);
+    expect(canonical).toEqual([
+      { kind: 'background-image', elementIndex: undefined, ref: 'background' },
+      { kind: 'image-src', elementIndex: 0, ref: 'image' },
+      { kind: 'video-src', elementIndex: 1, ref: 'video-src' },
+      { kind: 'video-media-ref', elementIndex: 1, ref: 'video-ref' },
+      { kind: 'video-poster', elementIndex: 1, ref: 'video-poster' },
+      { kind: 'audio-src', elementIndex: 2, ref: 'audio' },
+    ]);
+  });
+});

--- a/tests/media/video-media-resolution-boundary.test.ts
+++ b/tests/media/video-media-resolution-boundary.test.ts
@@ -67,7 +67,7 @@ describe('video media resolution boundary', () => {
   it('routes the PPTX element path through the unified video resolver', () => {
     const source = readFileSync(join(process.cwd(), 'lib/export/use-export-pptx.ts'), 'utf8');
     expect(source).toMatch(
-      /import\s+\{\s*resolveVideoMediaForElement\s*\}\s+from\s+'@\/lib\/media\/media-task-resolution'/,
+      /import\s+\{[^}]*\bresolveVideoMediaForElement\b[^}]*\}\s+from\s+'@\/lib\/media\/media-task-resolution'/,
     );
     expect(source).toMatch(
       /el\.type === 'video'[\s\S]{0,200}?resolveVideoMediaForElement\([\s\S]{0,300}?documentElements/,

--- a/tests/video-export/assets.test.ts
+++ b/tests/video-export/assets.test.ts
@@ -95,6 +95,39 @@ describe('planAssets — audio', () => {
 });
 
 describe('planAssets — base frame & video', () => {
+  it('keeps ownership and presence separate when one ref is both narration audio and video', () => {
+    const res = plan(
+      [slide('s', [speech('a', 'Narration'), playVideo('v', 'clip')])],
+      { a: { id: 'shared-ref', present: false, format: 'mp3' } },
+      { clip: { id: 'shared-ref', present: true, format: 'mp4' } },
+      stubProbe({}, { v: 8_000 }),
+    );
+
+    const audioEntry = res.plan.entries.find((entry) => entry.kind === 'audio');
+    const videoEntry = res.plan.entries.find((entry) => entry.kind === 'video');
+    expect(audioEntry).toMatchObject({
+      assetId: 'shared-ref',
+      path: 'audio/001-s/speech-001.mp3',
+      present: false,
+    });
+    expect(videoEntry).toMatchObject({
+      assetId: 'shared-ref',
+      path: 'media/clip.mp4',
+      present: true,
+    });
+    expect(videoEntry).not.toHaveProperty('dedupOf');
+    expect(res.scenes[0].narration[0].audio).toMatchObject({
+      assetId: 'shared-ref',
+      present: false,
+    });
+    expect(res.scenes[0].narration[0].audio.assetRef).toBeUndefined();
+    expect(res.scenes[0].videos[0]).toMatchObject({
+      assetId: 'shared-ref',
+      assetRef: 'media/clip.mp4',
+      present: true,
+    });
+  });
+
   it('plans a base frame for a slide scene and stamps base.assetRef', () => {
     const res = plan([slide('s', [speech('a', '')])]);
     expect(res.scenes[0].base).toMatchObject({

--- a/tests/video-export/assets.test.ts
+++ b/tests/video-export/assets.test.ts
@@ -166,6 +166,6 @@ describe('planAssets — base frame & video', () => {
     );
     const path = res.scenes[0].videos[0].assetRef!;
     expect(path).not.toContain('..');
-    expect(path).toBe('media/clip.escape');
+    expect(path).toBe('media/clip.mp4');
   });
 });

--- a/tests/video-export/timeline-deps.test.ts
+++ b/tests/video-export/timeline-deps.test.ts
@@ -10,13 +10,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * user reported as "视频元素丢失"). These tests mock Dexie (no Dexie-in-node
  * harness, per the repo pattern) and run the real factory.
  */
-const mediaToArray = vi.fn();
-const audioGet = vi.fn((..._args: unknown[]) => Promise.resolve(undefined));
+const mediaRows = new Map<string, MediaFileRecord>();
+const mediaGet = vi.fn((id: string) => Promise.resolve(mediaRows.get(id)));
+const audioGet = vi.fn<(id: string) => Promise<unknown>>((_id) => Promise.resolve(undefined));
 vi.mock('@/lib/utils/database', () => ({
+  mediaFileKey: (stageId: string, ref: string) => `${stageId}:${ref}`,
   db: {
-    audioFiles: { get: (...args: unknown[]) => audioGet(...args) },
+    audioFiles: { get: (id: string) => audioGet(id) },
     mediaFiles: {
-      where: () => ({ equals: () => ({ toArray: () => mediaToArray() }) }),
+      get: (...args: [string]) => mediaGet(...args),
     },
   },
 }));
@@ -40,12 +42,16 @@ const fetchMediaUrlMock = vi.fn();
 vi.mock('@/lib/media/fetch-media-url', () => ({
   fetchMediaUrl: (...args: unknown[]) => fetchMediaUrlMock(...args),
 }));
-const resolveAudioBlobMock = vi.fn((..._args: unknown[]) => Promise.resolve(null));
+const resolveAudioBlobMock = vi.fn<(id: string) => Promise<Blob | null>>((_id) =>
+  Promise.resolve(null),
+);
 vi.mock('@/lib/media/resolve-audio-bytes', () => ({
-  resolveAudioBlob: (...args: unknown[]) => resolveAudioBlobMock(...args),
+  resolveAudioBlob: (id: string) => resolveAudioBlobMock(id),
 }));
 
 import { createVideoTimelineDeps } from '@/lib/video-export-app/timeline-deps';
+import { collectVideoAssets } from '@/lib/video-export-app/collect';
+import { compileVideoTimeline } from '@/lib/video-export';
 import { resolveVideoMediaForElement } from '@/lib/media/media-task-resolution';
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import type { MediaFileRecord } from '@/lib/utils/database';
@@ -109,8 +115,14 @@ function slideSceneWithId(
 
 const spotlight = (elementId: string) => ({ type: 'spotlight', elementId });
 
+/** Seed the mocked media table; rows are keyed by their compound id. */
+function seedMedia(...records: MediaFileRecord[]) {
+  for (const record of records) mediaRows.set(record.id, record);
+}
+
 beforeEach(() => {
-  mediaToArray.mockReset();
+  mediaRows.clear();
+  mediaGet.mockClear();
   audioGet.mockReset().mockImplementation(() => Promise.resolve(undefined));
   measureCalls.length = 0;
   fetchMediaUrlMock.mockReset();
@@ -136,10 +148,38 @@ function fakeAudioElement(durationSec: number) {
 }
 
 describe('createVideoTimelineDeps — legacy URL audio fallback', () => {
+  it('ignores slide-audio elements while still loading speech narration', async () => {
+    const slideAudioId = 'ast_slide_audio';
+    const speechAudioId = 'ast_speech_audio';
+    resolveAudioBlobMock.mockImplementation(async (id: string) =>
+      id === speechAudioId ? new Blob(['speech'], { type: 'audio/mpeg' }) : null,
+    );
+    audioGet.mockImplementation(async (id: string) =>
+      id === speechAudioId
+        ? { id, blob: new Blob(['speech'], { type: 'audio/mpeg' }), format: 'mp3', createdAt: 0 }
+        : undefined,
+    );
+    vi.stubGlobal('document', { createElement: () => fakeAudioElement(1.25) });
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:probe');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const speech = { id: 'speech', type: 'speech', text: 'Hello', audioId: speechAudioId };
+    const scene = slideScene({ id: 'slide-audio', type: 'audio', src: slideAudioId }, [speech]);
+
+    const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
+
+    expect(resolveAudioBlobMock).toHaveBeenCalledTimes(1);
+    expect(resolveAudioBlobMock).toHaveBeenCalledWith(speechAudioId);
+    expect(audioGet).toHaveBeenCalledTimes(1);
+    expect(audioGet).toHaveBeenCalledWith(speechAudioId);
+    expect(deps.assets.audio(speech as never)?.present).toBe(true);
+    expect(deps.timing.audioDurationMs(speech as never)).toBe(1250);
+
+    vi.unstubAllGlobals();
+  });
+
   it('ingests a dangling pair through its URL and surfaces a present, probed narration asset', async () => {
     const legacyUrl = 'https://server.example.com/audio/legacy.mp3';
-    mediaToArray.mockResolvedValue([]);
-    fetchMediaUrlMock.mockResolvedValue(
+        fetchMediaUrlMock.mockResolvedValue(
       new Response(new Blob(['narration'], { type: 'audio/mpeg' }), { status: 200 }),
     );
     // The duration probe needs a DOM audio element; this Node environment
@@ -170,8 +210,7 @@ describe('createVideoTimelineDeps — legacy URL audio fallback', () => {
 
   it('keeps a clip missing when the legacy URL will not fetch', async () => {
     const legacyUrl = 'https://server.example.com/audio/gone.mp3';
-    mediaToArray.mockResolvedValue([]);
-    fetchMediaUrlMock.mockResolvedValue(new Response(null, { status: 404 }));
+        fetchMediaUrlMock.mockResolvedValue(new Response(null, { status: 404 }));
 
     const action = { id: 'a1', type: 'speech', text: 'Hello', audioUrl: legacyUrl };
     const scene = slideScene({ id: 'text_1', type: 'text' }, [action]);
@@ -180,11 +219,101 @@ describe('createVideoTimelineDeps — legacy URL audio fallback', () => {
 
     expect(deps.assets.audio(action as never)).toBeNull();
   });
+
+  it('retains an evicted speech row so collection reaches its CDN fallback', async () => {
+    const audioId = 'ast_evicted_speech';
+    const ossKey = 'https://cdn.example/evicted.mp3';
+    const action = { id: 'a1', type: 'speech', text: 'Hello', audioId };
+    const scene = slideScene({ id: 'text_1', type: 'text' }, [action]);
+    const row = {
+      id: audioId,
+      blob: new Blob([], { type: 'audio/mpeg' }),
+      format: 'mp3',
+      duration: 3.25,
+      ossKey,
+      createdAt: 0,
+    };
+    audioGet.mockResolvedValue(row);
+    resolveAudioBlobMock.mockResolvedValue(null);
+    const fetchSpy = vi.fn(
+      async () => new Response(new Blob(['cdn-speech'], { type: 'audio/mpeg' })),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
+    expect(deps.records.audioById.get(audioId)).toBe(row);
+    expect(deps.assets.audio(action as never)).toMatchObject({ present: true, durationMs: 3250 });
+
+    const result = await collectVideoAssets(
+      {
+        assets: {
+          entries: [{ assetId: audioId, kind: 'audio', path: 'audio/evicted.mp3', present: true }],
+        },
+      } as never,
+      [scene],
+      deps.records,
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(ossKey);
+    expect(await result.blobs.get('audio/evicted.mp3')?.text()).toBe('cdn-speech');
+    expect(result.missing).toEqual([]);
+  });
+
+  it('round-trips one opaque ref as speech audio and later video media', async () => {
+    const sharedRef = 'ast_cross_kind';
+    const speech = { id: 'speech', type: 'speech', text: 'Hello', audioId: sharedRef };
+    const play = { id: 'play', type: 'play_video', elementId: 'video-1' };
+    const audioScene = slideSceneWithId('audio-scene', { id: 'text', type: 'text' }, [speech]);
+    const videoScene = slideSceneWithId(
+      'video-scene',
+      { id: 'video-1', type: 'video', mediaRef: sharedRef, autoplay: false },
+      [play],
+    );
+    const audioRow = {
+      id: sharedRef,
+      blob: new Blob([], { type: 'audio/mpeg' }),
+      format: 'mp3',
+      duration: 1,
+      ossKey: 'https://cdn.example/shared.mp3',
+      createdAt: 0,
+    };
+    audioGet.mockResolvedValue(audioRow);
+    resolveAudioBlobMock.mockResolvedValue(null);
+    seedMedia(
+      videoRecordFor(sharedRef, {
+        blob: new Blob([], { type: 'video/mp4' }),
+        ossKey: 'https://cdn.example/shared.mp4',
+      }),
+    );
+    const fetchSpy = vi.fn(
+      async (url: string) =>
+        new Response(
+          url.endsWith('.mp3')
+            ? new Blob(['speech-bytes'], { type: 'audio/mpeg' })
+            : new Blob(['video-bytes'], { type: 'video/mp4' }),
+        ),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const scenes = [audioScene, videoScene];
+    const deps = await createVideoTimelineDeps({
+      stage: { id: STAGE_ID },
+      scenes,
+      skipGeometry: true,
+    });
+    expect(deps.records.audioById.has(sharedRef)).toBe(true);
+    expect(deps.records.mediaByElementId.has(sharedRef)).toBe(true);
+
+    const ir = compileVideoTimeline({ stage: { id: STAGE_ID, name: 'Cross kind' }, scenes }, deps);
+    const result = await collectVideoAssets(ir, scenes, deps.records);
+    expect([...result.blobs.values()].some((blob) => blob.type === 'audio/mpeg')).toBe(true);
+    expect([...result.blobs.values()].some((blob) => blob.type === 'video/mp4')).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith('https://cdn.example/shared.mp4');
+  });
 });
 
 describe('createVideoTimelineDeps — media ref bridge', () => {
   it('resolves a play_video element id to its media record via mediaRef', async () => {
-    mediaToArray.mockResolvedValue([videoRecord()]);
+    seedMedia(videoRecord());
     const scene = slideScene({ id: ELEMENT_ID, type: 'video', mediaRef: MEDIA_REF });
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
@@ -197,7 +326,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
   });
 
   it('bridges a legacy placeholder `src` (gen_vid_…) when no explicit mediaRef', async () => {
-    mediaToArray.mockResolvedValue([videoRecord()]);
+    seedMedia(videoRecord());
     const scene = slideScene({ id: ELEMENT_ID, type: 'video', src: MEDIA_REF });
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
@@ -205,7 +334,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
   });
 
   it('returns null for an element with no generated media', async () => {
-    mediaToArray.mockResolvedValue([videoRecord()]);
+    seedMedia(videoRecord());
     const scene = slideScene({ id: 'plain_text', type: 'text' });
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
@@ -213,8 +342,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
   });
 
   it('plans a concrete src instead of a stale opaque mediaRef', async () => {
-    mediaToArray.mockResolvedValue([]);
-    const concreteSrc = 'https://cdn.example/direct.mp4';
+        const concreteSrc = 'https://cdn.example/direct.mp4';
     const element = {
       id: ELEMENT_ID,
       type: 'video',
@@ -244,7 +372,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
     const SHARED_ID = 'video_001';
     const REF_A = 'gen_vid_aaa';
     const REF_B = 'gen_vid_bbb';
-    mediaToArray.mockResolvedValue([videoRecordFor(REF_A), videoRecordFor(REF_B)]);
+    seedMedia(videoRecordFor(REF_A), videoRecordFor(REF_B));
 
     const play = (elementId: string) => ({ type: 'play_video', elementId });
     const sceneA = slideSceneWithId('scene-a', { id: SHARED_ID, type: 'video', mediaRef: REF_A }, [
@@ -266,8 +394,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
 
 describe('createVideoTimelineDeps — geometry probe', () => {
   it('pre-measures the content box of spotlight/laser/video targets and serves it', async () => {
-    mediaToArray.mockResolvedValue([]);
-    const scene = slideScene({ id: 'text_1', type: 'text' }, [spotlight('text_1')]);
+        const scene = slideScene({ id: 'text_1', type: 'text' }, [spotlight('text_1')]);
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
 
@@ -284,8 +411,7 @@ describe('createVideoTimelineDeps — geometry probe', () => {
   });
 
   it('does not render a scene with no effect/video targets', async () => {
-    mediaToArray.mockResolvedValue([]);
-    const scene = slideScene({ id: 'text_1', type: 'text' }, []);
+        const scene = slideScene({ id: 'text_1', type: 'text' }, []);
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
     expect(measureCalls).toHaveLength(0);

--- a/tests/video-export/timeline-deps.test.ts
+++ b/tests/video-export/timeline-deps.test.ts
@@ -177,6 +177,44 @@ describe('createVideoTimelineDeps — legacy URL audio fallback', () => {
     vi.unstubAllGlobals();
   });
 
+  it('loads and probes narration in speech order when the manifest sees slide audio first', async () => {
+    const audioA = new Blob(['speech-a'], { type: 'audio/mpeg' });
+    const audioB = new Blob(['speech-b'], { type: 'audio/mpeg' });
+    const blobs = new Map([
+      ['ast_speech_a', audioA],
+      ['ast_speech_b', audioB],
+    ]);
+    const probeOrder: string[] = [];
+    audioGet.mockImplementation(async (id: string) => ({
+      id,
+      blob: blobs.get(id),
+      format: 'mp3',
+      createdAt: 0,
+    }));
+    resolveAudioBlobMock.mockImplementation(async (id: string) => blobs.get(id) ?? null);
+    vi.stubGlobal('document', { createElement: () => fakeAudioElement(1) });
+    vi.spyOn(URL, 'createObjectURL').mockImplementation((blob) => {
+      probeOrder.push(blob === audioA ? 'ast_speech_a' : 'ast_speech_b');
+      return `blob:probe-${probeOrder.length}`;
+    });
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const scene = slideScene({ id: 'slide-audio-b', type: 'audio', src: 'ast_speech_b' }, [
+      { id: 'speech-a', type: 'speech', text: 'A', audioId: 'ast_speech_a' },
+      { id: 'speech-b', type: 'speech', text: 'B', audioId: 'ast_speech_b' },
+    ]);
+
+    await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
+
+    expect(audioGet.mock.calls.map(([id]) => id)).toEqual(['ast_speech_a', 'ast_speech_b']);
+    expect(resolveAudioBlobMock.mock.calls.map(([id]) => id)).toEqual([
+      'ast_speech_a',
+      'ast_speech_b',
+    ]);
+    expect(probeOrder).toEqual(['ast_speech_a', 'ast_speech_b']);
+
+    vi.unstubAllGlobals();
+  });
+
   it('ingests a dangling pair through its URL and surfaces a present, probed narration asset', async () => {
     const legacyUrl = 'https://server.example.com/audio/legacy.mp3';
     fetchMediaUrlMock.mockResolvedValue(

--- a/tests/video-export/timeline-deps.test.ts
+++ b/tests/video-export/timeline-deps.test.ts
@@ -179,7 +179,7 @@ describe('createVideoTimelineDeps — legacy URL audio fallback', () => {
 
   it('ingests a dangling pair through its URL and surfaces a present, probed narration asset', async () => {
     const legacyUrl = 'https://server.example.com/audio/legacy.mp3';
-        fetchMediaUrlMock.mockResolvedValue(
+    fetchMediaUrlMock.mockResolvedValue(
       new Response(new Blob(['narration'], { type: 'audio/mpeg' }), { status: 200 }),
     );
     // The duration probe needs a DOM audio element; this Node environment
@@ -210,7 +210,7 @@ describe('createVideoTimelineDeps — legacy URL audio fallback', () => {
 
   it('keeps a clip missing when the legacy URL will not fetch', async () => {
     const legacyUrl = 'https://server.example.com/audio/gone.mp3';
-        fetchMediaUrlMock.mockResolvedValue(new Response(null, { status: 404 }));
+    fetchMediaUrlMock.mockResolvedValue(new Response(null, { status: 404 }));
 
     const action = { id: 'a1', type: 'speech', text: 'Hello', audioUrl: legacyUrl };
     const scene = slideScene({ id: 'text_1', type: 'text' }, [action]);
@@ -342,7 +342,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
   });
 
   it('plans a concrete src instead of a stale opaque mediaRef', async () => {
-        const concreteSrc = 'https://cdn.example/direct.mp4';
+    const concreteSrc = 'https://cdn.example/direct.mp4';
     const element = {
       id: ELEMENT_ID,
       type: 'video',
@@ -394,7 +394,7 @@ describe('createVideoTimelineDeps — media ref bridge', () => {
 
 describe('createVideoTimelineDeps — geometry probe', () => {
   it('pre-measures the content box of spotlight/laser/video targets and serves it', async () => {
-        const scene = slideScene({ id: 'text_1', type: 'text' }, [spotlight('text_1')]);
+    const scene = slideScene({ id: 'text_1', type: 'text' }, [spotlight('text_1')]);
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
 
@@ -411,7 +411,7 @@ describe('createVideoTimelineDeps — geometry probe', () => {
   });
 
   it('does not render a scene with no effect/video targets', async () => {
-        const scene = slideScene({ id: 'text_1', type: 'text' }, []);
+    const scene = slideScene({ id: 'text_1', type: 'text' }, []);
 
     const deps = await createVideoTimelineDeps({ stage: { id: STAGE_ID }, scenes: [scene] });
     expect(measureCalls).toHaveLength(0);


### PR DESCRIPTION
Lands epic #1007 part 3: the standardized asset manifest and the export convergence on top of it. Stacked on #1101 (part 2c) and #1116 (part 3a, the shared byte resolver); rebased onto `main` after both merged.

**The manifest** lives in `@openmaic/dsl` (`asset-manifest.ts`, dsl 0.9.0 → 0.10.0): `enumerateAssetManifest(document, { metadata? })` is an IO-free enumeration of every media reference a document touches — allocated ids, legacy `gen_*` placeholders, and concrete URLs verbatim — one entry per distinct `(ref, kind)` pair in deterministic first-occurrence order, with kind and optional metadata. This settles #779's open question 4: the manifest is the id-based reference enumeration with metadata, explicitly not content hashes and not a resolution result. The `(ref, kind)` pairing matters because `AssetRef` is an unconstrained string alias: one ref can legally occur as image/video media and as narration audio, and consumers that partition entries by kind would otherwise silently drop a role. The optional metadata callback is caller-controlled enrichment; the enumeration itself is pure over the document and the callback must not mutate it. A new `@openmaic/exporter` package was deliberately not created. Media-role classification is single-sourced: the DSL exports a canonical read-only slide-media slot descriptor, and the app's slot walker and ownership/ref collection layer on top of it — adding a role is one edit, not three synchronized walkers.

**The convergence.** All three consumers derive their reference sets from the manifest:

- **ZIP**: reference sets come from the manifest instead of scanning the stage's Dexie tables. Behavior change, stated plainly: archives contain exactly the media the document references. Orphan rows no longer ride along, failed/byteless rows ship nothing, and referenced pool-only assets are now collected. The classroom ZIP intentionally excludes `Stage.whiteboard` refs: the classroom format does not serialize that field and import cannot reconstruct it (scene whiteboards remain portable). Byte resolution is pool-first, and after a pool miss it uses the referenced Dexie compatibility row as the legacy byte fallback (the frozen-base differential harness pins that relocation exactly: 702 helper-boundary null-to-bytes divergences, `ok`-row only, `row-blob` identity, identical call trace). Archive names never interpolate refs — sequential safe paths (`media/asset-<n>.<ext>`, `audio/audio-<n>.<ext>`) with the original ref preserved through an explicit `sourceRef` mapping on every independently indexed media entry: generated media assets, poster assets, primary narration, and legacy URL narration (the legacy URL itself is the entry's sourceRef). Extensions are allowlisted per kind. The one exception is the legacy sibling poster byte copy (`media/asset-<n>.poster.<ext>`, written next to its video when the video record still carries the pre-pool poster bytes): it is not an independently referenced document asset, so it has no mediaIndex entry or sourceRef of its own — its identity is derivable from its parent video entry, and import reconstructs it by sibling-path derivation from that entry, reusing the poster's own indexed allocation when one exists.
- **Video**: reference sets from the manifest; scene-scoped elementId→mediaRef bridge semantics preserved. Audio loading is speech-action-only — the manifest acts as a membership gate while `speechPairs` order is retained — slide audio is never loaded or duration-probed, and evicted speech rows (empty local blob, valid `ossKey`, stored duration) are retained so the CDN fallback still runs.
- **PPTX**: media reference candidates derive from the manifest (element iteration remains for layout/coordinates/z-order/video binding); one resolver-backed helper resolves them; the old placeholder gate that skipped allocated `ast_*` refs is gone.

**Media coherence contract.** The export contract guarantees label coherence: archive paths, filename extensions, and serialized MIME metadata are mutually coherent and are a canonical function of the authoritative kind metadata. It intentionally does not guarantee that those labels match the payload bytes, because exporters neither inspect nor transcode bytes; a byte/kind mismatch is already-corrupt store state outside the export contract. This matches runtime and renderer behavior, which likewise trust authoritative kind metadata. A 42-cell coherence matrix (3 kinds × 6 metadata classes × 7 surfaces) enforces the contract end to end — canonical path + serialized metadata + import classification per cell — with a boundary pin and mutation evidence.

**Ownership and hygiene.** The manifest's `referenceCounts`, the app's exclusive-ownership consumer, and the video-export planner all key owners positionally or by `(id, kind)` rather than user-controlled strings — duplicate ids are structurally valid documents and shared refs used across kinds keep independent ownership. Because `AssetRef` is unconstrained, a ref can legally be `"__proto__"` or `"constructor"`: every ref-keyed lookup this change introduces is prototype-safe (Map / null-prototype containers, explicit membership, string validation; media-task lookup centralized in one own-property-checked `lookupMediaTask`, pinned by a `buildPptxBlob` regression with a re-keyed adversarial task).

**Review.** Nine single-vendor red-team rounds (Codex) with fix rounds to closure, including the three review points above (safe archive paths + sourceRef mappings; canonical slot descriptor; manifest-derived consumer sets) and the subsequent hardening rounds: extension/kind/MIME coherence (the 42-cell matrix), narration order, cross-kind planner ownership, and the coherence-contract boundary. The final convergence gate (round 9) passed with zero findings. The second review pass's two findings — the task-owned poster binding through the PPTX manifest guard, and legacy-narration sourceRef completeness — are fixed with red→green coverage at this head.

**Validation** (Node 22): TypeScript, Prettier, and ESLint clean (changed files: 0 errors, 0 warnings). The root export/video/media/import battery passes 985 tests (5 skipped), `@openmaic/dsl` passes 238, and the package-version gate passes at `@openmaic/dsl` 0.9.0 → 0.10.0. The frozen-base differential harness (from #1116, updated to the current call-site option sets) pins resolver equivalence at 702 / 714 / 0 permitted divergences across ZIP / PPTX / video.

Refs #1007

