### PR TITLE
feat(pi): expose benchmark LLM usage

### DIFF
--- a/app/api/chat/pi/route.ts
+++ b/app/api/chat/pi/route.ts
@@ -25,6 +25,7 @@ import { apiError } from '@/lib/server/api-response';
 import type { ThinkingConfig } from '@/lib/types/provider';
 import type { StatelessChatRequest } from '@/lib/types/chat';
 import { resolveClassroomWebSearchConfig } from '@/lib/server/web-search-config';
+import { createPiChatUsageCollector } from '@/lib/chat/pi/usage';
 
 const log = createLogger('Pi Chat API');
 
@@ -74,6 +75,7 @@ export async function POST(req: NextRequest) {
       model: languageModel,
       apiKey: resolvedApiKey,
       providerId,
+      modelId: resolvedModelId,
       modelInfo,
       thinkingConfig: resolvedThinkingConfig,
     } = await resolveModel({
@@ -111,7 +113,9 @@ export async function POST(req: NextRequest) {
 
     const signal = req.signal;
     const abortController = new AbortController();
-    signal.addEventListener('abort', () => abortController.abort(), { once: true });
+    const abortFromRequest = () => abortController.abort(signal.reason);
+    if (signal.aborted) abortFromRequest();
+    else signal.addEventListener('abort', abortFromRequest, { once: true });
 
     const { readable, writable } = new TransformStream();
     const writer = writable.getWriter();
@@ -119,6 +123,11 @@ export async function POST(req: NextRequest) {
     const send: SendEvent = async (event) => {
       await writer.write(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
     };
+    const usageCollector = createPiChatUsageCollector({
+      send,
+      provider: providerId,
+      resolvedModel: resolvedModelId,
+    });
 
     const thinkingConfig: ThinkingConfig = resolvedThinkingConfig ?? {
       mode: 'disabled',
@@ -184,10 +193,12 @@ export async function POST(req: NextRequest) {
           childRuntimeMode,
           enableNativeChildSpotlight,
           nativeWebSearchConfig,
+          usageCollector,
         });
 
         if (signal.aborted) {
           stopHeartbeat();
+          await usageCollector.flush();
           await writer.close();
           return;
         }
@@ -208,9 +219,13 @@ export async function POST(req: NextRequest) {
 
         log.error('Pi chat stream error:', error);
         try {
+          await usageCollector.flush();
           await send({
             type: 'error',
-            data: { message: error instanceof Error ? error.message : String(error) },
+            data: {
+              message: error instanceof Error ? error.message : String(error),
+              usage: usageCollector.getSummary(),
+            },
           });
           await writer.close();
         } catch {

--- a/components/chat/use-chat-sessions.ts
+++ b/components/chat/use-chat-sessions.ts
@@ -412,6 +412,15 @@ export async function runPiSingleRequest(
       if (!dataLine) continue;
       const event = JSON.parse(dataLine.slice(6)) as StatelessEvent;
       if (event.type === 'done') sawDoneEvent = true;
+      // Benchmark usage lifecycle events are additive observability only. Do
+      // not let them instantiate or otherwise perturb the classroom UI buffer.
+      if (
+        event.type === 'llm_call_start' ||
+        event.type === 'llm_usage' ||
+        event.type === 'llm_call_end'
+      ) {
+        continue;
+      }
       consumer.onEvent(event);
     }
   }

--- a/lib/agent/runtime/stream-fn.ts
+++ b/lib/agent/runtime/stream-fn.ts
@@ -37,6 +37,7 @@ import {
 import { streamLLM } from '@/lib/ai/llm';
 import { normalizeUsage } from '@/lib/usage/normalize';
 import type { ThinkingConfig } from '@/lib/types/provider';
+import type { PiLlmUsageCall, PiLlmUsageObserver } from '@/lib/chat/pi/usage';
 import {
   captureToolCallMetadata,
   emitToolCallProviderOptions,
@@ -144,6 +145,8 @@ export interface CallLlmStreamFnOptions {
   source?: string;
   /** Optional abort signal forwarded to the underlying streamLLM call. */
   abortSignal?: AbortSignal;
+  /** Optional request-scoped observer for benchmark-visible Pi LLM usage. */
+  usageObserver?: PiLlmUsageObserver;
 }
 
 /**
@@ -270,6 +273,7 @@ async function pump(
   const mapper = createPartMapper(partial, (event) => stream.push(event));
   let settled = false;
   let cleanupAbortListeners = () => {};
+  let usageCall: PiLlmUsageCall | undefined;
 
   const setUsage = (rawUsage: LanguageModelUsage | undefined): void => {
     const usage = normalizeUsage(rawUsage);
@@ -294,7 +298,11 @@ async function pump(
     partial.content = partial.content.filter((content) => content.type !== 'toolCall');
   };
 
-  const settleError = (reason: 'error' | 'aborted', error: unknown): boolean => {
+  const settleError = (
+    reason: 'error' | 'aborted',
+    error: unknown,
+    finishReason?: FinishReason,
+  ): boolean => {
     if (settled) return false;
     settled = true;
     mapper.finalize();
@@ -305,6 +313,7 @@ async function pump(
       reason === 'aborted' ? 'Operation aborted' : 'LLM stream error',
     );
     cleanupAbortListeners();
+    usageCall?.settle(reason === 'aborted' ? 'cancelled' : 'error', undefined, finishReason);
     stream.push({ type: 'error', reason, error: partial });
     return true;
   };
@@ -318,10 +327,12 @@ async function pump(
     const hasToolCall = partial.content.some((content) => content.type === 'toolCall');
     mapper.finalize();
     setUsage(totalUsage);
+    if (totalUsage !== undefined) usageCall?.observeFinishStep(totalUsage);
 
     switch (finishReason) {
       case 'length':
         settled = true;
+        usageCall?.settle('completed', totalUsage, finishReason);
         if (hasToolCall) lengthToolCallMessages.add(partial);
         removeExecutableToolCalls();
         partial.stopReason = 'length';
@@ -331,21 +342,24 @@ async function pump(
       case 'content-filter':
       case 'error':
       case 'other':
-        return settleError('error', `LLM stream finished with ${finishReason}`);
+        return settleError('error', `LLM stream finished with ${finishReason}`, finishReason);
       case 'tool-calls':
         if (!hasToolCall) {
           return settleError(
             'error',
             'LLM stream reported tool-calls without a complete parsed tool call',
+            finishReason,
           );
         }
         settled = true;
+        usageCall?.settle('completed', totalUsage, finishReason);
         partial.stopReason = 'toolUse';
         cleanupAbortListeners();
         stream.push({ type: 'done', reason: 'toolUse', message: partial });
         return true;
       case 'stop':
         settled = true;
+        usageCall?.settle('completed', totalUsage, finishReason);
         partial.stopReason = hasToolCall ? 'toolUse' : 'stop';
         cleanupAbortListeners();
         stream.push({
@@ -384,34 +398,51 @@ async function pump(
       return;
     }
 
+    // Admission identity is allocated only after both pre-abort checks and
+    // immediately before the actual OpenMAIC streamLLM invocation.
+    usageCall = opts.usageObserver?.beginCall();
+
     const requestedMaxTokens = streamOptions?.maxTokens;
     const maxOutputTokens =
       opts.maxOutputTokens && requestedMaxTokens
         ? Math.min(opts.maxOutputTokens, requestedMaxTokens)
         : (requestedMaxTokens ?? opts.maxOutputTokens);
-    const result = await streamLLM(
-      {
-        model: opts.languageModel,
-        system: context.systemPrompt,
-        messages: toModelMessages(context.messages, {
-          includeReasoning:
-            typeof opts.languageModel !== 'string' &&
-            opts.languageModel.provider === 'kimi.chat' &&
-            opts.languageModel.modelId === 'kimi-k3',
-        }),
-        tools: toAiTools(context.tools ?? []),
-        toolChoice: 'auto',
-        // pi's loop owns multi-step; one LLM turn per streamFn call.
-        stopWhen: stepCountIs(1),
-        maxOutputTokens,
-        abortSignal: combinedAbort.signal,
-      },
-      opts.source ?? 'maic-agent',
-      opts.thinkingConfig,
-    );
+    let result: ReturnType<typeof streamLLM>;
+    try {
+      result = streamLLM(
+        {
+          model: opts.languageModel,
+          system: context.systemPrompt,
+          messages: toModelMessages(context.messages, {
+            includeReasoning:
+              typeof opts.languageModel !== 'string' &&
+              opts.languageModel.provider === 'kimi.chat' &&
+              opts.languageModel.modelId === 'kimi-k3',
+          }),
+          tools: toAiTools(context.tools ?? []),
+          toolChoice: 'auto',
+          // pi's loop owns multi-step; one LLM turn per streamFn call.
+          stopWhen: stepCountIs(1),
+          maxOutputTokens,
+          abortSignal: combinedAbort.signal,
+        },
+        opts.source ?? 'maic-agent',
+        opts.thinkingConfig,
+      );
+    } catch (error) {
+      settleError('error', error);
+      return;
+    }
 
     for await (const part of result.fullStream as AsyncIterable<Record<string, unknown>>) {
       if (settled) break;
+      if (part.type === 'finish-step') {
+        const response = part.response as { modelId?: unknown } | undefined;
+        usageCall?.observeFinishStep(
+          part.usage as LanguageModelUsage | undefined,
+          typeof response?.modelId === 'string' ? response.modelId : undefined,
+        );
+      }
       if (part.type === 'finish') {
         settleFinish(
           part.finishReason as FinishReason | undefined,

--- a/lib/chat/pi/director-loop.ts
+++ b/lib/chat/pi/director-loop.ts
@@ -19,6 +19,7 @@ import {
   type DirectorSceneEvidencePacket,
 } from './tools/read-scene';
 import type { NativeWebSearchConfig } from './tools/web-search';
+import type { PiChatUsageCollector } from './usage';
 
 function formatSceneEvidenceForDelegation(evidence: DirectorSceneEvidencePacket[]): string {
   return evidence.map((packet) => packet.content).join('\n\n');
@@ -40,6 +41,7 @@ export async function runPiDirectorLoop(opts: {
   childRuntimeMode?: ChildRuntimeMode;
   enableNativeChildSpotlight?: boolean;
   nativeWebSearchConfig?: NativeWebSearchConfig;
+  usageCollector?: PiChatUsageCollector;
 }): Promise<void> {
   let totalAgents = 0;
   let totalActions = 0;
@@ -108,9 +110,20 @@ export async function runPiDirectorLoop(opts: {
     thinkingConfig: opts.thinkingConfig,
     source: 'pi-chat-director',
     abortSignal: opts.abortSignal,
+    usageObserver: opts.usageCollector?.createObserver({ scope: 'director' }),
+  });
+  const compactionStreamFn = createCallLlmStreamFn({
+    languageModel: opts.languageModel,
+    maxOutputTokens: opts.maxOutputTokens,
+    thinkingConfig: opts.thinkingConfig,
+    // Keep the deployment-wide usage JSONL source stable. The benchmark-only
+    // observer carries the distinct compaction phase.
+    source: 'pi-chat-director',
+    abortSignal: opts.abortSignal,
+    usageObserver: opts.usageCollector?.createObserver({ scope: 'compaction' }),
   });
   const compactionRuntime = createDirectorCompactionRuntime({
-    streamFn,
+    streamFn: compactionStreamFn,
     contextWindow: opts.contextWindow,
     maxOutputTokens: opts.maxOutputTokens,
   });
@@ -154,6 +167,7 @@ export async function runPiDirectorLoop(opts: {
       enableNativeChildSpotlight: opts.enableNativeChildSpotlight === true,
       nativeWebSearchConfig: opts.nativeWebSearchConfig,
       requestStartCurrentScene,
+      usageCollector: opts.usageCollector,
       isUserCued: () => userCued,
       isSessionClosed: () => sessionClosed,
       takeSceneEvidence: () => {
@@ -239,6 +253,7 @@ export async function runPiDirectorLoop(opts: {
     await cueUser({ fromAgentId: piAgentResponses.at(-1)?.agentId });
   }
 
+  await opts.usageCollector?.flush();
   await opts.send({
     type: 'done',
     data: {
@@ -260,6 +275,7 @@ export async function runPiDirectorLoop(opts: {
         // state and follow-up payloads without being read back.
         whiteboardLedger: piWhiteboardLedger,
       },
+      ...(opts.usageCollector ? { usage: opts.usageCollector.getSummary() } : {}),
     },
   });
 }

--- a/lib/chat/pi/tools/call-agent.ts
+++ b/lib/chat/pi/tools/call-agent.ts
@@ -30,6 +30,7 @@ import {
   toHistoryMessages,
 } from '../prompts';
 import type { SendEvent } from '../types';
+import type { PiChatUsageCollector } from '../usage';
 import {
   buildChildActionTools,
   createPiWhiteboardRuntimeState,
@@ -548,6 +549,7 @@ export function buildCallAgentTool(opts: {
   isUserCued?: () => boolean;
   isSessionClosed?: () => boolean;
   takeSceneEvidence?: () => RuntimeEvidenceAttachment<DirectorSceneEvidenceMetadata[]> | undefined;
+  usageCollector?: PiChatUsageCollector;
 }): AgentTool<typeof CallAgentParams> {
   // Loop-guard (model-agnostic): an empty/errored child turn used to bypass onAgentDone,
   // so the completed-turn count never advanced and the maxAgentTurns guard was defeated — a model
@@ -672,6 +674,12 @@ export function buildCallAgentTool(opts: {
       }
 
       const messageId = nanoid();
+      const childRuntimeMode = opts.childRuntimeMode ?? 'legacy';
+      const usageObserver = opts.usageCollector?.createObserver({
+        scope: 'child',
+        agentId: agent.id,
+        runtimeMode: childRuntimeMode,
+      });
       let text = '';
       let actionCount = 0;
       let sawStructuredOutput = false;
@@ -702,7 +710,6 @@ export function buildCallAgentTool(opts: {
         },
       });
 
-      const childRuntimeMode = opts.childRuntimeMode ?? 'legacy';
       if (childRuntimeMode === 'native') {
         const capturedScene = opts.requestStartCurrentScene;
         const hasMatchingCurrentSceneEvidence = Boolean(
@@ -746,6 +753,7 @@ export function buildCallAgentTool(opts: {
               thinkingConfig: opts.thinkingConfig,
               maxOutputTokens: opts.maxOutputTokens,
               abortSignal: childAbort.signal,
+              usageObserver,
             }),
             systemPrompt: buildNativeChildPrompt(
               opts.body,
@@ -839,6 +847,7 @@ export function buildCallAgentTool(opts: {
           thinkingConfig: opts.thinkingConfig,
           maxOutputTokens: opts.maxOutputTokens,
           abortSignal: childAbort.signal,
+          usageObserver,
         }),
         systemPrompt: buildChildPrompt(
           opts.body,

--- a/lib/chat/pi/usage.ts
+++ b/lib/chat/pi/usage.ts
@@ -1,0 +1,398 @@
+import type { LanguageModelUsage } from 'ai';
+import { nanoid } from 'nanoid';
+
+export type PiLlmCallPhase =
+  | 'director_initial'
+  | 'director_continuation'
+  | 'child_initial'
+  | 'child_continuation'
+  | 'compaction';
+
+export type PiLlmCallStatus = 'completed' | 'error' | 'cancelled';
+export type PiLlmUsageStatus = 'complete' | 'partial' | 'missing';
+export type PiLlmCallScope = 'director' | 'child' | 'compaction';
+
+export interface PiNormalizedLlmUsage {
+  /** Total input tokens. Cache token classes below are subsets, not additions. */
+  inputTokens?: number;
+  /** Total output tokens. reasoningTokens below is a subset, not an addition. */
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  reasoningTokens?: number;
+  totalTokens?: number;
+}
+
+export interface PiLlmCallIdentity {
+  requestUsageId: string;
+  callId: string;
+  sequence: number;
+  phase: PiLlmCallPhase;
+  transportIndex: number;
+  provider: string;
+  resolvedModel: string;
+  agentId?: string;
+  runtimeMode?: 'legacy' | 'native';
+}
+
+export interface PiLlmCallStartData extends PiLlmCallIdentity {
+  startedAt: number;
+}
+
+export interface PiLlmUsageData extends PiLlmCallIdentity {
+  actualModel?: string;
+  status: PiLlmCallStatus;
+  usageStatus: Exclude<PiLlmUsageStatus, 'missing'>;
+  rawUsage: unknown;
+  normalizedUsage: PiNormalizedLlmUsage;
+  observedAt: number;
+}
+
+export interface PiLlmCallEndData extends PiLlmCallIdentity {
+  actualModel?: string;
+  status: PiLlmCallStatus;
+  finishReason?: string;
+  usageStatus: PiLlmUsageStatus;
+  completedAt: number;
+}
+
+export interface PiChatUsageSummary {
+  requestUsageId: string;
+  callCount: number;
+  endedCallCount: number;
+  usageEventCount: number;
+  complete: boolean;
+  partialCallCount: number;
+  missingCallCount: number;
+  observedRetryCount: number;
+  retryVisibility: 'openmaic_only';
+  totals: PiNormalizedLlmUsage;
+}
+
+export type PiUsageLifecycleEvent =
+  | { type: 'llm_call_start'; data: PiLlmCallStartData }
+  | { type: 'llm_usage'; data: PiLlmUsageData }
+  | { type: 'llm_call_end'; data: PiLlmCallEndData };
+
+export interface PiLlmUsageCall {
+  observeFinishStep(usage: LanguageModelUsage | undefined, actualModel?: string): void;
+  settle(status: PiLlmCallStatus, finalUsage?: LanguageModelUsage, finishReason?: string): void;
+}
+
+export interface PiLlmUsageObserver {
+  beginCall(): PiLlmUsageCall;
+}
+
+interface StoredCall {
+  identity: PiLlmCallIdentity;
+  startedAt: number;
+  observedAt?: number;
+  completedAt?: number;
+  status?: PiLlmCallStatus;
+  finishReason?: string;
+  usageStatus: PiLlmUsageStatus;
+  rawUsage?: unknown;
+  normalizedUsage?: PiNormalizedLlmUsage;
+  actualModel?: string;
+}
+
+export interface PiChatUsageCollector {
+  requestUsageId: string;
+  createObserver(options: {
+    scope: PiLlmCallScope;
+    agentId?: string;
+    runtimeMode?: 'legacy' | 'native';
+  }): PiLlmUsageObserver;
+  flush(): Promise<void>;
+  getSummary(): PiChatUsageSummary;
+}
+
+export function createPiChatUsageCollector(options: {
+  send: (event: PiUsageLifecycleEvent) => Promise<void>;
+  provider: string;
+  resolvedModel: string;
+  requestUsageId?: string;
+  now?: () => Date;
+  createId?: () => string;
+}): PiChatUsageCollector {
+  const requestUsageId = options.requestUsageId ?? nanoid();
+  const now = options.now ?? (() => new Date());
+  const createId = options.createId ?? nanoid;
+  const calls: StoredCall[] = [];
+  let sequence = 0;
+  let delivery = Promise.resolve();
+
+  const enqueue = (event: PiUsageLifecycleEvent): void => {
+    // Usage lifecycle events share one request-local queue. A rejected write is
+    // observed and does not create an unhandled rejection; the request owner
+    // still controls cancellation and stream closure.
+    delivery = delivery.then(() => options.send(event)).catch(() => undefined);
+  };
+
+  const createObserver = ({
+    scope,
+    agentId,
+    runtimeMode,
+  }: {
+    scope: PiLlmCallScope;
+    agentId?: string;
+    runtimeMode?: 'legacy' | 'native';
+  }) => {
+    let transportIndex = 0;
+    return {
+      beginCall(): PiLlmUsageCall {
+        transportIndex += 1;
+        sequence += 1;
+        const phase = phaseFor(scope, transportIndex);
+        const identity: PiLlmCallIdentity = {
+          requestUsageId,
+          callId: createId(),
+          sequence,
+          phase,
+          transportIndex,
+          provider: options.provider,
+          resolvedModel: options.resolvedModel,
+          ...(agentId ? { agentId } : {}),
+          ...(runtimeMode ? { runtimeMode } : {}),
+        };
+        const call: StoredCall = {
+          identity,
+          startedAt: now().getTime(),
+          usageStatus: 'missing',
+        };
+        // Registration precedes delivery so request summaries can never omit an
+        // admitted provider invocation merely because its SSE write failed.
+        calls.push(call);
+        enqueue({ type: 'llm_call_start', data: { ...identity, startedAt: call.startedAt } });
+
+        let settled = false;
+        return {
+          observeFinishStep(usage, actualModel) {
+            if (settled) return;
+            if (usage !== undefined) {
+              call.rawUsage = toJsonSafe(usage);
+              const analyzed = analyzeBenchmarkUsage(usage);
+              call.normalizedUsage = analyzed.normalizedUsage;
+              call.usageStatus = analyzed.usageStatus;
+              call.observedAt = now().getTime();
+            }
+            const model = nonEmptyString(actualModel);
+            if (model) call.actualModel = model;
+          },
+          settle(status, finalUsage, finishReason) {
+            if (settled) return;
+            settled = true;
+            if (finalUsage !== undefined) {
+              // The final aggregate is authoritative and replaces (never adds
+              // to) any provisional finish-step usage.
+              call.rawUsage = toJsonSafe(finalUsage);
+              const analyzed = analyzeBenchmarkUsage(finalUsage);
+              call.normalizedUsage = analyzed.normalizedUsage;
+              call.usageStatus = analyzed.usageStatus;
+              call.observedAt = now().getTime();
+            }
+            call.status = status;
+            call.finishReason = nonEmptyString(finishReason);
+            call.completedAt = now().getTime();
+            if (call.usageStatus !== 'missing' && call.rawUsage !== undefined) {
+              enqueue({
+                type: 'llm_usage',
+                data: {
+                  ...call.identity,
+                  ...(call.actualModel ? { actualModel: call.actualModel } : {}),
+                  status,
+                  usageStatus: call.usageStatus,
+                  rawUsage: call.rawUsage,
+                  normalizedUsage: call.normalizedUsage ?? {},
+                  observedAt: call.observedAt ?? call.completedAt,
+                },
+              });
+            }
+            enqueue({
+              type: 'llm_call_end',
+              data: {
+                ...call.identity,
+                ...(call.actualModel ? { actualModel: call.actualModel } : {}),
+                status,
+                ...(call.finishReason ? { finishReason: call.finishReason } : {}),
+                usageStatus: call.usageStatus,
+                completedAt: call.completedAt,
+              },
+            });
+          },
+        };
+      },
+    };
+  };
+
+  return {
+    requestUsageId,
+    createObserver,
+    flush: () => delivery,
+    getSummary: () => summarize(requestUsageId, calls),
+  };
+}
+
+function phaseFor(scope: PiLlmCallScope, transportIndex: number): PiLlmCallPhase {
+  if (scope === 'compaction') return 'compaction';
+  if (scope === 'director') {
+    return transportIndex === 1 ? 'director_initial' : 'director_continuation';
+  }
+  return transportIndex === 1 ? 'child_initial' : 'child_continuation';
+}
+
+type TokenField = { value?: number; invalid: boolean };
+
+function tokenField(value: unknown): TokenField {
+  if (value === undefined) return { invalid: false };
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return { value, invalid: false };
+  }
+  return { invalid: true };
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function preferTokenField(primary: unknown, fallback: unknown): TokenField {
+  const primaryField = tokenField(primary);
+  const fallbackField = tokenField(fallback);
+  const conflict =
+    primaryField.value !== undefined &&
+    fallbackField.value !== undefined &&
+    primaryField.value !== fallbackField.value;
+  return {
+    value: primaryField.value ?? fallbackField.value,
+    invalid: primaryField.invalid || fallbackField.invalid || conflict,
+  };
+}
+
+function analyzeBenchmarkUsage(usage: LanguageModelUsage): {
+  normalizedUsage?: PiNormalizedLlmUsage;
+  usageStatus: PiLlmUsageStatus;
+} {
+  const input = tokenField(usage.inputTokens);
+  const output = tokenField(usage.outputTokens);
+  const cacheRead = preferTokenField(
+    usage.inputTokenDetails?.cacheReadTokens,
+    usage.cachedInputTokens,
+  );
+  const cacheCreation = tokenField(usage.inputTokenDetails?.cacheWriteTokens);
+  const reasoning = preferTokenField(
+    usage.outputTokenDetails?.reasoningTokens,
+    usage.reasoningTokens,
+  );
+  const providerTotal = tokenField(usage.totalTokens);
+  let invalid =
+    input.invalid ||
+    output.invalid ||
+    cacheRead.invalid ||
+    cacheCreation.invalid ||
+    reasoning.invalid ||
+    providerTotal.invalid;
+
+  const inputTokens = input.value;
+  const outputTokens = output.value;
+  let cacheReadTokens = cacheRead.value;
+  let cacheCreationTokens = cacheCreation.value;
+  let reasoningTokens = reasoning.value;
+
+  if (
+    inputTokens !== undefined &&
+    (cacheReadTokens ?? 0) + (cacheCreationTokens ?? 0) > inputTokens
+  ) {
+    invalid = true;
+    cacheReadTokens = undefined;
+    cacheCreationTokens = undefined;
+  }
+  if (outputTokens !== undefined && (reasoningTokens ?? 0) > outputTokens) {
+    invalid = true;
+    reasoningTokens = undefined;
+  }
+
+  let usableProviderTotal = providerTotal.value;
+  const knownTokenLowerBound = (inputTokens ?? 0) + (outputTokens ?? 0);
+  if (usableProviderTotal !== undefined && usableProviderTotal < knownTokenLowerBound) {
+    invalid = true;
+    usableProviderTotal = undefined;
+  }
+  const totalTokens =
+    inputTokens !== undefined && outputTokens !== undefined
+      ? inputTokens + outputTokens
+      : usableProviderTotal;
+  if (
+    providerTotal.value !== undefined &&
+    inputTokens !== undefined &&
+    outputTokens !== undefined &&
+    providerTotal.value !== totalTokens
+  ) {
+    invalid = true;
+  }
+
+  const normalizedUsage: PiNormalizedLlmUsage = {
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+    ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+  };
+  if (Object.keys(normalizedUsage).length === 0) {
+    return { usageStatus: 'missing' };
+  }
+  return {
+    normalizedUsage,
+    usageStatus:
+      !invalid && inputTokens !== undefined && outputTokens !== undefined ? 'complete' : 'partial',
+  };
+}
+
+function toJsonSafe(value: unknown): unknown {
+  try {
+    return JSON.parse(
+      JSON.stringify(value, (_key, item) => {
+        if (typeof item === 'bigint') return item.toString();
+        if (typeof item === 'number' && !Number.isFinite(item)) return undefined;
+        return item;
+      }),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function summarize(requestUsageId: string, calls: StoredCall[]): PiChatUsageSummary {
+  const ended = calls.filter((call) => call.status !== undefined);
+  const partialCallCount = ended.filter((call) => call.usageStatus === 'partial').length;
+  const missingCallCount = ended.filter((call) => call.usageStatus === 'missing').length;
+  const usageCalls = ended.filter((call) => call.usageStatus !== 'missing');
+  const totals = usageCalls.reduce<PiNormalizedLlmUsage>((sum, call) => {
+    for (const key of [
+      'inputTokens',
+      'outputTokens',
+      'cacheReadTokens',
+      'cacheCreationTokens',
+      'reasoningTokens',
+    ] as const) {
+      const value = call.normalizedUsage?.[key];
+      if (value !== undefined) sum[key] = (sum[key] ?? 0) + value;
+    }
+    return sum;
+  }, {});
+  if (totals.inputTokens !== undefined && totals.outputTokens !== undefined) {
+    totals.totalTokens = totals.inputTokens + totals.outputTokens;
+  }
+  return {
+    requestUsageId,
+    callCount: calls.length,
+    endedCallCount: ended.length,
+    usageEventCount: usageCalls.length,
+    complete: calls.length === ended.length && partialCallCount === 0 && missingCallCount === 0,
+    partialCallCount,
+    missingCallCount,
+    observedRetryCount: 0,
+    retryVisibility: 'openmaic_only',
+    totals,
+  };
+}

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -449,6 +449,9 @@ export type StatelessEvent =
       data: { stage: 'director' | 'agent_loading'; agentId?: string };
     }
   | { type: 'cue_user'; data: { fromAgentId?: string; prompt?: string } }
+  | { type: 'llm_call_start'; data: import('@/lib/chat/pi/usage').PiLlmCallStartData }
+  | { type: 'llm_usage'; data: import('@/lib/chat/pi/usage').PiLlmUsageData }
+  | { type: 'llm_call_end'; data: import('@/lib/chat/pi/usage').PiLlmCallEndData }
   | {
       type: 'done';
       data: {
@@ -461,6 +464,10 @@ export type StatelessEvent =
         directorCompaction?: DirectorCompactionTrace;
         directorToolTrace?: DirectorToolTraceEntry[];
         directorState?: DirectorState;
+        usage?: import('@/lib/chat/pi/usage').PiChatUsageSummary;
       };
     }
-  | { type: 'error'; data: { message: string } };
+  | {
+      type: 'error';
+      data: { message: string; usage?: import('@/lib/chat/pi/usage').PiChatUsageSummary };
+    };

--- a/tests/lib/agent/runtime/legacy-child-transport-consumer.test.ts
+++ b/tests/lib/agent/runtime/legacy-child-transport-consumer.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
 vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
 
 import { buildCallAgentTool } from '@/lib/chat/pi/tools/call-agent';
+import { createPiChatUsageCollector } from '@/lib/chat/pi/usage';
 
 const ZERO_USAGE = {
   inputTokens: 0,
@@ -93,6 +94,14 @@ function makeHarness() {
   const summaries: AgentTurnSummary[] = [];
   const onActionDone = vi.fn();
   const abortController = new AbortController();
+  const usageCollector = createPiChatUsageCollector({
+    send: async (event) => {
+      events.push(event);
+    },
+    provider: 'test-provider',
+    resolvedModel: 'child-model',
+    requestUsageId: 'request-1',
+  });
   const tool = buildCallAgentTool({
     body: makeBody(),
     agentConfigs: [teacher],
@@ -111,15 +120,18 @@ function makeHarness() {
     getWhiteboardLedger: () => [],
     maxActionsPerAgent: 2,
     enableWhiteboardTools: true,
+    usageCollector,
   });
-  return { events, summaries, onActionDone, tool };
+  return { events, summaries, onActionDone, tool, usageCollector };
 }
 
 async function execute(harness: ReturnType<typeof makeHarness>) {
-  return harness.tool.execute('delegate-1', {
+  const result = await harness.tool.execute('delegate-1', {
     agentId: teacher.id,
     instruction: 'Teach briefly.',
   });
+  await harness.usageCollector.flush();
+  return result;
 }
 
 function actionOutput(text = 'I opened the board.') {
@@ -163,6 +175,23 @@ describe('Legacy Pi Child shared transport consumer', () => {
       expect.objectContaining({ data: expect.objectContaining({ actionName: 'wb_open' }) }),
     ]);
     expect(harness.onActionDone).toHaveBeenCalledTimes(1);
+    expect(harness.usageCollector.getSummary()).toMatchObject({
+      callCount: 1,
+      endedCallCount: 1,
+      usageEventCount: 1,
+      complete: true,
+      observedRetryCount: 0,
+    });
+    expect(harness.events.filter((event) => event.type === 'llm_call_start')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          phase: 'child_initial',
+          transportIndex: 1,
+          agentId: teacher.id,
+        }),
+      }),
+    ]);
+    expect(harness.events.filter((event) => event.type === 'llm_call_end')).toHaveLength(1);
     expect(harness.summaries).toEqual([
       expect.objectContaining({
         agentId: teacher.id,

--- a/tests/lib/agent/runtime/stream-fn-usage.test.ts
+++ b/tests/lib/agent/runtime/stream-fn-usage.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
 vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
 
 import { createCallLlmStreamFn } from '@/lib/agent/runtime/stream-fn';
+import { createPiChatUsageCollector } from '@/lib/chat/pi/usage';
+import type { StatelessEvent } from '@/lib/types/chat';
 
 describe('createCallLlmStreamFn usage', () => {
   beforeEach(() => mocks.streamLLM.mockReset());
@@ -42,6 +44,128 @@ describe('createCallLlmStreamFn usage', () => {
       cacheRead: 10,
       cacheWrite: 5,
       totalTokens: 150,
+    });
+  });
+
+  it('emits provisional usage on a later provider error and preserves actual model identity', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = createPiChatUsageCollector({
+      send: async (event) => {
+        events.push(event);
+      },
+      provider: 'openai',
+      resolvedModel: 'resolved-model',
+      requestUsageId: 'request-1',
+      createId: () => 'call-1',
+    });
+    mocks.streamLLM.mockReturnValue({
+      fullStream: (async function* () {
+        yield {
+          type: 'finish-step',
+          response: { modelId: 'actual-model' },
+          usage: { inputTokens: 8, outputTokens: 2, totalTokens: 10 },
+        };
+        yield { type: 'error', error: new Error('provider failed after step') };
+      })(),
+    });
+    const streamFn = createCallLlmStreamFn({
+      languageModel: {} as never,
+      usageObserver: collector.createObserver({ scope: 'director' }),
+    });
+
+    const stream = await streamFn(
+      {} as never,
+      { systemPrompt: 'test', messages: [], tools: [] },
+      {},
+    );
+    const message = await stream.result();
+    await collector.flush();
+
+    expect(message.stopReason).toBe('error');
+    expect(events.map((event) => event.type)).toEqual([
+      'llm_call_start',
+      'llm_usage',
+      'llm_call_end',
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: 'llm_call_end',
+      data: {
+        status: 'error',
+        usageStatus: 'complete',
+        actualModel: 'actual-model',
+      },
+    });
+  });
+
+  it('does not allocate identity or emit lifecycle events for a pre-aborted invocation', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = createPiChatUsageCollector({
+      send: async (event) => {
+        events.push(event);
+      },
+      provider: 'openai',
+      resolvedModel: 'resolved-model',
+      requestUsageId: 'request-1',
+    });
+    const controller = new AbortController();
+    controller.abort(new Error('already cancelled'));
+    const streamFn = createCallLlmStreamFn({
+      languageModel: {} as never,
+      abortSignal: controller.signal,
+      usageObserver: collector.createObserver({ scope: 'director' }),
+    });
+
+    const stream = await streamFn(
+      {} as never,
+      { systemPrompt: 'test', messages: [], tools: [] },
+      {},
+    );
+    await stream.result();
+    await collector.flush();
+
+    expect(mocks.streamLLM).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+    expect(collector.getSummary()).toMatchObject({ callCount: 0, endedCallCount: 0 });
+  });
+
+  it('settles an admitted stream setup exception as one error call with missing usage', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = createPiChatUsageCollector({
+      send: async (event) => {
+        events.push(event);
+      },
+      provider: 'openai',
+      resolvedModel: 'resolved-model',
+      requestUsageId: 'request-1',
+      createId: () => 'call-1',
+    });
+    mocks.streamLLM.mockReturnValue({
+      fullStream: {
+        [Symbol.asyncIterator]() {
+          throw new Error('sync setup failure');
+        },
+      },
+    });
+    const streamFn = createCallLlmStreamFn({
+      languageModel: {} as never,
+      usageObserver: collector.createObserver({ scope: 'director' }),
+    });
+
+    const stream = await streamFn(
+      {} as never,
+      { systemPrompt: 'test', messages: [], tools: [] },
+      {},
+    );
+    for await (const _event of stream) {
+      // Drain the protocol stream so setup failure remains an explicit Pi
+      // error event rather than an unread terminal event.
+    }
+    await stream.result();
+    await collector.flush();
+
+    expect(events.map((event) => event.type)).toEqual(['llm_call_start', 'llm_call_end']);
+    expect(events.at(-1)).toMatchObject({
+      data: { status: 'error', usageStatus: 'missing' },
     });
   });
 });

--- a/tests/lib/chat/pi/director-compaction-usage.test.ts
+++ b/tests/lib/chat/pi/director-compaction-usage.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+
+const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
+
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+import { createCallLlmStreamFn } from '@/lib/agent/runtime/stream-fn';
+import { createDirectorCompactionRuntime } from '@/lib/chat/pi/director-compaction';
+import { createPiChatUsageCollector } from '@/lib/chat/pi/usage';
+import type { StatelessEvent } from '@/lib/types/chat';
+
+const USAGE = { inputTokens: 100, outputTokens: 20, totalTokens: 120 };
+
+function longHistory(label: string): AgentMessage[] {
+  return Array.from({ length: 12 }, (_, index) => ({
+    role: 'user' as const,
+    content: `${label}-${index}: ${'important classroom context '.repeat(80)}`,
+    timestamp: index,
+  }));
+}
+
+describe('Director compaction usage wiring', () => {
+  beforeEach(() => {
+    mocks.streamLLM.mockReset();
+    mocks.streamLLM.mockImplementation(() => ({
+      fullStream: (async function* () {
+        yield { type: 'text-delta', text: 'Compact the classroom memory without losing facts.' };
+        yield {
+          type: 'finish-step',
+          response: { modelId: 'actual-compaction-model' },
+          usage: USAGE,
+        };
+        yield { type: 'finish', finishReason: 'stop', totalUsage: USAGE };
+      })(),
+    }));
+  });
+
+  it('uses a request-scoped 1-based counter across repeated compaction transports', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = createPiChatUsageCollector({
+      send: async (event) => {
+        events.push(event);
+      },
+      provider: 'openai',
+      resolvedModel: 'resolved-model',
+      requestUsageId: 'request-1',
+    });
+    const runtime = createDirectorCompactionRuntime({
+      streamFn: createCallLlmStreamFn({
+        languageModel: {} as never,
+        usageObserver: collector.createObserver({ scope: 'compaction' }),
+      }),
+      contextWindow: 600,
+      maxOutputTokens: 200,
+      settings: { enabled: true, reserveTokens: 160, keepRecentTokens: 120 },
+    });
+
+    try {
+      await runtime.transformContext(longHistory('first'));
+      await runtime.transformContext(longHistory('second'));
+      await collector.flush();
+
+      expect(runtime.getTrace().triggerCount).toBe(2);
+      const starts = events.filter((event) => event.type === 'llm_call_start');
+      expect(starts.map((event) => [event.data.phase, event.data.transportIndex])).toEqual([
+        ['compaction', 1],
+        ['compaction', 2],
+      ]);
+      expect(events.filter((event) => event.type === 'llm_usage')).toHaveLength(2);
+      expect(events.filter((event) => event.type === 'llm_call_end')).toHaveLength(2);
+      expect(
+        events
+          .filter((event) => event.type === 'llm_call_end')
+          .every((event) => event.data.actualModel === 'actual-compaction-model'),
+      ).toBe(true);
+    } finally {
+      runtime.dispose();
+    }
+  });
+});

--- a/tests/lib/chat/pi/native-child-route-wiring.test.ts
+++ b/tests/lib/chat/pi/native-child-route-wiring.test.ts
@@ -54,10 +54,11 @@ function resultFrom(parts: Array<Record<string, unknown>>) {
   };
 }
 
-function makeRequest(overrides: Record<string, unknown> = {}): NextRequest {
+function makeRequest(overrides: Record<string, unknown> = {}, signal?: AbortSignal): NextRequest {
   return new Request('http://localhost/api/chat/pi', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    signal,
     body: JSON.stringify({
       messages: [
         {
@@ -146,6 +147,7 @@ describe('PR2 Native Child route production wiring', () => {
       model: resolvedModel,
       apiKey: 'resolved-key',
       providerId: 'test-provider',
+      modelId: 'openmaic-resolved-model',
       modelInfo: { outputWindow: 512, contextWindow: 16_000 },
       thinkingConfig: { mode: 'disabled', enabled: false },
     });
@@ -232,8 +234,62 @@ describe('PR2 Native Child route production wiring', () => {
       }),
     ]);
     expect(events.find((event) => event.type === 'done')).toMatchObject({
-      data: { totalAgents: 1, totalActions: 1, agentHadContent: true },
+      data: {
+        totalAgents: 1,
+        totalActions: 1,
+        agentHadContent: true,
+        usage: {
+          callCount: 5,
+          endedCallCount: 5,
+          usageEventCount: 5,
+          complete: true,
+          observedRetryCount: 0,
+          retryVisibility: 'openmaic_only',
+        },
+      },
     });
+    const starts = events.filter((event) => event.type === 'llm_call_start');
+    const usage = events.filter((event) => event.type === 'llm_usage');
+    const ends = events.filter((event) => event.type === 'llm_call_end');
+    expect(starts.map((event) => [event.data.phase, event.data.transportIndex])).toEqual([
+      ['director_initial', 1],
+      ['director_continuation', 2],
+      ['child_initial', 1],
+      ['child_continuation', 2],
+      ['director_continuation', 3],
+    ]);
+    expect(starts.every((event) => event.data.provider === 'test-provider')).toBe(true);
+    expect(starts.every((event) => event.data.resolvedModel === 'openmaic-resolved-model')).toBe(
+      true,
+    );
+    expect(starts.filter((event) => event.data.agentId === 'teacher-1')).toHaveLength(2);
+    expect(
+      starts
+        .filter((event) => event.data.agentId === 'teacher-1')
+        .every((event) => event.data.runtimeMode === 'native'),
+    ).toBe(true);
+    expect(
+      starts
+        .filter((event) => event.data.agentId === undefined)
+        .every((event) => event.data.runtimeMode === undefined),
+    ).toBe(true);
+    expect(starts.every((event) => typeof event.data.startedAt === 'number')).toBe(true);
+    expect(new Set(starts.map((event) => event.data.callId)).size).toBe(5);
+    expect(usage).toHaveLength(5);
+    expect(
+      usage.every(
+        (event) => event.data.status === 'completed' && typeof event.data.observedAt === 'number',
+      ),
+    ).toBe(true);
+    expect(ends).toHaveLength(5);
+    expect(
+      ends.every(
+        (event) =>
+          typeof event.data.finishReason === 'string' && typeof event.data.completedAt === 'number',
+      ),
+    ).toBe(true);
+    const doneIndex = events.findIndex((event) => event.type === 'done');
+    expect(events.findLastIndex((event) => event.type === 'llm_call_end')).toBeLessThan(doneIndex);
   }, 15_000);
 
   it('keeps the production route on Legacy when the Native runtime flag is absent', async () => {
@@ -288,9 +344,36 @@ describe('PR2 Native Child route production wiring', () => {
       }),
     ]);
     expect(events.find((event) => event.type === 'done')).toMatchObject({
-      data: { totalAgents: 1, totalActions: 0, agentHadContent: true },
+      data: {
+        totalAgents: 1,
+        totalActions: 0,
+        agentHadContent: true,
+        usage: { callCount: 4, endedCallCount: 4, complete: true },
+      },
     });
+    const legacyStarts = events.filter((event) => event.type === 'llm_call_start');
+    expect(legacyStarts.filter((event) => event.data.phase === 'child_initial')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ runtimeMode: 'legacy', agentId: 'teacher-1' }),
+      }),
+    ]);
+    expect(legacyStarts.filter((event) => event.data.phase === 'child_continuation')).toHaveLength(
+      0,
+    );
   }, 15_000);
+
+  it('does not allocate usage identity or start a provider transport for an already-aborted route request', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('request already cancelled'));
+
+    const { POST } = await import('@/app/api/chat/pi/route');
+    const response = await POST(makeRequest({}, controller.signal));
+    const events = await readSseEvents(response);
+
+    expect(response.status).toBe(200);
+    expect(mocks.streamLLM).not.toHaveBeenCalled();
+    expect(events.filter((event) => event.type.startsWith('llm_'))).toEqual([]);
+  });
 
   it('keeps web_search exclusively in the Native Child inventory', async () => {
     const directorResponses = [

--- a/tests/lib/chat/pi/usage.test.ts
+++ b/tests/lib/chat/pi/usage.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from 'vitest';
+import type { LanguageModelUsage } from 'ai';
+import { createPiChatUsageCollector } from '@/lib/chat/pi/usage';
+import type { StatelessEvent } from '@/lib/types/chat';
+
+function makeCollector(events: StatelessEvent[]) {
+  let id = 0;
+  let tick = 0;
+  return createPiChatUsageCollector({
+    send: async (event) => {
+      events.push(event);
+    },
+    provider: 'openai',
+    resolvedModel: 'gpt-test',
+    requestUsageId: 'request-1',
+    createId: () => `call-${++id}`,
+    now: () => new Date(1_700_000_000_000 + tick++ * 1_000),
+  });
+}
+
+function makeUsage(
+  overrides: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
+    inputTokenDetails?: Partial<LanguageModelUsage['inputTokenDetails']>;
+    outputTokenDetails?: Partial<LanguageModelUsage['outputTokenDetails']>;
+  } = {},
+): LanguageModelUsage {
+  return {
+    inputTokens: overrides.inputTokens,
+    outputTokens: overrides.outputTokens,
+    totalTokens: overrides.totalTokens,
+    cachedInputTokens: overrides.cachedInputTokens,
+    reasoningTokens: overrides.reasoningTokens,
+    inputTokenDetails: {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+      ...overrides.inputTokenDetails,
+    },
+    outputTokenDetails: {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+      ...overrides.outputTokenDetails,
+    },
+  };
+}
+
+describe('Pi Chat usage collector', () => {
+  it('emits one ordered lifecycle and replaces provisional usage with final totalUsage', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = makeCollector(events);
+    const call = collector.createObserver({ scope: 'director' }).beginCall();
+
+    call.observeFinishStep(
+      makeUsage({
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+        inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 1 },
+        outputTokenDetails: { reasoningTokens: 1 },
+      }),
+      'provider-preview-model',
+    );
+    call.settle(
+      'completed',
+      makeUsage({
+        inputTokens: 20,
+        outputTokens: 5,
+        totalTokens: 25,
+        inputTokenDetails: { cacheReadTokens: 4, cacheWriteTokens: 2 },
+        outputTokenDetails: { reasoningTokens: 2 },
+      }),
+      'stop',
+    );
+    // A losing terminal must not emit or mutate a second settlement.
+    call.settle('error', makeUsage({ inputTokens: 999, outputTokens: 999, totalTokens: 1998 }));
+    await collector.flush();
+
+    expect(events.map((event) => event.type)).toEqual([
+      'llm_call_start',
+      'llm_usage',
+      'llm_call_end',
+    ]);
+    expect(events[0]).toMatchObject({
+      type: 'llm_call_start',
+      data: {
+        requestUsageId: 'request-1',
+        callId: 'call-1',
+        sequence: 1,
+        phase: 'director_initial',
+        transportIndex: 1,
+        provider: 'openai',
+        resolvedModel: 'gpt-test',
+        startedAt: 1_700_000_000_000,
+      },
+    });
+    expect(events[1]).toMatchObject({
+      type: 'llm_usage',
+      data: {
+        actualModel: 'provider-preview-model',
+        status: 'completed',
+        usageStatus: 'complete',
+        normalizedUsage: {
+          inputTokens: 20,
+          outputTokens: 5,
+          cacheReadTokens: 4,
+          cacheCreationTokens: 2,
+          reasoningTokens: 2,
+          totalTokens: 25,
+        },
+        observedAt: 1_700_000_002_000,
+      },
+    });
+    expect(events[2]).toMatchObject({
+      type: 'llm_call_end',
+      data: {
+        status: 'completed',
+        finishReason: 'stop',
+        usageStatus: 'complete',
+        completedAt: 1_700_000_003_000,
+      },
+    });
+    expect(collector.getSummary()).toEqual({
+      requestUsageId: 'request-1',
+      callCount: 1,
+      endedCallCount: 1,
+      usageEventCount: 1,
+      complete: true,
+      partialCallCount: 0,
+      missingCallCount: 0,
+      observedRetryCount: 0,
+      retryVisibility: 'openmaic_only',
+      totals: {
+        inputTokens: 20,
+        outputTokens: 5,
+        cacheReadTokens: 4,
+        cacheCreationTokens: 2,
+        reasoningTokens: 2,
+        totalTokens: 25,
+      },
+    });
+  });
+
+  it('keeps logical run counters independent while sequence and callId stay request-unique', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = makeCollector(events);
+    const director = collector.createObserver({ scope: 'director' });
+    const childA = collector.createObserver({
+      scope: 'child',
+      agentId: 'teacher-a',
+      runtimeMode: 'native',
+    });
+    const childB = collector.createObserver({
+      scope: 'child',
+      agentId: 'teacher-b',
+      runtimeMode: 'legacy',
+    });
+    const compaction = collector.createObserver({ scope: 'compaction' });
+
+    for (const observer of [director, director, childA, childA, childB, compaction, compaction]) {
+      observer.beginCall().settle('error');
+    }
+    await collector.flush();
+
+    const starts = events.filter(
+      (event): event is Extract<StatelessEvent, { type: 'llm_call_start' }> =>
+        event.type === 'llm_call_start',
+    );
+    expect(starts.map((event) => [event.data.phase, event.data.transportIndex])).toEqual([
+      ['director_initial', 1],
+      ['director_continuation', 2],
+      ['child_initial', 1],
+      ['child_continuation', 2],
+      ['child_initial', 1],
+      ['compaction', 1],
+      ['compaction', 2],
+    ]);
+    expect(starts.map((event) => event.data.sequence)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(new Set(starts.map((event) => event.data.callId)).size).toBe(7);
+  });
+
+  it('distinguishes missing and invalid partial usage without fabricating zero tokens', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = makeCollector(events);
+    collector
+      .createObserver({ scope: 'child', runtimeMode: 'native' })
+      .beginCall()
+      .settle('cancelled');
+    collector
+      .createObserver({ scope: 'child', runtimeMode: 'native' })
+      .beginCall()
+      .settle(
+        'error',
+        makeUsage({
+          inputTokens: 4,
+          outputTokens: -1,
+          totalTokens: 3,
+          inputTokenDetails: { cacheReadTokens: 5 },
+        }),
+      );
+    await collector.flush();
+
+    const usageEvents = events.filter((event) => event.type === 'llm_usage');
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      data: {
+        usageStatus: 'partial',
+        normalizedUsage: { inputTokens: 4 },
+      },
+    });
+    expect(usageEvents[0]).not.toMatchObject({ data: { normalizedUsage: { outputTokens: 0 } } });
+    expect(collector.getSummary()).toMatchObject({
+      complete: false,
+      partialCallCount: 1,
+      missingCallCount: 1,
+      totals: { inputTokens: 4 },
+    });
+  });
+
+  it('serializes start, usage, and end writes even when the first write is delayed', async () => {
+    const events: StatelessEvent[] = [];
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const collector = createPiChatUsageCollector({
+      send: async (event) => {
+        if (event.type === 'llm_call_start') await startGate;
+        events.push(event);
+      },
+      provider: 'openai',
+      resolvedModel: 'gpt-test',
+      requestUsageId: 'request-1',
+      createId: () => 'call-1',
+    });
+    collector
+      .createObserver({ scope: 'director' })
+      .beginCall()
+      .settle('completed', makeUsage({ inputTokens: 1, outputTokens: 1, totalTokens: 2 }));
+
+    await Promise.resolve();
+    expect(events).toEqual([]);
+    releaseStart();
+    await collector.flush();
+    expect(events.map((event) => event.type)).toEqual([
+      'llm_call_start',
+      'llm_usage',
+      'llm_call_end',
+    ]);
+  });
+
+  it('treats wholly invalid usage as missing and never emits an empty usage event', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = makeCollector(events);
+    collector
+      .createObserver({ scope: 'director' })
+      .beginCall()
+      .settle(
+        'error',
+        makeUsage({ inputTokens: Number.NaN, outputTokens: -1, totalTokens: Infinity }),
+      );
+    await collector.flush();
+
+    expect(events.filter((event) => event.type === 'llm_usage')).toEqual([]);
+    expect(events.at(-1)).toMatchObject({
+      type: 'llm_call_end',
+      data: { status: 'error', usageStatus: 'missing' },
+    });
+    expect(collector.getSummary()).toMatchObject({
+      complete: false,
+      missingCallCount: 1,
+      totals: {},
+    });
+  });
+
+  it('derives aggregate totalTokens only from aggregate input and output totals', async () => {
+    const events: StatelessEvent[] = [];
+    const collector = makeCollector(events);
+    collector
+      .createObserver({ scope: 'director' })
+      .beginCall()
+      .settle('completed', makeUsage({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }));
+    collector
+      .createObserver({ scope: 'director' })
+      .beginCall()
+      .settle('completed', makeUsage({ totalTokens: 20 }));
+    await collector.flush();
+
+    expect(collector.getSummary()).toMatchObject({
+      complete: false,
+      partialCallCount: 1,
+      totals: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+  });
+});

--- a/tests/lib/chat/use-chat-sessions.test.ts
+++ b/tests/lib/chat/use-chat-sessions.test.ts
@@ -439,6 +439,105 @@ describe('shouldAwaitPresentationAction', () => {
 });
 
 describe('runPiSingleRequest', () => {
+  it('does not forward benchmark-only usage lifecycle events into the classroom buffer', async () => {
+    const encoder = new TextEncoder();
+    const events = [
+      {
+        type: 'llm_call_start',
+        data: {
+          requestUsageId: 'request-1',
+          callId: 'call-1',
+          sequence: 1,
+          phase: 'director_initial',
+          transportIndex: 1,
+          provider: 'openai',
+          resolvedModel: 'model',
+          startedAt: '2026-08-18T00:00:00.000Z',
+        },
+      },
+      {
+        type: 'llm_usage',
+        data: {
+          requestUsageId: 'request-1',
+          callId: 'call-1',
+          sequence: 1,
+          phase: 'director_initial',
+          transportIndex: 1,
+          provider: 'openai',
+          resolvedModel: 'model',
+          usageStatus: 'complete',
+          rawUsage: { inputTokens: 1, outputTokens: 1 },
+          normalizedUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      },
+      {
+        type: 'llm_call_end',
+        data: {
+          requestUsageId: 'request-1',
+          callId: 'call-1',
+          sequence: 1,
+          phase: 'director_initial',
+          transportIndex: 1,
+          provider: 'openai',
+          resolvedModel: 'model',
+          status: 'completed',
+          usageStatus: 'complete',
+          endedAt: '2026-08-18T00:00:01.000Z',
+        },
+      },
+      {
+        type: 'done',
+        data: { totalAgents: 0, totalActions: 0, endReason: 'completed' },
+      },
+    ];
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join('')),
+        );
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+    const onEvent = vi.fn();
+    const onIterationEnd = vi.fn(async () => ({
+      directorState: undefined,
+      totalAgents: 0,
+      agentHadContent: false,
+      cueUserReceived: false,
+    }));
+
+    try {
+      await runPiSingleRequest(
+        'session-1',
+        {
+          messages: [],
+          storeState: {},
+          config: { agentIds: ['teacher-1'] },
+          apiKey: '',
+        } as unknown as Parameters<typeof runPiSingleRequest>[1],
+        new AbortController(),
+        'qa',
+        () => ({ onEvent, onIterationEnd }),
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        { current: vi.fn() },
+        (key) => key,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'done' }));
+    expect(onIterationEnd).toHaveBeenCalledOnce();
+  });
+
   it('does not accept the first-request context when fetch fails before a response', async () => {
     vi.stubGlobal(
       'fetch',


### PR DESCRIPTION
## Summary

Adds request-scoped LLM usage observability to Pi Chat for benchmark consumers.

- emits additive `llm_call_start`, optional `llm_usage`, and `llm_call_end` SSE events for OpenMAIC-visible `streamLLM` invocations;
- includes stable call identity, phase, provider/resolved model, optional actual model, status, and normalized/raw usage;
- aggregates request usage into the existing terminal `done` / best-effort `error` payload;
- covers Director, Native Child, the current single-transport Legacy Child, same-Child continuations, and Director compaction;
- preserves completed call usage across later cancellation or timeout;
- ignores the additive lifecycle events in the classroom client before buffer allocation.

## Contract boundaries

- OpenMAIC remains the only provider/model-resolution authority.
- Retry visibility is explicitly `openmaic_only`; hidden SDK/provider HTTP retries are not claimed as measured.
- This PR does not calculate cost, add provider/fetch instrumentation, collect independent Web Search provider usage, or add durable telemetry.
- Existing text, action, cue-user, replay, and done behavior remains unchanged.

## Companion consumer

Companion MAIC-Mono PR #1868 consumes these events, persists execution usage, reconstructs incomplete lifecycle prefixes, and performs benchmark-local versioned pricing.  https://github.com/CogEvol/MAIC-Mono/pull/1868

## Validation

- Expanded Pi/runtime regression gate: **29 files / 275 tests passed**
- Targeted ESLint: passed
- Prettier: passed
- `git diff --check`: passed
- Independent final code reviews: **PASS**

Full workspace `tsc --noEmit` remains affected by existing current-main workspace dependency/build resolution outside the changed files; no TypeScript diagnostic was attributed to this diff. GitHub CI is the required final gate.