### PR TITLE
fix(renderer): preserve literal text line breaks

### DIFF
--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/renderer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React component for rendering PPTist-style Slide JSON, extracted from OpenMAIC.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/renderer/src/elements/shape/BaseShapeElement.tsx
+++ b/packages/@openmaic/renderer/src/elements/shape/BaseShapeElement.tsx
@@ -130,6 +130,7 @@ export function BaseShapeElement({ elementInfo, renderLabel }: BaseShapeElementP
         style={{
           // @ts-expect-error CSS custom properties
           '--paragraphSpace': `${text.paragraphSpace === undefined ? 5 : text.paragraphSpace}px`,
+          whiteSpace: 'pre-line',
         }}
         dangerouslySetInnerHTML={{ __html: text.content }}
       />

--- a/packages/@openmaic/renderer/src/elements/shape/BaseShapeElement.tsx
+++ b/packages/@openmaic/renderer/src/elements/shape/BaseShapeElement.tsx
@@ -8,6 +8,7 @@ import { useElementFlip } from '../shared/useElementFlip';
 import { useElementFill } from '../shared/useElementFill';
 import { GradientDefs } from './GradientDefs';
 import { PatternDefs } from './PatternDefs';
+import { preservesPlainTextLineBreaks } from '../../utils/richText';
 
 export interface BaseShapeElementProps {
   elementInfo: PPTShapeElement;
@@ -130,7 +131,7 @@ export function BaseShapeElement({ elementInfo, renderLabel }: BaseShapeElementP
         style={{
           // @ts-expect-error CSS custom properties
           '--paragraphSpace': `${text.paragraphSpace === undefined ? 5 : text.paragraphSpace}px`,
-          whiteSpace: 'pre-line',
+          whiteSpace: preservesPlainTextLineBreaks(text.content) ? 'pre-line' : undefined,
         }}
         dangerouslySetInnerHTML={{ __html: text.content }}
       />

--- a/packages/@openmaic/renderer/src/elements/text/BaseTextElement.tsx
+++ b/packages/@openmaic/renderer/src/elements/text/BaseTextElement.tsx
@@ -23,6 +23,7 @@ export function BaseTextElement({ elementInfo, target, renderContent }: BaseText
       style={{
         position: 'relative',
         pointerEvents: target === 'thumbnail' ? 'none' : undefined,
+        whiteSpace: 'pre-line',
       }}
       dangerouslySetInnerHTML={{ __html: elementInfo.content }}
     />

--- a/packages/@openmaic/renderer/src/elements/text/BaseTextElement.tsx
+++ b/packages/@openmaic/renderer/src/elements/text/BaseTextElement.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties, ReactNode } from 'react';
 import type { PPTTextElement } from '@openmaic/dsl';
 import { useElementShadow } from '../shared/useElementShadow';
 import { ElementOutline } from '../shared/ElementOutline';
+import { preservesPlainTextLineBreaks } from '../../utils/richText';
 
 export interface BaseTextElementProps {
   elementInfo: PPTTextElement;
@@ -23,7 +24,7 @@ export function BaseTextElement({ elementInfo, target, renderContent }: BaseText
       style={{
         position: 'relative',
         pointerEvents: target === 'thumbnail' ? 'none' : undefined,
-        whiteSpace: 'pre-line',
+        whiteSpace: preservesPlainTextLineBreaks(elementInfo.content) ? 'pre-line' : undefined,
       }}
       dangerouslySetInnerHTML={{ __html: elementInfo.content }}
     />

--- a/packages/@openmaic/renderer/src/styles.ts
+++ b/packages/@openmaic/renderer/src/styles.ts
@@ -16,6 +16,9 @@ export const SLIDE_RENDERER_STYLES = `
 .slide-renderer-prose p:last-child {
   margin-bottom: 0;
 }
+.slide-renderer-prose p:empty::before {
+  content: '\\00a0';
+}
 .slide-renderer-prose .katex-display {
   margin: 0 !important;
 }

--- a/packages/@openmaic/renderer/src/utils/richText.ts
+++ b/packages/@openmaic/renderer/src/utils/richText.ts
@@ -1,0 +1,10 @@
+/**
+ * `content` is an HTML-string contract. Only tag-free values can safely use
+ * `white-space: pre-line`: a newline between rich HTML block tags is source
+ * formatting, not visible slide content.
+ */
+const HTML_TAG_PATTERN = /<\/?[a-z][^>]*>/i;
+
+export function preservesPlainTextLineBreaks(content: string): boolean {
+  return !HTML_TAG_PATTERN.test(content);
+}

--- a/packages/@openmaic/renderer/src/utils/richText.ts
+++ b/packages/@openmaic/renderer/src/utils/richText.ts
@@ -1,10 +1,10 @@
 /**
- * `content` is an HTML-string contract. Only tag-free values can safely use
+ * `content` is an HTML-string contract. Only markup-free values can safely use
  * `white-space: pre-line`: a newline between rich HTML block tags is source
  * formatting, not visible slide content.
  */
-const HTML_TAG_PATTERN = /<\/?[a-z][^>]*>/i;
+const HTML_MARKUP_PATTERN = /<\/?[a-z][^>]*>|<![^>]*>/i;
 
 export function preservesPlainTextLineBreaks(content: string): boolean {
-  return !HTML_TAG_PATTERN.test(content);
+  return !HTML_MARKUP_PATTERN.test(content);
 }

--- a/packages/@openmaic/renderer/test/SlideCanvas.test.tsx
+++ b/packages/@openmaic/renderer/test/SlideCanvas.test.tsx
@@ -84,6 +84,15 @@ describe('SlideCanvas', () => {
     expect(findRule('.slide-renderer-prose li')?.style.display).toBe('list-item');
   });
 
+  it('gives empty static paragraphs a line box', () => {
+    const { container } = render(<SlideCanvas slide={slide} scale={1} chrome={false} />);
+
+    expect(container.querySelector('style')?.textContent).toContain(
+      '.slide-renderer-prose p:empty::before',
+    );
+    expect(container.querySelector('style')?.textContent).toContain("content: '\\00a0';");
+  });
+
   it('does not render elements listed in hiddenElementIds', () => {
     const html = renderToStaticMarkup(
       createElement(SlideCanvas, {

--- a/packages/@openmaic/renderer/test/SlideElement.test.ts
+++ b/packages/@openmaic/renderer/test/SlideElement.test.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
-import type { PPTAudioElement, PPTTextElement } from '../../dsl/src';
+import type { PPTAudioElement, PPTShapeElement, PPTTextElement } from '../../dsl/src';
 import { SlideElement } from '../src/SlideElement';
 
 const textElement: PPTTextElement = {
@@ -32,7 +32,48 @@ const audioElement: PPTAudioElement = {
   src: 'lesson.mp3',
 };
 
+const shapeElement: PPTShapeElement = {
+  id: 'shape-1',
+  type: 'shape',
+  left: 24,
+  top: 32,
+  width: 120,
+  height: 48,
+  rotate: 0,
+  viewBox: [100, 100],
+  path: 'M 0 0 L 100 0 L 100 100 L 0 100 Z',
+  fixedRatio: false,
+  fill: '#ffffff',
+  text: {
+    content: 'First line\nSecond line',
+    align: 'middle',
+    defaultFontName: 'Arial',
+    defaultColor: '#111111',
+  },
+};
+
 describe('SlideElement', () => {
+  it('preserves literal line endings in shape labels', () => {
+    const html = renderToStaticMarkup(
+      createElement(SlideElement, { elementInfo: shapeElement, elementIndex: 3 }),
+    );
+
+    expect(html).toContain('white-space:pre-line');
+  });
+
+  it('does not apply literal-line-ending styling to injected shape-label editor content', () => {
+    const html = renderToStaticMarkup(
+      createElement(SlideElement, {
+        elementInfo: shapeElement,
+        elementIndex: 3,
+        renderShapeLabel: () => createElement('div', { 'data-shape-label-editor': '' }),
+      }),
+    );
+
+    expect(html).toContain('data-shape-label-editor=""');
+    expect(html).not.toContain('white-space:pre-line');
+  });
+
   it('keeps the full-slide root non-interactive and restores events on the visual element target', () => {
     const html = renderToStaticMarkup(
       createElement(SlideElement, {

--- a/packages/@openmaic/renderer/test/SlideElement.test.ts
+++ b/packages/@openmaic/renderer/test/SlideElement.test.ts
@@ -61,6 +61,20 @@ describe('SlideElement', () => {
     expect(html).toContain('white-space:pre-line');
   });
 
+  it('does not preserve source-formatting line endings in rich shape labels', () => {
+    const html = renderToStaticMarkup(
+      createElement(SlideElement, {
+        elementInfo: {
+          ...shapeElement,
+          text: { ...shapeElement.text!, content: '<p>First line</p>\n<p>Second line</p>' },
+        },
+        elementIndex: 3,
+      }),
+    );
+
+    expect(html).not.toContain('white-space:pre-line');
+  });
+
   it('does not apply literal-line-ending styling to injected shape-label editor content', () => {
     const html = renderToStaticMarkup(
       createElement(SlideElement, {

--- a/packages/@openmaic/renderer/test/elements/text/BaseTextElement.test.ts
+++ b/packages/@openmaic/renderer/test/elements/text/BaseTextElement.test.ts
@@ -18,6 +18,28 @@ const textElement: PPTTextElement = {
 };
 
 describe('BaseTextElement', () => {
+  it('preserves literal line endings in static text content', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(BaseTextElement, {
+        elementInfo: { ...textElement, content: 'First line\nSecond line' },
+      }),
+    );
+
+    expect(markup).toContain('white-space:pre-line');
+  });
+
+  it('does not apply literal-line-ending styling to injected editable content', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(BaseTextElement, {
+        elementInfo: textElement,
+        renderContent: () => React.createElement('div', { 'data-text-editor': '' }),
+      }),
+    );
+
+    expect(markup).toContain('data-text-editor=""');
+    expect(markup).not.toContain('white-space:pre-line');
+  });
+
   it('top-aligns text when vAlign is omitted', () => {
     const markup = renderToStaticMarkup(
       React.createElement(BaseTextElement, { elementInfo: textElement }),

--- a/packages/@openmaic/renderer/test/elements/text/BaseTextElement.test.ts
+++ b/packages/@openmaic/renderer/test/elements/text/BaseTextElement.test.ts
@@ -28,6 +28,16 @@ describe('BaseTextElement', () => {
     expect(markup).toContain('white-space:pre-line');
   });
 
+  it('does not preserve source-formatting line endings in rich HTML content', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(BaseTextElement, {
+        elementInfo: { ...textElement, content: '<p>First line</p>\n<p>Second line</p>' },
+      }),
+    );
+
+    expect(markup).not.toContain('white-space:pre-line');
+  });
+
   it('does not apply literal-line-ending styling to injected editable content', () => {
     const markup = renderToStaticMarkup(
       React.createElement(BaseTextElement, {

--- a/packages/@openmaic/renderer/test/utils/richText.test.ts
+++ b/packages/@openmaic/renderer/test/utils/richText.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { preservesPlainTextLineBreaks } from '../../src/utils/richText';
+
+describe('preservesPlainTextLineBreaks', () => {
+  it.each(['First line\nSecond line', 'A&nbsp;\nB', '2 < 3'])
+    ('keeps literal line endings for tag-free content: %j', (content) => {
+      expect(preservesPlainTextLineBreaks(content)).toBe(true);
+    });
+
+  it.each([
+    '<p>A</p>\n<p>B</p>',
+    '<my-widget>content</my-widget>',
+    'A<!-- source note -->\nB',
+    '<!doctype html>\nA',
+  ])('does not preserve source-formatting line endings in HTML markup: %j', (content) => {
+    expect(preservesPlainTextLineBreaks(content)).toBe(false);
+  });
+});

--- a/packages/@openmaic/renderer/test/utils/richText.test.ts
+++ b/packages/@openmaic/renderer/test/utils/richText.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { preservesPlainTextLineBreaks } from '../../src/utils/richText';
 
 describe('preservesPlainTextLineBreaks', () => {
-  it.each(['First line\nSecond line', 'A&nbsp;\nB', '2 < 3'])
-    ('keeps literal line endings for tag-free content: %j', (content) => {
+  it.each(['First line\nSecond line', 'A&nbsp;\nB', '2 < 3'])(
+    'keeps literal line endings for tag-free content: %j',
+    (content) => {
       expect(preservesPlainTextLineBreaks(content)).toBe(true);
-    });
+    },
+  );
 
   it.each([
     '<p>A</p>\n<p>B</p>',


### PR DESCRIPTION
## Summary
- render literal line endings in text elements and shape labels with `white-space: pre-line`
- keep the style scoped to static content so injected editors are unaffected
- bump `@openmaic/renderer` to `0.1.1`

## Validation
- `pnpm --filter @openmaic/renderer test`
- `pnpm --filter @openmaic/renderer typecheck`