### PR TITLE
fix(video-export): constrain GenUI iframe visibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,9 +86,10 @@ services:
       - NET_ADMIN
     environment:
       - PORT=9000
-      # The standard CPU profile is explicit: BeginFrame, one producer worker,
-      # one render, and one extraction. Select low-memory explicitly instead of
-      # allowing producer to silently change capture mode from cgroup heuristics.
+      # The standard CPU profile prefers BeginFrame but permits producer's
+      # compatibility fallback (for example iframe GenUI). It still fixes one
+      # producer worker, one render, and one extraction. Select low-memory to
+      # force screenshot instead of relying on producer auto-selection.
       - RENDER_RESOURCE_PROFILE=${RENDER_RESOURCE_PROFILE:-standard}
       - PRODUCER_HEADLESS_SHELL_PATH=/usr/bin/chromium-headless-shell
       - RENDER_MAX_CONCURRENCY=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,9 +108,9 @@ services:
       # per-user identity (see render-service/README.md).
       - RENDER_MAX_JOBS_PER_USER=0
     # Bound RAM: each render (Chromium + FFmpeg + archive expansion) is memory-heavy.
-    # The standard profile requires 10 GiB. For the explicit low-memory profile,
+    # The standard profile requires 8 GiB. For the explicit low-memory profile,
     # set RENDER_RESOURCE_PROFILE=low-memory and RENDER_SERVICE_MEMORY_LIMIT=4g.
-    mem_limit: ${RENDER_SERVICE_MEMORY_LIMIT:-10g}
+    mem_limit: ${RENDER_SERVICE_MEMORY_LIMIT:-8g}
     # Chromium media/frame work can exceed Docker's 64 MiB default shared-memory
     # mount. This is a ceiling inside the selected profile cgroup, not eager allocation.
     shm_size: 2gb

--- a/lib/video-export/emit-hyperframes/index.ts
+++ b/lib/video-export/emit-hyperframes/index.ts
@@ -252,17 +252,25 @@ function placeholderContent(scene: VideoTimelineScene, reason: string, reasonAtt
 }
 
 /** The base layer for one scene: snapshot, packaged frozen HTML, or placeholder. */
+function sceneBaseId(scene: VideoTimelineScene): string {
+  return `scene-${scene.index + 1}-base`;
+}
+
+function interactiveBaseContentId(scene: VideoTimelineScene): string {
+  return `${sceneBaseId(scene)}-content`;
+}
+
 function renderBase(scene: VideoTimelineScene, labels: VideoExportLabels): string {
   const start = sec(scene.startMs);
   const duration = sec(scene.durationMs);
-  const id = `scene-${scene.index + 1}-base`;
+  const id = sceneBaseId(scene);
   const clip = `id="${id}" class="clip" data-start="${start}" data-duration="${duration}" data-track-index="0"`;
   if (scene.base.kind === 'slide-snapshot' && scene.base.assetRef) {
     return `<img ${clip} src="${escapeHtml(assetUrl(scene.base.assetRef))}" alt="" style="position:absolute;left:0;top:0;width:100%;height:100%;object-fit:contain" />`;
   }
   if (scene.base.kind === 'visual-segments') return '';
   if (scene.base.kind === 'interactive-html' && scene.base.assetRef) {
-    const contentId = `${id}-content`;
+    const contentId = interactiveBaseContentId(scene);
     const fallback = placeholderContent(
       scene,
       labels.interactive.fallback,
@@ -294,7 +302,7 @@ function renderBase(scene: VideoTimelineScene, labels: VideoExportLabels): strin
  */
 function interactiveBaseVisibilityStatements(scene: VideoTimelineScene): string[] {
   if (scene.base.kind !== 'interactive-html' || !scene.base.assetRef) return [];
-  const id = `scene-${scene.index + 1}-base-content`;
+  const id = interactiveBaseContentId(scene);
   const start = sec(scene.startMs);
   const end = sec(scene.startMs + scene.durationMs);
   return [`tl.set('#${id}',{autoAlpha:1},${start});`, `tl.set('#${id}',{autoAlpha:0},${end});`];

--- a/lib/video-export/emit-hyperframes/index.ts
+++ b/lib/video-export/emit-hyperframes/index.ts
@@ -262,15 +262,18 @@ function renderBase(scene: VideoTimelineScene, labels: VideoExportLabels): strin
   }
   if (scene.base.kind === 'visual-segments') return '';
   if (scene.base.kind === 'interactive-html' && scene.base.assetRef) {
+    const contentId = `${id}-content`;
     const fallback = placeholderContent(
       scene,
       labels.interactive.fallback,
       'data-interactive-fallback-reason',
     );
     return [
-      `<div ${clip} data-interactive-static-host data-scene-id="${escapeHtml(scene.id)}" data-ready-timeout-ms="${scene.base.readyTimeoutMs}" data-content-hash="${escapeHtml(scene.base.contentHash)}" style="position:absolute;inset:0;background:#0f172a">`,
-      `  <div data-interactive-fallback>${fallback}</div>`,
-      `  <iframe data-interactive-static-frame data-src="${escapeHtml(assetUrl(scene.base.assetRef))}" title="${escapeHtml(scene.title)}" sandbox="allow-scripts" style="position:absolute;inset:0;width:100%;height:100%;border:0;visibility:hidden;pointer-events:none;background:#fff"></iframe>`,
+      `<div ${clip} data-interactive-static-host data-scene-id="${escapeHtml(scene.id)}" data-ready-timeout-ms="${scene.base.readyTimeoutMs}" data-content-hash="${escapeHtml(scene.base.contentHash)}" style="position:absolute;inset:0">`,
+      `  <div id="${contentId}" data-interactive-static-visibility-wrapper style="position:absolute;inset:0;background:#0f172a;visibility:hidden;opacity:0">`,
+      `    <div data-interactive-fallback>${fallback}</div>`,
+      `    <iframe data-interactive-static-frame data-src="${escapeHtml(assetUrl(scene.base.assetRef))}" title="${escapeHtml(scene.title)}" sandbox="allow-scripts" style="position:absolute;inset:0;width:100%;height:100%;border:0;visibility:hidden;pointer-events:none;background:#fff"></iframe>`,
+      `  </div>`,
       `</div>`,
     ].join('\n');
   }
@@ -281,6 +284,20 @@ function renderBase(scene: VideoTimelineScene, labels: VideoExportLabels): strin
         ? (scene.base.reason ?? '')
         : '';
   return `<div ${clip}>${placeholderContent(scene, reason)}</div>`;
+}
+
+/**
+ * Screenshot capture in Hyperframes 0.7.x does not reliably apply a generic
+ * HTML clip's visibility window when that clip contains an iframe. Keep the
+ * framework-owned clip intact, but guard its visual contents with the same
+ * seek-safe timeline used by the rest of the emitted composition.
+ */
+function interactiveBaseVisibilityStatements(scene: VideoTimelineScene): string[] {
+  if (scene.base.kind !== 'interactive-html' || !scene.base.assetRef) return [];
+  const id = `scene-${scene.index + 1}-base-content`;
+  const start = sec(scene.startMs);
+  const end = sec(scene.startMs + scene.durationMs);
+  return [`tl.set('#${id}',{autoAlpha:1},${start});`, `tl.set('#${id}',{autoAlpha:0},${end});`];
 }
 
 /** Parent-side readiness/fallback bridge for every packaged interactive iframe. */
@@ -1209,6 +1226,7 @@ export function emitHyperframes(
   for (const scene of ir.scenes) {
     sceneHtml.push(`<!-- scene ${scene.index + 1}: ${escapeHtml(scene.title)} -->`);
     sceneHtml.push(renderBase(scene, labels));
+    statements.push(...interactiveBaseVisibilityStatements(scene));
     const visuals = renderVisuals(
       scene,
       labels,

--- a/render-service/README.md
+++ b/render-service/README.md
@@ -34,7 +34,7 @@ poll, then download. Job ids are opaque.
 | Var                                      | Default                     | Meaning                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                                   | `9000`                      | Listen port.                                                                                                                                                                                                                                                                                                                                                        |
-| `RENDER_RESOURCE_PROFILE`                | `standard`                  | `standard` prefers BeginFrame, permits producer compatibility fallback to screenshot, and requires 10 GiB; `low-memory` forces screenshot capture and requires 4 GiB. Both fix one producer worker, one render, and one extraction.                                                                                                                                    |
+| `RENDER_RESOURCE_PROFILE`                | `standard`                  | `standard` prefers BeginFrame, permits producer compatibility fallback to screenshot, and requires 8 GiB; `low-memory` forces screenshot capture and requires 4 GiB. Both fix one producer worker, one render, and one extraction.                                                                                                                                     |
 | `RENDER_MAX_CONCURRENCY`                 | profile: `1`                | Must match the selected profile. Renders beyond the single execution slot queue FIFO.                                                                                                                                                                                                                                                                               |
 | `RENDER_MAX_CONCURRENT_EXTRACTIONS`      | profile: `1`                | Must match the selected profile; bounds archive expansion to one 512 MiB expanded archive at a time.                                                                                                                                                                                                                                                                |
 | `RENDER_MAX_JOBS_PER_USER`               | `1`                         | Active jobs allowed per client identity (0 disables the guard — see note below).                                                                                                                                                                                                                                                                                    |
@@ -119,7 +119,7 @@ docker compose --profile video-export up --build
 ### Standalone (development)
 
 Requires Node 22, Chromium's old headless shell, and FFmpeg on `PATH`. The
-standard profile checks for 10 GiB of available host/cgroup memory before
+standard profile checks for 8 GiB of available host/cgroup memory before
 listening:
 
 ```bash
@@ -139,7 +139,7 @@ The default `standard` CPU profile is the intended 1080p / 30 fps / standard
 quality path: it prefers BeginFrame, while allowing producer to select screenshot
 for compatibility-sensitive compositions such as iframe GenUI. Producer workers
 are fixed at one, and the service admits one render plus one archive extraction
-at a time. It requires at least 10 GiB of host/cgroup memory and an existing
+at a time. It requires at least 8 GiB of host/cgroup memory and an existing
 headless shell so ordinary compositions remain BeginFrame-eligible. No host GPU
 is required or requested; Chromium uses its software/SwiftShader selector.
 

--- a/render-service/README.md
+++ b/render-service/README.md
@@ -34,7 +34,7 @@ poll, then download. Job ids are opaque.
 | Var                                      | Default                     | Meaning                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                                   | `9000`                      | Listen port.                                                                                                                                                                                                                                                                                                                                                        |
-| `RENDER_RESOURCE_PROFILE`                | `standard`                  | `standard` requires BeginFrame and 10 GiB; `low-memory` requires screenshot capture and 4 GiB. Both fix one producer worker, one render, and one extraction.                                                                                                                                                                                                          |
+| `RENDER_RESOURCE_PROFILE`                | `standard`                  | `standard` prefers BeginFrame, permits producer compatibility fallback to screenshot, and requires 10 GiB; `low-memory` forces screenshot capture and requires 4 GiB. Both fix one producer worker, one render, and one extraction.                                                                                                                                    |
 | `RENDER_MAX_CONCURRENCY`                 | profile: `1`                | Must match the selected profile. Renders beyond the single execution slot queue FIFO.                                                                                                                                                                                                                                                                               |
 | `RENDER_MAX_CONCURRENT_EXTRACTIONS`      | profile: `1`                | Must match the selected profile; bounds archive expansion to one 512 MiB expanded archive at a time.                                                                                                                                                                                                                                                                |
 | `RENDER_MAX_JOBS_PER_USER`               | `1`                         | Active jobs allowed per client identity (0 disables the guard — see note below).                                                                                                                                                                                                                                                                                    |
@@ -53,7 +53,7 @@ poll, then download. Job ids are opaque.
 | `PRODUCER_MAX_WORKERS`                   | profile: `1`                | Explicit for both supported profiles so producer auto-sizing cannot raise the worker count.                                                                                                                                                                                                                                                                        |
 | `PRODUCER_ENABLE_BROWSER_POOL`           | profile: `false`            | Disabled because both supported profiles use one worker; no additional Chromium instances are admitted.                                                                                                                                                                                                                                                            |
 | `PRODUCER_HEADLESS_SHELL_PATH`           | `/usr/bin/chromium-headless-shell` (container) | Chromium **headless shell** executable used by producer's beginFrame resolver. Regular Chromium is not equivalent: it may resolve as beginFrame-capable and then reject `HeadlessExperimental.beginFrame`, causing a screenshot fallback.                                                                                                                                |
-| `RENDER_REQUIRE_BEGINFRAME`              | profile-controlled          | `standard` fails the job when producer reports anything except exactly `beginframe`; `low-memory` expects screenshot and does not require BeginFrame.                                                                                                                                                                                                                |
+| `RENDER_REQUIRE_BEGINFRAME`              | profile-controlled          | `false` for both supported profiles. `standard` requests BeginFrame but accepts producer compatibility fallback; `low-memory` forces screenshot. This internal compatibility knob must not be overridden independently.                                                                                                                                            |
 | `PRODUCER_PUPPETEER_PROTOCOL_TIMEOUT_MS` | `900000` (set in Compose)   | CDP timeout headroom for long frame ranges. The producer default of 300 seconds caused long jobs to fall back from four workers to two.                                                                                                                                                                                                                             |
 | `HF_STATIC_DEDUP`                        | `false` (set in Compose)    | Temporary OpenMAIC-export workaround: these long slide compositions currently exhaust producer's 15-second verification budget and disable dedup anyway. Skipping the doomed verification removes the fixed startup cost without changing frames.                                                                                                                   |
 | `RENDER_HOME`                            | `/app`                      | Writable home used after the entrypoint drops privileges. Producer font caches live under `$RENDER_HOME/.cache`, never `/root/.cache`.                                                                                                                                                                                                                              |
@@ -136,13 +136,12 @@ npm start
 ## Resource profiles
 
 The default `standard` CPU profile is the intended 1080p / 30 fps / standard
-quality path: BeginFrame is required, producer workers are fixed at one, and the
-service admits one render plus one archive extraction at a time. It requires at
-least 10 GiB of host/cgroup memory. A missing headless shell, insufficient
-memory, or a producer result whose actual mode is `screenshot`, mixed, or
-unknown fails clearly rather than completing under a different capture path.
-No host GPU is required or requested; Chromium uses its software/SwiftShader
-selector in the standard profile.
+quality path: it prefers BeginFrame, while allowing producer to select screenshot
+for compatibility-sensitive compositions such as iframe GenUI. Producer workers
+are fixed at one, and the service admits one render plus one archive extraction
+at a time. It requires at least 10 GiB of host/cgroup memory and an existing
+headless shell so ordinary compositions remain BeginFrame-eligible. No host GPU
+is required or requested; Chromium uses its software/SwiftShader selector.
 
 Use the safe `low-memory` profile only when BeginFrame latency is less important
 than a smaller memory ceiling. It fixes screenshot capture, one worker, one
@@ -155,10 +154,10 @@ docker compose --profile video-export up --build
 ```
 
 Both `/health` and `GET /render/:jobId` make the selection observable. Health
-reports the requested profile, capture mode, worker/concurrency bounds, minimum
+reports the capture policy, requested mode, worker/concurrency bounds, minimum
 memory, and observed Node, producer, Chromium, and FFmpeg versions. A completed
-or capture-mode-rejected job reports requested versus actual capture mode and
-worker count with the same version record.
+job reports requested versus actual capture mode and worker count with the same
+version record, so a standard-profile screenshot fallback remains explicit.
 
 The previous fixed 720p short-sample comparison that motivated these profiles was:
 

--- a/render-service/src/config.ts
+++ b/render-service/src/config.ts
@@ -40,7 +40,7 @@ export const config = {
   maxConcurrentExtractions: resourceProfile.maxConcurrentExtractions,
   /** Explicit per-job worker count fixed by the selected resource profile. */
   producerWorkers: resourceProfile.producerWorkers,
-  /** Strict-mode hook; current profiles prefer or force a mode without rejecting fallback. */
+  /** Explicit false guard so inherited env cannot turn screenshot fallback rejection back on. */
   requireBeginFrame: resourceProfile.requireBeginFrame,
   /** Active (queued+running) jobs allowed per client identity. 0 disables the guard. */
   maxJobsPerUser: intEnvAllowZero('RENDER_MAX_JOBS_PER_USER', 1),

--- a/render-service/src/config.ts
+++ b/render-service/src/config.ts
@@ -40,7 +40,7 @@ export const config = {
   maxConcurrentExtractions: resourceProfile.maxConcurrentExtractions,
   /** Explicit per-job worker count fixed by the selected resource profile. */
   producerWorkers: resourceProfile.producerWorkers,
-  /** Fail a job if the selected profile requires BeginFrame and producer reports otherwise. */
+  /** Strict-mode hook; current profiles prefer or force a mode without rejecting fallback. */
   requireBeginFrame: resourceProfile.requireBeginFrame,
   /** Active (queued+running) jobs allowed per client identity. 0 disables the guard. */
   maxJobsPerUser: intEnvAllowZero('RENDER_MAX_JOBS_PER_USER', 1),

--- a/render-service/src/main.ts
+++ b/render-service/src/main.ts
@@ -277,6 +277,7 @@ async function main(): Promise<void> {
     console.log(
       `[render-service] listening on :${info.port} ` +
         `(resourceProfile=${config.resourceProfile.name}, ` +
+        `capturePolicy=${config.resourceProfile.capturePolicy}, ` +
         `requestedCaptureMode=${config.resourceProfile.requestedCaptureMode}, ` +
         `maxConcurrency=${config.maxConcurrency}, producerWorkers=${config.producerWorkers}, ` +
         `browserGpuMode=${process.env.PRODUCER_BROWSER_GPU_MODE ?? 'producer-default'}, ` +

--- a/render-service/src/render-executor.ts
+++ b/render-service/src/render-executor.ts
@@ -128,6 +128,7 @@ export function buildRenderExecutionMetrics(
   const failure = observedFailureCapture(job);
   return {
     resourceProfile: config.resourceProfile.name,
+    capturePolicy: config.resourceProfile.capturePolicy,
     requestedCaptureMode: config.resourceProfile.requestedCaptureMode,
     actualCaptureMode:
       job.perfSummary?.drawElement?.mode ??

--- a/render-service/src/resource-profile.ts
+++ b/render-service/src/resource-profile.ts
@@ -43,7 +43,7 @@ function defineProfile(
 }
 
 const PROFILES: Record<ResourceProfileName, ResourceProfile> = {
-  standard: defineProfile('standard', 'prefer-beginframe', 10 * GIB),
+  standard: defineProfile('standard', 'prefer-beginframe', 8 * GIB),
   'low-memory': defineProfile('low-memory', 'screenshot-only', 4 * GIB),
 };
 

--- a/render-service/src/resource-profile.ts
+++ b/render-service/src/resource-profile.ts
@@ -5,9 +5,11 @@ const GIB = 1024 ** 3;
 
 export type ResourceProfileName = 'standard' | 'low-memory';
 export type RequestedCaptureMode = 'beginframe' | 'screenshot';
+export type CapturePolicy = 'prefer-beginframe' | 'screenshot-only';
 
 export interface ResourceProfile {
   name: ResourceProfileName;
+  capturePolicy: CapturePolicy;
   requestedCaptureMode: RequestedCaptureMode;
   requireBeginFrame: boolean;
   producerWorkers: 1;
@@ -24,21 +26,25 @@ const COMMON_LIMITS = {
 
 function defineProfile(
   name: ResourceProfileName,
-  requestedCaptureMode: RequestedCaptureMode,
+  capturePolicy: CapturePolicy,
   minimumMemoryBytes: number,
 ): ResourceProfile {
+  const requestedCaptureMode = capturePolicy === 'screenshot-only' ? 'screenshot' : 'beginframe';
   return {
     name,
+    capturePolicy,
     requestedCaptureMode,
-    requireBeginFrame: requestedCaptureMode === 'beginframe',
+    // BeginFrame is preferred by the standard profile, but producer may select
+    // screenshot for compatibility-sensitive compositions such as iframe GenUI.
+    requireBeginFrame: false,
     ...COMMON_LIMITS,
     minimumMemoryBytes,
   };
 }
 
 const PROFILES: Record<ResourceProfileName, ResourceProfile> = {
-  standard: defineProfile('standard', 'beginframe', 10 * GIB),
-  'low-memory': defineProfile('low-memory', 'screenshot', 4 * GIB),
+  standard: defineProfile('standard', 'prefer-beginframe', 10 * GIB),
+  'low-memory': defineProfile('low-memory', 'screenshot-only', 4 * GIB),
 };
 
 function requiredProducerEnvironment(profile: ResourceProfile): Record<string, string> {
@@ -137,7 +143,7 @@ export function validateResourceProfileStartup(
     );
   }
 
-  if (profile.requireBeginFrame) {
+  if (profile.requestedCaptureMode === 'beginframe') {
     const headlessShellPath = options.headlessShellPath ?? process.env.PRODUCER_HEADLESS_SHELL_PATH;
     const pathExists = options.pathExists ?? existsSync;
     if (!headlessShellPath || !pathExists(headlessShellPath)) {
@@ -152,6 +158,7 @@ export function validateResourceProfileStartup(
 export function publicResourceProfile(profile: ResourceProfile) {
   return {
     name: profile.name,
+    capturePolicy: profile.capturePolicy,
     requestedCaptureMode: profile.requestedCaptureMode,
     requireBeginFrame: profile.requireBeginFrame,
     producerWorkers: profile.producerWorkers,

--- a/render-service/src/types.ts
+++ b/render-service/src/types.ts
@@ -31,6 +31,7 @@ export interface RuntimeVersions {
 
 export interface RenderExecutionMetrics {
   resourceProfile: 'standard' | 'low-memory';
+  capturePolicy: 'prefer-beginframe' | 'screenshot-only';
   requestedCaptureMode: 'beginframe' | 'screenshot';
   actualCaptureMode: string;
   requestedWorkers: number;

--- a/render-service/src/types.ts
+++ b/render-service/src/types.ts
@@ -5,6 +5,11 @@
  * from `@hyperframes/producer`'s internal `RenderJob` so the HTTP contract
  * (and therefore the app) stays stable if the producer's internals change.
  */
+import type {
+  CapturePolicy,
+  RequestedCaptureMode,
+  ResourceProfileName,
+} from './resource-profile.js';
 
 /** Lifecycle of a render job as the app observes it. */
 export type RenderJobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
@@ -30,9 +35,9 @@ export interface RuntimeVersions {
 }
 
 export interface RenderExecutionMetrics {
-  resourceProfile: 'standard' | 'low-memory';
-  capturePolicy: 'prefer-beginframe' | 'screenshot-only';
-  requestedCaptureMode: 'beginframe' | 'screenshot';
+  resourceProfile: ResourceProfileName;
+  capturePolicy: CapturePolicy;
+  requestedCaptureMode: RequestedCaptureMode;
   actualCaptureMode: string;
   requestedWorkers: number;
   actualWorkers: number | null;

--- a/render-service/test/config.test.ts
+++ b/render-service/test/config.test.ts
@@ -63,7 +63,10 @@ describe('config maxJobsPerUser', () => {
 describe('config producerWorkers', () => {
   it('defaults to one explicit worker in the standard profile', async () => {
     delete process.env.PRODUCER_MAX_WORKERS;
-    expect((await loadConfig()).producerWorkers).toBe(1);
+    const config = await loadConfig();
+    expect(config.producerWorkers).toBe(1);
+    expect(config.resourceProfile.capturePolicy).toBe('prefer-beginframe');
+    expect(config.requireBeginFrame).toBe(false);
   });
 
   it('accepts an explicit single-worker profile without silently raising it', async () => {

--- a/render-service/test/container-config.test.ts
+++ b/render-service/test/container-config.test.ts
@@ -24,7 +24,7 @@ describe('render-service container contract', () => {
     expect(compose).toContain('PRODUCER_HEADLESS_SHELL_PATH=/usr/bin/chromium-headless-shell');
     expect(compose).toContain('PRODUCER_PUPPETEER_PROTOCOL_TIMEOUT_MS=900000');
     expect(compose).toContain('HF_STATIC_DEDUP=false');
-    expect(compose).toContain('mem_limit: ${RENDER_SERVICE_MEMORY_LIMIT:-10g}');
+    expect(compose).toContain('mem_limit: ${RENDER_SERVICE_MEMORY_LIMIT:-8g}');
   });
 
   it('configures a beginFrame-capable capture profile in the image', () => {

--- a/render-service/test/render-executor.test.ts
+++ b/render-service/test/render-executor.test.ts
@@ -100,6 +100,7 @@ describe('InProcessExecutor', () => {
       },
       metrics: {
         resourceProfile: 'standard',
+        capturePolicy: 'prefer-beginframe',
         requestedCaptureMode: 'beginframe',
         actualCaptureMode: 'beginframe',
         requestedWorkers: 1,
@@ -197,6 +198,30 @@ describe('InProcessExecutor', () => {
       expect(result.failure.code).toBe('unsupported_capture_mode');
       expect(result.failure.message).toMatch(/beginFrame/i);
     }
+  });
+
+  it('accepts a screenshot fallback under the default prefer-beginframe policy', async () => {
+    const executor = new InProcessExecutor(
+      { runtimeVersions },
+      {
+        createJob(options) {
+          return createRenderJob(options);
+        },
+        async executeJob(job) {
+          setPerformance(job, 'screenshot');
+        },
+      },
+    );
+
+    await expect(executor.execute(request())).resolves.toMatchObject({
+      status: 'succeeded',
+      metrics: {
+        resourceProfile: 'standard',
+        capturePolicy: 'prefer-beginframe',
+        requestedCaptureMode: 'beginframe',
+        actualCaptureMode: 'screenshot',
+      },
+    });
   });
 
   it('does not treat request observability as actual mode on hard failure', async () => {

--- a/render-service/test/render-route.test.ts
+++ b/render-service/test/render-route.test.ts
@@ -127,7 +127,7 @@ describe('POST /render buffering/extraction bound', () => {
         requireBeginFrame: false,
         producerWorkers: 1,
         maxConcurrency: 1,
-        minimumMemoryMiB: 10 * 1024,
+        minimumMemoryMiB: 8 * 1024,
       },
       versions: runtimeVersions,
     });

--- a/render-service/test/render-route.test.ts
+++ b/render-service/test/render-route.test.ts
@@ -122,7 +122,9 @@ describe('POST /render buffering/extraction bound', () => {
       ok: true,
       resourceProfile: {
         name: 'standard',
+        capturePolicy: 'prefer-beginframe',
         requestedCaptureMode: 'beginframe',
+        requireBeginFrame: false,
         producerWorkers: 1,
         maxConcurrency: 1,
         minimumMemoryMiB: 10 * 1024,

--- a/render-service/test/resource-profile.test.ts
+++ b/render-service/test/resource-profile.test.ts
@@ -68,6 +68,12 @@ describe('resource profiles', () => {
         RENDER_MAX_CONCURRENCY: '2',
       }),
     ).toThrow(/requires RENDER_MAX_CONCURRENCY=1/);
+    expect(() =>
+      resolveResourceProfile({
+        RENDER_RESOURCE_PROFILE: 'standard',
+        RENDER_REQUIRE_BEGINFRAME: 'true',
+      }),
+    ).toThrow(/requires RENDER_REQUIRE_BEGINFRAME=false/);
   });
 
   it('fails before startup when memory is below the selected profile minimum', () => {

--- a/render-service/test/resource-profile.test.ts
+++ b/render-service/test/resource-profile.test.ts
@@ -4,14 +4,15 @@ import { resolveResourceProfile, validateResourceProfileStartup } from '../src/r
 const GIB = 1024 ** 3;
 
 describe('resource profiles', () => {
-  it('resolves the standard profile to one BeginFrame worker and bounded service concurrency', () => {
+  it('resolves standard to prefer BeginFrame while allowing compatibility fallback', () => {
     const env: NodeJS.ProcessEnv = {};
     const profile = resolveResourceProfile(env);
 
     expect(profile).toMatchObject({
       name: 'standard',
+      capturePolicy: 'prefer-beginframe',
       requestedCaptureMode: 'beginframe',
-      requireBeginFrame: true,
+      requireBeginFrame: false,
       producerWorkers: 1,
       maxConcurrency: 1,
       maxConcurrentExtractions: 1,
@@ -24,7 +25,7 @@ describe('resource profiles', () => {
       PRODUCER_BROWSER_GPU_MODE: 'software',
       PRODUCER_ENABLE_BROWSER_POOL: 'false',
       PRODUCER_EXPECTED_CHROMIUM_MAJOR: '151',
-      RENDER_REQUIRE_BEGINFRAME: 'true',
+      RENDER_REQUIRE_BEGINFRAME: 'false',
     });
   });
 
@@ -34,6 +35,7 @@ describe('resource profiles', () => {
 
     expect(profile).toMatchObject({
       name: 'low-memory',
+      capturePolicy: 'screenshot-only',
       requestedCaptureMode: 'screenshot',
       requireBeginFrame: false,
       producerWorkers: 1,

--- a/render-service/test/resource-profile.test.ts
+++ b/render-service/test/resource-profile.test.ts
@@ -16,7 +16,7 @@ describe('resource profiles', () => {
       producerWorkers: 1,
       maxConcurrency: 1,
       maxConcurrentExtractions: 1,
-      minimumMemoryBytes: 10 * GIB,
+      minimumMemoryBytes: 8 * GIB,
     });
     expect(env).toMatchObject({
       PRODUCER_MAX_WORKERS: '1',
@@ -74,11 +74,11 @@ describe('resource profiles', () => {
     const standard = resolveResourceProfile({ RENDER_RESOURCE_PROFILE: 'standard' });
     expect(() =>
       validateResourceProfileStartup(standard, {
-        memoryBytes: 8 * GIB,
+        memoryBytes: 7 * GIB,
         headlessShellPath: '/chromium-headless-shell',
         pathExists: () => true,
       }),
-    ).toThrow(/requires at least 10 GiB memory/);
+    ).toThrow(/requires at least 8 GiB memory/);
 
     const lowMemory = resolveResourceProfile({ RENDER_RESOURCE_PROFILE: 'low-memory' });
     expect(() => validateResourceProfileStartup(lowMemory, { memoryBytes: 3 * GIB })).toThrow(
@@ -90,7 +90,7 @@ describe('resource profiles', () => {
     const standard = resolveResourceProfile({ RENDER_RESOURCE_PROFILE: 'standard' });
     expect(() =>
       validateResourceProfileStartup(standard, {
-        memoryBytes: 10 * GIB,
+        memoryBytes: 8 * GIB,
         headlessShellPath: '/missing',
         pathExists: () => false,
       }),

--- a/tests/video-export/emit-hyperframes.test.ts
+++ b/tests/video-export/emit-hyperframes.test.ts
@@ -243,6 +243,54 @@ describe('emitHyperframes frozen interactive HTML', () => {
     expect(html).toContain('window.__openmaicVideoManifest.runtimeDiagnostics');
     expect(html).not.toContain('openmaic-runtime-diagnostics.json');
   });
+
+  it('keeps a later iframe visually inert outside its scene window', () => {
+    const guardedIr = compileVideoTimeline(
+      {
+        stage: { id: 'stage', name: 'Interactive clip visibility' },
+        scenes: [
+          slide('before-widget', [speech('before-widget-speech', 'Before the widget')]),
+          interactive(
+            'later-widget',
+            '<!doctype html><h1>Later widget</h1>',
+            [speech('later-widget-speech', 'The widget scene')],
+            1,
+          ),
+        ],
+      },
+      {
+        timing: NO_PROBE,
+        assets: NO_ASSETS,
+        interactive: stubInteractiveHtml({
+          'later-widget': {
+            id: 'interactive:later-widget',
+            present: true,
+            contentHash: 'c'.repeat(64),
+          },
+        }),
+      },
+    );
+    const guardedHtml = emitHyperframes(guardedIr, { width: 1280, height: 720 }).files.find(
+      (file) => file.path === 'index.html',
+    )!.content;
+    const widget = guardedIr.scenes[1];
+    const start = widget.startMs / 1000;
+    const end = (widget.startMs + widget.durationMs) / 1000;
+    const hostTag = guardedHtml.match(
+      /<div id="scene-2-base"[^>]*data-interactive-static-host[^>]*>/,
+    )?.[0];
+
+    expect(hostTag).toBeDefined();
+    expect(hostTag).not.toContain('background:');
+    expect(guardedHtml).toContain(
+      'id="scene-2-base-content" data-interactive-static-visibility-wrapper',
+    );
+    expect(guardedHtml).toMatch(
+      /id="scene-2-base-content"[^>]*style="[^"]*visibility:hidden;opacity:0[^"]*"/,
+    );
+    expect(guardedHtml).toContain(`tl.set('#scene-2-base-content',{autoAlpha:1},${start});`);
+    expect(guardedHtml).toContain(`tl.set('#scene-2-base-content',{autoAlpha:0},${end});`);
+  });
 });
 
 describe('emitHyperframes static Quiz/PBL cover cards', () => {


### PR DESCRIPTION
## Summary

Fix GenUI iframe visibility during MP4 export so an interactive slide cannot cover earlier slides. The render-service standard profile now prefers BeginFrame while accepting producer-selected screenshot fallback for iframe compatibility.

This PR is AI-assisted and was manually reviewed and tested.

## Related Issues

Fixes #1124

## Changes

- Wrap interactive iframe contents in an explicitly timed, seek-safe GSAP visibility layer while preserving the framework-owned clip.
- Change the standard render profile from BeginFrame-only behavior to `prefer-beginframe`, while keeping the low-memory profile screenshot-only.
- Report capture policy and requested/actual capture modes through health and job metrics.
- Set the standard profile and Compose default memory floor to 8 GiB.
- Consolidate emitted wrapper IDs and render policy types following AI code review.
- Update render-service tests and operator documentation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open `ICW-Bench：互动课件评估解析.maic.zip` and request an MP4 export through render-service.
2. Verify that slides 1–5 render without the slide 6 GenUI iframe, including their slide-action highlights.
3. Verify that the GenUI iframe becomes visible only during slide 6.
4. Confirm the render job reports requested mode `beginframe` and actual mode `screenshot` for the iframe composition.

### What you personally verified

- Manually exported the reproduction deck successfully through OpenMAIC and render-service.
- Confirmed the exported video no longer shows the slide 6 GenUI content over slides 1–5.
- Confirmed the 8 GiB / 6 CPU validation container reports `prefer-beginframe`, `requireBeginFrame=false`, and `minimumMemoryMiB=8192`.
- Ran the OpenMAIC emitter suite (39 tests) and render-service suite (58 tests).
- Ran repository and render-service TypeScript checks, ESLint, Prettier, and `git diff --check`.

### Evidence

- Local automated verification: 39 emitter tests and 58 render-service tests passed.
- Local manual verification: the reported deck exported successfully without cross-slide GenUI coverage.
- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
