### PR TITLE
feat(agent): add the background session runner

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -22,8 +22,8 @@ export async function register(): Promise<void> {
 
   let runner: import('@/lib/server/agent-runtime/runner').AgentRunnerHandle | undefined;
   try {
-    const { isAgentRuntimeEnabled } = await import('@/lib/config/feature-flags');
-    if (isAgentRuntimeEnabled() && !!process.env.DATABASE_URL?.trim()) {
+    const { isAgentRuntimeConfigured } = await import('@/lib/config/feature-flags');
+    if (isAgentRuntimeConfigured()) {
       // startAgentRunner only installs a timer. Store/schema initialization is
       // retained behind the store's lazy promise and never blocks register().
       const runtime = await import('@/lib/server/agent-runtime/runner');

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -18,5 +18,51 @@ export async function register(): Promise<void> {
   // Imported dynamically so the Edge bundle never pulls in `pg`.
   const { startAssetCollectorSchedule } =
     await import('@/lib/persistence/asset-collector-schedule');
-  startAssetCollectorSchedule();
+  const assetSchedule = startAssetCollectorSchedule();
+
+  let runner: import('@/lib/server/agent-runtime/runner').AgentRunnerHandle | undefined;
+  try {
+    const { isAgentRuntimeEnabled } = await import('@/lib/config/feature-flags');
+    if (isAgentRuntimeEnabled() && !!process.env.DATABASE_URL?.trim()) {
+      // startAgentRunner only installs a timer. Store/schema initialization is
+      // retained behind the store's lazy promise and never blocks register().
+      const runtime = await import('@/lib/server/agent-runtime/runner');
+      runner = runtime.startAgentRunner();
+    }
+  } catch (error) {
+    console.error('[instrumentation] Agent runtime startup failed', error);
+  }
+
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      // Park sessions before any pool they use is closed. This preserves the
+      // last durable entry-tree checkpoint for immediate takeover.
+      try {
+        await runner?.stop();
+      } catch (error) {
+        console.error('[instrumentation] Agent runner drain failed', error);
+      }
+      try {
+        await assetSchedule?.stop();
+      } catch (error) {
+        console.error('[instrumentation] Asset collector drain failed', error);
+      }
+      const connectionString = process.env.DATABASE_URL?.trim();
+      if (connectionString) {
+        try {
+          const { getServerPersistenceProvider } =
+            await import('@/lib/persistence/server-provider');
+          const { pool } = await getServerPersistenceProvider(connectionString);
+          await pool.end();
+        } catch (error) {
+          console.error('[instrumentation] Persistence pool shutdown failed', error);
+        }
+      }
+    })();
+    return shutdownPromise;
+  };
+
+  process.once('SIGTERM', () => void shutdown());
+  process.once('SIGINT', () => void shutdown());
 }

--- a/lib/config/feature-flags.ts
+++ b/lib/config/feature-flags.ts
@@ -12,6 +12,23 @@ function readBoolean(envValue: string | undefined): boolean {
 }
 
 /**
+ * Server-only gate for durable background agent execution. This is evaluated
+ * at process runtime and is never exposed to the browser bundle.
+ */
+export function isAgentRuntimeEnabled(): boolean {
+  return readBoolean(process.env.OPENMAIC_AGENT_RUNTIME_ENABLED);
+}
+
+/**
+ * Build-time workbench affordance. This public flag is separate from the
+ * server runtime gate because Next.js inlines NEXT_PUBLIC values into client
+ * bundles; both gates must be on before a workbench page is reachable.
+ */
+export function isProWorkbenchEnabled(): boolean {
+  return readBoolean(process.env.NEXT_PUBLIC_PRO_WORKBENCH_ENABLED);
+}
+
+/**
  * MAIC Editor (Pro mode) gate. Default OFF — gates only the Pro toggle
  * affordance in `Header`. The `StageMode` type union is unaffected so
  * existing code paths typecheck identically with the flag in either

--- a/lib/config/feature-flags.ts
+++ b/lib/config/feature-flags.ts
@@ -19,6 +19,11 @@ export function isAgentRuntimeEnabled(): boolean {
   return readBoolean(process.env.OPENMAIC_AGENT_RUNTIME_ENABLED);
 }
 
+/** The Node runtime can start the runner only with a non-empty database URL. */
+export function isAgentRuntimeConfigured(): boolean {
+  return isAgentRuntimeEnabled() && Boolean(process.env.DATABASE_URL?.trim());
+}
+
 /**
  * Build-time workbench affordance. This public flag is separate from the
  * server runtime gate because Next.js inlines NEXT_PUBLIC values into client

--- a/lib/server/agent-runtime/ask-user.ts
+++ b/lib/server/agent-runtime/ask-user.ts
@@ -1,0 +1,126 @@
+/**
+ * The backend half of an agent asking the user a question.
+ *
+ * A successful call emits the complete question envelope before returning.
+ * The runner then terminates the current run, leaving the next ordinary user
+ * message to requeue the conversation and supply the answer.
+ */
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { Type, type Static } from 'typebox';
+
+/** The complete question envelope, echoed in the tool result and event. */
+export interface AskUserQuestion {
+  question: string;
+  options?: { id: string; label: string }[];
+  multiSelect?: boolean;
+}
+
+export interface AskUserToolDeps {
+  /** Emit the durable user-question lifecycle event. */
+  onUserQuestion: (question: AskUserQuestion) => void;
+}
+
+const AskUserParams = Type.Object({
+  question: Type.String({
+    description: 'The question, phrased for the user to answer in chat. It must be self-contained.',
+  }),
+  options: Type.Optional(
+    Type.Array(
+      Type.Object({
+        id: Type.String({
+          description: 'Stable, short option id. It must be unique across the options.',
+        }),
+        label: Type.String({ description: 'Human-readable option label.' }),
+      }),
+      {
+        description: 'Optional multiple-choice options the interface can render as buttons.',
+      },
+    ),
+  ),
+  multiSelect: Type.Optional(
+    Type.Boolean({ description: 'True when the user may pick several options.' }),
+  ),
+});
+
+export function buildAskUserTool(deps: AskUserToolDeps): AgentTool<typeof AskUserParams, unknown> {
+  return {
+    name: 'ask_user',
+    label: 'Ask the user',
+    description:
+      "Ask the user a question and end the turn. The current run stops, and the user's answer arrives as the next chat message. Use this for a decision the user must own instead of guessing.",
+    parameters: AskUserParams,
+    async execute(_id, params: Static<typeof AskUserParams>, signal) {
+      if (signal?.aborted) throw new Error('aborted');
+      const question = params.question?.trim();
+      if (!question) {
+        return {
+          content: [{ type: 'text' as const, text: 'ask_user needs a non-empty question.' }],
+          details: { error: 'empty-question' },
+          isError: true,
+        };
+      }
+
+      const options =
+        params.options && params.options.length > 0
+          ? params.options
+              .map((option) => ({
+                id: String(option.id ?? '').trim(),
+                label: String(option.label ?? '').trim(),
+              }))
+              .filter((option) => option.id && option.label)
+          : undefined;
+      if (params.options && params.options.length > 0 && (!options || options.length === 0)) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'ask_user options must have both a non-empty id and label.',
+            },
+          ],
+          details: { error: 'invalid-options' },
+          isError: true,
+        };
+      }
+
+      if (options) {
+        const seen = new Set<string>();
+        const duplicates = new Set<string>();
+        for (const option of options) {
+          if (seen.has(option.id)) duplicates.add(option.id);
+          seen.add(option.id);
+        }
+        if (duplicates.size > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `ask_user option ids must be unique; these are repeated: ${[
+                  ...duplicates,
+                ].join(', ')}. Give every option its own id and call again.`,
+              },
+            ],
+            details: { error: 'duplicate-option-ids', duplicates: [...duplicates] },
+            isError: true,
+          };
+        }
+      }
+
+      const envelope: AskUserQuestion = {
+        question,
+        ...(options ? { options } : {}),
+        ...(params.multiSelect ? { multiSelect: true } : {}),
+      };
+      if (signal?.aborted) throw new Error('aborted');
+      deps.onUserQuestion(envelope);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Question sent to the user: "${question}". The run stops here; the user's answer arrives as the next message.`,
+          },
+        ],
+        details: envelope,
+      };
+    },
+  };
+}

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -372,6 +372,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
   let chain: Promise<void> = Promise.resolve();
   let criticalWriteError: unknown;
   let entryWritesHealthy = true;
+  let terminalFrameEmitted = false;
 
   const markLeaseLost = () => {
     leaseLost = true;
@@ -446,6 +447,10 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       return;
     }
     runEventEmitted = true;
+    if (type === LIFECYCLE.sessionEnd) terminalFrameEmitted = true;
+    // Once another worker owns the lease, both the event log and entry tree
+    // reject this generation's writes. The new owner's session_resumed frame
+    // is therefore the durable interruption marker for a lease steal.
     if (leaseLost) return;
 
     const now = Date.now();
@@ -691,6 +696,9 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       return cursor.idle ? users : Math.max(0, users - 1);
     };
     const drainMessages = async (): Promise<number> => {
+      // These reads deliberately avoid a shared transaction: a message added
+      // between them is left for the next serialized drain, while the lease
+      // snapshot prevents steering after ownership has already changed.
       const all = await store.listUserMessages(id);
       const current = await store.getSession(id);
       if (!leaseMatches(current, WORKER_ID, attempt)) {
@@ -748,8 +756,9 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         await agent.continue();
       }
 
-      // A follow-up arriving while the loop winds down extends this run. Only
-      // settle after an idle/drain cycle finds no new durable message.
+      // Capture messages that arrive while the loop winds down. Pi is already
+      // idle here, so an accepted steer is durably detected and requeued by
+      // the settle check for the next claim rather than extending this run.
       for (;;) {
         await agent.waitForIdle();
         if (abort.signal.aborted) break;
@@ -777,8 +786,10 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         return;
       }
 
-      const error = !cancelled && loopError ? loopError : undefined;
-      const status = cancelled ? 'cancelled' : error ? 'failed' : 'succeeded';
+      const settledCancelled = cancelled || (await store.isCancelRequested(id));
+      if (settledCancelled) abort.abort();
+      const error = !settledCancelled && loopError ? loopError : undefined;
+      const status = settledCancelled ? 'cancelled' : error ? 'failed' : 'succeeded';
       emit(LIFECYCLE.sessionEnd, { status, toolCalls, ...(error ? { error } : {}) });
       await flushAll();
       await store.finishSession(id, WORKER_ID, {
@@ -786,7 +797,9 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         ...(error ? { error } : {}),
         resetAttempt: status !== 'failed',
       });
-      if (cancelled) {
+      // Clear only the cancel request included in the terminal verdict. A poll
+      // that observes a later request must not erase it with a stale verdict.
+      if (settledCancelled) {
         await store.clearCancel(id);
       } else {
         await requeueIfUndelivered('settle');
@@ -797,13 +810,19 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       const message = error instanceof Error ? error.message : String(error);
       if (ctx.shuttingDown || leaseLost || tripwireViolated) {
         emit(LIFECYCLE.sessionInterrupted, {
-          reason: tripwireViolated ? 'runner event-order tripwire' : 'runner shutdown',
+          reason: tripwireViolated
+            ? 'runner event-order tripwire'
+            : leaseLost
+              ? 'lease lost'
+              : 'runner shutdown',
           attempt,
         });
         await flushAll(false);
         if (!leaseLost) await store.releaseLease(id, WORKER_ID);
       } else {
-        emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
+        if (!terminalFrameEmitted) {
+          emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
+        }
         await flushAll(false);
         await store.finishSession(id, WORKER_ID, { status: 'failed', error: message });
         await requeueIfUndelivered('run failure');
@@ -827,7 +846,9 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       }
       if (!leaseLost) await store.releaseLease(id, WORKER_ID).catch(() => {});
     } else {
-      emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
+      if (!terminalFrameEmitted) {
+        emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
+      }
       await flushAll(false).catch(() => {});
       await store
         .finishSession(id, WORKER_ID, { status: 'failed', error: message })

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -1,0 +1,904 @@
+/**
+ * Lease-coordinated background execution for durable agent conversations.
+ *
+ * Every application process may run this loop. PostgreSQL is the authority for
+ * claims, lease generations, event ordering, cancellation, and conversation
+ * recovery. A client connection is never part of the execution lifetime.
+ */
+import { randomUUID } from 'node:crypto';
+import { Session, type AgentEvent, type AgentMessage } from '@earendil-works/pi-agent-core';
+import {
+  AgentSessionLeaseLostError,
+  type AgentSessionClaimReason,
+  type AgentSessionMeta,
+  type AgentSessionUserMessage,
+  type ClaimedAgentSession,
+} from '@openmaic/storage';
+
+import { buildAgent } from '@/lib/agent/runtime/build-agent';
+import { createCallLlmStreamFn } from '@/lib/agent/runtime/stream-fn';
+import { HOST_AGENT_LIFECYCLE as LIFECYCLE } from '@/lib/agent-runtime/lifecycle';
+import { createLogger } from '@/lib/logger';
+
+import { resolveAgentDriverModel } from './agent-driver-model';
+import { buildAskUserTool } from './ask-user';
+import { agentRuntimeConfig as config } from './config';
+import {
+  AgentSessionEntryStorage,
+  loadSessionEntryHistory,
+  type SessionEntryHistory,
+} from './entry-tree-storage';
+import { planResume, type ResumeAction } from './resume';
+import { getAgentSessionStore } from './store';
+
+const log = createLogger('AgentRunner');
+const WORKER_ID = `${randomUUID().slice(0, 8)}:${process.pid}`;
+const SESSION_WAKEUP_FALLBACK_MS = 5_000;
+const MESSAGE_UPDATE_MIN_INTERVAL_MS = 150;
+
+/** The runner starts with one capability and no product-specific tools. */
+export const MINIMAL_AGENT_TOOL_NAMES = new Set(['ask_user']);
+
+/** Product-neutral prompt for the zero-tool runtime slice. */
+export const AGENT_RUNTIME_SYSTEM_PROMPT = [
+  'You are a capable assistant working in a durable background session.',
+  'Complete the user request carefully and explain the result clearly.',
+  'The conversation may pause, restart on another worker, or receive follow-up messages.',
+  'Treat earlier conversation messages as durable context.',
+  'Do not claim access to tools or data that are not present in this session.',
+  'Your only available tool is ask_user.',
+  'Use ask_user only when a decision genuinely belongs to the user.',
+  'Make every question self-contained and concise.',
+  'Offer stable, unique option ids when choices are useful.',
+  'After ask_user succeeds, stop and wait for the next user message.',
+  'Do not answer your own question or invent the user decision.',
+  'If no clarification is needed, answer directly without calling a tool.',
+  'Follow later user messages as updates to the same conversation.',
+  'Be honest about uncertainty and unavailable capabilities.',
+  "Reply in the user's language unless the user requests another language.",
+].join('\n');
+
+function isLeaseLostError(error: unknown): boolean {
+  let current = error;
+  const visited = new Set<unknown>();
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    if (current instanceof AgentSessionLeaseLostError) return true;
+    visited.add(current);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/** A required tree write cannot be downgraded to telemetry. */
+export async function writeRequiredSessionEntry(
+  write: () => Promise<void>,
+  onLeaseLost: () => void,
+): Promise<void> {
+  try {
+    await write();
+  } catch (error) {
+    if (isLeaseLostError(error)) {
+      onLeaseLost();
+      return;
+    }
+    throw error;
+  }
+}
+
+interface RunResultMessage {
+  role?: unknown;
+  stopReason?: unknown;
+  errorMessage?: unknown;
+}
+
+function messageContentLength(message: unknown): number {
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return 0;
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === 'string') return content.length;
+  if (!Array.isArray(content)) return 0;
+  return content.reduce((length, block) => {
+    if (typeof block === 'string') return length + block.length;
+    if (!block || typeof block !== 'object' || Array.isArray(block)) return length;
+    const text = (block as { text?: unknown }).text;
+    const thinking = (block as { thinking?: unknown }).thinking;
+    return (
+      length +
+      (typeof text === 'string' ? text.length : 0) +
+      (typeof thinking === 'string' ? thinking.length : 0)
+    );
+  }, 0);
+}
+
+function slimRunResultMessage(message: unknown): RunResultMessage {
+  const source = (message ?? {}) as RunResultMessage;
+  return {
+    role: source.role,
+    stopReason: source.stopReason,
+    errorMessage: source.errorMessage,
+  };
+}
+
+const TOOL_RESULT_LOG_FIELDS = ['role', 'toolCallId', 'toolName', 'isError', 'timestamp'] as const;
+
+function slimToolResultsForLog(toolResults: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(toolResults)) return null;
+  const results: Record<string, unknown>[] = [];
+  for (const result of toolResults) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return null;
+    const source = result as Record<string, unknown>;
+    if (
+      source.role !== 'toolResult' ||
+      typeof source.toolCallId !== 'string' ||
+      typeof source.toolName !== 'string' ||
+      typeof source.isError !== 'boolean' ||
+      typeof source.timestamp !== 'number' ||
+      !Array.isArray(source.content)
+    ) {
+      return null;
+    }
+    const slimmed: Record<string, unknown> = {};
+    for (const field of TOOL_RESULT_LOG_FIELDS) slimmed[field] = source[field];
+    results.push(slimmed);
+  }
+  return results;
+}
+
+/** Keep replay payloads small without mutating pi's recovery transcript. */
+export function slimEventDataForLog(type: string, data: unknown): unknown {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return data;
+  const source = data as Record<string, unknown>;
+
+  if (type === 'agent_end' && Array.isArray(source.messages)) {
+    const last = source.messages[source.messages.length - 1];
+    return {
+      ...source,
+      messageCount: source.messages.length,
+      lastMessageContentLength: messageContentLength(last),
+      messages: last === undefined ? [] : [slimRunResultMessage(last)],
+    };
+  }
+
+  if (type === 'turn_end') {
+    const slimmed: Record<string, unknown> = {
+      ...source,
+      ...(source.message === undefined ? {} : { message: slimRunResultMessage(source.message) }),
+    };
+    if (source.toolResults !== undefined) {
+      const toolResults = slimToolResultsForLog(source.toolResults);
+      if (toolResults === null) {
+        log.warn(
+          'turn_end toolResults shape unrecognized; preserving original payload via deep clone',
+        );
+        try {
+          slimmed.toolResults = structuredClone(source.toolResults);
+        } catch (error) {
+          log.warn(
+            'turn_end toolResults deep clone failed; preserving original payload reference',
+            error,
+          );
+          slimmed.toolResults = source.toolResults;
+        }
+      } else {
+        slimmed.toolResults = toolResults;
+      }
+    }
+    return slimmed;
+  }
+
+  if (type === 'tool_execution_update') {
+    const slimmed = { ...source };
+    delete slimmed.args;
+    delete slimmed.partialResult;
+    return slimmed;
+  }
+
+  if (type === 'message_start' || type === 'message_end') {
+    const message = source.message;
+    if (message && typeof message === 'object' && !Array.isArray(message)) {
+      const messageSource = message as Record<string, unknown>;
+      if (messageSource.role === 'toolResult') {
+        return { ...source, message: { ...messageSource, content: [] } };
+      }
+    }
+  }
+  return data;
+}
+
+/** The cap itself is a legal run; a claim after it is a verdict-only claim. */
+export function isOverAttemptCap(meta: { attempt: number }): boolean {
+  return meta.attempt > config.maxAttempts;
+}
+
+const RUN_LIFECYCLE_EVENT_TYPES = new Set<string>([
+  LIFECYCLE.sessionStart,
+  LIFECYCLE.sessionResumed,
+  LIFECYCLE.sessionInterrupted,
+  LIFECYCLE.sessionEnd,
+]);
+
+/** Runtime tripwire for the client's attempt-reset fence. */
+export function markRunEventEmitted(alreadyEmitted: boolean, type: string): boolean {
+  return alreadyEmitted || RUN_LIFECYCLE_EVENT_TYPES.has(type);
+}
+
+export const LENGTH_STOP_ERROR =
+  'model output hit the max token limit and was truncated; this run did not finish';
+
+export function terminalLoopError(
+  messages: readonly AgentMessage[],
+  errorMessage: string | undefined,
+): string | undefined {
+  if (errorMessage) return errorMessage;
+  const lastAssistant = messages.findLast((message) => message.role === 'assistant') as
+    | (AgentMessage & { stopReason?: unknown })
+    | undefined;
+  return lastAssistant?.stopReason === 'length' ? LENGTH_STOP_ERROR : undefined;
+}
+
+export type UndeliveredRequeueAction = 'none' | 'reset' | 'retry';
+
+/** Classify undelivered work relative to the exact claim watermark. */
+export function planUndeliveredRequeue(input: {
+  logged: { seq: number; ts: number }[];
+  handled: number;
+  claimSeq: number;
+  atVerdict: boolean;
+}): UndeliveredRequeueAction {
+  const undelivered = input.logged.slice(input.handled);
+  if (undelivered.length === 0) return 'none';
+  if (undelivered.some((message) => message.seq > input.claimSeq)) return 'reset';
+  return input.atVerdict ? 'none' : 'retry';
+}
+
+export type RunStart = { kind: 'prompt'; text: string } | { kind: 'continue' };
+
+export interface FollowUpMessage {
+  text: string;
+  materials?: Array<{
+    materialId?: string;
+    originalName?: string;
+    mime?: string;
+    bytes?: number;
+  }>;
+}
+
+/** Derive delivery from the immutable entry sequence, not in-memory state. */
+export function loggedMessageCursor(input: {
+  transcriptUserCount: number;
+  firstTranscriptUserText?: string;
+  loggedCount: number;
+  firstLoggedText?: string;
+  idleAttach?: boolean;
+}): { idle: boolean; delivered: number } {
+  const idle = input.idleAttach === true;
+  return {
+    idle,
+    delivered: idle ? input.transcriptUserCount : Math.max(0, input.transcriptUserCount - 1),
+  };
+}
+
+export function composeFollowUpText(message: FollowUpMessage): string {
+  if (!message.materials?.length) return message.text;
+  const list = message.materials
+    .map((material) => {
+      const id = material.materialId ?? 'attached material';
+      const mime = material.mime ?? 'unknown mime';
+      return `"${material.originalName ?? id}" (${mime}, ${material.bytes ?? 0} bytes)`;
+    })
+    .join(', ');
+  return `${message.text}\n\n[The user attached session material: ${list}. It is registered with this session; reading support will be provided in a later delivery.]`;
+}
+
+export function planRunStart(input: {
+  plan: ResumeAction;
+  claimReason: AgentSessionClaimReason;
+  pending: FollowUpMessage[];
+  prompt: string;
+  idleAttach?: boolean;
+}): RunStart {
+  if (input.plan.kind === 'start' && input.pending.length > 0 && input.idleAttach) {
+    return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
+  }
+  if (input.plan.kind === 'start') return { kind: 'prompt', text: input.prompt };
+  if (input.claimReason === 'queued' && input.pending.length > 0) {
+    return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
+  }
+  return { kind: 'continue' };
+}
+
+export function shouldTerminateAfterToolCall(toolName: string, isError: boolean): boolean {
+  return toolName === 'ask_user' && !isError;
+}
+
+/** Make successful ask_user termination sticky across a mixed tool batch. */
+export function createAskUserTerminateLatch(): {
+  shouldTerminate(toolName: string, isError: boolean): boolean;
+} {
+  let committed = false;
+  return {
+    shouldTerminate(toolName, isError) {
+      if (shouldTerminateAfterToolCall(toolName, isError)) committed = true;
+      return committed;
+    },
+  };
+}
+
+export interface AgentRunnerHandle {
+  readonly workerId: string;
+  stop(options?: { timeoutMs?: number }): Promise<void>;
+}
+
+export interface RunContext {
+  running: Map<string, { abort: AbortController }>;
+  shuttingDown: boolean;
+}
+
+function toFollowUp(message: AgentSessionUserMessage): FollowUpMessage {
+  return {
+    text: message.text,
+    ...(message.materials.length
+      ? { materials: message.materials as FollowUpMessage['materials'] }
+      : {}),
+  };
+}
+
+function leaseMatches(
+  session: AgentSessionMeta | null,
+  workerId: string,
+  attempt: number,
+): boolean {
+  return session?.lease?.workerId === workerId && session.attempt === attempt;
+}
+
+// Session execution is intentionally one large state machine: its nested
+// finally blocks pair every timer, subscription, and agent listener with the
+// exact lifetime in which it can fire.
+export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Promise<void> {
+  const id = meta.id;
+  const attempt = meta.attempt;
+  const claimSeq = meta.claimSeq;
+  const abort = new AbortController();
+  ctx.running.set(id, { abort });
+
+  let store: Awaited<ReturnType<typeof getAgentSessionStore>>;
+  try {
+    store = await getAgentSessionStore();
+  } catch (error) {
+    ctx.running.delete(id);
+    throw error;
+  }
+  let leaseLost = false;
+  let cancelled = false;
+  let chain: Promise<void> = Promise.resolve();
+  let criticalWriteError: unknown;
+  let entryWritesHealthy = true;
+
+  const markLeaseLost = () => {
+    leaseLost = true;
+    abort.abort();
+  };
+  const enqueue = (write: () => Promise<void>, critical = false): void => {
+    chain = chain.then(async () => {
+      if (leaseLost || (critical && !entryWritesHealthy)) return;
+      try {
+        if (critical) await writeRequiredSessionEntry(write, markLeaseLost);
+        else await write();
+      } catch (error) {
+        if (isLeaseLostError(error)) {
+          markLeaseLost();
+          return;
+        }
+        log.error(`session ${id}: ${critical ? 'entry' : 'event'} write failed`, error);
+        if (critical && criticalWriteError === undefined) {
+          entryWritesHealthy = false;
+          criticalWriteError = error;
+          abort.abort();
+        }
+      }
+    });
+  };
+  const flushAll = async (propagateEntryFailure = true): Promise<void> => {
+    await chain;
+    if (propagateEntryFailure && criticalWriteError !== undefined && !leaseLost) {
+      throw criticalWriteError;
+    }
+  };
+
+  let entrySession: Session | undefined;
+  const loadEntryHistory = async (): Promise<SessionEntryHistory> => {
+    entrySession ??= new Session(
+      await AgentSessionEntryStorage.open({ sessionId: id, workerId: WORKER_ID, attempt }),
+    );
+    return loadSessionEntryHistory(entrySession, {
+      sessionId: id,
+      hasPriorRun: await store.hasSessionRunHistory(id),
+    });
+  };
+
+  let runEventEmitted = false;
+  let tripwireViolated = false;
+  let lastMessageUpdateAt = 0;
+  let messageHadThinking = false;
+  let thinkingEndPending = false;
+  let thinkingEndEmitted = false;
+
+  const appendEvent = (type: string, data: unknown, ts: number): void => {
+    enqueue(async () => {
+      const seq = await store.appendRunEvent(id, WORKER_ID, {
+        ts,
+        attempt,
+        type,
+        data: slimEventDataForLog(type, data),
+      });
+      if (seq === null) markLeaseLost();
+    });
+  };
+
+  const emit = (type: string, data: unknown): void => {
+    if (!markRunEventEmitted(runEventEmitted, type)) {
+      if (!tripwireViolated) {
+        tripwireViolated = true;
+        log.error(
+          `TRIPWIRE VIOLATION session ${id}: first runner event must be lifecycle, got ${type}`,
+        );
+        abort.abort();
+      }
+      return;
+    }
+    runEventEmitted = true;
+    if (leaseLost) return;
+
+    const now = Date.now();
+    const endOwesThinkingEnd = type === 'message_end' && thinkingEndPending && !thinkingEndEmitted;
+    if (type === 'message_start' || type === 'message_end') {
+      lastMessageUpdateAt = 0;
+      messageHadThinking = false;
+      thinkingEndPending = false;
+      thinkingEndEmitted = false;
+    }
+    if (type === 'message_start' || type === 'message_update') {
+      const message = (data as { message?: { role?: string; content?: unknown[] } })?.message;
+      if (message?.role === 'assistant' && Array.isArray(message.content)) {
+        let hasThinking = false;
+        let hasText = false;
+        for (const block of message.content as Array<{
+          type?: string;
+          text?: string;
+          thinking?: string;
+        }>) {
+          if (block?.type === 'thinking' && String(block.thinking ?? '').trim()) {
+            hasThinking = true;
+          }
+          if (block?.type === 'text' && String(block.text ?? '').trim()) hasText = true;
+        }
+        if (hasThinking) messageHadThinking = true;
+        if (hasText && messageHadThinking && !thinkingEndEmitted) thinkingEndPending = true;
+      }
+    }
+    if (type === 'message_update') {
+      if (now - lastMessageUpdateAt < MESSAGE_UPDATE_MIN_INTERVAL_MS) return;
+      lastMessageUpdateAt = now;
+    }
+
+    appendEvent(type, data, now);
+    if (type === 'message_update' && thinkingEndPending && !thinkingEndEmitted) {
+      thinkingEndPending = false;
+      thinkingEndEmitted = true;
+      appendEvent(LIFECYCLE.thinkingEnd, {}, now);
+    }
+    if (endOwesThinkingEnd) {
+      thinkingEndEmitted = true;
+      appendEvent(LIFECYCLE.thinkingEnd, {}, now);
+    }
+  };
+
+  /** Every terminal exit checks whether a durable message lacked a consumer. */
+  const requeueIfUndelivered = async (why: string, atVerdict = false): Promise<void> => {
+    try {
+      const logged = await store.listUserMessages(id);
+      const history = await loadEntryHistory();
+      const users = history.cursorMessages.filter((message) => message.role === 'user');
+      const handled = loggedMessageCursor({
+        transcriptUserCount: users.length,
+        firstTranscriptUserText:
+          typeof users[0]?.content === 'string' ? users[0].content : undefined,
+        loggedCount: logged.length,
+        firstLoggedText: logged[0]?.text,
+        idleAttach: meta.existingCourse,
+      }).delivered;
+      const action = planUndeliveredRequeue({ logged, handled, claimSeq, atVerdict });
+      if (action === 'reset' && (await store.requeueSession(id))) {
+        log.info(
+          `session ${id}: ${logged.length - handled} fresh undelivered message(s) at ${why}; requeued with attempt reset`,
+        );
+      } else if (action === 'retry' && (await store.requeueForRetry(id))) {
+        log.info(
+          `session ${id}: ${logged.length - handled} stranded message(s) at ${why}; requeued preserving attempt`,
+        );
+      }
+    } catch (error) {
+      log.warn(`session ${id}: post-terminal requeue check (${why}) failed`, error);
+    }
+  };
+
+  // A verdict claim never executes the model. A message posted after the
+  // claim still receives one attended redemption through the common check.
+  if (isOverAttemptCap(meta)) {
+    try {
+      const error =
+        `session failed ${config.maxAttempts} consecutive unattended attempts; ` +
+        'send a new message to retry';
+      emit(LIFECYCLE.sessionEnd, { status: 'failed', error });
+      await flushAll();
+      await store.finishSession(id, WORKER_ID, { status: 'failed', error });
+      await requeueIfUndelivered('over-cap verdict', true);
+      return;
+    } finally {
+      await flushAll(false);
+      ctx.running.delete(id);
+    }
+  }
+
+  const heartbeatTimer = setInterval(() => {
+    store
+      .heartbeat(id, WORKER_ID)
+      .then((held) => {
+        if (!held && !leaseLost) {
+          log.warn(`session ${id}: lease lost; aborting local run`);
+          markLeaseLost();
+        }
+      })
+      .catch((error) => log.warn(`session ${id}: heartbeat failed`, error));
+  }, config.heartbeatIntervalMs);
+  heartbeatTimer.unref?.();
+
+  const checkCancel = (): void => {
+    store
+      .isCancelRequested(id)
+      .then((requested) => {
+        if (requested) {
+          cancelled = true;
+          abort.abort();
+        }
+      })
+      .catch(() => {});
+  };
+  const cancelPoll = setInterval(checkCancel, SESSION_WAKEUP_FALLBACK_MS);
+  cancelPoll.unref?.();
+
+  try {
+    const recovery = await loadEntryHistory();
+    const historyMessages = recovery.messages;
+    const plan = planResume(historyMessages);
+    const repairedCount = plan.kind === 'continue' ? plan.repairedToolCalls.length : 0;
+    const plannedMessages = plan.kind === 'start' ? [] : plan.messages;
+    const retainedCount = plannedMessages.length - repairedCount;
+
+    // planResume may strip an incomplete suffix and synthesize missing tool
+    // results. Reflect both changes in the append-only tree before execution.
+    if (retainedCount < historyMessages.length) {
+      const targetId = retainedCount > 0 ? recovery.contextEntryIds[retainedCount - 1]! : null;
+      await writeRequiredSessionEntry(async () => {
+        await entrySession!.moveTo(targetId);
+      }, markLeaseLost);
+    }
+    for (const repaired of plannedMessages.slice(retainedCount)) {
+      await writeRequiredSessionEntry(async () => {
+        await entrySession!.appendMessage(repaired);
+      }, markLeaseLost);
+    }
+    if (leaseLost) throw new AgentSessionLeaseLostError(id, WORKER_ID, attempt);
+
+    const loggedMessages = await store.listUserMessages(id);
+    const historyUsers = recovery.cursorMessages.filter((message) => message.role === 'user');
+    const cursor = loggedMessageCursor({
+      transcriptUserCount: historyUsers.length,
+      firstTranscriptUserText:
+        typeof historyUsers[0]?.content === 'string' ? historyUsers[0].content : undefined,
+      loggedCount: loggedMessages.length,
+      firstLoggedText: loggedMessages[0]?.text,
+      idleAttach: meta.existingCourse,
+    });
+    const followUpsDelivered = cursor.delivered;
+    const pending = loggedMessages.slice(followUpsDelivered).map(toFollowUp);
+    const idleAttach = cursor.idle;
+
+    if (plan.kind === 'already-complete' && pending.length === 0) {
+      emit(LIFECYCLE.sessionEnd, {
+        status: 'succeeded',
+        note: 'entry history already terminal',
+      });
+      await flushAll();
+      await store.finishSession(id, WORKER_ID, {
+        status: 'succeeded',
+        resetAttempt: true,
+      });
+      await requeueIfUndelivered('early settle');
+      return;
+    }
+
+    if (plan.kind === 'start' && (pending.length === 0 || !idleAttach)) {
+      emit(LIFECYCLE.sessionStart, {
+        workerId: WORKER_ID,
+        pid: process.pid,
+        prompt: meta.prompt,
+      });
+    } else {
+      emit(LIFECYCLE.sessionResumed, {
+        workerId: WORKER_ID,
+        pid: process.pid,
+        attempt,
+        reason: plan.kind === 'start' || meta.claimReason === 'queued' ? 'follow_up' : 'crash',
+        transcriptMessages: plan.kind === 'start' ? 0 : plan.messages.length,
+        repairedToolCalls: plan.kind === 'continue' ? plan.repairedToolCalls : [],
+      });
+    }
+
+    const plannedStart = planRunStart({
+      plan,
+      claimReason: meta.claimReason,
+      pending,
+      prompt: meta.prompt,
+      idleAttach,
+    });
+    const driver = await resolveAgentDriverModel();
+    const streamFn = createCallLlmStreamFn({
+      languageModel: driver.connection.model,
+      maxOutputTokens: driver.wireMaxOutputTokens,
+      omitMaxOutputTokens: driver.wireMaxOutputTokens === undefined,
+      thinkingConfig: driver.connection.thinkingConfig,
+      source: 'agent-runtime',
+      abortSignal: abort.signal,
+    });
+    const askUserTool = buildAskUserTool({
+      onUserQuestion: (question) => emit(LIFECYCLE.userQuestion, question),
+    });
+    const tools = [askUserTool];
+    const askUserLatch = createAskUserTerminateLatch();
+    let toolCalls = 0;
+    const agent = buildAgent({
+      streamFn,
+      systemPrompt: AGENT_RUNTIME_SYSTEM_PROMPT,
+      model: driver.piModel,
+      tools,
+      allowedToolNames: MINIMAL_AGENT_TOOL_NAMES,
+      ...(plan.kind === 'start' ? {} : { history: plan.messages }),
+      afterToolCall: (toolContext) => {
+        toolCalls += 1;
+        if (askUserLatch.shouldTerminate(toolContext.toolCall.name, toolContext.isError)) {
+          return { terminate: true };
+        }
+        return undefined;
+      },
+    });
+
+    const unsubscribe = agent.subscribe((event: AgentEvent) => {
+      emit(event.type, event);
+      if (event.type === 'message_end') {
+        enqueue(async () => {
+          await entrySession!.appendMessage(event.message);
+        }, true);
+      }
+    });
+    const abortAgent = () => agent.abort();
+    abort.signal.addEventListener('abort', abortAgent);
+
+    // Same-run steering needs a guard because steer() accepts a message before
+    // its eventual message_end has reached the durable tree.
+    let steeredThisAttempt = 0;
+    const deliveredFollowUps = (): number => {
+      const users = agent.state.messages.filter((message) => message.role === 'user').length;
+      return cursor.idle ? users : Math.max(0, users - 1);
+    };
+    const drainMessages = async (): Promise<number> => {
+      const all = await store.listUserMessages(id);
+      const current = await store.getSession(id);
+      if (!leaseMatches(current, WORKER_ID, attempt)) {
+        markLeaseLost();
+        return 0;
+      }
+      const handled = Math.max(deliveredFollowUps(), steeredThisAttempt);
+      let delivered = 0;
+      for (const [index, message] of all.entries()) {
+        if (index < handled) continue;
+        agent.steer({
+          role: 'user',
+          content: composeFollowUpText(toFollowUp(message)),
+        } as unknown as AgentMessage);
+        delivered += 1;
+      }
+      if (delivered > 0) {
+        steeredThisAttempt = handled + delivered;
+        log.info(`session ${id}: steered ${delivered} follow-up message(s)`);
+      }
+      return delivered;
+    };
+
+    // Serialize drains so a timer firing during the settle drain cannot steer
+    // the same message twice. A queued request is absorbed into the same cycle.
+    let drainInFlight: Promise<number> | null = null;
+    let drainQueued = false;
+    const requestDrain = (): Promise<number> => {
+      if (drainInFlight) {
+        drainQueued = true;
+        return drainInFlight;
+      }
+      drainInFlight = (async () => {
+        let delivered = 0;
+        do {
+          drainQueued = false;
+          delivered += await drainMessages().catch(() => 0);
+        } while (drainQueued && !abort.signal.aborted);
+        return delivered;
+      })().finally(() => {
+        drainInFlight = null;
+      });
+      return drainInFlight;
+    };
+    const messagePoll = setInterval(() => void requestDrain(), SESSION_WAKEUP_FALLBACK_MS);
+    messagePoll.unref?.();
+
+    try {
+      if (plannedStart.kind === 'prompt') {
+        if (plan.kind !== 'start' || pending.length > 0) {
+          steeredThisAttempt = followUpsDelivered + 1;
+        }
+        await agent.prompt(plannedStart.text);
+      } else {
+        await agent.continue();
+      }
+
+      // A follow-up arriving while the loop winds down extends this run. Only
+      // settle after an idle/drain cycle finds no new durable message.
+      for (;;) {
+        await agent.waitForIdle();
+        if (abort.signal.aborted) break;
+        const before = steeredThisAttempt;
+        const delivered = await requestDrain();
+        if (abort.signal.aborted) break;
+        if (delivered === 0 || steeredThisAttempt === before) break;
+      }
+      await flushAll();
+
+      const loopError = terminalLoopError(agent.state.messages, agent.state.errorMessage);
+      const shutdown = ctx.shuttingDown && abort.signal.aborted && !cancelled;
+      if (shutdown || tripwireViolated || (leaseLost && abort.signal.aborted)) {
+        emit(LIFECYCLE.sessionInterrupted, {
+          reason: shutdown
+            ? 'runner shutdown'
+            : tripwireViolated
+              ? 'runner event-order tripwire'
+              : 'lease lost',
+          attempt,
+        });
+        await flushAll();
+        if (!leaseLost) await store.releaseLease(id, WORKER_ID);
+        log.info(`session ${id} parked at attempt ${attempt}`);
+        return;
+      }
+
+      const error = !cancelled && loopError ? loopError : undefined;
+      const status = cancelled ? 'cancelled' : error ? 'failed' : 'succeeded';
+      emit(LIFECYCLE.sessionEnd, { status, toolCalls, ...(error ? { error } : {}) });
+      await flushAll();
+      await store.finishSession(id, WORKER_ID, {
+        status,
+        ...(error ? { error } : {}),
+        resetAttempt: status !== 'failed',
+      });
+      if (cancelled) {
+        await store.clearCancel(id);
+      } else {
+        await requeueIfUndelivered('settle');
+      }
+      log.info(`session ${id} -> ${status} (attempt ${attempt}, ${toolCalls} tool calls)`);
+    } catch (error) {
+      if (isLeaseLostError(error)) markLeaseLost();
+      const message = error instanceof Error ? error.message : String(error);
+      if (ctx.shuttingDown || leaseLost || tripwireViolated) {
+        emit(LIFECYCLE.sessionInterrupted, {
+          reason: tripwireViolated ? 'runner event-order tripwire' : 'runner shutdown',
+          attempt,
+        });
+        await flushAll(false);
+        if (!leaseLost) await store.releaseLease(id, WORKER_ID);
+      } else {
+        emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
+        await flushAll(false);
+        await store.finishSession(id, WORKER_ID, { status: 'failed', error: message });
+        await requeueIfUndelivered('run failure');
+        log.error(`session ${id} failed`, error);
+      }
+    } finally {
+      abort.signal.removeEventListener('abort', abortAgent);
+      unsubscribe();
+      clearInterval(messagePoll);
+    }
+  } catch (error) {
+    if (isLeaseLostError(error)) markLeaseLost();
+    const message = error instanceof Error ? error.message : String(error);
+    if (ctx.shuttingDown || leaseLost || tripwireViolated) {
+      if (tripwireViolated) {
+        emit(LIFECYCLE.sessionInterrupted, {
+          reason: 'runner event-order tripwire',
+          attempt,
+        });
+        await flushAll(false).catch(() => {});
+      }
+      if (!leaseLost) await store.releaseLease(id, WORKER_ID).catch(() => {});
+    } else {
+      emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
+      await flushAll(false).catch(() => {});
+      await store
+        .finishSession(id, WORKER_ID, { status: 'failed', error: message })
+        .catch(() => {});
+      await requeueIfUndelivered('setup failure');
+    }
+    log.error(`session ${id} failed during setup`, error);
+  } finally {
+    clearInterval(heartbeatTimer);
+    clearInterval(cancelPoll);
+    await flushAll(false);
+    ctx.running.delete(id);
+  }
+}
+
+/** Start scanning. Store/schema construction remains lazy behind each scan. */
+export function startAgentRunner(): AgentRunnerHandle {
+  const ctx: RunContext = { running: new Map(), shuttingDown: false };
+  let scanTimer: ReturnType<typeof setInterval> | null = null;
+  let scanning = false;
+
+  const scan = async (): Promise<void> => {
+    if (scanning || ctx.shuttingDown) return;
+    scanning = true;
+    try {
+      const store = await getAgentSessionStore();
+      while (ctx.running.size < config.maxConcurrent && !ctx.shuttingDown) {
+        const meta = await store.claimNextSession(WORKER_ID, process.pid, {
+          leaseTtlMs: config.leaseTtlMs,
+          maxAttempts: config.maxAttempts,
+        });
+        if (!meta) break;
+        // Process-local fence in addition to the store's lease exclusion.
+        if (ctx.running.has(meta.id)) continue;
+        log.info(`claiming ${meta.id} (attempt ${meta.attempt})`);
+        void runSession(ctx, meta).catch((error) => {
+          log.error(`runSession ${meta.id} crashed`, error);
+          ctx.running.delete(meta.id);
+        });
+      }
+    } catch (error) {
+      log.error('claim scan failed', error);
+    } finally {
+      scanning = false;
+    }
+  };
+
+  scanTimer = setInterval(() => void scan(), config.scanIntervalMs);
+  scanTimer.unref?.();
+  void scan();
+  log.info(
+    `runner ${WORKER_ID} started (scan=${config.scanIntervalMs}ms, ` +
+      `heartbeat=${config.heartbeatIntervalMs}ms, leaseTtl=${config.leaseTtlMs}ms, ` +
+      `maxConcurrent=${config.maxConcurrent}, maxAttempts=${config.maxAttempts})`,
+  );
+  log.info('minimal tool set enabled: ask_user');
+
+  return {
+    workerId: WORKER_ID,
+    async stop(options?: { timeoutMs?: number }): Promise<void> {
+      ctx.shuttingDown = true;
+      if (scanTimer) clearInterval(scanTimer);
+      const deadlineAt = Date.now() + (options?.timeoutMs ?? 15_000);
+      for (const session of ctx.running.values()) session.abort.abort();
+      while (ctx.running.size > 0 && Date.now() < deadlineAt) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+      if (ctx.running.size > 0) {
+        log.warn(`stop() timed out with ${ctx.running.size} session(s) still settling`);
+      }
+      log.info(`runner ${WORKER_ID} stopped`);
+    },
+  };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { isAgentRuntimeEnabled, isProWorkbenchEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured, isProWorkbenchEnabled } from '@/lib/config/feature-flags';
 
 /** Convert string to Uint8Array */
 function encode(str: string): Uint8Array {
@@ -47,13 +47,13 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Return an actual server-side 404 when either half of the workbench is off.
-  // The public flag is inlined into the client build, while the runtime flag
-  // remains server-only; requiring both prevents a visible interface from
-  // targeting a background runtime that is not running.
-  if (
-    !(isProWorkbenchEnabled() && isAgentRuntimeEnabled()) &&
-    (pathname === '/workbench' || pathname.startsWith('/workbench/'))
-  ) {
+  // Edge middleware cannot reliably inspect server-only deployment variables,
+  // so it enforces the public gate and leaves the complete runtime/database
+  // check to Node. A Node-hosted middleware uses the same gate as startup.
+  const canInspectServerRuntime = process.env.NEXT_RUNTIME !== 'edge';
+  const workbenchEnabled =
+    isProWorkbenchEnabled() && (!canInspectServerRuntime || isAgentRuntimeConfigured());
+  if (!workbenchEnabled && (pathname === '/workbench' || pathname.startsWith('/workbench/'))) {
     return new NextResponse('Not found', { status: 404 });
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { isAgentRuntimeEnabled, isProWorkbenchEnabled } from '@/lib/config/feature-flags';
+
 /** Convert string to Uint8Array */
 function encode(str: string): Uint8Array {
   return new TextEncoder().encode(str);
@@ -42,12 +44,23 @@ async function verifyToken(token: string, accessCode: string): Promise<boolean> 
 }
 
 export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Return an actual server-side 404 when either half of the workbench is off.
+  // The public flag is inlined into the client build, while the runtime flag
+  // remains server-only; requiring both prevents a visible interface from
+  // targeting a background runtime that is not running.
+  if (
+    !(isProWorkbenchEnabled() && isAgentRuntimeEnabled()) &&
+    (pathname === '/workbench' || pathname.startsWith('/workbench/'))
+  ) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
   const accessCode = process.env.ACCESS_CODE;
   if (!accessCode) {
     return NextResponse.next();
   }
-
-  const { pathname } = request.nextUrl;
 
   // Whitelist: access-code endpoints, health check
   if (pathname.startsWith('/api/access-code/') || pathname === '/api/health') {

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -493,10 +493,16 @@ export class PgAgentSessionStore
         const previous = locked.rows[0];
         if (!previous) return null;
         const now = this.clock();
+        // PostgreSQL evaluates every SET expression from the locked pre-update
+        // row, so lease_worker_id still identifies the prior holder here.
         const updated = await tx.query<SessionRow>(
           `UPDATE ${this.table('sessions')}
            SET status = 'running',
-               attempt = attempt + CASE WHEN status = 'queued' THEN 1 ELSE 0 END,
+               attempt = attempt + CASE
+                 WHEN status = 'queued'
+                   OR (status = 'running' AND lease_worker_id IS NOT NULL) THEN 1
+                 ELSE 0
+               END,
                lease_worker_id = $2,
                lease_worker_pid = $3, lease_heartbeat_at = $4, error = NULL, updated_at = now()
            WHERE id = $1 AND deleted_at IS NULL RETURNING ${SESSION_COLUMNS}`,

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -495,7 +495,9 @@ export class PgAgentSessionStore
         const now = this.clock();
         const updated = await tx.query<SessionRow>(
           `UPDATE ${this.table('sessions')}
-           SET status = 'running', attempt = attempt + 1, lease_worker_id = $2,
+           SET status = 'running',
+               attempt = attempt + CASE WHEN status = 'queued' THEN 1 ELSE 0 END,
+               lease_worker_id = $2,
                lease_worker_pid = $3, lease_heartbeat_at = $4, error = NULL, updated_at = now()
            WHERE id = $1 AND deleted_at IS NULL RETURNING ${SESSION_COLUMNS}`,
           [candidate.id, workerId, workerPid, now],

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -458,6 +458,11 @@ export class PgAgentSessionStore
     });
   }
 
+  /**
+   * Attempt charging is per takeover: queued claims and abandoned (non-null
+   * stale lease) takeovers increment `attempt`; clean-park (null lease)
+   * takeovers do not. Full contract in {@link AgentSessionStore}.
+   */
   async claimNextSession(
     workerId: string,
     workerPid: number,

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -233,6 +233,7 @@ export interface AgentSessionStore {
   /**
    * Scan optimistically, then lock and recheck one candidate. The second
    * check is the authority: candidate snapshots are stale as soon as read.
+   * Queued claims advance the failure generation; orphaned takeovers retain it.
    */
   claimNextSession(
     workerId: string,

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -233,7 +233,12 @@ export interface AgentSessionStore {
   /**
    * Scan optimistically, then lock and recheck one candidate. The second
    * check is the authority: candidate snapshots are stale as soon as read.
-   * Queued claims advance the failure generation; orphaned takeovers retain it.
+   *
+   * Attempt charging is per takeover: queued claims and takeovers of an
+   * abandoned (non-null stale) lease each consume one attempt, while takeovers
+   * of a cleanly-released (null) lease consume none. Clean parks therefore
+   * never falsely cap a healthy session, while crashloops stay bounded by
+   * {@link ClaimAgentSessionOptions.maxAttempts}.
    */
   claimNextSession(
     workerId: string,

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -31,7 +31,7 @@ export function runAgentSessionConcurrencyContract(
         maxAttempts: 3,
       });
       expect(stolen).toMatchObject({
-        attempt: 2,
+        attempt: 1,
         claimReason: 'orphaned',
         claimSeq: 1,
         lease: { workerId: 'worker-b' },
@@ -45,6 +45,32 @@ export function runAgentSessionConcurrencyContract(
         }),
       ).toBeNull();
       expect(await store.heartbeat('session-1', 'worker-a')).toBe(false);
+    });
+
+    test('does not charge clean park and takeover cycles to the attempt cap', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+
+      let claim = await store.claimNextSession('worker-0', 100, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 5,
+      });
+      expect(claim).toMatchObject({ attempt: 1, claimReason: 'queued' });
+
+      for (let cycle = 0; cycle < 6; cycle += 1) {
+        await store.releaseLease('session-1', `worker-${cycle}`);
+        const workerId = `worker-${cycle + 1}`;
+        claim = await store.claimNextSession(workerId, 101 + cycle, {
+          leaseTtlMs: 10_000,
+          maxAttempts: 5,
+        });
+        expect(claim).toMatchObject({ attempt: 1, claimReason: 'orphaned' });
+      }
+
+      expect(await store.getSession('session-1')).toMatchObject({
+        status: 'running',
+        attempt: 1,
+      });
     });
 
     test.skipIf(!options.genuineConcurrency)(

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -73,6 +73,33 @@ export function runAgentSessionConcurrencyContract(
       });
     });
 
+    test('charges abandoned lease takeovers to the attempt cap', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+
+      let claim = await store.claimNextSession('worker-0', 100, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 5,
+      });
+      expect(claim).toMatchObject({ attempt: 1, claimReason: 'queued' });
+
+      for (let cycle = 0; cycle < 6; cycle += 1) {
+        const workerId = `worker-${cycle + 1}`;
+        // A negative TTL deterministically treats the still-owned lease as
+        // stale without cleanly releasing it through the store contract.
+        claim = await store.claimNextSession(workerId, 101 + cycle, {
+          leaseTtlMs: -1,
+          maxAttempts: 5,
+        });
+        expect(claim).toMatchObject({ attempt: cycle + 2, claimReason: 'orphaned' });
+      }
+
+      expect(await store.getSession('session-1')).toMatchObject({
+        status: 'running',
+        attempt: 7,
+      });
+    });
+
     test.skipIf(!options.genuineConcurrency)(
       'allows exactly one worker to win a simultaneous claim',
       async () => {

--- a/tests/agent-runtime/attempt-cap.test.ts
+++ b/tests/agent-runtime/attempt-cap.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentRuntimeConfig } from '@/lib/server/agent-runtime/config';
+import {
+  isOverAttemptCap,
+  LENGTH_STOP_ERROR,
+  markRunEventEmitted,
+  planUndeliveredRequeue,
+  terminalLoopError,
+} from '@/lib/server/agent-runtime/runner';
+
+describe('runner correctness helpers', () => {
+  it('requires a lifecycle event to anchor each run', () => {
+    expect(markRunEventEmitted(false, 'checkpoint')).toBe(false);
+    expect(markRunEventEmitted(false, 'session_start')).toBe(true);
+    expect(markRunEventEmitted(true, 'checkpoint')).toBe(true);
+  });
+
+  it('turns a final length stop into a visible failure', () => {
+    expect(
+      terminalLoopError(
+        [{ role: 'assistant', content: [], stopReason: 'length' } as never],
+        undefined,
+      ),
+    ).toBe(LENGTH_STOP_ERROR);
+    expect(terminalLoopError([], 'provider failed')).toBe('provider failed');
+  });
+
+  it('allows the cap attempt and rejects later verdict claims', () => {
+    expect(isOverAttemptCap({ attempt: agentRuntimeConfig.maxAttempts })).toBe(false);
+    expect(isOverAttemptCap({ attempt: agentRuntimeConfig.maxAttempts + 1 })).toBe(true);
+  });
+});
+
+describe('one knock, one redemption', () => {
+  const message = (seq: number) => ({ seq, ts: 0 });
+
+  it('does nothing when every message is handled', () => {
+    expect(
+      planUndeliveredRequeue({
+        logged: [message(1)],
+        handled: 1,
+        claimSeq: 10,
+        atVerdict: false,
+      }),
+    ).toBe('none');
+  });
+
+  it('resets for a post-claim message, including in the verdict window', () => {
+    expect(
+      planUndeliveredRequeue({
+        logged: [message(11)],
+        handled: 0,
+        claimSeq: 10,
+        atVerdict: true,
+      }),
+    ).toBe('reset');
+  });
+
+  it('preserves the chain for inherited work and stops at the verdict', () => {
+    const input = { logged: [message(9)], handled: 0, claimSeq: 10 };
+    expect(planUndeliveredRequeue({ ...input, atVerdict: false })).toBe('retry');
+    expect(planUndeliveredRequeue({ ...input, atVerdict: true })).toBe('none');
+  });
+});

--- a/tests/agent-runtime/event-log-slim.test.ts
+++ b/tests/agent-runtime/event-log-slim.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { slimEventDataForLog } from '@/lib/server/agent-runtime/runner';
+
+describe('runner event-log payload slimming', () => {
+  it('keeps only the terminal metadata needed from agent_end', () => {
+    const source = {
+      type: 'agent_end',
+      messages: [
+        { role: 'user', content: 'Start' },
+        {
+          role: 'assistant',
+          stopReason: 'error',
+          errorMessage: 'provider unavailable',
+          content: [{ type: 'text', text: 'large partial response' }],
+        },
+      ],
+    };
+    expect(slimEventDataForLog('agent_end', source)).toEqual({
+      type: 'agent_end',
+      messageCount: 2,
+      lastMessageContentLength: 22,
+      messages: [
+        {
+          role: 'assistant',
+          stopReason: 'error',
+          errorMessage: 'provider unavailable',
+        },
+      ],
+    });
+  });
+
+  it('slims turn_end messages and valid tool results', () => {
+    const source = {
+      type: 'turn_end',
+      message: {
+        role: 'assistant',
+        stopReason: 'error',
+        errorMessage: 'stream failed',
+        content: [{ type: 'text', text: 'large final response' }],
+      },
+      toolResults: [
+        {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'ask_user',
+          content: [{ type: 'text', text: 'large result' }],
+          details: { large: true },
+          isError: false,
+          timestamp: 1_000,
+        },
+      ],
+    };
+    expect(slimEventDataForLog('turn_end', source)).toEqual({
+      type: 'turn_end',
+      message: { role: 'assistant', stopReason: 'error', errorMessage: 'stream failed' },
+      toolResults: [
+        {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'ask_user',
+          isError: false,
+          timestamp: 1_000,
+        },
+      ],
+    });
+  });
+
+  it('never mutates the transcript object', () => {
+    const toolResult = {
+      role: 'toolResult',
+      toolCallId: 'call-1',
+      toolName: 'ask_user',
+      content: [{ type: 'text', text: 'full result' }],
+      details: { question: 'Choose' },
+      isError: false,
+      timestamp: 1_000,
+    };
+    const event = { type: 'message_end', message: toolResult };
+    const slimmed = slimEventDataForLog('message_end', event) as typeof event;
+    expect(slimmed).not.toBe(event);
+    expect(slimmed.message).not.toBe(toolResult);
+    expect(slimmed.message.content).toEqual([]);
+    expect(toolResult.content).toEqual([{ type: 'text', text: 'full result' }]);
+    expect(toolResult.details).toEqual({ question: 'Choose' });
+  });
+
+  it('deep-clones an unrecognized tool-results payload and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const toolResults = [{ content: [{ type: 'text', text: 'unknown shape' }] }];
+    const slimmed = slimEventDataForLog('turn_end', {
+      type: 'turn_end',
+      toolResults,
+    }) as { toolResults: unknown };
+    expect(slimmed.toolResults).toEqual(toolResults);
+    expect(slimmed.toolResults).not.toBe(toolResults);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('toolResults shape unrecognized; preserving original payload'),
+    );
+    warn.mockRestore();
+  });
+
+  it('counts text and thinking while ignoring malformed blocks', () => {
+    const source = {
+      type: 'agent_end',
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            null,
+            42,
+            { type: 'image', source: 'asset://image' },
+            [{ type: 'text', text: 'nested' }],
+            { type: 'text', text: 'answer' },
+            { type: 'thinking', thinking: 'reason' },
+          ],
+        },
+      ],
+    };
+    expect(slimEventDataForLog('agent_end', source)).toMatchObject({
+      lastMessageContentLength: 12,
+    });
+  });
+
+  it('handles empty transcripts and user-terminal transcripts', () => {
+    expect(slimEventDataForLog('agent_end', { type: 'agent_end', messages: [] })).toEqual({
+      type: 'agent_end',
+      messageCount: 0,
+      lastMessageContentLength: 0,
+      messages: [],
+    });
+    expect(
+      slimEventDataForLog('agent_end', {
+        type: 'agent_end',
+        messages: [{ role: 'user', content: 'Please continue' }],
+      }),
+    ).toMatchObject({
+      messageCount: 1,
+      lastMessageContentLength: 15,
+      messages: [{ role: 'user' }],
+    });
+  });
+
+  it('drops repeated progress bodies', () => {
+    const source = {
+      type: 'tool_execution_update',
+      toolCallId: 'call-1',
+      toolName: 'ask_user',
+      args: { large: true },
+      partialResult: { large: true },
+    };
+    expect(slimEventDataForLog('tool_execution_update', source)).toEqual({
+      type: 'tool_execution_update',
+      toolCallId: 'call-1',
+      toolName: 'ask_user',
+    });
+    expect(source.args).toEqual({ large: true });
+  });
+});

--- a/tests/agent-runtime/park-attempt-budget.pg.test.ts
+++ b/tests/agent-runtime/park-attempt-budget.pg.test.ts
@@ -28,7 +28,7 @@ function transactionFor(pool: Pool): WithTransaction {
   };
 }
 
-describe.skipIf(!contractUrl)('parked session attempt budget', () => {
+describe.skipIf(!contractUrl)('session attempt budget takeovers', () => {
   let pool: Pool;
   let store: PgAgentSessionStore;
 
@@ -78,6 +78,40 @@ describe.skipIf(!contractUrl)('parked session attempt budget', () => {
     expect(await store.getSession('parked-session')).toMatchObject({
       status: 'running',
       attempt: 1,
+    });
+  });
+
+  it('caps six unclean-death takeovers with a cap of five', async () => {
+    await store.createSession({
+      id: 'crashloop-session',
+      ownerId: 'owner',
+      prompt: 'Keep crashing',
+      stageId: 'stage',
+    });
+
+    let claim = await store.claimNextSession('worker-0', 100, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 5,
+    });
+    expect(claim).not.toBeNull();
+    expect(isOverAttemptCap(claim!)).toBe(false);
+
+    for (let cycle = 0; cycle < 6; cycle += 1) {
+      await pool.query(
+        `UPDATE agent_sessions SET lease_heartbeat_at = 0
+         WHERE id = 'crashloop-session'`,
+      );
+      claim = await store.claimNextSession(`worker-${cycle + 1}`, 101 + cycle, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 5,
+      });
+      expect(claim).toMatchObject({ attempt: cycle + 2, claimReason: 'orphaned' });
+    }
+
+    expect(isOverAttemptCap(claim!)).toBe(true);
+    expect(await store.getSession('crashloop-session')).toMatchObject({
+      status: 'running',
+      attempt: 7,
     });
   });
 });

--- a/tests/agent-runtime/park-attempt-budget.pg.test.ts
+++ b/tests/agent-runtime/park-attempt-budget.pg.test.ts
@@ -7,7 +7,6 @@ import {
   type Queryable,
   type WithTransaction,
 } from '../../packages/@openmaic/storage/src/agent-session/pg';
-import { isOverAttemptCap } from '@/lib/server/agent-runtime/runner';
 
 const contractUrl = process.env.PG_CONTRACT_URL;
 
@@ -29,6 +28,11 @@ function transactionFor(pool: Pool): WithTransaction {
 }
 
 describe.skipIf(!contractUrl)('session attempt budget takeovers', () => {
+  /** The suite's own bound; every claim below tells the store the same value. */
+  const maxAttempts = 5;
+  /** Mirrors the runner's verdict against this suite's bound, not its config. */
+  const overAttemptCap = (claim: { attempt: number }) => claim.attempt > maxAttempts;
+
   let pool: Pool;
   let store: PgAgentSessionStore;
 
@@ -60,19 +64,19 @@ describe.skipIf(!contractUrl)('session attempt budget takeovers', () => {
 
     let claim = await store.claimNextSession('worker-0', 100, {
       leaseTtlMs: 10_000,
-      maxAttempts: 5,
+      maxAttempts,
     });
     expect(claim).not.toBeNull();
-    expect(isOverAttemptCap(claim!)).toBe(false);
+    expect(overAttemptCap(claim!)).toBe(false);
 
     for (let cycle = 0; cycle < 6; cycle += 1) {
       await store.releaseLease('parked-session', `worker-${cycle}`);
       claim = await store.claimNextSession(`worker-${cycle + 1}`, 101 + cycle, {
         leaseTtlMs: 10_000,
-        maxAttempts: 5,
+        maxAttempts,
       });
       expect(claim).toMatchObject({ attempt: 1, claimReason: 'orphaned' });
-      expect(isOverAttemptCap(claim!)).toBe(false);
+      expect(overAttemptCap(claim!)).toBe(false);
     }
 
     expect(await store.getSession('parked-session')).toMatchObject({
@@ -91,10 +95,10 @@ describe.skipIf(!contractUrl)('session attempt budget takeovers', () => {
 
     let claim = await store.claimNextSession('worker-0', 100, {
       leaseTtlMs: 10_000,
-      maxAttempts: 5,
+      maxAttempts,
     });
     expect(claim).not.toBeNull();
-    expect(isOverAttemptCap(claim!)).toBe(false);
+    expect(overAttemptCap(claim!)).toBe(false);
 
     for (let cycle = 0; cycle < 6; cycle += 1) {
       await pool.query(
@@ -103,12 +107,12 @@ describe.skipIf(!contractUrl)('session attempt budget takeovers', () => {
       );
       claim = await store.claimNextSession(`worker-${cycle + 1}`, 101 + cycle, {
         leaseTtlMs: 10_000,
-        maxAttempts: 5,
+        maxAttempts,
       });
       expect(claim).toMatchObject({ attempt: cycle + 2, claimReason: 'orphaned' });
     }
 
-    expect(isOverAttemptCap(claim!)).toBe(true);
+    expect(overAttemptCap(claim!)).toBe(true);
     expect(await store.getSession('crashloop-session')).toMatchObject({
       status: 'running',
       attempt: 7,

--- a/tests/agent-runtime/park-attempt-budget.pg.test.ts
+++ b/tests/agent-runtime/park-attempt-budget.pg.test.ts
@@ -1,0 +1,83 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureAgentSessionSchema,
+  PgAgentSessionStore,
+  type Queryable,
+  type WithTransaction,
+} from '../../packages/@openmaic/storage/src/agent-session/pg';
+import { isOverAttemptCap } from '@/lib/server/agent-runtime/runner';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+function transactionFor(pool: Pool): WithTransaction {
+  return async (body) => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client as Queryable);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+describe.skipIf(!contractUrl)('parked session attempt budget', () => {
+  let pool: Pool;
+  let store: PgAgentSessionStore;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl });
+    await ensureAgentSessionSchema(pool as Queryable);
+  });
+
+  beforeEach(async () => {
+    await pool.query(
+      `TRUNCATE agent_session_entries, agent_session_events,
+                agent_owner_session_events, agent_owner_session_event_counters,
+                agent_sessions`,
+    );
+    store = new PgAgentSessionStore(pool as Queryable, { withTransaction: transactionFor(pool) });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('survives six clean park and takeover cycles with a cap of five', async () => {
+    await store.createSession({
+      id: 'parked-session',
+      ownerId: 'owner',
+      prompt: 'Keep working',
+      stageId: 'stage',
+    });
+
+    let claim = await store.claimNextSession('worker-0', 100, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 5,
+    });
+    expect(claim).not.toBeNull();
+    expect(isOverAttemptCap(claim!)).toBe(false);
+
+    for (let cycle = 0; cycle < 6; cycle += 1) {
+      await store.releaseLease('parked-session', `worker-${cycle}`);
+      claim = await store.claimNextSession(`worker-${cycle + 1}`, 101 + cycle, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 5,
+      });
+      expect(claim).toMatchObject({ attempt: 1, claimReason: 'orphaned' });
+      expect(isOverAttemptCap(claim!)).toBe(false);
+    }
+
+    expect(await store.getSession('parked-session')).toMatchObject({
+      status: 'running',
+      attempt: 1,
+    });
+  });
+});

--- a/tests/agent-runtime/run-start.test.ts
+++ b/tests/agent-runtime/run-start.test.ts
@@ -1,0 +1,102 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import { describe, expect, it } from 'vitest';
+
+import { planResume } from '@/lib/server/agent-runtime/resume';
+import {
+  composeFollowUpText,
+  loggedMessageCursor,
+  planRunStart,
+} from '@/lib/server/agent-runtime/runner';
+
+const user = (text: string) => ({ role: 'user', content: text }) as unknown as AgentMessage;
+const assistant = (text: string) =>
+  ({ role: 'assistant', content: [{ type: 'text', text }] }) as unknown as AgentMessage;
+const toolCall = () =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'toolCall', id: 'call-1', name: 'finish', arguments: {} }],
+  }) as unknown as AgentMessage;
+const toolResult = () =>
+  ({
+    role: 'toolResult',
+    toolCallId: 'call-1',
+    toolName: 'finish',
+    content: [{ type: 'text', text: 'Done' }],
+  }) as unknown as AgentMessage;
+
+describe('planRunStart', () => {
+  it('uses the original prompt on a first run', () => {
+    expect(
+      planRunStart({
+        plan: planResume(null),
+        claimReason: 'queued',
+        pending: [],
+        prompt: 'Build a lesson',
+      }),
+    ).toEqual({ kind: 'prompt', text: 'Build a lesson' });
+  });
+
+  it('uses the first message for an idle existing-session attachment', () => {
+    expect(
+      planRunStart({
+        plan: planResume(null),
+        claimReason: 'queued',
+        pending: [{ text: 'Shorten the second section' }],
+        prompt: 'Existing lesson',
+        idleAttach: true,
+      }),
+    ).toEqual({ kind: 'prompt', text: 'Shorten the second section' });
+  });
+
+  it('prompts a queued follow-up but continues an orphaned run', () => {
+    const plan = planResume([user('Start'), assistant('Working'), toolCall(), toolResult()]);
+    expect(
+      planRunStart({
+        plan,
+        claimReason: 'queued',
+        pending: [{ text: 'Add an example' }],
+        prompt: 'Start',
+      }),
+    ).toEqual({ kind: 'prompt', text: 'Add an example' });
+    expect(
+      planRunStart({
+        plan,
+        claimReason: 'orphaned',
+        pending: [{ text: 'Are you there?' }],
+        prompt: 'Start',
+      }),
+    ).toEqual({ kind: 'continue' });
+  });
+});
+
+describe('loggedMessageCursor', () => {
+  it('accounts for the synthetic first prompt only on new sessions', () => {
+    expect(
+      loggedMessageCursor({ transcriptUserCount: 1, loggedCount: 1, idleAttach: true }),
+    ).toEqual({ idle: true, delivered: 1 });
+    expect(loggedMessageCursor({ transcriptUserCount: 1, loggedCount: 1 })).toEqual({
+      idle: false,
+      delivered: 0,
+    });
+  });
+});
+
+describe('composeFollowUpText', () => {
+  it('leaves bare text untouched and exposes only safe attachment metadata', () => {
+    expect(composeFollowUpText({ text: 'Continue' })).toBe('Continue');
+    const text = composeFollowUpText({
+      text: 'Use this recording',
+      materials: [
+        {
+          materialId: 'material-1',
+          originalName: 'lecture.mp4',
+          mime: 'video/mp4',
+          bytes: 10,
+        },
+      ],
+    });
+    expect(text).toContain('lecture.mp4');
+    expect(text).toContain('video/mp4');
+    expect(text).toContain('reading support will be provided in a later delivery');
+  });
+});

--- a/tests/agent-runtime/runner-event-order.test.ts
+++ b/tests/agent-runtime/runner-event-order.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  appendRunEvent: vi.fn(async (..._args: unknown[]) => 1),
+  finishSession: vi.fn(async () => true),
+  releaseLease: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: vi.fn(async () => ({
+    appendRunEvent: mocks.appendRunEvent,
+    clearCancel: vi.fn(async () => undefined),
+    finishSession: mocks.finishSession,
+    getSession: vi.fn(async () => null),
+    hasSessionRunHistory: vi.fn(async () => false),
+    heartbeat: vi.fn(async () => true),
+    isCancelRequested: vi.fn(async () => false),
+    listUserMessages: vi.fn(async () => []),
+    releaseLease: mocks.releaseLease,
+    requeueForRetry: vi.fn(async () => false),
+    requeueSession: vi.fn(async () => false),
+  })),
+}));
+
+vi.mock('@/lib/server/agent-runtime/entry-tree-storage', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@/lib/server/agent-runtime/entry-tree-storage')>();
+  const { InMemorySessionRepo } = await import('@earendil-works/pi-agent-core');
+  return {
+    ...actual,
+    AgentSessionEntryStorage: {
+      open: async () =>
+        (await new InMemorySessionRepo().create({ id: 'session-order' })).getStorage(),
+    },
+  };
+});
+
+vi.mock('@/lib/server/agent-runtime/agent-driver-model', () => ({
+  resolveAgentDriverModel: vi.fn(async () => {
+    throw new Error('driver setup unavailable');
+  }),
+}));
+
+import { runSession } from '@/lib/server/agent-runtime/runner';
+
+describe('runSession durable event ordering', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('persists a lifecycle frame before any other runner event', async () => {
+    await runSession(
+      { running: new Map(), shuttingDown: false },
+      {
+        id: 'session-order',
+        ownerId: 'owner-1',
+        prompt: 'Build a lesson',
+        stageId: 'stage-1',
+        existingCourse: false,
+        status: 'running',
+        attempt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+        claimReason: 'queued',
+        claimSeq: 0,
+      },
+    );
+
+    expect(mocks.appendRunEvent).toHaveBeenCalled();
+    expect(mocks.appendRunEvent.mock.calls[0]?.[2]).toMatchObject({
+      type: 'session_start',
+      attempt: 1,
+    });
+    expect(mocks.finishSession).toHaveBeenCalled();
+    const types = mocks.appendRunEvent.mock.calls.map(
+      (call) => (call[2] as { type?: string } | undefined)?.type,
+    );
+    expect(types.at(-1)).toBe('session_end');
+    expect(types).not.toContain('session_interrupted');
+  });
+});


### PR DESCRIPTION
Third application-layer slice on this integration branch: the background job loop itself. Still no HTTP surface (routes land next) and a minimal tool set (ask_user only) — every tool, skill, material, and course-editing capability lands in later slices.

## Runner
Claim with lease-based stealing, heartbeat, generation-fenced event appends, durable entry-tree resume with repair/rollback, message draining with an ownership recheck, layered critical/non-critical event emission with a thinking-throttle and an event-order tripwire, and three terminal exits (settle / interrupted-park on shutdown / setup failure). Consumes the landed store, event log, entry tree, owner seam, and driver contract. Abort propagates from cancel through to the pi agent within the poll interval.

## Attempt-budget correctness (storage 0.5.0 → 0.6.0)
While translating the runner, review surfaced a latent session-killer: a clean interruption (deploy/steal park) was consuming the consecutive-attempt budget, so a handful of deploys could falsely fail a healthy long-running session. Fixed at the right layer — `claimNextSession` now charges the attempt budget for **queued** takeovers and takeovers of an **abandoned** (stale, non-null) lease, but **not** for a cleanly-released (null) lease. Two concurrency-contract tests pin both ends: six clean park→takeover cycles stay well under the cap; six unclean-death takeovers still reach it (crashloops stay bounded). The charging contract is documented on the store interface.

## Startup
Runner start + graceful drain (drain precedes pool close) wired into instrumentation without awaiting schema/store construction at register time; two feature flags (server-side runtime enable + build-time workbench enable) gate it, and the workbench 404 gate is added to middleware ahead of the existing access gate.

Tests: run-start, event ordering, attempt cap, slim event log, plus the two attempt-budget contract tests. Real PostgreSQL 16 suite green locally; storage-pg-contract covers it on push.