### PR TITLE
feat(storage): allow path-style addressing for S3-compatible asset st…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -402,6 +402,12 @@ DEFAULT_MODEL=
 # are resolved through the standard AWS SDK environment / credential chain.
 # ASSET_S3_BUCKET=
 
+# Use path-style bucket addressing (endpoint/bucket/key). S3-compatible servers
+# reached through AWS_ENDPOINT_URL(_S3) — MinIO, Ceph, other self-hosted
+# gateways — generally require it; the AWS SDK offers no variable of its own
+# for this flag. Leave unset for Amazon S3.
+# AWS_S3_FORCE_PATH_STYLE=1
+
 # Opt into indirect asset byte egress: answer asset byte GETs with a short-lived
 # signed S3 URL (a 302, or a JSON descriptor for the packaged client) instead of
 # the bytes. Unset or "direct" keeps direct egress (the safe default). Requires

--- a/lib/persistence/asset-byte-store.ts
+++ b/lib/persistence/asset-byte-store.ts
@@ -60,6 +60,12 @@ export function configuredS3Bucket(value: string | undefined): string | undefine
  * dependency and its ignored native import, so resolution happens from the
  * package that declares the peer rather than from this app — and only when a
  * bucket is actually configured.
+ *
+ * `ASSET_S3_BUCKET` is this app's variable; region, endpoint, and credentials
+ * belong to the AWS SDK's own environment chain. `AWS_S3_FORCE_PATH_STYLE` is
+ * the one exception: the SDK exposes no variable for path-style addressing, so
+ * this app reads it and passes it through explicitly. S3-compatible servers
+ * (MinIO, Ceph, …) behind `AWS_ENDPOINT_URL(_S3)` generally need `=1`.
  */
 export async function createAssetByteStore(
   bucket: string | undefined,
@@ -67,7 +73,9 @@ export async function createAssetByteStore(
 ): Promise<AssetByteStore> {
   if (!bucket) return new PgAssetByteStore(queryable);
   const storage = await import('@openmaic/storage/asset/s3-bytes');
-  return storage.loadS3AssetByteStore(bucket);
+  return storage.loadS3AssetByteStore(bucket, {
+    forcePathStyle: process.env.AWS_S3_FORCE_PATH_STYLE === '1',
+  });
 }
 
 /**

--- a/packages/@openmaic/storage/src/asset/s3-bytes.ts
+++ b/packages/@openmaic/storage/src/asset/s3-bytes.ts
@@ -79,8 +79,25 @@ export interface S3AssetByteStoreOptions {
 const AWS_S3_CLIENT_PACKAGE = '@aws-sdk/client-s3';
 const AWS_S3_PRESIGNER_PACKAGE = '@aws-sdk/s3-request-presigner';
 
+/**
+ * The slice of the AWS SDK client config this package passes through. Kept
+ * explicit so the empty-options construction below stays honest: the SDK owns
+ * region, endpoint, and credential resolution through its environment chain,
+ * and a host opts into addressing modes the SDK exposes no variable for by
+ * supplying them here instead.
+ */
+export interface S3AssetByteStoreClientConfig {
+  /**
+   * Path-style addressing (`endpoint/bucket/key` instead of `bucket.endpoint/key`).
+   * S3-compatible servers reached through `AWS_ENDPOINT_URL(_S3)` — MinIO, Ceph,
+   * and other self-hosted gateways — usually require it, and the AWS SDK offers
+   * no environment variable for the flag.
+   */
+  forcePathStyle?: boolean;
+}
+
 interface S3Sdk {
-  S3Client: new (options: Record<string, never>) => S3AssetByteStoreClient;
+  S3Client: new (options: S3AssetByteStoreClientConfig) => S3AssetByteStoreClient;
   PutObjectCommand: new (input: S3PutObjectInput) => unknown;
   GetObjectCommand: new (input: S3GetObjectInput) => unknown;
   DeleteObjectCommand: new (input: S3ObjectInput) => unknown;
@@ -158,12 +175,15 @@ function missingPresigner(error: unknown): Error {
  * never runs for it. A host that wants resolution deferred to first use can
  * construct `new S3AssetByteStore({ client, bucket })` itself instead.
  */
-export async function loadS3AssetByteStore(bucket: string): Promise<AssetByteStore> {
+export async function loadS3AssetByteStore(
+  bucket: string,
+  options: S3AssetByteStoreClientConfig = {},
+): Promise<AssetByteStore> {
   try {
     const sdk = await importS3Sdk();
     return new S3AssetByteStore({
       bucket,
-      client: new sdk.S3Client({}),
+      client: new sdk.S3Client({ forcePathStyle: options.forcePathStyle }),
       commands: sdkCommands(sdk),
     });
   } catch (error) {


### PR DESCRIPTION
## What

  `loadS3AssetByteStore` constructed its S3 client with empty options, so a deployment pointing the AWS SDK env chain (`AWS_ENDPOINT_URL_S3`) at an
  S3-compatible server was stuck with virtual-hosted addressing. MinIO, Ceph, and other self-hosted gateways generally only answer path-style — and the AWS
  SDK exposes no environment variable for the flag.

  - `loadS3AssetByteStore(bucket, { forcePathStyle })` passes the flag through. The package still reads no environment itself: region / endpoint / credentials
  stay owned by the SDK's own chain, matching the seam's existing rule.
  - The app's byte-store selection reads `AWS_S3_FORCE_PATH_STYLE=1` and forwards it — the same division as today, where the app owns `ASSET_S3_BUCKET` while
  the SDK owns `AWS_*`.
  - `.env.example` documents the variable next to `ASSET_S3_BUCKET`.

  ## Verification

  - `@openmaic/storage` unit suite: 856 passed (4 skipped files unchanged).
  - S3 contract suite against a real MinIO instance (`S3_CONTRACT_ENDPOINT` + `S3_CONTRACT_BUCKET` + `STORAGE_S3_CONTRACT_REQUIRED=1`): 3 passed.
  - `prettier --check` / `eslint` / `tsc --noEmit` clean on the touched files.
