### PR TITLE
fix(editor): keep class roster cards reachable when roster overflows

### DIFF
--- a/components/edit/AgentsView/AgentRosterPanel.tsx
+++ b/components/edit/AgentsView/AgentRosterPanel.tsx
@@ -169,7 +169,7 @@ function TeacherCard({ agent, open, onToggle, onUpdate }: TeacherCardProps) {
 
   return (
     <div
-      className="mb-3"
+      className="mb-3 shrink-0"
       style={{
         borderRadius: 13,
         border: '1px solid #e9d8fb',
@@ -297,7 +297,7 @@ function ClassmateCard({
 
   return (
     <div
-      className="mb-[9px]"
+      className="mb-[9px] shrink-0"
       style={{
         borderRadius: 13,
         border: open ? `1px solid ${ringColor}66` : '1px solid #f0f0f2',


### PR DESCRIPTION
## Summary

Prevent class roster cards from shrinking when the roster contains more classmates than the panel can display. This keeps expanded card content and the “Remove from class” control reachable by scrolling.

## Related Issues

Fixes #1134

## Changes

- Add `shrink-0` to teacher and classmate roster cards.
- Keep the fix limited to the roster card layout; no new automated test code was added.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Start OpenMAIC from `main` with the Pro editor enabled.
2. Open a classroom, switch to **Class roster**, and add enough classmates to exceed the panel height.
3. Expand a lower roster card, scroll the roster panel, and use **Remove from class**.

### What you personally verified

- Tested locally in Chromium with a 9-member roster.
- Confirmed the roster scroll container had `scrollHeight=989` and `clientHeight=559`.
- Confirmed the expanded card footer and **Remove from class** were visible after scrolling.
- Clicked **Remove from class** and confirmed the roster changed from 9 members to 8.
- No automated regression test was added; the overflow regression was verified through the real browser flow above.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6fc401c7-36c7-4d94-8dd7-10b33402df05" />


## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings

This change was prepared with AI assistance and reviewed against the upstream source and local browser behavior.

cc @wyuc
