### PR TITLE
fix(editor): align editable shape labels with text

### DIFF
--- a/packages/@openmaic/editor/package.json
+++ b/packages/@openmaic/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/editor",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Composable slide editing core, React surface, and UI for OpenMAIC.",
   "type": "module",
   "main": "./dist/core/index.js",

--- a/packages/@openmaic/editor/src/react/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/editor/src/react/EditableSlideCanvas.tsx
@@ -616,8 +616,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
               style={{
                 position: 'absolute',
                 inset: 0,
-                pointerEvents:
-                  hasActiveEditor || creationActive ? 'none' : 'auto',
+                pointerEvents: hasActiveEditor || creationActive ? 'none' : 'auto',
                 touchAction: editingTouchAction,
               }}
             />

--- a/packages/@openmaic/editor/src/react/EditableSlideCanvas.tsx
+++ b/packages/@openmaic/editor/src/react/EditableSlideCanvas.tsx
@@ -128,6 +128,9 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
       !element.lock &&
       !hiddenElementIds?.includes(element.id),
   )?.id;
+  const hasActiveEditor = Boolean(
+    activeEditingTextId || activeEditingShapeId || activeEditingTableId,
+  );
   const textControllerRef = useRef<TextEditorController | null>(null);
   const tableEditorRef = useRef<RendererTableEditorController | null>(null);
   const textAutoSizeRef = useRef<TextAutoSizeController | null>(null);
@@ -171,7 +174,13 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
 
   const handleTextClick = useCallback(
     (element: PPTElement, event: ReactPointerEvent) => {
-      if (!textEditingEnabled || element.type !== 'text' || element.lock) return;
+      if (
+        !textEditingEnabled ||
+        (element.type !== 'text' && element.type !== 'shape') ||
+        element.lock ||
+        (element.type === 'shape' && isSemanticallyEmptyText(element.text?.content ?? ''))
+      )
+        return;
       pendingTextFocusPointRef.current = {
         elementId: element.id,
         left: event.clientX,
@@ -447,9 +456,15 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
     (element: PPTShapeElement, defaultContent: ReactNode) => {
       if (activeEditingShapeId !== element.id)
         return renderShapeLabel?.(element, defaultContent) ?? defaultContent;
+      const pendingFocusPoint = pendingTextFocusPointRef.current;
+      const initialFocusPoint =
+        pendingFocusPoint?.elementId === element.id
+          ? { left: pendingFocusPoint.left, top: pendingFocusPoint.top }
+          : undefined;
       return (
         <RendererShapeLabelEditor
           element={element}
+          initialFocusPoint={initialFocusPoint}
           onContentChange={onTextContentChange}
           onFormatChange={onTextFormatChange}
           onControllerChange={handleTextEditorChange}
@@ -520,7 +535,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
   const handleCanvasPointerDownCapture = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
       if (creationActive) return;
-      if ((!activeEditingTextId && !activeEditingTableId) || event.button !== 0) return;
+      if (!hasActiveEditor || event.button !== 0) return;
       const target = event.target;
       if (
         target instanceof Element &&
@@ -532,7 +547,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
       }
       publishSelection(EMPTY_SELECTION);
     },
-    [activeEditingTableId, activeEditingTextId, creationActive, publishSelection],
+    [creationActive, hasActiveEditor, publishSelection],
   );
 
   return (
@@ -602,7 +617,7 @@ export function EditableSlideCanvas(props: EditableSlideCanvasProps) {
                 position: 'absolute',
                 inset: 0,
                 pointerEvents:
-                  activeEditingTextId || activeEditingTableId || creationActive ? 'none' : 'auto',
+                  hasActiveEditor || creationActive ? 'none' : 'auto',
                 touchAction: editingTouchAction,
               }}
             />

--- a/packages/@openmaic/editor/src/react/shape/RendererShapeLabelEditor.tsx
+++ b/packages/@openmaic/editor/src/react/shape/RendererShapeLabelEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, type CSSProperties } from 'react';
 import type { PPTShapeElement, ShapeText } from '@openmaic/dsl';
 
 import { useElementFlip } from '@openmaic/renderer/elements';
@@ -11,6 +11,7 @@ import type { EditIntent } from '../types';
 
 export interface RendererShapeLabelEditorProps {
   element: PPTShapeElement;
+  initialFocusPoint?: { left: number; top: number };
   onContentChange?: (change: TextContentChange) => void;
   onFormatChange?: (elementId: string, state: TextFormatState) => void;
   onControllerChange?: (controller: TextEditorController | null) => void;
@@ -33,6 +34,7 @@ function shapeText(element: PPTShapeElement): ShapeText {
 /** Inline ProseMirror label editor for a Shape selected in the renderer canvas. */
 export function RendererShapeLabelEditor({
   element,
+  initialFocusPoint,
   onContentChange,
   onFormatChange,
   onControllerChange,
@@ -72,7 +74,7 @@ export function RendererShapeLabelEditor({
   return (
     <div
       data-renderer-shape-label-editor={element.id}
-      className="shape-text"
+      className="shape-text slide-renderer-prose"
       style={{
         position: 'absolute',
         inset: 0,
@@ -82,6 +84,11 @@ export function RendererShapeLabelEditor({
         overflowWrap: 'break-word',
         lineHeight: text.lineHeight,
         letterSpacing: `${text.wordSpace || 0}px`,
+        // Match BaseShapeElement: paragraph margins affect the content height,
+        // which in turn affects vertically centered Shape labels.
+        ...({
+          '--paragraphSpace': `${text.paragraphSpace === undefined ? 5 : text.paragraphSpace}px`,
+        } as CSSProperties),
         transform: flipStyle,
       }}
     >
@@ -92,6 +99,7 @@ export function RendererShapeLabelEditor({
         defaultColor={text.defaultColor}
         defaultFontName={text.defaultFontName}
         autoFocus
+        initialFocusPoint={initialFocusPoint}
         onContentChange={onContentChange}
         onFormatChange={onFormatChange}
         onControllerChange={handleControllerChange}

--- a/packages/@openmaic/editor/src/react/styles.ts
+++ b/packages/@openmaic/editor/src/react/styles.ts
@@ -1,4 +1,8 @@
+import { createTextProseStyles } from '@openmaic/renderer';
+
 export const EDITOR_REACT_STYLES = `
+${createTextProseStyles('.renderer-prosemirror-editor .ProseMirror')}
+
 .renderer-prosemirror-editor {
   cursor: text;
 }
@@ -8,25 +12,4 @@ export const EDITOR_REACT_STYLES = `
   outline: none;
 }
 
-.renderer-prosemirror-editor ul {
-  list-style-position: outside !important;
-  padding-inline-start: 1.5rem !important;
-}
-
-.renderer-prosemirror-editor ul:not([style*='list-style-type']) {
-  list-style-type: disc !important;
-}
-
-.renderer-prosemirror-editor ol {
-  list-style-position: outside !important;
-  padding-inline-start: 1.5rem !important;
-}
-
-.renderer-prosemirror-editor ol:not([style*='list-style-type']) {
-  list-style-type: decimal !important;
-}
-
-.renderer-prosemirror-editor li {
-  display: list-item !important;
-}
 `;

--- a/packages/@openmaic/editor/src/react/text/prosemirror/commands/setTextIndent.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/commands/setTextIndent.ts
@@ -28,6 +28,9 @@ function setNodeIndentMarkup(
   const nodeAttrs = {
     ...node.attrs,
     [indentKey]: indent,
+    // A toolbar indent adjustment takes over from an imported absolute CSS
+    // length and uses the editor's canonical em-based indent representation.
+    ...(indentKey === 'textIndent' ? { textIndentCss: '' } : null),
   };
 
   return tr.setNodeMarkup(pos, node.type, nodeAttrs, node.marks);

--- a/packages/@openmaic/editor/src/react/text/prosemirror/document.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/document.ts
@@ -12,7 +12,12 @@ export function createTextDocument(html: string): ProseMirrorNode {
   if (HTML_MARKUP_PATTERN.test(html)) {
     template.innerHTML = html;
   } else {
-    const lines = html.split(/\r\n?|\n/);
+    // Match the renderer's `dangerouslySetInnerHTML` semantics for entities
+    // while keeping the tag-free path as text, then make its literal line
+    // endings explicit ProseMirror hard breaks.
+    const decoded = document.createElement('template');
+    decoded.innerHTML = html;
+    const lines = (decoded.content.textContent ?? '').split(/\r\n?|\n/);
     lines.forEach((line, index) => {
       if (index > 0) template.content.append(document.createElement('br'));
       template.content.append(document.createTextNode(line));

--- a/packages/@openmaic/editor/src/react/text/prosemirror/document.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/document.ts
@@ -5,9 +5,19 @@ import {
 } from 'prosemirror-model';
 import { textSchema } from './schema';
 
+const HTML_MARKUP_PATTERN = /<\/?[a-z][^>]*>|<![^>]*>/i;
+
 export function createTextDocument(html: string): ProseMirrorNode {
   const template = document.createElement('template');
-  template.innerHTML = html;
+  if (HTML_MARKUP_PATTERN.test(html)) {
+    template.innerHTML = html;
+  } else {
+    const lines = html.split(/\r\n?|\n/);
+    lines.forEach((line, index) => {
+      if (index > 0) template.content.append(document.createElement('br'));
+      template.content.append(document.createTextNode(line));
+    });
+  }
   return ProseMirrorDOMParser.fromSchema(textSchema).parse(template.content);
 }
 

--- a/packages/@openmaic/editor/src/react/text/prosemirror/schema/marks.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/schema/marks.ts
@@ -1,6 +1,9 @@
 import { marks } from 'prosemirror-schema-basic';
 import type { MarkSpec } from 'prosemirror-model';
 
+const CSS_LENGTH_PATTERN =
+  /^-?(?:\d+|\d*\.\d+)(?:px|pt|pc|mm|cm|in|rem|em|ex|ch|vw|vh|vmin|vmax|%)$/i;
+
 const subscript: MarkSpec = {
   excludes: 'subscript',
   parseDOM: [
@@ -115,6 +118,55 @@ const fontsize: MarkSpec = {
   },
 };
 
+const letterSpacing: MarkSpec = {
+  attrs: {
+    letterSpacing: {},
+  },
+  inline: true,
+  group: 'inline',
+  parseDOM: [
+    {
+      style: 'letter-spacing',
+      getAttrs: (letterSpacing) => (letterSpacing ? { letterSpacing } : {}),
+    },
+  ],
+  toDOM: (mark) => ['span', { style: `letter-spacing: ${mark.attrs.letterSpacing};` }, 0],
+};
+
+const inlineBlock: MarkSpec = {
+  attrs: {
+    width: {},
+    textIndent: { default: '' },
+    boxSizing: { default: '' },
+  },
+  parseDOM: [
+    {
+      tag: 'span',
+      getAttrs: (dom) => {
+        const element = dom as HTMLElement;
+        const { display, width, textIndent, boxSizing } = element.style;
+        if (
+          !element.textContent?.trim() ||
+          display !== 'inline-block' ||
+          !CSS_LENGTH_PATTERN.test(width)
+        )
+          return false;
+        return {
+          width,
+          textIndent: textIndent === '0px' || textIndent === '0' ? '0' : '',
+          boxSizing: boxSizing === 'border-box' ? boxSizing : '',
+        };
+      },
+    },
+  ],
+  toDOM: (mark) => {
+    let style = `display: inline-block; width: ${mark.attrs.width};`;
+    if (mark.attrs.textIndent) style += 'text-indent: 0;';
+    if (mark.attrs.boxSizing) style += `box-sizing: ${mark.attrs.boxSizing};`;
+    return ['span', { style }, 0];
+  },
+};
+
 const fontname: MarkSpec = {
   attrs: {
     fontname: {},
@@ -189,6 +241,8 @@ const schemaMarks = {
   em,
   strong,
   fontsize,
+  letterSpacing,
+  inlineBlock,
   fontname,
   code,
   forecolor,

--- a/packages/@openmaic/editor/src/react/text/prosemirror/schema/marks.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/schema/marks.ts
@@ -136,6 +136,10 @@ const letterSpacing: MarkSpec = {
 const inlineBlock: MarkSpec = {
   attrs: {
     width: {},
+    height: { default: '' },
+    verticalAlign: { default: '' },
+    margin: { default: '' },
+    padding: { default: '' },
     textIndent: { default: '' },
     boxSizing: { default: '' },
   },
@@ -144,7 +148,8 @@ const inlineBlock: MarkSpec = {
       tag: 'span',
       getAttrs: (dom) => {
         const element = dom as HTMLElement;
-        const { display, width, textIndent, boxSizing } = element.style;
+        const { display, width, height, verticalAlign, margin, padding, textIndent, boxSizing } =
+          element.style;
         if (
           !element.textContent?.trim() ||
           display !== 'inline-block' ||
@@ -153,6 +158,10 @@ const inlineBlock: MarkSpec = {
           return false;
         return {
           width,
+          height,
+          verticalAlign,
+          margin,
+          padding,
           textIndent: textIndent === '0px' || textIndent === '0' ? '0' : '',
           boxSizing: boxSizing === 'border-box' ? boxSizing : '',
         };
@@ -161,6 +170,10 @@ const inlineBlock: MarkSpec = {
   ],
   toDOM: (mark) => {
     let style = `display: inline-block; width: ${mark.attrs.width};`;
+    if (mark.attrs.height) style += `height: ${mark.attrs.height};`;
+    if (mark.attrs.verticalAlign) style += `vertical-align: ${mark.attrs.verticalAlign};`;
+    if (mark.attrs.margin) style += `margin: ${mark.attrs.margin};`;
+    if (mark.attrs.padding) style += `padding: ${mark.attrs.padding};`;
     if (mark.attrs.textIndent) style += 'text-indent: 0;';
     if (mark.attrs.boxSizing) style += `box-sizing: ${mark.attrs.boxSizing};`;
     return ['span', { style }, 0];

--- a/packages/@openmaic/editor/src/react/text/prosemirror/schema/marks.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/schema/marks.ts
@@ -139,7 +139,15 @@ const inlineBlock: MarkSpec = {
     height: { default: '' },
     verticalAlign: { default: '' },
     margin: { default: '' },
+    marginTop: { default: '' },
+    marginRight: { default: '' },
+    marginBottom: { default: '' },
+    marginLeft: { default: '' },
     padding: { default: '' },
+    paddingTop: { default: '' },
+    paddingRight: { default: '' },
+    paddingBottom: { default: '' },
+    paddingLeft: { default: '' },
     textIndent: { default: '' },
     boxSizing: { default: '' },
   },
@@ -148,8 +156,24 @@ const inlineBlock: MarkSpec = {
       tag: 'span',
       getAttrs: (dom) => {
         const element = dom as HTMLElement;
-        const { display, width, height, verticalAlign, margin, padding, textIndent, boxSizing } =
-          element.style;
+        const {
+          display,
+          width,
+          height,
+          verticalAlign,
+          margin,
+          marginTop,
+          marginRight,
+          marginBottom,
+          marginLeft,
+          padding,
+          paddingTop,
+          paddingRight,
+          paddingBottom,
+          paddingLeft,
+          textIndent,
+          boxSizing,
+        } = element.style;
         if (
           !element.textContent?.trim() ||
           display !== 'inline-block' ||
@@ -161,7 +185,15 @@ const inlineBlock: MarkSpec = {
           height,
           verticalAlign,
           margin,
+          marginTop,
+          marginRight,
+          marginBottom,
+          marginLeft,
           padding,
+          paddingTop,
+          paddingRight,
+          paddingBottom,
+          paddingLeft,
           textIndent: textIndent === '0px' || textIndent === '0' ? '0' : '',
           boxSizing: boxSizing === 'border-box' ? boxSizing : '',
         };
@@ -173,7 +205,15 @@ const inlineBlock: MarkSpec = {
     if (mark.attrs.height) style += `height: ${mark.attrs.height};`;
     if (mark.attrs.verticalAlign) style += `vertical-align: ${mark.attrs.verticalAlign};`;
     if (mark.attrs.margin) style += `margin: ${mark.attrs.margin};`;
+    if (mark.attrs.marginTop) style += `margin-top: ${mark.attrs.marginTop};`;
+    if (mark.attrs.marginRight) style += `margin-right: ${mark.attrs.marginRight};`;
+    if (mark.attrs.marginBottom) style += `margin-bottom: ${mark.attrs.marginBottom};`;
+    if (mark.attrs.marginLeft) style += `margin-left: ${mark.attrs.marginLeft};`;
     if (mark.attrs.padding) style += `padding: ${mark.attrs.padding};`;
+    if (mark.attrs.paddingTop) style += `padding-top: ${mark.attrs.paddingTop};`;
+    if (mark.attrs.paddingRight) style += `padding-right: ${mark.attrs.paddingRight};`;
+    if (mark.attrs.paddingBottom) style += `padding-bottom: ${mark.attrs.paddingBottom};`;
+    if (mark.attrs.paddingLeft) style += `padding-left: ${mark.attrs.paddingLeft};`;
     if (mark.attrs.textIndent) style += 'text-indent: 0;';
     if (mark.attrs.boxSizing) style += `box-sizing: ${mark.attrs.boxSizing};`;
     return ['span', { style }, 0];

--- a/packages/@openmaic/editor/src/react/text/prosemirror/schema/nodes.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/schema/nodes.ts
@@ -224,7 +224,7 @@ const paragraph: NodeSpec = {
         let textIndentLevel = 0;
         let textIndentCss = '';
         if (textIndent) {
-          if (/em/.test(textIndent)) {
+          if (/^-?(?:\d+|\d*\.\d+)em$/i.test(textIndent)) {
             textIndentLevel = parseFloat(textIndent);
           } else if (/px/.test(textIndent)) {
             textIndentLevel = Math.floor(parseFloat(textIndent) / 16);

--- a/packages/@openmaic/editor/src/react/text/prosemirror/schema/nodes.ts
+++ b/packages/@openmaic/editor/src/react/text/prosemirror/schema/nodes.ts
@@ -4,6 +4,67 @@ import { listItem as _listItem } from 'prosemirror-schema-list';
 
 type Attr = Record<string, number | string>;
 
+const CSS_LENGTH_PATTERN =
+  /^-?(?:\d+|\d*\.\d+)(?:px|pt|pc|mm|cm|in|rem|em|ex|ch|vw|vh|vmin|vmax|%)$/i;
+const WHITE_SPACE_VALUES = new Set([
+  'normal',
+  'nowrap',
+  'pre',
+  'pre-wrap',
+  'pre-line',
+  'break-spaces',
+]);
+
+const inlineSpacer: NodeSpec = {
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: false,
+  attrs: {
+    width: { default: '' },
+  },
+  parseDOM: [
+    {
+      tag: 'span',
+      getAttrs: (dom) => {
+        const element = dom as HTMLElement;
+        const { display, width } = element.style;
+        if (
+          element.textContent?.trim() ||
+          display !== 'inline-block' ||
+          !CSS_LENGTH_PATTERN.test(width)
+        ) {
+          return false;
+        }
+        return { width };
+      },
+    },
+  ],
+  toDOM: (node: Node) => ['span', { style: `display: inline-block; width: ${node.attrs.width};` }],
+};
+
+const textContainer: NodeSpec = {
+  group: 'block',
+  content: 'block+',
+  attrs: {
+    padding: { default: '' },
+  },
+  parseDOM: [
+    {
+      tag: 'div',
+      getAttrs: (dom) => {
+        const padding = (dom as HTMLElement).style.padding;
+        return padding ? { padding } : false;
+      },
+    },
+  ],
+  toDOM: (node: Node) => [
+    'div',
+    node.attrs.padding ? { style: `padding: ${node.attrs.padding};` } : {},
+    0,
+  ],
+};
+
 const orderedList: NodeSpec = {
   attrs: {
     order: {
@@ -111,10 +172,31 @@ const paragraph: NodeSpec = {
     textIndent: {
       default: 0,
     },
+    // PPTX import serializes first-line indentation in px. Keep that exact
+    // CSS length while editing so it does not drift when the paragraph uses a
+    // font size other than the editor's historical 16px conversion base.
+    textIndentCss: {
+      default: '',
+    },
     fontsize: {
       default: '',
     },
     lineHeight: {
+      default: '',
+    },
+    marginLeft: {
+      default: '',
+    },
+    marginTop: {
+      default: '',
+    },
+    marginBottom: {
+      default: '',
+    },
+    paddingTop: {
+      default: '',
+    },
+    whiteSpace: {
       default: '',
     },
   },
@@ -124,18 +206,32 @@ const paragraph: NodeSpec = {
     {
       tag: 'p',
       getAttrs: (dom) => {
-        const { textAlign, textIndent, fontSize, lineHeight } = (dom as HTMLElement).style;
+        const {
+          textAlign,
+          textIndent,
+          fontSize,
+          lineHeight,
+          marginLeft,
+          marginTop,
+          marginBottom,
+          paddingTop,
+          whiteSpace,
+        } = (dom as HTMLElement).style;
 
         let align = (dom as HTMLElement).getAttribute('align') || textAlign || '';
         align = /(left|right|center|justify)/.test(align) ? align : '';
 
         let textIndentLevel = 0;
+        let textIndentCss = '';
         if (textIndent) {
           if (/em/.test(textIndent)) {
-            textIndentLevel = parseInt(textIndent);
+            textIndentLevel = parseFloat(textIndent);
           } else if (/px/.test(textIndent)) {
-            textIndentLevel = Math.floor(parseInt(textIndent) / 16);
+            textIndentLevel = Math.floor(parseFloat(textIndent) / 16);
             if (!textIndentLevel) textIndentLevel = 1;
+            textIndentCss = textIndent;
+          } else if (CSS_LENGTH_PATTERN.test(textIndent)) {
+            textIndentCss = textIndent;
           }
         }
 
@@ -145,8 +241,14 @@ const paragraph: NodeSpec = {
           align,
           indent,
           textIndent: textIndentLevel,
+          textIndentCss,
           fontsize: fontSize,
           lineHeight,
+          marginLeft,
+          marginTop,
+          marginBottom,
+          paddingTop,
+          whiteSpace: WHITE_SPACE_VALUES.has(whiteSpace) ? whiteSpace : '',
         };
       },
     },
@@ -160,12 +262,30 @@ const paragraph: NodeSpec = {
     },
   ],
   toDOM: (node: Node) => {
-    const { align, indent, textIndent, fontsize, lineHeight } = node.attrs;
+    const {
+      align,
+      indent,
+      textIndent,
+      textIndentCss,
+      fontsize,
+      lineHeight,
+      marginLeft,
+      marginTop,
+      marginBottom,
+      paddingTop,
+      whiteSpace,
+    } = node.attrs;
     let style = '';
     if (align && align !== 'left') style += `text-align: ${align};`;
-    if (textIndent) style += `text-indent: ${textIndent}em;`;
+    if (textIndentCss) style += `text-indent: ${textIndentCss};`;
+    else if (textIndent) style += `text-indent: ${textIndent}em;`;
     if (fontsize) style += `font-size: ${fontsize};`;
     if (lineHeight) style += `line-height: ${lineHeight};`;
+    if (marginLeft) style += `margin-left: ${marginLeft};`;
+    if (marginTop) style += `margin-top: ${marginTop};`;
+    if (marginBottom) style += `margin-bottom: ${marginBottom};`;
+    if (paddingTop) style += `padding-top: ${paddingTop};`;
+    if (whiteSpace) style += `white-space: ${whiteSpace};`;
 
     const attr: Attr = { style };
     if (indent) attr['data-indent'] = indent;
@@ -174,16 +294,19 @@ const paragraph: NodeSpec = {
   },
 };
 
-const { doc, blockquote, text } = nodes;
+const { doc, blockquote, hard_break, text } = nodes;
 
 const schemaNodes = {
   doc,
   paragraph,
   blockquote,
+  hard_break,
   text,
+  text_container: textContainer,
   ordered_list: orderedList,
   bullet_list: bulletList,
   list_item: listItem,
+  inline_spacer: inlineSpacer,
 };
 
 export default schemaNodes;

--- a/packages/@openmaic/editor/test/react/EditableSlideCanvas.shape.test.tsx
+++ b/packages/@openmaic/editor/test/react/EditableSlideCanvas.shape.test.tsx
@@ -99,9 +99,9 @@ describe('EditableSlideCanvas — Shape label editing', () => {
     fireEvent.pointerDown(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
     fireEvent.pointerUp(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
 
-    expect((container.querySelector('[data-marquee-surface]') as HTMLElement).style.pointerEvents).toBe(
-      'none',
-    );
+    expect(
+      (container.querySelector('[data-marquee-surface]') as HTMLElement).style.pointerEvents,
+    ).toBe('none');
   });
 
   it('exits Shape label editing when the blank canvas is pressed', () => {

--- a/packages/@openmaic/editor/test/react/EditableSlideCanvas.shape.test.tsx
+++ b/packages/@openmaic/editor/test/react/EditableSlideCanvas.shape.test.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { fireEvent } from '@testing-library/dom';
+import { EditorView } from 'prosemirror-view';
 import type { PPTShapeElement, Slide } from '@openmaic/dsl';
 import type { EditIntent, Selection } from '../../src/react/types';
 import { EditableSlideCanvas } from '../../src/react/EditableSlideCanvas';
@@ -53,13 +54,15 @@ function Harness() {
 
 function EmptyLabelHarness({
   onElementsChange,
+  editing = true,
 }: {
   onElementsChange: (intents: EditIntent[]) => void;
+  editing?: boolean;
 }) {
   const [selection, setSelection] = useState<Selection>({
     elementIds: ['shape-1'],
     primaryId: 'shape-1',
-    editingId: 'shape-1',
+    editingId: editing ? 'shape-1' : undefined,
   });
   return (
     <EditableSlideCanvas
@@ -77,13 +80,85 @@ function EmptyLabelHarness({
 }
 
 describe('EditableSlideCanvas — Shape label editing', () => {
-  it('enters a Shape label editor only after a double click', () => {
+  it('enters a non-empty Shape label editor after a click', () => {
+    vi.spyOn(EditorView.prototype, 'posAtCoords').mockReturnValue({ pos: 1, inside: -1 });
     const { container } = render(<Harness />);
     const target = container.querySelector('[data-select-element-id="shape-1"]') as HTMLElement;
 
     expect(container.querySelector('[data-renderer-shape-label-editor="shape-1"]')).toBeNull();
-    fireEvent.doubleClick(target);
+    fireEvent.pointerDown(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
+    fireEvent.pointerUp(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
     expect(container.querySelector('[data-renderer-shape-label-editor="shape-1"]')).not.toBeNull();
+  });
+
+  it('does not leave the marquee capture surface above an editing Shape label', () => {
+    vi.spyOn(EditorView.prototype, 'posAtCoords').mockReturnValue({ pos: 1, inside: -1 });
+    const { container } = render(<Harness />);
+    const target = container.querySelector('[data-select-element-id="shape-1"]') as HTMLElement;
+
+    fireEvent.pointerDown(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
+    fireEvent.pointerUp(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
+
+    expect((container.querySelector('[data-marquee-surface]') as HTMLElement).style.pointerEvents).toBe(
+      'none',
+    );
+  });
+
+  it('exits Shape label editing when the blank canvas is pressed', () => {
+    const onSelectionChange = vi.fn();
+    const { container } = render(
+      <EditableSlideCanvas
+        slide={slide}
+        scale={1}
+        selection={{ elementIds: ['shape-1'], primaryId: 'shape-1', editingId: 'shape-1' }}
+        onSelectionChange={onSelectionChange}
+        onElementsChange={vi.fn()}
+        onTextContentChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.pointerDown(container.querySelector('[data-editable-slide-canvas]') as HTMLElement, {
+      button: 0,
+      pointerId: 1,
+    });
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ elementIds: [] });
+  });
+
+  it('places the Shape label caret at the clicked position when entering edit mode', () => {
+    const posAtCoords = vi
+      .spyOn(EditorView.prototype, 'posAtCoords')
+      .mockReturnValue({ pos: 4, inside: 1 });
+    const { container } = render(<Harness />);
+    const target = container.querySelector('[data-select-element-id="shape-1"]') as HTMLElement;
+
+    fireEvent.pointerDown(target, { button: 0, pointerId: 1, clientX: 180, clientY: 125 });
+    fireEvent.pointerUp(target, { button: 0, pointerId: 1, clientX: 180, clientY: 125 });
+
+    expect(posAtCoords).toHaveBeenCalledWith({ left: 180, top: 125 });
+  });
+
+  it('keeps an empty Shape label out of editing after a click', () => {
+    const { container } = render(<EmptyLabelHarness editing={false} onElementsChange={vi.fn()} />);
+    const target = container.querySelector('[data-select-element-id="shape-1"]') as HTMLElement;
+
+    fireEvent.pointerDown(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
+    fireEvent.pointerUp(target, { button: 0, pointerId: 1, clientX: 130, clientY: 130 });
+
+    expect(container.querySelector('[data-renderer-shape-label-editor="shape-1"]')).toBeNull();
+  });
+
+  it('uses the renderer prose spacing rules while editing a Shape label', () => {
+    const { container } = render(<Harness />);
+    const target = container.querySelector('[data-select-element-id="shape-1"]') as HTMLElement;
+
+    fireEvent.doubleClick(target);
+
+    const editor = container.querySelector(
+      '[data-renderer-shape-label-editor="shape-1"]',
+    ) as HTMLElement;
+    expect(editor).toHaveClass('slide-renderer-prose');
+    expect(editor.style.getPropertyValue('--paragraphSpace')).toBe('5px');
   });
 
   it('removes an empty Shape label when its editor blurs', () => {

--- a/packages/@openmaic/editor/test/react/EditableSlideCanvas.text.test.tsx
+++ b/packages/@openmaic/editor/test/react/EditableSlideCanvas.text.test.tsx
@@ -56,7 +56,7 @@ describe('EditableSlideCanvas text rendering', () => {
     );
   });
 
-  it('injects ProseMirror list styles when used without the UI wrapper', () => {
+  it('injects the shared renderer prose layout rules for ProseMirror', () => {
     const { container } = render(
       <EditableSlideCanvas
         slide={slide}
@@ -69,8 +69,13 @@ describe('EditableSlideCanvas text rendering', () => {
     );
 
     expect(
-      [...container.querySelectorAll('style')].some((style) =>
-        style.textContent?.includes('.renderer-prosemirror-editor ul {'),
+      [...container.querySelectorAll('style')].some(
+        (style) =>
+          style.textContent?.includes('.renderer-prosemirror-editor .ProseMirror p {') &&
+          style.textContent?.includes(
+            '.renderer-prosemirror-editor .ProseMirror p:empty::before {',
+          ) &&
+          style.textContent?.includes('.renderer-prosemirror-editor .ProseMirror ul {'),
       ),
     ).toBe(true);
   });

--- a/packages/@openmaic/editor/test/react/text/RendererTextEditor.test.tsx
+++ b/packages/@openmaic/editor/test/react/text/RendererTextEditor.test.tsx
@@ -139,6 +139,39 @@ describe('RendererTextEditor', () => {
     expect(onContentChange).not.toHaveBeenCalled();
   });
 
+  it.each(['text', 'shape'] as const)(
+    'keeps literal line breaks when saving a %s editor',
+    (target) => {
+      let controller: TextEditorController | null = null;
+      const onContentChange = vi.fn<(change: TextContentChange) => void>();
+      render(
+        <RendererTextEditor
+          elementId="txt"
+          target={target}
+          value={'First line\nSecond line'}
+          defaultColor="#000000"
+          defaultFontName="Inter"
+          onControllerChange={(next) => {
+            controller = next;
+          }}
+          onContentChange={onContentChange}
+        />,
+      );
+
+      act(() => controller?.execute({ command: 'insert', value: '!' }));
+      act(() => vi.advanceTimersByTime(300));
+
+      expect(onContentChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          intent: expect.objectContaining({
+            target,
+            content: expect.stringContaining('First line<br>Second line'),
+          }),
+        }),
+      );
+    },
+  );
+
   it('marks ProseMirror undo content as history-neutral and releases focus on unmount', () => {
     let controller: TextEditorController | null = null;
     const onControllerChange = vi.fn((next: TextEditorController | null) => {

--- a/packages/@openmaic/editor/test/react/text/prosemirror-schema.test.ts
+++ b/packages/@openmaic/editor/test/react/text/prosemirror-schema.test.ts
@@ -40,6 +40,15 @@ describe('renderer ProseMirror schema', () => {
     expect(output).toContain('letter-spacing: 1.5pt');
   });
 
+  it('preserves rem first-line indentation without converting its unit', () => {
+    const output = serializeTextDocument(
+      createTextDocument('<p style="text-indent: 1rem">Indented text</p>'),
+    );
+
+    expect(output).toContain('text-indent: 1rem');
+    expect(output).not.toContain('text-indent: 1em');
+  });
+
   it('preserves an empty inline-block spacer used for PPTX first-line indentation', () => {
     const output = serializeTextDocument(
       createTextDocument(
@@ -89,6 +98,20 @@ describe('renderer ProseMirror schema', () => {
     expect(output).toContain('■');
   });
 
+  it('preserves inline-block layout styles used by imported PPTX text', () => {
+    const output = serializeTextDocument(
+      createTextDocument(
+        '<p><span style="display: inline-block; width: 30px; height: 24px; vertical-align: middle; margin: 1px 2px; padding: 3px 4px">■</span>Text</p>',
+      ),
+    );
+
+    expect(output).toContain('display: inline-block');
+    expect(output).toContain('height: 24px');
+    expect(output).toContain('vertical-align: middle');
+    expect(output).toContain('margin: 1px 2px');
+    expect(output).toContain('padding: 3px 4px');
+  });
+
   it('preserves explicit PPTX line breaks instead of reflowing them', () => {
     const output = serializeTextDocument(
       createTextDocument(
@@ -97,5 +120,11 @@ describe('renderer ProseMirror schema', () => {
     );
 
     expect(output).toMatch(/1954年清华大学首创“先进集体”<\/span><br><span[^>]*>评选制度/);
+  });
+
+  it('turns literal plain-text newlines into explicit line breaks', () => {
+    const output = serializeTextDocument(createTextDocument('First line\nSecond line'));
+
+    expect(output).toContain('First line<br>Second line');
   });
 });

--- a/packages/@openmaic/editor/test/react/text/prosemirror-schema.test.ts
+++ b/packages/@openmaic/editor/test/react/text/prosemirror-schema.test.ts
@@ -28,4 +28,74 @@ describe('renderer ProseMirror schema', () => {
     expect(output).toMatch(/<p style="[^"]*font-size: 14px/);
     expect(output).toMatch(/<p style="[^"]*line-height: 1.2/);
   });
+
+  it('preserves PPTX character spacing and pixel first-line indentation', () => {
+    const output = serializeTextDocument(
+      createTextDocument(
+        '<p style="text-indent: 78px"><span style="letter-spacing: 1.5pt">Indented text</span></p>',
+      ),
+    );
+
+    expect(output).toContain('text-indent: 78px');
+    expect(output).toContain('letter-spacing: 1.5pt');
+  });
+
+  it('preserves an empty inline-block spacer used for PPTX first-line indentation', () => {
+    const output = serializeTextDocument(
+      createTextDocument(
+        '<p><span style="display: inline-block; width: 1.50em"></span>Indented text</p>',
+      ),
+    );
+
+    expect(output).toContain('display: inline-block');
+    expect(output).toContain('width: 1.5em');
+    expect(output).toContain('Indented text');
+  });
+
+  it('preserves PPTX text-container and paragraph geometry while editing', () => {
+    const output = serializeTextDocument(
+      createTextDocument(
+        '<div style="padding: 4.8px 9.6px"><p style="margin-left: 78px; text-indent: -30px; padding-top: 7.3px; margin-top: 8px; margin-bottom: 5px">Text</p></div>',
+      ),
+    );
+
+    expect(output).toContain('padding: 4.8px 9.6px');
+    expect(output).toContain('margin-left: 78px');
+    expect(output).toContain('text-indent: -30px');
+    expect(output).toContain('padding-top: 7.3px');
+    expect(output).toContain('margin-top: 8px');
+    expect(output).toContain('margin-bottom: 5px');
+  });
+
+  it('preserves no-wrap paragraphs imported from PPTX', () => {
+    const output = serializeTextDocument(
+      createTextDocument('<p style="white-space: nowrap">在集体中成长，与集体共成长</p>'),
+    );
+
+    expect(output).toContain('white-space: nowrap');
+  });
+
+  it('preserves a sized inline-block slot containing a PPTX bullet glyph', () => {
+    const output = serializeTextDocument(
+      createTextDocument(
+        '<p><span style="display: inline-block; width: 30px; text-indent: 0; box-sizing: border-box">■</span>1954年清华大学首创</p>',
+      ),
+    );
+
+    expect(output).toContain('display: inline-block');
+    expect(output).toContain('width: 30px');
+    expect(output).toContain('text-indent: 0');
+    expect(output).toContain('box-sizing: border-box');
+    expect(output).toContain('■');
+  });
+
+  it('preserves explicit PPTX line breaks instead of reflowing them', () => {
+    const output = serializeTextDocument(
+      createTextDocument(
+        '<p><span style="font-size: 29.3px">1954年清华大学首创“先进集体”</span><br><span style="font-size: 29.3px">评选制度</span></p>',
+      ),
+    );
+
+    expect(output).toMatch(/1954年清华大学首创“先进集体”<\/span><br><span[^>]*>评选制度/);
+  });
 });

--- a/packages/@openmaic/editor/test/react/text/prosemirror-schema.test.ts
+++ b/packages/@openmaic/editor/test/react/text/prosemirror-schema.test.ts
@@ -101,7 +101,7 @@ describe('renderer ProseMirror schema', () => {
   it('preserves inline-block layout styles used by imported PPTX text', () => {
     const output = serializeTextDocument(
       createTextDocument(
-        '<p><span style="display: inline-block; width: 30px; height: 24px; vertical-align: middle; margin: 1px 2px; padding: 3px 4px">■</span>Text</p>',
+        '<p><span style="display: inline-block; width: 30px; height: 24px; vertical-align: middle; margin: 1px 2px; padding: 3px 4px">■</span><span style="display: inline-block; width: 12px; margin-left: 5px; padding-right: 6px">•</span>Text</p>',
       ),
     );
 
@@ -109,7 +109,9 @@ describe('renderer ProseMirror schema', () => {
     expect(output).toContain('height: 24px');
     expect(output).toContain('vertical-align: middle');
     expect(output).toContain('margin: 1px 2px');
+    expect(output).toContain('margin-left: 5px');
     expect(output).toContain('padding: 3px 4px');
+    expect(output).toContain('padding-right: 6px');
   });
 
   it('preserves explicit PPTX line breaks instead of reflowing them', () => {
@@ -126,5 +128,11 @@ describe('renderer ProseMirror schema', () => {
     const output = serializeTextDocument(createTextDocument('First line\nSecond line'));
 
     expect(output).toContain('First line<br>Second line');
+  });
+
+  it('decodes plain-text HTML entities while preserving literal line breaks', () => {
+    const output = serializeTextDocument(createTextDocument('A&nbsp;\nB &amp; C'));
+
+    expect(output).toContain('A&nbsp;<br>B &amp; C');
   });
 });

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/renderer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React component for rendering PPTist-style Slide JSON, extracted from OpenMAIC.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/renderer/src/index.ts
+++ b/packages/@openmaic/renderer/src/index.ts
@@ -35,5 +35,6 @@ export {
 } from './utils/geometry';
 export { cn } from './utils/cn';
 export { getElementRange, getLineElementPath, getTableSubThemeColor } from './utils/element';
+export { createTextProseStyles } from './styles';
 
 export * from './types';

--- a/packages/@openmaic/renderer/src/styles.ts
+++ b/packages/@openmaic/renderer/src/styles.ts
@@ -8,37 +8,50 @@
  * `--paragraphSpace` CSS variable. List rules restore semantic markers that
  * host resets such as Tailwind Preflight remove.
  */
-export const SLIDE_RENDERER_STYLES = `
-.slide-renderer-prose p {
+/**
+ * Generates the reset rules that define rich-text geometry inside a slide.
+ *
+ * Both the static renderer and the ProseMirror editor need these exact rules:
+ * keeping the selector configurable lets them share one layout contract while
+ * retaining their different DOM roots.
+ */
+export function createTextProseStyles(selector: string): string {
+  return `
+${selector} p {
   margin-top: 0;
   margin-bottom: var(--paragraphSpace, 0);
 }
-.slide-renderer-prose p:last-child {
+${selector} p:last-child {
   margin-bottom: 0;
 }
-.slide-renderer-prose p:empty::before {
+${selector} p:empty::before {
   content: '\\00a0';
 }
-.slide-renderer-prose .katex-display {
+${selector} .katex-display {
   margin: 0 !important;
 }
-.slide-renderer-prose ul {
+${selector} ul {
   list-style-position: outside !important;
   padding-inline-start: 1.5rem !important;
 }
-.slide-renderer-prose ul:not([style*="list-style-type"]) {
+${selector} ul:not([style*="list-style-type"]) {
   list-style-type: disc !important;
 }
-.slide-renderer-prose ol {
+${selector} ol {
   list-style-position: outside !important;
   padding-inline-start: 1.5rem !important;
 }
-.slide-renderer-prose ol:not([style*="list-style-type"]) {
+${selector} ol:not([style*="list-style-type"]) {
   list-style-type: decimal !important;
 }
-.slide-renderer-prose li {
+${selector} li {
   display: list-item !important;
 }
+`;
+}
+
+export const SLIDE_RENDERER_STYLES = `
+${createTextProseStyles('.slide-renderer-prose')}
 /* Table cell inner container — matches the classroom (Vue) .cell-text design:
    tight base line-height, and a small spacing between adjacent <p> siblings
    so multi-paragraph cells don't collapse into a single visual block. The

--- a/tests/packages/editor-manifest.test.ts
+++ b/tests/packages/editor-manifest.test.ts
@@ -14,7 +14,7 @@ const editorPackage = JSON.parse(
 
 describe('@openmaic/editor publish manifest', () => {
   it('declares provenance repository metadata at the next release version', () => {
-    expect(editorPackage.version).toBe('0.0.2');
+    expect(editorPackage.version).toBe('0.0.3');
     expect(editorPackage.repository).toEqual({
       type: 'git',
       url: 'https://github.com/THU-MAIC/OpenMAIC',


### PR DESCRIPTION
## Summary
- make shape labels use the same ProseMirror editing path, click-to-caret behavior, and empty-label handling as text elements
- keep shape editing interactions above the canvas marquee layer while preserving blank-canvas exit behavior
- preserve literal line breaks only for plain-text renderer content, avoiding extra whitespace for formatted HTML
- bump `@openmaic/editor` to `0.0.3` and `@openmaic/renderer` to `0.1.2`

## Validation
- `pnpm --filter @openmaic/editor test`
- `pnpm --filter @openmaic/editor typecheck`
- `pnpm --filter @openmaic/editor build`