### PR TITLE
feat(agent): adapt the agent-session store and runtime foundations

### DIFF
--- a/lib/agent-runtime/lifecycle.ts
+++ b/lib/agent-runtime/lifecycle.ts
@@ -1,0 +1,107 @@
+/**
+ * Host lifecycle event names, importable from
+ * both sides of the wire.
+ *
+ * This lives outside `lib/server/` and imports nothing on purpose. These names
+ * are needed by the server (which emits them into the durable log) AND by the
+ * browser (which must subscribe to each NAMED SSE frame by name: an
+ * `EventSource` delivers `event: user_question` only to a listener registered
+ * for that exact type, never to `onmessage`). The storage package also exports advisory lifecycle names. This host set remains
+ * separate because it adds presentation-level events and is the browser-safe
+ * subscription source; importing it must never pull a database dependency into
+ * the client bundle.
+ */
+export interface StageLinkLifecycleData {
+  stageId: string;
+  title: string;
+  url: string;
+}
+
+export const HOST_AGENT_LIFECYCLE = {
+  sessionStart: 'session_start',
+  sessionResumed: 'session_resumed',
+  checkpoint: 'checkpoint',
+  sessionEnd: 'session_end',
+  /**
+   * The run stopped WITHOUT a terminal status: the runner is shutting down
+   * (deploy) or lost the lease. Not terminal — the session row stays
+   * `running`, and the instance that steals it appends `session_resumed`.
+   */
+  sessionInterrupted: 'session_interrupted',
+  /**
+   * A message from the user, written by the CONTROL PLANE the moment it is
+   * received — before any run or steer acts on it, so a crash loses nothing.
+   * `data.delivery` is 'steer' (session was running; the worker injects it
+   * mid-run) or 'queued' (session was idle; it drives the next run).
+   */
+  userMessage: 'user_message',
+  /** Sub-step progress inside one long tool call (per-LLM-round-trip). */
+  trace: 'trace',
+  /**
+   * The run's reasoning handed over to visible text: the first update of the
+   * current message that carries text after carrying thinking. The chat fold
+   * settles the streaming thinking bar on THIS durable frame, so the bar's
+   * clock stops at the same instant live and on replay — token deltas are
+   * volatile (compacted away on replay), a part's completion must not be.
+   */
+  thinkingEnd: 'thinking_end',
+  /** Quiet progress/completion marker for a material attached to this session. */
+  materialExtraction: 'material_extraction',
+  /**
+   * The agent asked the user a question and the run ended on it (ask_user is
+   * terminal for the current run). `data` is the COMPLETE question envelope
+   * the ask_user tool validated and echoed in its result:
+   *
+   *   {
+   *     question: string,
+   *     options?: { id: string; label: string }[],
+   *     multiSelect?: boolean
+   *   }
+   *
+   * The user answers through the ordinary message channel (postUserMessage),
+   * which requeues the session for a new run; there is deliberately NO
+   * answer-correlation id — the question is a UI affordance (a question card,
+   * `components/workbench/chat/question-card.tsx`, plus the pinned panel above
+   * the composer), and the answer is simply the next user message, which is
+   * also what retires it. An old frontend that does not know this type ignores
+   * it (the chat fold's default case) and loses nothing but the affordance.
+   */
+  userQuestion: 'user_question',
+  /**
+   * A tool produced or returned a stage link. `data` is
+   * `{ stageId, title, url }`. The workbench opens each stageId only on its
+   * first appearance in that session; later events for the same stage are
+   * intentionally inert so a user's manual navigation is never overridden.
+   *
+   * DURABLE COMPAT: the pre-rename event name `course_link` is already written
+   * into historical session logs. Emitters only ever write `stage_link`, but
+   * the browser must keep accepting BOTH names on replay — the fold's reducer
+   * matches both with identical semantics, and `WORKBENCH_EVENT_TYPES` keeps
+   * subscribing to the old name (see `use-workbench-session.ts`).
+   */
+  stageLink: 'stage_link',
+  /**
+   * The owner's course LIBRARY changed shape — a course or folder was created,
+   * a course was filed somewhere else, or a course was renamed. `data` is
+   * `{ change: 'stage_created' | 'folder_created' | 'stage_moved' | 'stage_renamed', ... }`,
+   * and
+   * the payload's detail is diagnostic only: the workbench folds this into a
+   * counter (`WorkbenchFold.libraryRevision`) and the workspace answers by
+   * refetching the authoritative list, exactly as it already answers the first
+   * committed page (`course-discovery-sync.ts`). Deliberately ONE event
+   * for all four: the consumer's question is never "what changed" but "is my
+   * tree stale", and the server is not the right place to diff a tree the client
+   * is about to refetch anyway.
+   *
+   * This is what makes `create_stage` / `create_folder` / `move_to_folder` /
+   * `rename_stage` show
+   * up in the left rail without a reload. Page checkpoints do NOT emit it — a
+   * page landing inside a course the tree already lists is not a library change,
+   * and the existing first-page trigger already covers the one case where it is.
+   */
+  libraryChanged: 'library_changed',
+} as const;
+
+/** Every lifecycle event name the runner and control plane can write. */
+export type HostAgentLifecycleEventType =
+  (typeof HOST_AGENT_LIFECYCLE)[keyof typeof HOST_AGENT_LIFECYCLE];

--- a/lib/persistence/server-provider.ts
+++ b/lib/persistence/server-provider.ts
@@ -14,6 +14,7 @@ import { APP_RUNTIME_PAYLOAD_VALIDATORS } from '@/lib/runtime/payload-validators
 export type PersistencePoolFactory = (connectionString: string) => Pool;
 
 export interface ServerPersistenceProvider {
+  pool: Pool;
   runtimeStore: PgRuntimeStore;
   documentStore: PgDocumentStore;
   assetStore: PgAssetStore;
@@ -43,6 +44,7 @@ async function createServerPersistenceProvider(
     const withTransaction = nodePostgresTransaction(queryable);
     const byteStore = lazyAssetByteStore(process.env.ASSET_S3_BUCKET, queryable);
     return {
+      pool,
       runtimeStore: new PgRuntimeStore(queryable, {
         withTransaction,
         payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,

--- a/lib/server/agent-runtime/config.ts
+++ b/lib/server/agent-runtime/config.ts
@@ -1,0 +1,37 @@
+/** Server-only agent runtime configuration. */
+const numberFromEnv = (value: string | undefined, fallback: number) =>
+  value ? Number(value) : fallback;
+
+export const agentRuntimeConfig = {
+  /** How often the runner scans for claimable sessions. */
+  scanIntervalMs: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_SCAN_INTERVAL_MS, 1000),
+  /** How often a running session's lease heartbeat is refreshed. */
+  heartbeatIntervalMs: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_HEARTBEAT_MS, 2000),
+  /**
+   * A running session with an older heartbeat is orphaned and may be resumed
+   * elsewhere. Keep this comfortably above the heartbeat interval so a slow
+   * heartbeat is not mistaken for a dead worker.
+   */
+  leaseTtlMs: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_LEASE_TTL_MS, 10_000),
+  /** Maximum sessions one application instance runs concurrently. */
+  maxConcurrent: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_MAX_CONCURRENT, 2),
+  /** Maximum consecutive unattended starts or resumptions. */
+  maxAttempts: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_MAX_ATTEMPTS, 5),
+  /** Native conversation compaction is deliberately opt-in at this layer. */
+  compaction: {
+    enabled: process.env.OPENMAIC_AGENT_COMPACTION_ENABLED === 'true',
+    ...(process.env.OPENMAIC_AGENT_COMPACTION_RESERVE_TOKENS
+      ? {
+          reserveTokens: numberFromEnv(process.env.OPENMAIC_AGENT_COMPACTION_RESERVE_TOKENS, 0),
+        }
+      : {}),
+    ...(process.env.OPENMAIC_AGENT_COMPACTION_KEEP_RECENT_TOKENS
+      ? {
+          keepRecentTokens: numberFromEnv(
+            process.env.OPENMAIC_AGENT_COMPACTION_KEEP_RECENT_TOKENS,
+            0,
+          ),
+        }
+      : {}),
+  },
+} as const;

--- a/lib/server/agent-runtime/config.ts
+++ b/lib/server/agent-runtime/config.ts
@@ -17,7 +17,13 @@ export const agentRuntimeConfig = {
   maxConcurrent: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_MAX_CONCURRENT, 2),
   /** Maximum consecutive unattended starts or resumptions. */
   maxAttempts: numberFromEnv(process.env.OPENMAIC_AGENT_RUNTIME_MAX_ATTEMPTS, 5),
-  /** Native conversation compaction is deliberately opt-in at this layer. */
+  /**
+   * Native conversation compaction is opt-in at this layer: it runs only when
+   * OPENMAIC_AGENT_COMPACTION_ENABLED=true. This is a deliberate inversion of
+   * the reference runtime's opt-out default — the reusable compaction runtime
+   * lands in a later slice, and until then the runner runs without context
+   * transformation.
+   */
   compaction: {
     enabled: process.env.OPENMAIC_AGENT_COMPACTION_ENABLED === 'true',
     ...(process.env.OPENMAIC_AGENT_COMPACTION_RESERVE_TOKENS

--- a/lib/server/agent-runtime/entry-tree-storage.ts
+++ b/lib/server/agent-runtime/entry-tree-storage.ts
@@ -1,0 +1,223 @@
+import {
+  Session,
+  SessionError,
+  type AgentMessage,
+  type SessionMetadata,
+  type SessionStorage,
+  type SessionTreeEntry,
+} from '@earendil-works/pi-agent-core';
+import {
+  AgentSessionEntryTreeError,
+  AgentSessionLeaseLostError,
+  type AgentSessionEntry,
+  type AgentSessionEntryTreeHandle,
+  type AgentSessionMeta,
+} from '@openmaic/storage';
+
+import { getAgentSessionStore } from './store';
+
+export class SessionEntryHistoryError extends Error {
+  override readonly name = 'SessionEntryHistoryError';
+
+  constructor(
+    readonly sessionId: string,
+    reason: string,
+  ) {
+    super(`Session ${sessionId} has no usable complete entry tree: ${reason}`);
+  }
+}
+
+export interface SessionEntryHistory {
+  branch: SessionTreeEntry[];
+  messages: AgentMessage[];
+  /** Entry that materialized each buildContext message, in the same order. */
+  contextEntryIds: string[];
+  /** Raw append-only messages, unaffected by compaction, for delivery cursors. */
+  cursorMessages: AgentMessage[];
+}
+
+/**
+ * Load and validate the one terminal entry-tree architecture understood by the
+ * runner. An empty tree is legal only before a session has ever started.
+ */
+export async function loadSessionEntryHistory(
+  session: Session,
+  options: { sessionId: string; hasPriorRun: boolean },
+): Promise<SessionEntryHistory> {
+  const entries = await session.getEntries();
+  if (entries.length === 0) {
+    if (options.hasPriorRun) {
+      throw new SessionEntryHistoryError(options.sessionId, 'tree is empty after a prior run');
+    }
+    return { branch: [], messages: [], contextEntryIds: [], cursorMessages: [] };
+  }
+
+  let branch: SessionTreeEntry[];
+  try {
+    branch = await session.getBranch();
+  } catch (error) {
+    throw new SessionEntryHistoryError(
+      options.sessionId,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  const seen = new Set<string>();
+  for (const entry of branch) {
+    if (entry.type === 'compaction' && !seen.has(entry.firstKeptEntryId)) {
+      throw new SessionEntryHistoryError(
+        options.sessionId,
+        `compaction ${entry.id} has a non-backward firstKeptEntryId ${entry.firstKeptEntryId}`,
+      );
+    }
+    seen.add(entry.id);
+  }
+
+  const context = await session.buildContext();
+  const latestCompactionIndex = branch.findLastIndex((entry) => entry.type === 'compaction');
+  const contextEntries =
+    latestCompactionIndex < 0
+      ? branch.filter(
+          (entry) =>
+            entry.type === 'message' ||
+            entry.type === 'custom_message' ||
+            (entry.type === 'branch_summary' && Boolean(entry.summary)),
+        )
+      : [
+          branch[latestCompactionIndex]!,
+          ...branch.slice(0, latestCompactionIndex).filter((entry, index, all) => {
+            const compaction = branch[latestCompactionIndex];
+            if (!compaction || compaction.type !== 'compaction') return false;
+            const firstKeptIndex = all.findIndex(
+              (candidate) => candidate.id === compaction.firstKeptEntryId,
+            );
+            return (
+              index >= firstKeptIndex &&
+              (entry.type === 'message' ||
+                entry.type === 'custom_message' ||
+                (entry.type === 'branch_summary' && Boolean(entry.summary)))
+            );
+          }),
+          ...branch
+            .slice(latestCompactionIndex + 1)
+            .filter(
+              (entry) =>
+                entry.type === 'message' ||
+                entry.type === 'custom_message' ||
+                (entry.type === 'branch_summary' && Boolean(entry.summary)),
+            ),
+        ];
+  if (contextEntries.length !== context.messages.length) {
+    throw new SessionEntryHistoryError(
+      options.sessionId,
+      'context-to-entry mapping is inconsistent',
+    );
+  }
+  return {
+    branch,
+    messages: context.messages,
+    contextEntryIds: contextEntries.map((entry) => entry.id),
+    cursorMessages: branch.flatMap((entry) => (entry.type === 'message' ? [entry.message] : [])),
+  };
+}
+
+export interface AgentSessionEntryStorageOpenOptions {
+  sessionId: string;
+  workerId: string;
+  attempt: number;
+}
+
+function translateStorageError(error: unknown): never {
+  if (error instanceof AgentSessionEntryTreeError) {
+    throw new SessionError('invalid_session', error.message, error);
+  }
+  if (error instanceof AgentSessionLeaseLostError) {
+    throw new SessionError('storage', error.message, error);
+  }
+  throw error;
+}
+
+async function translated<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    return translateStorageError(error);
+  }
+}
+
+/** Thin pi storage adapter over the package-owned append-only entry tree. */
+export class AgentSessionEntryStorage implements SessionStorage<SessionMetadata> {
+  private constructor(
+    private readonly metadata: SessionMetadata,
+    private readonly tree: AgentSessionEntryTreeHandle,
+  ) {}
+
+  static async open(
+    options: AgentSessionEntryStorageOpenOptions,
+  ): Promise<AgentSessionEntryStorage> {
+    const store = await getAgentSessionStore();
+    const session = await store.getSession(options.sessionId);
+    if (!session) {
+      throw new SessionError('not_found', `Session not found: ${options.sessionId}`);
+    }
+    const tree = await translated(() =>
+      store.openEntryTree(options.sessionId, options.workerId, options.attempt),
+    );
+    return AgentSessionEntryStorage.fromHandle(session, tree);
+  }
+
+  /** Test and composition seam for an already-open package handle. */
+  static fromHandle(
+    session: Pick<AgentSessionMeta, 'id' | 'createdAt'>,
+    tree: AgentSessionEntryTreeHandle,
+  ): AgentSessionEntryStorage {
+    return new AgentSessionEntryStorage(
+      { id: session.id, createdAt: new Date(session.createdAt).toISOString() },
+      tree,
+    );
+  }
+
+  async getMetadata(): Promise<SessionMetadata> {
+    return this.metadata;
+  }
+
+  async getLeafId(): Promise<string | null> {
+    return translated(() => this.tree.getLeafId());
+  }
+
+  async setLeafId(leafId: string | null): Promise<void> {
+    return translated(() => this.tree.setLeafId(leafId));
+  }
+
+  async createEntryId(): Promise<string> {
+    return translated(() => this.tree.createEntryId());
+  }
+
+  async appendEntry(entry: SessionTreeEntry): Promise<void> {
+    return translated(() => this.tree.appendEntry(entry as AgentSessionEntry));
+  }
+
+  async getEntry(id: string): Promise<SessionTreeEntry | undefined> {
+    return translated(async () => (await this.tree.getEntry(id)) as SessionTreeEntry | undefined);
+  }
+
+  async findEntries<TType extends SessionTreeEntry['type']>(
+    type: TType,
+  ): Promise<Array<Extract<SessionTreeEntry, { type: TType }>>> {
+    return translated(
+      async () =>
+        (await this.tree.findEntries(type)) as Array<Extract<SessionTreeEntry, { type: TType }>>,
+    );
+  }
+
+  async getLabel(id: string): Promise<string | undefined> {
+    return translated(() => this.tree.getLabel(id));
+  }
+
+  async getPathToRoot(leafId: string | null): Promise<SessionTreeEntry[]> {
+    return translated(async () => (await this.tree.getPathToRoot(leafId)) as SessionTreeEntry[]);
+  }
+
+  async getEntries(): Promise<SessionTreeEntry[]> {
+    return translated(async () => (await this.tree.getEntries()) as SessionTreeEntry[]);
+  }
+}

--- a/lib/server/agent-runtime/entry-tree-storage.ts
+++ b/lib/server/agent-runtime/entry-tree-storage.ts
@@ -128,10 +128,25 @@ export interface AgentSessionEntryStorageOpenOptions {
 
 function translateStorageError(error: unknown): never {
   if (error instanceof AgentSessionEntryTreeError) {
-    throw new SessionError('invalid_session', error.message, error);
+    // Keep the reference's distinction between a caller-referenced entry that
+    // is merely absent (not_found) and a tree whose own structure is corrupt
+    // (invalid_session): the package reports both as the same class, keyed by
+    // the reason text.
+    throw new SessionError(
+      error.message.includes('missing entry') ? 'not_found' : 'invalid_session',
+      error.message,
+      error,
+    );
   }
   if (error instanceof AgentSessionLeaseLostError) {
     throw new SessionError('storage', error.message, error);
+  }
+  // A session can vanish (for example, a concurrent soft-delete) between
+  // open()'s existence pre-check and the package's own load; the package
+  // reports that race as a plain error rather than a typed one, so classify
+  // it the same way as the pre-check's not_found.
+  if (error instanceof Error && error.message.includes('unknown session')) {
+    throw new SessionError('not_found', error.message, error);
   }
   throw error;
 }

--- a/lib/server/agent-runtime/owner.ts
+++ b/lib/server/agent-runtime/owner.ts
@@ -32,21 +32,28 @@ function anonymousCookieHeader(id: string): string {
  *
  * Session lists are user-visible data keyed by owner. A shared constant would
  * let unrelated visitors see one another's sessions, while an anonymous cookie
- * provides the smallest useful isolation boundary. This function is also the
- * single seam that a future authenticated principal resolver can replace.
+ * provides the smallest useful isolation boundary.
  *
- * When a cookie must be minted, `responseHeaders` receives the outgoing
- * Set-Cookie header. Until HTTP routes consume this seam, it may be omitted;
- * route callers must pass the headers they return to the client.
+ * An explicit `authenticatedOwnerId` (from the host's auth layer) is returned
+ * verbatim: authenticated principals must not be partitioned under a fresh
+ * anonymous identity, and no anonymous cookie is minted for them.
+ *
+ * Otherwise the identity comes from a valid anonymous cookie, or a fresh UUID
+ * is minted. A mint is only useful when it is persisted, so `responseHeaders`
+ * — the headers the caller returns to the client — is required: it receives
+ * the outgoing Set-Cookie header whenever a new cookie is issued.
  */
 export function resolveRequestOwnerId(
   req: Pick<Request, 'headers'>,
-  responseHeaders?: Headers,
+  responseHeaders: Headers,
+  authenticatedOwnerId?: string,
 ): string {
+  if (authenticatedOwnerId) return authenticatedOwnerId;
+
   const existingId = readCookie(req.headers, ANONYMOUS_COOKIE);
   if (existingId && UUID_V4.test(existingId)) return `anon:${existingId}`;
 
   const id = randomUUID();
-  responseHeaders?.append('Set-Cookie', anonymousCookieHeader(id));
+  responseHeaders.append('Set-Cookie', anonymousCookieHeader(id));
   return `anon:${id}`;
 }

--- a/lib/server/agent-runtime/owner.ts
+++ b/lib/server/agent-runtime/owner.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'node:crypto';
+
+const ANONYMOUS_COOKIE = 'anonymous_id';
+const ANONYMOUS_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function readCookie(headers: Headers, name: string): string | undefined {
+  const encoded = headers.get('cookie');
+  if (!encoded) return undefined;
+  for (const item of encoded.split(';')) {
+    const separator = item.indexOf('=');
+    if (separator < 0 || item.slice(0, separator).trim() !== name) continue;
+    try {
+      return decodeURIComponent(item.slice(separator + 1).trim());
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function anonymousCookieHeader(id: string): string {
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  return (
+    `${ANONYMOUS_COOKIE}=${id}; Path=/; HttpOnly; SameSite=Lax; ` +
+    `Max-Age=${ANONYMOUS_COOKIE_MAX_AGE_SECONDS}${secure}`
+  );
+}
+
+/**
+ * Resolve the request identity used to partition agent sessions.
+ *
+ * Session lists are user-visible data keyed by owner. A shared constant would
+ * let unrelated visitors see one another's sessions, while an anonymous cookie
+ * provides the smallest useful isolation boundary. This function is also the
+ * single seam that a future authenticated principal resolver can replace.
+ *
+ * When a cookie must be minted, `responseHeaders` receives the outgoing
+ * Set-Cookie header. Until HTTP routes consume this seam, it may be omitted;
+ * route callers must pass the headers they return to the client.
+ */
+export function resolveRequestOwnerId(
+  req: Pick<Request, 'headers'>,
+  responseHeaders?: Headers,
+): string {
+  const existingId = readCookie(req.headers, ANONYMOUS_COOKIE);
+  if (existingId && UUID_V4.test(existingId)) return `anon:${existingId}`;
+
+  const id = randomUUID();
+  responseHeaders?.append('Set-Cookie', anonymousCookieHeader(id));
+  return `anon:${id}`;
+}

--- a/lib/server/agent-runtime/resume.ts
+++ b/lib/server/agent-runtime/resume.ts
@@ -1,0 +1,178 @@
+/**
+ * Resume semantics: turn a crash-truncated transcript back into one that pi's
+ * `agent.continue()` will accept.
+ *
+ * The durable checkpoint is the pi `AgentMessage[]` transcript, re-written after
+ * every message/turn/tool boundary. An aborted/failed/length-truncated
+ * generation may append a suffix of interrupted assistant frames, including
+ * already-streamed thinking or text; content-less assistant frames can also be
+ * left while unwinding.
+ * Those incomplete frames are removed first. The remaining tail is in one of
+ * these states:
+ *
+ *   empty                        -> nothing ran yet; start with `prompt()`
+ *   ends with `user`             -> the prompt was recorded, no assistant turn
+ *                                   completed; `continue()` picks it up
+ *   ends with `toolResult`       -> a tool committed but the next LLM turn never
+ *                                   finished; `continue()` resumes there — EXCEPT
+ *                                   a trailing successful `ask_user` result,
+ *                                   which is the run's terminal "waiting for the
+ *                                   user's answer" state and settles as
+ *                                   already-complete (the agent must not answer
+ *                                   its own question)
+ *   ends with `assistant` + calls-> we died DURING tool execution. The calls have
+ *                                   no results, so the transcript is not a legal
+ *                                   continuation point. We synthesize an error
+ *                                   tool result per dangling call telling the
+ *                                   model the step was interrupted, then continue.
+ *   ends with non-empty
+ *   `assistant`, none            -> the model had already stopped calling tools;
+ *                                   the run was effectively complete.
+ *
+ * The synthesized-error branch is what makes tool execution AT-LEAST-ONCE: a
+ * tool that ran but whose result never got persisted will be re-issued by the
+ * model. Every tool in this system must therefore be idempotent — `putScene` is,
+ * on (stageId, sceneId), and `generate_scene` derives its scene id from the
+ * outline entry rather than minting one.
+ *
+ * Ported verbatim (semantics) from the spike's `spike/src/resume.ts`.
+ */
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { AssistantMessage, ToolCall, ToolResultMessage } from '@earendil-works/pi-ai';
+
+export type ResumeAction =
+  | { kind: 'start' }
+  | { kind: 'continue'; messages: AgentMessage[]; repairedToolCalls: string[] }
+  | { kind: 'already-complete'; messages: AgentMessage[] };
+
+const INTERRUPTED_TEXT =
+  'This tool call was interrupted by a worker restart and produced no recorded result. ' +
+  'The underlying store is idempotent, so re-issue the same call if the step is still needed.';
+
+function isEmptyAssistantMessage(message: AgentMessage): boolean {
+  if (message.role !== 'assistant') return false;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return true;
+  return !content.some((part: unknown) => {
+    // Unknown/future block shapes are content, not emptiness. Preserving an
+    // image/audio/custom output is safer than silently deleting it.
+    if (!part || typeof part !== 'object') return true;
+    const block = part as { type?: unknown; text?: unknown; thinking?: unknown };
+    if (block.type === 'toolCall') return true;
+    if (block.type === 'text') {
+      // A known block is empty only when its payload is a valid string that
+      // trims to nothing. Missing/malformed payloads are preserved just like
+      // unknown future blocks: deleting evidence we do not understand is the
+      // unsafe direction for crash recovery.
+      return typeof block.text !== 'string' || block.text.trim().length > 0;
+    }
+    if (block.type === 'thinking') {
+      return typeof block.thinking !== 'string' || block.thinking.trim().length > 0;
+    }
+    return true;
+  });
+}
+
+function isInterruptedAssistantMessage(message: AgentMessage): boolean {
+  if (message.role !== 'assistant') return false;
+  const frame = message as { stopReason?: unknown; errorMessage?: unknown };
+  return (
+    frame.stopReason === 'aborted' ||
+    frame.stopReason === 'length' ||
+    frame.stopReason === 'error' ||
+    (typeof frame.errorMessage === 'string' && frame.errorMessage.trim().length > 0)
+  );
+}
+
+function isDiscardableAssistantTail(message: AgentMessage): boolean {
+  if (message.role !== 'assistant') return false;
+  const stopReason = (message as { stopReason?: unknown }).stopReason;
+  // `stop` proves that the model completed normally. A worker may die after
+  // checkpointing this frame but before finishSession; stripping it would
+  // rerun an answer that should instead early-settle.
+  if (stopReason === 'stop') return false;
+  return isEmptyAssistantMessage(message) || isInterruptedAssistantMessage(message);
+}
+
+export function planResume(transcript: AgentMessage[] | null): ResumeAction {
+  if (!transcript || transcript.length === 0) return { kind: 'start' };
+
+  const messages = [...transcript];
+  // pi's abort finalizer keeps already-streamed thinking/text but removes
+  // executable tool calls, so content alone cannot prove a completed turn.
+  // Remove the whole incomplete suffix before classifying the durable tail;
+  // this also keeps empty assistant context away from strict providers.
+  while (messages.length > 0 && isDiscardableAssistantTail(messages[messages.length - 1])) {
+    messages.pop();
+  }
+  if (messages.length === 0) return { kind: 'start' };
+
+  const last = messages[messages.length - 1];
+
+  if (last.role === 'user' || last.role === 'toolResult') {
+    // A trailing SUCCESSFUL ask_user is terminal: the runner's afterToolCall
+    // stopped the loop on it and the question was already emitted as a durable
+    // `user_question` event — the run is waiting for the user's answer, and the
+    // worker dying between the transcript checkpoint and finishSession must not
+    // let a takeover `continue()` the agent past that gate (it would answer its
+    // own question). Settle as already-complete: the runner early-settles
+    // `succeeded` with no pending message, or — when the user HAS answered —
+    // drives the new run with that answer as the prompt, exactly the normal
+    // follow-up path. The check is precise: `toolName === 'ask_user'` AND a
+    // non-error result, and it scans the whole trailing tool-result run so a
+    // batch (ask_user issued together with another tool — a mixed trailing batch) is caught even
+    // when another result landed last. An ERRORING ask_user is a plain tool
+    // result the model must recover from, so it stays a normal continuation.
+    const trailingToolResults = [];
+    for (let i = messages.length - 1; i >= 0 && messages[i].role === 'toolResult'; i -= 1) {
+      trailingToolResults.push(messages[i] as ToolResultMessage);
+    }
+    const terminalSideEffectComplete = trailingToolResults.some(
+      (result) =>
+        (result.toolName === 'ask_user' || result.toolName === 'create_skill') && !result.isError,
+    );
+    if (terminalSideEffectComplete) return { kind: 'already-complete', messages };
+    return { kind: 'continue', messages, repairedToolCalls: [] };
+  }
+
+  if (last.role === 'assistant') {
+    const calls = (last as AssistantMessage).content.filter(
+      (c): c is ToolCall => c.type === 'toolCall',
+    );
+    if (calls.length === 0) return { kind: 'already-complete', messages };
+
+    // Results for this assistant turn can only appear after it, so any call id
+    // not already answered is dangling.
+    const answered = new Set(
+      messages
+        .filter((m): m is ToolResultMessage => m.role === 'toolResult')
+        .map((m) => m.toolCallId),
+    );
+    const dangling = calls.filter((c) => !answered.has(c.id));
+    if (dangling.length === 0) {
+      // Every call was answered but the results were re-ordered before the
+      // assistant message; treat as a normal continuation point.
+      return { kind: 'continue', messages, repairedToolCalls: [] };
+    }
+    for (const call of dangling) {
+      messages.push({
+        role: 'toolResult',
+        toolCallId: call.id,
+        toolName: call.name,
+        content: [{ type: 'text', text: INTERRUPTED_TEXT }],
+        isError: true,
+        timestamp: Date.now(),
+      } as unknown as AgentMessage);
+    }
+    return { kind: 'continue', messages, repairedToolCalls: dangling.map((c) => c.id) };
+  }
+
+  // Unknown/custom trailing role: safest legal continuation point is the
+  // longest prefix ending in a user or toolResult message.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user' || messages[i].role === 'toolResult') {
+      return { kind: 'continue', messages: messages.slice(0, i + 1), repairedToolCalls: [] };
+    }
+  }
+  return { kind: 'start' };
+}

--- a/lib/server/agent-runtime/resume.ts
+++ b/lib/server/agent-runtime/resume.ts
@@ -35,7 +35,7 @@
  * on (stageId, sceneId), and `generate_scene` derives its scene id from the
  * outline entry rather than minting one.
  *
- * Ported verbatim (semantics) from the spike's `spike/src/resume.ts`.
+ * Ported verbatim (semantics) from the runtime spike prototype.
  */
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { AssistantMessage, ToolCall, ToolResultMessage } from '@earendil-works/pi-ai';

--- a/lib/server/agent-runtime/store.ts
+++ b/lib/server/agent-runtime/store.ts
@@ -1,0 +1,75 @@
+import {
+  PgAgentSessionStore,
+  ensureAgentSessionSchema,
+  type Queryable,
+  type WithTransaction,
+} from '@openmaic/storage/agent-session/pg';
+import type { Pool } from 'pg';
+
+import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
+
+interface AgentSessionStoreState {
+  connectionString?: string;
+  storePromise?: Promise<PgAgentSessionStore>;
+}
+
+const AGENT_SESSION_STORE_STATE_KEY = Symbol.for('openmaic.agent-session.store');
+const globalState = globalThis as typeof globalThis & {
+  [AGENT_SESSION_STORE_STATE_KEY]?: AgentSessionStoreState;
+};
+const storeState = (globalState[AGENT_SESSION_STORE_STATE_KEY] ??= {});
+
+/**
+ * Adapt a node-postgres pool to the storage package's transaction contract.
+ * Every transaction uses one checked-out client for its entire lifetime.
+ */
+export function nodePostgresTransaction(pool: Pool): WithTransaction {
+  return async <T>(body: (queryable: Queryable) => Promise<T>): Promise<T> => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+async function createAgentSessionStore(connectionString: string): Promise<PgAgentSessionStore> {
+  const { pool } = await getServerPersistenceProvider(connectionString);
+  await ensureAgentSessionSchema(pool);
+  return new PgAgentSessionStore(pool, {
+    withTransaction: nodePostgresTransaction(pool),
+  });
+}
+
+/**
+ * Return the process-wide agent-session store, initializing its schema lazily.
+ * Failed initialization is cleared so a later request can retry after the
+ * database becomes available.
+ */
+export function getAgentSessionStore(): Promise<PgAgentSessionStore> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    return Promise.reject(new Error('Agent runtime requires DATABASE_URL'));
+  }
+  if (storeState.storePromise && storeState.connectionString === connectionString) {
+    return storeState.storePromise;
+  }
+
+  storeState.connectionString = connectionString;
+  const initialization = createAgentSessionStore(connectionString).catch((error) => {
+    if (storeState.storePromise === initialization) {
+      storeState.storePromise = undefined;
+      storeState.connectionString = undefined;
+    }
+    throw error;
+  });
+  storeState.storePromise = initialization;
+  return initialization;
+}

--- a/tests/agent-runtime/entry-tree-storage.test.ts
+++ b/tests/agent-runtime/entry-tree-storage.test.ts
@@ -1,0 +1,129 @@
+import { SessionError, type SessionTreeEntry } from '@earendil-works/pi-agent-core';
+import {
+  PgAgentSessionStore,
+  ensureAgentSessionSchema,
+  type Queryable,
+  type WithTransaction,
+} from '@openmaic/storage/agent-session/pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Pool } from 'pg';
+
+import { AgentSessionEntryStorage } from '@/lib/server/agent-runtime/entry-tree-storage';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+function transactionFor(pool: Pool): WithTransaction {
+  return async <T>(body: (queryable: Queryable) => Promise<T>): Promise<T> => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+describe.skipIf(!contractUrl)('AgentSessionEntryStorage with PostgreSQL 16', () => {
+  let pool: Pool;
+  let store: PgAgentSessionStore;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl });
+    await ensureAgentSessionSchema(pool);
+    store = new PgAgentSessionStore(pool, { withTransaction: transactionFor(pool) });
+  });
+
+  beforeEach(async () => {
+    await pool.query(
+      'TRUNCATE agent_owner_session_events, agent_owner_session_event_counters, ' +
+        'agent_session_entries, agent_session_events, agent_sessions CASCADE',
+    );
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  it('delegates append and path reads to an opened package tree', async () => {
+    const session = await store.createSession({
+      id: 'adapter-round-trip',
+      ownerId: 'anon:test-owner',
+      prompt: 'Build a concise lesson.',
+    });
+    const claim = await store.claimNextSession('worker-a', 101, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 5,
+      sessionId: session.id,
+    });
+    expect(claim).not.toBeNull();
+    const tree = await store.openEntryTree(session.id, 'worker-a', claim!.attempt);
+    const storage = AgentSessionEntryStorage.fromHandle(session, tree);
+    const first: SessionTreeEntry = {
+      type: 'message',
+      id: 'entry-one',
+      parentId: null,
+      timestamp: '2026-08-24T00:00:00.000Z',
+      message: { role: 'user', content: 'Start.', timestamp: 1 },
+    };
+    const second: SessionTreeEntry = {
+      type: 'message',
+      id: 'entry-two',
+      parentId: first.id,
+      timestamp: '2026-08-24T00:00:01.000Z',
+      message: { role: 'user', content: 'Continue.', timestamp: 2 },
+    };
+
+    await storage.appendEntry(first);
+    await storage.appendEntry(second);
+
+    await expect(storage.getPathToRoot(second.id)).resolves.toEqual([first, second]);
+    await expect(storage.getMetadata()).resolves.toEqual({
+      id: session.id,
+      createdAt: new Date(session.createdAt).toISOString(),
+    });
+  });
+
+  it('translates a superseded package lease fence into a pi SessionError', async () => {
+    const session = await store.createSession({
+      id: 'adapter-lease-loss',
+      ownerId: 'anon:test-owner',
+      prompt: 'Resume safely.',
+    });
+    const firstClaim = await store.claimNextSession('worker-a', 101, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 5,
+      sessionId: session.id,
+    });
+    const staleTree = await store.openEntryTree(session.id, 'worker-a', firstClaim!.attempt);
+    const storage = AgentSessionEntryStorage.fromHandle(session, staleTree);
+    await store.finishSession(session.id, 'worker-a', { status: 'failed' });
+    await store.requeueForRetry(session.id);
+    const nextClaim = await store.claimNextSession('worker-b', 202, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 5,
+      sessionId: session.id,
+    });
+    expect(nextClaim?.attempt).toBe(firstClaim!.attempt + 1);
+
+    const append = storage.appendEntry({
+      type: 'message',
+      id: 'stale-entry',
+      parentId: null,
+      timestamp: '2026-08-24T00:00:00.000Z',
+      message: { role: 'user', content: 'Do not persist.', timestamp: 1 },
+    });
+
+    await expect(append).rejects.toMatchObject({
+      name: 'SessionError',
+      code: 'storage',
+      cause: { name: 'AgentSessionLeaseLostError' },
+    } satisfies Partial<SessionError>);
+    await expect(staleTree.getEntries()).resolves.toEqual([]);
+  });
+});

--- a/tests/agent-runtime/entry-tree-storage.test.ts
+++ b/tests/agent-runtime/entry-tree-storage.test.ts
@@ -126,4 +126,51 @@ describe.skipIf(!contractUrl)('AgentSessionEntryStorage with PostgreSQL 16', () 
     } satisfies Partial<SessionError>);
     await expect(staleTree.getEntries()).resolves.toEqual([]);
   });
+
+  it('maps a missing referenced entry to not_found and a corrupt tree to invalid_session', async () => {
+    const session = await store.createSession({
+      id: 'adapter-code-mapping',
+      ownerId: 'anon:test-owner',
+      prompt: 'Distinguish error codes.',
+    });
+    const claim = await store.claimNextSession('worker-a', 101, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 5,
+      sessionId: session.id,
+    });
+    expect(claim).not.toBeNull();
+    const tree = await store.openEntryTree(session.id, 'worker-a', claim!.attempt);
+    const storage = AgentSessionEntryStorage.fromHandle(session, tree);
+    const root: SessionTreeEntry = {
+      type: 'message',
+      id: 'code-map-root',
+      parentId: null,
+      timestamp: '2026-08-24T00:00:00.000Z',
+      message: { role: 'user', content: 'Start.', timestamp: 1 },
+    };
+    await storage.appendEntry(root);
+
+    // A caller-referenced entry that is not in the tree is not_found...
+    await expect(storage.setLeafId('missing-target')).rejects.toMatchObject({
+      name: 'SessionError',
+      code: 'not_found',
+    });
+    await expect(storage.getPathToRoot('missing-leaf')).rejects.toMatchObject({
+      name: 'SessionError',
+      code: 'not_found',
+    });
+
+    // ...while a tree whose own leaf pointer dangles is invalid_session.
+    await storage.appendEntry({
+      type: 'leaf',
+      id: 'code-map-leaf',
+      parentId: root.id,
+      timestamp: '2026-08-24T00:00:01.000Z',
+      targetId: 'ghost-leaf',
+    });
+    await expect(storage.getLeafId()).rejects.toMatchObject({
+      name: 'SessionError',
+      code: 'invalid_session',
+    });
+  });
 });

--- a/tests/agent-runtime/owner.test.ts
+++ b/tests/agent-runtime/owner.test.ts
@@ -50,4 +50,27 @@ describe('resolveRequestOwnerId', () => {
 
     expect(responseHeaders.get('set-cookie')).toMatch(/; Secure$/);
   });
+
+  it('uses an explicit authenticated owner without minting an anonymous cookie', () => {
+    const responseHeaders = new Headers();
+
+    const ownerId = resolveRequestOwnerId(
+      new Request('http://localhost/agent'),
+      responseHeaders,
+      'user-42',
+    );
+
+    expect(ownerId).toBe('user-42');
+    expect(responseHeaders.has('set-cookie')).toBe(false);
+  });
+
+  it('prefers an authenticated owner over an existing anonymous cookie', () => {
+    const responseHeaders = new Headers();
+    const request = new Request('http://localhost/agent', {
+      headers: { cookie: 'anonymous_id=a652e716-0e2e-47f5-8432-4ee60f6f0977' },
+    });
+
+    expect(resolveRequestOwnerId(request, responseHeaders, 'user-42')).toBe('user-42');
+    expect(responseHeaders.has('set-cookie')).toBe(false);
+  });
 });

--- a/tests/agent-runtime/owner.test.ts
+++ b/tests/agent-runtime/owner.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('resolveRequestOwnerId', () => {
+  it('mints a UUID-backed anonymous owner when the cookie is absent', () => {
+    const responseHeaders = new Headers();
+
+    const ownerId = resolveRequestOwnerId(new Request('http://localhost/agent'), responseHeaders);
+
+    expect(ownerId.startsWith('anon:')).toBe(true);
+    expect(ownerId.slice('anon:'.length)).toMatch(UUID_V4);
+    expect(responseHeaders.get('set-cookie')).toContain(
+      `anonymous_id=${ownerId.slice('anon:'.length)}`,
+    );
+  });
+
+  it('reuses a valid anonymous cookie without returning another cookie header', () => {
+    const id = 'a652e716-0e2e-47f5-8432-4ee60f6f0977';
+    const responseHeaders = new Headers();
+    const request = new Request('http://localhost/agent', {
+      headers: { cookie: `theme=dark; anonymous_id=${id}; locale=en` },
+    });
+
+    expect(resolveRequestOwnerId(request, responseHeaders)).toBe(`anon:${id}`);
+    expect(responseHeaders.has('set-cookie')).toBe(false);
+  });
+
+  it('sets a long-lived, HTTP-only, SameSite=Lax cookie at the root path', () => {
+    const responseHeaders = new Headers();
+
+    resolveRequestOwnerId(new Request('http://localhost/agent'), responseHeaders);
+
+    expect(responseHeaders.get('set-cookie')).toMatch(
+      /^anonymous_id=[0-9a-f-]+; Path=\/; HttpOnly; SameSite=Lax; Max-Age=2592000$/i,
+    );
+  });
+
+  it('adds Secure to the cookie in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const responseHeaders = new Headers();
+
+    resolveRequestOwnerId(new Request('https://example.test/agent'), responseHeaders);
+
+    expect(responseHeaders.get('set-cookie')).toMatch(/; Secure$/);
+  });
+});

--- a/tests/agent-runtime/resume.test.ts
+++ b/tests/agent-runtime/resume.test.ts
@@ -1,0 +1,336 @@
+/**
+ * planResume: the five transcript tail states a crash can leave behind.
+ *
+ * These are pure-function tests of the resume planner — the state machine that
+ * decides whether a reclaimed session starts fresh, continues, repairs dangling
+ * tool calls, or is already done. The PG-backed claim path that feeds it is
+ * covered by session-store.pg.test.ts.
+ */
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import { describe, expect, it } from 'vitest';
+
+import { planResume } from '@/lib/server/agent-runtime/resume';
+
+const user = (text: string) => ({ role: 'user', content: text }) as unknown as AgentMessage;
+
+const assistantText = (text: string) =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+  }) as unknown as AgentMessage;
+
+const interruptedAssistant = (
+  content: unknown[],
+  marker: { stopReason?: string; errorMessage?: string } = { stopReason: 'aborted' },
+) =>
+  ({
+    role: 'assistant',
+    content,
+    ...marker,
+  }) as unknown as AgentMessage;
+
+const assistantWithCalls = (calls: { id: string; name: string }[]) =>
+  ({
+    role: 'assistant',
+    content: calls.map((c) => ({ type: 'toolCall', id: c.id, name: c.name, arguments: {} })),
+  }) as unknown as AgentMessage;
+
+const toolResult = (toolCallId: string, toolName = 'generate_scene') =>
+  ({
+    role: 'toolResult',
+    toolCallId,
+    toolName,
+    content: [{ type: 'text', text: 'ok' }],
+    isError: false,
+  }) as unknown as AgentMessage;
+
+const failingToolResult = (toolCallId: string, toolName = 'ask_user') =>
+  ({
+    role: 'toolResult',
+    toolCallId,
+    toolName,
+    content: [{ type: 'text', text: 'nope' }],
+    isError: true,
+  }) as unknown as AgentMessage;
+
+describe('planResume', () => {
+  it('starts fresh on an empty or missing transcript', () => {
+    expect(planResume(null)).toEqual({ kind: 'start' });
+    expect(planResume([])).toEqual({ kind: 'start' });
+  });
+
+  it('continues when the tail is the user prompt (no assistant turn completed)', () => {
+    const transcript = [user('build a course')];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind === 'continue') {
+      expect(plan.messages).toHaveLength(1);
+      expect(plan.repairedToolCalls).toEqual([]);
+    }
+  });
+
+  it('continues when the tail is a tool result (tool committed, next turn never ran)', () => {
+    const transcript = [
+      user('build a course'),
+      assistantWithCalls([{ id: 'c1', name: 'generate_outline' }]),
+      toolResult('c1', 'generate_outline'),
+    ];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind === 'continue') {
+      expect(plan.messages).toHaveLength(3);
+      expect(plan.repairedToolCalls).toEqual([]);
+    }
+  });
+
+  it('settles already-complete when the tail is a SUCCESSFUL ask_user result (crash before finishSession)', () => {
+    // The worker died after the ask_user checkpoint but before finishSession:
+    // the runner's afterToolCall had already stopped the loop on the question,
+    // so a takeover must NOT `continue()` the agent — it would answer its own
+    // question and cross the consent gate.
+    const transcript = [
+      user('plan my week'),
+      assistantWithCalls([{ id: 'c1', name: 'ask_user' }]),
+      toolResult('c1', 'ask_user'),
+    ];
+    expect(planResume(transcript)).toEqual({ kind: 'already-complete', messages: transcript });
+  });
+
+  it('settles after a durable successful create_skill instead of creating it twice on takeover', () => {
+    const transcript = [
+      user('Save this method as a skill'),
+      assistantWithCalls([{ id: 'c1', name: 'create_skill' }]),
+      toolResult('c1', 'create_skill'),
+    ];
+    expect(planResume(transcript)).toEqual({ kind: 'already-complete', messages: transcript });
+  });
+
+  it('settles already-complete when ask_user shares a trailing batch with another tool (its result may not be last)', () => {
+    // a mixed trailing batch residue: ask_user + another tool in one batch. The other result can
+    // land AFTER ask_user's in the checkpointed transcript; the trailing
+    // successful ask_user must still be recognized as the run's terminal state.
+    const transcript = [
+      user('plan my week'),
+      assistantWithCalls([
+        { id: 'c1', name: 'ask_user' },
+        { id: 'c2', name: 'list_scenes' },
+      ]),
+      toolResult('c1', 'ask_user'),
+      toolResult('c2', 'list_scenes'),
+    ];
+    expect(planResume(transcript)).toEqual({ kind: 'already-complete', messages: transcript });
+  });
+
+  it('still continues when the trailing ask_user result is an ERROR (the agent recovers)', () => {
+    const transcript = [
+      user('plan my week'),
+      assistantWithCalls([{ id: 'c1', name: 'ask_user' }]),
+      failingToolResult('c1', 'ask_user'),
+    ];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind === 'continue') expect(plan.repairedToolCalls).toEqual([]);
+  });
+
+  it('continues when a successful ask_user is in the MIDDLE of the transcript (already answered, work followed)', () => {
+    // ask_user at turn 1 was answered; the answer's run did real work after.
+    // Only the TRAILING tool-result run is scanned, so this stays a normal
+    // continuation point rather than a false already-complete.
+    const transcript = [
+      user('plan my week'),
+      assistantWithCalls([{ id: 'c1', name: 'ask_user' }]),
+      toolResult('c1', 'ask_user'),
+      user('option B'),
+      assistantWithCalls([{ id: 'c2', name: 'generate_outline' }]),
+      toolResult('c2', 'generate_outline'),
+    ];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind === 'continue') expect(plan.repairedToolCalls).toEqual([]);
+  });
+
+  it('synthesizes error results for dangling tool calls (died DURING tool execution)', () => {
+    const transcript = [
+      user('build a course'),
+      assistantWithCalls([
+        { id: 'c1', name: 'generate_scene' },
+        { id: 'c2', name: 'generate_scene' },
+      ]),
+      // c1 committed before the crash; c2 dangled.
+      toolResult('c1'),
+      assistantText('page 1 done'),
+      assistantWithCalls([{ id: 'c3', name: 'generate_scene' }]),
+    ];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind !== 'continue') throw new Error('unreachable');
+    expect(plan.repairedToolCalls).toEqual(['c3']);
+    const repaired = plan.messages[plan.messages.length - 1] as unknown as {
+      role: string;
+      toolCallId: string;
+      isError: boolean;
+      content: { text: string }[];
+    };
+    expect(repaired.role).toBe('toolResult');
+    expect(repaired.toolCallId).toBe('c3');
+    expect(repaired.isError).toBe(true);
+    expect(repaired.content[0].text).toMatch(/interrupted/);
+  });
+
+  it('reports already-complete when the tail assistant message has no tool calls', () => {
+    const transcript = [user('build a course'), assistantText('all done, enjoy the course')];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('already-complete');
+  });
+
+  it('continues after abort during non-empty thinking instead of settling a partial turn', () => {
+    const transcript = [
+      user('build a course'),
+      interruptedAssistant([{ type: 'thinking', thinking: 'I should first inspect the outline' }]),
+    ];
+    expect(planResume(transcript)).toEqual({
+      kind: 'continue',
+      messages: [transcript[0]],
+      repairedToolCalls: [],
+    });
+  });
+
+  it('continues after abort during partial text instead of settling a partial answer', () => {
+    const transcript = [
+      user('build a course'),
+      interruptedAssistant([{ type: 'text', text: 'I have created the first' }]),
+    ];
+    expect(planResume(transcript)).toEqual({
+      kind: 'continue',
+      messages: [transcript[0]],
+      repairedToolCalls: [],
+    });
+  });
+
+  it.each([
+    ['error stop reason', { stopReason: 'error' }],
+    ['length stop reason', { stopReason: 'length' }],
+    ['non-empty errorMessage', { errorMessage: 'provider disconnected' }],
+  ] as const)('strips a partial assistant frame marked by %s', (_label, marker) => {
+    const transcript = [
+      user('build'),
+      interruptedAssistant([{ type: 'text', text: 'partial' }], marker),
+    ];
+    expect(planResume(transcript)).toMatchObject({ kind: 'continue', messages: [transcript[0]] });
+  });
+
+  it('continues from a durable tool result when abort happens during the next tool turn', () => {
+    const transcript = [
+      user('build a course'),
+      assistantWithCalls([{ id: 'c1', name: 'generate_scene' }]),
+      toolResult('c1'),
+      interruptedAssistant([], { stopReason: 'aborted' }),
+    ];
+    expect(planResume(transcript)).toEqual({
+      kind: 'continue',
+      messages: transcript.slice(0, -1),
+      repairedToolCalls: [],
+    });
+  });
+
+  it('keeps a clean stop frame terminal even if its content is empty', () => {
+    const completed = interruptedAssistant([], { stopReason: 'stop' });
+    const transcript = [user('nothing more to add'), completed];
+    expect(planResume(transcript)).toEqual({ kind: 'already-complete', messages: transcript });
+  });
+
+  it('treats unknown future content blocks as non-empty', () => {
+    const futureOutput = interruptedAssistant([{ type: 'audio', data: 'durable-output' }], {
+      stopReason: 'stop',
+    });
+    const transcript = [user('make audio'), futureOutput];
+    expect(planResume(transcript)).toEqual({ kind: 'already-complete', messages: transcript });
+  });
+
+  it.each([
+    ['missing text', { type: 'text' }],
+    ['non-string text', { type: 'text', text: 42 }],
+    ['missing thinking', { type: 'thinking' }],
+    ['non-string thinking', { type: 'thinking', thinking: { partial: true } }],
+  ])('conservatively preserves a malformed known block: %s', (_label, block) => {
+    const malformed = interruptedAssistant([block], { stopReason: 'toolUse' });
+    const transcript = [user('keep evidence'), malformed];
+    expect(planResume(transcript)).toEqual({ kind: 'already-complete', messages: transcript });
+  });
+
+  it('removes consecutive empty assistant tail frames before resuming', () => {
+    const empty = { role: 'assistant', content: [] } as unknown as AgentMessage;
+    const whitespaceOnly = {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: '  \n ' },
+        { type: 'text', text: '\t' },
+      ],
+    } as unknown as AgentMessage;
+    const transcript = [user('build a course'), empty, whitespaceOnly];
+    expect(planResume(transcript)).toEqual({
+      kind: 'continue',
+      messages: [transcript[0]],
+      repairedToolCalls: [],
+    });
+  });
+
+  it('starts fresh when stripping empty assistant frames empties the transcript', () => {
+    const malformed = { role: 'assistant' } as unknown as AgentMessage;
+    expect(planResume([malformed])).toEqual({ kind: 'start' });
+  });
+
+  it('repairs dangling calls exposed by stripping an empty assistant tail', () => {
+    const transcript = [
+      user('build a course'),
+      assistantWithCalls([{ id: 'c1', name: 'generate_scene' }]),
+      { role: 'assistant', content: [] } as unknown as AgentMessage,
+    ];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind !== 'continue') throw new Error('unreachable');
+    expect(plan.repairedToolCalls).toEqual(['c1']);
+    expect(plan.messages).not.toContain(transcript[2]);
+    expect(plan.messages.at(-1)).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'c1',
+      isError: true,
+    });
+  });
+
+  it('preserves a successful terminal side effect exposed by stripping an empty tail', () => {
+    const transcript = [
+      user('plan my week'),
+      assistantWithCalls([{ id: 'c1', name: 'ask_user' }]),
+      toolResult('c1', 'ask_user'),
+      { role: 'assistant', content: [] } as unknown as AgentMessage,
+    ];
+    expect(planResume(transcript)).toEqual({
+      kind: 'already-complete',
+      messages: transcript.slice(0, -1),
+    });
+  });
+
+  it('treats fully-answered trailing calls as a normal continuation point', () => {
+    const transcript = [
+      user('build a course'),
+      // Results precede the assistant message (re-ordered before checkpoint).
+      toolResult('c1'),
+      assistantWithCalls([{ id: 'c1', name: 'list_scenes' }]),
+    ];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind === 'continue') expect(plan.repairedToolCalls).toEqual([]);
+  });
+
+  it('falls back to the longest legal prefix on an unknown trailing role', () => {
+    const weird = { role: 'custom', content: [] } as unknown as AgentMessage;
+    const transcript = [user('a'), assistantText('b'), toolResult('c1'), weird];
+    const plan = planResume(transcript);
+    expect(plan.kind).toBe('continue');
+    if (plan.kind === 'continue') {
+      expect(plan.messages).toHaveLength(3);
+      expect(plan.messages[plan.messages.length - 1].role).toBe('toolResult');
+    }
+  });
+});


### PR DESCRIPTION
Second application-layer slice on this integration branch (after the driver contract). No HTTP surface yet — the runner and routes land in follow-up slices.

- `store.ts`: a `PgAgentSessionStore` singleton over the `@openmaic/storage` agent-session store, with a lazy schema-init promise (mirrors the persistence provider's pattern; nothing awaited at module top) and a per-callback `WithTransaction` implementation. Host hooks are omitted, so owner resolution is identity and no material/URL side-bands are attached at this layer.
- `owner.ts`: request owner identity via an anonymous `anon:<uuid>` cookie (httpOnly, SameSite=Lax), minted on first request. Agent-session listings are owner-scoped user data, so a shared constant would let visitors see each other's sessions; the cookie is the minimal isolation and the same seam a real auth integration would replace.
- `config.ts` / `resume.ts` / `lifecycle.ts` / `entry-tree-storage.ts`: trimmed runtime config (compaction opt-in here — the reusable compaction runtime is a later slice), the pure resume planner, lifecycle event constants, and a pi `SessionStorage` adapter over the package's entry tree with error translation.

Tests: resume planner, entry-tree adapter (incl. lease-lost translation), owner cookie minting/reuse. Real PostgreSQL 16 contract suite green locally; the storage-pg-contract job covers it on push.