### PR TITLE
perf(docker): add optional mirrors and pnpm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ RUN if [ -n "$ALPINE_MIRROR" ]; then \
     fi && \
     apk add --no-cache libc6-compat
 
-RUN if [ -n "$NPM_REGISTRY" ]; then \
-      export COREPACK_NPM_REGISTRY="$NPM_REGISTRY"; \
+RUN npm_registry="$NPM_REGISTRY"; \
+    while [ "${npm_registry%/}" != "$npm_registry" ]; do \
+      npm_registry="${npm_registry%/}"; \
+    done; \
+    if [ -n "$npm_registry" ]; then \
+      export COREPACK_NPM_REGISTRY="$npm_registry"; \
     fi && \
     corepack enable && \
     corepack prepare pnpm@10.28.0 --activate
@@ -32,8 +36,12 @@ COPY packages/ ./packages/
 COPY scripts/ ./scripts/
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    if [ -n "$NPM_REGISTRY" ]; then \
-      pnpm config set registry "$NPM_REGISTRY"; \
+    npm_registry="$NPM_REGISTRY"; \
+    while [ "${npm_registry%/}" != "$npm_registry" ]; do \
+      npm_registry="${npm_registry%/}"; \
+    done; \
+    if [ -n "$npm_registry" ]; then \
+      pnpm config set registry "$npm_registry"; \
     fi && \
     pnpm install --frozen-lockfile
 
@@ -82,9 +90,13 @@ ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 
 RUN if [ -n "$ALPINE_MIRROR" ]; then \
+      cp /etc/apk/repositories /tmp/apk.repositories; \
       sed -i "s|dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories; \
     fi && \
-    apk add --no-cache libc6-compat cairo pango jpeg giflib librsvg
+    apk add --no-cache libc6-compat cairo pango jpeg giflib librsvg && \
+    if [ -n "$ALPINE_MIRROR" ]; then \
+      mv /tmp/apk.repositories /etc/apk/repositories; \
+    fi
 
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,28 @@
+# syntax=docker/dockerfile:1
+
 # ---- Stage 1: Base ----
 FROM node:22-alpine AS base
 
-RUN apk add --no-cache libc6-compat
-RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+ARG ALPINE_MIRROR=""
+ARG NPM_REGISTRY=""
+
+RUN if [ -n "$ALPINE_MIRROR" ]; then \
+      sed -i "s|dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories; \
+    fi && \
+    apk add --no-cache libc6-compat
+
+RUN if [ -n "$NPM_REGISTRY" ]; then \
+      export COREPACK_NPM_REGISTRY="$NPM_REGISTRY"; \
+    fi && \
+    corepack enable && \
+    corepack prepare pnpm@10.28.0 --activate
 
 WORKDIR /app
 
 # ---- Stage 2: Dependencies ----
 FROM base AS deps
+
+ARG NPM_REGISTRY
 
 # Native build tools for sharp, @napi-rs/canvas
 RUN apk add --no-cache python3 build-base g++ cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev
@@ -16,7 +31,11 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/ ./packages/
 COPY scripts/ ./scripts/
 
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    if [ -n "$NPM_REGISTRY" ]; then \
+      pnpm config set registry "$NPM_REGISTRY"; \
+    fi && \
+    pnpm install --frozen-lockfile
 
 # ---- Stage 3: Builder ----
 FROM base AS builder
@@ -54,13 +73,18 @@ RUN pnpm build
 # ---- Stage 4: Runner ----
 FROM node:22-alpine AS runner
 
+ARG ALPINE_MIRROR=""
+
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 
-RUN apk add --no-cache libc6-compat cairo pango jpeg giflib librsvg
+RUN if [ -n "$ALPINE_MIRROR" ]; then \
+      sed -i "s|dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories; \
+    fi && \
+    apk add --no-cache libc6-compat cairo pango jpeg giflib librsvg
 
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/README-zh.md
+++ b/README-zh.md
@@ -295,6 +295,9 @@ Alpine 和 npm 的上游软件源。
 - `ALPINE_MIRROR` 接收不带 `https://` 的 Alpine 镜像站主机名。
 - `NPM_REGISTRY` 接收完整的 npm registry URL。
 
+这些构建参数仅用于公共镜像地址。请勿在其中嵌入用户名、密码或访问令牌，因为
+Docker 可能把构建参数记录到镜像元数据或构建证明中。
+
 使用 Docker Compose：
 
 ```bash

--- a/README-zh.md
+++ b/README-zh.md
@@ -287,6 +287,36 @@ cp .env.example .env.local
 docker compose up --build
 ```
 
+#### 慢速网络 / 中国大陆构建加速
+
+Docker 构建支持两个可选参数。两者默认均为空，因此上面的标准命令仍会使用
+Alpine 和 npm 的上游软件源。
+
+- `ALPINE_MIRROR` 接收不带 `https://` 的 Alpine 镜像站主机名。
+- `NPM_REGISTRY` 接收完整的 npm registry URL。
+
+使用 Docker Compose：
+
+```bash
+ALPINE_MIRROR=mirrors.tuna.tsinghua.edu.cn \
+NPM_REGISTRY=https://registry.npmmirror.com \
+docker compose up --build
+```
+
+直接构建镜像：
+
+```bash
+docker build \
+  --build-arg ALPINE_MIRROR=mirrors.tuna.tsinghua.edu.cn \
+  --build-arg NPM_REGISTRY=https://registry.npmmirror.com \
+  -t openmaic:local .
+```
+
+这些参数不会加速 Docker Hub 拉取，包括 Dockerfile frontend 和
+`node:22-alpine` 基础镜像。若这些步骤较慢，需要单独配置 Docker daemon 的
+registry mirror。同一个 BuildKit builder 会在常规缓存清理前跨构建复用 pnpm
+store；缓存只用于提升性能，不是正确完成构建的必要条件。
+
 ### 可选：MinerU（增强文档解析）
 
 [MinerU](https://github.com/opendatalab/MinerU) 提供更强的表格、公式和 OCR 解析能力。你可以使用 [MinerU 官方 API](https://mineru.net/) 或[自行部署](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/)。

--- a/README.md
+++ b/README.md
@@ -287,6 +287,38 @@ cp .env.example .env.local
 docker compose up --build
 ```
 
+#### Slow-network / China build acceleration
+
+Docker builds support two optional build arguments. Both are empty by default,
+so the standard command above keeps using the upstream Alpine and npm
+registries.
+
+- `ALPINE_MIRROR` is an Alpine mirror hostname without `https://`.
+- `NPM_REGISTRY` is a complete npm registry URL.
+
+With Docker Compose:
+
+```bash
+ALPINE_MIRROR=mirrors.tuna.tsinghua.edu.cn \
+NPM_REGISTRY=https://registry.npmmirror.com \
+docker compose up --build
+```
+
+For a direct image build:
+
+```bash
+docker build \
+  --build-arg ALPINE_MIRROR=mirrors.tuna.tsinghua.edu.cn \
+  --build-arg NPM_REGISTRY=https://registry.npmmirror.com \
+  -t openmaic:local .
+```
+
+These arguments do not accelerate Docker Hub pulls, including the Dockerfile
+frontend and the `node:22-alpine` base image. Configure a Docker daemon registry
+mirror separately if those pulls are slow. The pnpm store cache is reused by the
+same BuildKit builder across builds, subject to normal cache garbage collection;
+the cache only improves performance and is not required for a correct build.
+
 ### Server-backed persistence (PostgreSQL)
 
 The `server-persistence` profile runs exactly two containers: the OpenMAIC app

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ registries.
 - `ALPINE_MIRROR` is an Alpine mirror hostname without `https://`.
 - `NPM_REGISTRY` is a complete npm registry URL.
 
+Use public mirror endpoints only. Do not embed usernames, passwords, or access
+tokens in these build arguments because Docker may record them in image metadata
+or build provenance.
+
 With Docker Compose:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       args:
+        - ALPINE_MIRROR=${ALPINE_MIRROR:-}
+        - NPM_REGISTRY=${NPM_REGISTRY:-}
         # NEXT_PUBLIC_* values are compiled into the browser bundle. Leave them
         # empty unless the corresponding client feature is explicitly enabled;
         # persistence and other build-time flags can be supplied on the command line.


### PR DESCRIPTION
## Summary

Adds opt-in Docker build acceleration for slow-network and China-mainland environments while preserving the current upstream behavior when no build arguments are supplied.

Related to #663.

## Changes

- add optional `ALPINE_MIRROR` and `NPM_REGISTRY` Docker build arguments with empty defaults
- use the npm registry for both Corepack's pnpm download and `pnpm install`, normalizing trailing slashes first
- add a BuildKit cache mount for the pnpm store
- restore the runner stage's original Alpine repositories after installing runtime packages, so the mirror does not persist into the final image
- pass both optional arguments through Docker Compose
- document direct Docker and Docker Compose usage in English and Chinese, including scope and secret-handling warnings

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [x] CI/CD or build tooling
- [ ] Breaking change

## Verification

### Passed on PR head (`3d2db42`)

- `CI=true COREPACK_HOME=/private/tmp/openmaic-corepack corepack pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm lint` (0 errors; 15 existing warnings)
- `pnpm exec next typegen && pnpm exec tsc --noEmit`
- `pnpm test` (450 test files passed, 3 skipped; 4,752 tests passed, 61 skipped)
- GitHub Actions: 4/4 checks passed
- `docker buildx build --check --progress=plain .` (no warnings)
- `docker buildx build --check --progress=plain --build-arg ALPINE_MIRROR=mirrors.tuna.tsinghua.edu.cn --build-arg NPM_REGISTRY=https://registry.npmmirror.com .` (no warnings)

### Docker build status

The default and mirror-argument builds completed end to end on the earlier base `b4834f5c`.

On the current upstream code, the unchanged builder-stage `RUN pnpm build` reaches the Next.js TypeScript check and then exhausts Node's default approximately 2 GB V8 heap. This failure was reproduced twice from a clean snapshot of upstream `main`, independently of this PR, and a single-variable 4 GB Node heap control completed the build. It is now tracked separately in #1157.

Because the remaining end-to-end build blocker is independently reproducible upstream and is outside this PR's mirror/cache changes, this PR is ready for maintainer review. The latest-base end-to-end item remains explicitly unchecked below.

## AI-assisted development disclosure

This PR was developed with Codex assistance. I reviewed the resulting diff and verification evidence and remain responsible for the changes and follow-up revisions.

## Checklist

- [x] I have reviewed the changes in this PR
- [x] Default build arguments remain empty and preserve upstream registries
- [x] Documentation was updated in both `README.md` and `README-zh.md`
- [x] No credentials or private registry values are committed
- [ ] Both Docker build modes pass end to end on the latest upstream base
