### PR TITLE
feat(storage): add an agent-session store with PG backend and layered contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     # only ever proves one part merged into the branch, so without a push
     # trigger the accumulated state of the branch that eventually reaches main
     # is never built on its own.
-    branches: [main, integration/kv-asset-server-backend]
+    branches: [main, integration/kv-asset-server-backend, integration/agent-workbench]
   pull_request:
     branches:
       [
@@ -15,6 +15,7 @@ on:
         feat/maic-editor-v1,
         runtime-server-backend,
         integration/kv-asset-server-backend,
+        integration/agent-workbench,
       ]
 
 concurrency:

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/runtime/pg.d.ts",
       "import": "./dist/runtime/pg.js"
     },
+    "./agent-session/pg": {
+      "types": "./dist/agent-session/pg.d.ts",
+      "import": "./dist/agent-session/pg.js"
+    },
     "./asset/pg": {
       "types": "./dist/asset/pg.d.ts",
       "import": "./dist/asset/pg.js"

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -802,9 +802,19 @@ export class PgAgentSessionStore
            AND EXISTS (SELECT 1 FROM ${this.table('sessions')} s
                        WHERE s.id = $1 AND s.deleted_at IS NULL)
          ORDER BY e.seq LIMIT $3
+       ), span AS (
+         -- One extra row on each side of the page so lag/lead see the true
+         -- neighbors across page boundaries instead of NULL at the edges; the
+         -- anchor row (seq = $2) is the cursor's own row, discarded below.
+         SELECT e.seq, e.type
+         FROM ${this.table('events')} e
+         WHERE e.session_id = $1 AND e.seq >= $2
+           AND EXISTS (SELECT 1 FROM ${this.table('sessions')} s
+                       WHERE s.id = $1 AND s.deleted_at IS NULL)
+         ORDER BY e.seq LIMIT $4
        ), ranked AS (
          SELECT seq, lag(type) OVER (ORDER BY seq) AS prev_type,
-                lead(type) OVER (ORDER BY seq) AS next_type FROM page
+                lead(type) OVER (ORDER BY seq) AS next_type FROM span
        )
        SELECT p.seq, p.ts, p.attempt, p.type, p.data, p.scanned
        FROM page p INNER JOIN ranked r ON r.seq = p.seq
@@ -812,7 +822,7 @@ export class PgAgentSessionStore
           OR r.prev_type IS DISTINCT FROM 'message_update'
           OR r.next_type IS DISTINCT FROM 'message_update'
        ORDER BY p.seq`,
-      [sessionId, afterSeq, limit],
+      [sessionId, afterSeq, limit, limit + 2],
     );
     return {
       events: result.rows.map((row) => ({

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -1,0 +1,1284 @@
+/**
+ * PostgreSQL backend for durable agent sessions.
+ *
+ * The backend imports no database driver. A host supplies a direct queryable
+ * and a transaction hook that checks out and pins one connection for the
+ * complete callback. READ COMMITTED isolation is assumed by the parent-row
+ * lock followed by max-plus-one child allocation used by both append logs.
+ */
+import { randomUUID } from 'node:crypto';
+
+import type { QueryResult, Queryable, WithTransaction } from '../runtime/pg.js';
+import {
+  AGENT_SESSION_LIFECYCLE,
+  AgentSessionAccessError,
+  AgentSessionEntryTreeError,
+  AgentSessionLeaseLostError,
+  type AgentSessionEntry,
+  type AgentSessionEntryTree,
+  type AgentSessionEntryTreeHandle,
+  type AgentSessionEventLog,
+  type AgentSessionHooks,
+  type AgentSessionMeta,
+  type AgentSessionStore,
+  type AgentSessionTransaction,
+  type AgentSessionUserMessage,
+  type ClaimedAgentSession,
+  type ClaimAgentSessionOptions,
+  type CreateAgentSessionInput,
+  type FinishAgentSessionPatch,
+  type NewAgentSessionEvent,
+  type NewOwnerSessionEvent,
+  type OwnerSessionEventProjection,
+  type PersistedAgentSessionEvent,
+  type PersistedOwnerSessionEvent,
+  type PostAgentUserMessageOptions,
+  type PostAgentUserMessageResult,
+} from './types.js';
+
+export type { QueryResult, Queryable, WithTransaction } from '../runtime/pg.js';
+
+export interface AgentSessionTableNames {
+  sessions: string;
+  events: string;
+  entries: string;
+  ownerEventCounters: string;
+  ownerEvents: string;
+}
+
+export const DEFAULT_AGENT_SESSION_TABLE_NAMES: Readonly<AgentSessionTableNames> = {
+  sessions: 'agent_sessions',
+  events: 'agent_session_events',
+  entries: 'agent_session_entries',
+  ownerEventCounters: 'agent_owner_session_event_counters',
+  ownerEvents: 'agent_owner_session_events',
+};
+
+export interface AgentSessionLogger {
+  error(message: string, context: Record<string, unknown>, error: unknown): void;
+}
+
+export interface PgAgentSessionStoreOptions extends AgentSessionHooks {
+  /**
+   * Checks out a fresh connection, begins a transaction, pins every callback
+   * query to it, then commits or rolls back before releasing the connection.
+   */
+  withTransaction: WithTransaction;
+  tableNames?: Partial<AgentSessionTableNames>;
+  logger?: AgentSessionLogger;
+  /** Test seams; production callers normally use the defaults. */
+  createId?: () => string;
+  now?: () => number;
+}
+
+/** Pinned default schema for the PostgreSQL agent-session backend. */
+export const AGENT_SESSION_PG_SCHEMA = `
+CREATE TABLE IF NOT EXISTS agent_sessions (
+  id                  TEXT PRIMARY KEY,
+  owner_id            TEXT NOT NULL,
+  prompt              TEXT NOT NULL,
+  stage_id            TEXT NOT NULL,
+  active_stage_id     TEXT,
+  skill_id            TEXT,
+  origin              TEXT,
+  existing_course     BOOLEAN NOT NULL DEFAULT FALSE,
+  status              TEXT NOT NULL DEFAULT 'queued',
+  attempt             INTEGER NOT NULL DEFAULT 0,
+  lease_worker_id     TEXT,
+  lease_worker_pid    INTEGER,
+  lease_heartbeat_at  BIGINT,
+  cancel_requested_at BIGINT,
+  error               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at          TIMESTAMPTZ,
+  CONSTRAINT agent_sessions_attempt_nonnegative CHECK (attempt >= 0),
+  CONSTRAINT agent_sessions_status_known
+    CHECK (status IN ('queued','running','succeeded','failed','cancelled'))
+);
+
+CREATE INDEX IF NOT EXISTS agent_sessions_status_live_idx
+  ON agent_sessions (status, created_at) WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS agent_sessions_owner_live_idx
+  ON agent_sessions (owner_id, created_at) WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS agent_session_events (
+  session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+  seq        INTEGER NOT NULL,
+  ts         BIGINT NOT NULL,
+  attempt    INTEGER NOT NULL,
+  type       TEXT NOT NULL,
+  data       JSONB,
+  PRIMARY KEY (session_id, seq),
+  CONSTRAINT agent_session_events_seq_positive CHECK (seq > 0)
+);
+
+CREATE TABLE IF NOT EXISTS agent_session_entries (
+  session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+  seq        INTEGER NOT NULL,
+  entry_id   TEXT NOT NULL,
+  parent_id  TEXT,
+  type       TEXT NOT NULL,
+  data       JSONB NOT NULL,
+  ts         TIMESTAMPTZ NOT NULL,
+  attempt    INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  CONSTRAINT agent_session_entries_entry_id_unique UNIQUE (session_id, entry_id),
+  CONSTRAINT agent_session_entries_parent_fk
+    FOREIGN KEY (session_id, parent_id)
+    REFERENCES agent_session_entries (session_id, entry_id)
+);
+
+CREATE INDEX IF NOT EXISTS agent_session_entries_type_idx
+  ON agent_session_entries (session_id, type, seq);
+
+CREATE TABLE IF NOT EXISTS agent_owner_session_event_counters (
+  owner_id TEXT PRIMARY KEY,
+  n        BIGINT NOT NULL DEFAULT 0,
+  CONSTRAINT agent_owner_session_event_counters_nonnegative CHECK (n >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS agent_owner_session_events (
+  owner_id   TEXT NOT NULL,
+  id         BIGINT NOT NULL,
+  ts         BIGINT NOT NULL,
+  session_id TEXT NOT NULL,
+  type       TEXT NOT NULL,
+  status     TEXT,
+  attempt    INTEGER,
+  data       JSONB NOT NULL,
+  PRIMARY KEY (owner_id, id),
+  CONSTRAINT agent_owner_session_events_type_known CHECK (type IN
+    ('session_created','session_status','session_deleted',
+     'session_active_stage','session_cancel_requested')),
+  CONSTRAINT agent_owner_session_events_status_known CHECK (status IS NULL OR status IN
+    ('queued','running','succeeded','failed','cancelled')),
+  CONSTRAINT agent_owner_session_events_attempt_nonnegative
+    CHECK (attempt IS NULL OR attempt >= 0)
+);
+`;
+
+function quoteIdentifier(identifier: string): string {
+  if (!/^[a-z_][a-z0-9_]*$/.test(identifier)) {
+    throw new Error(
+      `@openmaic/storage: invalid agent-session table name ${JSON.stringify(identifier)}`,
+    );
+  }
+  return `"${identifier}"`;
+}
+
+function resolveTableNames(overrides?: Partial<AgentSessionTableNames>): AgentSessionTableNames {
+  const names = { ...DEFAULT_AGENT_SESSION_TABLE_NAMES, ...overrides };
+  for (const name of Object.values(names)) quoteIdentifier(name);
+  return names;
+}
+
+function schemaFor(names: AgentSessionTableNames): string {
+  if (
+    Object.entries(DEFAULT_AGENT_SESSION_TABLE_NAMES).every(
+      ([key, value]) => names[key as keyof AgentSessionTableNames] === value,
+    )
+  ) {
+    return AGENT_SESSION_PG_SCHEMA;
+  }
+  const s = quoteIdentifier(names.sessions);
+  const e = quoteIdentifier(names.events);
+  const t = quoteIdentifier(names.entries);
+  const c = quoteIdentifier(names.ownerEventCounters);
+  const o = quoteIdentifier(names.ownerEvents);
+  const prefix = names.sessions.replace(/_sessions$/, '').replace(/[^a-z0-9_]/g, '_');
+  return AGENT_SESSION_PG_SCHEMA.replaceAll(
+    'agent_owner_session_event_counters',
+    names.ownerEventCounters,
+  )
+    .replaceAll('agent_owner_session_events', names.ownerEvents)
+    .replaceAll('agent_session_entries', names.entries)
+    .replaceAll('agent_session_events', names.events)
+    .replaceAll('agent_sessions', names.sessions)
+    .replaceAll('agent_session_entries_type_idx', `${prefix}_session_entries_type_idx`)
+    .replaceAll('agent_sessions_status_live_idx', `${prefix}_sessions_status_live_idx`)
+    .replaceAll('agent_sessions_owner_live_idx', `${prefix}_sessions_owner_live_idx`)
+    .replaceAll(`REFERENCES ${names.sessions}`, `REFERENCES ${s}`)
+    .replaceAll(`ON ${names.sessions}`, `ON ${s}`)
+    .replaceAll(`ON ${names.entries}`, `ON ${t}`)
+    .replaceAll(`CREATE TABLE IF NOT EXISTS ${names.sessions}`, `CREATE TABLE IF NOT EXISTS ${s}`)
+    .replaceAll(`CREATE TABLE IF NOT EXISTS ${names.events}`, `CREATE TABLE IF NOT EXISTS ${e}`)
+    .replaceAll(`CREATE TABLE IF NOT EXISTS ${names.entries}`, `CREATE TABLE IF NOT EXISTS ${t}`)
+    .replaceAll(
+      `CREATE TABLE IF NOT EXISTS ${names.ownerEventCounters}`,
+      `CREATE TABLE IF NOT EXISTS ${c}`,
+    )
+    .replaceAll(
+      `CREATE TABLE IF NOT EXISTS ${names.ownerEvents}`,
+      `CREATE TABLE IF NOT EXISTS ${o}`,
+    );
+}
+
+/** Create all backend-owned tables when absent; existing schemas require migrations. */
+export async function ensureAgentSessionSchema(
+  queryable: Queryable,
+  tableNames?: Partial<AgentSessionTableNames>,
+): Promise<void> {
+  const schema = schemaFor(resolveTableNames(tableNames));
+  for (const sql of schema.split(';')) {
+    const statement = sql.trim();
+    if (statement !== '') await queryable.query(statement);
+  }
+}
+
+interface SessionRow extends Record<string, unknown> {
+  id: string;
+  owner_id: string;
+  prompt: string;
+  stage_id: string;
+  active_stage_id: string | null;
+  skill_id: string | null;
+  origin: string | null;
+  existing_course: boolean;
+  status: AgentSessionMeta['status'];
+  attempt: number;
+  lease_worker_id: string | null;
+  lease_worker_pid: number | null;
+  lease_heartbeat_at: number | string | null;
+  error: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+const SESSION_COLUMNS = `id, owner_id, prompt, stage_id, active_stage_id, skill_id, origin,
+  existing_course, status, attempt, lease_worker_id, lease_worker_pid,
+  lease_heartbeat_at, error, created_at, updated_at`;
+
+function epoch(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+function sessionMeta(row: SessionRow): AgentSessionMeta {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    prompt: row.prompt,
+    stageId: row.stage_id,
+    ...(row.active_stage_id ? { activeStageId: row.active_stage_id } : {}),
+    ...(row.skill_id ? { skillId: row.skill_id } : {}),
+    ...(row.origin ? { origin: row.origin } : {}),
+    existingCourse: row.existing_course,
+    status: row.status,
+    attempt: Number(row.attempt),
+    createdAt: epoch(row.created_at),
+    updatedAt: epoch(row.updated_at),
+    ...(row.lease_worker_id
+      ? {
+          lease: {
+            workerId: row.lease_worker_id,
+            workerPid: row.lease_worker_pid ?? 0,
+            heartbeatAt: Number(row.lease_heartbeat_at ?? 0),
+          },
+        }
+      : {}),
+    ...(row.error ? { error: row.error } : {}),
+  };
+}
+
+function encodeJson(value: unknown, label: string): string {
+  try {
+    const encoded = JSON.stringify(value === undefined ? null : value);
+    if (encoded === undefined) throw new TypeError('value is not JSON-serializable');
+    return encoded;
+  } catch (error) {
+    throw new Error(`@openmaic/storage: ${label} is not JSON-serializable`, { cause: error });
+  }
+}
+
+function decodedObject(value: unknown): Record<string, unknown> {
+  const decoded = typeof value === 'string' ? (JSON.parse(value) as unknown) : value;
+  return decoded && typeof decoded === 'object' ? (decoded as Record<string, unknown>) : {};
+}
+
+let savepointSerial = 0;
+
+export class PgAgentSessionStore
+  implements
+    AgentSessionStore,
+    AgentSessionEventLog,
+    AgentSessionEntryTree,
+    OwnerSessionEventProjection
+{
+  private readonly queryable: Queryable;
+  private readonly transactionHook: WithTransaction;
+  private readonly tables: AgentSessionTableNames;
+  private readonly logger: AgentSessionLogger;
+  private readonly createId: () => string;
+  private readonly clock: () => number;
+  private readonly resolveOwnerHook: NonNullable<AgentSessionHooks['resolveFinalOwner']>;
+  private readonly createdHook?: AgentSessionHooks['onSessionCreated'];
+  private readonly messageHook?: AgentSessionHooks['onUserMessagePosted'];
+
+  constructor(queryable: Queryable, options: PgAgentSessionStoreOptions) {
+    if (typeof options?.withTransaction !== 'function') {
+      throw new Error(
+        '@openmaic/storage: withTransaction is required and must pin a fresh connection and ' +
+          'transaction for every call',
+      );
+    }
+    this.queryable = queryable;
+    this.transactionHook = options.withTransaction;
+    this.tables = resolveTableNames(options.tableNames);
+    this.logger =
+      options.logger ??
+      ({
+        error: (message, context, error) => console.error(message, context, error),
+      } satisfies AgentSessionLogger);
+    this.createId = options.createId ?? randomUUID;
+    this.clock = options.now ?? Date.now;
+    this.resolveOwnerHook = options.resolveFinalOwner ?? (async (_tx, ownerId) => ownerId);
+    this.createdHook = options.onSessionCreated;
+    this.messageHook = options.onUserMessagePosted;
+  }
+
+  private table(name: keyof AgentSessionTableNames): string {
+    return quoteIdentifier(this.tables[name]);
+  }
+
+  private transaction<T>(body: (tx: Queryable) => Promise<T>): Promise<T> {
+    return this.transactionHook(body);
+  }
+
+  private async loadSession(
+    queryable: Queryable,
+    sessionId: string,
+    lock = false,
+    includeDeleted = false,
+  ): Promise<SessionRow | undefined> {
+    const result = await queryable.query<SessionRow>(
+      `SELECT ${SESSION_COLUMNS} FROM ${this.table('sessions')}
+       WHERE id = $1${includeDeleted ? '' : ' AND deleted_at IS NULL'}${lock ? ' FOR UPDATE' : ''}`,
+      [sessionId],
+    );
+    return result.rows[0];
+  }
+
+  async createSession(input: CreateAgentSessionInput): Promise<AgentSessionMeta> {
+    const id = input.id ?? this.createId();
+    return this.transaction(async (tx) => {
+      const ownerId = await this.resolveOwnerHook(tx, input.ownerId);
+      const result = await tx.query<SessionRow>(
+        `INSERT INTO ${this.table('sessions')}
+          (id, owner_id, prompt, stage_id, skill_id, origin, existing_course, status, attempt)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0)
+         RETURNING ${SESSION_COLUMNS}`,
+        [
+          id,
+          ownerId,
+          input.prompt,
+          input.stageId ?? `stage-${id.slice(0, 8)}`,
+          input.skillId ?? null,
+          input.origin ?? null,
+          input.existingCourse ?? false,
+          input.status ?? 'queued',
+        ],
+      );
+      const meta = sessionMeta(result.rows[0]!);
+      await this.createdHook?.(tx, meta);
+      await this.appendProjection(
+        {
+          type: 'session_created',
+          sessionId: id,
+          ts: this.clock(),
+          status: meta.status,
+          attempt: 0,
+        },
+        tx,
+      );
+      return meta;
+    });
+  }
+
+  async getSession(sessionId: string): Promise<AgentSessionMeta | null> {
+    const row = await this.loadSession(this.queryable, sessionId);
+    return row ? sessionMeta(row) : null;
+  }
+
+  async listSessionsByOwner(ownerId: string): Promise<AgentSessionMeta[]> {
+    const result = await this.queryable.query<SessionRow>(
+      `SELECT ${SESSION_COLUMNS} FROM ${this.table('sessions')}
+       WHERE owner_id = $1 AND deleted_at IS NULL ORDER BY created_at, id`,
+      [ownerId],
+    );
+    return result.rows.map(sessionMeta);
+  }
+
+  async softDeleteSession(sessionId: string, ownerId: string): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const result = await tx.query<{ id: string }>(
+        `UPDATE ${this.table('sessions')}
+         SET deleted_at = now(), updated_at = now()
+         WHERE id = $1 AND owner_id = $2 AND deleted_at IS NULL RETURNING id`,
+        [sessionId, ownerId],
+      );
+      if (!result.rows[0]) return false;
+      await this.appendProjection({ type: 'session_deleted', sessionId, ts: this.clock() }, tx);
+      return true;
+    });
+  }
+
+  async resolveActiveStage(sessionId: string): Promise<string> {
+    const result = await this.queryable.query<{ stage_id: string; active_stage_id: string | null }>(
+      `SELECT stage_id, active_stage_id FROM ${this.table('sessions')}
+       WHERE id = $1 AND deleted_at IS NULL`,
+      [sessionId],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error(`@openmaic/storage: unknown session ${JSON.stringify(sessionId)}`);
+    return row.active_stage_id ?? row.stage_id;
+  }
+
+  async setActiveStage(sessionId: string, stageId: string): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const locked = await tx.query<{ active_stage_id: string | null }>(
+        `SELECT active_stage_id FROM ${this.table('sessions')}
+         WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
+        [sessionId],
+      );
+      const prior = locked.rows[0];
+      if (!prior) return false;
+      await tx.query(
+        `UPDATE ${this.table('sessions')} SET active_stage_id = $2, updated_at = now()
+         WHERE id = $1 AND deleted_at IS NULL`,
+        [sessionId, stageId],
+      );
+      if (prior.active_stage_id !== stageId) {
+        await this.appendProjection(
+          { type: 'session_active_stage', sessionId, ts: this.clock(), activeStageId: stageId },
+          tx,
+        );
+      }
+      return true;
+    });
+  }
+
+  async claimNextSession(
+    workerId: string,
+    workerPid: number,
+    options: ClaimAgentSessionOptions,
+  ): Promise<ClaimedAgentSession | null> {
+    const staleBefore = this.clock() - options.leaseTtlMs;
+    const params: unknown[] = [staleBefore, workerId, options.maxAttempts + 1];
+    const targeted = options.sessionId ? ` AND id = $${params.push(options.sessionId)}` : '';
+    const candidates = await this.queryable.query<{ id: string }>(
+      `SELECT id FROM ${this.table('sessions')}
+       WHERE deleted_at IS NULL
+         AND (status = 'queued' OR
+              (status = 'running'
+               AND (lease_heartbeat_at IS NULL OR lease_heartbeat_at < $1)
+               AND (lease_worker_id IS NULL OR lease_worker_id <> $2)))
+         AND (attempt < $3 OR status = 'running')${targeted}
+       ORDER BY created_at LIMIT 5`,
+      params,
+    );
+    for (const candidate of candidates.rows) {
+      const claimed = await this.transaction(async (tx) => {
+        const locked = await tx.query<{ status: string }>(
+          `SELECT status FROM ${this.table('sessions')}
+           WHERE id = $1 AND deleted_at IS NULL
+             AND (status = 'queued' OR
+                  (status = 'running'
+                   AND (lease_heartbeat_at IS NULL OR lease_heartbeat_at < $2)
+                   AND (lease_worker_id IS NULL OR lease_worker_id <> $3)))
+             AND (attempt < $4 OR status = 'running')
+           FOR UPDATE`,
+          [candidate.id, staleBefore, workerId, options.maxAttempts + 1],
+        );
+        const previous = locked.rows[0];
+        if (!previous) return null;
+        const now = this.clock();
+        const updated = await tx.query<SessionRow>(
+          `UPDATE ${this.table('sessions')}
+           SET status = 'running', attempt = attempt + 1, lease_worker_id = $2,
+               lease_worker_pid = $3, lease_heartbeat_at = $4, error = NULL, updated_at = now()
+           WHERE id = $1 AND deleted_at IS NULL RETURNING ${SESSION_COLUMNS}`,
+          [candidate.id, workerId, workerPid, now],
+        );
+        const row = updated.rows[0];
+        if (!row) return null;
+        await this.appendProjection(
+          {
+            type: 'session_status',
+            sessionId: candidate.id,
+            ts: now,
+            status: 'running',
+            attempt: Number(row.attempt),
+          },
+          tx,
+        );
+        const seq = await tx.query<{ max: number | string | null }>(
+          `SELECT max(seq) AS max FROM ${this.table('events')} WHERE session_id = $1`,
+          [candidate.id],
+        );
+        return {
+          ...sessionMeta(row),
+          claimReason: previous.status === 'queued' ? 'queued' : 'orphaned',
+          claimSeq: Number(seq.rows[0]?.max ?? 0),
+        } as ClaimedAgentSession;
+      });
+      if (claimed) return claimed;
+    }
+    return null;
+  }
+
+  async heartbeat(sessionId: string, workerId: string): Promise<boolean> {
+    const result = await this.queryable.query<{ id: string }>(
+      `UPDATE ${this.table('sessions')}
+       SET lease_heartbeat_at = $3, updated_at = now()
+       WHERE id = $1 AND lease_worker_id = $2 AND deleted_at IS NULL RETURNING id`,
+      [sessionId, workerId, this.clock()],
+    );
+    return result.rows.length > 0;
+  }
+
+  async finishSession(
+    sessionId: string,
+    workerId: string,
+    patch: FinishAgentSessionPatch,
+  ): Promise<boolean> {
+    const release = patch.releaseLease !== false;
+    return this.transaction(async (tx) => {
+      const result = await tx.query<{ attempt: number }>(
+        `UPDATE ${this.table('sessions')}
+         SET status = $3, error = CASE WHEN $4::boolean THEN $5 ELSE error END,
+             lease_worker_id = CASE WHEN $6::boolean THEN NULL ELSE lease_worker_id END,
+             lease_worker_pid = CASE WHEN $6::boolean THEN NULL ELSE lease_worker_pid END,
+             lease_heartbeat_at = CASE WHEN $6::boolean THEN NULL ELSE lease_heartbeat_at END,
+             attempt = CASE WHEN $7::boolean THEN 0 ELSE attempt END,
+             updated_at = now()
+         WHERE id = $1 AND lease_worker_id = $2 AND deleted_at IS NULL RETURNING attempt`,
+        [
+          sessionId,
+          workerId,
+          patch.status,
+          patch.error !== undefined,
+          patch.error ?? null,
+          release,
+          patch.resetAttempt === true,
+        ],
+      );
+      const row = result.rows[0];
+      if (!row) return false;
+      await this.appendProjection(
+        {
+          type: 'session_status',
+          sessionId,
+          ts: this.clock(),
+          status: patch.status,
+          attempt: Number(row.attempt),
+        },
+        tx,
+      );
+      return true;
+    });
+  }
+
+  async releaseLease(sessionId: string, workerId: string): Promise<void> {
+    await this.queryable.query(
+      `UPDATE ${this.table('sessions')}
+       SET lease_worker_id = NULL, lease_worker_pid = NULL, lease_heartbeat_at = NULL,
+           updated_at = now()
+       WHERE id = $1 AND lease_worker_id = $2 AND deleted_at IS NULL`,
+      [sessionId, workerId],
+    );
+  }
+
+  private async lockForAppend(
+    tx: Queryable,
+    sessionId: string,
+    workerId: string | null,
+  ): Promise<{ owner_id: string; status: AgentSessionMeta['status']; attempt: number } | null> {
+    const result = await tx.query<{
+      owner_id: string;
+      status: AgentSessionMeta['status'];
+      attempt: number;
+    }>(
+      `SELECT owner_id, status, attempt FROM ${this.table('sessions')}
+       WHERE id = $1 AND deleted_at IS NULL${workerId === null ? '' : ' AND lease_worker_id = $2'}
+       FOR UPDATE`,
+      workerId === null ? [sessionId] : [sessionId, workerId],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  private async insertEvent(
+    tx: Queryable,
+    sessionId: string,
+    event: NewAgentSessionEvent,
+  ): Promise<number> {
+    const result = await tx.query<{ seq: number }>(
+      `INSERT INTO ${this.table('events')} (session_id, seq, ts, attempt, type, data)
+       SELECT $1, COALESCE(MAX(seq), 0) + 1, $2, $3, $4, $5::jsonb
+       FROM ${this.table('events')} WHERE session_id = $1 RETURNING seq`,
+      [sessionId, event.ts, event.attempt, event.type, encodeJson(event.data, 'event data')],
+    );
+    return Number(result.rows[0]!.seq);
+  }
+
+  async appendRunEvent(
+    sessionId: string,
+    workerId: string,
+    event: NewAgentSessionEvent,
+  ): Promise<number | null> {
+    return this.transaction(async (tx) => {
+      const parent = await this.lockForAppend(tx, sessionId, workerId);
+      if (!parent || Number(parent.attempt) !== event.attempt) return null;
+      return this.insertEvent(tx, sessionId, event);
+    });
+  }
+
+  async appendControlEvent(sessionId: string, event: NewAgentSessionEvent): Promise<number | null> {
+    return this.transaction(async (tx) => {
+      const parent = await this.lockForAppend(tx, sessionId, null);
+      if (!parent) return null;
+      return this.insertEvent(tx, sessionId, event);
+    });
+  }
+
+  async appendUserMessage(
+    sessionId: string,
+    input: { text: string; delivery: 'steer' | 'queued'; clientRequestId?: string },
+  ): Promise<number> {
+    return this.transaction(async (tx) => {
+      const parent = await this.lockForAppend(tx, sessionId, null);
+      if (!parent)
+        throw new Error(`@openmaic/storage: unknown session ${JSON.stringify(sessionId)}`);
+      return this.insertEvent(tx, sessionId, {
+        ts: this.clock(),
+        attempt: 0,
+        type: AGENT_SESSION_LIFECYCLE.userMessage,
+        data: input,
+      });
+    });
+  }
+
+  async postUserMessage(
+    sessionId: string,
+    input: { text: string },
+    options: PostAgentUserMessageOptions = {},
+  ): Promise<PostAgentUserMessageResult> {
+    const clientRequestId = this.createId();
+    return this.transaction(async (tx) => {
+      if (options.expectedOwnerId) {
+        const finalOwner = await this.resolveOwnerHook(tx, options.expectedOwnerId);
+        if (finalOwner !== options.expectedOwnerId) throw new AgentSessionAccessError(sessionId);
+      }
+      const parent = await this.lockForAppend(tx, sessionId, null);
+      if (!parent)
+        throw new Error(`@openmaic/storage: unknown session ${JSON.stringify(sessionId)}`);
+      if (options.expectedOwnerId && parent.owner_id !== options.expectedOwnerId) {
+        throw new AgentSessionAccessError(sessionId);
+      }
+      const live = parent.status === 'running';
+      const delivery = live ? 'steer' : 'queued';
+      const seq = await this.insertEvent(tx, sessionId, {
+        ts: this.clock(),
+        attempt: 0,
+        type: AGENT_SESSION_LIFECYCLE.userMessage,
+        data: { text: input.text, delivery, clientRequestId },
+      });
+      const row = await this.loadSession(tx, sessionId, false);
+      await this.messageHook?.(tx, {
+        session: sessionMeta(row!),
+        text: input.text,
+        seq,
+        delivery,
+        clientRequestId,
+      });
+      let requeued = false;
+      if (parent.status === 'queued') {
+        await tx.query(
+          `UPDATE ${this.table('sessions')}
+           SET attempt = 0, error = NULL, cancel_requested_at = NULL, updated_at = now()
+           WHERE id = $1 AND deleted_at IS NULL`,
+          [sessionId],
+        );
+        await this.appendProjection(
+          { type: 'session_status', sessionId, ts: this.clock(), status: 'queued', attempt: 0 },
+          tx,
+        );
+      } else if (!live) {
+        requeued = await this.requeueIn(tx, sessionId, true);
+      }
+      return { seq, delivery, requeued };
+    });
+  }
+
+  async listUserMessages(sessionId: string): Promise<AgentSessionUserMessage[]> {
+    const result = await this.queryable.query<{
+      seq: number;
+      ts: number | string;
+      data: unknown;
+    }>(
+      `SELECT e.seq, e.ts, e.data FROM ${this.table('events')} e
+       INNER JOIN ${this.table('sessions')} s ON s.id = e.session_id
+       WHERE e.session_id = $1 AND e.type = $2 AND s.deleted_at IS NULL ORDER BY e.seq`,
+      [sessionId, AGENT_SESSION_LIFECYCLE.userMessage],
+    );
+    return result.rows.map((row) => {
+      const data = decodedObject(row.data);
+      return {
+        seq: Number(row.seq),
+        ts: Number(row.ts),
+        text: String(data.text ?? ''),
+        delivery: String(data.delivery ?? ''),
+        materials: Array.isArray(data.materials) ? data.materials : [],
+      };
+    });
+  }
+
+  async lastEventSeq(sessionId: string): Promise<number> {
+    const result = await this.queryable.query<{ max: number | string | null }>(
+      `SELECT max(e.seq) AS max FROM ${this.table('events')} e
+       INNER JOIN ${this.table('sessions')} s ON s.id = e.session_id
+       WHERE e.session_id = $1 AND s.deleted_at IS NULL`,
+      [sessionId],
+    );
+    return Number(result.rows[0]?.max ?? 0);
+  }
+
+  async readEventsAfter(
+    sessionId: string,
+    afterSeq: number,
+    limit = 500,
+  ): Promise<PersistedAgentSessionEvent[]> {
+    const result = await this.queryable.query<{
+      seq: number;
+      ts: number | string;
+      attempt: number;
+      type: string;
+      data: unknown;
+    }>(
+      `SELECT e.seq, e.ts, e.attempt, e.type, e.data
+       FROM ${this.table('events')} e
+       INNER JOIN ${this.table('sessions')} s ON s.id = e.session_id
+       WHERE e.session_id = $1 AND e.seq > $2 AND s.deleted_at IS NULL
+       ORDER BY e.seq LIMIT $3`,
+      [sessionId, afterSeq, limit],
+    );
+    return result.rows.map((row) => ({
+      id: Number(row.seq),
+      ts: Number(row.ts),
+      attempt: Number(row.attempt),
+      type: row.type,
+      data: typeof row.data === 'string' ? JSON.parse(row.data) : row.data,
+    }));
+  }
+
+  async readEventsAfterForReplay(
+    sessionId: string,
+    afterSeq: number,
+    limit = 500,
+  ): Promise<{ events: PersistedAgentSessionEvent[]; scanned: number }> {
+    const result = await this.queryable.query<{
+      seq: number;
+      ts: number | string;
+      attempt: number;
+      type: string;
+      data: unknown;
+      scanned: number | string;
+    }>(
+      `WITH page AS (
+         SELECT e.seq, e.ts, e.attempt, e.type, e.data, count(*) OVER () AS scanned
+         FROM ${this.table('events')} e
+         WHERE e.session_id = $1 AND e.seq > $2
+           AND EXISTS (SELECT 1 FROM ${this.table('sessions')} s
+                       WHERE s.id = $1 AND s.deleted_at IS NULL)
+         ORDER BY e.seq LIMIT $3
+       ), ranked AS (
+         SELECT seq, lag(type) OVER (ORDER BY seq) AS prev_type,
+                lead(type) OVER (ORDER BY seq) AS next_type FROM page
+       )
+       SELECT p.seq, p.ts, p.attempt, p.type, p.data, p.scanned
+       FROM page p INNER JOIN ranked r ON r.seq = p.seq
+       WHERE p.type <> 'message_update'
+          OR r.prev_type IS DISTINCT FROM 'message_update'
+          OR r.next_type IS DISTINCT FROM 'message_update'
+       ORDER BY p.seq`,
+      [sessionId, afterSeq, limit],
+    );
+    return {
+      events: result.rows.map((row) => ({
+        id: Number(row.seq),
+        ts: Number(row.ts),
+        attempt: Number(row.attempt),
+        type: row.type,
+        data: typeof row.data === 'string' ? JSON.parse(row.data) : row.data,
+      })),
+      scanned: Number(result.rows[0]?.scanned ?? 0),
+    };
+  }
+
+  async hasSessionRunHistory(sessionId: string): Promise<boolean> {
+    const types = [
+      AGENT_SESSION_LIFECYCLE.sessionStart,
+      AGENT_SESSION_LIFECYCLE.sessionResumed,
+      AGENT_SESSION_LIFECYCLE.sessionInterrupted,
+      AGENT_SESSION_LIFECYCLE.sessionEnd,
+    ];
+    const result = await this.queryable.query<{ present: number }>(
+      `SELECT 1 AS present FROM ${this.table('events')} e
+       INNER JOIN ${this.table('sessions')} s ON s.id = e.session_id
+       WHERE e.session_id = $1 AND e.type = ANY($2::text[]) AND s.deleted_at IS NULL LIMIT 1`,
+      [sessionId, types],
+    );
+    return result.rows.length > 0;
+  }
+
+  private async requeueIn(tx: Queryable, sessionId: string, reset: boolean): Promise<boolean> {
+    const result = await tx.query<{ attempt: number }>(
+      `UPDATE ${this.table('sessions')}
+       SET status = 'queued', attempt = CASE WHEN $2::boolean THEN 0 ELSE attempt END,
+           error = NULL, cancel_requested_at = NULL, updated_at = now()
+       WHERE id = $1 AND deleted_at IS NULL
+         AND status IN ('succeeded', 'failed', 'cancelled') RETURNING attempt`,
+      [sessionId, reset],
+    );
+    const row = result.rows[0];
+    if (!row) return false;
+    await this.appendProjection(
+      {
+        type: 'session_status',
+        sessionId,
+        ts: this.clock(),
+        status: 'queued',
+        attempt: Number(row.attempt),
+      },
+      tx,
+    );
+    return true;
+  }
+
+  async requeueSession(sessionId: string): Promise<boolean> {
+    return this.transaction((tx) => this.requeueIn(tx, sessionId, true));
+  }
+
+  async requeueForRetry(sessionId: string): Promise<boolean> {
+    return this.transaction((tx) => this.requeueIn(tx, sessionId, false));
+  }
+
+  async requestCancel(sessionId: string): Promise<void> {
+    await this.transaction(async (tx) => {
+      const ts = this.clock();
+      const result = await tx.query<{ id: string }>(
+        `UPDATE ${this.table('sessions')}
+         SET cancel_requested_at = $2, updated_at = now()
+         WHERE id = $1 AND deleted_at IS NULL AND cancel_requested_at IS NULL RETURNING id`,
+        [sessionId, ts],
+      );
+      if (result.rows[0]) {
+        await this.appendProjection({ type: 'session_cancel_requested', sessionId, ts }, tx);
+      }
+    });
+  }
+
+  async isCancelRequested(sessionId: string): Promise<boolean> {
+    const result = await this.queryable.query<{ requested: boolean }>(
+      `SELECT cancel_requested_at IS NOT NULL AS requested FROM ${this.table('sessions')}
+       WHERE id = $1 AND deleted_at IS NULL`,
+      [sessionId],
+    );
+    return result.rows[0]?.requested === true;
+  }
+
+  async clearCancel(sessionId: string): Promise<void> {
+    await this.queryable.query(
+      `UPDATE ${this.table('sessions')}
+       SET cancel_requested_at = NULL, updated_at = now()
+       WHERE id = $1 AND deleted_at IS NULL`,
+      [sessionId],
+    );
+  }
+
+  async openEntryTree(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+  ): Promise<AgentSessionEntryTreeHandle> {
+    const session = await this.loadSession(this.queryable, sessionId);
+    if (!session)
+      throw new Error(`@openmaic/storage: unknown session ${JSON.stringify(sessionId)}`);
+    const result = await this.queryable.query<{
+      entry_id: string;
+      parent_id: string | null;
+      type: string;
+      data: unknown;
+      ts: Date | string;
+    }>(
+      `SELECT entry_id, parent_id, type, data, ts FROM ${this.table('entries')}
+       WHERE session_id = $1 ORDER BY seq`,
+      [sessionId],
+    );
+    const entries = result.rows.map((row) => ({
+      ...decodedObject(row.data),
+      id: row.entry_id,
+      parentId: row.parent_id,
+      type: row.type,
+      timestamp: (row.ts instanceof Date ? row.ts : new Date(row.ts)).toISOString(),
+    })) as AgentSessionEntry[];
+    return new PgAgentSessionEntryTreeHandle(this, sessionId, workerId, attempt, entries);
+  }
+
+  async appendTreeEntry(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    entry: AgentSessionEntry,
+  ): Promise<void> {
+    const { id, parentId, type, timestamp, ...data } = entry;
+    if (!id || !type || !Number.isFinite(new Date(timestamp).getTime())) {
+      throw new AgentSessionEntryTreeError(
+        sessionId,
+        'entry identity, type, or timestamp is invalid',
+      );
+    }
+    await this.transaction(async (tx) => {
+      const parent = await this.lockForAppend(tx, sessionId, workerId);
+      if (!parent || Number(parent.attempt) !== attempt) {
+        throw new AgentSessionLeaseLostError(sessionId, workerId, attempt);
+      }
+      await tx.query(
+        `INSERT INTO ${this.table('entries')}
+          (session_id, seq, entry_id, parent_id, type, data, ts, attempt)
+         SELECT $1, COALESCE(MAX(seq), 0) + 1, $2, $3, $4, $5::jsonb, $6, $7
+         FROM ${this.table('entries')} WHERE session_id = $1`,
+        [sessionId, id, parentId, type, encodeJson(data, 'entry data'), timestamp, attempt],
+      );
+    });
+  }
+
+  async append(
+    event: NewOwnerSessionEvent,
+    transaction: AgentSessionTransaction,
+  ): Promise<bigint | null> {
+    return this.appendProjection(event, transaction);
+  }
+
+  private async appendProjection(
+    event: NewOwnerSessionEvent,
+    transaction: AgentSessionTransaction,
+  ): Promise<bigint | null> {
+    const savepoint = `agent_session_projection_${(savepointSerial += 1)}`;
+    try {
+      await transaction.query(`SAVEPOINT ${savepoint}`);
+      const locked = await transaction.query<{ owner_id: string }>(
+        `SELECT owner_id FROM ${this.table('sessions')} WHERE id = $1 FOR UPDATE`,
+        [event.sessionId],
+      );
+      const session = locked.rows[0];
+      if (!session) throw new Error(`cannot project missing session ${event.sessionId}`);
+      await transaction.query(
+        `INSERT INTO ${this.table('ownerEventCounters')} (owner_id, n) VALUES ($1, 0)
+         ON CONFLICT (owner_id) DO NOTHING`,
+        [session.owner_id],
+      );
+      const allocated = await transaction.query<{ n: bigint | string }>(
+        `UPDATE ${this.table('ownerEventCounters')} SET n = n + 1
+         WHERE owner_id = $1 RETURNING n`,
+        [session.owner_id],
+      );
+      const counter = allocated.rows[0];
+      if (!counter) throw new Error(`cannot allocate owner event id for ${session.owner_id}`);
+      const status = 'status' in event ? event.status : null;
+      const attempt = 'attempt' in event ? event.attempt : null;
+      const data =
+        event.type === 'session_active_stage' ? { activeStageId: event.activeStageId } : {};
+      await transaction.query(
+        `INSERT INTO ${this.table('ownerEvents')}
+          (owner_id, id, ts, session_id, type, status, attempt, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+        [
+          session.owner_id,
+          String(counter.n),
+          event.ts,
+          event.sessionId,
+          event.type,
+          status,
+          attempt,
+          encodeJson(data, 'owner event data'),
+        ],
+      );
+      await transaction.query(`RELEASE SAVEPOINT ${savepoint}`);
+      return BigInt(counter.n);
+    } catch (error) {
+      try {
+        await transaction.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+        await transaction.query(`RELEASE SAVEPOINT ${savepoint}`);
+      } catch {
+        // The outer transaction may already be unusable; preserve the projection error for logging.
+      }
+      this.logger.error(
+        'owner session projection failed; committing business mutation for full-list reconciliation',
+        { type: event.type, sessionId: event.sessionId },
+        error,
+      );
+      return null;
+    }
+  }
+
+  async readAfter(
+    ownerId: string,
+    afterId: bigint,
+    limit = 500,
+  ): Promise<PersistedOwnerSessionEvent[]> {
+    const result = await this.queryable.query<{
+      owner_id: string;
+      id: bigint | string;
+      ts: number | string;
+      session_id: string;
+      type: PersistedOwnerSessionEvent['type'];
+      status: AgentSessionMeta['status'] | null;
+      attempt: number | null;
+      data: unknown;
+    }>(
+      `SELECT owner_id, id, ts, session_id, type, status, attempt, data
+       FROM ${this.table('ownerEvents')}
+       WHERE owner_id = $1 AND id > $2 ORDER BY id LIMIT $3`,
+      [ownerId, afterId.toString(), limit],
+    );
+    return result.rows.map((row) => {
+      const base = {
+        id: String(row.id),
+        ownerId: row.owner_id,
+        sessionId: row.session_id,
+        ts: Number(row.ts),
+      };
+      if (row.type === 'session_active_stage') {
+        return {
+          ...base,
+          type: row.type,
+          activeStageId: String(decodedObject(row.data).activeStageId ?? ''),
+        };
+      }
+      if (row.type === 'session_created' || row.type === 'session_status') {
+        return {
+          ...base,
+          type: row.type,
+          status: row.status!,
+          attempt: Number(row.attempt ?? 0),
+        };
+      }
+      return { ...base, type: row.type } as PersistedOwnerSessionEvent;
+    });
+  }
+
+  async readMaxId(ownerId: string): Promise<bigint> {
+    const result = await this.queryable.query<{ n: bigint | string }>(
+      `SELECT n FROM ${this.table('ownerEventCounters')} WHERE owner_id = $1`,
+      [ownerId],
+    );
+    return BigInt(result.rows[0]?.n ?? 0);
+  }
+
+  async readRetirement(ownerId: string): Promise<string | null> {
+    return this.transaction(async (tx) => {
+      const finalOwner = await this.resolveOwnerHook(tx, ownerId);
+      return finalOwner === ownerId ? null : finalOwner;
+    });
+  }
+
+  async mergeOwner(fromOwnerId: string, toOwnerId: string): Promise<number> {
+    if (fromOwnerId === toOwnerId) return 0;
+    return this.transaction(async (tx) => {
+      const finalTarget = await this.resolveOwnerHook(tx, toOwnerId);
+      const locked = await tx.query<{ id: string; owner_id: string }>(
+        `SELECT id, owner_id FROM ${this.table('sessions')}
+         WHERE owner_id IN ($1, $2) ORDER BY id FOR UPDATE`,
+        [fromOwnerId, finalTarget],
+      );
+      const sourceIds = new Set(
+        locked.rows.filter((row) => row.owner_id === fromOwnerId).map((row) => row.id),
+      );
+      if (sourceIds.size > 0) {
+        await tx.query(
+          `UPDATE ${this.table('sessions')} SET owner_id = $2, updated_at = now()
+           WHERE owner_id = $1`,
+          [fromOwnerId, finalTarget],
+        );
+      }
+      const savepoint = `agent_session_merge_projection_${(savepointSerial += 1)}`;
+      try {
+        await tx.query(`SAVEPOINT ${savepoint}`);
+        const owners = [fromOwnerId, finalTarget].sort();
+        for (const ownerId of owners) {
+          await tx.query(
+            `INSERT INTO ${this.table('ownerEventCounters')} (owner_id, n) VALUES ($1, 0)
+             ON CONFLICT (owner_id) DO NOTHING`,
+            [ownerId],
+          );
+          await tx.query(
+            `SELECT n FROM ${this.table('ownerEventCounters')} WHERE owner_id = $1 FOR UPDATE`,
+            [ownerId],
+          );
+        }
+        await tx.query(
+          `WITH bounds AS (
+             SELECT greatest(
+               coalesce((SELECT max(n) FROM ${this.table('ownerEventCounters')}
+                         WHERE owner_id IN ($1, $2)), 0),
+               coalesce((SELECT max(id) FROM ${this.table('ownerEvents')}
+                         WHERE owner_id IN ($1, $2)), 0)
+             ) AS high
+           ), source_events AS MATERIALIZED (
+             SELECT e.*, row_number() OVER (ORDER BY e.id, e.ts, e.session_id) AS ordinal
+             FROM ${this.table('ownerEvents')} e WHERE e.owner_id = $1
+           )
+           INSERT INTO ${this.table('ownerEvents')}
+             (owner_id, id, ts, session_id, type, status, attempt, data)
+           SELECT $2, bounds.high + source_events.ordinal, source_events.ts,
+                  source_events.session_id, source_events.type, source_events.status,
+                  source_events.attempt, source_events.data
+           FROM source_events CROSS JOIN bounds`,
+          [fromOwnerId, finalTarget],
+        );
+        await tx.query(`DELETE FROM ${this.table('ownerEvents')} WHERE owner_id = $1`, [
+          fromOwnerId,
+        ]);
+        await tx.query(
+          `UPDATE ${this.table('ownerEventCounters')}
+           SET n = greatest(n, coalesce((SELECT max(id) FROM ${this.table('ownerEvents')}
+                                        WHERE owner_id = $1), 0))
+           WHERE owner_id = $1`,
+          [finalTarget],
+        );
+        await tx.query(`DELETE FROM ${this.table('ownerEventCounters')} WHERE owner_id = $1`, [
+          fromOwnerId,
+        ]);
+        await tx.query(`RELEASE SAVEPOINT ${savepoint}`);
+      } catch (error) {
+        try {
+          await tx.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+          await tx.query(`RELEASE SAVEPOINT ${savepoint}`);
+        } catch {
+          // Preserve the package-owned business merge when only its projection is damaged.
+        }
+        this.logger.error(
+          'owner session projection merge failed; committing session ownership changes',
+          { fromOwnerId, toOwnerId: finalTarget },
+          error,
+        );
+      }
+      return sourceIds.size;
+    });
+  }
+}
+
+class PgAgentSessionEntryTreeHandle implements AgentSessionEntryTreeHandle {
+  private readonly entries: AgentSessionEntry[];
+  private readonly byId: Map<string, AgentSessionEntry>;
+  private readonly labelsById = new Map<string, string>();
+  private currentLeafId: string | null = null;
+
+  constructor(
+    private readonly store: PgAgentSessionStore,
+    private readonly sessionId: string,
+    private readonly workerId: string,
+    private readonly attempt: number,
+    entries: AgentSessionEntry[],
+  ) {
+    this.entries = entries;
+    this.byId = new Map();
+    for (const entry of entries) {
+      if (this.byId.has(entry.id)) {
+        throw new AgentSessionEntryTreeError(sessionId, `duplicate entry id ${entry.id}`);
+      }
+      if (entry.parentId !== null && !this.byId.has(entry.parentId)) {
+        throw new AgentSessionEntryTreeError(sessionId, `missing parent ${entry.parentId}`);
+      }
+      this.byId.set(entry.id, entry);
+      this.updateLabel(entry);
+      this.currentLeafId = entry.type === 'leaf' ? String(entry.targetId ?? '') || null : entry.id;
+    }
+  }
+
+  private updateLabel(entry: AgentSessionEntry): void {
+    if (entry.type !== 'label') return;
+    const targetId = String(entry.targetId ?? '');
+    const label = typeof entry.label === 'string' ? entry.label.trim() : '';
+    if (label) this.labelsById.set(targetId, label);
+    else this.labelsById.delete(targetId);
+  }
+
+  async getEntries(): Promise<AgentSessionEntry[]> {
+    return [...this.entries];
+  }
+
+  async getEntry(id: string): Promise<AgentSessionEntry | undefined> {
+    return this.byId.get(id);
+  }
+
+  async findEntries<TType extends AgentSessionEntry['type']>(
+    type: TType,
+  ): Promise<Array<Extract<AgentSessionEntry, { type: TType }> | AgentSessionEntry>> {
+    return this.entries.filter((entry) => entry.type === type);
+  }
+
+  async getLabel(id: string): Promise<string | undefined> {
+    return this.labelsById.get(id);
+  }
+
+  async getPathToRoot(leafId: string | null): Promise<AgentSessionEntry[]> {
+    if (leafId === null) return [];
+    const path: AgentSessionEntry[] = [];
+    let current = this.byId.get(leafId);
+    if (!current) throw new AgentSessionEntryTreeError(this.sessionId, `missing entry ${leafId}`);
+    while (current) {
+      path.unshift(current);
+      if (current.parentId === null) break;
+      const parent = this.byId.get(current.parentId);
+      if (!parent) {
+        throw new AgentSessionEntryTreeError(this.sessionId, `missing parent ${current.parentId}`);
+      }
+      current = parent;
+    }
+    return path;
+  }
+
+  async getLeafId(): Promise<string | null> {
+    if (this.currentLeafId !== null && !this.byId.has(this.currentLeafId)) {
+      throw new AgentSessionEntryTreeError(this.sessionId, `missing leaf ${this.currentLeafId}`);
+    }
+    return this.currentLeafId;
+  }
+
+  async setLeafId(leafId: string | null): Promise<void> {
+    if (leafId !== null && !this.byId.has(leafId)) {
+      throw new AgentSessionEntryTreeError(this.sessionId, `missing entry ${leafId}`);
+    }
+    await this.appendEntry({
+      id: await this.createEntryId(),
+      parentId: this.currentLeafId,
+      type: 'leaf',
+      timestamp: new Date().toISOString(),
+      targetId: leafId,
+    });
+  }
+
+  async appendEntry(entry: AgentSessionEntry): Promise<void> {
+    if (this.byId.has(entry.id)) {
+      throw new AgentSessionEntryTreeError(this.sessionId, `duplicate entry id ${entry.id}`);
+    }
+    if (entry.parentId !== null && !this.byId.has(entry.parentId)) {
+      throw new AgentSessionEntryTreeError(this.sessionId, `missing parent ${entry.parentId}`);
+    }
+    await this.store.appendTreeEntry(this.sessionId, this.workerId, this.attempt, entry);
+    this.entries.push(entry);
+    this.byId.set(entry.id, entry);
+    this.updateLabel(entry);
+    this.currentLeafId = entry.type === 'leaf' ? String(entry.targetId ?? '') || null : entry.id;
+  }
+
+  async createEntryId(): Promise<string> {
+    for (let index = 0; index < 100; index += 1) {
+      const id = randomUUID().slice(0, 8);
+      if (!this.byId.has(id)) return id;
+    }
+    return randomUUID();
+  }
+}

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -8,7 +8,7 @@
  */
 import { randomUUID } from 'node:crypto';
 
-import type { QueryResult, Queryable, WithTransaction } from '../runtime/pg.js';
+import type { Queryable, WithTransaction } from '../runtime/pg.js';
 import {
   AGENT_SESSION_LIFECYCLE,
   AgentSessionAccessError,
@@ -187,7 +187,10 @@ function schemaFor(names: AgentSessionTableNames): string {
   const t = quoteIdentifier(names.entries);
   const c = quoteIdentifier(names.ownerEventCounters);
   const o = quoteIdentifier(names.ownerEvents);
-  const prefix = names.sessions.replace(/_sessions$/, '').replace(/[^a-z0-9_]/g, '_');
+  // Index names derive from the table-name substitution verbatim: the template
+  // index names (`agent_sessions_status_live_idx`, ...) are re-keyed by the
+  // same replaceAll that re-keys their tables, so no separate prefix rewriting
+  // is performed or needed.
   return AGENT_SESSION_PG_SCHEMA.replaceAll(
     'agent_owner_session_event_counters',
     names.ownerEventCounters,
@@ -196,9 +199,6 @@ function schemaFor(names: AgentSessionTableNames): string {
     .replaceAll('agent_session_entries', names.entries)
     .replaceAll('agent_session_events', names.events)
     .replaceAll('agent_sessions', names.sessions)
-    .replaceAll('agent_session_entries_type_idx', `${prefix}_session_entries_type_idx`)
-    .replaceAll('agent_sessions_status_live_idx', `${prefix}_sessions_status_live_idx`)
-    .replaceAll('agent_sessions_owner_live_idx', `${prefix}_sessions_owner_live_idx`)
     .replaceAll(`REFERENCES ${names.sessions}`, `REFERENCES ${s}`)
     .replaceAll(`ON ${names.sessions}`, `ON ${s}`)
     .replaceAll(`ON ${names.entries}`, `ON ${t}`)
@@ -633,11 +633,19 @@ export class PgAgentSessionStore
     });
   }
 
-  async appendControlEvent(sessionId: string, event: NewAgentSessionEvent): Promise<number | null> {
+  async appendControlEvent(
+    sessionId: string,
+    event: Omit<NewAgentSessionEvent, 'attempt'>,
+  ): Promise<number | null> {
     return this.transaction(async (tx) => {
       const parent = await this.lockForAppend(tx, sessionId, null);
       if (!parent) return null;
-      return this.insertEvent(tx, sessionId, event);
+      // The stored attempt is the current generation under the row lock
+      // (reference material-event semantics), never a host-chosen value.
+      return this.insertEvent(tx, sessionId, {
+        ...event,
+        attempt: Number(parent.attempt),
+      });
     });
   }
 
@@ -684,6 +692,9 @@ export class PgAgentSessionStore
         data: { text: input.text, delivery, clientRequestId },
       });
       const row = await this.loadSession(tx, sessionId, false);
+      // The hook is a deliberate veto point (reference semantics): a throw
+      // rolls back the staged message and any requeue, and the caller must
+      // retry. The event only becomes durable at COMMIT.
       await this.messageHook?.(tx, {
         session: sessionMeta(row!),
         text: input.text,
@@ -1077,6 +1088,11 @@ export class PgAgentSessionStore
   }
 
   async readRetirement(ownerId: string): Promise<string | null> {
+    // The host resolver runs inside a transaction because the hook contract
+    // assumes transactional execution (its advisory locks are transaction-
+    // scoped); running it on the shared queryable would release those locks
+    // before the resolver's read. The read itself takes no row locks beyond
+    // what the resolver chooses to take.
     return this.transaction(async (tx) => {
       const finalOwner = await this.resolveOwnerHook(tx, ownerId);
       return finalOwner === ownerId ? null : finalOwner;
@@ -1087,6 +1103,12 @@ export class PgAgentSessionStore
     if (fromOwnerId === toOwnerId) return 0;
     return this.transaction(async (tx) => {
       const finalTarget = await this.resolveOwnerHook(tx, toOwnerId);
+      // The literal guard above only catches the same-string case. A resolver
+      // that collapses the target back onto the source (a merge chain that
+      // already collapsed) must also be a no-op: proceeding would re-key
+      // sessions to themselves and renumber the owner's own projection above
+      // its high-water mark.
+      if (fromOwnerId === finalTarget) return 0;
       const locked = await tx.query<{ id: string; owner_id: string }>(
         `SELECT id, owner_id FROM ${this.table('sessions')}
          WHERE owner_id IN ($1, $2) ORDER BY id FOR UPDATE`,
@@ -1175,6 +1197,14 @@ class PgAgentSessionEntryTreeHandle implements AgentSessionEntryTreeHandle {
   private readonly labelsById = new Map<string, string>();
   private currentLeafId: string | null = null;
 
+  /** Reference `leafIdAfterEntry`: a leaf target is the leaf id, verbatim. */
+  private static leafIdAfter(entry: AgentSessionEntry): string | null {
+    if (entry.type !== 'leaf') return entry.id;
+    // An empty-string target is preserved as '' instead of collapsing to null;
+    // only a missing (malformed) target normalizes to null.
+    return (entry.targetId as string | null | undefined) ?? null;
+  }
+
   constructor(
     private readonly store: PgAgentSessionStore,
     private readonly sessionId: string,
@@ -1193,7 +1223,7 @@ class PgAgentSessionEntryTreeHandle implements AgentSessionEntryTreeHandle {
       }
       this.byId.set(entry.id, entry);
       this.updateLabel(entry);
-      this.currentLeafId = entry.type === 'leaf' ? String(entry.targetId ?? '') || null : entry.id;
+      this.currentLeafId = PgAgentSessionEntryTreeHandle.leafIdAfter(entry);
     }
   }
 
@@ -1215,8 +1245,10 @@ class PgAgentSessionEntryTreeHandle implements AgentSessionEntryTreeHandle {
 
   async findEntries<TType extends AgentSessionEntry['type']>(
     type: TType,
-  ): Promise<Array<Extract<AgentSessionEntry, { type: TType }> | AgentSessionEntry>> {
-    return this.entries.filter((entry) => entry.type === type);
+  ): Promise<Array<Extract<AgentSessionEntry, { type: TType }>>> {
+    return this.entries.filter(
+      (entry): entry is Extract<AgentSessionEntry, { type: TType }> => entry.type === type,
+    );
   }
 
   async getLabel(id: string): Promise<string | undefined> {
@@ -1271,7 +1303,7 @@ class PgAgentSessionEntryTreeHandle implements AgentSessionEntryTreeHandle {
     this.entries.push(entry);
     this.byId.set(entry.id, entry);
     this.updateLabel(entry);
-    this.currentLeafId = entry.type === 'leaf' ? String(entry.targetId ?? '') || null : entry.id;
+    this.currentLeafId = PgAgentSessionEntryTreeHandle.leafIdAfter(entry);
   }
 
   async createEntryId(): Promise<string> {

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -256,6 +256,7 @@ export interface AgentSessionStore {
   /**
    * Lock, persist, classify delivery, and revive a terminal session in one
    * transaction so a message cannot fall into the runner's settle window.
+   * A message posted to a queued session clears any pending cancel request.
    */
   postUserMessage(
     sessionId: string,

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -1,0 +1,410 @@
+/**
+ * Durable contracts for background agent sessions.
+ *
+ * The four interfaces deliberately separate lifecycle coordination, the
+ * per-session event stream, the append-only entry tree, and the sparse
+ * per-owner projection. Hosts commonly use one backend for all four, but the
+ * split prevents a control-plane reader from accidentally gaining lease-bound
+ * write authority and lets projection damage be repaired independently.
+ */
+
+export const AGENT_SESSION_STATUSES = [
+  'queued',
+  'running',
+  'succeeded',
+  'failed',
+  'cancelled',
+] as const;
+
+export type AgentSessionStatus = (typeof AGENT_SESSION_STATUSES)[number];
+
+export const AGENT_SESSION_LIFECYCLE = {
+  sessionStart: 'session_start',
+  sessionResumed: 'session_resumed',
+  checkpoint: 'checkpoint',
+  sessionEnd: 'session_end',
+  sessionInterrupted: 'session_interrupted',
+  userMessage: 'user_message',
+  trace: 'trace',
+  thinkingEnd: 'thinking_end',
+  materialExtraction: 'material_extraction',
+  userQuestion: 'user_question',
+  activeStageChanged: 'active_stage_changed',
+  libraryChanged: 'library_changed',
+} as const;
+
+export type AgentSessionLifecycleEventType =
+  (typeof AGENT_SESSION_LIFECYCLE)[keyof typeof AGENT_SESSION_LIFECYCLE];
+
+export interface AgentSessionLease {
+  workerId: string;
+  workerPid: number;
+  heartbeatAt: number;
+}
+
+export interface AgentSessionMeta {
+  id: string;
+  ownerId: string;
+  prompt: string;
+  /** The immutable stage with which the conversation was created. */
+  stageId: string;
+  /** The current tool target; absence means that {@link stageId} is active. */
+  activeStageId?: string;
+  skillId?: string;
+  origin?: string;
+  existingCourse: boolean;
+  status: AgentSessionStatus;
+  /** The consecutive-failure generation, incremented by every successful claim. */
+  attempt: number;
+  createdAt: number;
+  updatedAt: number;
+  lease?: AgentSessionLease;
+  error?: string;
+}
+
+export interface CreateAgentSessionInput {
+  /** An optional caller-minted stable id. */
+  id?: string;
+  ownerId: string;
+  prompt: string;
+  /** Defaults to a stable value derived from the final session id. */
+  stageId?: string;
+  skillId?: string;
+  origin?: string;
+  existingCourse?: boolean;
+  /** Existing-course sessions may begin terminal and requeue on the first message. */
+  status?: 'queued' | 'succeeded';
+}
+
+export type AgentSessionClaimReason = 'queued' | 'orphaned';
+
+export interface ClaimedAgentSession extends AgentSessionMeta {
+  claimReason: AgentSessionClaimReason;
+  /** Event-log high-water mark observed while the claim held the session row lock. */
+  claimSeq: number;
+}
+
+export interface ClaimAgentSessionOptions {
+  leaseTtlMs: number;
+  maxAttempts: number;
+  /** Restricts a claim to one session instead of scanning the oldest candidates. */
+  sessionId?: string;
+}
+
+export interface FinishAgentSessionPatch {
+  status: AgentSessionStatus;
+  error?: string;
+  /** Defaults to true. False is useful for an interruption marker written first. */
+  releaseLease?: boolean;
+  /** Clean endings reset the consecutive-failure chain when requested. */
+  resetAttempt?: boolean;
+}
+
+export interface PostAgentUserMessageResult {
+  seq: number;
+  delivery: 'steer' | 'queued';
+  requeued: boolean;
+}
+
+export interface PostAgentUserMessageOptions {
+  /** Revalidates an owner snapshot after the transaction has acquired its locks. */
+  expectedOwnerId?: string;
+}
+
+/** A control-plane write was attempted through a retired or different owner. */
+export class AgentSessionAccessError extends Error {
+  override readonly name = 'AgentSessionAccessError';
+
+  constructor(readonly sessionId: string) {
+    super(
+      `@openmaic/storage: session ${JSON.stringify(sessionId)} is not accessible by this owner`,
+    );
+  }
+}
+
+/** An opened tree attempted to append after its lease generation was superseded. */
+export class AgentSessionLeaseLostError extends Error {
+  override readonly name = 'AgentSessionLeaseLostError';
+
+  constructor(
+    readonly sessionId: string,
+    readonly workerId: string,
+    readonly attempt: number,
+  ) {
+    super(
+      `@openmaic/storage: session ${JSON.stringify(sessionId)} lease or attempt fence was lost ` +
+        `by ${JSON.stringify(workerId)} at attempt ${attempt}`,
+    );
+  }
+}
+
+/** A tree contains a dangling parent, duplicate id, or invalid leaf target. */
+export class AgentSessionEntryTreeError extends Error {
+  override readonly name = 'AgentSessionEntryTreeError';
+
+  constructor(
+    readonly sessionId: string,
+    reason: string,
+  ) {
+    super(
+      `@openmaic/storage: invalid entry tree for session ${JSON.stringify(sessionId)}: ${reason}`,
+    );
+  }
+}
+
+/** Minimal framework-independent shape stored by the append-only tree. */
+export interface AgentSessionEntryBase {
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface AgentSessionMessageEntry extends AgentSessionEntryBase {
+  type: 'message';
+  message: unknown;
+}
+
+export interface AgentSessionLabelEntry extends AgentSessionEntryBase {
+  type: 'label';
+  targetId: string;
+  label?: string;
+}
+
+export interface AgentSessionLeafEntry extends AgentSessionEntryBase {
+  type: 'leaf';
+  targetId: string | null;
+}
+
+export interface AgentSessionCompactionEntry extends AgentSessionEntryBase {
+  type: 'compaction';
+  firstKeptEntryId: string;
+  summary?: unknown;
+}
+
+export interface AgentSessionBranchSummaryEntry extends AgentSessionEntryBase {
+  type: 'branch_summary';
+  summary?: unknown;
+}
+
+export interface AgentSessionCustomMessageEntry extends AgentSessionEntryBase {
+  type: 'custom_message';
+  message: unknown;
+}
+
+export type AgentSessionEntry =
+  | AgentSessionMessageEntry
+  | AgentSessionLabelEntry
+  | AgentSessionLeafEntry
+  | AgentSessionCompactionEntry
+  | AgentSessionBranchSummaryEntry
+  | AgentSessionCustomMessageEntry
+  | AgentSessionEntryBase;
+
+export interface AgentSessionEntryTreeHandle {
+  getEntries(): Promise<AgentSessionEntry[]>;
+  getEntry(id: string): Promise<AgentSessionEntry | undefined>;
+  findEntries<TType extends AgentSessionEntry['type']>(
+    type: TType,
+  ): Promise<Array<Extract<AgentSessionEntry, { type: TType }> | AgentSessionEntry>>;
+  getLabel(id: string): Promise<string | undefined>;
+  getPathToRoot(leafId: string | null): Promise<AgentSessionEntry[]>;
+  getLeafId(): Promise<string | null>;
+  /**
+   * Append a leaf marker instead of mutating prior rows. This keeps cursor
+   * movement auditable and ensures a crash can only lose the newest marker.
+   */
+  setLeafId(leafId: string | null): Promise<void>;
+  appendEntry(entry: AgentSessionEntry): Promise<void>;
+  createEntryId(): Promise<string>;
+}
+
+/** Lifecycle and lease coordination for independently running processes. */
+export interface AgentSessionStore {
+  createSession(input: CreateAgentSessionInput): Promise<AgentSessionMeta>;
+  getSession(sessionId: string): Promise<AgentSessionMeta | null>;
+  listSessionsByOwner(ownerId: string): Promise<AgentSessionMeta[]>;
+  /** Tombstone a visible session while deliberately preserving every child row. */
+  softDeleteSession(sessionId: string, ownerId: string): Promise<boolean>;
+  resolveActiveStage(sessionId: string): Promise<string>;
+  setActiveStage(sessionId: string, stageId: string): Promise<boolean>;
+  /**
+   * Scan optimistically, then lock and recheck one candidate. The second
+   * check is the authority: candidate snapshots are stale as soon as read.
+   */
+  claimNextSession(
+    workerId: string,
+    workerPid: number,
+    options: ClaimAgentSessionOptions,
+  ): Promise<ClaimedAgentSession | null>;
+  heartbeat(sessionId: string, workerId: string): Promise<boolean>;
+  finishSession(
+    sessionId: string,
+    workerId: string,
+    patch: FinishAgentSessionPatch,
+  ): Promise<boolean>;
+  releaseLease(sessionId: string, workerId: string): Promise<void>;
+  requestCancel(sessionId: string): Promise<void>;
+  isCancelRequested(sessionId: string): Promise<boolean>;
+  clearCancel(sessionId: string): Promise<void>;
+  /** An attended retry clears the consecutive-failure generation. */
+  requeueSession(sessionId: string): Promise<boolean>;
+  /** An unattended retry preserves the consecutive-failure generation. */
+  requeueForRetry(sessionId: string): Promise<boolean>;
+  /**
+   * Lock, persist, classify delivery, and revive a terminal session in one
+   * transaction so a message cannot fall into the runner's settle window.
+   */
+  postUserMessage(
+    sessionId: string,
+    input: { text: string },
+    options?: PostAgentUserMessageOptions,
+  ): Promise<PostAgentUserMessageResult>;
+  /**
+   * Re-key package-owned session data and owner projection history. Hosts
+   * remain responsible for merging product tables outside this package.
+   */
+  mergeOwner(fromOwnerId: string, toOwnerId: string): Promise<number>;
+}
+
+export interface NewAgentSessionEvent {
+  ts: number;
+  attempt: number;
+  type: string;
+  data: unknown;
+}
+
+export interface PersistedAgentSessionEvent extends NewAgentSessionEvent {
+  /** Monotonic, one-based, per-session replay cursor. */
+  id: number;
+}
+
+export interface AgentSessionUserMessage {
+  seq: number;
+  ts: number;
+  text: string;
+  delivery: string;
+  materials: unknown[];
+}
+
+/** The durable stream has separate lease-bound and control-plane writers. */
+export interface AgentSessionEventLog {
+  appendRunEvent(
+    sessionId: string,
+    workerId: string,
+    event: NewAgentSessionEvent,
+  ): Promise<number | null>;
+  appendControlEvent(sessionId: string, event: NewAgentSessionEvent): Promise<number | null>;
+  appendUserMessage(
+    sessionId: string,
+    input: { text: string; delivery: 'steer' | 'queued'; clientRequestId?: string },
+  ): Promise<number>;
+  listUserMessages(sessionId: string): Promise<AgentSessionUserMessage[]>;
+  readEventsAfter(
+    sessionId: string,
+    afterSeq: number,
+    limit?: number,
+  ): Promise<PersistedAgentSessionEvent[]>;
+  /** Returns raw rows scanned separately from the compacted replay frames. */
+  readEventsAfterForReplay(
+    sessionId: string,
+    afterSeq: number,
+    limit?: number,
+  ): Promise<{ events: PersistedAgentSessionEvent[]; scanned: number }>;
+  lastEventSeq(sessionId: string): Promise<number>;
+  hasSessionRunHistory(sessionId: string): Promise<boolean>;
+}
+
+/** Opens an append-only tree fenced to one worker and claim generation. */
+export interface AgentSessionEntryTree {
+  openEntryTree(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+  ): Promise<AgentSessionEntryTreeHandle>;
+}
+
+export const OWNER_SESSION_EVENT_TYPES = [
+  'session_created',
+  'session_status',
+  'session_deleted',
+  'session_active_stage',
+  'session_cancel_requested',
+] as const;
+
+export type OwnerSessionEventType = (typeof OWNER_SESSION_EVENT_TYPES)[number];
+
+interface OwnerSessionEventBase {
+  sessionId: string;
+  ts: number;
+}
+
+export type NewOwnerSessionEvent =
+  | (OwnerSessionEventBase & {
+      type: 'session_created' | 'session_status';
+      status: AgentSessionStatus;
+      attempt: number;
+    })
+  | (OwnerSessionEventBase & { type: 'session_deleted' | 'session_cancel_requested' })
+  | (OwnerSessionEventBase & { type: 'session_active_stage'; activeStageId: string });
+
+export type PersistedOwnerSessionEvent = NewOwnerSessionEvent & {
+  /** Decimal bigint text avoids rounding a replay cursor in JavaScript. */
+  id: string;
+  ownerId: string;
+};
+
+export interface OwnerSessionEventProjection {
+  /**
+   * Append inside the caller's business transaction through a SAVEPOINT.
+   * Any projection error is logged and returns null: derived navigation data
+   * must never veto the authoritative lifecycle write. A client repairs a
+   * missing summary through periodic full-list reconciliation, so hosts must
+   * retain that reconciliation path whenever they enable this projection.
+   */
+  append(event: NewOwnerSessionEvent, transaction: AgentSessionTransaction): Promise<bigint | null>;
+  readAfter(
+    ownerId: string,
+    afterId: bigint,
+    limit?: number,
+  ): Promise<PersistedOwnerSessionEvent[]>;
+  /** Reads the durable counter, not max(id), because event rows may be pruned. */
+  readMaxId(ownerId: string): Promise<bigint>;
+  /** Returns a replacement identity when the host's resolver retires this owner. */
+  readRetirement(ownerId: string): Promise<string | null>;
+}
+
+/** The minimal transaction surface exposed to hooks without a driver dependency. */
+export interface AgentSessionTransaction {
+  query<TRow extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: TRow[] }>;
+}
+
+/**
+ * Host integration hooks execute in the authoritative business transaction.
+ * `resolveFinalOwner` must perform the transaction's first statement and use
+ * the same advisory-lock order as the host operation that retires an owner;
+ * otherwise a create can commit under an identity immediately after merge.
+ */
+export interface AgentSessionHooks {
+  resolveFinalOwner?: (transaction: AgentSessionTransaction, ownerId: string) => Promise<string>;
+  /** Runs after insertion, before the creation transaction can commit. */
+  onSessionCreated?: (
+    transaction: AgentSessionTransaction,
+    meta: AgentSessionMeta,
+  ) => Promise<void>;
+  /** Runs after the message event is durable but before classification commits. */
+  onUserMessagePosted?: (
+    transaction: AgentSessionTransaction,
+    input: {
+      session: AgentSessionMeta;
+      text: string;
+      seq: number;
+      delivery: 'steer' | 'queued';
+      clientRequestId: string;
+    },
+  ) => Promise<void>;
+}

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -415,9 +415,11 @@ export interface AgentSessionHooks {
     meta: AgentSessionMeta,
   ) => Promise<void>;
   /**
-   * Runs after the message event is staged in the transaction but before the
-   * delivery classification and any requeue commit. The event is NOT durable
-   * yet — durability exists only at COMMIT — and this hook is an abort point:
+   * Runs after the message event is staged in the transaction, once its
+   * delivery (steer/queued) has already been classified and written into the
+   * staged event, but before any requeue and before COMMIT. The event is NOT
+   * durable yet — durability exists only at COMMIT — and this hook is an
+   * abort point:
    * a throwing hook aborts the whole `postUserMessage`, the message is not
    * persisted, the session is not requeued, and the caller receives the error.
    * That veto semantics matches the reference, whose in-transaction host steps

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -205,9 +205,10 @@ export type AgentSessionEntry =
 export interface AgentSessionEntryTreeHandle {
   getEntries(): Promise<AgentSessionEntry[]>;
   getEntry(id: string): Promise<AgentSessionEntry | undefined>;
+  /** Entries whose `type` is exactly the requested type, narrowed like the reference. */
   findEntries<TType extends AgentSessionEntry['type']>(
     type: TType,
-  ): Promise<Array<Extract<AgentSessionEntry, { type: TType }> | AgentSessionEntry>>;
+  ): Promise<Array<Extract<AgentSessionEntry, { type: TType }>>>;
   getLabel(id: string): Promise<string | undefined>;
   getPathToRoot(leafId: string | null): Promise<AgentSessionEntry[]>;
   getLeafId(): Promise<string | null>;
@@ -295,7 +296,17 @@ export interface AgentSessionEventLog {
     workerId: string,
     event: NewAgentSessionEvent,
   ): Promise<number | null>;
-  appendControlEvent(sessionId: string, event: NewAgentSessionEvent): Promise<number | null>;
+  /**
+   * Append a control-plane event without borrowing the runner's lease. The
+   * stored attempt is the session's current generation, read under the session
+   * row lock — it is never host-chosen — so the log carries the generation
+   * that was current when the event was written (reference material-event
+   * semantics).
+   */
+  appendControlEvent(
+    sessionId: string,
+    event: Omit<NewAgentSessionEvent, 'attempt'>,
+  ): Promise<number | null>;
   appendUserMessage(
     sessionId: string,
     input: { text: string; delivery: 'steer' | 'queued'; clientRequestId?: string },
@@ -371,7 +382,14 @@ export interface OwnerSessionEventProjection {
   ): Promise<PersistedOwnerSessionEvent[]>;
   /** Reads the durable counter, not max(id), because event rows may be pruned. */
   readMaxId(ownerId: string): Promise<bigint>;
-  /** Returns a replacement identity when the host's resolver retires this owner. */
+  /**
+   * Returns a replacement identity when the host's resolver retires this owner.
+   * Unlike the reference's direct `owner_merges` table read, this package has
+   * no retirement table — the host resolver is the source of truth, so it is
+   * invoked inside a short transaction because the hook contract assumes
+   * transactional execution (its advisory locks are transaction-scoped). A host
+   * whose resolver is a plain read-only lookup sees a single-statement read.
+   */
   readRetirement(ownerId: string): Promise<string | null>;
 }
 
@@ -396,7 +414,16 @@ export interface AgentSessionHooks {
     transaction: AgentSessionTransaction,
     meta: AgentSessionMeta,
   ) => Promise<void>;
-  /** Runs after the message event is durable but before classification commits. */
+  /**
+   * Runs after the message event is staged in the transaction but before the
+   * delivery classification and any requeue commit. The event is NOT durable
+   * yet — durability exists only at COMMIT — and this hook is an abort point:
+   * a throwing hook aborts the whole `postUserMessage`, the message is not
+   * persisted, the session is not requeued, and the caller receives the error.
+   * That veto semantics matches the reference, whose in-transaction host steps
+   * (`bindMaterials`) abort the same way; the hook is never a fire-and-forget
+   * notification.
+   */
   onUserMessagePosted?: (
     transaction: AgentSessionTransaction,
     input: {

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -113,6 +113,46 @@ export type {
 export { RuntimeAppendConflictError } from './runtime/types.js';
 export { BrowserRuntimeStore, type BrowserRuntimeStoreOptions } from './runtime/browser.js';
 
+export {
+  AGENT_SESSION_LIFECYCLE,
+  AGENT_SESSION_STATUSES,
+  OWNER_SESSION_EVENT_TYPES,
+  AgentSessionAccessError,
+  AgentSessionEntryTreeError,
+  AgentSessionLeaseLostError,
+  type AgentSessionClaimReason,
+  type AgentSessionCompactionEntry,
+  type AgentSessionCustomMessageEntry,
+  type AgentSessionEntry,
+  type AgentSessionEntryBase,
+  type AgentSessionEntryTree,
+  type AgentSessionEntryTreeHandle,
+  type AgentSessionEventLog,
+  type AgentSessionHooks,
+  type AgentSessionLabelEntry,
+  type AgentSessionLeafEntry,
+  type AgentSessionLease,
+  type AgentSessionLifecycleEventType,
+  type AgentSessionMessageEntry,
+  type AgentSessionMeta,
+  type AgentSessionStatus,
+  type AgentSessionStore,
+  type AgentSessionTransaction,
+  type AgentSessionUserMessage,
+  type ClaimedAgentSession,
+  type ClaimAgentSessionOptions,
+  type CreateAgentSessionInput,
+  type FinishAgentSessionPatch,
+  type NewAgentSessionEvent,
+  type NewOwnerSessionEvent,
+  type OwnerSessionEventProjection,
+  type OwnerSessionEventType,
+  type PersistedAgentSessionEvent,
+  type PersistedOwnerSessionEvent,
+  type PostAgentUserMessageOptions,
+  type PostAgentUserMessageResult,
+} from './agent-session/types.js';
+
 // Re-export the DSL-owned asset contract for convenience, so consumers can get
 // the interface and a backend from one import without reaching into the DSL.
 export type { AssetRef, AssetMeta, BinaryBlob, StorageProvider } from '@openmaic/dsl';

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -76,7 +76,7 @@ export function runAgentSessionConcurrencyContract(
     );
 
     test.skipIf(!options.genuineConcurrency)(
-      'keeps mergeOwner and cross-owner projections free of an ABBA deadlock',
+      'keeps mergeOwner and cross-owner projections result-consistent under concurrent contention',
       async () => {
         const store = makeStore();
         await store.createSession(makeAgentSessionInput());
@@ -86,12 +86,17 @@ export function runAgentSessionConcurrencyContract(
         await store.createSession(
           makeAgentSessionInput({ id: 'session-3', ownerId: 'owner-b', stageId: 'stage-3' }),
         );
-        // The order-sensitive path is the cross-owner one: mergeOwner locks
-        // every session of both owners (id-ordered single statement) before the
-        // two counters in sorted order, while each concurrent projection locks
-        // its session row first and then that owner's counter. Racing them must
-        // never form a lock-acquisition cycle (a deadlock surfaces here as a
-        // PostgreSQL 40P01 abort, failing the test).
+        // This is a result-consistency probe, not a deadlock probe. Every
+        // writer in this package (mergeOwner and the projection writers) uses a
+        // single global lock order — the parent session row before its child
+        // rows, and the session row before that owner's counter — so no
+        // opposite-order path exists for this race to exercise a deadlock.
+        // Deadlock freedom follows from that invariant, which this free-running
+        // race cannot falsify. What it does verify deterministically: the
+        // session-row locks serialize each projection against the merge, so all
+        // four transactions commit, and the assertions below pin the merged
+        // result (duplicate-free stream, durable counter == highest allocated
+        // id, source counter deleted, owner rosters).
         await Promise.all([
           store.mergeOwner('owner-a', 'owner-b'),
           store.setActiveStage('session-1', 'stage-1b'),

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -74,5 +74,44 @@ export function runAgentSessionConcurrencyContract(
         expect(await store.readMaxId('owner-a')).toBe(BigInt(4));
       },
     );
+
+    test.skipIf(!options.genuineConcurrency)(
+      'keeps mergeOwner and cross-owner projections free of an ABBA deadlock',
+      async () => {
+        const store = makeStore();
+        await store.createSession(makeAgentSessionInput());
+        await store.createSession(
+          makeAgentSessionInput({ id: 'session-2', ownerId: 'owner-b', stageId: 'stage-2' }),
+        );
+        await store.createSession(
+          makeAgentSessionInput({ id: 'session-3', ownerId: 'owner-b', stageId: 'stage-3' }),
+        );
+        // The order-sensitive path is the cross-owner one: mergeOwner locks
+        // every session of both owners (id-ordered single statement) before the
+        // two counters in sorted order, while each concurrent projection locks
+        // its session row first and then that owner's counter. Racing them must
+        // never form a lock-acquisition cycle (a deadlock surfaces here as a
+        // PostgreSQL 40P01 abort, failing the test).
+        await Promise.all([
+          store.mergeOwner('owner-a', 'owner-b'),
+          store.setActiveStage('session-1', 'stage-1b'),
+          store.requestCancel('session-2'),
+          store.postUserMessage('session-3', { text: 'Concurrent message' }),
+        ]);
+        // All four committed: the merged owner stream is duplicate-free and
+        // its durable counter matches the highest allocated id.
+        const targetEvents = await store.readAfter('owner-b', BigInt(0));
+        const ids = targetEvents.map((event) => Number(event.id));
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(await store.readMaxId('owner-b')).toBe(BigInt(Math.max(0, ...ids)));
+        expect(await store.readMaxId('owner-a')).toBe(BigInt(0));
+        expect(await store.listSessionsByOwner('owner-a')).toEqual([]);
+        expect((await store.listSessionsByOwner('owner-b')).map((session) => session.id)).toEqual([
+          'session-1',
+          'session-2',
+          'session-3',
+        ]);
+      },
+    );
   });
 }

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -71,7 +71,7 @@ export function runAgentSessionConcurrencyContract(
           store.postUserMessage('session-1', { text: 'Concurrent message' }),
           store.requestCancel('session-1'),
         ]);
-        expect(await store.readMaxId('owner-a')).toBe(4n);
+        expect(await store.readMaxId('owner-a')).toBe(BigInt(4));
       },
     );
   });

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+
+import type { AgentSessionContractStore } from './agent-session-contract.js';
+import { makeAgentSessionInput } from './agent-session-contract.js';
+
+/**
+ * Locking semantics shared by database-backed implementations. Embedded
+ * single-connection engines run the stale-takeover and generation checks;
+ * only a multi-connection PostgreSQL harness enables the races whose result
+ * depends on real row-lock waits.
+ */
+export function runAgentSessionConcurrencyContract(
+  name: string,
+  makeStore: () => AgentSessionContractStore,
+  options: { genuineConcurrency: boolean },
+): void {
+  describe(`AgentSession concurrency contract: ${name}`, () => {
+    test('steals a released or stale lease and preserves the claim watermark', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      const first = await store.claimNextSession('worker-a', 101, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      expect(first).toMatchObject({ attempt: 1, claimSeq: 0 });
+      await store.appendUserMessage('session-1', { text: 'Pending', delivery: 'steer' });
+      await store.releaseLease('session-1', 'worker-a');
+
+      const stolen = await store.claimNextSession('worker-b', 102, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      expect(stolen).toMatchObject({
+        attempt: 2,
+        claimReason: 'orphaned',
+        claimSeq: 1,
+        lease: { workerId: 'worker-b' },
+      });
+      expect(
+        await store.appendRunEvent('session-1', 'worker-a', {
+          ts: 2,
+          attempt: 1,
+          type: 'late',
+          data: null,
+        }),
+      ).toBeNull();
+      expect(await store.heartbeat('session-1', 'worker-a')).toBe(false);
+    });
+
+    test.skipIf(!options.genuineConcurrency)(
+      'allows exactly one worker to win a simultaneous claim',
+      async () => {
+        const store = makeStore();
+        await store.createSession(makeAgentSessionInput());
+        const [left, right] = await Promise.all([
+          store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 }),
+          store.claimNextSession('worker-b', 102, { leaseTtlMs: 10_000, maxAttempts: 3 }),
+        ]);
+        expect([left, right].filter(Boolean)).toHaveLength(1);
+        expect((await store.getSession('session-1'))?.attempt).toBe(1);
+      },
+    );
+
+    test.skipIf(!options.genuineConcurrency)(
+      'keeps session and owner-counter lock order free of a smoke-test deadlock',
+      async () => {
+        const store = makeStore();
+        await store.createSession(makeAgentSessionInput());
+        await Promise.all([
+          store.setActiveStage('session-1', 'stage-2'),
+          store.postUserMessage('session-1', { text: 'Concurrent message' }),
+          store.requestCancel('session-1'),
+        ]);
+        expect(await store.readMaxId('owner-a')).toBe(4n);
+      },
+    );
+  });
+}

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  AGENT_SESSION_LIFECYCLE,
+  AgentSessionEntryTreeError,
+  AgentSessionLeaseLostError,
+  type AgentSessionEntryTree,
+  type AgentSessionEventLog,
+  type AgentSessionStore,
+  type OwnerSessionEventProjection,
+} from '../src/agent-session/types.js';
+
+export type AgentSessionContractStore = AgentSessionStore &
+  AgentSessionEventLog &
+  AgentSessionEntryTree &
+  OwnerSessionEventProjection;
+
+export function makeAgentSessionInput(
+  overrides: Partial<Parameters<AgentSessionStore['createSession']>[0]> = {},
+) {
+  return {
+    id: 'session-1',
+    ownerId: 'owner-a',
+    prompt: 'Build a short course',
+    stageId: 'stage-1',
+    ...overrides,
+  };
+}
+
+/**
+ * Backend-neutral, single-process semantics. These checks intentionally avoid
+ * claims that need two simultaneously open database connections; those live
+ * in the concurrency contract so a serialized embedded backend can still
+ * prove CRUD, fencing, replay, tree, and projection behavior.
+ */
+export function runAgentSessionStoreContract(
+  name: string,
+  makeStore: () => AgentSessionContractStore,
+): void {
+  describe(`AgentSessionStore contract: ${name}`, () => {
+    test('creates, reads, lists, and resolves an active stage', async () => {
+      const store = makeStore();
+      const created = await store.createSession(
+        makeAgentSessionInput({ skillId: 'skill-a', origin: 'https://example.test' }),
+      );
+
+      expect(created).toMatchObject({
+        id: 'session-1',
+        ownerId: 'owner-a',
+        stageId: 'stage-1',
+        skillId: 'skill-a',
+        status: 'queued',
+        attempt: 0,
+      });
+      expect(await store.getSession('session-1')).toEqual(created);
+      expect(await store.listSessionsByOwner('owner-a')).toEqual([created]);
+      expect(await store.resolveActiveStage('session-1')).toBe('stage-1');
+      expect(await store.setActiveStage('session-1', 'stage-2')).toBe(true);
+      expect(await store.resolveActiveStage('session-1')).toBe('stage-2');
+    });
+
+    test('tombstones only through the owner and hides all public child reads', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.appendControlEvent('session-1', {
+        ts: 1,
+        attempt: 0,
+        type: 'control',
+        data: { retained: true },
+      });
+
+      expect(await store.softDeleteSession('session-1', 'owner-b')).toBe(false);
+      expect(await store.softDeleteSession('session-1', 'owner-a')).toBe(true);
+      expect(await store.softDeleteSession('session-1', 'owner-a')).toBe(false);
+      expect(await store.getSession('session-1')).toBeNull();
+      expect(await store.listSessionsByOwner('owner-a')).toEqual([]);
+      expect(await store.readEventsAfter('session-1', 0)).toEqual([]);
+    });
+
+    test('claims, heartbeats, finishes, and rejects stale lease writes', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      const claim = await store.claimNextSession('worker-a', 101, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      expect(claim).toMatchObject({
+        id: 'session-1',
+        status: 'running',
+        attempt: 1,
+        claimReason: 'queued',
+        claimSeq: 0,
+      });
+      expect(await store.heartbeat('session-1', 'worker-a')).toBe(true);
+      expect(
+        await store.appendRunEvent('session-1', 'worker-a', {
+          ts: 2,
+          attempt: 0,
+          type: 'stale',
+          data: null,
+        }),
+      ).toBeNull();
+      expect(
+        await store.appendRunEvent('session-1', 'worker-b', {
+          ts: 2,
+          attempt: 1,
+          type: 'wrong-worker',
+          data: null,
+        }),
+      ).toBeNull();
+      expect(
+        await store.appendRunEvent('session-1', 'worker-a', {
+          ts: 3,
+          attempt: 1,
+          type: AGENT_SESSION_LIFECYCLE.sessionStart,
+          data: { ok: true },
+        }),
+      ).toBe(1);
+      expect(await store.finishSession('session-1', 'worker-b', { status: 'failed' })).toBe(false);
+      expect(
+        await store.finishSession('session-1', 'worker-a', {
+          status: 'succeeded',
+          resetAttempt: true,
+        }),
+      ).toBe(true);
+      expect(await store.heartbeat('session-1', 'worker-a')).toBe(false);
+      expect(await store.getSession('session-1')).toMatchObject({
+        status: 'succeeded',
+        attempt: 0,
+      });
+    });
+
+    test('appends ordered events and compacts only middle message updates on replay', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      for (const [index, type] of [
+        'before',
+        'message_update',
+        'message_update',
+        'message_update',
+        'after',
+      ].entries()) {
+        await store.appendControlEvent('session-1', {
+          ts: index + 1,
+          attempt: 0,
+          type,
+          data: { index },
+        });
+      }
+      expect(await store.lastEventSeq('session-1')).toBe(5);
+      expect((await store.readEventsAfter('session-1', 1)).map((event) => event.id)).toEqual([
+        2, 3, 4, 5,
+      ]);
+      const replay = await store.readEventsAfterForReplay('session-1', 0);
+      expect(replay.scanned).toBe(5);
+      expect(replay.events.map((event) => event.id)).toEqual([1, 2, 4, 5]);
+    });
+
+    test('classifies posted messages and atomically revives terminal sessions', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput({ status: 'succeeded' }));
+      const idle = await store.postUserMessage('session-1', { text: 'Continue' });
+      expect(idle).toMatchObject({ delivery: 'queued', requeued: true, seq: 1 });
+      expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 0 });
+      expect(await store.listUserMessages('session-1')).toMatchObject([
+        { seq: 1, text: 'Continue', delivery: 'queued' },
+      ]);
+
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      const live = await store.postUserMessage('session-1', { text: 'Add a quiz' });
+      expect(live).toMatchObject({ delivery: 'steer', requeued: false, seq: 2 });
+      expect(await store.getSession('session-1')).toMatchObject({ status: 'running' });
+    });
+
+    test('supports cancellation and distinct attended and unattended requeues', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.requestCancel('session-1');
+      await store.requestCancel('session-1');
+      expect(await store.isCancelRequested('session-1')).toBe(true);
+      await store.clearCancel('session-1');
+      expect(await store.isCancelRequested('session-1')).toBe(false);
+
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      await store.finishSession('session-1', 'worker-a', { status: 'failed', error: 'failure' });
+      expect(await store.requeueForRetry('session-1')).toBe(true);
+      expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 1 });
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      await store.finishSession('session-1', 'worker-a', { status: 'failed' });
+      expect(await store.requeueSession('session-1')).toBe(true);
+      expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 0 });
+    });
+
+    test('appends and reopens an entry tree with labels, paths, and leaf markers', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      const tree = await store.openEntryTree('session-1', 'worker-a', 1);
+      await tree.appendEntry({
+        id: 'root',
+        parentId: null,
+        type: 'message',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        message: { role: 'user', content: 'Hello' },
+      });
+      await tree.appendEntry({
+        id: 'child',
+        parentId: 'root',
+        type: 'custom_message',
+        timestamp: '2026-01-01T00:00:01.000Z',
+        message: { role: 'assistant', content: 'Hi' },
+      });
+      await tree.appendEntry({
+        id: 'label',
+        parentId: 'child',
+        type: 'label',
+        timestamp: '2026-01-01T00:00:02.000Z',
+        targetId: 'child',
+        label: 'Answer',
+      });
+      expect(await tree.getLabel('child')).toBe('Answer');
+      expect((await tree.getPathToRoot('child')).map((entry) => entry.id)).toEqual([
+        'root',
+        'child',
+      ]);
+      await tree.setLeafId('child');
+      expect(await tree.getLeafId()).toBe('child');
+
+      const reopened = await store.openEntryTree('session-1', 'worker-a', 1);
+      expect(await reopened.getLeafId()).toBe('child');
+      expect((await reopened.findEntries('message')).map((entry) => entry.id)).toEqual(['root']);
+      await expect(
+        reopened.appendEntry({
+          id: 'dangling',
+          parentId: 'missing',
+          type: 'message',
+          timestamp: '2026-01-01T00:00:03.000Z',
+          message: {},
+        }),
+      ).rejects.toBeInstanceOf(AgentSessionEntryTreeError);
+    });
+
+    test('fences an already-open tree after a newer claim', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      const tree = await store.openEntryTree('session-1', 'worker-a', 1);
+      await store.releaseLease('session-1', 'worker-a');
+      await store.claimNextSession('worker-b', 102, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      await expect(
+        tree.appendEntry({
+          id: 'late',
+          parentId: null,
+          type: 'message',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: {},
+        }),
+      ).rejects.toBeInstanceOf(AgentSessionLeaseLostError);
+    });
+
+    test('maintains a sparse per-owner projection and its durable counter', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.setActiveStage('session-1', 'stage-2');
+      await store.requestCancel('session-1');
+      const events = await store.readAfter('owner-a', 0n);
+      expect(events.map((event) => event.type)).toEqual([
+        'session_created',
+        'session_active_stage',
+        'session_cancel_requested',
+      ]);
+      expect(events.map((event) => event.id)).toEqual(['1', '2', '3']);
+      expect(await store.readMaxId('owner-a')).toBe(3n);
+      expect(await store.readRetirement('owner-a')).toBeNull();
+    });
+
+    test('moves sessions and renumbers source projection events above the target high water', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.createSession(
+        makeAgentSessionInput({ id: 'session-2', ownerId: 'owner-b', stageId: 'stage-2' }),
+      );
+      await store.requestCancel('session-1');
+      expect(await store.mergeOwner('owner-a', 'owner-b')).toBe(1);
+      expect(await store.listSessionsByOwner('owner-a')).toEqual([]);
+      expect((await store.listSessionsByOwner('owner-b')).map((session) => session.id)).toEqual([
+        'session-1',
+        'session-2',
+      ]);
+      const targetEvents = await store.readAfter('owner-b', 0n);
+      expect(targetEvents.map((event) => event.id)).toEqual(['1', '3', '4']);
+      expect(await store.readMaxId('owner-b')).toBe(4n);
+      expect(await store.mergeOwner('owner-a', 'owner-b')).toBe(0);
+    });
+  });
+}

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -155,6 +155,43 @@ export function runAgentSessionStoreContract(
       expect(replay.events.map((event) => event.id)).toEqual([1, 2, 4, 5]);
     });
 
+    test('carries message_update compaction across page boundaries', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      // Reviewer repro: one non-update, a run of ten updates, then another
+      // non-update, read in pages of six. Page-local lag/lead used to keep the
+      // first and last update of each page (2,6,7,11) instead of the true run
+      // survivors (2,11).
+      for (const [index, type] of [
+        'before',
+        ...Array.from({ length: 10 }, () => 'message_update'),
+        'after',
+      ].entries()) {
+        await store.appendControlEvent('session-1', {
+          ts: index + 1,
+          type,
+          data: { index },
+        });
+      }
+      expect(await store.lastEventSeq('session-1')).toBe(12);
+
+      const first = await store.readEventsAfterForReplay('session-1', 0, 6);
+      // `scanned` counts the raw rows after the cursor (12 total), untouched by
+      // the compaction window; the page itself still returns at most `limit`.
+      expect(first.scanned).toBe(12);
+      expect(first.events.map((event) => event.id)).toEqual([1, 2]);
+
+      const second = await store.readEventsAfterForReplay('session-1', 6, 6);
+      expect(second.scanned).toBe(6);
+      expect(second.events.map((event) => event.id)).toEqual([11, 12]);
+
+      expect(
+        [...first.events, ...second.events]
+          .filter((event) => event.type === 'message_update')
+          .map((event) => event.id),
+      ).toEqual([2, 11]);
+    });
+
     test('records control events with the current attempt generation', async () => {
       const store = makeStore();
       await store.createSession(makeAgentSessionInput());

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -263,14 +263,14 @@ export function runAgentSessionStoreContract(
       await store.createSession(makeAgentSessionInput());
       await store.setActiveStage('session-1', 'stage-2');
       await store.requestCancel('session-1');
-      const events = await store.readAfter('owner-a', 0n);
+      const events = await store.readAfter('owner-a', BigInt(0));
       expect(events.map((event) => event.type)).toEqual([
         'session_created',
         'session_active_stage',
         'session_cancel_requested',
       ]);
       expect(events.map((event) => event.id)).toEqual(['1', '2', '3']);
-      expect(await store.readMaxId('owner-a')).toBe(3n);
+      expect(await store.readMaxId('owner-a')).toBe(BigInt(3));
       expect(await store.readRetirement('owner-a')).toBeNull();
     });
 
@@ -287,9 +287,9 @@ export function runAgentSessionStoreContract(
         'session-1',
         'session-2',
       ]);
-      const targetEvents = await store.readAfter('owner-b', 0n);
+      const targetEvents = await store.readAfter('owner-b', BigInt(0));
       expect(targetEvents.map((event) => event.id)).toEqual(['1', '3', '4']);
-      expect(await store.readMaxId('owner-b')).toBe(4n);
+      expect(await store.readMaxId('owner-b')).toBe(BigInt(4));
       expect(await store.mergeOwner('owner-a', 'owner-b')).toBe(0);
     });
   });

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, expectTypeOf, test } from 'vitest';
 
 import {
   AGENT_SESSION_LIFECYCLE,
@@ -6,6 +6,7 @@ import {
   AgentSessionLeaseLostError,
   type AgentSessionEntryTree,
   type AgentSessionEventLog,
+  type AgentSessionMessageEntry,
   type AgentSessionStore,
   type OwnerSessionEventProjection,
 } from '../src/agent-session/types.js';
@@ -64,7 +65,6 @@ export function runAgentSessionStoreContract(
       await store.createSession(makeAgentSessionInput());
       await store.appendControlEvent('session-1', {
         ts: 1,
-        attempt: 0,
         type: 'control',
         data: { retained: true },
       });
@@ -142,7 +142,6 @@ export function runAgentSessionStoreContract(
       ].entries()) {
         await store.appendControlEvent('session-1', {
           ts: index + 1,
-          attempt: 0,
           type,
           data: { index },
         });
@@ -154,6 +153,23 @@ export function runAgentSessionStoreContract(
       const replay = await store.readEventsAfterForReplay('session-1', 0);
       expect(replay.scanned).toBe(5);
       expect(replay.events.map((event) => event.id)).toEqual([1, 2, 4, 5]);
+    });
+
+    test('records control events with the current attempt generation', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      // The attempt is derived from the parent row under the lock (reference
+      // material-event semantics), never accepted from the caller.
+      const seq = await store.appendControlEvent('session-1', {
+        ts: 5,
+        type: 'control',
+        data: { ok: true },
+      });
+      expect(seq).toBe(1);
+      expect(await store.readEventsAfter('session-1', 0)).toMatchObject([
+        { id: 1, ts: 5, attempt: 1, type: 'control' },
+      ]);
     });
 
     test('classifies posted messages and atomically revives terminal sessions', async () => {
@@ -228,7 +244,11 @@ export function runAgentSessionStoreContract(
 
       const reopened = await store.openEntryTree('session-1', 'worker-a', 1);
       expect(await reopened.getLeafId()).toBe('child');
-      expect((await reopened.findEntries('message')).map((entry) => entry.id)).toEqual(['root']);
+      // `findEntries` keeps the reference's narrowing: a 'message' query
+      // yields exactly AgentSessionMessageEntry[] (compile-time pinned).
+      const messages = await reopened.findEntries('message');
+      expectTypeOf(messages).toEqualTypeOf<AgentSessionMessageEntry[]>();
+      expect(messages.map((entry) => entry.id)).toEqual(['root']);
       await expect(
         reopened.appendEntry({
           id: 'dangling',

--- a/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
@@ -1,0 +1,76 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  PgAgentSessionStore,
+  ensureAgentSessionSchema,
+  type Queryable,
+  type WithTransaction,
+} from '../src/agent-session/pg.js';
+import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
+import { runAgentSessionStoreContract } from './agent-session-contract.js';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+if (process.env.STORAGE_PG_CONTRACT_REQUIRED === '1' && !contractUrl) {
+  throw new Error(
+    '@openmaic/storage: STORAGE_PG_CONTRACT_REQUIRED=1 requires PG_CONTRACT_URL; ' +
+      'refusing to skip the PostgreSQL agent-session contract suite',
+  );
+}
+
+function transactionFor(pool: Pool): WithTransaction {
+  return async (body) => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client as Queryable);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the transaction body's original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
+  let pool: Pool;
+  let store: PgAgentSessionStore;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl, max: 16 });
+    await ensureAgentSessionSchema(pool as Queryable);
+  });
+
+  beforeEach(async () => {
+    await pool.query(
+      `TRUNCATE agent_session_entries, agent_session_events,
+                agent_owner_session_events, agent_owner_session_event_counters,
+                agent_sessions`,
+    );
+    store = new PgAgentSessionStore(pool as Queryable, { withTransaction: transactionFor(pool) });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  runAgentSessionStoreContract('PostgreSQL 16 (node-postgres)', () => store);
+  runAgentSessionConcurrencyContract('PostgreSQL 16 (node-postgres)', () => store, {
+    genuineConcurrency: true,
+  });
+
+  test('runs against PostgreSQL 16 or newer', async () => {
+    const result = await pool.query<{ version_num: string }>(
+      `SELECT current_setting('server_version_num') AS version_num`,
+    );
+    expect(Number(result.rows[0]!.version_num)).toBeGreaterThanOrEqual(160_000);
+  });
+});

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -1,0 +1,139 @@
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  DEFAULT_AGENT_SESSION_TABLE_NAMES,
+  PgAgentSessionStore,
+  ensureAgentSessionSchema,
+  type PgAgentSessionStoreOptions,
+  type Queryable,
+} from '../src/agent-session/pg.js';
+import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
+import { makeAgentSessionInput, runAgentSessionStoreContract } from './agent-session-contract.js';
+
+function optionsFor(db: PGlite): PgAgentSessionStoreOptions {
+  return { withTransaction: (body) => db.transaction((tx: Queryable) => body(tx)) };
+}
+
+describe('PgAgentSessionStore with PGlite', () => {
+  let db: PGlite;
+  let store: PgAgentSessionStore;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureAgentSessionSchema(db);
+    store = new PgAgentSessionStore(db, optionsFor(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  runAgentSessionStoreContract('Postgres (PGlite)', () => store);
+  runAgentSessionConcurrencyContract('Postgres (PGlite)', () => store, {
+    genuineConcurrency: false,
+  });
+
+  test('provisions all five tables idempotently', async () => {
+    await expect(ensureAgentSessionSchema(db)).resolves.toBeUndefined();
+    const result = await db.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = ANY($1::text[]) ORDER BY table_name`,
+      [Object.values(DEFAULT_AGENT_SESSION_TABLE_NAMES)],
+    );
+    expect(result.rows.map((row) => row.table_name)).toEqual(
+      Object.values(DEFAULT_AGENT_SESSION_TABLE_NAMES).sort(),
+    );
+  });
+
+  test('requires a correctly pinned transaction hook', () => {
+    expect(() => new PgAgentSessionStore(db, {} as PgAgentSessionStoreOptions)).toThrow(
+      /withTransaction.*fresh.*connection.*transaction/i,
+    );
+  });
+
+  test('runs owner resolution before insertion and creation hook before commit', async () => {
+    const observed: string[] = [];
+    const hooked = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      resolveFinalOwner: async (tx, ownerId) => {
+        const count = await tx.query<{ n: string }>(
+          'SELECT count(*)::text AS n FROM agent_sessions',
+        );
+        observed.push(`resolve:${count.rows[0]!.n}`);
+        return `${ownerId}-final`;
+      },
+      onSessionCreated: async (tx, meta) => {
+        const row = await tx.query<{ owner_id: string }>(
+          'SELECT owner_id FROM agent_sessions WHERE id = $1',
+          [meta.id],
+        );
+        observed.push(`created:${row.rows[0]!.owner_id}`);
+      },
+    });
+
+    await hooked.createSession(makeAgentSessionInput());
+    expect(observed).toEqual(['resolve:0', 'created:owner-a-final']);
+  });
+
+  test('swallows a projection failure without rolling back the business mutation', async () => {
+    const logged: unknown[] = [];
+    const brokenProjection = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      logger: { error: (...args) => logged.push(args) },
+    });
+    await db.query(
+      `ALTER TABLE agent_owner_session_events
+       ADD CONSTRAINT reject_projection CHECK (type <> 'session_created')`,
+    );
+
+    await expect(brokenProjection.createSession(makeAgentSessionInput())).resolves.toMatchObject({
+      id: 'session-1',
+    });
+    expect(await brokenProjection.getSession('session-1')).not.toBeNull();
+    expect(await brokenProjection.readMaxId('owner-a')).toBe(0n);
+    expect(logged).toHaveLength(1);
+  });
+
+  test('keeps event and tree rows physically present after a tombstone', async () => {
+    await store.createSession(makeAgentSessionInput());
+    await store.appendControlEvent('session-1', {
+      ts: 1,
+      attempt: 0,
+      type: 'control',
+      data: {},
+    });
+    await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+    const tree = await store.openEntryTree('session-1', 'worker-a', 1);
+    await tree.appendEntry({
+      id: 'root',
+      parentId: null,
+      type: 'message',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      message: {},
+    });
+    await store.softDeleteSession('session-1', 'owner-a');
+
+    expect((await db.query('SELECT 1 FROM agent_session_events')).rows).toHaveLength(1);
+    expect((await db.query('SELECT 1 FROM agent_session_entries')).rows).toHaveLength(1);
+  });
+
+  test('supports isolated custom table names', async () => {
+    const custom = {
+      sessions: 'spec_sessions',
+      events: 'spec_events',
+      entries: 'spec_entries',
+      ownerEventCounters: 'spec_owner_event_counters',
+      ownerEvents: 'spec_owner_events',
+    };
+    await ensureAgentSessionSchema(db, custom);
+    const customStore = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      tableNames: custom,
+    });
+    await customStore.createSession(makeAgentSessionInput({ id: 'custom-1' }));
+    expect(await customStore.getSession('custom-1')).toMatchObject({ id: 'custom-1' });
+    expect(await store.getSession('custom-1')).toBeNull();
+  });
+});

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -8,6 +8,7 @@ import {
   type PgAgentSessionStoreOptions,
   type Queryable,
 } from '../src/agent-session/pg.js';
+import { AgentSessionEntryTreeError } from '../src/agent-session/types.js';
 import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
 import { makeAgentSessionInput, runAgentSessionStoreContract } from './agent-session-contract.js';
 
@@ -96,11 +97,82 @@ describe('PgAgentSessionStore with PGlite', () => {
     expect(logged).toHaveLength(1);
   });
 
+  test('lets a throwing onUserMessagePosted veto the message and its requeue', async () => {
+    const hooked = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      onUserMessagePosted: async () => {
+        throw new Error('host material binding failed');
+      },
+    });
+    await hooked.createSession(makeAgentSessionInput({ status: 'succeeded' }));
+    // The hook is a veto point (reference semantics): a throw aborts the whole
+    // postUserMessage — the message row is not persisted, the terminal session
+    // is not requeued, and the caller receives the error.
+    await expect(hooked.postUserMessage('session-1', { text: 'Continue' })).rejects.toThrow(
+      'host material binding failed',
+    );
+    expect(await hooked.listUserMessages('session-1')).toEqual([]);
+    expect(await hooked.getSession('session-1')).toMatchObject({ status: 'succeeded' });
+    expect(await hooked.readMaxId('owner-a')).toBe(BigInt(1));
+  });
+
+  test('treats a resolver-collapsed merge target as a no-op self-merge', async () => {
+    const hooked = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      resolveFinalOwner: async (_tx, ownerId) => (ownerId === 'owner-b' ? 'owner-a' : ownerId),
+    });
+    await hooked.createSession(makeAgentSessionInput());
+    await hooked.createSession(makeAgentSessionInput({ id: 'session-2', stageId: 'stage-2' }));
+    // toOwnerId resolves back onto fromOwnerId: the merge must be a no-op
+    // instead of re-keying sessions to themselves and renumbering the owner's
+    // own projection above its high-water mark.
+    expect(await hooked.mergeOwner('owner-a', 'owner-b')).toBe(0);
+    expect((await hooked.listSessionsByOwner('owner-a')).map((session) => session.id)).toEqual([
+      'session-1',
+      'session-2',
+    ]);
+    expect(await hooked.listSessionsByOwner('owner-b')).toEqual([]);
+    expect(await hooked.readMaxId('owner-a')).toBe(BigInt(2));
+    expect((await hooked.readAfter('owner-a', BigInt(0))).map((event) => event.id)).toEqual([
+      '1',
+      '2',
+    ]);
+  });
+
+  test('reads retirement through the host resolver inside a transaction', async () => {
+    const hooked = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      resolveFinalOwner: async (_tx, ownerId) =>
+        ownerId === 'retired-owner' ? 'current-owner' : ownerId,
+    });
+    await hooked.createSession(
+      makeAgentSessionInput({ id: 'session-1', ownerId: 'current-owner' }),
+    );
+    expect(await hooked.readRetirement('current-owner')).toBeNull();
+    expect(await hooked.readRetirement('retired-owner')).toBe('current-owner');
+  });
+
+  test('preserves an empty-string leaf target instead of collapsing it to null', async () => {
+    await store.createSession(makeAgentSessionInput());
+    await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+    const tree = await store.openEntryTree('session-1', 'worker-a', 1);
+    await tree.appendEntry({
+      id: 'marker',
+      parentId: null,
+      type: 'leaf',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      targetId: '',
+    });
+    // The '' target is preserved as the leaf id (reference leafIdAfterEntry
+    // returns it verbatim), so getLeafId validates it like any other leaf id
+    // and finds no entry with id '' — instead of silently returning null.
+    await expect(tree.getLeafId()).rejects.toBeInstanceOf(AgentSessionEntryTreeError);
+  });
+
   test('keeps event and tree rows physically present after a tombstone', async () => {
     await store.createSession(makeAgentSessionInput());
     await store.appendControlEvent('session-1', {
       ts: 1,
-      attempt: 0,
       type: 'control',
       data: {},
     });
@@ -135,5 +207,21 @@ describe('PgAgentSessionStore with PGlite', () => {
     await customStore.createSession(makeAgentSessionInput({ id: 'custom-1' }));
     expect(await customStore.getSession('custom-1')).toMatchObject({ id: 'custom-1' });
     expect(await store.getSession('custom-1')).toBeNull();
+    // Index names derive from the table-name substitution verbatim — the
+    // template index names are re-keyed by the same replaceAll that re-keys
+    // their tables, with no separate prefix rewriting. This pins that the
+    // entries index is `spec_entries_type_idx`, never the prefix-derived
+    // `spec_session_entries_type_idx` that the old dead rename lines claimed.
+    const indexNames = (
+      await db.query<{ index_name: string }>(
+        `SELECT indexname AS index_name FROM pg_indexes
+         WHERE schemaname = 'public' AND tablename = ANY($1::text[])`,
+        [['spec_sessions', 'spec_entries']],
+      )
+    ).rows.map((row) => row.index_name);
+    expect(indexNames).toContain('spec_sessions_status_live_idx');
+    expect(indexNames).toContain('spec_sessions_owner_live_idx');
+    expect(indexNames).toContain('spec_entries_type_idx');
+    expect(indexNames).not.toContain('spec_session_entries_type_idx');
   });
 });

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -92,7 +92,7 @@ describe('PgAgentSessionStore with PGlite', () => {
       id: 'session-1',
     });
     expect(await brokenProjection.getSession('session-1')).not.toBeNull();
-    expect(await brokenProjection.readMaxId('owner-a')).toBe(0n);
+    expect(await brokenProjection.readMaxId('owner-a')).toBe(BigInt(0));
     expect(logged).toHaveLength(1);
   });
 

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { AGENT_SESSION_PG_SCHEMA, ensureAgentSessionSchema } from '../src/agent-session/pg.js';
 import { DOCUMENT_PG_SCHEMA, ensureDocumentSchema } from '../src/document/pg.js';
 import { RUNTIME_PG_SCHEMA, ensureSchema } from '../src/runtime/pg.js';
 import type { Queryable } from '../src/runtime/pg.js';
@@ -90,6 +91,93 @@ CREATE INDEX IF NOT EXISTS runtime_records_session_scene_idx
   ON runtime_records (session_id, scene_id);
 `;
 
+const EXPECTED_AGENT_SESSION_PG_SCHEMA = `
+CREATE TABLE IF NOT EXISTS agent_sessions (
+  id                  TEXT PRIMARY KEY,
+  owner_id            TEXT NOT NULL,
+  prompt              TEXT NOT NULL,
+  stage_id            TEXT NOT NULL,
+  active_stage_id     TEXT,
+  skill_id            TEXT,
+  origin              TEXT,
+  existing_course     BOOLEAN NOT NULL DEFAULT FALSE,
+  status              TEXT NOT NULL DEFAULT 'queued',
+  attempt             INTEGER NOT NULL DEFAULT 0,
+  lease_worker_id     TEXT,
+  lease_worker_pid    INTEGER,
+  lease_heartbeat_at  BIGINT,
+  cancel_requested_at BIGINT,
+  error               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at          TIMESTAMPTZ,
+  CONSTRAINT agent_sessions_attempt_nonnegative CHECK (attempt >= 0),
+  CONSTRAINT agent_sessions_status_known
+    CHECK (status IN ('queued','running','succeeded','failed','cancelled'))
+);
+
+CREATE INDEX IF NOT EXISTS agent_sessions_status_live_idx
+  ON agent_sessions (status, created_at) WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS agent_sessions_owner_live_idx
+  ON agent_sessions (owner_id, created_at) WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS agent_session_events (
+  session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+  seq        INTEGER NOT NULL,
+  ts         BIGINT NOT NULL,
+  attempt    INTEGER NOT NULL,
+  type       TEXT NOT NULL,
+  data       JSONB,
+  PRIMARY KEY (session_id, seq),
+  CONSTRAINT agent_session_events_seq_positive CHECK (seq > 0)
+);
+
+CREATE TABLE IF NOT EXISTS agent_session_entries (
+  session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+  seq        INTEGER NOT NULL,
+  entry_id   TEXT NOT NULL,
+  parent_id  TEXT,
+  type       TEXT NOT NULL,
+  data       JSONB NOT NULL,
+  ts         TIMESTAMPTZ NOT NULL,
+  attempt    INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  CONSTRAINT agent_session_entries_entry_id_unique UNIQUE (session_id, entry_id),
+  CONSTRAINT agent_session_entries_parent_fk
+    FOREIGN KEY (session_id, parent_id)
+    REFERENCES agent_session_entries (session_id, entry_id)
+);
+
+CREATE INDEX IF NOT EXISTS agent_session_entries_type_idx
+  ON agent_session_entries (session_id, type, seq);
+
+CREATE TABLE IF NOT EXISTS agent_owner_session_event_counters (
+  owner_id TEXT PRIMARY KEY,
+  n        BIGINT NOT NULL DEFAULT 0,
+  CONSTRAINT agent_owner_session_event_counters_nonnegative CHECK (n >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS agent_owner_session_events (
+  owner_id   TEXT NOT NULL,
+  id         BIGINT NOT NULL,
+  ts         BIGINT NOT NULL,
+  session_id TEXT NOT NULL,
+  type       TEXT NOT NULL,
+  status     TEXT,
+  attempt    INTEGER,
+  data       JSONB NOT NULL,
+  PRIMARY KEY (owner_id, id),
+  CONSTRAINT agent_owner_session_events_type_known CHECK (type IN
+    ('session_created','session_status','session_deleted',
+     'session_active_stage','session_cancel_requested')),
+  CONSTRAINT agent_owner_session_events_status_known CHECK (status IS NULL OR status IN
+    ('queued','running','succeeded','failed','cancelled')),
+  CONSTRAINT agent_owner_session_events_attempt_nonnegative
+    CHECK (attempt IS NULL OR attempt >= 0)
+);
+`;
+
 /** Records the statements an ensure function actually issues. */
 function recordingQueryable(): { statements: string[]; queryable: Queryable } {
   const statements: string[] = [];
@@ -123,6 +211,12 @@ const schemas = [
     actual: RUNTIME_PG_SCHEMA,
     expected: EXPECTED_RUNTIME_PG_SCHEMA,
     ensure: ensureSchema,
+  },
+  {
+    name: 'AGENT_SESSION_PG_SCHEMA',
+    actual: AGENT_SESSION_PG_SCHEMA,
+    expected: EXPECTED_AGENT_SESSION_PG_SCHEMA,
+    ensure: ensureAgentSessionSchema,
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds an **agent-session store** to `@openmaic/storage`: persistence for long-running, multi-process background agent sessions — session lifecycle, lease-based claiming with stale-lease stealing, an append-only event log with generation fencing, an append-only session entry tree, and a per-owner replayable event projection.

This is the storage foundation for the agent workbench line landing on `integration/agent-workbench`; nothing in the app consumes it yet (package-only change plus the CI trigger for the integration branch).

## Shape

Follows the package's existing house patterns throughout:

- **Backend-agnostic core**: the PG backend depends only on the injected `Queryable` / `WithTransaction` contract — no driver dependency (node-postgres, PGlite, and host adapters all fit).
- **Pinned schema**: `AGENT_SESSION_PG_SCHEMA` is a gold-standard constant (every statement `CREATE TABLE|INDEX IF NOT EXISTS`, `;`-splittable for `ensureSchema`), pinned by the schema-contract test alongside the existing stores. Table names are remappable via a `tableNames` option.
- **Layered contracts** (a deliberate extension of the single-contract pattern): `runAgentSessionStoreContract` covers single-process semantics and runs on every backend; a separate concurrency contract covers what only a real database can prove — competing claims, stale-lease stealing, in-lock watermark reads, and deterministic results under contention — and runs on PostgreSQL. The PG16 suite enforces `STORAGE_PG_CONTRACT_REQUIRED=1` so it cannot skip silently on CI.
- **Injected host hooks** (`resolveFinalOwner`, `onSessionCreated`, `onUserMessagePosted`) let a host attach identity resolution and side-band bookkeeping without the store knowing those concepts; the transaction and lock-order contract for hooks is documented on the types.

## Key semantics (argued in the docblocks)

- Claiming is two-phase: an unlocked candidate scan followed by an in-lock recheck, so claim reasons and event watermarks always come from locked reads.
- Appends are generation-fenced: an event carrying a stale attempt is dropped rather than interleaved into a newer run.
- The owner projection deliberately swallows its own failures (business writes must not be vetoed by projection breakage; clients repair via full resync) — the one place the store is not fail-loud, and the docblock argues why.
- Soft-deletion is a tombstone; child data is retained.

## Testing

- Full storage package suite passes (PGlite + in-memory paths).
- Real PostgreSQL 16 contract suite passes (store contract + concurrency contract), verified locally in Docker; the `storage-pg-contract` CI job covers it on every push.
- Repo-root typecheck, prettier, eslint clean.
