### PR TITLE
feat(agent): add the driver model contract and stage route dialect

### DIFF
--- a/lib/agent/runtime/build-agent.ts
+++ b/lib/agent/runtime/build-agent.ts
@@ -43,6 +43,11 @@ export interface BuildAgentOptions {
   streamFn: StreamFn;
   systemPrompt: string;
   tools: AgentTool[];
+  /**
+   * Optional pi model for the agent's initial state. Defaults to the connector
+   * metadata stub; the injected StreamFn resolves the real model itself.
+   */
+  model?: Model<Api>;
   /** Tool names allowed for this agent. Defaults to the editor v0 allowlist. */
   allowedToolNames?: ReadonlySet<string>;
   /** Prior conversation turns to seed the agent with, so it has multi-turn memory. */
@@ -67,7 +72,7 @@ export function buildAgent(opts: BuildAgentOptions): Agent {
     toolExecution: 'sequential',
     initialState: {
       systemPrompt: opts.systemPrompt,
-      model: STUB_MODEL,
+      model: opts.model ?? STUB_MODEL,
       tools: opts.tools,
       // Seed prior turns so `agent.prompt(newMessage)` runs with the full
       // conversation in context — without this the agent is stateless per turn.

--- a/lib/agent/runtime/stream-fn.ts
+++ b/lib/agent/runtime/stream-fn.ts
@@ -140,6 +140,13 @@ export interface CallLlmStreamFnOptions {
   /** Resolved Vercel AI SDK model instance (from resolveModelFromRequest). */
   languageModel: LanguageModel;
   maxOutputTokens?: number;
+  /**
+   * When true, never send a max output tokens cap on the wire, even when pi
+   * supplies one via streamOptions.maxTokens. pi's per-call budget is an
+   * internal compaction estimate, not an API limit, so it must not become a
+   * hard max_tokens on the provider call.
+   */
+  omitMaxOutputTokens?: boolean;
   thinkingConfig?: ThinkingConfig;
   source?: string;
   /** Optional abort signal forwarded to the underlying streamLLM call. */
@@ -385,8 +392,9 @@ async function pump(
     }
 
     const requestedMaxTokens = streamOptions?.maxTokens;
-    const maxOutputTokens =
-      opts.maxOutputTokens && requestedMaxTokens
+    const maxOutputTokens = opts.omitMaxOutputTokens
+      ? undefined
+      : opts.maxOutputTokens && requestedMaxTokens
         ? Math.min(opts.maxOutputTokens, requestedMaxTokens)
         : (requestedMaxTokens ?? opts.maxOutputTokens);
     const result = await streamLLM(

--- a/lib/server/agent-runtime/agent-driver-model.ts
+++ b/lib/server/agent-runtime/agent-driver-model.ts
@@ -1,0 +1,90 @@
+import type { Api, Model } from '@earendil-works/pi-ai';
+
+import { getStageRoute } from '@/lib/server/model-routes';
+import { resolveModel, type ResolvedModel } from '@/lib/server/resolve-model';
+
+export const AGENT_DRIVER_STAGE = 'maic-agent-driver' as const;
+export const UNKNOWN_MODEL_RESERVED_OUTPUT_TOKENS = 8_192;
+// The driver route owns the model choice. This adapter only enforces its transport
+// contract: a resolvable provider prefix, no thinking effort, and an explicit
+// OpenAI-compatible pi api/dialect. The actual HTTP transport is selected by
+// lib/ai/providers.ts.
+const OPENAI_PI_APIS = new Set<Api>(['openai-completions', 'openai-responses']);
+
+export function buildPiDriverModel(
+  connection: ResolvedModel,
+  configuredApi?: string,
+  routeContextWindow?: number,
+): Model<Api> {
+  if (!configuredApi || !OPENAI_PI_APIS.has(configuredApi)) {
+    throw new Error(
+      `MODEL_ROUTES stage "${AGENT_DRIVER_STAGE}" has unsupported pi api/dialect ` +
+        `${JSON.stringify(configuredApi)} for model id ${connection.modelId}.`,
+    );
+  }
+  return {
+    id: connection.modelId,
+    name: connection.modelId,
+    api: configuredApi,
+    provider: connection.providerId,
+    baseUrl: connection.baseUrl ?? '',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    // Context-window value chain: route operator pin > catalog model window >
+    // conservative 128k fallback. The fallback is only an internal estimate
+    // used to decide when to compact; it is not sent to the model API. It must
+    // stay below the gateway's real request limit so compaction remains
+    // reachable before the gateway rejects an oversized prompt.
+    contextWindow: routeContextWindow ?? connection.modelInfo?.contextWindow ?? 128_000,
+    // Pi requires Model.maxTokens. For known models this is the real catalog
+    // output window. For unknown models 8192 is only a deterministic internal
+    // compaction reservation; resolveAgentDriverModel deliberately exposes an
+    // independent undefined wireMaxOutputTokens so it never becomes an API cap.
+    maxTokens: connection.modelInfo?.outputWindow ?? UNKNOWN_MODEL_RESERVED_OUTPUT_TOKENS,
+  } as Model<Api>;
+}
+
+/** Resolve the driver from its dedicated route; DEFAULT_MODEL is never consulted. */
+export async function resolveAgentDriverModel(): Promise<{
+  connection: ResolvedModel;
+  piModel: Model<Api>;
+  /** Catalog-backed API limit; undefined means omit max_tokens on the wire. */
+  wireMaxOutputTokens?: number;
+  /** Internal compaction output-space estimate; never used as a conversation API limit. */
+  reservedOutputTokens: number;
+}> {
+  const route = getStageRoute(AGENT_DRIVER_STAGE);
+  if (!route) {
+    throw new Error(
+      `MODEL_ROUTES must explicitly configure stage "${AGENT_DRIVER_STAGE}" ` +
+        `with a provider-prefixed model id and an api/dialect.`,
+    );
+  }
+  // The provider prefix must be explicit. parseModelString silently defaults a
+  // bare model id to the openai provider, so the driver must fail here before
+  // resolveModel reaches that fallback and routes to the wrong provider.
+  const providerSeparator = route.model.indexOf(':');
+  const modelId = providerSeparator > 0 ? route.model.slice(providerSeparator + 1) : undefined;
+  if (!modelId) {
+    throw new Error(
+      `MODEL_ROUTES stage "${AGENT_DRIVER_STAGE}" must use a model id with an explicit ` +
+        `provider prefix; ` +
+        `received ${JSON.stringify(route.model)}.`,
+    );
+  }
+  if (route.thinking?.effort !== undefined) {
+    throw new Error(
+      `MODEL_ROUTES stage "${AGENT_DRIVER_STAGE}" must not set thinking.effort because ` +
+        `${modelId} cannot combine reasoning_effort with function tools on this transport.`,
+    );
+  }
+  const connection = await resolveModel({ stage: AGENT_DRIVER_STAGE });
+  const wireMaxOutputTokens = connection.modelInfo?.outputWindow;
+  return {
+    connection,
+    piModel: buildPiDriverModel(connection, route.api, route.contextWindow),
+    wireMaxOutputTokens,
+    reservedOutputTokens: wireMaxOutputTokens ?? UNKNOWN_MODEL_RESERVED_OUTPUT_TOKENS,
+  };
+}

--- a/lib/server/model-routes.ts
+++ b/lib/server/model-routes.ts
@@ -41,15 +41,26 @@ const VALID_EFFORTS: readonly ThinkingEffort[] = [
 ];
 const VALID_LEVELS: readonly ThinkingLevel[] = ['minimal', 'low', 'medium', 'high'];
 
-/** A resolved route entry: the model string plus an optional full thinking config. */
+/**
+ * A resolved route entry: the model string plus an optional full thinking config.
+ *
+ * `api`/`dialect` and `contextWindow` are parsed for every routable stage but are
+ * currently consumed only by the agent-driver stage (`maic-agent-driver`); on any
+ * other stage they are inert (accepted silently, never applied). `thinking` is the
+ * only field honored by the generic callLLM stages.
+ */
 export interface StageRoute {
   model: string;
-  /** Explicit pi transport dialect (for example openai-completions). */
+  /**
+   * Explicit pi transport dialect (for example openai-completions). Consumed only
+   * by the agent-driver stage; inert on every other routable stage.
+   */
   api?: string;
   /**
    * Effective context window for this stage, overriding the provider catalog
    * value. Consumed by pi-native compaction thresholds (e.g. the agent driver)
    * so an operator can pin a conservative window below the catalog number.
+   * Consumed only by the agent-driver stage; inert on every other routable stage.
    */
   contextWindow?: number;
   /**
@@ -162,10 +173,18 @@ function parseRouteValue(key: string, value: unknown): StageRoute | undefined {
     const dialect = typeof obj.dialect === 'string' ? obj.dialect.trim() : '';
     if (api || dialect) route.api = api || dialect;
     if (obj.api !== undefined && !api) {
-      log.warn(`Invalid api for stage "${key}" in MODEL_ROUTES; ignored.`);
+      log.warn(
+        dialect
+          ? `Invalid api for stage "${key}" in MODEL_ROUTES; using dialect "${dialect}" instead.`
+          : `Invalid api for stage "${key}" in MODEL_ROUTES; ignored.`,
+      );
     }
     if (obj.dialect !== undefined && !dialect) {
-      log.warn(`Invalid dialect for stage "${key}" in MODEL_ROUTES; ignored.`);
+      log.warn(
+        api
+          ? `Invalid dialect for stage "${key}" in MODEL_ROUTES; using api "${api}" instead.`
+          : `Invalid dialect for stage "${key}" in MODEL_ROUTES; ignored.`,
+      );
     }
     if (api && dialect && api !== dialect) {
       log.warn(`Both api and dialect are set for stage "${key}"; api wins.`);
@@ -179,7 +198,7 @@ function parseRouteValue(key: string, value: unknown): StageRoute | undefined {
       if (
         typeof contextWindow === 'number' &&
         Number.isFinite(contextWindow) &&
-        contextWindow > 0
+        Math.floor(contextWindow) >= 1
       ) {
         route.contextWindow = Math.floor(contextWindow);
       } else {

--- a/lib/server/model-routes.ts
+++ b/lib/server/model-routes.ts
@@ -44,6 +44,14 @@ const VALID_LEVELS: readonly ThinkingLevel[] = ['minimal', 'low', 'medium', 'hig
 /** A resolved route entry: the model string plus an optional full thinking config. */
 export interface StageRoute {
   model: string;
+  /** Explicit pi transport dialect (for example openai-completions). */
+  api?: string;
+  /**
+   * Effective context window for this stage, overriding the provider catalog
+   * value. Consumed by pi-native compaction thresholds (e.g. the agent driver)
+   * so an operator can pin a conservative window below the catalog number.
+   */
+  contextWindow?: number;
   /**
    * Full thinking config for this stage (the unified ThinkingConfig abstraction:
    * mode / effort / level / enabled / budgetTokens / excludeReasoningOutput).
@@ -129,6 +137,7 @@ export const LLM_STAGES = [
   'generate-classroom',
   'web-search-query-rewrite',
   'maic-agent',
+  'maic-agent-driver',
 ] as const;
 
 export type LlmStage = (typeof LLM_STAGES)[number];
@@ -149,9 +158,33 @@ function parseRouteValue(key: string, value: unknown): StageRoute | undefined {
       return undefined;
     }
     const route: StageRoute = { model };
+    const api = typeof obj.api === 'string' ? obj.api.trim() : '';
+    const dialect = typeof obj.dialect === 'string' ? obj.dialect.trim() : '';
+    if (api || dialect) route.api = api || dialect;
+    if (obj.api !== undefined && !api) {
+      log.warn(`Invalid api for stage "${key}" in MODEL_ROUTES; ignored.`);
+    }
+    if (obj.dialect !== undefined && !dialect) {
+      log.warn(`Invalid dialect for stage "${key}" in MODEL_ROUTES; ignored.`);
+    }
+    if (api && dialect && api !== dialect) {
+      log.warn(`Both api and dialect are set for stage "${key}"; api wins.`);
+    }
     if (obj.thinking !== undefined) {
       const thinking = parseThinking(key, obj.thinking);
       if (thinking) route.thinking = thinking;
+    }
+    if (obj.contextWindow !== undefined) {
+      const contextWindow = obj.contextWindow;
+      if (
+        typeof contextWindow === 'number' &&
+        Number.isFinite(contextWindow) &&
+        contextWindow > 0
+      ) {
+        route.contextWindow = Math.floor(contextWindow);
+      } else {
+        log.warn(`Invalid contextWindow for stage "${key}" in MODEL_ROUTES; ignored.`);
+      }
     }
     return route;
   }

--- a/tests/agent-runtime/agent-driver-model.test.ts
+++ b/tests/agent-runtime/agent-driver-model.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ resolveModel: vi.fn(), streamLLM: vi.fn() }));
+
+vi.mock('@/lib/server/resolve-model', () => ({ resolveModel: mocks.resolveModel }));
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+
+function finishedStream() {
+  return {
+    fullStream: (async function* () {
+      yield { type: 'finish', finishReason: 'stop', totalUsage: ZERO_USAGE };
+    })(),
+    usage: Promise.resolve(ZERO_USAGE),
+  };
+}
+
+async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const _event of stream) {
+    // Drain the protocol stream so the async transport call settles.
+  }
+}
+
+describe('agent driver model route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.resolveModel.mockReset();
+    mocks.streamLLM.mockReset();
+    delete process.env.MODEL_ROUTES;
+  });
+
+  it('fails loud when the dedicated route is missing', async () => {
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    await expect(resolveAgentDriverModel()).rejects.toThrow('must explicitly configure');
+    expect(mocks.resolveModel).not.toHaveBeenCalled();
+  });
+
+  it('fails loud when reasoning effort is configured for the tool-using driver', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        thinking: { effort: 'medium' },
+        api: 'openai-completions',
+      },
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    await expect(resolveAgentDriverModel()).rejects.toThrow('must not set thinking.effort');
+  });
+
+  it('requires an explicit provider prefix', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'gpt-5.6-luna',
+        api: 'openai-completions',
+      },
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    await expect(resolveAgentDriverModel()).rejects.toThrow('explicit provider prefix');
+    expect(mocks.resolveModel).not.toHaveBeenCalled();
+  });
+
+  it.each(['gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'accepts configured driver model %s and passes the explicit pi API dialect',
+    async (modelId) => {
+      process.env.MODEL_ROUTES = JSON.stringify({
+        'maic-agent-driver': {
+          model: `openai:${modelId}`,
+          api: 'openai-completions',
+        },
+      });
+      mocks.resolveModel.mockResolvedValue({
+        model: {},
+        modelInfo: { contextWindow: 1_050_000, outputWindow: 128_000 },
+        modelString: `openai:${modelId}`,
+        providerId: 'openai',
+        modelId,
+        apiKey: 'secret',
+        baseUrl: 'https://gateway.example/v1',
+        thinkingConfig: undefined,
+      });
+      const { resolveAgentDriverModel } =
+        await import('@/lib/server/agent-runtime/agent-driver-model');
+      const resolved = await resolveAgentDriverModel();
+
+      expect(mocks.resolveModel).toHaveBeenCalledWith({ stage: 'maic-agent-driver' });
+      expect(resolved.piModel).toMatchObject({
+        id: modelId,
+        provider: 'openai',
+        api: 'openai-completions',
+      });
+    },
+  );
+
+  it('uses the provider catalog window when the model is known', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', api: 'openai-completions' },
+    });
+    mocks.resolveModel.mockResolvedValue({
+      model: {},
+      modelInfo: { contextWindow: 200_000, outputWindow: 16_384 },
+      modelString: 'openai:gpt-5.6-luna',
+      providerId: 'openai',
+      modelId: 'gpt-5.6-luna',
+      apiKey: 'secret',
+      baseUrl: 'https://gateway.example/v1',
+      thinkingConfig: undefined,
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    const resolved = await resolveAgentDriverModel();
+
+    expect(resolved.piModel.contextWindow).toBe(200_000);
+    expect(resolved.piModel.maxTokens).toBe(16_384);
+    expect(resolved.wireMaxOutputTokens).toBe(16_384);
+    expect(resolved.reservedOutputTokens).toBe(16_384);
+  });
+
+  it('falls back to a conservative real window for an unknown model', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'custom:some-model', api: 'openai-completions' },
+    });
+    mocks.resolveModel.mockResolvedValue({
+      model: {},
+      modelInfo: null,
+      modelString: 'custom:some-model',
+      providerId: 'custom',
+      modelId: 'some-model',
+      apiKey: 'secret',
+      baseUrl: 'https://gateway.example/v1',
+      thinkingConfig: undefined,
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    const resolved = await resolveAgentDriverModel();
+
+    // The old 1_050_000 fallback made pi's compaction threshold unreachable;
+    // the calibrated fallback is a conservative real window.
+    expect(resolved.piModel.contextWindow).toBe(128_000);
+    expect(resolved.piModel.maxTokens).toBe(8_192);
+    expect(resolved.wireMaxOutputTokens).toBeUndefined();
+    expect(resolved.reservedOutputTokens).toBe(8_192);
+  });
+
+  it('omits the unknown-model output limit even when compaction supplies its reservation', async () => {
+    mocks.streamLLM.mockReturnValue(finishedStream());
+    const { createCallLlmStreamFn } = await import('@/lib/agent/runtime/stream-fn');
+    const streamFn = createCallLlmStreamFn({
+      languageModel: {} as never,
+      maxOutputTokens: undefined,
+      omitMaxOutputTokens: true,
+    });
+
+    const stream = await streamFn(
+      {} as never,
+      { systemPrompt: 'system', messages: [], tools: [] },
+      { maxTokens: 8_192 },
+    );
+    await drain(stream);
+
+    expect(mocks.streamLLM.mock.calls[0]?.[0]?.maxOutputTokens).toBeUndefined();
+  });
+
+  it('keeps the catalog output limit on the wire for a known model', async () => {
+    mocks.streamLLM.mockReturnValue(finishedStream());
+    const { createCallLlmStreamFn } = await import('@/lib/agent/runtime/stream-fn');
+    const streamFn = createCallLlmStreamFn({
+      languageModel: {} as never,
+      maxOutputTokens: 16_384,
+    });
+
+    const stream = await streamFn({} as never, { systemPrompt: 'system', messages: [], tools: [] });
+    await drain(stream);
+
+    expect(mocks.streamLLM.mock.calls[0]?.[0]?.maxOutputTokens).toBe(16_384);
+  });
+
+  it('lets the route pin a contextWindow below the catalog value', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        api: 'openai-completions',
+        contextWindow: 32_000,
+      },
+    });
+    mocks.resolveModel.mockResolvedValue({
+      model: {},
+      modelInfo: { contextWindow: 1_050_000, outputWindow: 128_000 },
+      modelString: 'openai:gpt-5.6-luna',
+      providerId: 'openai',
+      modelId: 'gpt-5.6-luna',
+      apiKey: 'secret',
+      baseUrl: 'https://gateway.example/v1',
+      thinkingConfig: undefined,
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    const resolved = await resolveAgentDriverModel();
+
+    expect(resolved.piModel.contextWindow).toBe(32_000);
+  });
+
+  it('propagates an unresolvable provider failure', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'custom:gpt-5.6-luna',
+        api: 'openai-completions',
+      },
+    });
+    mocks.resolveModel.mockRejectedValue(new Error('Unknown provider: custom'));
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    await expect(resolveAgentDriverModel()).rejects.toThrow('Unknown provider: custom');
+  });
+
+  it('fails loud for an incompatible pi API dialect', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        api: 'anthropic-messages',
+      },
+    });
+    mocks.resolveModel.mockResolvedValue({
+      model: {},
+      modelInfo: {},
+      modelString: 'openai:gpt-5.6-luna',
+      providerId: 'openai',
+      modelId: 'gpt-5.6-luna',
+      apiKey: 'secret',
+      baseUrl: 'https://gateway.example/v1',
+      thinkingConfig: { effort: 'medium' },
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    await expect(resolveAgentDriverModel()).rejects.toThrow('unsupported pi api/dialect');
+  });
+
+  it('fails loud when api/dialect is omitted', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+      },
+    });
+    mocks.resolveModel.mockResolvedValue({
+      model: {},
+      modelInfo: {},
+      modelString: 'openai:gpt-5.6-luna',
+      providerId: 'openai',
+      modelId: 'gpt-5.6-luna',
+      apiKey: 'secret',
+      baseUrl: 'https://gateway.example/v1',
+      thinkingConfig: undefined,
+    });
+    const { resolveAgentDriverModel } =
+      await import('@/lib/server/agent-runtime/agent-driver-model');
+    await expect(resolveAgentDriverModel()).rejects.toThrow('unsupported pi api/dialect');
+  });
+});

--- a/tests/server/model-routes.test.ts
+++ b/tests/server/model-routes.test.ts
@@ -131,6 +131,129 @@ describe('model-routes', () => {
     expect(getStageModel('scene-content')).toBe('openai:gpt-5.4');
   });
 
+  it('parses an api and a contextWindow on an object route value', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        api: 'openai-completions',
+        contextWindow: 32_000,
+      },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({
+      model: 'openai:gpt-5.6-luna',
+      api: 'openai-completions',
+      contextWindow: 32_000,
+    });
+  });
+
+  it('accepts dialect as an alias for api', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', dialect: 'openai-responses' },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({
+      model: 'openai:gpt-5.6-luna',
+      api: 'openai-responses',
+    });
+  });
+
+  it('prefers api over dialect and warns on conflict', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        api: 'openai-completions',
+        dialect: 'anthropic-messages',
+      },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({
+      model: 'openai:gpt-5.6-luna',
+      api: 'openai-completions',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Both api and dialect are set for stage "maic-agent-driver"; api wins.',
+    );
+  });
+
+  it('ignores a non-string api with a warning but keeps the model', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', api: 123 },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({ model: 'openai:gpt-5.6-luna' });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('ignores a non-string dialect with a warning but keeps the model', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', dialect: ['openai-completions'] },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({ model: 'openai:gpt-5.6-luna' });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('floors a fractional positive contextWindow', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', contextWindow: 32_000.9 },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({
+      model: 'openai:gpt-5.6-luna',
+      contextWindow: 32_000,
+    });
+  });
+
+  it('drops a non-positive contextWindow with a warning but keeps the model', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', contextWindow: 0 },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({ model: 'openai:gpt-5.6-luna' });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('drops a non-numeric contextWindow with a warning but keeps the model', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', contextWindow: '32000' },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({ model: 'openai:gpt-5.6-luna' });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('routes the agent driver stage (maic-agent-driver)', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        api: 'openai-completions',
+      },
+    });
+    const { getStageModel } = await import('@/lib/server/model-routes');
+    expect(getStageModel('maic-agent-driver')).toBe('openai:gpt-5.6-luna');
+  });
+
   it('supports the full thinking config (budgetTokens/enabled/level/mode)', async () => {
     process.env.MODEL_ROUTES = JSON.stringify({
       'scene-content:interactive': {
@@ -216,6 +339,8 @@ describe('model-routes', () => {
         'chat-adapter',
         'generate-classroom',
         'web-search-query-rewrite',
+        'maic-agent',
+        'maic-agent-driver',
       ]),
     );
   });

--- a/tests/server/model-routes.test.ts
+++ b/tests/server/model-routes.test.ts
@@ -180,6 +180,28 @@ describe('model-routes', () => {
     );
   });
 
+  it('uses dialect when api is invalid and warns that dialect won', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:gpt-5.6-luna',
+        api: 123,
+        dialect: 'openai-completions',
+      },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({
+      model: 'openai:gpt-5.6-luna',
+      api: 'openai-completions',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Invalid api for stage "maic-agent-driver" in MODEL_ROUTES; using dialect "openai-completions" instead.',
+    );
+  });
+
   it('ignores a non-string api with a warning but keeps the model', async () => {
     const warn = vi.fn();
     vi.doMock('@/lib/logger', () => ({
@@ -215,6 +237,19 @@ describe('model-routes', () => {
       model: 'openai:gpt-5.6-luna',
       contextWindow: 32_000,
     });
+  });
+
+  it('drops a contextWindow that floors below 1 with a warning but keeps the model', async () => {
+    const warn = vi.fn();
+    vi.doMock('@/lib/logger', () => ({
+      createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    }));
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': { model: 'openai:gpt-5.6-luna', contextWindow: 0.5 },
+    });
+    const { getStageRoute } = await import('@/lib/server/model-routes');
+    expect(getStageRoute('maic-agent-driver')).toEqual({ model: 'openai:gpt-5.6-luna' });
+    expect(warn).toHaveBeenCalled();
   });
 
   it('drops a non-positive contextWindow with a warning but keeps the model', async () => {


### PR DESCRIPTION
First application-layer slice of the agent runtime line on this integration branch.

- `StageRoute` gains optional `api`/`dialect` (transport dialect for pi model metadata; api wins on conflict) and `contextWindow` (route-pinned window, validated >= 1); `LLM_STAGES` gains `maic-agent-driver`.
- New `agent-driver-model.ts`: fail-loud resolution for the driver's model — a missing route, a bare model id without a provider prefix, any configured `thinking.effort`, or a non-OpenAI-compatible dialect all throw. The manual prefix parse exists because `parseModelString` silently defaults bare ids to the openai provider; the driver must fail before reaching that fallback.
- `stream-fn` gains `omitMaxOutputTokens` (a pi-side token budget is an internal compaction estimate, not an API cap); `buildAgent` accepts an injected `Model` (stub retained as default).

No behavior change for existing consumers; the runner lands in a follow-up slice. Tests: driver contract (guards, window precedence, wire-cap omission) + route parsing cases.