### PR TITLE
feat(materials): material library manifest and id-addressed generation images (#1153 part 2)

### DIFF
--- a/app/api/extract-document/route.ts
+++ b/app/api/extract-document/route.ts
@@ -24,13 +24,13 @@ import {
 } from '@/lib/persistence/resolve-server-asset';
 import { apiError, apiSuccess } from '@/lib/server/api-response';
 import { validateUrlForSSRF } from '@/lib/server/ssrf-guard';
+import { MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES } from '@/lib/constants/generation';
 
 // The asset-id path resolves bytes from the server asset store, which lives in
 // the PostgreSQL persistence backend; it needs the Node runtime, not the edge.
 export const runtime = 'nodejs';
 
 const log = createLogger('Extract Document');
-const MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 
 /**
  * A normalized extraction input, independent of how the bytes arrived: either

--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -28,6 +28,7 @@ import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { resolveVocationalActive } from '@/lib/config/feature-flags';
 import { MAX_VISION_IMAGES } from '@/lib/constants/generation';
 import { sortDocumentImagesForVision } from '@/lib/document/bundle';
+import { DEFAULT_INGEST_AWAIT_TIMEOUT_MS } from '@/lib/document/extract-source';
 import {
   resolveVisionImagesForPrompt,
   type VisionPromptImage,
@@ -37,6 +38,24 @@ import { generatePBLV2Project } from '@/lib/pbl/v2/agents/planner';
 const log = createLogger('Scene Content API');
 
 export const maxDuration = 300;
+
+/**
+ * Aggregate budget for the WHOLE resolve-with-refill phase, reused from the
+ * shared 15 s ingest-drain constant (the same constant the extraction cache's
+ * probe phase reuses). Each probe is an unbounded server-side store round trip
+ * (no statement timeout), so an all-fail phase must not churn every candidate
+ * sequentially: when the budget expires the phase STOPS and generation
+ * proceeds with whatever resolved so far (degrade, never fail).
+ */
+const VISION_RESOLUTION_BUDGET_MS = DEFAULT_INGEST_AWAIT_TIMEOUT_MS;
+
+/**
+ * Consecutive-failure fuse for the resolve-with-refill loop: after this many
+ * unresolvable/errored candidates IN A ROW the store is evidently down, so
+ * probing stops instead of churning the remaining candidates (one summary warn
+ * names the fuse). A resolved candidate resets the streak.
+ */
+const MAX_CONSECUTIVE_UNRESOLVABLE_VISION_IMAGES = 3;
 
 export async function POST(req: NextRequest) {
   let outlineTitle: string | undefined;
@@ -197,32 +216,96 @@ export async function POST(req: NextRequest) {
     let resolvedVisionImages: VisionPromptImage[] | undefined;
     if (assignedImages && assignedImages.length > 0 && hasVision && imageMapping) {
       const { withSrc } = partitionImagesForVision(assignedImages, imageMapping, MAX_VISION_IMAGES);
-      const resolved: VisionPromptImage[] = [];
-      const unresolvableIds = new Set<string>();
-      for (const candidate of withSrc) {
-        if (resolved.length >= MAX_VISION_IMAGES) break;
-        const attempted = await resolveVisionImagesForPrompt(
-          [
-            {
-              id: candidate.id,
-              src: imageMapping[candidate.id],
-              ...(candidate.width !== undefined ? { width: candidate.width } : {}),
-              ...(candidate.height !== undefined ? { height: candidate.height } : {}),
-            },
-          ],
-          req.headers,
+      // Bound the resolve-with-refill loop (review P2, round 3): the store may
+      // be down, and each probe is an unbounded server-side round trip, so an
+      // all-fail phase must not churn every candidate (and emit a warn per
+      // candidate) until the route's 300 s platform cap. Two stops, both
+      // degrading to "whatever resolved so far" — never failing the request:
+      // (a) an aggregate budget for the WHOLE phase (the shared 15 s ingest
+      // constant, raced against each probe so even ONE hanging probe cannot
+      // outlive it) and (b) a consecutive-failure fuse (3 unresolvable/errored
+      // candidates in a row → stop). When a stop fires, every candidate that
+      // did not resolve — unresolvable OR unprobed — is STRIPPED from the
+      // mapping, so the generator can never hand an unresolved allocated id to
+      // the defensive aiCall resolution (which would re-open the unbounded
+      // probe the stop just closed); ONE summary warn names the stop.
+      let phaseTimer: ReturnType<typeof setTimeout> | undefined;
+      const phaseBudget = new Promise<'__vision-resolution-budget-expired__'>((resolve) => {
+        phaseTimer = setTimeout(
+          () => resolve('__vision-resolution-budget-expired__'),
+          VISION_RESOLUTION_BUDGET_MS,
         );
+      });
+      const resolvedById = new Map<string, VisionPromptImage>();
+      let consecutiveUnresolvable = 0;
+      let stopReason: 'fuse' | 'budget' | null = null;
+      for (const candidate of withSrc) {
+        if (resolvedById.size >= MAX_VISION_IMAGES) break;
+        if (consecutiveUnresolvable >= MAX_CONSECUTIVE_UNRESOLVABLE_VISION_IMAGES) {
+          stopReason = 'fuse';
+          break;
+        }
+        let attempted: VisionPromptImage[] | '__vision-resolution-budget-expired__';
+        try {
+          attempted = await Promise.race([
+            resolveVisionImagesForPrompt(
+              [
+                {
+                  id: candidate.id,
+                  src: imageMapping[candidate.id],
+                  ...(candidate.width !== undefined ? { width: candidate.width } : {}),
+                  ...(candidate.height !== undefined ? { height: candidate.height } : {}),
+                },
+              ],
+              req.headers,
+            ),
+            phaseBudget,
+          ]);
+        } catch (error) {
+          // A throwing probe counts as an unresolvable candidate (an errored
+          // store must degrade, never fail the request).
+          log.error(
+            `Vision image resolution probe for "${candidate.id}" failed; treating it as unresolvable:`,
+            error,
+          );
+          attempted = [];
+        }
+        if (attempted === '__vision-resolution-budget-expired__') {
+          stopReason = 'budget';
+          break;
+        }
         if (attempted.length === 1) {
-          resolved.push(attempted[0]!);
+          resolvedById.set(attempted[0]!.id, attempted[0]!);
+          consecutiveUnresolvable = 0;
         } else {
-          unresolvableIds.add(candidate.id);
+          consecutiveUnresolvable += 1;
         }
       }
-      resolvedVisionImages = resolved;
-      if (unresolvableIds.size > 0) {
-        assignedImages = assignedImages.filter((img) => !unresolvableIds.has(img.id));
+      if (phaseTimer !== undefined) clearTimeout(phaseTimer);
+      resolvedVisionImages = [...resolvedById.values()];
+      // Every candidate that did not resolve — an unresolvable probe, OR an
+      // unprobed one when the fuse/budget stopped the phase — is stripped from
+      // the mapping and the assigned set, so the generator's re-slice (same
+      // helper, same cap) can never admit an image this route has not resolved
+      // (possibly all of them = text-only generation).
+      const droppedIds = new Set(
+        withSrc
+          .filter((candidate) => !resolvedById.has(candidate.id))
+          .map((candidate) => candidate.id),
+      );
+      if (droppedIds.size > 0) {
+        assignedImages = assignedImages.filter((img) => !droppedIds.has(img.id));
         visionImageMapping = Object.fromEntries(
-          Object.entries(imageMapping).filter(([id]) => !unresolvableIds.has(id)),
+          Object.entries(imageMapping).filter(([id]) => !droppedIds.has(id)),
+        );
+      }
+      if (stopReason !== null) {
+        log.warn(
+          `Stopped probing vision image candidates early: the ${
+            stopReason === 'fuse'
+              ? `consecutive-failure fuse (${MAX_CONSECUTIVE_UNRESOLVABLE_VISION_IMAGES} unresolvable in a row)`
+              : `${VISION_RESOLUTION_BUDGET_MS}ms aggregate resolution budget`
+          } fired; proceeding to generation with ${resolvedById.size} resolved image(s) and the rest dropped to text-only (degrade, not fail).`,
         );
       }
     }

--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -12,6 +12,7 @@ import {
   applyOutlineFallbacks,
   generateSceneContent,
   buildVisionUserContent,
+  partitionImagesForVision,
 } from '@openmaic/generation';
 import type { AgentInfo } from '@openmaic/generation';
 import type {
@@ -27,7 +28,10 @@ import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { resolveVocationalActive } from '@/lib/config/feature-flags';
 import { MAX_VISION_IMAGES } from '@/lib/constants/generation';
 import { sortDocumentImagesForVision } from '@/lib/document/bundle';
-import { resolveVisionImagesForPrompt } from '@/lib/persistence/resolve-vision-images';
+import {
+  resolveVisionImagesForPrompt,
+  type VisionPromptImage,
+} from '@/lib/persistence/resolve-vision-images';
 import { generatePBLV2Project } from '@/lib/pbl/v2/agents/planner';
 
 const log = createLogger('Scene Content API');
@@ -99,11 +103,14 @@ export async function POST(req: NextRequest) {
     const hasVision = !!modelInfo?.capabilities?.vision;
 
     // Vision-aware AI call function. On a server-backed transport the
-    // `imageMapping` values are allocated asset ids, so the vision srcs reach
-    // here as ids; N3 (below) has already filtered `assignedImages` to the
-    // resolvable set, so every id this resolution sees succeeds — the
-    // resolution drops nothing here, it only turns the surviving ids into the
-    // same bytes the base64 path would send (RFC #1153 part 2 B).
+    // `imageMapping` values are allocated asset ids; the N3 pre-resolution
+    // below has already resolved the vision slice's ids to bytes and stripped
+    // every unresolvable id from the mapping, so the srcs this closure sees
+    // are concrete data URLs and this resolution is a DEFENSIVE NO-OP — it
+    // passes concrete srcs through untouched (RFC #1153 part 2 B) and would
+    // only drop an id that still carried an allocated id, which the
+    // pre-resolution makes impossible. Kept so a package consumer that
+    // generates without pre-resolving still degrades cleanly.
     const aiCall = async (
       systemPrompt: string,
       userPrompt: string,
@@ -169,39 +176,55 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // ── N3: resolve the vision slice BEFORE prompt assembly ──
+    // ── N3: resolve-then-slice the vision candidates BEFORE prompt assembly ──
     // The prompt text and the multimodal attachments must be built from the
     // SAME resolved set: an image the server cannot resolve (a reclaimed
     // asset, a store failure) is dropped from BOTH — its `[see attached]`
     // text mention and its attachment — instead of leaving a dangling promise
-    // in the prompt. Per-image: one bad id never aborts the rest; slice order
-    // stays stable. The original `imageMapping` (allocated asset ids) is still
-    // passed to the generator so `resolveImageIds` writes the ALLOCATED ID
-    // into `PPTImageElement.src` (part 2 B) — the pre-resolution only decides
-    // which images survive into `assignedImages`; `generateSlideContent` then
-    // builds text and `visionImages` from the surviving set, and the aiCall
-    // below resolves those ids to bytes for the LLM message.
+    // in the prompt. The candidates are computed in the generator's OWN order
+    // (the shared `partitionImagesForVision` helper, so the route and the
+    // generator cannot drift) and resolved IN ORDER with refill until the cap
+    // is met or the candidates are exhausted: a drop admits the next image
+    // WITH its resolution, so the generator's re-slice (same helper, same
+    // cap) can never admit an image this route has not resolved (review P2).
+    // Every id the resolution drops is STRIPPED from the `imageMapping` (and
+    // `assignedImages`) passed onward, so a model-hallucinated reference to a
+    // dropped id takes the existing clean "no mapping → remove element" path
+    // in `resolveImageIds` instead of writing a dangling allocated id into
+    // `src` (review P3). The resolved slice is passed to the generator so
+    // `aiCall` does not re-resolve (its resolution is a defensive no-op).
+    let visionImageMapping: ImageMapping | undefined = imageMapping;
+    let resolvedVisionImages: VisionPromptImage[] | undefined;
     if (assignedImages && assignedImages.length > 0 && hasVision && imageMapping) {
-      const sorted = sortDocumentImagesForVision(assignedImages);
-      const visionSlice = sorted.filter((img) => imageMapping[img.id]).slice(0, MAX_VISION_IMAGES);
-      const resolvedVisionImages = await resolveVisionImagesForPrompt(
-        visionSlice.map((img) => ({
-          id: img.id,
-          src: imageMapping[img.id],
-          ...(img.width !== undefined ? { width: img.width } : {}),
-          ...(img.height !== undefined ? { height: img.height } : {}),
-        })),
-        req.headers,
-      );
-      const resolvedIds = new Set(resolvedVisionImages.map((img) => img.id));
-      // Drop unresolvable vision images from the assigned set so they produce
-      // NO text mention and NO attachment; images never promised an attachment
-      // (no mapping entry, or beyond the vision slice) stay as plain
-      // descriptions.
-      const visionSliceIds = new Set(visionSlice.map((img) => img.id));
-      assignedImages = assignedImages.filter(
-        (img) => !visionSliceIds.has(img.id) || resolvedIds.has(img.id),
-      );
+      const { withSrc } = partitionImagesForVision(assignedImages, imageMapping, MAX_VISION_IMAGES);
+      const resolved: VisionPromptImage[] = [];
+      const unresolvableIds = new Set<string>();
+      for (const candidate of withSrc) {
+        if (resolved.length >= MAX_VISION_IMAGES) break;
+        const attempted = await resolveVisionImagesForPrompt(
+          [
+            {
+              id: candidate.id,
+              src: imageMapping[candidate.id],
+              ...(candidate.width !== undefined ? { width: candidate.width } : {}),
+              ...(candidate.height !== undefined ? { height: candidate.height } : {}),
+            },
+          ],
+          req.headers,
+        );
+        if (attempted.length === 1) {
+          resolved.push(attempted[0]!);
+        } else {
+          unresolvableIds.add(candidate.id);
+        }
+      }
+      resolvedVisionImages = resolved;
+      if (unresolvableIds.size > 0) {
+        assignedImages = assignedImages.filter((img) => !unresolvableIds.has(img.id));
+        visionImageMapping = Object.fromEntries(
+          Object.entries(imageMapping).filter(([id]) => !unresolvableIds.has(id)),
+        );
+      }
     }
 
     // ── Media generation is handled client-side in parallel (media-orchestrator.ts) ──
@@ -218,9 +241,10 @@ export async function POST(req: NextRequest) {
 
     const content = await generateSceneContent(effectiveOutline, aiCall, {
       assignedImages,
-      imageMapping,
+      imageMapping: visionImageMapping,
       visionEnabled: hasVision,
       generatedMediaMapping,
+      resolvedVisionImages,
       agents,
       languageDirective,
       targetLanguage: userLocale || undefined,

--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -25,6 +25,7 @@ import { apiError, apiSuccess } from '@/lib/server/api-response';
 import { llmApiError } from '@/lib/server/llm-error-response';
 import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { resolveVocationalActive } from '@/lib/config/feature-flags';
+import { MAX_VISION_IMAGES } from '@/lib/constants/generation';
 import { sortDocumentImagesForVision } from '@/lib/document/bundle';
 import { resolveVisionImagesForPrompt } from '@/lib/persistence/resolve-vision-images';
 import { generatePBLV2Project } from '@/lib/pbl/v2/agents/planner';
@@ -97,7 +98,12 @@ export async function POST(req: NextRequest) {
     // Detect vision capability
     const hasVision = !!modelInfo?.capabilities?.vision;
 
-    // Vision-aware AI call function
+    // Vision-aware AI call function. On a server-backed transport the
+    // `imageMapping` values are allocated asset ids, so the vision srcs reach
+    // here as ids; N3 (below) has already filtered `assignedImages` to the
+    // resolvable set, so every id this resolution sees succeeds — the
+    // resolution drops nothing here, it only turns the surviving ids into the
+    // same bytes the base64 path would send (RFC #1153 part 2 B).
     const aiCall = async (
       systemPrompt: string,
       userPrompt: string,
@@ -160,6 +166,41 @@ export async function POST(req: NextRequest) {
       const suggestedIds = new Set(effectiveOutline.suggestedImageIds);
       assignedImages = sortDocumentImagesForVision(
         pdfImages.filter((img) => suggestedIds.has(img.id)),
+      );
+    }
+
+    // ── N3: resolve the vision slice BEFORE prompt assembly ──
+    // The prompt text and the multimodal attachments must be built from the
+    // SAME resolved set: an image the server cannot resolve (a reclaimed
+    // asset, a store failure) is dropped from BOTH — its `[see attached]`
+    // text mention and its attachment — instead of leaving a dangling promise
+    // in the prompt. Per-image: one bad id never aborts the rest; slice order
+    // stays stable. The original `imageMapping` (allocated asset ids) is still
+    // passed to the generator so `resolveImageIds` writes the ALLOCATED ID
+    // into `PPTImageElement.src` (part 2 B) — the pre-resolution only decides
+    // which images survive into `assignedImages`; `generateSlideContent` then
+    // builds text and `visionImages` from the surviving set, and the aiCall
+    // below resolves those ids to bytes for the LLM message.
+    if (assignedImages && assignedImages.length > 0 && hasVision && imageMapping) {
+      const sorted = sortDocumentImagesForVision(assignedImages);
+      const visionSlice = sorted.filter((img) => imageMapping[img.id]).slice(0, MAX_VISION_IMAGES);
+      const resolvedVisionImages = await resolveVisionImagesForPrompt(
+        visionSlice.map((img) => ({
+          id: img.id,
+          src: imageMapping[img.id],
+          ...(img.width !== undefined ? { width: img.width } : {}),
+          ...(img.height !== undefined ? { height: img.height } : {}),
+        })),
+        req.headers,
+      );
+      const resolvedIds = new Set(resolvedVisionImages.map((img) => img.id));
+      // Drop unresolvable vision images from the assigned set so they produce
+      // NO text mention and NO attachment; images never promised an attachment
+      // (no mapping entry, or beyond the vision slice) stay as plain
+      // descriptions.
+      const visionSliceIds = new Set(visionSlice.map((img) => img.id));
+      assignedImages = assignedImages.filter(
+        (img) => !visionSliceIds.has(img.id) || resolvedIds.has(img.id),
       );
     }
 

--- a/app/api/generate/scene-content/route.ts
+++ b/app/api/generate/scene-content/route.ts
@@ -26,6 +26,7 @@ import { llmApiError } from '@/lib/server/llm-error-response';
 import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { resolveVocationalActive } from '@/lib/config/feature-flags';
 import { sortDocumentImagesForVision } from '@/lib/document/bundle';
+import { resolveVisionImagesForPrompt } from '@/lib/persistence/resolve-vision-images';
 import { generatePBLV2Project } from '@/lib/pbl/v2/agents/planner';
 
 const log = createLogger('Scene Content API');
@@ -103,6 +104,11 @@ export async function POST(req: NextRequest) {
       images?: Array<{ id: string; src: string }>,
     ): Promise<string> => {
       if (images?.length && hasVision) {
+        // Server-backed transport: `imageMapping` values are allocated asset
+        // ids, so the image srcs reach here as ids. Resolve them to the same
+        // bytes the base64 path would send BEFORE prompt assembly, keeping the
+        // vision prompt byte-identical in both modes (RFC #1153 part 2 B).
+        const resolvedImages = await resolveVisionImagesForPrompt(images, req.headers);
         const result = await callLLM(
           {
             model: languageModel,
@@ -110,7 +116,7 @@ export async function POST(req: NextRequest) {
             messages: [
               {
                 role: 'user' as const,
-                content: buildVisionUserContent(userPrompt, images),
+                content: buildVisionUserContent(userPrompt, resolvedImages),
               },
             ],
             maxOutputTokens: modelInfo?.outputWindow,

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -386,6 +386,15 @@ export async function POST(req: NextRequest) {
         resolvedImageMapping = Object.fromEntries(
           Object.entries(imageMapping).filter(([id]) => resolvedIds.has(id)),
         );
+        // Shift-in is IMPOSSIBLE here by construction (unlike the scene-content
+        // route's re-slice): `visionImages` — the ONLY attachments this route
+        // sends — IS the resolved slice, resolved once from the original
+        // `visionSlice` and never re-sliced, so a dropped image admits NO new
+        // image into the attachments; and `resolvedImageMapping` names only
+        // the resolved slice's ids, so the standard branch's `[see attached]`
+        // text matches the attachments exactly (images beyond the slice and
+        // no-src images keep plain descriptions because their mapping entries
+        // are stripped).
       } else {
         // Text-only mode: full descriptions
         availableImagesText = pdfImages.map((img) => formatImageDescription(img)).join('\n');

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -38,6 +38,7 @@ import { apiError } from '@/lib/server/api-response';
 import { createLogger } from '@/lib/logger';
 import { resolveModelFromRequest } from '@/lib/server/resolve-model';
 import { sortDocumentImagesForVision } from '@/lib/document/bundle';
+import { resolveVisionImagesForPrompt } from '@/lib/persistence/resolve-vision-images';
 import { resolveVocationalActive } from '@/lib/config/feature-flags';
 const log = createLogger('Outlines Stream');
 
@@ -334,17 +335,35 @@ export async function POST(req: NextRequest) {
         const textOnlySlice = allWithSrc.slice(MAX_VISION_IMAGES);
         const noSrcImages = sortedImages.filter((img) => !imageMapping[img.id]);
 
-        const visionDescriptions = visionSlice.map((img) => formatImagePlaceholder(img));
+        // Server-backed transport: `imageMapping` values are allocated asset
+        // ids, so the vision srcs reach here as ids. Resolve them to the same
+        // bytes the base64 path would send BEFORE prompt assembly, keeping the
+        // vision prompt byte-identical in both modes (RFC #1153 part 2 B). An
+        // id the server cannot resolve is dropped here, so the placeholder
+        // text below never promises an image that will not be attached.
+        const resolvedVisionImages = await resolveVisionImagesForPrompt(
+          visionSlice.map((img) => ({
+            id: img.id,
+            src: imageMapping[img.id],
+            ...(img.width !== undefined ? { width: img.width } : {}),
+            ...(img.height !== undefined ? { height: img.height } : {}),
+          })),
+          req.headers,
+        );
+        const visionImageById = new Map(sortedImages.map((img) => [img.id, img] as const));
+        const visionDescriptions = resolvedVisionImages.map((img) =>
+          formatImagePlaceholder(visionImageById.get(img.id) ?? { ...img, pageNumber: 1, src: '' }),
+        );
         const textDescriptions = [...textOnlySlice, ...noSrcImages].map((img) =>
           formatImageDescription(img),
         );
         availableImagesText = [...visionDescriptions, ...textDescriptions].join('\n');
 
-        visionImages = visionSlice.map((img) => ({
+        visionImages = resolvedVisionImages.map((img) => ({
           id: img.id,
-          src: imageMapping[img.id],
-          width: img.width,
-          height: img.height,
+          src: img.src,
+          ...(img.width !== undefined ? { width: img.width } : {}),
+          ...(img.height !== undefined ? { height: img.height } : {}),
         }));
       } else {
         // Text-only mode: full descriptions

--- a/app/api/generate/scene-outlines-stream/route.ts
+++ b/app/api/generate/scene-outlines-stream/route.ts
@@ -325,6 +325,13 @@ export async function POST(req: NextRequest) {
     // Build prompt (same logic as generateSceneOutlinesFromRequirements)
     let availableImagesText = 'No images available';
     let visionImages: Array<{ id: string; src: string }> | undefined;
+    // N3: the RESOLVED slice, threaded into the standard buildOutlinePrompt
+    // branch below. The vision resolution drops images the server cannot
+    // resolve; the standard branch must rebuild its placeholder text from the
+    // same resolved set so a dropped image drops its text mention AND its
+    // attachment there too.
+    let resolvedPdfImages: PdfImage[] | undefined;
+    let resolvedImageMapping: ImageMapping | undefined;
 
     if (pdfImages && pdfImages.length > 0) {
       if (hasVision && imageMapping) {
@@ -350,6 +357,7 @@ export async function POST(req: NextRequest) {
           })),
           req.headers,
         );
+        const resolvedIds = new Set(resolvedVisionImages.map((img) => img.id));
         const visionImageById = new Map(sortedImages.map((img) => [img.id, img] as const));
         const visionDescriptions = resolvedVisionImages.map((img) =>
           formatImagePlaceholder(visionImageById.get(img.id) ?? { ...img, pageNumber: 1, src: '' }),
@@ -365,6 +373,19 @@ export async function POST(req: NextRequest) {
           ...(img.width !== undefined ? { width: img.width } : {}),
           ...(img.height !== undefined ? { height: img.height } : {}),
         }));
+
+        // N3: the standard branch (buildOutlinePrompt) rebuilds its own
+        // placeholder text from pdfImages × imageMapping — feed it the RESOLVED
+        // set: unresolvable vision images removed from the slice and a mapping
+        // naming only the resolved ids, so its `[see attached]` promises match
+        // the attachments this route attaches exactly.
+        const visionSliceIds = new Set(visionSlice.map((img) => img.id));
+        resolvedPdfImages = pdfImages.filter(
+          (img) => !visionSliceIds.has(img.id) || resolvedIds.has(img.id),
+        );
+        resolvedImageMapping = Object.fromEntries(
+          Object.entries(imageMapping).filter(([id]) => resolvedIds.has(id)),
+        );
       } else {
         // Text-only mode: full descriptions
         availableImagesText = pdfImages.map((img) => formatImageDescription(img)).join('\n');
@@ -385,11 +406,14 @@ export async function POST(req: NextRequest) {
     const taskEngineMode = resolveVocationalActive(requirements);
     // Standard outline generation is byte-identical to the package path. The
     // two app-only modes retain their own templates but share the same inputs.
+    // The standard branch receives the N3 RESOLVED slice (unresolvable vision
+    // images removed, mapping naming only resolved ids) so its placeholder
+    // text never promises an image this route will not attach.
     let prompts: { system: string; user: string } | null = buildOutlinePrompt(requirements, {
       pdfText,
-      pdfImages,
+      pdfImages: resolvedPdfImages ?? pdfImages,
       visionEnabled: hasVision,
-      imageMapping,
+      imageMapping: resolvedImageMapping ?? imageMapping,
       imageGenerationEnabled,
       videoGenerationEnabled,
       researchContext,

--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -128,13 +128,14 @@ export default function ClassroomDetailPage() {
       // Reconstruct imageMapping for the resumed generation. A server-backed
       // deployment stored allocated asset ids on the session's pdfImages (RFC
       // #1153 part 2 B): the extracted images are pool assets, so generation
-      // is fed by id and the routes resolve the bytes server-side. A
-      // browser-backed deployment stores IndexedDB storage ids instead and
-      // materializes base64 data URLs exactly as before.
+      // is fed by id and the routes resolve the bytes server-side. Per source
+      // (N4) the mapping may MIX allocated asset ids and IndexedDB data URLs —
+      // a source whose cache write failed materialized its own images — so the
+      // resume mapping merges both, instead of choosing one transport for the
+      // whole set and silently dropping the other half.
       const pdfImages = (params.pdfImages || []) as Array<
         { id: string; assetId?: string; storageId?: string } & Record<string, unknown>
       >;
-      const assetMapped = pdfImages.filter((img) => img.assetId);
       const finishResume = (imageMapping: Record<string, string>) =>
         generateRemaining({
           pdfImages: params.pdfImages,
@@ -149,14 +150,19 @@ export default function ClassroomDetailPage() {
           languageDirective: params.languageDirective || stage.languageDirective,
         });
 
-      if (assetMapped.length > 0) {
-        finishResume(Object.fromEntries(assetMapped.map((img) => [img.id, img.assetId as string])));
-      } else {
-        const storageIds = pdfImages
-          .map((img) => img.storageId)
-          .filter((id): id is string => Boolean(id));
-        loadImageMapping(storageIds).then(finishResume);
+      const imageMapping: Record<string, string> = {};
+      for (const img of pdfImages) {
+        if (img.assetId) imageMapping[img.id] = img.assetId;
       }
+      const storageIds = pdfImages
+        .filter((img) => !img.assetId && img.storageId)
+        .map((img) => img.storageId as string);
+      void (async () => {
+        if (storageIds.length > 0) {
+          Object.assign(imageMapping, await loadImageMapping(storageIds));
+        }
+        finishResume(imageMapping);
+      })();
     } else if (outlines.length > 0 && stage) {
       // All scenes are generated, but some media may not have finished.
       // Resume media generation for any tasks not yet in IndexedDB.

--- a/app/classroom/[id]/page.tsx
+++ b/app/classroom/[id]/page.tsx
@@ -125,12 +125,17 @@ export default function ClassroomDetailPage() {
       const genParamsStr = sessionStorage.getItem('generationParams');
       const params = genParamsStr ? JSON.parse(genParamsStr) : {};
 
-      // Reconstruct imageMapping from IndexedDB using pdfImages storageIds
-      const storageIds = (params.pdfImages || [])
-        .map((img: { storageId?: string }) => img.storageId)
-        .filter(Boolean);
-
-      loadImageMapping(storageIds).then((imageMapping) => {
+      // Reconstruct imageMapping for the resumed generation. A server-backed
+      // deployment stored allocated asset ids on the session's pdfImages (RFC
+      // #1153 part 2 B): the extracted images are pool assets, so generation
+      // is fed by id and the routes resolve the bytes server-side. A
+      // browser-backed deployment stores IndexedDB storage ids instead and
+      // materializes base64 data URLs exactly as before.
+      const pdfImages = (params.pdfImages || []) as Array<
+        { id: string; assetId?: string; storageId?: string } & Record<string, unknown>
+      >;
+      const assetMapped = pdfImages.filter((img) => img.assetId);
+      const finishResume = (imageMapping: Record<string, string>) =>
         generateRemaining({
           pdfImages: params.pdfImages,
           imageMapping,
@@ -143,7 +148,15 @@ export default function ClassroomDetailPage() {
           userProfile: params.userProfile,
           languageDirective: params.languageDirective || stage.languageDirective,
         });
-      });
+
+      if (assetMapped.length > 0) {
+        finishResume(Object.fromEntries(assetMapped.map((img) => [img.id, img.assetId as string])));
+      } else {
+        const storageIds = pdfImages
+          .map((img) => img.storageId)
+          .filter((id): id is string => Boolean(id));
+        loadImageMapping(storageIds).then(finishResume);
+      }
     } else if (outlines.length > 0 && stage) {
       // All scenes are generated, but some media may not have finished.
       // Resume media generation for any tasks not yet in IndexedDB.

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -44,13 +44,17 @@ import {
   resolveExpectedExtractor,
   type ExtractionCacheDomain,
 } from '@/lib/document/extraction-cache';
+import { DEFAULT_INGEST_AWAIT_TIMEOUT_MS } from '@/lib/document/extract-source';
+import {
+  awaitWithFallback,
+  materializeBundleImages,
+} from '@/lib/document/extraction-materialization';
 import { SUPPORTED_MEDIA_MIME_TYPES } from '@/lib/document/mime';
 import { MAX_VISION_IMAGES } from '@/lib/constants/generation';
 import {
   MAX_DOCUMENT_BUNDLE_FILES,
   MAX_DOCUMENT_BUNDLE_TOTAL_SIZE_BYTES,
   buildDocumentBundle,
-  type ParsedDocumentImage,
   type ParsedDocumentPart,
 } from '@/lib/document/bundle';
 import { buildVideoManifestFromOutlines } from '@/lib/media/video-manifest';
@@ -536,10 +540,20 @@ function GenerationPreviewContent() {
             // name the images by id without materializing their bytes. When
             // no ids are available (KV unavailable), the source falls back to
             // the data-URL transport below — the routes accept both.
+            //
+            // N2: the await is BOUNDED by the same 15 s budget as the
+            // upload-time ingest drain, so a server that accepts the
+            // connection but never answers degrades to the per-source
+            // data-URL fallback instead of hanging startGeneration. The
+            // detached write keeps running and benefits the NEXT run (the
+            // extraction-cache L5 contract stays true — it is this caller's
+            // await that is bounded).
             let imageAssetIds: Map<string, string> | undefined;
             if (serverBacked && !extractionOutcome.cacheHit) {
-              const derived = await (extractionOutcome.cacheWrite ?? Promise.resolve([])).catch(
-                () => [],
+              const derived = await awaitWithFallback(
+                (extractionOutcome.cacheWrite ?? Promise.resolve([])).catch(() => []),
+                DEFAULT_INGEST_AWAIT_TIMEOUT_MS,
+                [],
               );
               if (derived.length > 0) {
                 imageAssetIds = new Map(derived.map((image) => [image.id, image.assetId]));
@@ -582,17 +596,22 @@ function GenerationPreviewContent() {
         );
 
         const bundle = buildDocumentBundle(parsedParts);
-        // Part 2 B/C: a server-backed deployment feeds generation by allocated
-        // asset id and skips IndexedDB materialization entirely. When no asset
-        // ids are available (a failed best-effort cache write, a legacy
-        // session), fall back to materializing base64 exactly as before — the
-        // routes accept both transports.
-        const assetMappedImages = bundle.images.filter(
-          (img): img is ParsedDocumentImage & { visionPriority: number; assetId: string } =>
-            !!img.assetId,
+        // Part 2 B/C + N4: the byte transport is decided PER SOURCE, not for
+        // the whole bundle. A server-backed source whose images all carry
+        // allocated asset ids feeds generation by id; a source with any image
+        // lacking an id (a failed best-effort cache write, a legacy session)
+        // materializes ITS images into IndexedDB as data URLs — one source's
+        // failure never silently drops another source's images. The resulting
+        // `imageMapping` may MIX asset ids and data URLs; the routes and
+        // `resolveImageIds` are shape-based and accept both.
+        const { storageIds: perImageStorageIds } = await materializeBundleImages(
+          serverBacked,
+          bundle.images,
+          storeImages,
         );
-        const materializeBytes = !serverBacked || assetMappedImages.length === 0;
-        const imageStorageIds = materializeBytes ? await storeImages(bundle.images) : [];
+        const imageStorageIds = perImageStorageIds.filter(
+          (storageId): storageId is string => storageId !== undefined,
+        );
 
         const pdfImages: PdfImage[] = bundle.images.map((img, i) => ({
           id: img.id,
@@ -606,10 +625,10 @@ function GenerationPreviewContent() {
           sourceDocumentName: img.sourceDocumentName,
           sourceDocumentOrder: img.sourceDocumentOrder,
           visionPriority: img.visionPriority,
-          // Server-backed images carry their pool asset id; browser-backed
+          // Per source: id-fed images carry their pool asset id; materialized
           // images carry their IndexedDB storage id (never both).
-          ...(img.assetId ? { assetId: img.assetId } : {}),
-          ...(materializeBytes ? { storageId: imageStorageIds[i] } : {}),
+          ...(img.assetId && perImageStorageIds[i] === undefined ? { assetId: img.assetId } : {}),
+          ...(perImageStorageIds[i] !== undefined ? { storageId: perImageStorageIds[i] } : {}),
         }));
 
         // Update session with extracted document data
@@ -700,14 +719,30 @@ function GenerationPreviewContent() {
       // (RFC #1153 part 2 B): a server-backed pool names images by their
       // allocated asset ids (the extracted images are pool assets — part 1); a
       // browser-backed pool materializes base64 data URLs exactly as before.
+      // Per source (N4) the mapping may MIX allocated asset ids and IndexedDB
+      // data URLs — a source whose cache write failed materializes its own
+      // images — and the routes / `resolveImageIds` are shape-based, so both
+      // value kinds ride the same mapping.
       let imageMapping: ImageMapping = {};
       const sessionImages = currentSession.pdfImages ?? [];
-      const assetMappedImages = sessionImages.filter(
-        (img): img is PdfImage & { assetId: string } => !!img.assetId,
-      );
-      if (serverBacked && assetMappedImages.length > 0) {
-        log.debug('Using asset-id imageMapping (server-backed pool)');
-        imageMapping = Object.fromEntries(assetMappedImages.map((img) => [img.id, img.assetId]));
+      if (serverBacked) {
+        const mapped: ImageMapping = {};
+        for (const img of sessionImages) {
+          if (img.assetId) mapped[img.id] = img.assetId;
+        }
+        const storageIds = sessionImages
+          .filter((img): img is PdfImage & { storageId: string } => !img.assetId && !!img.storageId)
+          .map((img) => img.storageId);
+        if (storageIds.length > 0) {
+          Object.assign(mapped, await loadImageMapping(storageIds));
+        } else if (currentSession.imageStorageIds && currentSession.imageStorageIds.length > 0) {
+          // Legacy session: storage ids live on the session, not on pdfImages.
+          Object.assign(mapped, await loadImageMapping(currentSession.imageStorageIds));
+        }
+        if (Object.keys(mapped).length > 0) {
+          log.debug('Using per-source imageMapping (server-backed pool, ids + data URLs)');
+          imageMapping = mapped;
+        }
       } else if (currentSession.imageStorageIds && currentSession.imageStorageIds.length > 0) {
         log.debug('Loading images from IndexedDB');
         imageMapping = await loadImageMapping(currentSession.imageStorageIds);

--- a/app/generation-preview/page.tsx
+++ b/app/generation-preview/page.tsx
@@ -50,6 +50,7 @@ import {
   MAX_DOCUMENT_BUNDLE_FILES,
   MAX_DOCUMENT_BUNDLE_TOTAL_SIZE_BYTES,
   buildDocumentBundle,
+  type ParsedDocumentImage,
   type ParsedDocumentPart,
 } from '@/lib/document/bundle';
 import { buildVideoManifestFromOutlines } from '@/lib/media/video-manifest';
@@ -82,6 +83,8 @@ type ParsedDocumentResponseImage = {
   description?: string;
   width?: number;
   height?: number;
+  /** Pool asset id of the image bytes (server-backed cache-hit rebuilds). */
+  assetId?: string;
 };
 
 function validateDocumentSources(
@@ -326,6 +329,13 @@ function GenerationPreviewContent() {
     // Use a local mutable copy so we can update it after document extraction
     let currentSession = generationSession;
 
+    // A server-backed asset pool can resolve bytes by allocated asset id; a
+    // browser-backed (self-deploy) pool cannot, so the client keeps the byte
+    // transport. The probe is read ONCE per run so a mid-run configuration
+    // change cannot split the bundle across the two forms (RFC #1153 part 0/1,
+    // and part 2's imageMapping transport decision rides the same probe).
+    const serverBacked = isAssetPoolServerBacked();
+
     setError(null);
     setCurrentStepIndex(0);
 
@@ -346,12 +356,6 @@ function GenerationPreviewContent() {
       if (hasPdfToAnalyze) {
         log.debug('=== Generation Preview: Extracting course material bundle ===');
         validateDocumentSources(documentSources, t);
-        // A server-backed asset pool can resolve the uploaded bytes by asset
-        // id; a browser-backed (self-deploy) pool cannot, so the client keeps
-        // uploading the bytes exactly as before. The probe is read once per
-        // run so a mid-run configuration change cannot split the bundle across
-        // the two forms.
-        const serverBacked = isAssetPoolServerBacked();
         const sortedDocumentSources = [...documentSources].sort((a, b) => a.order - b.order);
         // K3 (in-run dedupe): sources with the same content digest AND the same
         // expected extractor identity share ONE extraction, so two same-byte
@@ -408,6 +412,8 @@ function GenerationPreviewContent() {
             // Cache lookup first; on a miss this runs the extract API (asset-id
             // JSON form with a per-source fallback to the legacy byte upload,
             // see `fetchExtractionResponse`) and caches the result best-effort.
+            // The full outcome is kept — a server-backed run needs the
+            // best-effort cache write's derived image ids, not just the data.
             const runExtraction = () =>
               fetchExtractionWithCache({
                 serverBacked,
@@ -496,12 +502,19 @@ function GenerationPreviewContent() {
                 baseUrl: sourceBaseUrl,
                 sourceDocAssetId: source.assetId,
                 parseFailedMessage: t('generation.courseMaterialParseFailed'),
-              }).then((outcome) => outcome.data);
+                // Part 2 B: a server-backed deployment names images by their
+                // allocated pool asset ids, so a cache hit feeds generation by
+                // id instead of materializing image bytes client-side.
+                imageMappingMode: serverBacked ? 'asset-id' : 'data-url',
+              });
             // K3 (in-run dedupe): sources whose extraction cache key is
             // identical (same content digest + domain + expected extractor +
             // config fingerprint) share ONE extraction; two same-byte files
             // never both pay, and per-source config differences never share.
-            const parseData =
+            // The memo now carries the FULL outcome, so a deduplicated second
+            // source reaches the shared derivation's image asset ids through
+            // the winner's cacheWrite (part 2 B).
+            const extractionOutcome =
               source.contentDigest && expectedExtractor && sourceConfigFingerprint
                 ? await deduplicateExtraction.run(
                     {
@@ -514,7 +527,24 @@ function GenerationPreviewContent() {
                     runExtraction,
                   )
                 : await runExtraction();
+            const parseData = extractionOutcome.data;
 
+            // Part 2 B: on a server-backed deployment the extracted images are
+            // pool assets (part 1). A cache hit carries their ids on the
+            // rebuilt result; a fresh extraction's ids come from the
+            // best-effort cache write — awaited here because the session must
+            // name the images by id without materializing their bytes. When
+            // no ids are available (KV unavailable), the source falls back to
+            // the data-URL transport below — the routes accept both.
+            let imageAssetIds: Map<string, string> | undefined;
+            if (serverBacked && !extractionOutcome.cacheHit) {
+              const derived = await (extractionOutcome.cacheWrite ?? Promise.resolve([])).catch(
+                () => [],
+              );
+              if (derived.length > 0) {
+                imageAssetIds = new Map(derived.map((image) => [image.id, image.assetId]));
+              }
+            }
             const rawImages = parseData.metadata?.pdfImages;
             const images = rawImages
               ? rawImages.map((img: ParsedDocumentResponseImage) => ({
@@ -524,6 +554,8 @@ function GenerationPreviewContent() {
                   description: img.description,
                   width: img.width,
                   height: img.height,
+                  ...(img.assetId ? { assetId: img.assetId } : {}),
+                  ...(imageAssetIds?.get(img.id) ? { assetId: imageAssetIds.get(img.id) } : {}),
                 }))
               : ((parseData.images as string[] | undefined) ?? []).map((src, i) => ({
                   id: `img_${i + 1}`,
@@ -550,7 +582,17 @@ function GenerationPreviewContent() {
         );
 
         const bundle = buildDocumentBundle(parsedParts);
-        const imageStorageIds = await storeImages(bundle.images);
+        // Part 2 B/C: a server-backed deployment feeds generation by allocated
+        // asset id and skips IndexedDB materialization entirely. When no asset
+        // ids are available (a failed best-effort cache write, a legacy
+        // session), fall back to materializing base64 exactly as before — the
+        // routes accept both transports.
+        const assetMappedImages = bundle.images.filter(
+          (img): img is ParsedDocumentImage & { visionPriority: number; assetId: string } =>
+            !!img.assetId,
+        );
+        const materializeBytes = !serverBacked || assetMappedImages.length === 0;
+        const imageStorageIds = materializeBytes ? await storeImages(bundle.images) : [];
 
         const pdfImages: PdfImage[] = bundle.images.map((img, i) => ({
           id: img.id,
@@ -564,7 +606,10 @@ function GenerationPreviewContent() {
           sourceDocumentName: img.sourceDocumentName,
           sourceDocumentOrder: img.sourceDocumentOrder,
           visionPriority: img.visionPriority,
-          storageId: imageStorageIds[i],
+          // Server-backed images carry their pool asset id; browser-backed
+          // images carry their IndexedDB storage id (never both).
+          ...(img.assetId ? { assetId: img.assetId } : {}),
+          ...(materializeBytes ? { storageId: imageStorageIds[i] } : {}),
         }));
 
         // Update session with extracted document data
@@ -650,9 +695,20 @@ function GenerationPreviewContent() {
         activeSteps = getActiveSteps(currentSession);
       }
 
-      // Load imageMapping early (needed for both outline and scene generation)
+      // Load imageMapping early (needed for both outline and scene generation).
+      // The transport is decided once per run by the same probe as part 0/1
+      // (RFC #1153 part 2 B): a server-backed pool names images by their
+      // allocated asset ids (the extracted images are pool assets — part 1); a
+      // browser-backed pool materializes base64 data URLs exactly as before.
       let imageMapping: ImageMapping = {};
-      if (currentSession.imageStorageIds && currentSession.imageStorageIds.length > 0) {
+      const sessionImages = currentSession.pdfImages ?? [];
+      const assetMappedImages = sessionImages.filter(
+        (img): img is PdfImage & { assetId: string } => !!img.assetId,
+      );
+      if (serverBacked && assetMappedImages.length > 0) {
+        log.debug('Using asset-id imageMapping (server-backed pool)');
+        imageMapping = Object.fromEntries(assetMappedImages.map((img) => [img.id, img.assetId]));
+      } else if (currentSession.imageStorageIds && currentSession.imageStorageIds.length > 0) {
         log.debug('Loading images from IndexedDB');
         imageMapping = await loadImageMapping(currentSession.imageStorageIds);
       } else if (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -226,6 +226,13 @@ function HomePage() {
   // from the settled promise just like the asset id (see
   // `resolvedAssetIdForIngest` for the commit-timing rationale).
   const pendingMaterialDigestsRef = useRef(new Map<string, Promise<string | undefined>>());
+  // Course-material ids whose ingest was ABANDONED: removed from the
+  // selection (the source file handle is gone) or released at prep-timeout
+  // because no durable holder would ever exist for the id. The material-library
+  // upsert skips these — minting would record bytes the user deliberately
+  // discarded (RFC #1153 part 2, N1). Written synchronously by the removal
+  // path and the prep-timeout drain, read by the upsert settlement below.
+  const abandonedMaterialIngestIdsRef = useRef(new Set<string>());
 
   const replaceThumbnails = (slides: Record<string, Slide>) => {
     const previous = thumbnailsRef.current;
@@ -555,13 +562,20 @@ function HomePage() {
     // Material library manifest (RFC #1153 part 2): once BOTH the ingest's
     // allocated asset id and the content digest have settled, upsert the
     // library entry keyed by digest — same bytes re-imported refresh the same
-    // entry (`addedAt` bumped, `assetId` advanced to the newest allocation).
-    // Best-effort by contract: a KV failure never fails the upload, and the
-    // library entry is durable even after this pool entry is released later.
-    void Promise.all([ingest, contentDigest]).then(([assetId, digest]) => {
+    // entry (`addedAt` bumped, `assetId` advanced). The library allocates its
+    // OWN pool entry from the file bytes and stores that id, so the entry
+    // stays resolvable after this selection's pool entry is released (N1,
+    // RFC §5 root model). The upsert must NOT fire for a material whose
+    // ingest was already abandoned — removed from the selection (the source
+    // file handle is gone) or released at prep-timeout — so it is gated on
+    // the same settlement as before AND on the abandoned set. Best-effort by
+    // contract: a KV failure or a failed library allocation never fails the
+    // upload.
+    void Promise.all([ingest, contentDigest]).then(([, digest]) => {
       if (!digest) return;
+      if (abandonedMaterialIngestIdsRef.current.has(addition.id)) return;
       void upsertMaterialLibraryEntry({
-        assetId,
+        file: addition.file,
         contentDigest: digest,
         name: addition.name,
         mimeType:
@@ -624,6 +638,11 @@ function HomePage() {
     // via the same state), so nothing can slip out of the set mid-prep.
     if (preparingGenerate) return;
     const removed = form.courseMaterials.find((item) => item.id === id);
+    // The source file handle is gone: the material-library upsert must not
+    // fire for this id once its ingest settles (N1). Mark it synchronously so
+    // the settlement closure — which runs after this handler returns — skips
+    // minting an entry for bytes the user deliberately discarded.
+    abandonedMaterialIngestIdsRef.current.add(id);
     // Release the pool entry allocated for this file, mirroring the blob-stash
     // cleanup: if the ingest is still in flight, release once it lands.
     const release = removed?.assetId
@@ -716,8 +735,11 @@ function HomePage() {
           timeoutMs: DEFAULT_INGEST_AWAIT_TIMEOUT_MS,
           onUnsettled: (ingestId, ingest) => {
             unsettledIngestIds.add(ingestId);
-            // No durable holder will ever exist for a timed-out id (the
-            // session is built without it), so release it when it lands.
+            // The ingest was abandoned: no durable holder will ever exist for
+            // its id, so release it when it lands — and mark it abandoned so
+            // the material-library upsert skips minting an entry for bytes
+            // the session deliberately discarded (N1).
+            abandonedMaterialIngestIdsRef.current.add(ingestId);
             void ingest
               .then((assetId) => (assetId ? removeAsset(assetId) : undefined))
               .catch((error) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,6 +53,7 @@ import {
   resolvedAssetIdForIngest,
 } from '@/lib/document/extract-source';
 import { computeContentDigest } from '@/lib/document/extraction-cache';
+import { upsertMaterialLibraryEntry } from '@/lib/materials/library';
 import type {
   SelectedCourseMaterial,
   SessionDocumentSource,
@@ -549,6 +550,29 @@ function HomePage() {
             }
           : prev,
       );
+    });
+
+    // Material library manifest (RFC #1153 part 2): once BOTH the ingest's
+    // allocated asset id and the content digest have settled, upsert the
+    // library entry keyed by digest — same bytes re-imported refresh the same
+    // entry (`addedAt` bumped, `assetId` advanced to the newest allocation).
+    // Best-effort by contract: a KV failure never fails the upload, and the
+    // library entry is durable even after this pool entry is released later.
+    void Promise.all([ingest, contentDigest]).then(([assetId, digest]) => {
+      if (!digest) return;
+      void upsertMaterialLibraryEntry({
+        assetId,
+        contentDigest: digest,
+        name: addition.name,
+        mimeType:
+          normalizeDocumentMimeType({
+            mimeType: addition.file.type,
+            fileName: addition.file.name,
+          }) || undefined,
+        size: addition.size,
+      }).catch((error) => {
+        log.error(`Failed to record the material library entry for "${addition.name}":`, error);
+      });
     });
   };
 

--- a/lib/constants/generation.ts
+++ b/lib/constants/generation.ts
@@ -8,3 +8,9 @@ export const MAX_PDF_CONTENT_CHARS = 50000;
 
 // Maximum number of images to send as vision content parts
 export const MAX_VISION_IMAGES = 20;
+
+// Size cap for one course material document (bytes), enforced by the extract
+// route on both the multipart and asset-id forms and by the vision-image
+// resolution (`resolveVisionImagesForPrompt`) so an oversized asset is
+// rejected at `identify` — before any bytes are materialized.
+export const MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES = 50 * 1024 * 1024;

--- a/lib/document/extraction-cache.ts
+++ b/lib/document/extraction-cache.ts
@@ -42,7 +42,7 @@ import { SUPPORTED_MEDIA_MIME_TYPES } from '@/lib/document/mime';
 import { createLogger } from '@/lib/logger';
 import { putAsset, removeAsset } from '@/lib/media/asset-pool';
 import type { AssetPoolStore } from '@/lib/media/asset-pool-config';
-import { withAssetUrl } from '@/lib/media/use-asset-url';
+import { assetRefExists, withAssetUrl } from '@/lib/media/use-asset-url';
 import {
   getPersistenceRequestHeaders,
   isBrowserPersistenceEnabled,
@@ -806,10 +806,11 @@ export interface ExtractionCacheLookupOptions {
    * bytes: `metadata.imageMapping` maps `img_N` → the image's pool asset id
    * and `metadata.pdfImages[].assetId` carries the same id, so a cache hit
    * feeds generation by id instead of shipping bytes to the client. In
-   * `'asset-id'` mode the per-image byte reads are skipped entirely (the
-   * bytes are resolved server-side at prompt-assembly time), so a record
-   * whose image assets were reclaimed is still a hit for the text — the
-   * generation-time resolution reports the missing image then.
+   * `'asset-id'` mode the per-image BYTE reads are skipped (the bytes are
+   * resolved server-side at prompt-assembly time), but each image asset is
+   * still probed for EXISTENCE through the pool's identity seam — a record
+   * naming a reclaimed image is a miss (reclaim = miss, the same invariant
+   * data-url mode and part-1 K6 enforce), never a hit with dangling ids.
    */
   imageMappingMode?: 'data-url' | 'asset-id';
 }
@@ -825,8 +826,10 @@ export interface ExtractionCacheLookupOptions {
  * that does not resolve, bytes that cannot be read, a record whose image list
  * disagrees with the stored artifact's own image asset ids, or a KV/pool
  * transport failure — so the caller treats it as a miss and runs the real
- * extraction. (In `'asset-id'` mode the per-image byte reads are skipped, so
- * only the artifact read and the record/artifact consistency check can miss.)
+ * extraction. (In `'asset-id'` mode the per-image BYTE reads are skipped, so
+ * a hit costs the artifact read, the record/artifact consistency check, and
+ * a per-image EXISTENCE probe through the pool's identity seam — a record
+ * naming a reclaimed image is a miss there too.)
  * A hit is logged so it is observable.
  */
 export async function lookupCachedExtraction(
@@ -925,13 +928,25 @@ export async function lookupCachedExtraction(
     // Every image asset must resolve and be readable in data-url mode; a
     // record naming a partially-reclaimed cache is a miss, and the real
     // extraction re-derives. In asset-id mode (RFC #1153 part 2 C) the image
-    // bytes are deliberately NOT materialized client-side — the generation
-    // routes resolve the ids server-side at prompt-assembly time — so the
-    // per-image byte reads are skipped and the record's asset ids flow into
-    // the rebuilt result verbatim.
+    // BYTES are deliberately NOT materialized client-side — the generation
+    // routes resolve the ids server-side at prompt-assembly time — but the
+    // reclaim-is-miss invariant (part-1 K6) is mode-independent: each image
+    // asset is still probed for EXISTENCE through the pool seam (an identity
+    // read — HEAD / registry lookup — never a byte fetch), and a record
+    // naming a reclaimed image is a miss, exactly like data-url mode. Only a
+    // record whose image assets all still exist serves a hit.
     const imagePayloads: string[] = [];
     if (assetIdMode) {
-      imagePayloads.push(...record.images.map((image) => image.assetId));
+      for (const image of record.images) {
+        const exists = await assetRefExists(image.assetId, options.pool);
+        if (!exists) {
+          log.warn(
+            `Extraction cache miss for ${key}: image asset ${image.assetId} no longer exists (reclaim = miss).`,
+          );
+          return null;
+        }
+        imagePayloads.push(image.assetId);
+      }
     } else {
       for (const image of record.images) {
         const dataUrl = await withAssetUrl(

--- a/lib/document/extraction-cache.ts
+++ b/lib/document/extraction-cache.ts
@@ -527,12 +527,21 @@ export interface ExtractionCacheWriteOptions {
  * KV failure disables the cache for a bounded window (K5/L4) — subsequent
  * writes are skipped BEFORE any asset is ingested, so a dead KV route costs no
  * putAsset-then-removeAsset churn.
+ *
+ * Resolves to the derived images (extraction id → pool asset id) when the
+ * write settled: this attempt's own images on success, the ADOPTED existing
+ * record's images when a same-key race superseded this attempt (K3), or an
+ * empty array when the write was skipped or failed. A server-backed caller can
+ * await the returned `cacheWrite` promise to learn the image asset ids without
+ * materializing image bytes client-side (RFC #1153 part 2 B).
  */
-export async function writeExtractionCache(options: ExtractionCacheWriteOptions): Promise<void> {
+export async function writeExtractionCache(
+  options: ExtractionCacheWriteOptions,
+): Promise<DerivedExtractionImage[]> {
   // K5: the KV route is unreachable (inside the disable window); skip the
   // write entirely BEFORE ingesting anything, so a dead backend costs no pool
   // churn.
-  if (isCacheDisabled()) return;
+  if (isCacheDisabled()) return [];
 
   const allocated: string[] = [];
   // Production ingests through the browser-wide pool seams; tests inject a
@@ -631,7 +640,9 @@ export async function writeExtractionCache(options: ExtractionCacheWriteOptions)
         `Extraction cache write for ${key} abandoned: an existing derivation record was adopted; ` +
           `${allocated.length} asset(s) allocated by this attempt were released.`,
       );
-      return;
+      // The adopted record's images are the LIVE asset ids a server-backed
+      // caller should use — this attempt's own ids were just released.
+      return existing.images;
     }
 
     const record: DerivationRecord = {
@@ -653,6 +664,7 @@ export async function writeExtractionCache(options: ExtractionCacheWriteOptions)
     if (aliasKey && aliasIdentity) {
       await writeAliasRecord(options.kv, aliasKey, aliasIdentity[0], record);
     }
+    return images;
   } catch (error) {
     if (isRouteLevelKVError(error)) {
       // The KV route itself is gone (K5): disable caching for a bounded
@@ -666,8 +678,9 @@ export async function writeExtractionCache(options: ExtractionCacheWriteOptions)
     }
     // Release every asset allocated in this partial attempt so the pool does
     // not accumulate orphans. The KV record was only written last, so nothing
-    // references the released ids.
+    // references the released ids. No live ids remain to hand back.
     await releaseAllocatedAssets(allocated, remove, 'a failed cache write');
+    return [];
   }
 }
 
@@ -785,18 +798,36 @@ export interface ExtractionCacheLookupOptions {
   baseUrl?: string;
   /** Fetch implementation; defaults to the global one. Injectable for tests. */
   fetchImpl?: typeof fetch;
+  /**
+   * How the rebuilt result's `imageMapping` / `pdfImages` are expressed
+   * (RFC #1153 part 2 section C). `'data-url'` (default) rebuilds image bytes
+   * client-side exactly as a real extraction returns them. `'asset-id'` —
+   * used by a server-backed deployment — rebuilds WITHOUT materializing image
+   * bytes: `metadata.imageMapping` maps `img_N` → the image's pool asset id
+   * and `metadata.pdfImages[].assetId` carries the same id, so a cache hit
+   * feeds generation by id instead of shipping bytes to the client. In
+   * `'asset-id'` mode the per-image byte reads are skipped entirely (the
+   * bytes are resolved server-side at prompt-assembly time), so a record
+   * whose image assets were reclaimed is still a hit for the text — the
+   * generation-time resolution reports the missing image then.
+   */
+  imageMappingMode?: 'data-url' | 'asset-id';
 }
 
 /**
  * Look up a cached extraction derivation and, on a hit, rebuild exactly the
- * parse result the page consumes (images back to data URLs).
+ * parse result the page consumes (images back to data URLs — or, in
+ * `'asset-id'` mode, images as their pool asset ids with no bytes
+ * materialized, per RFC #1153 part 2 C).
  *
  * Returns `null` on ANY inconsistency — no record, a record whose extractor
  * identity disagrees (and is not a recorded alias), an artifact or image asset
  * that does not resolve, bytes that cannot be read, a record whose image list
  * disagrees with the stored artifact's own image asset ids, or a KV/pool
  * transport failure — so the caller treats it as a miss and runs the real
- * extraction. A hit is logged so it is observable.
+ * extraction. (In `'asset-id'` mode the per-image byte reads are skipped, so
+ * only the artifact read and the record/artifact consistency check can miss.)
+ * A hit is logged so it is observable.
  */
 export async function lookupCachedExtraction(
   options: ExtractionCacheLookupOptions,
@@ -811,6 +842,10 @@ export async function lookupCachedExtraction(
   // (RFC #1153 part 1, M1). `undefined` until the key is built, so the catch
   // below can still name the key when the failure comes after it.
   let key: string | undefined;
+  // Asset-id mode (part 2 C): the rebuilt result names pool asset ids instead
+  // of image bytes, so the per-image byte reads below are skipped and the
+  // record's asset ids flow straight into the result.
+  const assetIdMode = options.imageMappingMode === 'asset-id';
   try {
     key = extractionCacheKey(
       options.contentDigest,
@@ -887,34 +922,45 @@ export async function lookupCachedExtraction(
       );
       return null;
     }
-    // Every image asset must resolve and be readable; a record naming a
-    // partially-reclaimed cache is a miss, and the real extraction re-derives.
-    const dataUrls: string[] = [];
-    for (const image of record.images) {
-      const dataUrl = await withAssetUrl(
-        image.assetId,
-        async (url) => {
-          if (!url) {
-            log.warn(
-              `Extraction cache miss for ${key}: image asset ${image.assetId} does not resolve.`,
-            );
-            return null;
-          }
-          return fetchBytesAsDataUrl(url, image.mimeType, fetchImpl);
-        },
-        options.pool,
-      );
-      if (!dataUrl) {
-        log.warn(
-          `Extraction cache miss for ${key}: image bytes for ${image.assetId} could not be read.`,
+    // Every image asset must resolve and be readable in data-url mode; a
+    // record naming a partially-reclaimed cache is a miss, and the real
+    // extraction re-derives. In asset-id mode (RFC #1153 part 2 C) the image
+    // bytes are deliberately NOT materialized client-side — the generation
+    // routes resolve the ids server-side at prompt-assembly time — so the
+    // per-image byte reads are skipped and the record's asset ids flow into
+    // the rebuilt result verbatim.
+    const imagePayloads: string[] = [];
+    if (assetIdMode) {
+      imagePayloads.push(...record.images.map((image) => image.assetId));
+    } else {
+      for (const image of record.images) {
+        const dataUrl = await withAssetUrl(
+          image.assetId,
+          async (url) => {
+            if (!url) {
+              log.warn(
+                `Extraction cache miss for ${key}: image asset ${image.assetId} does not resolve.`,
+              );
+              return null;
+            }
+            return fetchBytesAsDataUrl(url, image.mimeType, fetchImpl);
+          },
+          options.pool,
         );
-        return null;
+        if (!dataUrl) {
+          log.warn(
+            `Extraction cache miss for ${key}: image bytes for ${image.assetId} could not be read.`,
+          );
+          return null;
+        }
+        imagePayloads.push(dataUrl);
       }
-      dataUrls.push(dataUrl);
     }
-    const result = rebuildResult(artifact, record, dataUrls);
+    const result = rebuildResult(artifact, record, imagePayloads, assetIdMode);
     log.info(
-      `Extraction cache hit for ${key}: rebuilt ${record.images.length} image(s) from the pool.`,
+      `Extraction cache hit for ${key}: rebuilt ${record.images.length} image(s) ${
+        assetIdMode ? 'by asset id' : 'from the pool'
+      }.`,
     );
     return result;
   } catch (error) {
@@ -1010,11 +1056,21 @@ async function fetchBytesAsDataUrl(
   }
 }
 
-/** Rebuild the exact parse-result shape a real extraction returns. */
+/**
+ * Rebuild the exact parse-result shape a real extraction returns.
+ *
+ * In `assetIdMode` (RFC #1153 part 2 C) the payloads are pool asset ids, not
+ * data URLs: `metadata.imageMapping` maps `img_N` → asset id, each
+ * `metadata.pdfImages` entry carries the id on `assetId` (with `src` left
+ * empty — no image bytes were materialized), and the top-level `images` list
+ * is empty for the same reason. Browser-backed hits keep the data-URL shape
+ * byte-for-byte.
+ */
 function rebuildResult(
   artifact: StoredExtractionArtifact,
   record: DerivationRecord,
-  dataUrls: readonly string[],
+  imagePayloads: readonly string[],
+  assetIdMode = false,
 ): ParsedPdfContent {
   const metadata = {
     pageCount: artifact.metadata.pageCount ?? 0,
@@ -1028,14 +1084,15 @@ function rebuildResult(
   if (record.images.length > 0 || carriesImageShape) {
     metadata.imageMapping =
       record.images.length > 0
-        ? Object.fromEntries(record.images.map((image, index) => [image.id, dataUrls[index]!]))
+        ? Object.fromEntries(record.images.map((image, index) => [image.id, imagePayloads[index]!]))
         : {};
     metadata.pdfImages =
       record.images.length > 0
         ? record.images.map((image, index) => ({
             id: image.id,
-            src: dataUrls[index]!,
+            src: assetIdMode ? '' : imagePayloads[index]!,
             pageNumber: image.pageNumber ?? 1,
+            ...(assetIdMode && image.assetId ? { assetId: image.assetId } : {}),
             ...(image.description !== undefined ? { description: image.description } : {}),
             ...(image.width !== undefined ? { width: image.width } : {}),
             ...(image.height !== undefined ? { height: image.height } : {}),
@@ -1044,7 +1101,7 @@ function rebuildResult(
   }
   return {
     text: artifact.text,
-    images: [...dataUrls],
+    images: assetIdMode ? [] : [...imagePayloads],
     ...(artifact.tables !== undefined ? { tables: artifact.tables } : {}),
     ...(artifact.formulas !== undefined ? { formulas: artifact.formulas } : {}),
     ...(artifact.layout !== undefined ? { layout: artifact.layout } : {}),
@@ -1066,6 +1123,12 @@ export interface ExtractionFetchWithCacheOptions extends FetchExtractionResponse
   baseUrl?: string;
   /** Source-document pool asset id, recorded for lineage on the cache write. */
   sourceDocAssetId?: string;
+  /**
+   * How cache-rebuilt results express their images (`'data-url'` by default;
+   * `'asset-id'` on a server-backed deployment — see
+   * `ExtractionCacheLookupOptions.imageMappingMode`).
+   */
+  imageMappingMode?: 'data-url' | 'asset-id';
   /**
    * KV store for derivation records. Omitted in production, where the
    * browser-wide store is resolved lazily (and a resolution failure disables
@@ -1092,10 +1155,14 @@ export interface ExtractionFetchWithCacheResult {
   /**
    * The best-effort cache write, detached from the caller's result (L5). The
    * extraction result is returned WITHOUT waiting for the write; awaiting this
-   * promise is only for tests or observability. A page teardown mid-write can
-   * abandon the write — best-effort by contract.
+   * promise is only for tests, observability, or — on a server-backed
+   * deployment — learning the derived image asset ids without materializing
+   * image bytes (RFC #1153 part 2 B): it resolves to the derived images
+   * (extraction id → pool asset id), or an empty array when the write was
+   * skipped or failed. A page teardown mid-write can abandon the write —
+   * best-effort by contract.
    */
-  cacheWrite?: Promise<void>;
+  cacheWrite?: Promise<DerivedExtractionImage[]>;
 }
 
 /**
@@ -1146,8 +1213,19 @@ export async function fetchExtractionWithCache(
       extractorVersion: options.extractorVersion,
       baseUrl: options.baseUrl,
       fetchImpl: options.fetchImpl,
+      imageMappingMode: options.imageMappingMode,
     });
-    if (cached) return { data: cached, cacheHit: true };
+    if (cached) {
+      // The derivation exists (this hit proves it); point the material library
+      // entry at it by its key parts, best-effort.
+      recordMaterialDerivationBestEffort(
+        options.contentDigest,
+        options.domain ?? 'doc',
+        options.extractorId,
+        options.extractorVersion,
+      );
+      return { data: cached, cacheHit: true };
+    }
   }
 
   // 2. Real extraction (asset-id JSON form with the legacy byte fallback).
@@ -1201,18 +1279,56 @@ export async function fetchExtractionWithCache(
       ...(aliasExtractor ? { aliasExtractor } : {}),
       sourceDocAssetId: options.sourceDocAssetId,
       result: data,
-    }).catch((error) => {
-      // Defensive: `writeExtractionCache` already logs its own failures; this
-      // handler only guarantees the detached write can never surface as an
-      // unhandled rejection in the page's flow.
-      log.error(
-        'Failed to cache the extraction derivation; the extraction result is still returned:',
-        error,
-      );
-    });
+    })
+      .then((derivedImages) => {
+        // The derivation record now exists; point the material library entry at
+        // it by its key parts, best-effort. Runs detached like the write itself.
+        if (options.contentDigest) {
+          recordMaterialDerivationBestEffort(
+            options.contentDigest,
+            options.domain ?? 'doc',
+            actualExtractorId,
+            actualExtractorVersion,
+          );
+        }
+        return derivedImages;
+      })
+      .catch((error) => {
+        // Defensive: `writeExtractionCache` already logs its own failures; this
+        // handler only guarantees the detached write can never surface as an
+        // unhandled rejection in the page's flow, and hands back no live ids.
+        log.error(
+          'Failed to cache the extraction derivation; the extraction result is still returned:',
+          error,
+        );
+        return [];
+      });
     return { data, cacheHit: false, cacheWrite };
   }
   return { data, cacheHit: false };
+}
+
+/**
+ * Best-effort material-library pointer: append the extraction identity
+ * (domain × extractor@version) to the library entry for these bytes, so an
+ * agent consulting the entry can find the derivation record (and through it
+ * the derived image assets) by the key parts. Any failure is logged inside
+ * the library module and never affects the extraction flow.
+ */
+function recordMaterialDerivationBestEffort(
+  contentDigest: string,
+  domain: ExtractionCacheDomain,
+  extractorId: string,
+  extractorVersion: string,
+): void {
+  if (!contentDigest || !extractorId || !extractorVersion) return;
+  void import('@/lib/materials/library')
+    .then(({ recordMaterialDerivation }) =>
+      recordMaterialDerivation(contentDigest, { domain, extractorId, extractorVersion }),
+    )
+    .catch((error) => {
+      log.warn('Failed to record the material library derivation pointer:', error);
+    });
 }
 
 // ─── In-run extraction dedupe (RFC #1153 part 1, K3) ──────────────────────────
@@ -1246,16 +1362,18 @@ export interface InRunExtractionKey {
  * re-invokes instead of re-receiving the stale rejection. A per-run instance
  * is created once per generation run; the memoized promises live exactly as
  * long as the run.
+ *
+ * Generic over the extraction's result type: the page memoizes the full
+ * `fetchExtractionWithCache` outcome (data + best-effort cache write), so a
+ * deduplicated second source still reaches the shared derivation's image
+ * asset ids through the winner's `cacheWrite` (RFC #1153 part 2 B).
  */
 export function createExtractionDeduplicator(): {
-  run: (
-    key: InRunExtractionKey,
-    extraction: () => Promise<ParsedPdfContent>,
-  ) => Promise<ParsedPdfContent>;
+  run: <T>(key: InRunExtractionKey, extraction: () => Promise<T>) => Promise<T>;
 } {
-  const inflight = new Map<string, Promise<ParsedPdfContent>>();
+  const inflight = new Map<string, Promise<unknown>>();
   return {
-    run(key, extraction) {
+    run: <T>(key: InRunExtractionKey, extraction: () => Promise<T>): Promise<T> => {
       const memoKey = extractionCacheKey(
         key.contentDigest,
         key.extractorId,
@@ -1264,7 +1382,7 @@ export function createExtractionDeduplicator(): {
         key.domain,
       );
       const existing = inflight.get(memoKey);
-      if (existing) return existing;
+      if (existing) return existing as Promise<T>;
       const promise = extraction();
       inflight.set(memoKey, promise);
       // L3: a rejected shared promise must not poison later retries in the

--- a/lib/document/extraction-cache.ts
+++ b/lib/document/extraction-cache.ts
@@ -31,7 +31,10 @@ import type { AssetMeta } from '@openmaic/dsl';
 import { BrowserKVStore, HttpKVStore, HttpKVStoreError, type KVStore } from '@openmaic/storage';
 
 import type { FetchExtractionResponseOptions } from '@/lib/document/extract-source';
-import { fetchExtractionResponse } from '@/lib/document/extract-source';
+import {
+  DEFAULT_INGEST_AWAIT_TIMEOUT_MS,
+  fetchExtractionResponse,
+} from '@/lib/document/extract-source';
 import {
   getDocumentExtractorManifestEntry,
   getMediaExtractorManifestEntry,
@@ -48,8 +51,27 @@ import {
   isBrowserPersistenceEnabled,
 } from '@/lib/persistence/bootstrap';
 import type { ParsedPdfContent } from '@/lib/types/pdf';
+import { mapWithConcurrency } from '@/lib/utils/concurrency';
 
 const log = createLogger('ExtractionCache');
+
+/**
+ * Concurrency bound for the asset-id existence probes (review P3/O3): a hit's
+ * per-image probes are identity reads (HEAD / registry lookup) that can run in
+ * parallel, so they are dispatched in batches of this size instead of one
+ * sequential round-trip per image.
+ */
+const ASSET_PROBE_CONCURRENCY = 8;
+
+/**
+ * Aggregate budget for the WHOLE probe phase of one hit, reused from the
+ * ingest drain (`DEFAULT_INGEST_AWAIT_TIMEOUT_MS`). Each probe has its own
+ * per-probe deadline, but N sequential probes would still cost N × deadline
+ * on a stalled pool; this budget caps the phase, and an exhausted budget
+ * degrades the hit to a miss (the real extraction runs) with one warn —
+ * consistent with the degrade-to-miss contract.
+ */
+const ASSET_PROBE_BUDGET_MS = DEFAULT_INGEST_AWAIT_TIMEOUT_MS;
 
 /** Key-prefix of every derivation record; bump the `v3` on a record-shape change. */
 export const EXTRACTION_CACHE_KEY_PREFIX = 'derived-extraction:v3';
@@ -799,6 +821,12 @@ export interface ExtractionCacheLookupOptions {
   /** Fetch implementation; defaults to the global one. Injectable for tests. */
   fetchImpl?: typeof fetch;
   /**
+   * Aggregate budget for the asset-id existence probe phase (review P3/O3),
+   * in milliseconds. Defaults to the 15 s ingest-drain constant; injectable
+   * so tests can drive a tiny budget instead of waiting the full 15 s.
+   */
+  assetProbeBudgetMs?: number;
+  /**
    * How the rebuilt result's `imageMapping` / `pdfImages` are expressed
    * (RFC #1153 part 2 section C). `'data-url'` (default) rebuilds image bytes
    * client-side exactly as a real extraction returns them. `'asset-id'` —
@@ -937,15 +965,47 @@ export async function lookupCachedExtraction(
     // record whose image assets all still exist serves a hit.
     const imagePayloads: string[] = [];
     if (assetIdMode) {
-      for (const image of record.images) {
-        const exists = await assetRefExists(image.assetId, options.pool);
-        if (!exists) {
+      // O3: the probes run with bounded concurrency (batches of 8) AND an
+      // aggregate budget. N sequential HEADs would cost N round-trips on every
+      // hit (and N × per-probe deadline on a stalled pool); batching keeps the
+      // healthy-path cost to ceil(N / 8) waves, and the budget caps the whole
+      // phase — an exhausted budget degrades this hit to a miss with ONE warn
+      // (the real extraction runs), so a stalled persistence endpoint cannot
+      // hold the hit path for N × per-probe timeout.
+      const assetProbeBudgetMs = options.assetProbeBudgetMs ?? ASSET_PROBE_BUDGET_MS;
+      let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+      const probeOutcome = await Promise.race([
+        mapWithConcurrency(record.images, ASSET_PROBE_CONCURRENCY, (image) =>
+          assetRefExists(image.assetId, options.pool),
+        ).then(
+          (results) => ({ status: 'done' as const, results }),
+          (error) => ({ status: 'error' as const, error }),
+        ),
+        new Promise<{ status: 'timeout' }>((resolve) => {
+          budgetTimer = setTimeout(() => resolve({ status: 'timeout' }), assetProbeBudgetMs);
+        }),
+      ]);
+      if (budgetTimer !== undefined) clearTimeout(budgetTimer);
+      if (probeOutcome.status === 'timeout') {
+        log.warn(
+          `Extraction cache miss for ${key}: image asset existence probes exceeded the ` +
+            `${assetProbeBudgetMs}ms aggregate budget; running the real extraction.`,
+        );
+        return null;
+      }
+      if (probeOutcome.status === 'error') {
+        // A probe transport failure degrades through the outer catch below
+        // (warn + miss), exactly like the other pool failures.
+        throw probeOutcome.error;
+      }
+      for (let i = 0; i < record.images.length; i++) {
+        if (!probeOutcome.results[i]) {
           log.warn(
-            `Extraction cache miss for ${key}: image asset ${image.assetId} no longer exists (reclaim = miss).`,
+            `Extraction cache miss for ${key}: image asset ${record.images[i]!.assetId} no longer exists (reclaim = miss).`,
           );
           return null;
         }
-        imagePayloads.push(image.assetId);
+        imagePayloads.push(record.images[i]!.assetId);
       }
     } else {
       for (const image of record.images) {

--- a/lib/document/extraction-materialization.ts
+++ b/lib/document/extraction-materialization.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-source image transport for a generation run (RFC #1153 part 2, N2/N4).
+ *
+ * A server-backed deployment names extracted images by their allocated pool
+ * asset ids (the extraction cache rebuilds them by id); a browser-backed
+ * deployment materializes base64 data URLs into IndexedDB exactly as before.
+ * Part 2 B awaited the best-effort cache write to learn the ids and decided
+ * the byte fallback once for the WHOLE bundle — so one source whose cache
+ * write failed silently lost its images. These helpers keep the await bounded
+ * and the fallback decision PER SOURCE:
+ *
+ * - `awaitWithFallback` races a best-effort write against a time budget so a
+ *   stalled pool/KV never gates the user's generation (the detached write
+ *   keeps running and benefits the NEXT run).
+ * - `materializeBundleImages` decides per source: a source whose images ALL
+ *   carry allocated asset ids is fed by id; a source with any image lacking
+ *   an id (a failed best-effort cache write, a legacy session) materializes
+ *   ITS images into IndexedDB as data URLs. The resulting `imageMapping` may
+ *   therefore MIX asset ids and data URLs — the generation routes and
+ *   `resolveImageIds` are shape-based and accept both.
+ *
+ * Client-reachable module (imported by `app/generation-preview/page.tsx` and
+ * the classroom resume path): it must never import server-only code.
+ */
+import type { ParsedDocumentImage } from './bundle';
+
+/**
+ * Race a promise against a time budget, resolving `fallback` when the budget
+ * expires first. The racing promise keeps running detached — its work is
+ * best-effort by contract and still lands for the NEXT run. A rejection of
+ * the racing promise propagates only when it settles first; callers attach
+ * their own `.catch` for the best-effort case.
+ */
+export async function awaitWithFallback<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: T,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((resolve) => {
+        timer = setTimeout(() => resolve(fallback), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export interface MaterializedBundleImages {
+  /**
+   * IndexedDB storage ids aligned with the input image order; `undefined`
+   * where the image is fed by its allocated asset id (no bytes materialized).
+   */
+  storageIds: Array<string | undefined>;
+}
+
+/**
+ * Decide the byte transport per SOURCE (RFC #1153 part 2, N4): a server-backed
+ * source whose images ALL carry allocated asset ids is fed by id; any source
+ * with an image lacking an id materializes ITS image bytes through `store`
+ * (IndexedDB) as data URLs. One source's failure never drops another source's
+ * images — the bundle-level all-or-nothing decision is gone. Browser-backed
+ * runs materialize everything, exactly as before.
+ */
+export async function materializeBundleImages(
+  serverBacked: boolean,
+  images: ReadonlyArray<ParsedDocumentImage & { visionPriority: number }>,
+  store: (images: Array<ParsedDocumentImage & { visionPriority: number }>) => Promise<string[]>,
+): Promise<MaterializedBundleImages> {
+  const storageIds: Array<string | undefined> = new Array(images.length).fill(undefined);
+  if (!serverBacked) {
+    const stored = await store([...images]);
+    stored.forEach((storageId, index) => {
+      storageIds[index] = storageId;
+    });
+    return { storageIds };
+  }
+  const bySource = new Map<string, number[]>();
+  images.forEach((image, index) => {
+    const key = image.sourceDocumentId ?? 'unknown';
+    const group = bySource.get(key) ?? [];
+    group.push(index);
+    bySource.set(key, group);
+  });
+  for (const indices of bySource.values()) {
+    const group = indices.map((index) => images[index]!);
+    if (group.every((image) => image.assetId)) continue;
+    const stored = await store(group);
+    stored.forEach((storageId, offset) => {
+      storageIds[indices[offset]!] = storageId;
+    });
+  }
+  return { storageIds };
+}

--- a/lib/materials/library.ts
+++ b/lib/materials/library.ts
@@ -1,0 +1,447 @@
+/**
+ * The material library manifest (RFC #1153 part 2).
+ *
+ * A per-principal, KV-backed (`account` scope) manifest of the source
+ * documents a user has imported. Entries are minted at upload time, keyed by
+ * the SHA-256 content digest of the bytes: re-importing the same bytes
+ * refreshes the SAME entry (`addedAt` bumped, `assetId` advanced to the newest
+ * allocation) instead of minting a duplicate. Removing a selected material
+ * before generation never removes the library entry — the library is durable
+ * memory of what the user imported; the pool-entry release stays as-is.
+ *
+ * The two agent-facing atomic tools of RFC design §4 live here and are kept
+ * pure and JSON-serializable in/out so a later agent-tool wrapper is trivial:
+ *
+ * - `listMaterials()` — metadata only, newest first.
+ * - `readMaterial(assetId)` — bytes through the existing pool seams.
+ *
+ * Lineage is NOT duplicated into this manifest. A source entry points at the
+ * part-1 derivation records that were produced from its bytes by their key
+ * parts — content digest (already the entry key) × domain × extractor@version
+ * (`derivations`) — so the extracted images and their lineage stay owned by
+ * the derivation records and are reachable from the entry without copying
+ * asset ids into two places.
+ *
+ * Degradation is the part-1 pattern: the KV store is browser-backed by
+ * default and server-backed under the same persistence bootstrap flag, and
+ * every read/write is defensive against an unavailable backend. A KV failure
+ * answers an empty list (with one warn per disable episode) and never throws
+ * to the caller; `readMaterial` needs no KV at all and only depends on the
+ * pool. This is a client-reachable module: it must never import server-only
+ * code (the import-graph guard in
+ * `tests/document/material-library-manifest.test.ts` enforces that).
+ */
+import { BrowserKVStore, HttpKVStore, HttpKVStoreError, type KVStore } from '@openmaic/storage';
+
+import { createLogger } from '@/lib/logger';
+import type { AssetPoolStore } from '@/lib/media/asset-pool-config';
+import { withAssetUrl } from '@/lib/media/use-asset-url';
+import {
+  getPersistenceRequestHeaders,
+  isBrowserPersistenceEnabled,
+} from '@/lib/persistence/bootstrap';
+
+const log = createLogger('MaterialLibrary');
+
+/** Key-prefix of every library entry; bump the `v1` on a record-shape change. */
+export const MATERIAL_LIBRARY_KEY_PREFIX = 'material-library:v1';
+
+/** KV scope the manifest lives under: `account`, like the extraction cache. */
+export const MATERIAL_LIBRARY_KV_SCOPE = 'account' as const;
+
+/**
+ * One derivation pointer: the key parts of a part-1 derivation record
+ * (digest × domain × extractor@version) that were produced from this entry's
+ * bytes. The record's full cache key is
+ * `extractionCacheKey(contentDigest, extractorId, extractorVersion,
+ * configFingerprint, domain)`; the config-fingerprint half is per-run
+ * deployment config, so the agent resolves it with `computeConfigFingerprint`
+ * from `lib/document/extraction-cache.ts` (managed providers share the stable
+ * `'managed'` bucket).
+ */
+export interface MaterialDerivationRef {
+  /** Which extraction path produced the derivation (`doc` vs `media`). */
+  domain: 'doc' | 'media';
+  extractorId: string;
+  extractorVersion: string;
+}
+
+/**
+ * One library entry = the reviewable contract of RFC #1153 part 2.
+ *
+ * Keyed by `contentDigest` (same bytes re-imported = same entry). `assetId`
+ * names the NEWEST allocation of those bytes, so a durable reference an agent
+ * hands downstream stays resolvable even after the upload-time pool entry was
+ * released; `addedAt` is the newest import instant. `derivations` are pointers
+ * to the part-1 derivation records, appended once the extraction identity is
+ * known — never a copy of their lineage.
+ */
+export interface MaterialLibraryEntry {
+  /** Pool asset id of the newest allocation of these bytes. */
+  assetId: string;
+  /** SHA-256 of the bytes (lowercase hex); the entry key. */
+  contentDigest: string;
+  /** Display name of the imported file (the newest import's name). */
+  name: string;
+  /** Canonical MIME type of the imported file, when known. */
+  mimeType?: string;
+  /** Byte length of the imported file. */
+  size: number;
+  /** ISO-8601 instant of the newest import. */
+  addedAt: string;
+  /** Pointers to part-1 derivation records by their key parts. */
+  derivations?: MaterialDerivationRef[];
+}
+
+/** The exact KV key for one entry. */
+export function materialLibraryKey(contentDigest: string): string {
+  return `${MATERIAL_LIBRARY_KEY_PREFIX}:${contentDigest}`;
+}
+
+// ─── KV wiring (browser-backed default, HTTP-backed under persistence) ───────
+
+let libraryKv: KVStore | undefined;
+
+/**
+ * The browser-wide KV store for the material library, wired exactly like the
+ * extraction cache and the asset pool: browser-backed by default, and
+ * server-backed under the same persistence bootstrap flag
+ * (`NEXT_PUBLIC_PERSISTENCE=1`), where the account scope is served by the
+ * persistence API and the device scope stays on a local store. Every library
+ * operation is defensive against this store failing, so an unavailable
+ * backend only costs the manifest, never the user's upload or generation.
+ */
+export function getMaterialLibraryKV(): KVStore {
+  return (libraryKv ??= resolveConfiguredMaterialLibraryKV());
+}
+
+function resolveConfiguredMaterialLibraryKV(): KVStore {
+  if (isBrowserPersistenceEnabled()) {
+    return new HttpKVStore({
+      baseUrl: '/api/persistence',
+      headers: () => getPersistenceRequestHeaders(),
+      deviceStore: new BrowserKVStore(),
+    });
+  }
+  if (typeof window === 'undefined') {
+    throw new Error('The material library KV store requires browser storage.');
+  }
+  return new BrowserKVStore();
+}
+
+/** Test-only: clear the module singleton between tests. */
+export function resetMaterialLibraryForTests(): void {
+  libraryKv = undefined;
+  libraryDisabledUntilEpochMs = 0;
+}
+
+/**
+ * Test-only: replace the module KV store. Pass `null` to restore lazy
+ * resolution through the configured backend. The agent-facing read/write
+ * tools take no store arguments (they stay pure JSON in/out), so this is the
+ * injection point tests use to drive a fake KV.
+ */
+export function setMaterialLibraryKVForTests(kv: KVStore | null): void {
+  libraryKv = kv ?? undefined;
+}
+
+// ─── Bounded degradation (part-1 pattern) ────────────────────────────────────
+
+/**
+ * How long a route-level KV failure disables the library. The disable is
+ * timestamped, NOT permanent: a transient route-level 404 (a deploy window, a
+ * proxy 404 during rollout) must not kill the manifest for the tab lifetime,
+ * so the library re-probes the KV route once the window expires.
+ */
+const LIBRARY_DISABLE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Module-level (tab-wide) library disable, expressed as the epoch-ms instant
+ * the disable window ends; `0` means not disabled. Set once when the KV
+ * backend answers with a route-level failure (the KV route itself is gone, as
+ * with `NEXT_PUBLIC_PERSISTENCE=1` today): until the window expires every
+ * read answers an empty list and every write is skipped, so the degradation
+ * is quiet (one warn per disable episode) and cheap. After expiry a fresh
+ * route-level failure starts a new episode with its own single warn.
+ * Transient failures (network blips) keep the per-op behavior.
+ */
+let libraryDisabledUntilEpochMs = 0;
+
+/** Whether the library is inside a disable window right now. */
+function isLibraryDisabled(): boolean {
+  return libraryDisabledUntilEpochMs > Date.now();
+}
+
+/** A route-level KV failure: an HTTP 404 that is NOT the store's key-miss. */
+function isRouteLevelKVError(error: unknown): boolean {
+  return (
+    error instanceof HttpKVStoreError && error.status === 404 && error.code !== 'KEY_NOT_FOUND'
+  );
+}
+
+/** Disable the library for one window, logging exactly ONE warn per episode. */
+function disableLibraryForWindow(error: unknown): void {
+  if (isLibraryDisabled()) return;
+  libraryDisabledUntilEpochMs = Date.now() + LIBRARY_DISABLE_TTL_MS;
+  log.warn(
+    `The material library KV route is unreachable; disabling the library manifest for the next ${Math.round(
+      LIBRARY_DISABLE_TTL_MS / 60000,
+    )} minutes:`,
+    error,
+  );
+}
+
+// ─── Entry validation ─────────────────────────────────────────────────────────
+
+function isValidLibraryEntry(value: unknown): value is MaterialLibraryEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const entry = value as Partial<MaterialLibraryEntry>;
+  const derivationsValid =
+    entry.derivations === undefined ||
+    (Array.isArray(entry.derivations) &&
+      entry.derivations.every(
+        (ref) =>
+          typeof ref === 'object' &&
+          ref !== null &&
+          (ref.domain === 'doc' || ref.domain === 'media') &&
+          typeof ref.extractorId === 'string' &&
+          typeof ref.extractorVersion === 'string',
+      ));
+  return (
+    typeof entry.assetId === 'string' &&
+    typeof entry.contentDigest === 'string' &&
+    typeof entry.name === 'string' &&
+    (entry.mimeType === undefined || typeof entry.mimeType === 'string') &&
+    typeof entry.size === 'number' &&
+    typeof entry.addedAt === 'string' &&
+    derivationsValid
+  );
+}
+
+// ─── Write points ────────────────────────────────────────────────────────────
+
+export interface UpsertMaterialLibraryEntryInput {
+  /** Pool asset id of the newest allocation of these bytes. */
+  assetId: string;
+  /** SHA-256 of the bytes; the entry key. */
+  contentDigest: string;
+  /** Display name of the imported file. */
+  name: string;
+  /** Canonical MIME type of the imported file, when known. */
+  mimeType?: string;
+  /** Byte length of the imported file. */
+  size: number;
+}
+
+/**
+ * Upsert one library entry keyed by `contentDigest` (the upload-time write
+ * point, RFC #1153 part 2 section A). Same bytes re-imported = same entry:
+ * `addedAt` is refreshed to now and `assetId` advanced to the newest
+ * allocation; the entry's derivation pointers are preserved across the
+ * refresh. Best-effort by contract: a KV failure is logged and never fails
+ * the caller's upload (a route-level KV failure disables the manifest for a
+ * bounded window, mirroring part 1's cache degradation).
+ */
+export async function upsertMaterialLibraryEntry(
+  input: UpsertMaterialLibraryEntryInput,
+): Promise<void> {
+  if (isLibraryDisabled()) return;
+  let kv: KVStore;
+  try {
+    kv = getMaterialLibraryKV();
+  } catch (error) {
+    log.warn('The material library KV store is unavailable; skipping the library write:', error);
+    return;
+  }
+
+  const key = materialLibraryKey(input.contentDigest);
+  try {
+    const existing = await kv.get<MaterialLibraryEntry>(key, MATERIAL_LIBRARY_KV_SCOPE);
+    const entry: MaterialLibraryEntry = {
+      assetId: input.assetId,
+      contentDigest: input.contentDigest,
+      name: input.name,
+      ...(input.mimeType !== undefined ? { mimeType: input.mimeType } : {}),
+      size: input.size,
+      addedAt: new Date().toISOString(),
+      // Preserve the derivation pointers across a same-digest re-import.
+      ...(existing && isValidLibraryEntry(existing) && existing.derivations
+        ? { derivations: existing.derivations }
+        : {}),
+    };
+    await kv.set(key, entry, MATERIAL_LIBRARY_KV_SCOPE);
+  } catch (error) {
+    if (isRouteLevelKVError(error)) {
+      disableLibraryForWindow(error);
+    } else {
+      log.warn(
+        `Failed to upsert the material library entry for "${input.name}"; the upload is unaffected:`,
+        error,
+      );
+    }
+  }
+}
+
+/**
+ * Append a derivation pointer (domain × extractor@version) to the entry for
+ * these bytes. Called from the extraction-cache composition once the
+ * extraction identity is known (hit or miss), so the entry names the
+ * derivation records an agent can consult for derived images and lineage. A
+ * duplicate identity is a no-op; a missing entry is skipped with a warn; a KV
+ * failure is logged and ignored (best-effort, like every library write).
+ */
+export async function recordMaterialDerivation(
+  contentDigest: string,
+  ref: MaterialDerivationRef,
+): Promise<void> {
+  if (isLibraryDisabled()) return;
+  let kv: KVStore;
+  try {
+    kv = getMaterialLibraryKV();
+  } catch (error) {
+    log.warn(
+      'The material library KV store is unavailable; skipping the derivation record:',
+      error,
+    );
+    return;
+  }
+
+  const key = materialLibraryKey(contentDigest);
+  try {
+    const existing = await kv.get<MaterialLibraryEntry>(key, MATERIAL_LIBRARY_KV_SCOPE);
+    if (!existing || !isValidLibraryEntry(existing)) {
+      // No upload-time entry exists for these bytes (a legacy session, or the
+      // upload-time library write never settled). The pointer is best-effort —
+      // there is nothing to point at, and this is a normal condition, not an
+      // anomaly worth a warn.
+      log.debug(
+        `No material library entry exists for digest ${contentDigest}; skipping the derivation pointer.`,
+      );
+      return;
+    }
+    const derivations = existing.derivations ?? [];
+    const alreadyRecorded = derivations.some(
+      (item) =>
+        item.domain === ref.domain &&
+        item.extractorId === ref.extractorId &&
+        item.extractorVersion === ref.extractorVersion,
+    );
+    if (alreadyRecorded) return;
+    await kv.set(
+      key,
+      { ...existing, derivations: [...derivations, { ...ref }] },
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+  } catch (error) {
+    if (isRouteLevelKVError(error)) {
+      disableLibraryForWindow(error);
+    } else {
+      log.warn(`Failed to record the material derivation pointer for ${contentDigest}:`, error);
+    }
+  }
+}
+
+// ─── Read API (the agent-facing atomic tools) ────────────────────────────────
+
+/**
+ * List the material library, metadata only, newest first (`addedAt` desc).
+ * Any KV failure (an unavailable store, a route-level 404, unreadable
+ * entries) degrades to an EMPTY list with one warn per disable episode — an
+ * agent that cannot reach the manifest gets an honest "nothing known" instead
+ * of an error it cannot act on.
+ */
+export async function listMaterials(): Promise<MaterialLibraryEntry[]> {
+  if (isLibraryDisabled()) return [];
+  let kv: KVStore;
+  try {
+    kv = getMaterialLibraryKV();
+  } catch (error) {
+    log.warn('The material library KV store is unavailable; listing an empty library:', error);
+    return [];
+  }
+
+  try {
+    const keys = await kv.keys(MATERIAL_LIBRARY_KEY_PREFIX + ':', MATERIAL_LIBRARY_KV_SCOPE);
+    const entries = (
+      await Promise.all(
+        keys.map((key) => kv.get<MaterialLibraryEntry>(key, MATERIAL_LIBRARY_KV_SCOPE)),
+      )
+    ).filter((entry): entry is MaterialLibraryEntry => isValidLibraryEntry(entry));
+    return entries.sort(
+      (left, right) => new Date(right.addedAt).getTime() - new Date(left.addedAt).getTime(),
+    );
+  } catch (error) {
+    if (isRouteLevelKVError(error)) {
+      disableLibraryForWindow(error);
+    } else {
+      log.warn('Failed to list the material library; returning an empty list:', error);
+    }
+    return [];
+  }
+}
+
+/** The bytes of one library asset, JSON-serializable for an agent-tool wrapper. */
+export interface MaterialReadResult {
+  assetId: string;
+  /** The asset bytes as a base64 data URL (the existing pool transport). */
+  dataUrl: string;
+  mimeType?: string;
+  size?: number;
+}
+
+/**
+ * Read a material's bytes by its allocated asset id, through the existing
+ * pool seam (`withAssetUrl`, the same lease the renderer uses). Returns
+ * `null` when the asset does not resolve or its bytes cannot be read — never
+ * throws. KV is not involved: an asset id resolves in the pool directly, so
+ * `readMaterial` works even while the manifest itself is unreachable.
+ *
+ * The optional `pool` / `fetchImpl` are the test injection points; production
+ * omits them and `withAssetUrl` resolves the browser-wide pool itself (the
+ * shared owner module owns that access — see the asset-url-boundary guard),
+ * so the agent-facing signature stays `readMaterial(assetId)`.
+ */
+export async function readMaterial(
+  assetId: string,
+  pool?: AssetPoolStore,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MaterialReadResult | null> {
+  try {
+    return await withAssetUrl(
+      assetId,
+      async (url) => {
+        if (!url) return null;
+        try {
+          const response = await fetchImpl(url);
+          if (!response.ok) return null;
+          const blob = await response.blob();
+          if (blob.size === 0) return null;
+          return {
+            assetId,
+            dataUrl: await blobToDataUrl(blob),
+            ...(blob.type ? { mimeType: blob.type } : {}),
+            size: blob.size,
+          };
+        } catch {
+          return null;
+        }
+      },
+      pool,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Encode a Blob as a base64 data URL without a DOM FileReader (environment-agnostic). */
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return blob.arrayBuffer().then((buffer) => {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+    }
+    return `data:${blob.type || 'application/octet-stream'};base64,${btoa(binary)}`;
+  });
+}

--- a/lib/materials/library.ts
+++ b/lib/materials/library.ts
@@ -9,6 +9,15 @@
  * before generation never removes the library entry — the library is durable
  * memory of what the user imported; the pool-entry release stays as-is.
  *
+ * RFC §5 root model: each entry OWNS its reference. At upsert time the library
+ * allocates its OWN pool entry from the imported bytes (`putAsset` under
+ * library ownership — content addressing makes the second allocation
+ * physically free: the same blob, a new registry entry) and stores THAT id.
+ * The selection-entry lifecycle (part-0 removal, prep-timeout release) never
+ * touches the library's allocation, so `readMaterial` stays resolvable after
+ * removal and after a same-digest re-import swaps the id. Entry deletion — a
+ * later milestone — is what releases the library-owned allocation.
+ *
  * The two agent-facing atomic tools of RFC design §4 live here and are kept
  * pure and JSON-serializable in/out so a later agent-tool wrapper is trivial:
  *
@@ -35,6 +44,7 @@ import { BrowserKVStore, HttpKVStore, HttpKVStoreError, type KVStore } from '@op
 
 import { createLogger } from '@/lib/logger';
 import type { AssetPoolStore } from '@/lib/media/asset-pool-config';
+import { removeAsset, putAsset } from '@/lib/media/asset-pool';
 import { withAssetUrl } from '@/lib/media/use-asset-url';
 import {
   getPersistenceRequestHeaders,
@@ -70,14 +80,19 @@ export interface MaterialDerivationRef {
  * One library entry = the reviewable contract of RFC #1153 part 2.
  *
  * Keyed by `contentDigest` (same bytes re-imported = same entry). `assetId`
- * names the NEWEST allocation of those bytes, so a durable reference an agent
- * hands downstream stays resolvable even after the upload-time pool entry was
- * released; `addedAt` is the newest import instant. `derivations` are pointers
- * to the part-1 derivation records, appended once the extraction identity is
- * known — never a copy of their lineage.
+ * names the NEWEST **library-owned** allocation of those bytes: the library
+ * allocated it at upsert time with its own `putAsset`, so a durable reference
+ * an agent hands downstream stays resolvable even after the upload-time pool
+ * entry was released (part-0 removal, prep-timeout release). Only deleting the
+ * library entry — a later milestone — releases this allocation; a same-digest
+ * re-import swaps it for a fresh library-owned allocation and releases the
+ * previous one AFTER the entry points at the new id. `addedAt` is the newest
+ * import instant. `derivations` are pointers to the part-1 derivation
+ * records, appended once the extraction identity is known — never a copy of
+ * their lineage.
  */
 export interface MaterialLibraryEntry {
-  /** Pool asset id of the newest allocation of these bytes. */
+  /** Pool asset id of the NEWEST library-owned allocation of these bytes. */
   assetId: string;
   /** SHA-256 of the bytes (lowercase hex); the entry key. */
   contentDigest: string;
@@ -221,8 +236,8 @@ function isValidLibraryEntry(value: unknown): value is MaterialLibraryEntry {
 // ─── Write points ────────────────────────────────────────────────────────────
 
 export interface UpsertMaterialLibraryEntryInput {
-  /** Pool asset id of the newest allocation of these bytes. */
-  assetId: string;
+  /** The imported file bytes; the library allocates its OWN pool entry from them. */
+  file: Blob;
   /** SHA-256 of the bytes; the entry key. */
   contentDigest: string;
   /** Display name of the imported file. */
@@ -234,6 +249,23 @@ export interface UpsertMaterialLibraryEntryInput {
 }
 
 /**
+ * Union two derivation lists by their identity (domain × extractorId ×
+ * extractorVersion), preserving first-seen order. The merge-on-write pattern
+ * (N7) unions the freshly-read entry's derivations with the writer's own so a
+ * concurrent writer can never drop a pointer another writer appended.
+ */
+function unionDerivations(
+  left: readonly MaterialDerivationRef[] | undefined,
+  right: readonly MaterialDerivationRef[] | undefined,
+): MaterialDerivationRef[] {
+  const byIdentity = new Map<string, MaterialDerivationRef>();
+  for (const ref of [...(left ?? []), ...(right ?? [])]) {
+    byIdentity.set(`${ref.domain}:${ref.extractorId}:${ref.extractorVersion}`, ref);
+  }
+  return [...byIdentity.values()];
+}
+
+/**
  * Upsert one library entry keyed by `contentDigest` (the upload-time write
  * point, RFC #1153 part 2 section A). Same bytes re-imported = same entry:
  * `addedAt` is refreshed to now and `assetId` advanced to the newest
@@ -241,9 +273,23 @@ export interface UpsertMaterialLibraryEntryInput {
  * refresh. Best-effort by contract: a KV failure is logged and never fails
  * the caller's upload (a route-level KV failure disables the manifest for a
  * bounded window, mirroring part 1's cache degradation).
+ *
+ * Ownership (RFC §5 root model): the library allocates its OWN pool entry
+ * from `input.file` and stores that id, so the entry never points at the
+ * caller's selection entry (whose lifecycle — part-0 removal, prep-timeout
+ * release — releases it without the library's knowledge). A failed library
+ * allocation skips the upsert entirely with one warn; the caller's upload is
+ * unaffected. On a same-digest re-import the new library-owned id is
+ * allocated FIRST, the entry is written to point at it, and only THEN is the
+ * PREVIOUS library-owned allocation released best-effort (logged) — the entry
+ * never names a released id mid-swap.
+ *
+ * The optional `pool` is the test injection point; production omits it and
+ * `putAsset` / `removeAsset` resolve the browser-wide pool.
  */
 export async function upsertMaterialLibraryEntry(
   input: UpsertMaterialLibraryEntryInput,
+  pool?: AssetPoolStore,
 ): Promise<void> {
   if (isLibraryDisabled()) return;
   let kv: KVStore;
@@ -254,22 +300,59 @@ export async function upsertMaterialLibraryEntry(
     return;
   }
 
+  // The library-owned allocation, independent of the selection's upload-time
+  // entry. Content addressing makes it physically free (same blob, new
+  // registry entry); a failure skips the upsert — the upload is unaffected
+  // because the caller's own pool entry was already allocated separately.
+  const put = (data: Blob): Promise<string> => (pool ? pool.put(data) : putAsset(data));
+  const remove = (assetId: string): Promise<void> =>
+    pool ? pool.remove(assetId) : removeAsset(assetId);
+  let libraryAssetId: string;
+  try {
+    libraryAssetId = await put(input.file);
+  } catch (error) {
+    log.warn(
+      `Failed to allocate the library-owned pool entry for "${input.name}"; skipping the library upsert (the upload is unaffected):`,
+      error,
+    );
+    return;
+  }
+
   const key = materialLibraryKey(input.contentDigest);
   try {
+    // N7 merge-on-write: re-read once immediately before the set and merge
+    // with the freshly-read state, so two concurrent writers (a same-digest
+    // re-import racing a derivation record, or two imports) never drop each
+    // other's derivation pointers. The residual read→set last-writer window
+    // is milliseconds and accepted — the same class as the part-1 get→set
+    // acceptance.
     const existing = await kv.get<MaterialLibraryEntry>(key, MATERIAL_LIBRARY_KV_SCOPE);
     const entry: MaterialLibraryEntry = {
-      assetId: input.assetId,
+      assetId: libraryAssetId,
       contentDigest: input.contentDigest,
       name: input.name,
       ...(input.mimeType !== undefined ? { mimeType: input.mimeType } : {}),
       size: input.size,
       addedAt: new Date().toISOString(),
       // Preserve the derivation pointers across a same-digest re-import.
-      ...(existing && isValidLibraryEntry(existing) && existing.derivations
-        ? { derivations: existing.derivations }
+      ...(existing && isValidLibraryEntry(existing)
+        ? { derivations: unionDerivations(existing.derivations, undefined) }
         : {}),
     };
     await kv.set(key, entry, MATERIAL_LIBRARY_KV_SCOPE);
+
+    // The swap, ordered so the entry never names a released id: the entry now
+    // points at the NEW library-owned allocation, so the PREVIOUS one is
+    // released best-effort. A failure only orphans one registry entry
+    // (recoverable by re-importing) and is logged, never thrown.
+    if (existing && isValidLibraryEntry(existing) && existing.assetId !== libraryAssetId) {
+      await remove(existing.assetId).catch((error) => {
+        log.warn(
+          `Failed to release the superseded library-owned allocation ${existing.assetId} for "${input.name}":`,
+          error,
+        );
+      });
+    }
   } catch (error) {
     if (isRouteLevelKVError(error)) {
       disableLibraryForWindow(error);
@@ -289,6 +372,12 @@ export async function upsertMaterialLibraryEntry(
  * derivation records an agent can consult for derived images and lineage. A
  * duplicate identity is a no-op; a missing entry is skipped with a warn; a KV
  * failure is logged and ignored (best-effort, like every library write).
+ *
+ * N7 merge-on-write: the entry is re-read once immediately before the set and
+ * the derivations are UNIONED, so a concurrent same-digest upsert (which
+ * preserves derivations across the refresh) or another derivation record can
+ * never drop this pointer. The residual read→set last-writer window is
+ * milliseconds and accepted — the same class as the part-1 get→set acceptance.
  */
 export async function recordMaterialDerivation(
   contentDigest: string,
@@ -319,19 +408,9 @@ export async function recordMaterialDerivation(
       );
       return;
     }
-    const derivations = existing.derivations ?? [];
-    const alreadyRecorded = derivations.some(
-      (item) =>
-        item.domain === ref.domain &&
-        item.extractorId === ref.extractorId &&
-        item.extractorVersion === ref.extractorVersion,
-    );
-    if (alreadyRecorded) return;
-    await kv.set(
-      key,
-      { ...existing, derivations: [...derivations, { ...ref }] },
-      MATERIAL_LIBRARY_KV_SCOPE,
-    );
+    const merged = unionDerivations(existing.derivations, [ref]);
+    if (merged.length === (existing.derivations ?? []).length) return;
+    await kv.set(key, { ...existing, derivations: merged }, MATERIAL_LIBRARY_KV_SCOPE);
   } catch (error) {
     if (isRouteLevelKVError(error)) {
       disableLibraryForWindow(error);

--- a/lib/materials/library.ts
+++ b/lib/materials/library.ts
@@ -280,13 +280,19 @@ function unionDerivations(
  * release — releases it without the library's knowledge). A failed library
  * allocation skips the upsert entirely with one warn. A failed entry WRITE
  * (a kv.get/kv.set failure after a successful allocation) releases the fresh
- * library-owned allocation best-effort (logged) so it is never orphaned — the
- * entry cannot be pointing at it, since the write never completed. In both
- * failure directions the caller's upload is unaffected. On a same-digest
- * re-import the new library-owned id is allocated FIRST, the entry is written
- * to point at it, and only THEN is the PREVIOUS library-owned allocation
- * released best-effort (logged) — the entry never names a released id
- * mid-swap.
+ * library-owned allocation best-effort (logged) so it is never orphaned —
+ * guarded by an ambiguous-commit re-read (review P3, round 3): an HTTP KV
+ * `set` whose response is lost (proxy/gateway timeout, connection reset) may
+ * have committed server-side while rejecting, so before releasing, the entry
+ * is re-read once; the allocation is released ONLY when the re-read shows the
+ * entry does NOT point at the new id, kept (log info) when it does — the write
+ * actually landed — and the release is SKIPPED with one warn when the re-read
+ * itself fails (leak-over-dangling: a leaked entry is recoverable by
+ * re-import, a dangling entry breaks `readMaterial`). In both failure
+ * directions the caller's upload is unaffected. On a same-digest re-import the
+ * new library-owned id is allocated FIRST, the entry is written to point at
+ * it, and only THEN is the PREVIOUS library-owned allocation released
+ * best-effort (logged) — the entry never names a released id mid-swap.
  *
  * The optional `pool` is the test injection point; production omits it and
  * `putAsset` / `removeAsset` resolve the browser-wide pool.
@@ -359,32 +365,72 @@ export async function upsertMaterialLibraryEntry(
       });
     }
   } catch (error) {
-    // The fresh library-owned allocation never made it into an entry — the
-    // failure is a kv.get/kv.set (the superseded-release above has its own
-    // inline catch and cannot land here), so the entry cannot be pointing at
-    // the new id. Release it best-effort so a failed write does not orphan
-    // the allocation (review P3); the release is logged — its own warn when it
-    // fails, named inside the single upsert warn on the per-op path — and
-    // never thrown.
-    let releaseFailed = false;
+    // Ambiguous-commit guard (review P3, round 3): the failure is a
+    // kv.get/kv.set (the superseded-release above has its own inline catch and
+    // cannot land here), but a `set` that REJECTED may still have committed
+    // server-side (a response lost to a proxy/gateway timeout or reset), so
+    // the entry MIGHT be pointing at the new id. Re-read the entry best-effort
+    // before deciding: release the fresh library-owned allocation ONLY when
+    // the read shows the entry does NOT point at it; when it does, the write
+    // actually landed — keep the allocation (log info); when the read itself
+    // fails, SKIP the release (leak-over-dangling, one warn — a leaked entry
+    // is recoverable by re-import, a dangling one breaks `readMaterial`).
+    // Never thrown in any direction.
+    let committed = false;
+    let readFailed = false;
+    let reReadError: unknown;
     try {
-      await remove(libraryAssetId);
-    } catch (releaseError) {
-      releaseFailed = true;
-      log.warn(
-        `Failed to release the fresh library-owned allocation ${libraryAssetId} for "${input.name}":`,
-        releaseError,
-      );
+      const after = await kv.get<MaterialLibraryEntry>(key, MATERIAL_LIBRARY_KV_SCOPE);
+      committed = after !== null && isValidLibraryEntry(after) && after.assetId === libraryAssetId;
+    } catch (readError) {
+      readFailed = true;
+      reReadError = readError;
     }
+
+    let releaseFailed = false;
+    let releaseError: unknown;
+    if (committed) {
+      log.info(
+        `The material library entry for "${input.name}" actually committed server-side despite the ` +
+          `failed upsert; keeping the library-owned allocation ${libraryAssetId} (the write landed).`,
+      );
+    } else if (!readFailed) {
+      // The re-read shows the entry does NOT point at the new id — release it
+      // best-effort so a failed write does not orphan the allocation (review
+      // P3); a failed release is logged, never thrown.
+      try {
+        await remove(libraryAssetId);
+      } catch (removeError) {
+        releaseFailed = true;
+        releaseError = removeError;
+      }
+    }
+
     if (isRouteLevelKVError(error)) {
       disableLibraryForWindow(error);
+    } else if (committed) {
+      log.warn(
+        `Failed to upsert the material library entry for "${input.name}"; the upload is unaffected. ` +
+          `The write actually committed server-side (response lost), so the fresh library-owned ` +
+          `allocation ${libraryAssetId} was KEPT.`,
+        error,
+      );
+    } else if (readFailed) {
+      log.warn(
+        `Failed to upsert the material library entry for "${input.name}"; the upload is unaffected. ` +
+          `The post-failure re-read of the entry also failed, so the fresh library-owned allocation ` +
+          `${libraryAssetId} was NOT released (leak-over-dangling: a leaked entry is recoverable by ` +
+          `re-import, a dangling one breaks readMaterial):`,
+        error,
+        reReadError,
+      );
     } else {
       log.warn(
         `Failed to upsert the material library entry for "${input.name}"; the upload is unaffected. ` +
           `The fresh library-owned allocation ${libraryAssetId} was ${
             releaseFailed ? 'NOT released' : 'released best-effort'
           }.`,
-        error,
+        ...(releaseFailed ? [error, releaseError] : [error]),
       );
     }
   }

--- a/lib/materials/library.ts
+++ b/lib/materials/library.ts
@@ -278,11 +278,15 @@ function unionDerivations(
  * from `input.file` and stores that id, so the entry never points at the
  * caller's selection entry (whose lifecycle — part-0 removal, prep-timeout
  * release — releases it without the library's knowledge). A failed library
- * allocation skips the upsert entirely with one warn; the caller's upload is
- * unaffected. On a same-digest re-import the new library-owned id is
- * allocated FIRST, the entry is written to point at it, and only THEN is the
- * PREVIOUS library-owned allocation released best-effort (logged) — the entry
- * never names a released id mid-swap.
+ * allocation skips the upsert entirely with one warn. A failed entry WRITE
+ * (a kv.get/kv.set failure after a successful allocation) releases the fresh
+ * library-owned allocation best-effort (logged) so it is never orphaned — the
+ * entry cannot be pointing at it, since the write never completed. In both
+ * failure directions the caller's upload is unaffected. On a same-digest
+ * re-import the new library-owned id is allocated FIRST, the entry is written
+ * to point at it, and only THEN is the PREVIOUS library-owned allocation
+ * released best-effort (logged) — the entry never names a released id
+ * mid-swap.
  *
  * The optional `pool` is the test injection point; production omits it and
  * `putAsset` / `removeAsset` resolve the browser-wide pool.
@@ -343,8 +347,9 @@ export async function upsertMaterialLibraryEntry(
 
     // The swap, ordered so the entry never names a released id: the entry now
     // points at the NEW library-owned allocation, so the PREVIOUS one is
-    // released best-effort. A failure only orphans one registry entry
-    // (recoverable by re-importing) and is logged, never thrown.
+    // released best-effort. A superseded-release failure only orphans one
+    // registry entry (recoverable by re-importing) and is logged, never
+    // thrown.
     if (existing && isValidLibraryEntry(existing) && existing.assetId !== libraryAssetId) {
       await remove(existing.assetId).catch((error) => {
         log.warn(
@@ -354,11 +359,31 @@ export async function upsertMaterialLibraryEntry(
       });
     }
   } catch (error) {
+    // The fresh library-owned allocation never made it into an entry — the
+    // failure is a kv.get/kv.set (the superseded-release above has its own
+    // inline catch and cannot land here), so the entry cannot be pointing at
+    // the new id. Release it best-effort so a failed write does not orphan
+    // the allocation (review P3); the release is logged — its own warn when it
+    // fails, named inside the single upsert warn on the per-op path — and
+    // never thrown.
+    let releaseFailed = false;
+    try {
+      await remove(libraryAssetId);
+    } catch (releaseError) {
+      releaseFailed = true;
+      log.warn(
+        `Failed to release the fresh library-owned allocation ${libraryAssetId} for "${input.name}":`,
+        releaseError,
+      );
+    }
     if (isRouteLevelKVError(error)) {
       disableLibraryForWindow(error);
     } else {
       log.warn(
-        `Failed to upsert the material library entry for "${input.name}"; the upload is unaffected:`,
+        `Failed to upsert the material library entry for "${input.name}"; the upload is unaffected. ` +
+          `The fresh library-owned allocation ${libraryAssetId} was ${
+            releaseFailed ? 'NOT released' : 'released best-effort'
+          }.`,
         error,
       );
     }

--- a/lib/persistence/resolve-vision-images.ts
+++ b/lib/persistence/resolve-vision-images.ts
@@ -20,10 +20,17 @@
  * an opaque id string. On a healthy deployment nothing drops and the two
  * modes produce identical prompts.
  *
+ * Size bound (N5): the same 50 MB cap the extract route enforces is passed
+ * to `resolveServerAsset`'s `maxByteLength`, so an oversized asset is
+ * rejected at `identify` — the registry's recorded length, before any bytes
+ * are materialized — and dropped with the same warn-and-drop posture as an
+ * unresolvable one.
+ *
  * Server-only module: it must never be imported from client code (the
  * `resolveServerAsset` dependency chain is Node-only).
  */
 import { createLogger } from '@/lib/logger';
+import { MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES } from '@/lib/constants/generation';
 
 import { resolveServerAsset } from './resolve-server-asset';
 
@@ -62,7 +69,11 @@ export async function resolveVisionImagesForPrompt(
     }
     let resolution;
     try {
-      resolution = await resolveServerAsset(image.src, headers);
+      resolution = await resolveServerAsset(
+        image.src,
+        headers,
+        MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES,
+      );
     } catch (error) {
       // A store failure must never surface raw error text to the caller; log
       // server-side and drop the image so the prompt degrades gracefully.
@@ -70,6 +81,9 @@ export async function resolveVisionImagesForPrompt(
       continue;
     }
     if (resolution.status !== 'resolved') {
+      // Unresolvable and oversized images share the same posture: warn
+      // server-side and drop, so the prompt never names an image it cannot
+      // attach (N3) and never pulls an oversized asset into memory (N5).
       log.warn(
         `Vision image "${image.id}" does not resolve server-side (${resolution.status}); dropping it from the vision prompt.`,
       );

--- a/lib/persistence/resolve-vision-images.ts
+++ b/lib/persistence/resolve-vision-images.ts
@@ -1,0 +1,86 @@
+/**
+ * Server-side resolution of prompt-assembly vision images by allocated asset
+ * id (RFC #1153 part 2 section B).
+ *
+ * On a server-backed deployment the client sends `imageMapping` as
+ * (image id → allocated asset id) instead of base64 data URLs, and
+ * `resolveImageIds` writes those allocated ids into `PPTImageElement.src`.
+ * Where the generation routes currently read image bytes for the vision
+ * prompt, they resolve the ids to bytes HERE — reusing `resolveServerAsset`
+ * from part 0 — so the multimodal content handed to the LLM is byte-identical
+ * to what the browser-backed (data-URL) path would have sent: same images,
+ * same order, same selection. Only the transport differs.
+ *
+ * A src that is already a data URL or a concrete URL passes through untouched
+ * (a browser-backed request, or a legacy session that fell back to bytes), so
+ * the routes stay correct in both modes without a mode flag. An id that the
+ * server cannot resolve (missing asset, unconfigured/unauthenticated
+ * persistence, a store failure) is DROPPED from the vision set with a
+ * server-side warn — never echoed to the caller and never sent to the LLM as
+ * an opaque id string. On a healthy deployment nothing drops and the two
+ * modes produce identical prompts.
+ *
+ * Server-only module: it must never be imported from client code (the
+ * `resolveServerAsset` dependency chain is Node-only).
+ */
+import { createLogger } from '@/lib/logger';
+
+import { resolveServerAsset } from './resolve-server-asset';
+
+const log = createLogger('VisionImageResolution');
+
+/** One image in a vision prompt slice, as `generateSceneContent` builds it. */
+export interface VisionPromptImage {
+  id: string;
+  src: string;
+  width?: number;
+  height?: number;
+}
+
+/** Whether a src is already concrete bytes (data URL) or a remote URL. */
+function isConcreteImageSrc(src: string): boolean {
+  return /^(?:data:|https?:|blob:)/i.test(src);
+}
+
+/**
+ * Resolve a vision image list whose `src` values may be allocated asset ids
+ * into data URLs, so the prompt the LLM receives is the same in both the
+ * server-backed and the browser-backed transports. Images whose src is
+ * already concrete pass through; images whose id cannot be resolved
+ * server-side are dropped (warned server-side only).
+ */
+export async function resolveVisionImagesForPrompt(
+  images: readonly VisionPromptImage[],
+  headers: Headers,
+): Promise<VisionPromptImage[]> {
+  const resolved: VisionPromptImage[] = [];
+  for (const image of images) {
+    if (!image.src) continue;
+    if (isConcreteImageSrc(image.src)) {
+      resolved.push(image);
+      continue;
+    }
+    let resolution;
+    try {
+      resolution = await resolveServerAsset(image.src, headers);
+    } catch (error) {
+      // A store failure must never surface raw error text to the caller; log
+      // server-side and drop the image so the prompt degrades gracefully.
+      log.error(`Failed to resolve vision image asset "${image.id}" from the server store:`, error);
+      continue;
+    }
+    if (resolution.status !== 'resolved') {
+      log.warn(
+        `Vision image "${image.id}" does not resolve server-side (${resolution.status}); dropping it from the vision prompt.`,
+      );
+      continue;
+    }
+    resolved.push({
+      id: image.id,
+      src: `data:${resolution.mimeType};base64,${resolution.buffer.toString('base64')}`,
+      ...(image.width !== undefined ? { width: image.width } : {}),
+      ...(image.height !== undefined ? { height: image.height } : {}),
+    });
+  }
+  return resolved;
+}

--- a/lib/types/generation.ts
+++ b/lib/types/generation.ts
@@ -19,6 +19,13 @@ export interface PdfImage {
   pageNumber: number; // Page number in PDF
   description?: string; // Optional description for AI context
   storageId?: string; // Reference to IndexedDB (session_xxx_img_1)
+  /**
+   * Pool asset id of the image bytes. Present on server-backed deployments
+   * (RFC #1153 part 2 B): the extracted images are pool assets, so generation
+   * is fed by id and no IndexedDB bytes are materialized. Browser-backed
+   * images carry `storageId` instead — never both.
+   */
+  assetId?: string; // Allocated asset-pool id (server-backed transport)
   width?: number; // Image width (px or normalized)
   height?: number; // Image height (px or normalized)
   originalId?: string; // ID assigned by the extractor before bundle-level normalization

--- a/lib/types/pdf.ts
+++ b/lib/types/pdf.ts
@@ -53,6 +53,12 @@ export interface ParsedPdfContent {
       description?: string;
       width?: number;
       height?: number;
+      /**
+       * Pool asset id of the image bytes. Present only on cache-rebuilt
+       * results in asset-id mode (RFC #1153 part 2 C): a server-backed cache
+       * hit names the image's pool asset instead of materializing its bytes.
+       */
+      assetId?: string;
     }>;
     [key: string]: unknown;
   };

--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/src/index.ts
+++ b/packages/@openmaic/generation/src/index.ts
@@ -81,7 +81,7 @@ export type {
 } from './outline-generator.js';
 export { changeOutlineType } from './outline-type.js';
 export { uniquifyMediaElementIds } from './outline-media.js';
-export { partitionImagesForVision, sortDocumentImagesForVision } from './outline-formatters.js';
+export { partitionImagesForVision } from './outline-formatters.js';
 export type { VisionImagePartition } from './outline-formatters.js';
 export { parseJsonResponse } from './json-repair.js';
 export type { JsonParsingOptions } from './json-repair.js';

--- a/packages/@openmaic/generation/src/index.ts
+++ b/packages/@openmaic/generation/src/index.ts
@@ -13,6 +13,7 @@ export {
   generateSceneContent,
   generateWidgetContent,
   PBLGenerationError,
+  resolveImageIds,
 } from './scene-generator.js';
 export type { SceneActionsOptions, SceneContentOptions } from './scene-generator.js';
 export { buildCompleteScene } from './scene-builder.js';

--- a/packages/@openmaic/generation/src/index.ts
+++ b/packages/@openmaic/generation/src/index.ts
@@ -81,6 +81,8 @@ export type {
 } from './outline-generator.js';
 export { changeOutlineType } from './outline-type.js';
 export { uniquifyMediaElementIds } from './outline-media.js';
+export { partitionImagesForVision, sortDocumentImagesForVision } from './outline-formatters.js';
+export type { VisionImagePartition } from './outline-formatters.js';
 export { parseJsonResponse } from './json-repair.js';
 export type { JsonParsingOptions } from './json-repair.js';
 export { noopGenerationLogger } from './logger.js';

--- a/packages/@openmaic/generation/src/outline-formatters.ts
+++ b/packages/@openmaic/generation/src/outline-formatters.ts
@@ -1,4 +1,4 @@
-import type { PdfImage } from './outline-types.js';
+import type { ImageMapping, PdfImage } from './outline-types.js';
 
 export function formatImageDescription(img: PdfImage): string {
   let dimInfo = '';
@@ -35,4 +35,45 @@ export function sortDocumentImagesForVision<
     }
     return a.id.localeCompare(b.id);
   });
+}
+
+/**
+ * The ordered partition of assigned images the generator consumes: the vision
+ * slice (the first `maxVisionImages` images with a mapping entry) and the
+ * text-only remainder.
+ *
+ * Shared by the app's scene-content route and this package's generator so the
+ * two cannot drift (RFC #1153 part 2, N3): the route pre-resolves the SAME
+ * ordered candidates (`withSrc`) the generator re-slices, so a dropped image
+ * admits the next candidate WITH its resolution, never around it.
+ */
+export interface VisionImagePartition<T> {
+  /** Assigned images in the vision-priority order. */
+  sorted: T[];
+  /** Sorted images that carry a mapping entry — the attachment candidates. */
+  withSrc: T[];
+  /** The first `maxVisionImages` of `withSrc` — the vision attachments. */
+  visionSlice: T[];
+  /** `withSrc` beyond the cap — plain text descriptions, never attached. */
+  textOnlySlice: T[];
+  /** Sorted images WITHOUT a mapping entry — plain text descriptions. */
+  noSrcImages: T[];
+}
+
+export function partitionImagesForVision<
+  T extends Pick<PdfImage, 'visionPriority' | 'pageNumber' | 'id'>,
+>(
+  images: T[],
+  imageMapping: ImageMapping | undefined,
+  maxVisionImages: number,
+): VisionImagePartition<T> {
+  const sorted = sortDocumentImagesForVision(images);
+  const withSrc = imageMapping ? sorted.filter((img) => imageMapping[img.id]) : [];
+  return {
+    sorted,
+    withSrc,
+    visionSlice: withSrc.slice(0, maxVisionImages),
+    textOnlySlice: withSrc.slice(maxVisionImages),
+    noSrcImages: imageMapping ? sorted.filter((img) => !imageMapping[img.id]) : sorted,
+  };
 }

--- a/packages/@openmaic/generation/src/scene-generator.ts
+++ b/packages/@openmaic/generation/src/scene-generator.ts
@@ -20,7 +20,7 @@ import { MAX_VISION_IMAGES } from './constants.js';
 import {
   formatImageDescription,
   formatImagePlaceholder,
-  sortDocumentImagesForVision,
+  partitionImagesForVision,
 } from './outline-formatters.js';
 import type {
   ImageMapping,
@@ -77,6 +77,16 @@ export interface SceneContentOptions {
   imageMapping?: ImageMapping;
   visionEnabled?: boolean;
   generatedMediaMapping?: ImageMapping;
+  /**
+   * Pre-resolved bytes for the vision slice (RFC #1153 part 2, N3). The app's
+   * scene-content route resolves the slice's allocated asset ids server-side
+   * BEFORE calling the generator so the attachment bytes are settled before
+   * prompt assembly; when provided, the LLM message's vision images are built
+   * from these (matched to the slice ids), so the caller's aiCall resolution
+   * becomes a defensive no-op. Absent (package consumers, browser-backed
+   * runs), the srcs are derived from `imageMapping` exactly as before.
+   */
+  resolvedVisionImages?: Array<{ id: string; src: string; width?: number; height?: number }>;
   agents?: AgentInfo[];
   languageDirective?: string;
   /** Authoritative UI locale selected by the user, consumed by the PBL v2 planner. */
@@ -224,6 +234,7 @@ export async function generateSceneContent(
     imageMapping,
     visionEnabled,
     generatedMediaMapping,
+    resolvedVisionImages,
     agents,
     languageDirective,
     targetLanguage,
@@ -269,6 +280,7 @@ export async function generateSceneContent(
         imageMapping,
         visionEnabled,
         generatedMediaMapping,
+        resolvedVisionImages,
         agents,
         languageDirective,
         editDirective,
@@ -585,6 +597,7 @@ async function generateSlideContent(
   imageMapping?: ImageMapping,
   visionEnabled?: boolean,
   generatedMediaMapping?: ImageMapping,
+  resolvedVisionImages?: Array<{ id: string; src: string; width?: number; height?: number }>,
   agents?: AgentInfo[],
   languageDirective?: string,
   editDirective?: string,
@@ -596,28 +609,44 @@ async function generateSlideContent(
   let visionImages: Array<{ id: string; src: string }> | undefined;
 
   if (assignedImages && assignedImages.length > 0) {
-    const sortedAssignedImages = sortDocumentImagesForVision(assignedImages);
+    // The partition is the shared ordering (RFC #1153 part 2, N3): the app's
+    // scene-content route pre-resolves the SAME `withSrc` candidates in this
+    // order, so the slice below can never admit an image the route has not
+    // resolved. `visionEnabled && imageMapping` off → every image is a plain
+    // text description, exactly as before.
+    const { visionSlice, textOnlySlice, noSrcImages } = partitionImagesForVision(
+      assignedImages,
+      imageMapping,
+      MAX_VISION_IMAGES,
+    );
     if (visionEnabled && imageMapping) {
       // Vision mode: split into vision images and text-only
-      const withSrc = sortedAssignedImages.filter((img) => imageMapping[img.id]);
-      const visionSlice = withSrc.slice(0, MAX_VISION_IMAGES);
-      const textOnlySlice = withSrc.slice(MAX_VISION_IMAGES);
-      const noSrcImages = sortedAssignedImages.filter((img) => !imageMapping[img.id]);
-
       const visionDescriptions = visionSlice.map((img) => formatImagePlaceholder(img));
       const textDescriptions = [...textOnlySlice, ...noSrcImages].map((img) =>
         formatImageDescription(img),
       );
       assignedImagesText = [...visionDescriptions, ...textDescriptions].join('\n');
 
-      visionImages = visionSlice.map((img) => ({
-        id: img.id,
-        src: imageMapping[img.id],
-        width: img.width,
-        height: img.height,
-      }));
+      // When the route pre-resolved the slice, its resolved bytes are used
+      // verbatim (matched to the slice ids), so the caller's aiCall resolution
+      // is a defensive no-op; otherwise fall back to the mapping src (an
+      // allocated id the caller's aiCall resolves at prompt-assembly time).
+      const resolvedById = new Map(
+        (resolvedVisionImages ?? []).map((img) => [img.id, img] as const),
+      );
+      visionImages = visionSlice.map((img) => {
+        const resolved = resolvedById.get(img.id);
+        return (
+          resolved ?? {
+            id: img.id,
+            src: imageMapping[img.id],
+            width: img.width,
+            height: img.height,
+          }
+        );
+      });
     } else {
-      assignedImagesText = sortedAssignedImages
+      assignedImagesText = [...visionSlice, ...textOnlySlice, ...noSrcImages]
         .map((img) => formatImageDescription(img))
         .join('\n');
     }

--- a/packages/@openmaic/generation/src/scene-generator.ts
+++ b/packages/@openmaic/generation/src/scene-generator.ts
@@ -313,18 +313,25 @@ function isImageIdReference(value: string): boolean {
 }
 
 /**
- * Resolve image ID references in src field to actual base64 URLs
+ * Resolve image ID references in src field to the mapping's payload.
  *
  * AI generates: { type: "image", src: "img_1", ... }
- * This function replaces: { type: "image", src: "data:image/png;base64,...", ... }
+ * This function replaces: { type: "image", src: "<imageMapping[src]>", ... }
  *
  * Design rationale (Plan B):
  * - Simpler: AI only needs to know one field (src)
  * - Consistent: Generated JSON structure matches final PPTImageElement
  * - Intuitive: src is the image source, first as ID then as actual URL
  * - Less prompt complexity: No need to explain imageId vs src distinction
+ *
+ * The mapping VALUE is written verbatim, so the transport is decided entirely
+ * by the caller's `imageMapping` shape — no flag threading into this package
+ * (RFC #1153 part 2 B): a browser-backed mapping carries base64 data URLs and
+ * the element src becomes the data URL exactly as before; a server-backed
+ * mapping carries allocated pool asset ids and the element src becomes the
+ * asset id, which the renderer resolves through the pool registry.
  */
-function resolveImageIds(
+export function resolveImageIds(
   elements: GeneratedSlideData['elements'],
   imageMapping?: ImageMapping,
   generatedMediaMapping?: ImageMapping,
@@ -345,7 +352,7 @@ function resolveImageIds(
             log.warn(`No mapping for image ID: ${src}, removing element`);
             return null; // Remove invalid image elements
           }
-          log.debug(`Resolved image ID "${src}" to base64 URL`);
+          log.debug(`Resolved image ID "${src}" to its mapped source`);
           return { ...el, src: imageMapping[src] };
         }
 

--- a/packages/@openmaic/generation/src/scene-generator.ts
+++ b/packages/@openmaic/generation/src/scene-generator.ts
@@ -613,8 +613,12 @@ async function generateSlideContent(
     // scene-content route pre-resolves the SAME `withSrc` candidates in this
     // order, so the slice below can never admit an image the route has not
     // resolved. `visionEnabled && imageMapping` off → every image is a plain
-    // text description, exactly as before.
-    const { visionSlice, textOnlySlice, noSrcImages } = partitionImagesForVision(
+    // text description listed in the ORIGINAL full vision-priority
+    // interleaved order (`sorted` — the pre-partition `sortedAssignedImages`
+    // order), NOT the slices-concatenated order, so a non-vision run with a
+    // mapping present (a non-vision model on a server-backed deployment) sees
+    // exactly the text ordering it saw before the partition refactor.
+    const { sorted, visionSlice, textOnlySlice, noSrcImages } = partitionImagesForVision(
       assignedImages,
       imageMapping,
       MAX_VISION_IMAGES,
@@ -646,9 +650,7 @@ async function generateSlideContent(
         );
       });
     } else {
-      assignedImagesText = [...visionSlice, ...textOnlySlice, ...noSrcImages]
-        .map((img) => formatImageDescription(img))
-        .join('\n');
+      assignedImagesText = sorted.map((img) => formatImageDescription(img)).join('\n');
     }
   }
 

--- a/packages/@openmaic/generation/test/scene-generator-image-mapping.test.ts
+++ b/packages/@openmaic/generation/test/scene-generator-image-mapping.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
-import { resolveImageIds } from '@openmaic/generation';
-import type { GeneratedSlideData } from '@openmaic/generation';
+import { generateSceneContent, resolveImageIds } from '@openmaic/generation';
+import type { GeneratedSlideData, PdfImage } from '@openmaic/generation';
+
+import { slideOutline } from './scene-fixtures.js';
 
 function imageElement(src: string): GeneratedSlideData['elements'][number] {
   return {
@@ -46,5 +48,40 @@ describe('resolveImageIds — transport decided by the mapping value shape (RFC 
     });
     expect(resolved).toHaveLength(1);
     expect(resolved[0]).toMatchObject({ type: 'image', src: 'gen_img_alpha_001' });
+  });
+});
+
+describe('generateSceneContent — non-vision text ordering with a mapping present (RFC #1153 part 2, review P3)', () => {
+  test('visionEnabled off + imageMapping present lists images in the ORIGINAL sorted order, not slices-concatenated', async () => {
+    // Fixture where the full vision-priority interleave ≠ mapped-then-unmapped
+    // concat: img_1 and img_3 carry a mapping entry, img_2 and img_4 do not,
+    // and they INTERLEAVE in the sort (priority desc, then pageNumber asc).
+    // Concatenating [mapped, unmapped] would yield img_1, img_3, img_2, img_4;
+    // the pre-partition `sortedAssignedImages` order is the interleave
+    // img_1, img_2, img_3, img_4 — which the non-vision text must restore.
+    const assignedImages: PdfImage[] = [
+      { id: 'img_1', src: '', pageNumber: 1, visionPriority: 2 },
+      { id: 'img_2', src: '', pageNumber: 2, visionPriority: 1 },
+      { id: 'img_3', src: '', pageNumber: 3, visionPriority: 1 },
+      { id: 'img_4', src: '', pageNumber: 4, visionPriority: 0 },
+    ];
+    const imageMapping = { img_1: 'ast_1', img_3: 'ast_3' };
+    let userPrompt = '';
+    const aiCall = vi.fn(async (_system: string, user: string) => {
+      userPrompt = user;
+      return JSON.stringify({ elements: [], remark: '' });
+    });
+
+    await generateSceneContent(slideOutline(), aiCall, {
+      assignedImages,
+      imageMapping,
+      visionEnabled: false,
+    });
+
+    const availableMedia = userPrompt.split('- **Available Media**:')[1] ?? '';
+    const ids = [...availableMedia.matchAll(/\*\*(img_\d+)\*\*/g)].map((match) => match[1]);
+    expect(ids).toEqual(['img_1', 'img_2', 'img_3', 'img_4']);
+    // No `[see attached]` promise in the non-vision text.
+    expect(availableMedia).not.toContain('[see attached]');
   });
 });

--- a/packages/@openmaic/generation/test/scene-generator-image-mapping.test.ts
+++ b/packages/@openmaic/generation/test/scene-generator-image-mapping.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+
+import { resolveImageIds } from '@openmaic/generation';
+import type { GeneratedSlideData } from '@openmaic/generation';
+
+function imageElement(src: string): GeneratedSlideData['elements'][number] {
+  return {
+    id: 'el_1',
+    type: 'image',
+    src,
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 300,
+    rotate: 0,
+    fixedRatio: false,
+  };
+}
+
+describe('resolveImageIds — transport decided by the mapping value shape (RFC #1153 part 2 B)', () => {
+  test('writes the allocated asset id into src when the mapping value is an asset id', () => {
+    const resolved = resolveImageIds([imageElement('img_1')], {
+      img_1: 'ast_allocated_image_0001',
+    });
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({ type: 'image', src: 'ast_allocated_image_0001' });
+  });
+
+  test('writes the base64 data URL into src when the mapping value is a data URL', () => {
+    const dataUrl = 'data:image/png;base64,AQID';
+    const resolved = resolveImageIds([imageElement('img_1')], { img_1: dataUrl });
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({ type: 'image', src: dataUrl });
+  });
+
+  test('removes an image whose id has no mapping entry, in both transports', () => {
+    const resolved = resolveImageIds([imageElement('img_9')], { img_1: 'ast_something' });
+    expect(resolved).toHaveLength(0);
+  });
+
+  test('leaves generated-media placeholders untouched (async backfill path)', () => {
+    const resolved = resolveImageIds([imageElement('gen_img_alpha_001')], {
+      img_1: 'ast_something',
+    });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({ type: 'image', src: 'gen_img_alpha_001' });
+  });
+});

--- a/packages/@openmaic/generation/test/type-surface.test.ts
+++ b/packages/@openmaic/generation/test/type-surface.test.ts
@@ -18,6 +18,7 @@ type _SceneContentKeys = Assert<
     | 'imageMapping'
     | 'visionEnabled'
     | 'generatedMediaMapping'
+    | 'resolvedVisionImages'
     | 'agents'
     | 'languageDirective'
     | 'targetLanguage'

--- a/tests/document/extraction-cache.test.ts
+++ b/tests/document/extraction-cache.test.ts
@@ -120,6 +120,7 @@ interface FakePoolHarness {
   put: ReturnType<typeof vi.fn>;
   resolve: ReturnType<typeof vi.fn>;
   remove: ReturnType<typeof vi.fn>;
+  exists: ReturnType<typeof vi.fn>;
 }
 
 function makePool(): FakePoolHarness {
@@ -138,6 +139,7 @@ function makePool(): FakePoolHarness {
   const remove = vi.fn(async (ref: string): Promise<void> => {
     blobs.delete(ref);
   });
+  const exists = vi.fn(async (ref: string): Promise<boolean> => blobs.has(ref));
   const pool: AssetPoolStore = {
     put: put as AssetPoolStore['put'],
     resolve: resolve as AssetPoolStore['resolve'],
@@ -145,9 +147,10 @@ function makePool(): FakePoolHarness {
     remove: remove as AssetPoolStore['remove'],
     replace: vi.fn(async () => undefined),
     release: vi.fn(async () => undefined),
+    exists: exists as AssetPoolStore['exists'],
     close: vi.fn(async () => undefined),
   };
-  return { pool, blobs, put, resolve, remove };
+  return { pool, blobs, put, resolve, remove, exists };
 }
 
 /** A fetch implementation serving the fake pool's `test://<assetId>` URLs. */
@@ -879,10 +882,15 @@ describe('lookupCachedExtraction', () => {
     });
 
     expect(rebuilt).not.toBeNull();
-    // The image bytes were NOT fetched: only the artifact asset was resolved
-    // from the pool (data-url mode resolves artifact + every image).
+    // The image BYTES were NOT fetched: only the artifact asset was resolved
+    // from the pool (data-url mode resolves artifact + every image); each
+    // image asset was probed for EXISTENCE through the pool's identity seam
+    // (no byte fetch).
     expect(harness.resolve).toHaveBeenCalledTimes(1);
     expect(harness.resolve).toHaveBeenCalledWith(record!.artifactAssetId);
+    expect(harness.exists).toHaveBeenCalledTimes(2);
+    expect(harness.exists).toHaveBeenCalledWith('ast_test_0');
+    expect(harness.exists).toHaveBeenCalledWith('ast_test_1');
     // metadata.imageMapping maps img_N → the allocated asset id, and
     // pdfImages carry the id on `assetId` with src left empty.
     expect(rebuilt?.metadata?.imageMapping).toEqual({ img_1: 'ast_test_0', img_2: 'ast_test_1' });
@@ -900,6 +908,41 @@ describe('lookupCachedExtraction', () => {
     expect(rebuilt?.images).toEqual([]);
     // The text half is rebuilt exactly as a real extraction returns it.
     expect(rebuilt?.text).toBe(original.text);
+  });
+
+  it('reports a MISS in asset-id mode when an image asset was reclaimed (reclaim = miss, N6)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      result: fixtureResult(),
+    });
+    // Simulate a partially-reclaimed cache: one image asset's bytes are gone.
+    harness.blobs.delete('ast_test_1');
+
+    const rebuilt = await lookupCachedExtraction({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      fetchImpl: makeFetch(harness),
+      imageMappingMode: 'asset-id',
+    });
+
+    // A dangling id is a miss, exactly like data-url mode — the real
+    // extraction re-derives instead of serving text with a silently missing
+    // image. The existence probe is an identity read, never a byte fetch.
+    expect(rebuilt).toBeNull();
+    expect(harness.exists).toHaveBeenCalledWith('ast_test_1');
+    expect(harness.resolve).toHaveBeenCalledTimes(1); // artifact only
   });
 
   it('reports a miss when no record exists', async () => {

--- a/tests/document/extraction-cache.test.ts
+++ b/tests/document/extraction-cache.test.ts
@@ -20,6 +20,7 @@ import {
   type InRunExtractionKey,
 } from '@/lib/document/extraction-cache';
 import type { ExtractSourceFetchers } from '@/lib/document/extract-source';
+import { setMaterialLibraryKVForTests } from '@/lib/materials/library';
 import type { AssetPoolStore } from '@/lib/media/asset-pool-config';
 import type { ParsedPdfContent } from '@/lib/types/pdf';
 
@@ -31,6 +32,12 @@ let MANAGED_FP: string;
 
 beforeAll(async () => {
   MANAGED_FP = await computeConfigFingerprint();
+  // A working library KV for the best-effort derivation-pointer recording that
+  // `fetchExtractionWithCache` now performs: with the browser store unavailable
+  // in node, the library would otherwise warn per call and pollute the
+  // console.warn-count assertions in the K5 suite below. Installed for the
+  // whole file (entries accumulate harmlessly; no test reads the library).
+  setMaterialLibraryKVForTests(new FakeKV());
 });
 
 /** The full cache key for the stable (no baseUrl) config bucket, as callers use it. */
@@ -427,6 +434,97 @@ describe('writeExtractionCache', () => {
     expect(JSON.stringify(artifact)).not.toContain('data:image/');
   });
 
+  it('resolves to the derived images (extraction id → pool asset id) on success', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+
+    const derived = await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      result: fixtureResult(),
+    });
+
+    // A server-backed caller awaits the write to learn the image asset ids
+    // without materializing image bytes (RFC #1153 part 2 B).
+    expect(derived.map((image) => image.id)).toEqual(['img_1', 'img_2']);
+    expect(derived.map((image) => image.assetId)).toEqual(['ast_test_0', 'ast_test_1']);
+  });
+
+  it('returns the ADOPTED record images when a same-key race supersedes the attempt (K3)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+
+    const first = await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      result: fixtureResult(),
+    });
+    // A second write for the same key ingests its own assets, then adopts the
+    // existing record and releases them — the caller must receive the LIVE
+    // ids, not the released ones.
+    const second = await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      result: fixtureResult(),
+    });
+
+    expect(second).toEqual(first);
+    expect(second.map((image) => image.assetId)).toEqual(['ast_test_0', 'ast_test_1']);
+  });
+
+  it('resolves to an empty array when the write is skipped (route-level KV failure window)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    resetExtractionCacheForTests();
+    // Force the route-level disable window so the write is skipped pre-ingest.
+    const routeFailure = new HttpKVStoreError(404, 'ROUTE_GONE', 'route gone');
+    // The window is module-internal; simulate by a failing kv.get path that is
+    // treated as route-level — see the K5 suite below for the real mechanism.
+    const failingKv: KVStore = {
+      get: async () => {
+        throw routeFailure;
+      },
+      set: async () => undefined,
+      remove: async () => undefined,
+      keys: async () => [],
+    };
+    // First write: the route-level failure disables the cache for a window.
+    await writeExtractionCache({
+      kv: failingKv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      result: fixtureResult(),
+    });
+    const skipped = await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      result: fixtureResult(),
+    });
+    expect(skipped).toEqual([]);
+    expect(harness.blobs.size).toBe(0);
+    resetExtractionCacheForTests();
+  });
+
   it('releases every allocated asset and writes no record when an image ingest fails', async () => {
     const kv = new FakeKV();
     const harness = makePool();
@@ -447,7 +545,7 @@ describe('writeExtractionCache', () => {
         sourceDocAssetId: 'ast_source_doc',
         result: fixtureResult(),
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual([]);
 
     expect(kv.storedKeys()).toEqual([]);
     expect(harness.remove).toHaveBeenCalledWith('ast_test_0');
@@ -747,6 +845,61 @@ describe('lookupCachedExtraction', () => {
       width: 640,
       height: 480,
     });
+  });
+
+  it('rebuilds by asset id in asset-id mode WITHOUT materializing image bytes (RFC #1153 part 2 C)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    const original = fixtureResult();
+    await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      result: original,
+    });
+    const record = await kv.get<DerivationRecord>(
+      managedKey(DIGEST, 'mineru', '1'),
+      EXTRACTION_CACHE_KV_SCOPE,
+    );
+    expect(record?.images.map((image) => image.assetId)).toEqual(['ast_test_0', 'ast_test_1']);
+
+    const rebuilt = await lookupCachedExtraction({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      fetchImpl: makeFetch(harness),
+      imageMappingMode: 'asset-id',
+    });
+
+    expect(rebuilt).not.toBeNull();
+    // The image bytes were NOT fetched: only the artifact asset was resolved
+    // from the pool (data-url mode resolves artifact + every image).
+    expect(harness.resolve).toHaveBeenCalledTimes(1);
+    expect(harness.resolve).toHaveBeenCalledWith(record!.artifactAssetId);
+    // metadata.imageMapping maps img_N → the allocated asset id, and
+    // pdfImages carry the id on `assetId` with src left empty.
+    expect(rebuilt?.metadata?.imageMapping).toEqual({ img_1: 'ast_test_0', img_2: 'ast_test_1' });
+    expect(rebuilt?.metadata?.pdfImages?.[0]).toMatchObject({
+      id: 'img_1',
+      src: '',
+      assetId: 'ast_test_0',
+      description: 'Device overview',
+    });
+    expect(rebuilt?.metadata?.pdfImages?.[1]).toMatchObject({
+      id: 'img_2',
+      src: '',
+      assetId: 'ast_test_1',
+    });
+    expect(rebuilt?.images).toEqual([]);
+    // The text half is rebuilt exactly as a real extraction returns it.
+    expect(rebuilt?.text).toBe(original.text);
   });
 
   it('reports a miss when no record exists', async () => {
@@ -1347,6 +1500,51 @@ describe('fetchExtractionWithCache', () => {
     expect(spies.bytes).not.toHaveBeenCalled();
   });
 
+  it('feeds an asset-id imageMapping on a server-backed hit (RFC #1153 part 2 C)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      result: fixtureResult(),
+    });
+    const { fetchers, spies } = fetchersThatThrow();
+
+    const outcome = await fetchExtractionWithCache({
+      serverBacked: true,
+      hasAssetId: true,
+      fetchers,
+      logWarning: vi.fn(),
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      kv,
+      pool: harness.pool,
+      fetchImpl: makeFetch(harness),
+      imageMappingMode: 'asset-id',
+      parseFailedMessage: 'parse failed',
+    });
+
+    expect(outcome.cacheHit).toBe(true);
+    // The cache hit names images by their pool asset ids directly — no image
+    // bytes were materialized client-side — so generation can be fed by id.
+    expect(outcome.data.metadata?.imageMapping).toEqual({
+      img_1: 'ast_test_0',
+      img_2: 'ast_test_1',
+    });
+    expect(outcome.data.metadata?.pdfImages?.[0]?.assetId).toBe('ast_test_0');
+    expect(outcome.data.images).toEqual([]);
+    expect(spies.assetId).not.toHaveBeenCalled();
+    expect(spies.bytes).not.toHaveBeenCalled();
+  });
+
   it('runs the real extraction on a miss and caches the result', async () => {
     const kv = new FakeKV();
     const harness = makePool();
@@ -1387,6 +1585,45 @@ describe('fetchExtractionWithCache', () => {
     await expect(
       kv.get(managedKey(DIGEST, 'mineru', '1'), EXTRACTION_CACHE_KV_SCOPE),
     ).resolves.not.toBeNull();
+  });
+
+  it('resolves the cacheWrite to the derived image asset ids on a miss (RFC #1153 part 2 B)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    const assetIdForm = vi.fn(async () => {
+      return new Response(JSON.stringify({ success: true, data: fixtureResult() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const byteForm = vi.fn(async () => {
+      throw new Error('byte form must not be used');
+    });
+
+    const outcome = await fetchExtractionWithCache({
+      serverBacked: true,
+      hasAssetId: true,
+      fetchers: { submitAssetIdForm: assetIdForm, submitByteForm: byteForm },
+      logWarning: vi.fn(),
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      kv,
+      pool: harness.pool,
+      fetchImpl: makeFetch(harness),
+      imageMappingMode: 'asset-id',
+      parseFailedMessage: 'parse failed',
+    });
+
+    // A server-backed caller awaits the detached write to learn the image
+    // asset ids (extraction id → pool asset id) without materializing bytes.
+    const derived = await outcome.cacheWrite;
+    expect(derived).toEqual([
+      expect.objectContaining({ id: 'img_1', assetId: 'ast_test_0' }),
+      expect.objectContaining({ id: 'img_2', assetId: 'ast_test_1' }),
+    ]);
   });
 
   it('writes both keys when the actual extractor differs from the expected one, and hits via the expected key on re-import (K1)', async () => {

--- a/tests/document/extraction-cache.test.ts
+++ b/tests/document/extraction-cache.test.ts
@@ -79,6 +79,33 @@ function fixtureResult(): ParsedPdfContent {
   };
 }
 
+/** A document-extraction result with `count` images, for probe-batching tests. */
+function manyImageResult(count: number): ParsedPdfContent {
+  const imageSrcs = Array.from({ length: count }, (_, index) => {
+    const dataUrl = `data:image/png;base64,${Buffer.from(`img-${index + 1}`).toString('base64')}`;
+    return dataUrl;
+  });
+  return {
+    text: '# Many images',
+    images: imageSrcs,
+    metadata: {
+      pageCount: count,
+      parser: 'mineru',
+      fileName: 'many-images.pdf',
+      fileSize: 4096,
+      mimeType: 'application/pdf',
+      imageMapping: Object.fromEntries(imageSrcs.map((src, index) => [`img_${index + 1}`, src])),
+      pdfImages: imageSrcs.map((src, index) => ({
+        id: `img_${index + 1}`,
+        src,
+        pageNumber: index + 1,
+      })),
+      taskId: 'mineru-task-many',
+    },
+    tables: [],
+  };
+}
+
 /** A minimal in-memory KVStore with the same JSON round-trip semantics. */
 class FakeKV implements KVStore {
   private readonly entries = new Map<string, string>();
@@ -943,6 +970,94 @@ describe('lookupCachedExtraction', () => {
     expect(rebuilt).toBeNull();
     expect(harness.exists).toHaveBeenCalledWith('ast_test_1');
     expect(harness.resolve).toHaveBeenCalledTimes(1); // artifact only
+  });
+
+  it('probes every image existence with bounded concurrency on a many-image hit (O3)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    const count = 24;
+    await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      result: manyImageResult(count),
+    });
+    // Track the probe concurrency: how many exists calls are in flight at once.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    harness.exists.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return true;
+    });
+
+    const rebuilt = await lookupCachedExtraction({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      fetchImpl: makeFetch(harness),
+      imageMappingMode: 'asset-id',
+    });
+
+    expect(rebuilt).not.toBeNull();
+    // The happy path consults EVERY image asset — no probe is skipped.
+    expect(harness.exists).toHaveBeenCalledTimes(count);
+    // ... and the batch bound held: never more than 8 probes in flight.
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(8);
+  });
+
+  it('degrades a probe phase that outlives the aggregate budget to a miss, not a hang (O3)', async () => {
+    const kv = new FakeKV();
+    const harness = makePool();
+    await writeExtractionCache({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      sourceDocAssetId: 'ast_source_doc',
+      result: fixtureResult(),
+    });
+    // One image's existence probe never settles — a stalled persistence
+    // endpoint holding the HEAD open. Without an aggregate budget this would
+    // hold the hit path forever; with it, the phase degrades to a miss. The
+    // production default is the 15 s ingest-drain constant; the test injects
+    // a tiny budget so the degrade is observable without waiting 15 s.
+    harness.exists.mockImplementation(async (ref: string) => {
+      if (ref === 'ast_test_1') return new Promise<boolean>(() => undefined);
+      return true;
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const rebuilt = await lookupCachedExtraction({
+      kv,
+      pool: harness.pool,
+      contentDigest: DIGEST,
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+      fetchImpl: makeFetch(harness),
+      imageMappingMode: 'asset-id',
+      assetProbeBudgetMs: 50,
+    });
+
+    // The hit resolved to a miss after the budget — it did not wait on the
+    // hanging probe — with exactly ONE warn naming the budget.
+    expect(rebuilt).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('aggregate budget');
+    warn.mockRestore();
   });
 
   it('reports a miss when no record exists', async () => {

--- a/tests/document/extraction-materialization.test.ts
+++ b/tests/document/extraction-materialization.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  awaitWithFallback,
+  materializeBundleImages,
+} from '@/lib/document/extraction-materialization';
+import type { ParsedDocumentImage } from '@/lib/document/bundle';
+
+/**
+ * Per-source image transport for a generation run (RFC #1153 part 2, N2/N4):
+ * the cache-write await is bounded (a stalled pool/KV never gates the user's
+ * generation) and the data-URL fallback is decided PER SOURCE (one source's
+ * failed cache write never silently drops another source's images).
+ */
+
+function image(
+  over: Partial<ParsedDocumentImage>,
+): ParsedDocumentImage & { visionPriority: number } {
+  return {
+    id: 'img_1',
+    src: 'data:image/png;base64,AQID',
+    pageNumber: 1,
+    sourceDocumentId: 'src_a',
+    sourceDocumentOrder: 1,
+    visionPriority: 1,
+    ...over,
+  };
+}
+
+describe('awaitWithFallback (N2 — bounded cache-write await)', () => {
+  it('resolves the promise when it settles within the budget', async () => {
+    await expect(awaitWithFallback(Promise.resolve(['img_1']), 1000, [])).resolves.toEqual([
+      'img_1',
+    ]);
+  });
+
+  it('resolves the FALLBACK when the promise never settles, without hanging', async () => {
+    const neverSettling = new Promise<unknown[]>(() => undefined);
+    await expect(awaitWithFallback(neverSettling, 20, [])).resolves.toEqual([]);
+  });
+
+  it('lets a rejected promise propagate only when it settles first (callers catch best-effort writes)', async () => {
+    await expect(
+      awaitWithFallback(Promise.reject(new Error('write failed')), 1000, []),
+    ).rejects.toThrow('write failed');
+  });
+});
+
+describe('materializeBundleImages (N4 — per-source fallback)', () => {
+  it('materializes every image on a browser-backed run, exactly as before', async () => {
+    const images = [
+      image({ id: 'img_1', assetId: 'ast_1' }),
+      image({ id: 'img_2', sourceDocumentId: 'src_b' }),
+    ];
+    const store = vi.fn(async (group: Array<ParsedDocumentImage & { visionPriority: number }>) =>
+      group.map((img) => `session_x_${img.id}`),
+    );
+
+    const { storageIds } = await materializeBundleImages(false, images, store);
+
+    expect(storageIds).toEqual(['session_x_img_1', 'session_x_img_2']);
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(store).toHaveBeenCalledWith(images);
+  });
+
+  it('decides PER SOURCE on a server-backed run: an id-fed source is skipped, a failed source materializes only ITS images', async () => {
+    const images = [
+      // Source A: every image carries an allocated asset id → id-fed, no bytes.
+      image({ id: 'img_1', assetId: 'ast_a_1' }),
+      image({ id: 'img_2', assetId: 'ast_a_2' }),
+      // Source B: its cache write failed (no asset id) → materialize only B.
+      image({ id: 'img_3', sourceDocumentId: 'src_b', sourceDocumentOrder: 2 }),
+      image({ id: 'img_4', sourceDocumentId: 'src_b', sourceDocumentOrder: 2 }),
+    ];
+    const store = vi.fn(async (group: Array<ParsedDocumentImage & { visionPriority: number }>) =>
+      group.map((img) => `session_x_${img.id}`),
+    );
+
+    const { storageIds } = await materializeBundleImages(true, images, store);
+
+    // Only source B's images carry IndexedDB storage ids; source A stays
+    // id-fed (undefined), so its images are NOT dropped from generation.
+    expect(storageIds).toEqual([undefined, undefined, 'session_x_img_3', 'session_x_img_4']);
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(store).toHaveBeenCalledWith([images[2], images[3]]);
+  });
+
+  it('materializes a source that has a MIX of id-fed and id-less images (all-or-nothing per source)', async () => {
+    const images = [image({ id: 'img_1', assetId: 'ast_partial_1' }), image({ id: 'img_2' })];
+    const store = vi.fn(async (group: Array<ParsedDocumentImage & { visionPriority: number }>) =>
+      group.map((img) => `session_x_${img.id}`),
+    );
+
+    const { storageIds } = await materializeBundleImages(true, images, store);
+
+    expect(storageIds).toEqual(['session_x_img_1', 'session_x_img_2']);
+  });
+
+  it('composes with awaitWithFallback: a timed-out cache write (no ids) falls back to per-source materialization', async () => {
+    const images = [image({ id: 'img_1', sourceDocumentId: 'src_b', sourceDocumentOrder: 2 })];
+    const store = vi.fn(async () => ['session_x_img_1']);
+    const neverSettlingWrite = new Promise<unknown[]>(() => undefined);
+
+    // A server-backed run whose cache write hangs: the bounded await yields no
+    // ids, so the source's images are materialized instead of being dropped.
+    const derived = await awaitWithFallback(neverSettlingWrite, 20, []);
+    const { storageIds } = await materializeBundleImages(true, images, store);
+
+    expect(derived).toEqual([]);
+    expect(storageIds).toEqual(['session_x_img_1']);
+    expect(store).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/document/material-library-manifest.test.ts
+++ b/tests/document/material-library-manifest.test.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'node:fs';
-import { dirname, isAbsolute, resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -80,6 +81,11 @@ function importSpecifiers(source: string): string[] {
   while ((match = staticRe.exec(source)) !== null) specifiers.push(match[1]);
   const dynamicRe = /import\(\s*['"]([^'"]+)['"]\s*\)/g;
   while ((match = dynamicRe.exec(source)) !== null) specifiers.push(match[1]);
+  // `export … from '…'` re-exports are import-graph edges too: a server-only
+  // module re-exported through a client-reachable file would otherwise slip
+  // past the graph scan entirely and rely on `pnpm build` alone.
+  const reexportRe = /export\s+(?:type\s+)?(?:\*|\{[^}]*\})[^;]*?from\s+['"]([^'"]+)['"]/g;
+  while ((match = reexportRe.exec(source)) !== null) specifiers.push(match[1]);
   return specifiers;
 }
 
@@ -140,5 +146,22 @@ describe('material library manifest — browser-safe import graph', () => {
     expect(
       [...violations.entries()].map(([file, patterns]) => `${file}: ${patterns.join(', ')}`),
     ).toEqual([]);
+  });
+
+  it('descends into `export … from` re-export specifiers (a re-exported server-only module is still a violation)', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'material-library-manifest-'));
+    try {
+      const reexport = join(tmpDir, 'reexport.ts');
+      const poison = join(tmpDir, 'poison.ts');
+      // The forbidden dependency is reachable ONLY through an `export … from`
+      // re-export — the exact edge the re-export scan must follow.
+      writeFileSync(poison, `import sharp from 'sharp';\n`, 'utf8');
+      writeFileSync(reexport, `export * from './poison';\n`, 'utf8');
+
+      const violations = scanGraph(reexport);
+      expect([...violations.entries()].some(([file]) => file === poison)).toBe(true);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/document/material-library-manifest.test.ts
+++ b/tests/document/material-library-manifest.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Browser-safety contract for the material library manifest (RFC #1153 part 2).
+ *
+ * `lib/materials/library.ts` is a client-reachable module: the upload page
+ * (`app/page.tsx`) mints entries at ingest, and `lib/document/extraction-cache.ts`
+ * (also client-reachable) records derivation pointers. If it — or anything it
+ * transitively imports — ever reaches a server-only dependency, the
+ * server-only chain (sharp / @alicloud/* / child_process / fs / net, pulled in
+ * through the provider implementations or the server persistence backend)
+ * leaks back into the client bundle and the production build breaks exactly
+ * like the failure the extractor manifest was created to fix. This test pins
+ * the library's import GRAPH, mirroring
+ * `tests/document/extractor-manifest.test.ts`.
+ *
+ * One deliberate relaxation vs. the extractor-manifest guard: the library
+ * legitimately depends on the persistence bootstrap (`NEXT_PUBLIC_PERSISTENCE`
+ * env reads) and the shared logger (`LOG_LEVEL` / `LOG_FORMAT` env reads),
+ * both of which already ship to the client bundle today through the
+ * extraction-cache module. `process.env.NEXT_PUBLIC_*` is inlined by Next.js;
+ * the others degrade to `undefined` at runtime. Those specific patterns are
+ * stripped before the `process.` global check; a `process` reference that
+ * names something else (e.g. `DATABASE_URL`) would still fail.
+ */
+
+const REPO_ROOT = resolve(process.cwd());
+const LIBRARY_PATH = resolve(REPO_ROOT, 'lib/materials/library.ts');
+
+/** Import signatures that must never appear in the library's transitive import graph. */
+const FORBIDDEN_IMPORT_PATTERNS: RegExp[] = [
+  /from\s+['"]sharp['"]/,
+  /require\(['"]sharp['"]\)/,
+  /@alicloud\//,
+  /child_process/,
+  /from\s+['"](?:node:)?fs['"]/,
+  /require\(['"](?:node:)?fs['"]\)/,
+  /from\s+['"](?:node:)?net['"]/,
+  /require\(['"](?:node:)?net['"]\)/,
+  /from\s+['"](?:node:)?stream['"]/,
+  /require\(['"](?:node:)?stream['"]\)/,
+  /from\s+['"]unpdf['"]/,
+  /from\s+['"]detect-libc['"]/,
+];
+
+/**
+ * Node-only globals: a browser bundle cannot provide these at runtime. Only
+ * enforced in files with actual runtime code — a type-only module is erased at
+ * compile time. `process.env.NEXT_PUBLIC_*` and `process.env.LOG_*` reads are
+ * the documented, already-shipping client-safe exceptions (see the file
+ * docstring) and are stripped before matching.
+ */
+const FORBIDDEN_RUNTIME_GLOBALS: RegExp[] = [
+  /\bprocess\.(?!env\.NEXT_PUBLIC_|env\.LOG_)/,
+  /\bBuffer\b/,
+  /\b__dirname\b/,
+  /\b__filename\b/,
+];
+
+/** Whether the file contains runtime code (as opposed to pure type declarations). */
+const HAS_RUNTIME_CODE = /\b(?:const|let|var|function|class|enum)\b/;
+
+/** Strip block and line comments so docstring mentions can't trip the guard. */
+function stripComments(source: string): string {
+  return (
+    source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      // Line comments, keeping `https://`-style sequences (a `//` preceded by `:`) intact.
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+  );
+}
+
+/** Every static and dynamic import specifier in a source file. */
+function importSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const staticRe = /import\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = staticRe.exec(source)) !== null) specifiers.push(match[1]);
+  const dynamicRe = /import\(\s*['"]([^'"]+)['"]\s*\)/g;
+  while ((match = dynamicRe.exec(source)) !== null) specifiers.push(match[1]);
+  return specifiers;
+}
+
+function violationsIn(source: string): string[] {
+  const stripped = stripComments(source);
+  const importViolations = FORBIDDEN_IMPORT_PATTERNS.filter((pattern) =>
+    pattern.test(stripped),
+  ).map((pattern) => pattern.source);
+  // Node globals only matter in runtime code; type-only modules are erased.
+  if (!HAS_RUNTIME_CODE.test(stripped)) return importViolations;
+  const globalViolations = FORBIDDEN_RUNTIME_GLOBALS.filter((pattern) =>
+    pattern.test(stripped),
+  ).map((pattern) => pattern.source);
+  return [...importViolations, ...globalViolations];
+}
+
+/** Resolve a relative TS import specifier to a real file (extensions are implicit). */
+function resolveTsImport(fromDir: string, specifier: string): string | null {
+  const base = resolve(fromDir, specifier);
+  const candidates = [base, `${base}.ts`, `${base}.tsx`, `${base}/index.ts`, `${base}/index.tsx`];
+  return (
+    candidates.find((candidate) => {
+      try {
+        readFileSync(candidate, 'utf8');
+        return true;
+      } catch {
+        return false;
+      }
+    }) ?? null
+  );
+}
+
+/** Depth-first scan of the library's import graph; returns path → violations. */
+function scanGraph(
+  entryPath: string,
+  visited = new Set<string>(),
+  violations = new Map<string, string[]>(),
+): Map<string, string[]> {
+  const absolutePath = isAbsolute(entryPath) ? entryPath : resolve(REPO_ROOT, entryPath);
+  if (visited.has(absolutePath)) return violations;
+  visited.add(absolutePath);
+
+  const source = readFileSync(absolutePath, 'utf8');
+  const fileViolations = violationsIn(source);
+  if (fileViolations.length > 0) violations.set(absolutePath, fileViolations);
+
+  for (const specifier of importSpecifiers(source)) {
+    if (!specifier.startsWith('.')) continue; // package imports are guarded above
+    const child = resolveTsImport(dirname(absolutePath), specifier);
+    if (child) scanGraph(child, visited, violations);
+  }
+  return violations;
+}
+
+describe('material library manifest — browser-safe import graph', () => {
+  it('keeps the library and every transitive dependency free of server-only code', () => {
+    const violations = scanGraph(LIBRARY_PATH);
+    expect(
+      [...violations.entries()].map(([file, patterns]) => `${file}: ${patterns.join(', ')}`),
+    ).toEqual([]);
+  });
+});

--- a/tests/generation/resolve-image-ids-mixed.test.ts
+++ b/tests/generation/resolve-image-ids-mixed.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+
+import { resolveImageIds } from '@openmaic/generation';
+import type { GeneratedSlideData } from '@openmaic/generation';
+
+function imageElement(src: string): GeneratedSlideData['elements'][number] {
+  return {
+    id: 'el_1',
+    type: 'image',
+    src,
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 300,
+    rotate: 0,
+    fixedRatio: false,
+  };
+}
+
+/**
+ * Per-source byte fallback (RFC #1153 part 2, N4): a server-backed run can
+ * yield a mapping that MIXES allocated asset ids (sources whose cache write
+ * succeeded) and IndexedDB data URLs (sources whose cache write failed and
+ * materialized their own bytes). `resolveImageIds` is shape-based — each
+ * mapping value is written verbatim — so both transports must ride the same
+ * mapping without a mode flag.
+ */
+describe('resolveImageIds — mixed asset-id / data-URL mapping (N4)', () => {
+  test('writes the allocated id and the data URL verbatim from one mapping', () => {
+    const dataUrl = 'data:image/png;base64,AQID';
+    const resolved = resolveImageIds([imageElement('img_1'), imageElement('img_2')], {
+      img_1: 'ast_allocated_image_0001',
+      img_2: dataUrl,
+    });
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0]).toMatchObject({ type: 'image', src: 'ast_allocated_image_0001' });
+    expect(resolved[1]).toMatchObject({ type: 'image', src: dataUrl });
+  });
+
+  test('drops only the image whose id has NO mapping entry in a mixed mapping', () => {
+    const resolved = resolveImageIds(
+      [imageElement('img_1'), imageElement('img_2'), imageElement('img_9')],
+      {
+        img_1: 'ast_allocated_image_0001',
+        img_2: 'data:image/png;base64,AQID',
+      },
+    );
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved.map((el) => (el.type === 'image' ? el.src : undefined))).toEqual([
+      'ast_allocated_image_0001',
+      'data:image/png;base64,AQID',
+    ]);
+  });
+});

--- a/tests/generation/scene-content-asset-id-vision.test.ts
+++ b/tests/generation/scene-content-asset-id-vision.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SceneOutline } from '@/lib/types/generation';
+
+const callLLMMock = vi.hoisted(() => vi.fn());
+const resolveModelFromRequestMock = vi.hoisted(() => vi.fn());
+const resolveVisionImagesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/ai/llm', () => ({
+  callLLM: callLLMMock,
+}));
+
+vi.mock('@/lib/server/resolve-model', () => ({
+  resolveModelFromRequest: resolveModelFromRequestMock,
+}));
+
+vi.mock('@/lib/persistence/resolve-vision-images', () => ({
+  resolveVisionImagesForPrompt: resolveVisionImagesMock,
+}));
+
+/**
+ * Server-backed generation by allocated asset id (RFC #1153 part 2 B): the
+ * client sends `imageMapping` as (image id → allocated asset id), the route
+ * resolves those ids to bytes at prompt-assembly time (before
+ * `buildVisionUserContent`), and `resolveImageIds` writes the ALLOCATED ID
+ * into `PPTImageElement.src` for the renderer to resolve through the pool.
+ */
+describe('scene-content route — asset-id image transport', () => {
+  beforeEach(() => {
+    callLLMMock.mockReset();
+    resolveModelFromRequestMock.mockReset();
+    resolveVisionImagesMock.mockReset();
+    resolveModelFromRequestMock.mockResolvedValue({
+      model: { provider: 'test.chat', modelId: 'test-model' },
+      modelInfo: { outputWindow: 4096, capabilities: { vision: true } },
+      modelString: 'test:test-model',
+      thinkingConfig: undefined,
+    });
+  });
+
+  test('resolves asset ids to the same bytes the base64 path would send and writes the allocated id into src', async () => {
+    vi.resetModules();
+    // The vision slice reaches the route with the allocated id as its src.
+    resolveVisionImagesMock.mockImplementation(async (images: Array<{ id: string; src: string }>) =>
+      images.map((image) => ({
+        ...image,
+        src: `data:image/png;base64,${Buffer.from('resolved-bytes').toString('base64')}`,
+      })),
+    );
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          {
+            type: 'image',
+            src: 'img_1',
+            left: 100,
+            top: 100,
+            width: 400,
+            height: 300,
+            rotate: 0,
+          },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(),
+        pdfImages: [{ id: 'img_1', src: '', pageNumber: 1, width: 100, height: 100 }],
+        imageMapping: { img_1: 'ast_allocated_image_0001' },
+      }),
+    );
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    // The prompt-assembly resolution was asked for the allocated id.
+    expect(resolveVisionImagesMock).toHaveBeenCalledWith(
+      [
+        {
+          id: 'img_1',
+          src: 'ast_allocated_image_0001',
+          width: 100,
+          height: 100,
+        },
+      ],
+      expect.anything(),
+    );
+    // The LLM received the resolved bytes (same content the base64 path would
+    // send — `buildVisionUserContent` strips the data-URL prefix).
+    const messages = callLLMMock.mock.calls[0][0].messages;
+    const imagePart = messages[0].content.find((part: { type: string }) => part.type === 'image');
+    expect(imagePart).toMatchObject({
+      type: 'image',
+      image: Buffer.from('resolved-bytes').toString('base64'),
+      mimeType: 'image/png',
+    });
+    // The generated element's src is the ALLOCATED ID, resolved by the
+    // renderer through the pool registry.
+    expect(body.content.elements[0].src).toBe('ast_allocated_image_0001');
+  });
+
+  test('passes data URLs through untouched on a browser-backed request', async () => {
+    vi.resetModules();
+    const dataUrl = `data:image/png;base64,${Buffer.from('browser-bytes').toString('base64')}`;
+    resolveVisionImagesMock.mockImplementation(
+      async (images: Array<{ id: string; src: string }>) => images,
+    );
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          {
+            type: 'image',
+            src: 'img_1',
+            left: 100,
+            top: 100,
+            width: 400,
+            height: 300,
+            rotate: 0,
+          },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(),
+        pdfImages: [{ id: 'img_1', src: dataUrl, pageNumber: 1, width: 100, height: 100 }],
+        imageMapping: { img_1: dataUrl },
+      }),
+    );
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    // The data-URL payload reaches the resolver verbatim (pass-through), so
+    // the LLM content is byte-identical to the pre-part-2 path.
+    expect(resolveVisionImagesMock).toHaveBeenCalledWith(
+      [{ id: 'img_1', src: dataUrl, width: 100, height: 100 }],
+      expect.anything(),
+    );
+    expect(body.content.elements[0].src).toBe(dataUrl);
+  });
+});
+
+function mockRequest(body: {
+  outline: SceneOutline;
+  pdfImages?: Array<{
+    id: string;
+    src: string;
+    pageNumber: number;
+    width?: number;
+    height?: number;
+  }>;
+  imageMapping?: Record<string, string>;
+}) {
+  return {
+    json: async () => ({
+      outline: body.outline,
+      allOutlines: [body.outline],
+      stageId: 'stage-1',
+      stageInfo: { name: 'Test Stage' },
+      pdfImages: body.pdfImages ?? [],
+      imageMapping: body.imageMapping ?? {},
+    }),
+    headers: {
+      get: () => null,
+    },
+  } as unknown as Parameters<typeof import('@/app/api/generate/scene-content/route').POST>[0];
+}
+
+function slideOutline(): SceneOutline {
+  return {
+    id: 'scene-slide',
+    type: 'slide',
+    title: 'Safety Checklist',
+    description: 'Inspect the device before calibration.',
+    keyPoints: ['Inspect', 'Calibrate'],
+    order: 1,
+    suggestedImageIds: ['img_1'],
+  };
+}

--- a/tests/generation/scene-content-asset-id-vision.test.ts
+++ b/tests/generation/scene-content-asset-id-vision.test.ts
@@ -265,6 +265,169 @@ describe('scene-content route — asset-id image transport', () => {
     expect(body.content.elements[0].src).toBe('ast_mixed_1');
     expect(body.content.elements[1].src).toBe(dataUrl);
   });
+
+  test('multi-drop: refills the vision slice with RESOLVED candidates so no promise dangles (P2)', async () => {
+    vi.resetModules();
+    const dataUrlFor = (bytes: string) =>
+      `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`;
+    // 25 candidates (> MAX_VISION_IMAGES = 20); img_2, img_7 and img_15 are
+    // unresolvable. The old N3 filter dropped them and let the generator
+    // re-slice img_21..img_23 in UNRESOLVED; the refill must admit them WITH
+    // their resolution — every `[see attached]` promise has an attachment.
+    resolveVisionImagesMock.mockImplementation(async (images: Array<{ id: string; src: string }>) =>
+      images
+        .filter((image) => image.src !== 'ast_gone')
+        .map((image) => ({ ...image, src: dataUrlFor(`bytes-for-${image.id}`) })),
+    );
+    const ids = Array.from({ length: 25 }, (_, i) => `img_${i + 1}`);
+    const gone = new Set(['img_2', 'img_7', 'img_15']);
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          { type: 'image', src: 'img_1', left: 100, top: 100, width: 400, height: 300, rotate: 0 },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(ids),
+        pdfImages: ids.map((id, index) => ({
+          id,
+          src: '',
+          pageNumber: index + 1,
+          width: 100,
+          height: 100,
+        })),
+        imageMapping: Object.fromEntries(
+          ids.map((id) => [id, gone.has(id) ? 'ast_gone' : `ast_${id}`]),
+        ),
+      }),
+    );
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const content = callLLMMock.mock.calls[0][0].messages[0].content;
+    const textPart = content.find((part: { type: string }) => part.type === 'text');
+    const text = textPart.text as string;
+    // The dropped ids are gone from the text entirely (no dangling mention).
+    // Word-boundary matched: `img_2` must not match inside the refilled
+    // `img_21`..`img_23`.
+    for (const id of gone) {
+      expect(text).not.toMatch(new RegExp(`\\b${id}\\b`));
+    }
+    // Exactly 20 `[see attached]` promises — one per attachment, no more.
+    expect(text.match(/\[see attached\]/g)).toHaveLength(20);
+    // Every attachment is the RESOLVED bytes of a surviving candidate, in
+    // generator order — including the REFILLED img_21..img_23 (which the old
+    // filter would have admitted unresolved).
+    const expectedResolved = ids.filter((id) => !gone.has(id)).slice(0, 20);
+    const imageParts = content.filter((part: { type: string }) => part.type === 'image');
+    expect(imageParts).toHaveLength(20);
+    imageParts.forEach((part: { image: string }, index: number) => {
+      expect(part.image).toBe(
+        Buffer.from(`bytes-for-${expectedResolved[index]}`).toString('base64'),
+      );
+    });
+    for (const refilled of ['img_21', 'img_22', 'img_23']) {
+      expect(text).toContain(`**${refilled}**`);
+      expect(text).toContain('[see attached]');
+    }
+    // The surviving element still resolves to its ALLOCATED id (B transport).
+    expect(body.content.elements[0].src).toBe('ast_img_1');
+  });
+
+  test('hallucinated reference to a DROPPED id removes the element (no dangling src, P3)', async () => {
+    vi.resetModules();
+    const dataUrlFor = (bytes: string) =>
+      `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`;
+    resolveVisionImagesMock.mockImplementation(async (images: Array<{ id: string; src: string }>) =>
+      images
+        .filter((image) => image.src !== 'ast_gone')
+        .map((image) => ({ ...image, src: dataUrlFor(`bytes-for-${image.id}`) })),
+    );
+    // The model hallucinates a reference to img_2, which the route dropped
+    // (its allocated id does not resolve server-side — a reclaimed asset).
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          { type: 'image', src: 'img_1', left: 100, top: 100, width: 400, height: 300, rotate: 0 },
+          { type: 'image', src: 'img_2', left: 100, top: 420, width: 400, height: 300, rotate: 0 },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(['img_1', 'img_2']),
+        pdfImages: [
+          { id: 'img_1', src: '', pageNumber: 1, width: 100, height: 100 },
+          { id: 'img_2', src: '', pageNumber: 2, width: 200, height: 100 },
+        ],
+        imageMapping: { img_1: 'ast_ok', img_2: 'ast_gone' },
+      }),
+    );
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    // img_2 was STRIPPED from the mapping passed to the generator, so
+    // resolveImageIds takes the clean "no mapping → remove element" path
+    // instead of writing the dangling allocated id into src.
+    expect(body.content.elements).toHaveLength(1);
+    expect(body.content.elements[0].src).toBe('ast_ok');
+  });
+
+  test('browser-backed mode is unaffected: >cap data-URL images all keep their promises', async () => {
+    vi.resetModules();
+    const dataUrlFor = (bytes: string) =>
+      `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`;
+    // Data URLs pass through the resolver untouched — nothing can drop.
+    resolveVisionImagesMock.mockImplementation(
+      async (images: Array<{ id: string; src: string }>) => images,
+    );
+    const ids = Array.from({ length: 25 }, (_, i) => `img_${i + 1}`);
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          { type: 'image', src: 'img_1', left: 100, top: 100, width: 400, height: 300, rotate: 0 },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(ids),
+        pdfImages: ids.map((id, index) => ({
+          id,
+          src: '',
+          pageNumber: index + 1,
+          width: 100,
+          height: 100,
+        })),
+        imageMapping: Object.fromEntries(ids.map((id) => [id, dataUrlFor(id)])),
+      }),
+    );
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const content = callLLMMock.mock.calls[0][0].messages[0].content;
+    const textPart = content.find((part: { type: string }) => part.type === 'text');
+    // The same 20 + 5 split as before part 2: 20 attached, 5 plain text.
+    expect((textPart.text as string).match(/\[see attached\]/g)).toHaveLength(20);
+    const imageParts = content.filter((part: { type: string }) => part.type === 'image');
+    expect(imageParts).toHaveLength(20);
+    imageParts.forEach((part: { image: string }, index: number) => {
+      expect(part.image).toBe(Buffer.from(ids[index]).toString('base64'));
+    });
+    // The element src is the data URL verbatim, exactly as before.
+    expect(body.content.elements[0].src).toBe(dataUrlFor('img_1'));
+  });
 });
 
 function mockRequest(body: {

--- a/tests/generation/scene-content-asset-id-vision.test.ts
+++ b/tests/generation/scene-content-asset-id-vision.test.ts
@@ -18,6 +18,16 @@ vi.mock('@/lib/persistence/resolve-vision-images', () => ({
   resolveVisionImagesForPrompt: resolveVisionImagesMock,
 }));
 
+// The route's resolve-with-refill phase budget reuses the shared 15 s ingest
+// constant; the hanging-store test injects a tiny budget through this mock so
+// the aggregate budget is observable without waiting 15 s (the same injection
+// the extraction-cache test uses for `assetProbeBudgetMs`). Every other test
+// in this file resolves its probes instantly, so the small budget never fires.
+vi.mock('@/lib/document/extract-source', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/document/extract-source')>();
+  return { ...actual, DEFAULT_INGEST_AWAIT_TIMEOUT_MS: 50 };
+});
+
 /**
  * Server-backed generation by allocated asset id (RFC #1153 part 2 B): the
  * client sends `imageMapping` as (image id → allocated asset id), the route
@@ -339,6 +349,75 @@ describe('scene-content route — asset-id image transport', () => {
     expect(body.content.elements[0].src).toBe('ast_img_1');
   });
 
+  test('all-unresolvable fast-fail: the consecutive-failure fuse stops probing after 3 and generation proceeds text-only (P2-r3)', async () => {
+    vi.resetModules();
+    // Every candidate unresolvable, INSTANTLY (a fast-failing store). Without
+    // a fuse the loop would churn through ALL 25 candidates sequentially (one
+    // probe + one warn each); the fuse must stop after 3 consecutive failures
+    // and degrade to text-only generation — never fail the request.
+    const { ids, pdfImages, imageMapping } = manyCandidateImages(25);
+    resolveVisionImagesMock.mockResolvedValue([]);
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({ elements: [], remark: '' }),
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({ outline: slideOutline(ids), pdfImages, imageMapping }),
+    );
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    // The fuse tripped after exactly 3 probes — the other 22 were never
+    // probed (no N-warn churn).
+    expect(resolveVisionImagesMock).toHaveBeenCalledTimes(3);
+    // Generation proceeded with an empty resolved set: text-only (the aiCall
+    // sees no vision images, so callLLM gets a plain `prompt`), no dangling
+    // `[see attached]` promise.
+    expect(callLLMMock).toHaveBeenCalledTimes(1);
+    const prompt = callLLMMock.mock.calls[0][0].prompt as string;
+    expect(prompt).not.toContain('[see attached]');
+    expect(callLLMMock.mock.calls[0][0].messages).toBeUndefined();
+    // ONE summary warn names the fuse (the per-candidate warns are collapsed).
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('consecutive-failure fuse');
+    warn.mockRestore();
+  });
+
+  test('hanging store: the aggregate resolution budget stops the phase within the bound, no hang (P2-r3)', async () => {
+    vi.resetModules();
+    // The store accepts the probe but never answers — a stalled database with
+    // no statement timeout. Each probe would otherwise hold the route until
+    // the platform cap; the aggregate phase budget (the mocked 50 ms below,
+    // the shared 15 s constant in production) must stop the phase within the
+    // bound and degrade to text-only generation.
+    const { ids, pdfImages, imageMapping } = manyCandidateImages(25);
+    resolveVisionImagesMock.mockImplementation(() => new Promise(() => undefined));
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({ elements: [], remark: '' }),
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({ outline: slideOutline(ids), pdfImages, imageMapping }),
+    );
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    // Only the FIRST candidate was probed before the budget fired.
+    expect(resolveVisionImagesMock).toHaveBeenCalledTimes(1);
+    expect(callLLMMock).toHaveBeenCalledTimes(1);
+    const prompt = callLLMMock.mock.calls[0][0].prompt as string;
+    expect(prompt).not.toContain('[see attached]');
+    expect(callLLMMock.mock.calls[0][0].messages).toBeUndefined();
+    // ONE summary warn names the budget.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('aggregate resolution budget');
+    warn.mockRestore();
+  });
+
   test('hallucinated reference to a DROPPED id removes the element (no dangling src, P3)', async () => {
     vi.resetModules();
     const dataUrlFor = (bytes: string) =>
@@ -465,5 +544,21 @@ function slideOutline(suggestedImageIds: string[] = ['img_1']): SceneOutline {
     keyPoints: ['Inspect', 'Calibrate'],
     order: 1,
     suggestedImageIds,
+  };
+}
+
+/** `count` assigned images with distinct allocated ids and page numbers. */
+function manyCandidateImages(count: number) {
+  const ids = Array.from({ length: count }, (_, i) => `img_${i + 1}`);
+  return {
+    ids,
+    pdfImages: ids.map((id, index) => ({
+      id,
+      src: '',
+      pageNumber: index + 1,
+      width: 100,
+      height: 100,
+    })),
+    imageMapping: Object.fromEntries(ids.map((id) => [id, `ast_${id}`])),
   };
 }

--- a/tests/generation/scene-content-asset-id-vision.test.ts
+++ b/tests/generation/scene-content-asset-id-vision.test.ts
@@ -143,6 +143,128 @@ describe('scene-content route — asset-id image transport', () => {
     );
     expect(body.content.elements[0].src).toBe(dataUrl);
   });
+
+  test('drops an unresolvable image from BOTH the prompt text and the attachments (N3)', async () => {
+    vi.resetModules();
+    // The pre-resolution drops img_2 (the server cannot resolve its id);
+    // img_1 resolves to bytes, data URLs pass through.
+    resolveVisionImagesMock.mockImplementation(async (images: Array<{ id: string; src: string }>) =>
+      images
+        .filter((image) => image.src !== 'ast_gone')
+        .map((image) => ({
+          ...image,
+          src: image.src.startsWith('data:')
+            ? image.src
+            : `data:image/png;base64,${Buffer.from(`bytes-for-${image.id}`).toString('base64')}`,
+        })),
+    );
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          {
+            type: 'image',
+            src: 'img_1',
+            left: 100,
+            top: 100,
+            width: 400,
+            height: 300,
+            rotate: 0,
+          },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(['img_1', 'img_2']),
+        pdfImages: [
+          { id: 'img_1', src: '', pageNumber: 1, width: 100, height: 100 },
+          { id: 'img_2', src: '', pageNumber: 2, width: 200, height: 100 },
+        ],
+        imageMapping: { img_1: 'ast_ok', img_2: 'ast_gone' },
+      }),
+    );
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    // The prompt text promised `[see attached]` only for img_1 — img_2's
+    // text mention is gone with its attachment (no dangling promise).
+    const content = callLLMMock.mock.calls[0][0].messages[0].content;
+    const textPart = content.find((part: { type: string }) => part.type === 'text');
+    expect(textPart.text).toContain('img_1');
+    expect(textPart.text).toContain('[see attached]');
+    expect(textPart.text).not.toContain('img_2');
+    // Only img_1's bytes were attached.
+    const imageParts = content.filter((part: { type: string }) => part.type === 'image');
+    expect(imageParts).toHaveLength(1);
+    expect(imageParts[0].image).toBe(Buffer.from('bytes-for-img_1').toString('base64'));
+    // The surviving image still resolves to the ALLOCATED ID in the element
+    // src (part 2 B transport preserved).
+    expect(body.content.elements[0].src).toBe('ast_ok');
+  });
+
+  test('handles a MIXED imageMapping (allocated ids AND data URLs) in one request (N4)', async () => {
+    vi.resetModules();
+    const dataUrl = `data:image/png;base64,${Buffer.from('browser-bytes').toString('base64')}`;
+    resolveVisionImagesMock.mockImplementation(async (images: Array<{ id: string; src: string }>) =>
+      images.map((image) => ({
+        ...image,
+        src: image.src.startsWith('data:')
+          ? image.src
+          : `data:image/png;base64,${Buffer.from('resolved-bytes').toString('base64')}`,
+      })),
+    );
+    callLLMMock.mockResolvedValueOnce({
+      text: JSON.stringify({
+        elements: [
+          {
+            type: 'image',
+            src: 'img_1',
+            left: 100,
+            top: 100,
+            width: 400,
+            height: 300,
+            rotate: 0,
+          },
+          {
+            type: 'image',
+            src: 'img_2',
+            left: 100,
+            top: 420,
+            width: 400,
+            height: 300,
+            rotate: 0,
+          },
+        ],
+        remark: '',
+      }),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-content/route');
+    const response = await POST(
+      mockRequest({
+        outline: slideOutline(['img_1', 'img_2']),
+        pdfImages: [
+          { id: 'img_1', src: '', pageNumber: 1, width: 100, height: 100 },
+          { id: 'img_2', src: dataUrl, pageNumber: 2, width: 200, height: 100 },
+        ],
+        imageMapping: { img_1: 'ast_mixed_1', img_2: dataUrl },
+      }),
+    );
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    // The LLM received both images (id resolved, data URL passed through).
+    const content = callLLMMock.mock.calls[0][0].messages[0].content;
+    const imageParts = content.filter((part: { type: string }) => part.type === 'image');
+    expect(imageParts).toHaveLength(2);
+    // resolveImageIds writes each mapping value verbatim: the allocated id
+    // stays an id, the data URL stays a data URL — the renderer resolves both.
+    expect(body.content.elements[0].src).toBe('ast_mixed_1');
+    expect(body.content.elements[1].src).toBe(dataUrl);
+  });
 });
 
 function mockRequest(body: {
@@ -171,7 +293,7 @@ function mockRequest(body: {
   } as unknown as Parameters<typeof import('@/app/api/generate/scene-content/route').POST>[0];
 }
 
-function slideOutline(): SceneOutline {
+function slideOutline(suggestedImageIds: string[] = ['img_1']): SceneOutline {
   return {
     id: 'scene-slide',
     type: 'slide',
@@ -179,6 +301,6 @@ function slideOutline(): SceneOutline {
     description: 'Inspect the device before calibration.',
     keyPoints: ['Inspect', 'Calibrate'],
     order: 1,
-    suggestedImageIds: ['img_1'],
+    suggestedImageIds,
   };
 }

--- a/tests/generation/scene-outlines-standard-desync.test.ts
+++ b/tests/generation/scene-outlines-standard-desync.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ImageMapping, PdfImage } from '@/lib/types/generation';
+
+const streamLLMMock = vi.hoisted(() => vi.fn());
+const resolveModelFromRequestMock = vi.hoisted(() => vi.fn());
+const resolveVisionImagesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/ai/llm', () => ({
+  streamLLM: streamLLMMock,
+}));
+
+vi.mock('@/lib/server/resolve-model', () => ({
+  resolveModelFromRequest: resolveModelFromRequestMock,
+}));
+
+vi.mock('@/lib/persistence/resolve-vision-images', () => ({
+  resolveVisionImagesForPrompt: resolveVisionImagesMock,
+}));
+
+/**
+ * The standard (non-task-engine) outline branch must rebuild its placeholder
+ * text from the SAME RESOLVED set the route attaches (RFC #1153 part 2, N3):
+ * the task-engine/interactive branch already builds its text from
+ * `resolvedVisionImages`, but the standard `buildOutlinePrompt` branch
+ * rebuilds its own `[see attached]` placeholders from the unresolved slice —
+ * so an id the server cannot resolve used to leave a dangling promise in the
+ * standard prompt. This test pins the fixed branch: a dropped image drops its
+ * text mention AND its attachment.
+ */
+describe('scene-outlines-stream route — standard branch prompt parity on a dropped image (N3)', () => {
+  beforeEach(() => {
+    streamLLMMock.mockReset();
+    resolveModelFromRequestMock.mockReset();
+    resolveVisionImagesMock.mockReset();
+    resolveModelFromRequestMock.mockResolvedValue({
+      model: { provider: 'test.chat', modelId: 'test-model' },
+      modelInfo: { outputWindow: 4096, capabilities: { vision: true } },
+      modelString: 'test:test-model',
+      thinkingConfig: undefined,
+    });
+  });
+
+  test('drops an unresolvable image from the standard prompt text and the attachments', async () => {
+    vi.resetModules();
+    const dataUrlFor = (bytes: string) =>
+      `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`;
+    // The pre-resolution drops img_2 (its id does not resolve server-side);
+    // img_1 resolves to bytes.
+    resolveVisionImagesMock.mockImplementation(async (images: Array<{ id: string; src: string }>) =>
+      images
+        .filter((image) => image.src !== 'ast_gone')
+        .map((image) => ({ ...image, src: dataUrlFor(`outline-bytes-${image.id}`) })),
+    );
+    streamLLMMock.mockReturnValue({
+      textStream: (async function* () {
+        yield JSON.stringify({
+          languageDirective: 'Teach in English.',
+          outlines: [
+            {
+              id: 'scene_1',
+              type: 'slide',
+              title: 'Safety Checklist',
+              description: 'Inspect the device.',
+              keyPoints: ['Inspect', 'Calibrate'],
+              order: 1,
+            },
+          ],
+        });
+      })(),
+    });
+
+    const { POST } = await import('@/app/api/generate/scene-outlines-stream/route');
+    const response = await POST(
+      mockRequest({
+        pdfImages: [
+          { id: 'img_1', src: '', pageNumber: 1, width: 100, height: 100 },
+          { id: 'img_2', src: '', pageNumber: 2, width: 200, height: 100 },
+        ],
+        imageMapping: { img_1: 'ast_ok', img_2: 'ast_gone' },
+      }),
+    );
+    await readStreamBody(response);
+
+    // The standard branch ran with a vision-enabled model, so the LLM call is
+    // multimodal and its text half is the standard prompt's user text.
+    const streamParams = streamLLMMock.mock.calls[0][0] as {
+      system: string;
+      messages: Array<{
+        role: string;
+        content: Array<{ type: string; text?: string; image?: string }>;
+      }>;
+    };
+    expect(streamParams.messages).toBeDefined();
+    const content = streamParams.messages[0].content;
+    const textPart = content.find((part) => part.type === 'text');
+    // img_1 is promised `[see attached]` and IS attached; img_2's text
+    // mention is gone together with its attachment.
+    expect(textPart?.text).toContain('img_1');
+    expect(textPart?.text).toContain('[see attached]');
+    expect(textPart?.text).not.toContain('img_2');
+    const imageParts = content.filter((part) => part.type === 'image');
+    expect(imageParts).toHaveLength(1);
+    expect(imageParts[0]?.image).toBe(Buffer.from('outline-bytes-img_1').toString('base64'));
+  });
+});
+
+function readStreamBody(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  const pump = (): Promise<void> =>
+    reader!.read().then(({ done, value }) => {
+      if (done) return;
+      if (value) text += decoder.decode(value, { stream: true });
+      return pump();
+    });
+  return pump().then(() => text);
+}
+
+function mockRequest(body: {
+  pdfImages: Array<Pick<PdfImage, 'id' | 'src' | 'pageNumber' | 'width' | 'height'>>;
+  imageMapping: ImageMapping;
+}) {
+  return {
+    json: async () => ({
+      requirements: { requirement: 'Teach a safety checklist course.' },
+      pdfText: 'Inspect the device before calibration.',
+      pdfImages: body.pdfImages,
+      imageMapping: body.imageMapping,
+      researchContext: '',
+    }),
+    headers: {
+      get: () => null,
+    },
+  } as unknown as Parameters<
+    typeof import('@/app/api/generate/scene-outlines-stream/route').POST
+  >[0];
+}

--- a/tests/materials/library.test.ts
+++ b/tests/materials/library.test.ts
@@ -214,6 +214,55 @@ describe('material library — upsert by digest with a library-owned allocation'
     expect(kv.storedKeys()).toHaveLength(0);
   });
 
+  it('releases the fresh library-owned allocation when kv.set rejects (one warn, P3)', async () => {
+    vi.spyOn(kv, 'set').mockRejectedValueOnce(new Error('kv set failed'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      upsertMaterialLibraryEntry(
+        {
+          file: FILE_BYTES(),
+          contentDigest: DIGEST_A,
+          name: 'safety-checklist.pdf',
+          size: 2048,
+        },
+        harness.pool,
+      ),
+    ).resolves.toBeUndefined();
+
+    // The fresh library-owned allocation was released — a failed write must
+    // not orphan it (review P3) — and the entry was never written.
+    expect(harness.remove).toHaveBeenCalledWith('ast_lib_0');
+    expect(harness.blobs.has('ast_lib_0')).toBe(false);
+    expect(kv.storedKeys()).toHaveLength(0);
+    // The failure surfaced as exactly ONE warn (which logs the release).
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('releases the fresh library-owned allocation when kv.get rejects (one warn, P3)', async () => {
+    vi.spyOn(kv, 'get').mockRejectedValueOnce(new Error('kv get failed'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      upsertMaterialLibraryEntry(
+        {
+          file: FILE_BYTES(),
+          contentDigest: DIGEST_A,
+          name: 'safety-checklist.pdf',
+          size: 2048,
+        },
+        harness.pool,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(harness.remove).toHaveBeenCalledWith('ast_lib_0');
+    expect(harness.blobs.has('ast_lib_0')).toBe(false);
+    expect(kv.storedKeys()).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
   it('preserves recorded derivation pointers across a same-digest refresh', async () => {
     await upsertMaterialLibraryEntry(
       {

--- a/tests/materials/library.test.ts
+++ b/tests/materials/library.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { KVScope } from '@openmaic/storage';
 
@@ -49,30 +49,52 @@ class FakeKV {
   }
 }
 
-function makePool(): AssetPoolStore & { blobs: Map<string, Blob> } {
+interface FakePoolHarness {
+  pool: AssetPoolStore;
+  blobs: Map<string, Blob>;
+  put: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+/** A fake pool whose `put` mints a NEW id per allocation (like the real store). */
+function makePool(): FakePoolHarness {
   const blobs = new Map<string, Blob>();
   let next = 0;
+  const put = vi.fn(async (data: Blob): Promise<string> => {
+    const id = `ast_lib_${next}`;
+    next += 1;
+    blobs.set(id, data);
+    return id;
+  });
+  const remove = vi.fn(async (ref: string): Promise<void> => {
+    blobs.delete(ref);
+  });
   const pool: AssetPoolStore = {
-    put: async (data: Blob) => {
-      const id = `ast_test_${next}`;
-      next += 1;
-      blobs.set(id, data);
-      return id;
-    },
+    put: put as AssetPoolStore['put'],
     resolve: async (ref: string) => (blobs.has(ref) ? `test://${ref}` : null),
     invalidate: async () => undefined,
-    remove: async (ref: string) => {
-      blobs.delete(ref);
-    },
+    remove: remove as AssetPoolStore['remove'],
     replace: async () => undefined,
     release: async () => undefined,
     close: async () => undefined,
   };
-  return Object.assign(pool, { blobs });
+  return { pool, blobs, put, remove };
+}
+
+/** A fetch implementation serving the fake pool's `test://<assetId>` URLs. */
+function makeFetch(harness: Pick<FakePoolHarness, 'blobs'>): typeof fetch {
+  return (async (input: RequestInfo | URL): Promise<Response> => {
+    const id = String(input).replace(/^test:\/\//, '');
+    const blob = harness.blobs.get(id);
+    return blob ? new Response(blob, { status: 200 }) : new Response('missing', { status: 404 });
+  }) as typeof fetch;
 }
 
 const DIGEST_A = 'a'.repeat(64);
 const DIGEST_B = 'b'.repeat(64);
+
+/** The imported file bytes the library allocates its OWN pool entry from. */
+const FILE_BYTES = () => new Blob(['library-owned bytes'], { type: 'application/pdf' });
 
 function entry(over: Partial<MaterialLibraryEntry>): MaterialLibraryEntry {
   return {
@@ -86,11 +108,13 @@ function entry(over: Partial<MaterialLibraryEntry>): MaterialLibraryEntry {
   };
 }
 
-describe('material library — upsert by digest', () => {
+describe('material library — upsert by digest with a library-owned allocation', () => {
   let kv: FakeKV;
+  let harness: FakePoolHarness;
 
   beforeEach(() => {
     kv = new FakeKV();
+    harness = makePool();
     setMaterialLibraryKVForTests(kv);
   });
 
@@ -98,37 +122,46 @@ describe('material library — upsert by digest', () => {
     resetMaterialLibraryForTests();
   });
 
-  it('mints one entry keyed by contentDigest', async () => {
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_lib_1',
-      contentDigest: DIGEST_A,
-      name: 'safety-checklist.pdf',
-      mimeType: 'application/pdf',
-      size: 2048,
-    });
+  it('mints one entry keyed by contentDigest, pointing at the LIBRARY-owned allocation', async () => {
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist.pdf',
+        mimeType: 'application/pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
 
     const stored = await kv.get<MaterialLibraryEntry>(
       materialLibraryKey(DIGEST_A),
       MATERIAL_LIBRARY_KV_SCOPE,
     );
     expect(stored).toMatchObject({
-      assetId: 'ast_lib_1',
       contentDigest: DIGEST_A,
       name: 'safety-checklist.pdf',
       mimeType: 'application/pdf',
       size: 2048,
     });
+    // The entry names the library's OWN allocation (a fresh pool id), and the
+    // bytes it names actually exist in the pool.
+    expect(stored?.assetId).toBe('ast_lib_0');
+    expect(harness.blobs.has(stored!.assetId)).toBe(true);
     expect(typeof stored?.addedAt).toBe('string');
     expect(kv.storedKeys()).toHaveLength(1);
   });
 
-  it('re-importing the same bytes refreshes the SAME entry (no duplicate)', async () => {
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_lib_1',
-      contentDigest: DIGEST_A,
-      name: 'safety-checklist.pdf',
-      size: 2048,
-    });
+  it('re-importing the same bytes refreshes the SAME entry and releases the previous library allocation AFTER the swap', async () => {
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
     const first = await kv.get<MaterialLibraryEntry>(
       materialLibraryKey(DIGEST_A),
       MATERIAL_LIBRARY_KV_SCOPE,
@@ -136,44 +169,75 @@ describe('material library — upsert by digest', () => {
     // Simulate the second import resolving a moment later with a new
     // allocation and an updated display name.
     await new Promise((resolve) => setTimeout(resolve, 5));
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_lib_2',
-      contentDigest: DIGEST_A,
-      name: 'safety-checklist-copy.pdf',
-      size: 2048,
-    });
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist-copy.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
 
     const refreshed = await kv.get<MaterialLibraryEntry>(
       materialLibraryKey(DIGEST_A),
       MATERIAL_LIBRARY_KV_SCOPE,
     );
-    expect(refreshed?.assetId).toBe('ast_lib_2');
+    expect(refreshed?.assetId).toBe('ast_lib_1');
     expect(refreshed?.name).toBe('safety-checklist-copy.pdf');
     // Same entry: one key, `addedAt` advanced.
     expect(kv.storedKeys()).toHaveLength(1);
     expect(new Date(refreshed!.addedAt).getTime()).toBeGreaterThan(
       new Date(first!.addedAt).getTime(),
     );
+    // The swap released the PREVIOUS library-owned allocation — after the
+    // entry already pointed at the new one — and the new one is alive.
+    expect(harness.remove).toHaveBeenCalledWith(first!.assetId);
+    expect(harness.blobs.has(first!.assetId)).toBe(false);
+    expect(harness.blobs.has(refreshed!.assetId)).toBe(true);
+  });
+
+  it('a failed library putAsset skips the upsert with the KV untouched (upload unaffected)', async () => {
+    harness.put.mockRejectedValueOnce(new Error('pool put failed'));
+
+    await expect(
+      upsertMaterialLibraryEntry(
+        {
+          file: FILE_BYTES(),
+          contentDigest: DIGEST_A,
+          name: 'safety-checklist.pdf',
+          size: 2048,
+        },
+        harness.pool,
+      ),
+    ).resolves.toBeUndefined();
+    expect(kv.storedKeys()).toHaveLength(0);
   });
 
   it('preserves recorded derivation pointers across a same-digest refresh', async () => {
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_lib_1',
-      contentDigest: DIGEST_A,
-      name: 'safety-checklist.pdf',
-      size: 2048,
-    });
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
     await recordMaterialDerivation(DIGEST_A, {
       domain: 'doc',
       extractorId: 'mineru',
       extractorVersion: '1',
     });
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_lib_2',
-      contentDigest: DIGEST_A,
-      name: 'safety-checklist-copy.pdf',
-      size: 2048,
-    });
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist-copy.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
 
     const refreshed = await kv.get<MaterialLibraryEntry>(
       materialLibraryKey(DIGEST_A),
@@ -187,6 +251,57 @@ describe('material library — upsert by digest', () => {
 
 describe('material library — listMaterials', () => {
   let kv: FakeKV;
+  let harness: FakePoolHarness;
+
+  beforeEach(() => {
+    kv = new FakeKV();
+    harness = makePool();
+    setMaterialLibraryKVForTests(kv);
+  });
+
+  afterEach(() => {
+    resetMaterialLibraryForTests();
+  });
+
+  it('lists every entry, newest first by addedAt', async () => {
+    await upsertMaterialLibraryEntry(
+      { file: FILE_BYTES(), contentDigest: DIGEST_A, name: 'old.pdf', size: 10 },
+      harness.pool,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await upsertMaterialLibraryEntry(
+      { file: FILE_BYTES(), contentDigest: DIGEST_B, name: 'new.pdf', size: 20 },
+      harness.pool,
+    );
+
+    const listed = await listMaterials();
+    expect(listed.map((e) => e.name)).toEqual(['new.pdf', 'old.pdf']);
+    // Each entry names its own library-owned allocation, alive in the pool.
+    expect(listed[0]?.assetId).toBe('ast_lib_1');
+    expect(listed[1]?.assetId).toBe('ast_lib_0');
+    expect(harness.blobs.has(listed[0]!.assetId)).toBe(true);
+    expect(harness.blobs.has(listed[1]!.assetId)).toBe(true);
+  });
+
+  it('skips malformed entries instead of failing the list', async () => {
+    await upsertMaterialLibraryEntry(
+      { file: FILE_BYTES(), contentDigest: DIGEST_A, name: 'good.pdf', size: 10 },
+      harness.pool,
+    );
+    await kv.set(
+      materialLibraryKey(DIGEST_B),
+      { assetId: 'ast_bad', contentDigest: DIGEST_B }, // missing name/size/addedAt
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+
+    const listed = await listMaterials();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.name).toBe('good.pdf');
+  });
+});
+
+describe('material library — durability: the library owns its reference (RFC §5 root model)', () => {
+  let kv: FakeKV;
 
   beforeEach(() => {
     kv = new FakeKV();
@@ -197,43 +312,72 @@ describe('material library — listMaterials', () => {
     resetMaterialLibraryForTests();
   });
 
-  it('lists every entry, newest first by addedAt', async () => {
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_old',
-      contentDigest: DIGEST_A,
-      name: 'old.pdf',
-      size: 10,
-    });
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_new',
-      contentDigest: DIGEST_B,
-      name: 'new.pdf',
-      size: 20,
-    });
+  it('readMaterial still resolves AFTER the selection entry is removed (removal never touches the library allocation)', async () => {
+    const harness = makePool();
+    // The selection's upload-time pool entry (part 0): a DIFFERENT allocation
+    // of the same bytes, released by removeCourseMaterial.
+    const selectionAssetId = await harness.pool.put(FILE_BYTES());
 
-    const listed = await listMaterials();
-    expect(listed.map((e) => e.name)).toEqual(['new.pdf', 'old.pdf']);
-    expect(listed[0]?.assetId).toBe('ast_new');
-    expect(listed[1]?.assetId).toBe('ast_old');
-  });
-
-  it('skips malformed entries instead of failing the list', async () => {
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_good',
-      contentDigest: DIGEST_A,
-      name: 'good.pdf',
-      size: 10,
-    });
-    await kv.set(
-      materialLibraryKey(DIGEST_B),
-      { assetId: 'ast_bad', contentDigest: DIGEST_B }, // missing name/size/addedAt
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
+    const stored = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
       MATERIAL_LIBRARY_KV_SCOPE,
     );
+    expect(stored?.assetId).not.toBe(selectionAssetId);
 
-    const listed = await listMaterials();
-    expect(listed).toHaveLength(1);
-    expect(listed[0]?.name).toBe('good.pdf');
+    // The selection lifecycle releases ONLY the selection's entry.
+    await harness.pool.remove(selectionAssetId);
+    expect(harness.blobs.has(selectionAssetId)).toBe(false);
+    expect(harness.blobs.has(stored!.assetId)).toBe(true);
+
+    // The library's reference stays resolvable — the docstring's durability
+    // claim is now true.
+    const result = await readMaterial(stored!.assetId, harness.pool, makeFetch(harness));
+    expect(result?.assetId).toBe(stored!.assetId);
+    expect(result?.size).toBe((FILE_BYTES() as Blob).size);
+  });
+
+  it('re-import swap: the previous library allocation is released, the entry names the live one', async () => {
+    const harness = makePool();
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist-copy.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
+
+    const stored = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    expect(stored?.assetId).toBe('ast_lib_1');
+    // The superseded allocation is gone; the entry's allocation is live.
+    expect(harness.blobs.has('ast_lib_0')).toBe(false);
+    expect(harness.blobs.has(stored!.assetId)).toBe(true);
+    const result = await readMaterial(stored!.assetId, harness.pool, makeFetch(harness));
+    expect(result?.assetId).toBe(stored!.assetId);
+    // The released id no longer resolves.
+    await expect(readMaterial('ast_lib_0', harness.pool, makeFetch(harness))).resolves.toBeNull();
   });
 });
 
@@ -252,16 +396,9 @@ describe('material library — readMaterial via the pool seam', () => {
   it('returns the asset bytes as a data URL through the pool', async () => {
     const pool = makePool();
     const bytes = new Uint8Array([1, 2, 3, 4]);
-    const assetId = await pool.put(new Blob([bytes], { type: 'image/png' }));
-    // Serve the fake pool's `test://<assetId>` URLs, like the extraction-cache
-    // tests do.
-    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
-      const id = String(input).replace(/^test:\/\//, '');
-      const blob = pool.blobs.get(id);
-      return blob ? new Response(blob, { status: 200 }) : new Response('missing', { status: 404 });
-    }) as typeof fetch;
+    const assetId = await pool.pool.put(new Blob([bytes], { type: 'image/png' }));
 
-    const result = await readMaterial(assetId, pool, fetchImpl);
+    const result = await readMaterial(assetId, pool.pool, makeFetch(pool));
     expect(result?.assetId).toBe(assetId);
     expect(result?.mimeType).toBe('image/png');
     expect(result?.size).toBe(4);
@@ -270,7 +407,7 @@ describe('material library — readMaterial via the pool seam', () => {
 
   it('returns null for an unresolvable asset id, never throws', async () => {
     const pool = makePool();
-    await expect(readMaterial('ast_does_not_exist', pool)).resolves.toBeNull();
+    await expect(readMaterial('ast_does_not_exist', pool.pool)).resolves.toBeNull();
   });
 });
 
@@ -294,7 +431,8 @@ describe('material library — KV-unavailable degradation', () => {
     await expect(listMaterials()).resolves.toEqual([]);
   });
 
-  it('upsert and derivation recording never throw on a failing KV', async () => {
+  it('upsert and derivation recording never throw on a failing KV (the library allocation is still attempted)', async () => {
+    const harness = makePool();
     setMaterialLibraryKVForTests({
       get: async () => {
         throw new Error('kv down');
@@ -307,12 +445,15 @@ describe('material library — KV-unavailable degradation', () => {
     });
 
     await expect(
-      upsertMaterialLibraryEntry({
-        assetId: 'ast_lib_1',
-        contentDigest: DIGEST_A,
-        name: 'x.pdf',
-        size: 1,
-      }),
+      upsertMaterialLibraryEntry(
+        {
+          file: FILE_BYTES(),
+          contentDigest: DIGEST_A,
+          name: 'x.pdf',
+          size: 1,
+        },
+        harness.pool,
+      ),
     ).resolves.toBeUndefined();
     await expect(
       recordMaterialDerivation(DIGEST_A, {
@@ -325,13 +466,17 @@ describe('material library — KV-unavailable degradation', () => {
 
   it('records derivation pointers and deduplicates identical identities', async () => {
     const kv = new FakeKV();
+    const harness = makePool();
     setMaterialLibraryKVForTests(kv);
-    await upsertMaterialLibraryEntry({
-      assetId: 'ast_lib_1',
-      contentDigest: DIGEST_A,
-      name: 'safety-checklist.pdf',
-      size: 2048,
-    });
+    await upsertMaterialLibraryEntry(
+      {
+        file: FILE_BYTES(),
+        contentDigest: DIGEST_A,
+        name: 'safety-checklist.pdf',
+        size: 2048,
+      },
+      harness.pool,
+    );
 
     await recordMaterialDerivation(DIGEST_A, {
       domain: 'doc',

--- a/tests/materials/library.test.ts
+++ b/tests/materials/library.test.ts
@@ -263,6 +263,85 @@ describe('material library — upsert by digest with a library-owned allocation'
     warn.mockRestore();
   });
 
+  it('keeps the fresh allocation when a rejecting kv.set actually committed server-side (ambiguous commit, no release, info)', async () => {
+    // An HTTP KV PUT the server commits whose response is lost (proxy/gateway
+    // timeout, connection reset) rejects kv.set — the entry IS written. The
+    // ambiguous-commit re-read must detect it and NOT release the id the
+    // committed entry now names (releasing it would leave a dangling entry
+    // that breaks readMaterial).
+    const realSet = kv.set.bind(kv);
+    vi.spyOn(kv, 'set').mockImplementation(async (key, value, scope) => {
+      await realSet(key, value, scope);
+      throw new Error('kv set response lost');
+    });
+    // `log.info` emits through console.log.
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      upsertMaterialLibraryEntry(
+        {
+          file: FILE_BYTES(),
+          contentDigest: DIGEST_A,
+          name: 'safety-checklist.pdf',
+          size: 2048,
+        },
+        harness.pool,
+      ),
+    ).resolves.toBeUndefined();
+
+    // The entry committed and names the fresh allocation, which was KEPT.
+    const stored = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    expect(stored?.assetId).toBe('ast_lib_0');
+    expect(harness.remove).not.toHaveBeenCalled();
+    expect(harness.blobs.has('ast_lib_0')).toBe(true);
+    expect(kv.storedKeys()).toHaveLength(1);
+    // The keep decision is logged as info (the write actually landed).
+    expect(log.mock.calls.some((c) => String(c[0]).includes('actually committed'))).toBe(true);
+    warn.mockRestore();
+    log.mockRestore();
+  });
+
+  it('skips the release when the post-failure re-read ALSO fails (leak-over-dangling, one warn)', async () => {
+    // The upsert's pre-write get succeeds, the set rejects without committing,
+    // and the ambiguous-commit re-read fails too. The release must be SKIPPED
+    // (leak-over-dangling): a leaked pool entry is recoverable by re-import,
+    // while releasing an id a committed entry might name would create a
+    // dangling entry that breaks readMaterial.
+    const realGet = kv.get.bind(kv);
+    let getCalls = 0;
+    vi.spyOn(kv, 'get').mockImplementation((async (key: string, scope?: KVScope) => {
+      getCalls += 1;
+      if (getCalls === 2) throw new Error('kv get failed on re-read');
+      return realGet(key, scope);
+    }) as typeof kv.get);
+    vi.spyOn(kv, 'set').mockRejectedValueOnce(new Error('kv set failed'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      upsertMaterialLibraryEntry(
+        {
+          file: FILE_BYTES(),
+          contentDigest: DIGEST_A,
+          name: 'safety-checklist.pdf',
+          size: 2048,
+        },
+        harness.pool,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(harness.remove).not.toHaveBeenCalled();
+    expect(harness.blobs.has('ast_lib_0')).toBe(true);
+    expect(kv.storedKeys()).toHaveLength(0);
+    // ONE warn names the leak-over-dangling decision.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('leak-over-dangling');
+    warn.mockRestore();
+  });
+
   it('preserves recorded derivation pointers across a same-digest refresh', async () => {
     await upsertMaterialLibraryEntry(
       {

--- a/tests/materials/library.test.ts
+++ b/tests/materials/library.test.ts
@@ -1,0 +1,379 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { KVScope } from '@openmaic/storage';
+
+import {
+  listMaterials,
+  MATERIAL_LIBRARY_KV_SCOPE,
+  materialLibraryKey,
+  readMaterial,
+  recordMaterialDerivation,
+  resetMaterialLibraryForTests,
+  setMaterialLibraryKVForTests,
+  upsertMaterialLibraryEntry,
+  type MaterialLibraryEntry,
+} from '@/lib/materials/library';
+import type { AssetPoolStore } from '@/lib/media/asset-pool-config';
+
+/** A minimal in-memory KVStore with the same JSON round-trip semantics. */
+class FakeKV {
+  private readonly entries = new Map<string, string>();
+
+  private fullKey(key: string, scope: KVScope | undefined): string {
+    return `${scope ?? MATERIAL_LIBRARY_KV_SCOPE}:${key}`;
+  }
+
+  async get<T>(key: string, scope?: KVScope): Promise<T | null> {
+    const raw = this.entries.get(this.fullKey(key, scope));
+    return raw === undefined ? null : (JSON.parse(raw) as T);
+  }
+
+  async set<T>(key: string, value: T, scope?: KVScope): Promise<void> {
+    this.entries.set(this.fullKey(key, scope), JSON.stringify(value));
+  }
+
+  async remove(key: string, scope?: KVScope): Promise<void> {
+    this.entries.delete(this.fullKey(key, scope));
+  }
+
+  async keys(prefix = '', scope?: KVScope): Promise<string[]> {
+    const fullPrefix = this.fullKey('', scope);
+    return [...this.entries.keys()]
+      .filter((key) => key.startsWith(fullPrefix))
+      .map((key) => key.slice(fullPrefix.length))
+      .filter((key) => key.startsWith(prefix));
+  }
+
+  storedKeys(): string[] {
+    return [...this.entries.keys()];
+  }
+}
+
+function makePool(): AssetPoolStore & { blobs: Map<string, Blob> } {
+  const blobs = new Map<string, Blob>();
+  let next = 0;
+  const pool: AssetPoolStore = {
+    put: async (data: Blob) => {
+      const id = `ast_test_${next}`;
+      next += 1;
+      blobs.set(id, data);
+      return id;
+    },
+    resolve: async (ref: string) => (blobs.has(ref) ? `test://${ref}` : null),
+    invalidate: async () => undefined,
+    remove: async (ref: string) => {
+      blobs.delete(ref);
+    },
+    replace: async () => undefined,
+    release: async () => undefined,
+    close: async () => undefined,
+  };
+  return Object.assign(pool, { blobs });
+}
+
+const DIGEST_A = 'a'.repeat(64);
+const DIGEST_B = 'b'.repeat(64);
+
+function entry(over: Partial<MaterialLibraryEntry>): MaterialLibraryEntry {
+  return {
+    assetId: 'ast_lib_1',
+    contentDigest: DIGEST_A,
+    name: 'safety-checklist.pdf',
+    mimeType: 'application/pdf',
+    size: 2048,
+    addedAt: '2025-01-01T00:00:00.000Z',
+    ...over,
+  };
+}
+
+describe('material library — upsert by digest', () => {
+  let kv: FakeKV;
+
+  beforeEach(() => {
+    kv = new FakeKV();
+    setMaterialLibraryKVForTests(kv);
+  });
+
+  afterEach(() => {
+    resetMaterialLibraryForTests();
+  });
+
+  it('mints one entry keyed by contentDigest', async () => {
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_lib_1',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist.pdf',
+      mimeType: 'application/pdf',
+      size: 2048,
+    });
+
+    const stored = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    expect(stored).toMatchObject({
+      assetId: 'ast_lib_1',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist.pdf',
+      mimeType: 'application/pdf',
+      size: 2048,
+    });
+    expect(typeof stored?.addedAt).toBe('string');
+    expect(kv.storedKeys()).toHaveLength(1);
+  });
+
+  it('re-importing the same bytes refreshes the SAME entry (no duplicate)', async () => {
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_lib_1',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist.pdf',
+      size: 2048,
+    });
+    const first = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    // Simulate the second import resolving a moment later with a new
+    // allocation and an updated display name.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_lib_2',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist-copy.pdf',
+      size: 2048,
+    });
+
+    const refreshed = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    expect(refreshed?.assetId).toBe('ast_lib_2');
+    expect(refreshed?.name).toBe('safety-checklist-copy.pdf');
+    // Same entry: one key, `addedAt` advanced.
+    expect(kv.storedKeys()).toHaveLength(1);
+    expect(new Date(refreshed!.addedAt).getTime()).toBeGreaterThan(
+      new Date(first!.addedAt).getTime(),
+    );
+  });
+
+  it('preserves recorded derivation pointers across a same-digest refresh', async () => {
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_lib_1',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist.pdf',
+      size: 2048,
+    });
+    await recordMaterialDerivation(DIGEST_A, {
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+    });
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_lib_2',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist-copy.pdf',
+      size: 2048,
+    });
+
+    const refreshed = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    expect(refreshed?.derivations).toEqual([
+      { domain: 'doc', extractorId: 'mineru', extractorVersion: '1' },
+    ]);
+  });
+});
+
+describe('material library — listMaterials', () => {
+  let kv: FakeKV;
+
+  beforeEach(() => {
+    kv = new FakeKV();
+    setMaterialLibraryKVForTests(kv);
+  });
+
+  afterEach(() => {
+    resetMaterialLibraryForTests();
+  });
+
+  it('lists every entry, newest first by addedAt', async () => {
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_old',
+      contentDigest: DIGEST_A,
+      name: 'old.pdf',
+      size: 10,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_new',
+      contentDigest: DIGEST_B,
+      name: 'new.pdf',
+      size: 20,
+    });
+
+    const listed = await listMaterials();
+    expect(listed.map((e) => e.name)).toEqual(['new.pdf', 'old.pdf']);
+    expect(listed[0]?.assetId).toBe('ast_new');
+    expect(listed[1]?.assetId).toBe('ast_old');
+  });
+
+  it('skips malformed entries instead of failing the list', async () => {
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_good',
+      contentDigest: DIGEST_A,
+      name: 'good.pdf',
+      size: 10,
+    });
+    await kv.set(
+      materialLibraryKey(DIGEST_B),
+      { assetId: 'ast_bad', contentDigest: DIGEST_B }, // missing name/size/addedAt
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+
+    const listed = await listMaterials();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.name).toBe('good.pdf');
+  });
+});
+
+describe('material library — readMaterial via the pool seam', () => {
+  let kv: FakeKV;
+
+  beforeEach(() => {
+    kv = new FakeKV();
+    setMaterialLibraryKVForTests(kv);
+  });
+
+  afterEach(() => {
+    resetMaterialLibraryForTests();
+  });
+
+  it('returns the asset bytes as a data URL through the pool', async () => {
+    const pool = makePool();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const assetId = await pool.put(new Blob([bytes], { type: 'image/png' }));
+    // Serve the fake pool's `test://<assetId>` URLs, like the extraction-cache
+    // tests do.
+    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+      const id = String(input).replace(/^test:\/\//, '');
+      const blob = pool.blobs.get(id);
+      return blob ? new Response(blob, { status: 200 }) : new Response('missing', { status: 404 });
+    }) as typeof fetch;
+
+    const result = await readMaterial(assetId, pool, fetchImpl);
+    expect(result?.assetId).toBe(assetId);
+    expect(result?.mimeType).toBe('image/png');
+    expect(result?.size).toBe(4);
+    expect(result?.dataUrl).toBe(`data:image/png;base64,${Buffer.from(bytes).toString('base64')}`);
+  });
+
+  it('returns null for an unresolvable asset id, never throws', async () => {
+    const pool = makePool();
+    await expect(readMaterial('ast_does_not_exist', pool)).resolves.toBeNull();
+  });
+});
+
+describe('material library — KV-unavailable degradation', () => {
+  afterEach(() => {
+    resetMaterialLibraryForTests();
+  });
+
+  it('lists an EMPTY library when the KV store is unavailable, without throwing', async () => {
+    setMaterialLibraryKVForTests({
+      get: async () => {
+        throw new Error('kv down');
+      },
+      set: async () => undefined,
+      remove: async () => undefined,
+      keys: async () => {
+        throw new Error('kv down');
+      },
+    });
+
+    await expect(listMaterials()).resolves.toEqual([]);
+  });
+
+  it('upsert and derivation recording never throw on a failing KV', async () => {
+    setMaterialLibraryKVForTests({
+      get: async () => {
+        throw new Error('kv down');
+      },
+      set: async () => {
+        throw new Error('kv down');
+      },
+      remove: async () => undefined,
+      keys: async () => [],
+    });
+
+    await expect(
+      upsertMaterialLibraryEntry({
+        assetId: 'ast_lib_1',
+        contentDigest: DIGEST_A,
+        name: 'x.pdf',
+        size: 1,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      recordMaterialDerivation(DIGEST_A, {
+        domain: 'doc',
+        extractorId: 'mineru',
+        extractorVersion: '1',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('records derivation pointers and deduplicates identical identities', async () => {
+    const kv = new FakeKV();
+    setMaterialLibraryKVForTests(kv);
+    await upsertMaterialLibraryEntry({
+      assetId: 'ast_lib_1',
+      contentDigest: DIGEST_A,
+      name: 'safety-checklist.pdf',
+      size: 2048,
+    });
+
+    await recordMaterialDerivation(DIGEST_A, {
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+    });
+    await recordMaterialDerivation(DIGEST_A, {
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+    });
+    await recordMaterialDerivation(DIGEST_A, {
+      domain: 'media',
+      extractorId: 'alidocmind',
+      extractorVersion: '1',
+    });
+
+    const stored = await kv.get<MaterialLibraryEntry>(
+      materialLibraryKey(DIGEST_A),
+      MATERIAL_LIBRARY_KV_SCOPE,
+    );
+    expect(stored?.derivations).toEqual([
+      { domain: 'doc', extractorId: 'mineru', extractorVersion: '1' },
+      { domain: 'media', extractorId: 'alidocmind', extractorVersion: '1' },
+    ]);
+  });
+
+  it('skips the derivation pointer when no library entry exists for the digest', async () => {
+    const kv = new FakeKV();
+    setMaterialLibraryKVForTests(kv);
+    await recordMaterialDerivation(DIGEST_A, {
+      domain: 'doc',
+      extractorId: 'mineru',
+      extractorVersion: '1',
+    });
+    expect(kv.storedKeys()).toHaveLength(0);
+  });
+
+  it('entry shape contract is the reviewable document', () => {
+    const sample = entry({});
+    expect(Object.keys(sample).sort()).toEqual(
+      ['addedAt', 'assetId', 'contentDigest', 'mimeType', 'name', 'size'].sort(),
+    );
+  });
+});

--- a/tests/persistence/resolve-vision-images.test.ts
+++ b/tests/persistence/resolve-vision-images.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
+import { MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES } from '@/lib/constants/generation';
+
 const resolveServerAssetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/persistence/resolve-server-asset', () => ({
@@ -36,7 +38,11 @@ describe('resolveVisionImagesForPrompt (RFC #1153 part 2 B)', () => {
     expect(resolved).toEqual([
       { id: 'img_1', src: `data:image/png;base64,${BASE64}`, width: 640, height: 480 },
     ]);
-    expect(resolveServerAssetMock).toHaveBeenCalledWith('ast_allocated_1', HEADERS);
+    expect(resolveServerAssetMock).toHaveBeenCalledWith(
+      'ast_allocated_1',
+      HEADERS,
+      MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES,
+    );
   });
 
   it('passes data URLs and concrete URLs through untouched', async () => {
@@ -64,6 +70,23 @@ describe('resolveVisionImagesForPrompt (RFC #1153 part 2 B)', () => {
       HEADERS,
     );
     expect(resolved).toEqual([]);
+  });
+
+  it('drops an OVERSIZED asset with the same warn-and-drop posture, passing the shared size cap (N5)', async () => {
+    resolveServerAssetMock.mockResolvedValue({ status: 'too_large' });
+
+    const resolved = await resolveVisionImagesForPrompt(
+      [{ id: 'img_1', src: 'ast_huge' }],
+      HEADERS,
+    );
+    expect(resolved).toEqual([]);
+    // The cap rides the same resolve call: the store's `identify` rejects the
+    // asset from its recorded length BEFORE any bytes are materialized.
+    expect(resolveServerAssetMock).toHaveBeenCalledWith(
+      'ast_huge',
+      HEADERS,
+      MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES,
+    );
   });
 
   it('drops the image on a store failure (no raw error text reaches the caller)', async () => {

--- a/tests/persistence/resolve-vision-images.test.ts
+++ b/tests/persistence/resolve-vision-images.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const resolveServerAssetMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/persistence/resolve-server-asset', () => ({
+  resolveServerAsset: resolveServerAssetMock,
+}));
+
+import { resolveVisionImagesForPrompt } from '@/lib/persistence/resolve-vision-images';
+
+const BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const BASE64 = Buffer.from(BYTES).toString('base64');
+const HEADERS = new Headers();
+
+describe('resolveVisionImagesForPrompt (RFC #1153 part 2 B)', () => {
+  beforeEach(() => {
+    resolveServerAssetMock.mockReset();
+  });
+
+  it('resolves an allocated asset id to the SAME bytes the base64 path would send', async () => {
+    resolveServerAssetMock.mockResolvedValue({
+      status: 'resolved',
+      buffer: Buffer.from(BYTES),
+      mimeType: 'image/png',
+    });
+
+    const resolved = await resolveVisionImagesForPrompt(
+      [{ id: 'img_1', src: 'ast_allocated_1', width: 640, height: 480 }],
+      HEADERS,
+    );
+
+    // Fixture comparison: the browser-backed path sends the extraction bytes
+    // as `data:image/png;base64,<base64>`; the server-backed path must
+    // resolve the id to exactly that data URL so the vision prompt is
+    // byte-identical — only the transport differs.
+    expect(resolved).toEqual([
+      { id: 'img_1', src: `data:image/png;base64,${BASE64}`, width: 640, height: 480 },
+    ]);
+    expect(resolveServerAssetMock).toHaveBeenCalledWith('ast_allocated_1', HEADERS);
+  });
+
+  it('passes data URLs and concrete URLs through untouched', async () => {
+    const dataUrl = `data:image/png;base64,${BASE64}`;
+    const resolved = await resolveVisionImagesForPrompt(
+      [
+        { id: 'img_1', src: dataUrl },
+        { id: 'img_2', src: 'https://cdn.example.com/x.png' },
+      ],
+      HEADERS,
+    );
+
+    expect(resolved).toEqual([
+      { id: 'img_1', src: dataUrl },
+      { id: 'img_2', src: 'https://cdn.example.com/x.png' },
+    ]);
+    expect(resolveServerAssetMock).not.toHaveBeenCalled();
+  });
+
+  it('drops an id the server cannot resolve instead of leaking it to the LLM', async () => {
+    resolveServerAssetMock.mockResolvedValue({ status: 'missing' });
+
+    const resolved = await resolveVisionImagesForPrompt(
+      [{ id: 'img_1', src: 'ast_gone' }],
+      HEADERS,
+    );
+    expect(resolved).toEqual([]);
+  });
+
+  it('drops the image on a store failure (no raw error text reaches the caller)', async () => {
+    resolveServerAssetMock.mockRejectedValue(new Error('database connection refused'));
+
+    const resolved = await resolveVisionImagesForPrompt(
+      [{ id: 'img_1', src: 'ast_boom' }],
+      HEADERS,
+    );
+    expect(resolved).toEqual([]);
+  });
+
+  it('keeps the other images when only one fails to resolve', async () => {
+    resolveServerAssetMock.mockImplementation(async (assetId: string) =>
+      assetId === 'ast_ok'
+        ? { status: 'resolved' as const, buffer: Buffer.from(BYTES), mimeType: 'image/png' }
+        : { status: 'missing' as const },
+    );
+
+    const resolved = await resolveVisionImagesForPrompt(
+      [
+        { id: 'img_1', src: 'ast_ok' },
+        { id: 'img_2', src: 'ast_missing' },
+        { id: 'img_3', src: `data:image/png;base64,${BASE64}` },
+      ],
+      HEADERS,
+    );
+
+    expect(resolved.map((img) => img.id)).toEqual(['img_1', 'img_3']);
+    expect(resolved[0]?.src).toBe(`data:image/png;base64,${BASE64}`);
+  });
+});

--- a/tests/slide-renderer/use-resolved-image-src.test.ts
+++ b/tests/slide-renderer/use-resolved-image-src.test.ts
@@ -149,6 +149,18 @@ describe('resolveImageSrc (pure)', () => {
     expect(r.resolution).toEqual({ kind: 'placeholder' });
   });
 
+  it('renders an allocated asset id through the pool lease (RFC #1153 part 2)', () => {
+    // `resolveImageIds` writes the allocated pool asset id into
+    // `PPTImageElement.src` on server-backed deployments; the renderer already
+    // resolves opaque refs through the pool registry, so the resolved pool URL
+    // is what reaches the <img>.
+    const allocated = { ...PLACEHOLDER, src: 'ast_allocated_image_0001' };
+    const r = resolveImageSrc(allocated, STAGE, undefined, 'blob:pool-image');
+    expect(r.resolvedSrc).toBe('blob:pool-image');
+    expect(r.resolvedFromAsset).toBe(true);
+    expect(r.resolution).toEqual({ kind: 'url', url: 'blob:pool-image' });
+  });
+
   it('returns disabled for an unresolved placeholder when generation is off', () => {
     const r = resolveImageSrc(PLACEHOLDER, STAGE, undefined, null, true);
     expect(r.resolvedSrc).toBe('');


### PR DESCRIPTION
## Summary

Part 2 of RFC #1153: the material library — a per-principal, KV-backed manifest of imported source documents — and id-addressed generation images. Every imported source now has a durable, library-owned pool reference (surviving selection removal), and on server-backed deployments the generation flow references extracted images by allocated asset id end-to-end: the client sends `imageMapping` as id → asset id, the generation routes resolve bytes server-side at prompt-assembly time, and `resolveImageIds` writes the allocated id into `PPTImageElement.src` (the renderer already resolves allocated ids through the pool). Browser-backed deployments keep today's base64 flow byte-for-byte.

## Related Issues

Part 2 of #1153 (design §4–5). Builds on parts 0 (#1154) and 1 (#1164): the library points at part 1's derivation records for lineage instead of duplicating it, and `listMaterials()` / `readMaterial()` are the two agent-facing atomic tools §4 describes.

## Changes

- **Material library** (`lib/materials/library.ts`, new): entries keyed by content digest (`assetId`, name, MIME, size, `addedAt`, derivation pointers). The library OWNS its pool reference — upsert allocates its own entry from the file (physically free under content addressing), so selection removal and prep-timeout releases never dangle it; re-import advances the reference and releases the previous one only after the entry points at the new id, with an ambiguous-commit re-read guard (leak-over-dangling when a lost response may have committed). Derivation-pointer merges are read-merge-write. Failures degrade with the part-1 bounded-window pattern.
- **Id-addressed vision** (`app/api/generate/scene-content` + `scene-outlines-stream`, `lib/persistence/resolve-vision-images.ts`): the routes resolve the vision slice BEFORE prompt assembly from a shared slice-ordering helper (route and generator cannot drift), refilling past unresolvable ids so a drop admits the next image with its resolution; unresolvable ids are stripped from the mapping, so text mentions, attachments, and element references stay consistent (a hallucinated reference to a dropped id removes the element instead of writing a dangling src). The resolution phase is bounded (15 s aggregate budget raced per probe + a 3-consecutive-failure fuse; either stop degrades to fewer/no images, never a failed request) and size-capped via the shared 50 MB constant at the identity read (no oversized materialization).
- **Cache integration** (`lib/document/extraction-cache.ts`): on server-backed runs, a cache hit rebuilds `imageMapping` as asset ids with no byte materialization, while per-image existence probes (bounded concurrency 8, aggregate budget) keep the reclaim-is-miss invariant mode-independent; a miss learns the derived ids from the (bounded-await, still detached) cache write, falling back per source to data URLs.
- **Per-source transport**: a bundle can mix id-fed and byte-fed sources; `imageMapping` mixes asset ids and data URLs and `resolveImageIds` dispatches by shape. Classroom resume builds the same merged mapping.
- **Tests**: ~170 new assertions across library lifecycle (durability after removal, re-import swap, write-failure release/keep/skip matrix), multi-drop refill parity, hallucinated-id element removal, mixed mappings, timeout fallbacks, probe budgets, oversized-asset drop, and an import-graph guard (now also scanning re-exports) for the new client-reachable modules.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Verification

### Steps to reproduce / test

1. `pnpm check` / `pnpm lint` (0 errors) / `tsc --noEmit` / full vitest (5243 passed) / generation package (136 passed) / `pnpm build` — all green (Node 22).
2. Browser-backed: upload → generate — unchanged base64 flow.
3. Server-backed: upload → generate — network tab shows `imageMapping` carrying `ast_…` ids and no image-byte upload; slides render source images via pool resolution; removing the selected file after upload and calling `readMaterial(assetId)` still resolves (library-owned reference).

### Known limitations (deliberate, with pointers)

- The library manifest and cache index live in KV, which server deployments cannot serve until #1000 Part B; until then both degrade to browser-local with bounded-window probes (same posture as part 1).
- Library entries have no deletion/management surface yet — that UI and the entry-release path it implies are the next milestone of #1153; library-owned allocations accumulate until then.
- The agent-facing tools ship as the two pure functions (`listMaterials` / `readMaterial`); wiring them into an agent tool registry is intentionally left to the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
