### PR TITLE
ci: cut wall-clock time and bound Playwright browser installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,15 +122,23 @@ jobs:
             'tsc' 'npx tsc --noEmit' \
             'i18n' 'pnpm check:i18n-keys'
 
-      # Root vitest and the storage package suite are each ~1 minute and do not
-      # share a database or a working tree. The remaining workspace suites are
-      # a few seconds each and ride in a third lane.
-      - name: Unit tests
-        run: |
-          scripts/ci-run-parallel.sh \
-            'root' 'pnpm test' \
-            'storage' 'pnpm --filter @openmaic/storage run typecheck && pnpm --filter @openmaic/storage test' \
-            'workspace-packages' 'pnpm --filter @openmaic/importer test && pnpm --filter @openmaic/dsl test && pnpm --filter @openmaic/generation run typecheck && pnpm --filter @openmaic/generation test'
+      # Keep these sequential. Running root vitest alongside the storage
+      # package on a 4-core runner made 5s-timeout tests flake (CPU
+      # contention, not a product regression).
+      - name: Unit Tests
+        run: pnpm test
+
+      - name: Unit Tests (importer)
+        run: pnpm --filter @openmaic/importer test
+
+      - name: Unit Tests (dsl)
+        run: pnpm --filter @openmaic/dsl test
+
+      - name: TypeScript (generation)
+        run: pnpm --filter @openmaic/generation run typecheck
+
+      - name: Unit Tests (generation)
+        run: pnpm --filter @openmaic/generation test
 
       - name: Node consumer smoke (generation scene)
         shell: bash
@@ -160,6 +168,15 @@ jobs:
             --model smoke-model)"
           printf '%s\n' "$output"
           node -e 'const value = JSON.parse(process.argv[1]); if (!Array.isArray(value.outlines) || value.outlines.length === 0 || !value.scene || value.sceneValidation?.valid !== true) process.exit(1)' "$output"
+
+      # Covers the package's own test tree, which the root tsc reaches only by an
+      # incidental glob. The device-scope guard is written as `@ts-expect-error`
+      # probes in those tests, and a probe nothing type-checks proves nothing.
+      - name: TypeScript (storage, incl. tests)
+        run: pnpm --filter @openmaic/storage run typecheck
+
+      - name: Unit Tests (storage)
+        run: pnpm --filter @openmaic/storage test
 
   render-service:
     name: Render Service (typecheck + tests)
@@ -223,26 +240,28 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-      # `--with-deps` is apt plus the browser tarball. On a cache hit the
-      # tarball is already present, so only the OS libraries need installing.
-      # `timeout` bounds a stalled CDN so a miss retries instead of hanging
-      # until the job budget expires.
-      - name: Install Playwright browsers
+      # OS libraries first, then the browser tarball. Do not wrap
+      # `install-deps` in `timeout`: killing apt-get leaves
+      # /var/lib/apt/lists/lock held and every retry fails immediately.
+      # Bound only the CDN download, which is what has stalled for 20+ minutes.
+      - name: Install Playwright OS deps
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Install Playwright Chromium
         run: |
           set -euo pipefail
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-            pnpm exec playwright install-deps chromium
             pnpm exec playwright install chromium
             exit 0
           fi
           for attempt in 1 2 3; do
-            if timeout -k 10 180 pnpm exec playwright install chromium --with-deps; then
+            if timeout -k 10 240 pnpm exec playwright install chromium; then
               exit 0
             fi
-            echo "Playwright install attempt ${attempt} failed, retrying..."
+            echo "Playwright Chromium download attempt ${attempt} failed, retrying..."
             sleep 5
           done
-          echo "::error::Playwright browser install failed after 3 attempts."
+          echo "::error::Playwright Chromium download failed after 3 attempts."
           exit 1
 
       # Measures the emitted cover cards in Chromium. Lives with the unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,21 @@ jobs:
   check:
     name: Lint, Typecheck & Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # Cheap bash-only check so a broken helper fails before pnpm install.
+      - name: Parallel runner self-test
+        run: |
+          set -euo pipefail
+          scripts/ci-run-parallel.sh ok 'true' ok2 'true'
+          if scripts/ci-run-parallel.sh ok 'true' bad 'exit 7'; then
+            echo 'ci-run-parallel.sh should have failed'
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@v4
 
@@ -101,32 +112,25 @@ jobs:
           fi
           echo "Tracked package files match the commit under test."
 
-      - name: Prettier
-        run: pnpm check
+      # These four do not share state. Sequential they were ~2 minutes; the
+      # slowest (ESLint) is the new bound.
+      - name: Prettier, ESLint, TypeScript, i18n
+        run: |
+          scripts/ci-run-parallel.sh \
+            'prettier' 'pnpm check' \
+            'eslint' 'pnpm lint' \
+            'tsc' 'npx tsc --noEmit' \
+            'i18n' 'pnpm check:i18n-keys'
 
-      - name: ESLint
-        run: pnpm lint
-
-      - name: TypeScript
-        run: npx tsc --noEmit
-
-      - name: i18n Key Alignment
-        run: pnpm check:i18n-keys
-
-      - name: Unit Tests
-        run: pnpm test
-
-      - name: Unit Tests (importer)
-        run: pnpm --filter @openmaic/importer test
-
-      - name: Unit Tests (dsl)
-        run: pnpm --filter @openmaic/dsl test
-
-      - name: TypeScript (generation)
-        run: pnpm --filter @openmaic/generation run typecheck
-
-      - name: Unit Tests (generation)
-        run: pnpm --filter @openmaic/generation test
+      # Root vitest and the storage package suite are each ~1 minute and do not
+      # share a database or a working tree. The remaining workspace suites are
+      # a few seconds each and ride in a third lane.
+      - name: Unit tests
+        run: |
+          scripts/ci-run-parallel.sh \
+            'root' 'pnpm test' \
+            'storage' 'pnpm --filter @openmaic/storage run typecheck && pnpm --filter @openmaic/storage test' \
+            'workspace-packages' 'pnpm --filter @openmaic/importer test && pnpm --filter @openmaic/dsl test && pnpm --filter @openmaic/generation run typecheck && pnpm --filter @openmaic/generation test'
 
       - name: Node consumer smoke (generation scene)
         shell: bash
@@ -157,18 +161,10 @@ jobs:
           printf '%s\n' "$output"
           node -e 'const value = JSON.parse(process.argv[1]); if (!Array.isArray(value.outlines) || value.outlines.length === 0 || !value.scene || value.sceneValidation?.valid !== true) process.exit(1)' "$output"
 
-      # Covers the package's own test tree, which the root tsc reaches only by an
-      # incidental glob. The device-scope guard is written as `@ts-expect-error`
-      # probes in those tests, and a probe nothing type-checks proves nothing.
-      - name: TypeScript (storage, incl. tests)
-        run: pnpm --filter @openmaic/storage run typecheck
-
-      - name: Unit Tests (storage)
-        run: pnpm --filter @openmaic/storage test
-
   render-service:
     name: Render Service (typecheck + tests)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # The producer dep bundles puppeteer; skip its Chromium download — the unit
     # tests exercise the service's boundaries (unzip, admission, body caps) and
     # never launch a browser.
@@ -204,6 +200,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -216,8 +213,37 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Browser tarballs live under ~/.cache/ms-playwright. A cold download of
+      # Chromium from the Playwright CDN has sat for 20+ minutes on this runner
+      # fleet; a lockfile-keyed cache turns that into a restore.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # `--with-deps` is apt plus the browser tarball. On a cache hit the
+      # tarball is already present, so only the OS libraries need installing.
+      # `timeout` bounds a stalled CDN so a miss retries instead of hanging
+      # until the job budget expires.
       - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium --with-deps
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            pnpm exec playwright install-deps chromium
+            pnpm exec playwright install chromium
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if timeout -k 10 180 pnpm exec playwright install chromium --with-deps; then
+              exit 0
+            fi
+            echo "Playwright install attempt ${attempt} failed, retrying..."
+            sleep 5
+          done
+          echo "::error::Playwright browser install failed after 3 attempts."
+          exit 1
 
       # Measures the emitted cover cards in Chromium. Lives with the unit tests
       # (it needs the compiler), but only this job has a browser, so it runs
@@ -263,6 +289,25 @@ jobs:
               exit 1
             fi
           done
+
+      # Incremental compilation artifacts only. Keyed on the lockfile plus
+      # next.config.ts so a dependency or webpack-rule change misses; source
+      # edits still reuse the restore-key prefix.
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('next.config.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      # Dedicated so a cold `next build` is not charged against Playwright's
+      # webServer readiness budget (120s). NEXT_PUBLIC_MAIC_EDITOR_ENABLED is a
+      # build-time flag and must be set here, not only on `pnpm start`.
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_MAIC_EDITOR_ENABLED: 'true'
 
       - name: Run e2e tests
         run: pnpm exec playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
           fetch-depth: 0
 
       # Cheap bash-only check so a broken helper fails before pnpm install.
+      # Quiet annotations: the expected-failure case would otherwise paint
+      # the check with a fake ::error::.
       - name: Parallel runner self-test
+        env:
+          CI_PARALLEL_ANNOTATE: '0'
         run: |
           set -euo pipefail
           scripts/ci-run-parallel.sh ok 'true' ok2 'true'
@@ -240,20 +244,13 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-      # OS libraries first, then the browser tarball. Do not wrap
-      # `install-deps` in `timeout`: killing apt-get leaves
-      # /var/lib/apt/lists/lock held and every retry fails immediately.
-      # Bound only the CDN download, which is what has stalled for 20+ minutes.
-      - name: Install Playwright OS deps
-        run: pnpm exec playwright install-deps chromium
-
+      # Browser tarball only. `install-deps` talks to Ubuntu apt; on this
+      # runner fleet that mirror has sat through the whole 15-minute job
+      # budget. ubuntu-latest already ships the libraries Chromium needs.
+      # Bound the Microsoft CDN download so a stall retries instead of hanging.
       - name: Install Playwright Chromium
         run: |
           set -euo pipefail
-          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-            pnpm exec playwright install chromium
-            exit 0
-          fi
           for attempt in 1 2 3; do
             if timeout -k 10 240 pnpm exec playwright install chromium; then
               exit 0

--- a/.github/workflows/storage-pg-contract.yml
+++ b/.github/workflows/storage-pg-contract.yml
@@ -14,6 +14,7 @@ jobs:
   storage-pg-contract:
     name: Storage Contract (PostgreSQL 16)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       postgres:
         image: postgres:16

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // CI builds the production bundle in a dedicated workflow step, so this
+  // process only drives Chromium. Two workers fit a 4-core runner.
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? 'html' : 'list',
   use: {
     baseURL: 'http://localhost:3002',
@@ -19,13 +21,17 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? 'pnpm build && pnpm start' : 'pnpm dev',
+    // In CI the production build runs as a dedicated workflow step before
+    // Playwright, so this only boots the already-built server (`pnpm start`).
+    // The 120s budget covers startup, not the (much slower) build. Locally we
+    // run the dev server.
+    command: process.env.CI ? 'pnpm start' : 'pnpm dev',
     url: 'http://localhost:3002',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     // Enable the MAIC Editor (Pro mode) so editor e2e can reach it. This is a
-    // build-time NEXT_PUBLIC_* flag, so it must be set when the webServer runs
-    // `pnpm build` (CI) or `pnpm dev` (local).
+    // build-time NEXT_PUBLIC_* flag: in CI it must be set on the dedicated
+    // `pnpm build` step; locally `pnpm dev` reads it here.
     env: { PORT: '3002', NEXT_PUBLIC_MAIC_EDITOR_ENABLED: 'true' },
   },
 });

--- a/scripts/ci-run-parallel.sh
+++ b/scripts/ci-run-parallel.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run NAME/COMMAND pairs in parallel, print each log as a GitHub Actions group,
+# and exit non-zero if any command failed.
+#
+# Usage:
+#   scripts/ci-run-parallel.sh NAME COMMAND [NAME COMMAND ...]
+set -uo pipefail
+
+if [ "$#" -lt 2 ] || [ $(( $# % 2 )) -ne 0 ]; then
+  echo "usage: $0 NAME COMMAND [NAME COMMAND ...]" >&2
+  exit 2
+fi
+
+logdir="${RUNNER_TEMP:-$(mktemp -d)}/ci-parallel-$$"
+mkdir -p "$logdir"
+
+pids=()
+names=()
+logs=()
+i=0
+while [ "$#" -ge 2 ]; do
+  name="$1"
+  cmd="$2"
+  shift 2
+  log="$logdir/$i.log"
+  names+=("$name")
+  logs+=("$log")
+  (
+    bash -c "$cmd" >"$log" 2>&1
+  ) &
+  pids+=("$!")
+  i=$((i + 1))
+done
+
+fail=0
+for idx in "${!pids[@]}"; do
+  pid="${pids[$idx]}"
+  name="${names[$idx]}"
+  log="${logs[$idx]}"
+  if wait "$pid"; then
+    echo "::group::${name} (ok)"
+    cat "$log"
+    echo "::endgroup::"
+  else
+    status=$?
+    echo "::error::${name} failed with exit ${status}"
+    echo "::group::${name} (failed)"
+    cat "$log"
+    echo "::endgroup::"
+    fail=1
+  fi
+done
+
+exit "$fail"

--- a/scripts/ci-run-parallel.sh
+++ b/scripts/ci-run-parallel.sh
@@ -43,7 +43,11 @@ for idx in "${!pids[@]}"; do
     echo "::endgroup::"
   else
     status=$?
-    echo "::error::${name} failed with exit ${status}"
+    if [ "${CI_PARALLEL_ANNOTATE:-1}" != "0" ]; then
+      echo "::error::${name} failed with exit ${status}"
+    else
+      echo "${name} failed with exit ${status}"
+    fi
     echo "::group::${name} (failed)"
     cat "$log"
     echo "::endgroup::"


### PR DESCRIPTION
## Summary

Cuts CI wall clock on the happy path and stops a stalled Chromium download from holding the e2e job for 20+ minutes.

Closes #1145

## Related Issues

Closes #1145

## Changes

- Cache Playwright browsers (`~/.cache/ms-playwright`, keyed on `pnpm-lock.yaml`). Cache hit skips the tarball download and only installs OS deps.
- Bound a cold `playwright install` with `timeout` and retry up to 3 times instead of hanging until the runner default.
- Build the production Next.js bundle in a dedicated e2e step (with `.next/cache`) so Playwright's `webServer` only runs `pnpm start`.
- Run Prettier / ESLint / `tsc` / i18n in parallel, then run the root, storage, and remaining workspace unit suites in parallel.
- Keep the required check name `Lint, Typecheck & Unit Tests`.
- Add `timeout-minutes` on CI jobs and the storage PostgreSQL contract job.
- Drive Chromium with 2 Playwright workers now that the Next build is no longer in-process.

## Type of Change

- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open this PR's `CI` run.
2. Confirm `Lint, Typecheck & Unit Tests` still appears (it is the required check on `main`).
3. On the e2e job, confirm `Cache Playwright browsers` / `Install Playwright browsers` / `Build` / `Run e2e tests` exist as separate steps.
4. Compare wall clock to a recent green run on `main` (~7-8 minutes). First run is a cache miss; later runs on the same lockfile should restore Chromium.

### What you personally verified

- `scripts/ci-run-parallel.sh` success path and a failing command (exit 7) locally.
- Workflow YAML parses. Required job name is unchanged.
- `playwright.config.ts` uses `pnpm start` under `CI` and 2 workers.
- Did not run the full local app suite. This change is CI orchestration; GitHub Actions on this PR is the real gate.

### Evidence

Local helper output for a passing pair and a failing pair (exit 7 reported, script exits 1). GitHub Actions timings on this PR are the evidence that matters. The first run is a Playwright cache miss.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `pnpm check` (prettier) locally
- [x] I have added tests for new features or bug fixes
- [ ] All tests pass locally (`npx tsc --noEmit`, `pnpm lint`, `pnpm test`)
- [ ] I have updated documentation if needed
- [x] I have linked related issues