### PR TITLE
feat(agent): add agent session and owner event streams

### DIFF
--- a/app/api/agent/owner-events/route.ts
+++ b/app/api/agent/owner-events/route.ts
@@ -2,6 +2,10 @@
  * Durable, sparse SSE tail for the current owner's session summaries.
  * A degraded caught_up is not authoritative: clients should schedule one full
  * reconciliation and may later receive a non-degraded caught_up on recovery.
+ *
+ * Access model: there is no per-route auth challenge. Every request is
+ * granted an anonymous cookie identity, and every store read is scoped to
+ * that identity.
  */
 import type { PersistedOwnerSessionEvent } from '@openmaic/storage';
 import type { NextRequest } from 'next/server';
@@ -36,6 +40,10 @@ export async function GET(req: NextRequest) {
 
   // Identity belongs to the request, not the URL. EventSource reconnects to
   // this same stable path with the anonymous cookie minted on first attach.
+  // This slice resolves only the anonymous cookie identity; a future auth
+  // integration must thread `authenticatedOwnerId` through here, or sessions
+  // created under authenticated identities would be unreachable by their own
+  // owner.
   const responseHeaders = new Headers();
   const ownerId = resolveRequestOwnerId(req, responseHeaders);
   const store = await getAgentSessionStore();

--- a/app/api/agent/owner-events/route.ts
+++ b/app/api/agent/owner-events/route.ts
@@ -1,0 +1,298 @@
+/**
+ * Durable, sparse SSE tail for the current owner's session summaries.
+ * A degraded caught_up is not authoritative: clients should schedule one full
+ * reconciliation and may later receive a non-degraded caught_up on recovery.
+ */
+import type { PersistedOwnerSessionEvent } from '@openmaic/storage';
+import type { NextRequest } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+
+export const runtime = 'nodejs';
+// Self-hosted `next start` ignores maxDuration; Vercel's adapter can still use
+// it. The 25s heartbeat keeps this sparse stream active through idle periods.
+export const maxDuration = 300;
+
+// Polling is the correctness mechanism because the storage package does not
+// expose LISTEN/NOTIFY.
+export const OWNER_EVENT_POLL_INTERVAL_MS = 30_000;
+export const SSE_HEARTBEAT_INTERVAL_MS = 25_000;
+export const OWNER_EVENT_REPLAY_LIMIT = 1_000;
+const BACKLOG_PAGE = 500;
+
+function parseLastEventId(value: string | null): bigint {
+  if (!value || !/^\d+$/.test(value)) return BigInt(0);
+  try {
+    return BigInt(value);
+  } catch {
+    return BigInt(0);
+  }
+}
+
+export async function GET(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  // Identity belongs to the request, not the URL. EventSource reconnects to
+  // this same stable path with the anonymous cookie minted on first attach.
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const store = await getAgentSessionStore();
+
+  const url = new URL(req.url);
+  const lastEventId = parseLastEventId(
+    req.headers.get('last-event-id') ?? url.searchParams.get('lastEventId'),
+  );
+  const encoder = new TextEncoder();
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+
+  const clearTimers = () => {
+    if (pollTimer) clearTimeout(pollTimer);
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    pollTimer = null;
+    heartbeatTimer = null;
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let backlogDone = false;
+      let sentSinceAttach = 0;
+      let cursor = lastEventId;
+      let retirementCheckInFlight = false;
+      let consecutiveBacklogFailures = 0;
+      let degradedCaughtUp = false;
+      let attachCursorChecked = false;
+      let backlogSkippedForResync = false;
+      let repollRequested = false;
+      let pollInFlight: Promise<void> | null = null;
+
+      const write = (chunk: string) => {
+        if (closed) return false;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+          return true;
+        } catch {
+          // Some runtimes do not invoke cancel() for every broken socket.
+          // Treat an enqueue failure as closure so this dead connection cannot
+          // retain its heartbeat and poll timers indefinitely.
+          closed = true;
+          clearTimers();
+          return false;
+        }
+      };
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        clearTimers();
+        try {
+          controller.close();
+        } catch {
+          // The request closed between the guard and close.
+        }
+      };
+
+      const emitCaughtUp = (degraded = false) =>
+        write(
+          `event: caught_up\ndata: ${JSON.stringify({
+            type: 'caught_up',
+            replayed: sentSinceAttach,
+            fromEventId: lastEventId.toString(),
+            ...(degraded ? { degraded: true } : {}),
+          })}\n\n`,
+        );
+
+      const markCaughtUp = (degraded = false) => {
+        if (backlogDone) return;
+        if (!emitCaughtUp(degraded)) return;
+        backlogDone = true;
+        degradedCaughtUp = degraded;
+      };
+
+      const checkAttachCursor = async () => {
+        if (attachCursorChecked) return true;
+        let currentEventId: bigint;
+        try {
+          currentEventId = await store.readMaxId(ownerId);
+        } catch {
+          consecutiveBacklogFailures += 1;
+          if (consecutiveBacklogFailures >= 3) markCaughtUp(true);
+          return false;
+        }
+        consecutiveBacklogFailures = 0;
+        attachCursorChecked = true;
+
+        const reason =
+          lastEventId > currentEventId
+            ? 'cursor_ahead'
+            : currentEventId - lastEventId > BigInt(OWNER_EVENT_REPLAY_LIMIT)
+              ? 'too_far_behind'
+              : null;
+        if (!reason) return true;
+
+        cursor = currentEventId;
+        backlogDone = true;
+        degradedCaughtUp = false;
+        backlogSkippedForResync = true;
+        return write(
+          `event: resync_required\ndata: ${JSON.stringify({
+            type: 'resync_required',
+            reason,
+            fromEventId: lastEventId.toString(),
+            currentEventId: currentEventId.toString(),
+          })}\n\n`,
+        );
+      };
+
+      const writePage = (events: PersistedOwnerSessionEvent[]) => {
+        for (const event of events) {
+          if (
+            !write(
+              `id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify({
+                ...event,
+                // A degraded catch-up set `backlogDone` without draining, so
+                // the events that arrive while recovering are still history:
+                // keep labelling them backlog until the real signal goes out.
+                phase: backlogDone && !degradedCaughtUp ? 'live' : 'backlog',
+              })}\n\n`,
+            )
+          ) {
+            return false;
+          }
+          cursor = BigInt(event.id);
+          sentSinceAttach += 1;
+        }
+        return true;
+      };
+
+      const readPage = () => store.readAfter(ownerId, cursor, BACKLOG_PAGE);
+
+      const drainBacklog = async () => {
+        if (!(await checkAttachCursor()) || backlogSkippedForResync) return;
+        for (;;) {
+          if (closed) return;
+          let page: PersistedOwnerSessionEvent[];
+          try {
+            page = await readPage();
+          } catch {
+            consecutiveBacklogFailures += 1;
+            if (consecutiveBacklogFailures >= 3) markCaughtUp(true);
+            return;
+          }
+          consecutiveBacklogFailures = 0;
+          if (!writePage(page)) return;
+          if (page.length < BACKLOG_PAGE) break;
+        }
+        markCaughtUp();
+      };
+
+      const poll = async () => {
+        if (closed) return;
+        if (!attachCursorChecked) {
+          if (!(await checkAttachCursor()) || backlogSkippedForResync) return;
+        }
+        try {
+          const page = await readPage();
+          consecutiveBacklogFailures = 0;
+          if (!writePage(page)) return;
+          if (degradedCaughtUp) {
+            // The authoritative signal has to pass the SAME exhaustion check
+            // as the normal path. A degraded window is exactly when backlog
+            // piles up, so the first successful page is often full: emitting
+            // here would announce "the list is authoritative now" while
+            // thousands of events are still queued behind it.
+            if (page.length < BACKLOG_PAGE && emitCaughtUp()) degradedCaughtUp = false;
+            return;
+          }
+          if (!backlogDone && page.length < BACKLOG_PAGE) markCaughtUp();
+        } catch {
+          // Before initial catch-up, retain backlog mode and retry. Only after
+          // three consecutive failures do we unblock the UI with an explicit
+          // degraded signal. Live-tail failures simply retry next tick.
+          if (!backlogDone) {
+            consecutiveBacklogFailures += 1;
+            if (consecutiveBacklogFailures >= 3) markCaughtUp(true);
+          }
+        }
+      };
+
+      // Timer reads enter the same serialized gate. If another read is
+      // requested while one is in flight, exactly one follow-up read runs
+      // after it settles; concurrent reads could duplicate frames or move the
+      // cursor backwards.
+      const requestPoll = (): Promise<void> => {
+        if (closed) return Promise.resolve();
+        if (pollInFlight) {
+          repollRequested = true;
+          return pollInFlight;
+        }
+        pollInFlight = (async () => {
+          do {
+            repollRequested = false;
+            await poll();
+          } while (repollRequested && !closed);
+        })().finally(() => {
+          pollInFlight = null;
+        });
+        return pollInFlight;
+      };
+
+      const tick = () => {
+        if (closed) return;
+        pollTimer = setTimeout(() => {
+          if (closed) return;
+          void requestPoll().then(tick, tick);
+        }, OWNER_EVENT_POLL_INTERVAL_MS);
+      };
+
+      // Retirement is checked on the independent heartbeat, not every event
+      // poll. Owner merges are rare; this caps idle cost at one indexed lookup
+      // per 25s while noticing established stale streams.
+      heartbeatTimer = setInterval(() => {
+        if (closed) return;
+        write(': ping\n\n');
+        if (closed || retirementCheckInFlight) return;
+        retirementCheckInFlight = true;
+        void store
+          .readRetirement(ownerId)
+          .then((newOwnerId) => {
+            if (!newOwnerId || closed) return;
+            // Native EventSource reconnects a clean 200 EOF with the same
+            // Last-Event-ID. The client MUST close this instance, construct a
+            // new EventSource without that cursor, and perform one full session
+            // list reconciliation because session_created omits list fields
+            // such as prompt/stageId.
+            write(
+              `event: owner_moved\ndata: ${JSON.stringify({
+                type: 'owner_moved',
+                newOwnerId,
+                action: 'reconnect',
+              })}\n\n`,
+            );
+            close();
+          })
+          .catch(() => {
+            // A transient PG failure is retried on the next heartbeat.
+          })
+          .finally(() => {
+            retirementCheckInFlight = false;
+          });
+      }, SSE_HEARTBEAT_INTERVAL_MS);
+
+      await drainBacklog();
+      tick();
+    },
+    cancel() {
+      closed = true;
+      clearTimers();
+    },
+  });
+
+  responseHeaders.set('Content-Type', 'text/event-stream; charset=utf-8');
+  responseHeaders.set('Cache-Control', 'no-cache, no-transform');
+  responseHeaders.set('Connection', 'keep-alive');
+  return new Response(stream, { headers: responseHeaders });
+}

--- a/app/api/agent/sessions/[id]/events/route.ts
+++ b/app/api/agent/sessions/[id]/events/route.ts
@@ -22,6 +22,11 @@
  * the stream. Native `EventSource` then reconnects with `Last-Event-ID` and
  * resumes through the same replay path without losing durable events.
  *
+ * Access model: there is no per-route auth challenge. Every request is
+ * granted an anonymous cookie identity, and every store read is scoped to
+ * that identity. A session owned by another identity is indistinguishable
+ * from a missing one — both are 404 with the same response.
+ *
  * This handler is a pure READER of the store. A disconnect closes this
  * reader and nothing else: the runner keeps running, and its events keep
  * landing in the log.
@@ -57,13 +62,22 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     return new Response('Not found', { status: 404 });
   }
   const { id } = await params;
+  const responseHeaders = new Headers();
+  // The identity cookie is minted for the requester regardless of the target
+  // session, and the owner is resolved before the session lookup: a request
+  // for a missing session and one for a session owned by someone else return
+  // byte-identical 404s (same status, body, and cookie headers), so the
+  // response cannot be used to probe whether a session UUID exists. This
+  // slice resolves only the anonymous cookie identity; a future auth
+  // integration must thread `authenticatedOwnerId` through here, or sessions
+  // created under authenticated identities would be unreachable by their own
+  // owner.
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
   const store = await getAgentSessionStore();
   const meta = await store.getSession(id);
   if (!meta) {
-    return new Response('Not found', { status: 404 });
+    return new Response('Not found', { status: 404, headers: responseHeaders });
   }
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
   if (meta.ownerId !== ownerId) {
     return new Response('Not found', { status: 404, headers: responseHeaders });
   }

--- a/app/api/agent/sessions/[id]/events/route.ts
+++ b/app/api/agent/sessions/[id]/events/route.ts
@@ -1,0 +1,267 @@
+/**
+ * Agent runtime control plane — the session event stream (SSE).
+ *
+ *   GET /api/agent/sessions/:id/events
+ *     Honors `Last-Event-ID` (header or `?lastEventId=`): everything durable
+ *     with `seq > lastEventId` is replayed first (intermediate `message_update`
+ *     tokens are dropped; the last update in each run already has the full
+ *     text), then whatever lands afterwards. A client attaching mid-run and
+ *     one attaching between runs take the exact same path. The log is the
+ *     single source of truth; the live stream is just its tail.
+ *
+ * Frames:
+ *   - one `caught_up` event when the backlog has been drained (a real, named
+ *     event rather than a comment, which `EventSource` would drop). A
+ *     `degraded: true` caught_up is not authoritative and asks the client to
+ *     schedule a full reconciliation; recovery emits one plain caught_up;
+ *   - runner/pi/control-plane events as `id:` + `event:` + `data:`.
+ *
+ * The stream does NOT close at `session_end`: a session is a long-lived
+ * conversation (continuous chat), and a run boundary is just another frame.
+ * The attach ends when the client disconnects or an HTTP intermediary cuts
+ * the stream. Native `EventSource` then reconnects with `Last-Event-ID` and
+ * resumes through the same replay path without losing durable events.
+ *
+ * This handler is a pure READER of the store. A disconnect closes this
+ * reader and nothing else: the runner keeps running, and its events keep
+ * landing in the log.
+ */
+import type { PersistedAgentSessionEvent } from '@openmaic/storage';
+import type { NextRequest } from 'next/server';
+
+import { HOST_AGENT_LIFECYCLE as LIFECYCLE } from '@/lib/agent-runtime/lifecycle';
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+
+export const runtime = 'nodejs';
+// Self-hosted `next start` does not enforce maxDuration; it remains useful to
+// Vercel's build adapter. EventSource resumes durable events with Last-Event-ID.
+// The 25s heartbeat prevents idle intermediaries from ending the stream early.
+export const maxDuration = 300;
+
+// Polling is the correctness mechanism because the storage package does not
+// expose LISTEN/NOTIFY. Terminal streams retain their longer backoff.
+export const POLL_INTERVAL_MS = 5_000;
+// Terminal streams poll less often than active ones, but 10s is the ceiling.
+// The worst case is "session already terminal -> user steers": this is exactly
+// the moment the user is waiting for the result. Terminal streams exist only
+// while the user actually has that session open, so the extra cost is small.
+export const TERMINAL_POLL_INTERVAL_MS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 25_000;
+/** Same default as `readEventsAfter`. A full page means more backlog remains. */
+const BACKLOG_PAGE = 500;
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAgentRuntimeEnabled()) {
+    return new Response('Not found', { status: 404 });
+  }
+  const { id } = await params;
+  const store = await getAgentSessionStore();
+  const meta = await store.getSession(id);
+  if (!meta) {
+    return new Response('Not found', { status: 404 });
+  }
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  if (meta.ownerId !== ownerId) {
+    return new Response('Not found', { status: 404, headers: responseHeaders });
+  }
+
+  const url = new URL(req.url);
+  const headerId = req.headers.get('last-event-id');
+  const lastEventId = Number(headerId ?? url.searchParams.get('lastEventId') ?? 0) || 0;
+
+  const encoder = new TextEncoder();
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  // Hoisted so cancel() can stop an in-flight-then-scheduled poll, not just
+  // the timer: after a client disconnect, `closed` makes every later poll a
+  // no-op and `write` a dead end.
+  let closed = false;
+
+  const clearTimers = () => {
+    if (pollTimer) clearTimeout(pollTimer);
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    pollTimer = null;
+    heartbeatTimer = null;
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let backlogDone = false;
+      let sentSinceAttach = 0;
+      let cursor = lastEventId;
+      let terminal = false;
+      let consecutiveBacklogFailures = 0;
+      let degradedCaughtUp = false;
+      let repollRequested = false;
+      let pollInFlight: Promise<void> | null = null;
+
+      const write = (chunk: string) => {
+        if (closed) return false;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+          return true;
+        } catch {
+          // A broken socket is not guaranteed to invoke cancel() in every
+          // runtime. Stop both timers as soon as enqueue proves it is closed.
+          closed = true;
+          clearTimers();
+          return false;
+        }
+      };
+
+      // "You are caught up" is a real, named SSE event, not a comment: a
+      // client attaching during a long tool call would otherwise sit on
+      // "replaying" until the next event, and a re-attach at the last event
+      // id of an idle session would receive zero frames and wait forever.
+      const emitCaughtUp = (degraded = false) =>
+        write(
+          `event: caught_up\ndata: ${JSON.stringify({
+            type: 'caught_up',
+            replayed: sentSinceAttach,
+            fromEventId: lastEventId,
+            ...(degraded ? { degraded: true } : {}),
+          })}\n\n`,
+        );
+
+      const markCaughtUp = (degraded = false) => {
+        if (backlogDone) return;
+        if (!emitCaughtUp(degraded)) return;
+        backlogDone = true;
+        degradedCaughtUp = degraded;
+      };
+
+      const writePage = (events: PersistedAgentSessionEvent[]) => {
+        for (const event of events) {
+          if (
+            !write(
+              `id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify({
+                ...event,
+                // A degraded catch-up set `backlogDone` without draining, so
+                // events arriving while recovering are still history: keep
+                // labelling them backlog until the real signal goes out.
+                phase: backlogDone && !degradedCaughtUp ? 'live' : 'backlog',
+              })}\n\n`,
+            )
+          ) {
+            return false;
+          }
+          cursor = event.id;
+          sentSinceAttach += 1;
+          const data = event.data as { status?: unknown } | null;
+          const isTerminalEnd =
+            event.type === LIFECYCLE.sessionEnd &&
+            (data?.status === 'succeeded' ||
+              data?.status === 'failed' ||
+              data?.status === 'cancelled');
+          // A terminal session_end is normally the last frame. Any later
+          // durable frame proves activity resumed (usually user_message then
+          // session_start/session_resumed), so polling switches both ways.
+          if (isTerminalEnd) terminal = true;
+          else if (terminal) terminal = false;
+        }
+        return true;
+      };
+
+      const drainBacklog = async () => {
+        for (;;) {
+          if (closed) return;
+          let page;
+          try {
+            page = await store.readEventsAfterForReplay(id, cursor, BACKLOG_PAGE);
+          } catch {
+            consecutiveBacklogFailures += 1;
+            if (consecutiveBacklogFailures >= 3) markCaughtUp(true);
+            return;
+          }
+          consecutiveBacklogFailures = 0;
+          if (!writePage(page.events)) return;
+          // Pagination judges by the RAW page size (`scanned`), not the
+          // compacted length: a page of pure message_update compacts to two
+          // frames and would otherwise look "exhausted" mid-log.
+          if (page.scanned < BACKLOG_PAGE) break;
+        }
+        markCaughtUp();
+      };
+
+      const poll = async () => {
+        if (closed) return;
+        let page;
+        try {
+          page = await store.readEventsAfterForReplay(id, cursor, BACKLOG_PAGE);
+        } catch {
+          if (!backlogDone) {
+            consecutiveBacklogFailures += 1;
+            if (consecutiveBacklogFailures >= 3) markCaughtUp(true);
+          }
+          return; // transient PG hiccup — the next poll retries
+        }
+        consecutiveBacklogFailures = 0;
+        if (!writePage(page.events)) return;
+        if (degradedCaughtUp) {
+          // Same exhaustion check as the normal path below: a degraded window
+          // is when backlog piles up, so the first successful page is often
+          // full and announcing catch-up there would be another lie.
+          if (page.scanned < BACKLOG_PAGE && emitCaughtUp()) degradedCaughtUp = false;
+          return;
+        }
+        if (!backlogDone && page.scanned < BACKLOG_PAGE) markCaughtUp();
+      };
+
+      const requestPoll = (): Promise<void> => {
+        if (closed) return Promise.resolve();
+        if (pollInFlight) {
+          repollRequested = true;
+          return pollInFlight;
+        }
+        pollInFlight = (async () => {
+          do {
+            repollRequested = false;
+            await poll();
+          } while (repollRequested && !closed);
+        })().finally(() => {
+          pollInFlight = null;
+        });
+        return pollInFlight;
+      };
+
+      // Serialized polling: the next poll is scheduled only after the
+      // previous one has SETTLED, so a PG read slower than the interval can
+      // never start a second concurrent poll. Two in-flight polls share the
+      // cursor and would emit duplicate frames — worse, the slower one would
+      // rewind the cursor for the poll after it.
+      const tick = () => {
+        if (closed) return;
+        // An idle historical session may wait up to 10 seconds for its first
+        // reactivation frame; the user action already has optimistic UI. Once
+        // that frame arrives, the next read returns to the 5s cadence.
+        const interval = terminal ? TERMINAL_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+        pollTimer = setTimeout(() => {
+          if (closed) return;
+          // Reschedule only after poll settles. tick then re-reads terminal, so
+          // a reactivation discovered by this poll restores the 5s cadence.
+          void requestPoll().then(tick, tick);
+        }, interval);
+      };
+
+      write(`: replaying from event ${lastEventId}\n\n`);
+      heartbeatTimer = setInterval(() => {
+        if (closed) return;
+        write(': ping\n\n');
+      }, HEARTBEAT_INTERVAL_MS);
+      await drainBacklog();
+      tick();
+    },
+    cancel() {
+      closed = true;
+      clearTimers();
+    },
+  });
+
+  responseHeaders.set('Content-Type', 'text/event-stream; charset=utf-8');
+  responseHeaders.set('Cache-Control', 'no-cache, no-transform');
+  responseHeaders.set('Connection', 'keep-alive');
+  return new Response(stream, { headers: responseHeaders });
+}

--- a/lib/server/agent-runtime/owner.ts
+++ b/lib/server/agent-runtime/owner.ts
@@ -42,6 +42,12 @@ function anonymousCookieHeader(id: string): string {
  * is minted. A mint is only useful when it is persisted, so `responseHeaders`
  * — the headers the caller returns to the client — is required: it receives
  * the outgoing Set-Cookie header whenever a new cookie is issued.
+ *
+ * Current callers (the agent event-stream routes) pass no authenticated
+ * owner: for them this slice resolves only the anonymous cookie identity. A
+ * future auth integration must thread `authenticatedOwnerId` through those
+ * call sites, or sessions created under authenticated identities would be
+ * unreachable by their own owner.
  */
 export function resolveRequestOwnerId(
   req: Pick<Request, 'headers'>,

--- a/tests/agent-runtime/owner-events-route.test.ts
+++ b/tests/agent-runtime/owner-events-route.test.ts
@@ -77,6 +77,54 @@ describe('GET owner session events', () => {
     await reader.cancel();
   });
 
+  it('scopes every store read to the resolved request owner', async () => {
+    mocks.resolveRequestOwnerId.mockReturnValue('user:requestor');
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(BigInt(1));
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([
+      {
+        id: '1',
+        ownerId: 'user:requestor',
+        sessionId: 'session-1',
+        ts: 123,
+        type: 'session_status',
+        status: 'running',
+        attempt: 1,
+      },
+    ]);
+
+    const response = await call({ header: '0' });
+    const reader = response.body!.getReader();
+    const event = await readChunk(reader);
+
+    expect(event).toContain('id: 1\nevent: session_status');
+    expect(event).toContain('"ownerId":"user:requestor"');
+    expect(mocks.readOwnerSessionEventMaxId).toHaveBeenCalledWith('user:requestor');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith(
+      'user:requestor',
+      BigInt(0),
+      500,
+    );
+    await reader.cancel();
+  });
+
+  it('an owner with no sessions receives an empty stream scoped to that owner', async () => {
+    mocks.resolveRequestOwnerId.mockReturnValue('user:requestor');
+
+    const response = await call();
+    const reader = response.body!.getReader();
+    const caughtUp = await readChunk(reader);
+
+    expect(caughtUp).toContain('event: caught_up');
+    expect(caughtUp).toContain('"replayed":0');
+    expect(mocks.readOwnerSessionEventMaxId).toHaveBeenCalledWith('user:requestor');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith(
+      'user:requestor',
+      BigInt(0),
+      500,
+    );
+    await reader.cancel();
+  });
+
   it.each([
     ['query lastEventId=0', { query: '0' }, BigInt(0)],
     ['Last-Event-ID header', { header: '7', query: '2' }, BigInt(7)],

--- a/tests/agent-runtime/owner-events-route.test.ts
+++ b/tests/agent-runtime/owner-events-route.test.ts
@@ -1,0 +1,453 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  readOwnerRetirement: vi.fn(),
+  readOwnerSessionEventMaxId: vi.fn(),
+  readOwnerSessionEventsAfter: vi.fn(),
+  resolveRequestOwnerId: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({ isAgentRuntimeEnabled: () => true }));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: vi.fn(async () => ({
+    readRetirement: mocks.readOwnerRetirement,
+    readMaxId: mocks.readOwnerSessionEventMaxId,
+    readAfter: mocks.readOwnerSessionEventsAfter,
+  })),
+}));
+
+import {
+  GET,
+  OWNER_EVENT_POLL_INTERVAL_MS,
+  OWNER_EVENT_REPLAY_LIMIT,
+  SSE_HEARTBEAT_INTERVAL_MS,
+} from '@/app/api/agent/owner-events/route';
+
+function call(lastEventId?: { header?: string; query?: string }) {
+  const query = lastEventId?.query ? `?lastEventId=${lastEventId.query}` : '';
+  const req = new NextRequest(`http://localhost/api/agent/owner-events${query}`, {
+    headers: lastEventId?.header ? { 'last-event-id': lastEventId.header } : undefined,
+  });
+  return GET(req);
+}
+
+async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const chunk = await reader.read();
+  return chunk.done ? '' : new TextDecoder().decode(chunk.value);
+}
+
+async function readNonHeartbeatChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  for (;;) {
+    const chunk = await readChunk(reader);
+    if (chunk !== ': ping\n\n') return chunk;
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mocks.resolveRequestOwnerId.mockReturnValue('user:mine');
+  mocks.readOwnerRetirement.mockResolvedValue(null);
+  mocks.readOwnerSessionEventMaxId.mockResolvedValue(BigInt(0));
+  mocks.readOwnerSessionEventsAfter.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET owner session events', () => {
+  it('preserves an anonymous owner cookie on the SSE response', async () => {
+    mocks.resolveRequestOwnerId.mockImplementationOnce((_request, responseHeaders: Headers) => {
+      responseHeaders.set('Set-Cookie', 'anonymous_id=test; Path=/; HttpOnly');
+      return 'user:mine';
+    });
+
+    const response = await call();
+    const reader = response.body!.getReader();
+
+    expect(response.headers.get('set-cookie')).toBe('anonymous_id=test; Path=/; HttpOnly');
+    expect(mocks.resolveRequestOwnerId).toHaveBeenCalledOnce();
+    await reader.cancel();
+  });
+
+  it.each([
+    ['query lastEventId=0', { query: '0' }, BigInt(0)],
+    ['Last-Event-ID header', { header: '7', query: '2' }, BigInt(7)],
+    [
+      'BIGINT Last-Event-ID without JS rounding',
+      { header: '9007199254740993' },
+      BigInt('9007199254740993'),
+    ],
+  ])('replays from %s and emits a named caught_up event', async (_name, input, expectedCursor) => {
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(expectedCursor + BigInt(1));
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([
+      {
+        id: (expectedCursor + BigInt(1)).toString(),
+        ownerId: 'user:mine',
+        sessionId: 'session-1',
+        ts: 123,
+        type: 'session_status',
+        status: 'running',
+        attempt: 1,
+      },
+    ]);
+
+    const response = await call(input);
+    const reader = response.body!.getReader();
+
+    expect(response.status).toBe(200);
+    expect(await readChunk(reader)).toContain(
+      `id: ${expectedCursor + BigInt(1)}\nevent: session_status`,
+    );
+    expect(await readChunk(reader)).toContain('event: caught_up');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith(
+      'user:mine',
+      expectedCursor,
+      500,
+    );
+    await reader.cancel();
+  });
+
+  it('retries a failed backlog in backlog phase and emits caught_up only after success', async () => {
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(BigInt(8));
+    mocks.readOwnerSessionEventsAfter
+      .mockRejectedValueOnce(new Error('pg unavailable'))
+      .mockResolvedValueOnce([
+        {
+          id: '8',
+          ownerId: 'user:mine',
+          sessionId: 'session-after-retry',
+          ts: 789,
+          type: 'session_status',
+          status: 'queued',
+          attempt: 0,
+        },
+      ]);
+
+    const response = await call({ header: '7' });
+    const reader = response.body!.getReader();
+    await Promise.resolve();
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    const replayed = await readNonHeartbeatChunk(reader);
+    expect(replayed).toContain('id: 8\nevent: session_status');
+    expect(replayed).toContain('"phase":"backlog"');
+    const caughtUp = await readChunk(reader);
+    expect(caughtUp).toContain('event: caught_up');
+    expect(caughtUp).not.toContain('"degraded":true');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenNthCalledWith(
+      2,
+      'user:mine',
+      BigInt(7),
+      500,
+    );
+    await reader.cancel();
+  });
+
+  it('fails loud when the client cursor is ahead, resets to max, and keeps the live stream open', async () => {
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(BigInt(100));
+
+    const response = await call({ header: '101' });
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toBe(
+      'event: resync_required\ndata: {"type":"resync_required","reason":"cursor_ahead","fromEventId":"101","currentEventId":"100"}\n\n',
+    );
+    expect(mocks.readOwnerSessionEventsAfter).not.toHaveBeenCalled();
+
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([
+      {
+        id: '102',
+        ownerId: 'user:mine',
+        sessionId: 'session-live',
+        ts: 123,
+        type: 'session_status',
+        status: 'running',
+        attempt: 1,
+      },
+    ]);
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    const live = await readNonHeartbeatChunk(reader);
+    expect(live).toContain('id: 102\nevent: session_status');
+    expect(live).toContain('"phase":"live"');
+    expect(live).not.toContain('event: caught_up');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith('user:mine', BigInt(100), 500);
+    await reader.cancel();
+  });
+
+  it('resyncs instead of replaying beyond the bounded window, then tails after the max', async () => {
+    const current = BigInt(OWNER_EVENT_REPLAY_LIMIT) + BigInt(101);
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(current);
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([
+      {
+        id: '102',
+        ownerId: 'user:mine',
+        sessionId: 'would-be-backlog',
+        ts: 123,
+        type: 'session_status',
+        status: 'running',
+        attempt: 1,
+      },
+    ]);
+
+    const response = await call({ header: '100' });
+    const reader = response.body!.getReader();
+    const first = await readChunk(reader);
+    expect(first).toBe(
+      `event: resync_required\ndata: {"type":"resync_required","reason":"too_far_behind","fromEventId":"100","currentEventId":"${current}"}\n\n`,
+    );
+    expect(first).not.toContain('event: session_status');
+    expect(first).not.toContain('event: caught_up');
+    expect(mocks.readOwnerSessionEventsAfter).not.toHaveBeenCalled();
+
+    mocks.readOwnerSessionEventsAfter.mockReset().mockResolvedValueOnce([
+      {
+        id: String(current + BigInt(1)),
+        ownerId: 'user:mine',
+        sessionId: 'session-live',
+        ts: 456,
+        type: 'session_status',
+        status: 'succeeded',
+        attempt: 1,
+      },
+    ]);
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    const live = await readNonHeartbeatChunk(reader);
+    expect(live).toContain(`id: ${current + BigInt(1)}\nevent: session_status`);
+    expect(live).toContain('"phase":"live"');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith('user:mine', current, 500);
+    await reader.cancel();
+  });
+
+  it('still replays when the attach cursor is exactly at the replay limit', async () => {
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(BigInt(OWNER_EVENT_REPLAY_LIMIT));
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([]);
+
+    const response = await call({ header: '0' });
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toContain('event: caught_up');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith('user:mine', BigInt(0), 500);
+    await reader.cancel();
+  });
+
+  it('converges within the 30s polling interval', async () => {
+    // Absolute time bound, not the imported constant: this test pins how FAST
+    // the fallback converges. If the advance used the constant itself, a
+    // constant change (30s -> 300s) would silently keep every assertion green.
+    expect(OWNER_EVENT_POLL_INTERVAL_MS).toBeLessThanOrEqual(30_000);
+    const response = await call();
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toContain('event: caught_up');
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([
+      {
+        id: '1',
+        ownerId: 'user:mine',
+        sessionId: 'session-fallback',
+        ts: 123,
+        type: 'session_status',
+        status: 'succeeded',
+        attempt: 1,
+      },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(30_000 - 1);
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledTimes(1);
+    let delivered = false;
+    const fallbackFrame = readNonHeartbeatChunk(reader).then((chunk) => {
+      delivered = chunk.includes('id: 1\nevent: session_status');
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(delivered).toBe(true);
+    expect(await fallbackFrame).toContain('id: 1\nevent: session_status');
+    await reader.cancel();
+  });
+
+  it('emits degraded caught_up after three failures and one authoritative recovery signal', async () => {
+    mocks.readOwnerSessionEventsAfter.mockRejectedValue(new Error('pg unavailable'));
+
+    const response = await call();
+    const reader = response.body!.getReader();
+    let settled = false;
+    const firstFrame = readNonHeartbeatChunk(reader).then((chunk) => {
+      settled = true;
+      return chunk;
+    });
+
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS * 2 - 1);
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledTimes(2);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(await firstFrame).toContain(
+      'data: {"type":"caught_up","replayed":0,"fromEventId":"0","degraded":true}',
+    );
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledTimes(3);
+
+    mocks.readOwnerSessionEventsAfter.mockResolvedValue([]);
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    const recovered = await readNonHeartbeatChunk(reader);
+    expect(recovered).toContain('event: caught_up');
+    expect(recovered).not.toContain('"degraded":true');
+
+    let repeated = false;
+    const nextFrame = readChunk(reader).then((chunk) => {
+      repeated = chunk.includes('event: caught_up');
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    expect(repeated).toBe(false);
+    await reader.cancel();
+    await nextFrame;
+  });
+
+  it('recovers authoritatively after the attach high-water query degrades three times', async () => {
+    mocks.readOwnerSessionEventMaxId.mockRejectedValue(new Error('pg unavailable'));
+
+    const response = await call();
+    const reader = response.body!.getReader();
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS * 2);
+    expect(await readNonHeartbeatChunk(reader)).toContain(
+      'data: {"type":"caught_up","replayed":0,"fromEventId":"0","degraded":true}',
+    );
+    expect(mocks.readOwnerSessionEventMaxId).toHaveBeenCalledTimes(3);
+    expect(mocks.readOwnerSessionEventsAfter).not.toHaveBeenCalled();
+
+    mocks.readOwnerSessionEventMaxId.mockResolvedValue(BigInt(0));
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    const recovered = await readNonHeartbeatChunk(reader);
+    expect(recovered).toContain('event: caught_up');
+    expect(recovered).not.toContain('"degraded":true');
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith('user:mine', BigInt(0), 500);
+    await reader.cancel();
+  });
+
+  it('withholds the recovery signal while the first recovered page is still full', async () => {
+    mocks.readOwnerSessionEventsAfter.mockRejectedValue(new Error('pg unavailable'));
+    const response = await call();
+    const reader = response.body!.getReader();
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS * 2);
+    expect(await readNonHeartbeatChunk(reader)).toContain('"degraded":true');
+
+    // Recovery lands on a FULL page: the backlog that piled up during the
+    // degraded window is not drained yet, so announcing catch-up here would
+    // repeat the lie the degraded signal exists to avoid.
+    const fullPage = Array.from({ length: 500 }, (_, index) => ({
+      id: String(index + 1),
+      ownerId: 'user:mine',
+      type: 'session_status' as const,
+      sessionId: 'ses_backlog',
+      ts: 1,
+      status: 'running' as const,
+      attempt: 0,
+    }));
+    mocks.readOwnerSessionEventsAfter.mockResolvedValue(fullPage);
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    // Each event is its own frame, so read until the last one of the page has
+    // arrived rather than assuming a chunk count.
+    let recovering = '';
+    for (let read = 0; read < fullPage.length && !recovering.includes('id: 500\n'); read += 1) {
+      recovering += await readNonHeartbeatChunk(reader);
+    }
+    expect(recovering).toContain('id: 1\nevent: session_status');
+    expect(recovering).not.toContain('event: caught_up');
+    // Still history, not live tail: the degraded catch-up set backlogDone
+    // without draining.
+    expect(recovering).toContain('"phase":"backlog"');
+
+    // A short page proves exhaustion -> the authoritative signal goes out, but
+    // only AFTER that page's events. Frame order is what separates a guarded
+    // recovery from an unguarded one: without the exhaustion check the
+    // caught_up would already have been queued behind the full page above,
+    // and would therefore arrive BEFORE this event.
+    mocks.readOwnerSessionEventsAfter.mockResolvedValue([
+      {
+        id: '900',
+        ownerId: 'user:mine',
+        type: 'session_status',
+        sessionId: 'ses_tail',
+        ts: 2,
+        status: 'succeeded',
+        attempt: 0,
+      },
+    ]);
+    await vi.advanceTimersByTimeAsync(OWNER_EVENT_POLL_INTERVAL_MS);
+    const tailEvent = await readNonHeartbeatChunk(reader);
+    expect(tailEvent).toContain('id: 900\nevent: session_status');
+    expect(tailEvent).not.toContain('event: caught_up');
+    const recovered = await readChunk(reader);
+    expect(recovered).toContain('event: caught_up');
+    expect(recovered).not.toContain('"degraded":true');
+    await reader.cancel();
+  });
+
+  it('emits a 25s SSE comment heartbeat and cancel clears every timer', async () => {
+    const response = await call();
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toContain('event: caught_up');
+    expect(vi.getTimerCount()).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(SSE_HEARTBEAT_INTERVAL_MS);
+    expect(await readChunk(reader)).toBe(': ping\n\n');
+    expect(mocks.readOwnerRetirement).toHaveBeenCalledTimes(1);
+
+    await reader.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(SSE_HEARTBEAT_INTERVAL_MS * 2);
+    expect(mocks.readOwnerRetirement).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks retirement only on heartbeat, emits owner_moved, and ends the established stream', async () => {
+    mocks.resolveRequestOwnerId.mockReturnValueOnce('anon:old');
+    mocks.readOwnerRetirement.mockResolvedValueOnce('user:new');
+
+    const response = await call();
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toContain('event: caught_up');
+
+    await vi.advanceTimersByTimeAsync(SSE_HEARTBEAT_INTERVAL_MS - 1);
+    expect(mocks.readOwnerRetirement).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(await readChunk(reader)).toBe(': ping\n\n');
+    const moved = await readChunk(reader);
+    expect(moved).toContain('event: owner_moved');
+    expect(moved).toContain(
+      'data: {"type":"owner_moved","newOwnerId":"user:new","action":"reconnect"}',
+    );
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
+    expect(mocks.readOwnerRetirement).toHaveBeenCalledWith('anon:old');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('a new connection resolves the merged identity and replays its events', async () => {
+    mocks.resolveRequestOwnerId.mockReturnValueOnce('user:new');
+    mocks.readOwnerSessionEventMaxId.mockResolvedValueOnce(BigInt(9));
+    mocks.readOwnerSessionEventsAfter.mockResolvedValueOnce([
+      {
+        id: '9',
+        ownerId: 'user:new',
+        sessionId: 'session-after-merge',
+        ts: 456,
+        type: 'session_created',
+        status: 'queued',
+        attempt: 0,
+      },
+    ]);
+
+    const response = await call({ header: '8' });
+    const reader = response.body!.getReader();
+    const event = await readChunk(reader);
+
+    expect(mocks.readOwnerSessionEventsAfter).toHaveBeenCalledWith('user:new', BigInt(8), 500);
+    expect(event).toContain('id: 9\nevent: session_created');
+    await reader.cancel();
+  });
+});

--- a/tests/agent-runtime/session-events-route.test.ts
+++ b/tests/agent-runtime/session-events-route.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  readEventsAfterForReplay: vi.fn(),
+  resolveRequestOwnerId: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({ isAgentRuntimeEnabled: () => true }));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: vi.fn(async () => ({
+    getSession: mocks.getSession,
+    readEventsAfterForReplay: mocks.readEventsAfterForReplay,
+  })),
+}));
+
+import {
+  GET,
+  POLL_INTERVAL_MS,
+  TERMINAL_POLL_INTERVAL_MS,
+} from '@/app/api/agent/sessions/[id]/events/route';
+
+const terminalEvent = {
+  id: 4,
+  ts: 100,
+  attempt: 1,
+  type: 'session_end',
+  data: { status: 'succeeded' },
+};
+const resumedEvent = {
+  id: 5,
+  ts: 200,
+  attempt: 1,
+  type: 'session_start',
+  data: { workerId: 'worker-1' },
+};
+
+function call(lastEventId = '0') {
+  const req = new NextRequest('http://localhost/api/agent/sessions/session-1/events', {
+    headers: { 'last-event-id': lastEventId },
+  });
+  return GET(req, { params: Promise.resolve({ id: 'session-1' }) });
+}
+
+async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const chunk = await reader.read();
+  return chunk.done ? '' : new TextDecoder().decode(chunk.value);
+}
+
+async function readNonHeartbeatChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  for (;;) {
+    const chunk = await readChunk(reader);
+    if (chunk !== ': ping\n\n') return chunk;
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'user:mine' });
+  mocks.resolveRequestOwnerId.mockReturnValue('user:mine');
+  mocks.readEventsAfterForReplay.mockResolvedValue({ events: [], scanned: 0 });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET per-session events', () => {
+  it('preserves an anonymous owner cookie on the SSE response', async () => {
+    mocks.resolveRequestOwnerId.mockImplementationOnce((_request, responseHeaders: Headers) => {
+      responseHeaders.set('Set-Cookie', 'anonymous_id=test; Path=/; HttpOnly');
+      return 'user:mine';
+    });
+
+    const response = await call();
+    const reader = response.body!.getReader();
+
+    expect(response.headers.get('set-cookie')).toBe('anonymous_id=test; Path=/; HttpOnly');
+    expect(mocks.resolveRequestOwnerId).toHaveBeenCalledOnce();
+    await reader.cancel();
+  });
+
+  it('converges within the 5s polling interval', async () => {
+    // Absolute time bound, not the imported constant: this test pins how FAST
+    // the fallback converges. If the advance used the constant itself, a
+    // constant change (5s -> 300s) would silently keep every assertion green.
+    expect(POLL_INTERVAL_MS).toBeLessThanOrEqual(5_000);
+    const response = await call();
+    const reader = response.body!.getReader();
+    await readChunk(reader);
+    await readChunk(reader);
+    mocks.readEventsAfterForReplay.mockResolvedValueOnce({
+      events: [{ id: 1, ts: 123, attempt: 1, type: 'message_update', data: { text: 'fallback' } }],
+      scanned: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000 - 1);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenCalledTimes(1);
+    let delivered = false;
+    const fallbackFrame = readChunk(reader).then((chunk) => {
+      delivered = chunk.includes('id: 1\nevent: message_update');
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(delivered).toBe(true);
+    expect(await fallbackFrame).toContain('id: 1\nevent: message_update');
+    await reader.cancel();
+  });
+
+  it('retries backlog failures, degrades after three, and signals recovery only once', async () => {
+    mocks.readEventsAfterForReplay.mockRejectedValue(new Error('pg unavailable'));
+
+    const response = await call();
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toBe(': replaying from event 0\n\n');
+
+    let degradedSettled = false;
+    const degradedFrame = readChunk(reader).then((chunk) => {
+      degradedSettled = true;
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2 - 1);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenCalledTimes(2);
+    expect(degradedSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await degradedFrame).toContain(
+      'data: {"type":"caught_up","replayed":0,"fromEventId":0,"degraded":true}',
+    );
+    expect(mocks.readEventsAfterForReplay).toHaveBeenCalledTimes(3);
+
+    mocks.readEventsAfterForReplay.mockResolvedValue({ events: [], scanned: 0 });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const recovered = await readChunk(reader);
+    expect(recovered).toContain('event: caught_up');
+    expect(recovered).not.toContain('"degraded":true');
+
+    let repeated = false;
+    const nextFrame = readChunk(reader).then((chunk) => {
+      repeated = chunk.includes('event: caught_up');
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    expect(repeated).toBe(false);
+    await reader.cancel();
+    await nextFrame;
+  });
+
+  it('withholds the recovery signal while the recovered page is still unexhausted', async () => {
+    mocks.readEventsAfterForReplay.mockRejectedValue(new Error('pg unavailable'));
+    const response = await call();
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toBe(': replaying from event 0\n\n');
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2);
+    expect(await readChunk(reader)).toContain('"degraded":true');
+
+    // Recovery lands on an unexhausted page. Pagination judges by the RAW
+    // scanned count, so `scanned: 500` means more history follows even though
+    // compaction left a single frame -- the authoritative signal must wait.
+    mocks.readEventsAfterForReplay.mockResolvedValue({
+      events: [{ id: 1, seq: 1, ts: 1, type: 'message_update', data: {} }],
+      scanned: 500,
+    });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const recovering = await readChunk(reader);
+    expect(recovering).toContain('id: 1\nevent: message_update');
+    expect(recovering).not.toContain('event: caught_up');
+    // A degraded catch-up set backlogDone without draining, so this is still
+    // history rather than live tail.
+    expect(recovering).toContain('"phase":"backlog"');
+
+    // Exhausted page: the event goes out first, the authoritative caught_up
+    // after it. Frame order is what separates a guarded recovery from an
+    // unguarded one -- without the check the caught_up above would already
+    // have been queued and would arrive BEFORE this event.
+    mocks.readEventsAfterForReplay.mockResolvedValue({
+      events: [{ id: 2, seq: 2, ts: 2, type: 'message_update', data: {} }],
+      scanned: 1,
+    });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const tailEvent = await readChunk(reader);
+    expect(tailEvent).toContain('id: 2\nevent: message_update');
+    expect(tailEvent).not.toContain('event: caught_up');
+    const recovered = await readChunk(reader);
+    expect(recovered).toContain('event: caught_up');
+    expect(recovered).not.toContain('"degraded":true');
+    await reader.cancel();
+  });
+
+  it('emits a 25s comment heartbeat independently and cancel clears both timers', async () => {
+    const response = await call();
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toBe(': replaying from event 0\n\n');
+    expect(await readChunk(reader)).toContain('event: caught_up');
+    expect(vi.getTimerCount()).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(await readChunk(reader)).toBe(': ping\n\n');
+
+    await reader.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(50_000);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('attaching to a terminal backlog immediately schedules the longer fallback interval', async () => {
+    // Terminal backoff has an absolute ceiling too: a steer on a terminal
+    // session must still converge in bounded time, so pin the constant rather
+    // than letting it drift upward.
+    expect(TERMINAL_POLL_INTERVAL_MS).toBeLessThanOrEqual(10_000);
+    mocks.readEventsAfterForReplay
+      .mockResolvedValueOnce({ events: [terminalEvent], scanned: 1 })
+      .mockResolvedValue({ events: [], scanned: 0 });
+
+    const response = await call();
+    const reader = response.body!.getReader();
+    await readChunk(reader);
+    expect(await readChunk(reader)).toContain('id: 4\nevent: session_end');
+    await readChunk(reader);
+
+    await vi.advanceTimersByTimeAsync(TERMINAL_POLL_INTERVAL_MS - 1);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenCalledTimes(2);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenLastCalledWith('session-1', 4, 500);
+    await reader.cancel();
+  });
+
+  it('delivers in order from Last-Event-ID and resumes 5s fallback polling after new activity', async () => {
+    mocks.readEventsAfterForReplay
+      .mockResolvedValueOnce({ events: [terminalEvent], scanned: 1 })
+      .mockResolvedValueOnce({ events: [resumedEvent], scanned: 1 })
+      .mockResolvedValue({ events: [], scanned: 0 });
+
+    const response = await call('3');
+    const reader = response.body!.getReader();
+    expect(await readChunk(reader)).toBe(': replaying from event 3\n\n');
+    expect(await readChunk(reader)).toContain('id: 4\nevent: session_end');
+    await readChunk(reader);
+
+    await vi.advanceTimersByTimeAsync(TERMINAL_POLL_INTERVAL_MS);
+    expect(await readNonHeartbeatChunk(reader)).toContain('id: 5\nevent: session_start');
+    expect(mocks.readEventsAfterForReplay.mock.calls.slice(0, 2)).toEqual([
+      ['session-1', 3, 500],
+      ['session-1', 4, 500],
+    ]);
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS - 1);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mocks.readEventsAfterForReplay).toHaveBeenLastCalledWith('session-1', 5, 500);
+    await reader.cancel();
+  });
+});

--- a/tests/agent-runtime/session-events-route.test.ts
+++ b/tests/agent-runtime/session-events-route.test.ts
@@ -87,6 +87,43 @@ describe('GET per-session events', () => {
     await reader.cancel();
   });
 
+  it('does not stream a session owned by another identity: 404 and no event-log reads', async () => {
+    mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'user:someone-else' });
+    mocks.resolveRequestOwnerId.mockReturnValue('user:mine');
+
+    const response = await call();
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+    expect(mocks.resolveRequestOwnerId).toHaveBeenCalledOnce();
+    expect(mocks.readEventsAfterForReplay).not.toHaveBeenCalled();
+  });
+
+  it('mints the identity cookie on the 404 for a missing and a not-owned session alike', async () => {
+    const mint = () => {
+      mocks.resolveRequestOwnerId.mockImplementationOnce((_request, responseHeaders: Headers) => {
+        responseHeaders.set('Set-Cookie', 'anonymous_id=test; Path=/; HttpOnly');
+        return 'user:mine';
+      });
+    };
+
+    mint();
+    mocks.getSession.mockResolvedValue(null);
+    const missing = await call();
+    expect(missing.status).toBe(404);
+    expect(await missing.text()).toBe('Not found');
+    expect(missing.headers.get('set-cookie')).toBe('anonymous_id=test; Path=/; HttpOnly');
+    expect(mocks.readEventsAfterForReplay).not.toHaveBeenCalled();
+
+    mint();
+    mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'user:someone-else' });
+    const notOwned = await call();
+    expect(notOwned.status).toBe(404);
+    expect(await notOwned.text()).toBe('Not found');
+    expect(notOwned.headers.get('set-cookie')).toBe('anonymous_id=test; Path=/; HttpOnly');
+    expect(mocks.readEventsAfterForReplay).not.toHaveBeenCalled();
+  });
+
   it('converges within the 5s polling interval', async () => {
     // Absolute time bound, not the imported constant: this test pins how FAST
     // the fallback converges. If the advance used the constant itself, a


### PR DESCRIPTION
Fifth application-layer slice: the two SSE read surfaces (per-session event replay+tail, and the owner-level session-status channel). Together with the lifecycle routes this completes the agent runtime application layer on this integration branch.

- Session events route: Last-Event-ID replay, caught_up marker, live tail, degraded fallback, pagination by scanned count, serialized polling, and terminal transition — ported nearly verbatim from the reference.
- Owner-events route: owner-scoped replayable channel with resync_required / owner_moved and the 25s readRetirement seam preserved (inert under the identity owner resolver until a merge model is wired).
- Poll-only: the package has no LISTEN/NOTIFY yet, so both routes fall back to serialized polling (5s active / 10s terminal / 30s owner). This is a correctness fallback the reference already relied on, not a reduced implementation; a NOTIFY fast-path is a later package PR.
- Both routes are owner-scoped (no cross-owner access — verified with negative-case tests) and mint the anonymous cookie identity; the session-not-found path is indistinguishable whether or not the session exists (no existence oracle). A comment documents that a future auth integration threads authenticatedOwnerId through the owner seam.

Tests: replay/tail/caught_up/degraded, timer cleanup (getTimerCount → 0 after cancel), cross-owner negatives. Real PostgreSQL 16 suite green locally.