### PR TITLE
feat(agent): add agent session lifecycle routes

### DIFF
--- a/app/api/agent/runtime/route.ts
+++ b/app/api/agent/runtime/route.ts
@@ -1,0 +1,8 @@
+/** Server-side agent runtime status probe. */
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  return Response.json({ enabled: isAgentRuntimeEnabled() });
+}

--- a/app/api/agent/runtime/route.ts
+++ b/app/api/agent/runtime/route.ts
@@ -4,5 +4,6 @@ import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
 export const runtime = 'nodejs';
 
 export async function GET() {
+  // Intentionally no materials flag: isAgentMaterialsEnabled does not exist in this repo.
   return Response.json({ enabled: isAgentRuntimeEnabled() });
 }

--- a/app/api/agent/sessions/[id]/cancel/route.ts
+++ b/app/api/agent/sessions/[id]/cancel/route.ts
@@ -8,8 +8,8 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
-import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
 
 export const runtime = 'nodejs';
 
@@ -18,28 +18,28 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return new Response('Not found', { status: 404 });
   }
 
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
-  const { id } = await params;
-  const store = await getAgentSessionStore();
-  const meta = await store.getSession(id);
-  if (!meta || meta.ownerId !== ownerId) {
-    return new Response('Not found', { status: 404, headers: responseHeaders });
-  }
-  if (meta.status === 'succeeded' || meta.status === 'failed' || meta.status === 'cancelled') {
-    return NextResponse.json(
-      {
-        code: 'SESSION_ALREADY_TERMINAL',
-        status: meta.status,
-        error: `session is already ${meta.status}`,
-      },
-      { status: 409, headers: responseHeaders },
-    );
-  }
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getAgentSessionStore();
+    const meta = await store.getSession(id);
+    if (!meta || meta.ownerId !== ownerId) {
+      return new Response('Not found', { status: 404, headers: responseHeaders });
+    }
+    if (meta.status === 'succeeded' || meta.status === 'failed' || meta.status === 'cancelled') {
+      return NextResponse.json(
+        {
+          code: 'SESSION_ALREADY_TERMINAL',
+          status: meta.status,
+          error: `session is already ${meta.status}`,
+        },
+        { status: 409, headers: responseHeaders },
+      );
+    }
 
-  await store.requestCancel(id);
-  return NextResponse.json(
-    { id, cancelRequested: true },
-    { status: 202, headers: responseHeaders },
-  );
+    await store.requestCancel(id);
+    return NextResponse.json(
+      { id, cancelRequested: true },
+      { status: 202, headers: responseHeaders },
+    );
+  });
 }

--- a/app/api/agent/sessions/[id]/cancel/route.ts
+++ b/app/api/agent/sessions/[id]/cancel/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Agent runtime control plane for cancellation.
+ *
+ * The route makes the request durable. The lease holder observes it and
+ * writes the terminal event, keeping the event log single-writer.
+ */
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAgentRuntimeEnabled()) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const { id } = await params;
+  const store = await getAgentSessionStore();
+  const meta = await store.getSession(id);
+  if (!meta || meta.ownerId !== ownerId) {
+    return new Response('Not found', { status: 404, headers: responseHeaders });
+  }
+  if (meta.status === 'succeeded' || meta.status === 'failed' || meta.status === 'cancelled') {
+    return NextResponse.json(
+      {
+        code: 'SESSION_ALREADY_TERMINAL',
+        status: meta.status,
+        error: `session is already ${meta.status}`,
+      },
+      { status: 409, headers: responseHeaders },
+    );
+  }
+
+  await store.requestCancel(id);
+  return NextResponse.json(
+    { id, cancelRequested: true },
+    { status: 202, headers: responseHeaders },
+  );
+}

--- a/app/api/agent/sessions/[id]/messages/route.ts
+++ b/app/api/agent/sessions/[id]/messages/route.ts
@@ -5,8 +5,9 @@ import { NextResponse } from 'next/server';
 
 import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
-import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { MAX_SESSION_TEXT_LENGTH } from '@/lib/server/agent-runtime/limits';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
 
 export const runtime = 'nodejs';
 
@@ -15,41 +16,50 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return new Response('Not found', { status: 404 });
   }
 
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
-  const { id } = await params;
-  const store = await getAgentSessionStore();
-  const meta = await store.getSession(id);
-  if (!meta || meta.ownerId !== ownerId) {
-    return new Response('Not found', { status: 404, headers: responseHeaders });
-  }
-
-  let body: { text?: string } = {};
-  try {
-    body = ((await req.json()) ?? {}) as typeof body;
-  } catch {
-    const response = apiError('INVALID_REQUEST', 400, 'invalid JSON body');
-    responseHeaders.forEach((value, name) => response.headers.append(name, value));
-    return response;
-  }
-
-  const text = (body.text ?? '').toString().trim();
-  if (!text) {
-    const response = apiError('MISSING_REQUIRED_FIELD', 400, 'text is required');
-    responseHeaders.forEach((value, name) => response.headers.append(name, value));
-    return response;
-  }
-
-  try {
-    const posted = await store.postUserMessage(id, { text }, { expectedOwnerId: ownerId });
-    return NextResponse.json(
-      { id, message: { seq: posted.seq, text, delivery: posted.delivery } },
-      { status: 202, headers: responseHeaders },
-    );
-  } catch (error) {
-    if (error instanceof AgentSessionAccessError) {
-      return new Response('Forbidden', { status: 403, headers: responseHeaders });
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getAgentSessionStore();
+    const meta = await store.getSession(id);
+    if (!meta || meta.ownerId !== ownerId) {
+      return new Response('Not found', { status: 404, headers: responseHeaders });
     }
-    throw error;
-  }
+
+    let body: { text?: string } = {};
+    try {
+      body = ((await req.json()) ?? {}) as typeof body;
+    } catch {
+      const response = apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+      responseHeaders.forEach((value, name) => response.headers.append(name, value));
+      return response;
+    }
+
+    const text = (body.text ?? '').toString().trim();
+    if (!text) {
+      const response = apiError('MISSING_REQUIRED_FIELD', 400, 'text is required');
+      responseHeaders.forEach((value, name) => response.headers.append(name, value));
+      return response;
+    }
+    if (text.length > MAX_SESSION_TEXT_LENGTH) {
+      const response = apiError(
+        'INVALID_REQUEST',
+        400,
+        `text exceeds the ${MAX_SESSION_TEXT_LENGTH} character limit`,
+      );
+      responseHeaders.forEach((value, name) => response.headers.append(name, value));
+      return response;
+    }
+
+    try {
+      const posted = await store.postUserMessage(id, { text }, { expectedOwnerId: ownerId });
+      return NextResponse.json(
+        { id, message: { seq: posted.seq, text, delivery: posted.delivery } },
+        { status: 202, headers: responseHeaders },
+      );
+    } catch (error) {
+      if (error instanceof AgentSessionAccessError) {
+        return new Response('Forbidden', { status: 403, headers: responseHeaders });
+      }
+      throw error;
+    }
+  });
 }

--- a/app/api/agent/sessions/[id]/messages/route.ts
+++ b/app/api/agent/sessions/[id]/messages/route.ts
@@ -1,0 +1,55 @@
+/** Agent runtime control plane for durable follow-up messages. */
+import { AgentSessionAccessError } from '@openmaic/storage';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAgentRuntimeEnabled()) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const { id } = await params;
+  const store = await getAgentSessionStore();
+  const meta = await store.getSession(id);
+  if (!meta || meta.ownerId !== ownerId) {
+    return new Response('Not found', { status: 404, headers: responseHeaders });
+  }
+
+  let body: { text?: string } = {};
+  try {
+    body = ((await req.json()) ?? {}) as typeof body;
+  } catch {
+    const response = apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+    responseHeaders.forEach((value, name) => response.headers.append(name, value));
+    return response;
+  }
+
+  const text = (body.text ?? '').toString().trim();
+  if (!text) {
+    const response = apiError('MISSING_REQUIRED_FIELD', 400, 'text is required');
+    responseHeaders.forEach((value, name) => response.headers.append(name, value));
+    return response;
+  }
+
+  try {
+    const posted = await store.postUserMessage(id, { text }, { expectedOwnerId: ownerId });
+    return NextResponse.json(
+      { id, message: { seq: posted.seq, text, delivery: posted.delivery } },
+      { status: 202, headers: responseHeaders },
+    );
+  } catch (error) {
+    if (error instanceof AgentSessionAccessError) {
+      return new Response('Forbidden', { status: 403, headers: responseHeaders });
+    }
+    throw error;
+  }
+}

--- a/app/api/agent/sessions/[id]/route.ts
+++ b/app/api/agent/sessions/[id]/route.ts
@@ -3,8 +3,8 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
-import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
 
 export const runtime = 'nodejs';
 
@@ -13,13 +13,13 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     return new Response('Not found', { status: 404 });
   }
 
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
-  const { id } = await params;
-  const store = await getAgentSessionStore();
-  const meta = await store.getSession(id);
-  if (!meta || meta.ownerId !== ownerId) {
-    return new Response('Not found', { status: 404, headers: responseHeaders });
-  }
-  return NextResponse.json(meta, { headers: responseHeaders });
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getAgentSessionStore();
+    const meta = await store.getSession(id);
+    if (!meta || meta.ownerId !== ownerId) {
+      return new Response('Not found', { status: 404, headers: responseHeaders });
+    }
+    return NextResponse.json(meta, { headers: responseHeaders });
+  });
 }

--- a/app/api/agent/sessions/[id]/route.ts
+++ b/app/api/agent/sessions/[id]/route.ts
@@ -1,0 +1,25 @@
+/** Agent runtime control plane for reading one owned session. */
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAgentRuntimeEnabled()) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const { id } = await params;
+  const store = await getAgentSessionStore();
+  const meta = await store.getSession(id);
+  if (!meta || meta.ownerId !== ownerId) {
+    return new Response('Not found', { status: 404, headers: responseHeaders });
+  }
+  return NextResponse.json(meta, { headers: responseHeaders });
+}

--- a/app/api/agent/sessions/route.ts
+++ b/app/api/agent/sessions/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Agent runtime control plane for session creation and listing.
+ *
+ * These handlers only use the durable session store. A separately running
+ * worker claims queued sessions after the request has returned.
+ */
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+import { buildRequestOrigin } from '@/lib/server/classroom-storage';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+
+export const runtime = 'nodejs';
+
+interface CreateSessionBody {
+  prompt?: string;
+  stageId?: string;
+  skill?: string;
+  /** Attach to an already-built classroom instead of starting a new course. */
+  existingCourse?: boolean;
+}
+
+export async function POST(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  let body: CreateSessionBody = {};
+  try {
+    body = ((await req.json()) ?? {}) as CreateSessionBody;
+  } catch {
+    return apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+  }
+
+  const existingCourse = body.existingCourse === true;
+  const stageId = body.stageId?.toString().trim() || undefined;
+  if (existingCourse && !stageId) {
+    return apiError('MISSING_REQUIRED_FIELD', 400, 'existingCourse requires stageId');
+  }
+
+  const prompt =
+    (body.prompt ?? '').toString().trim() || (existingCourse ? (stageId ?? 'existing-course') : '');
+  if (!prompt) {
+    return apiError('MISSING_REQUIRED_FIELD', 400, 'prompt is required');
+  }
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const skillId = (body.skill ?? '').toString().trim() || undefined;
+
+  // Upstream classrooms do not carry an owner partition, so existing-course
+  // sessions validate the required identifier but cannot enforce ownership.
+  const store = await getAgentSessionStore();
+  const meta = await store.createSession({
+    ownerId,
+    prompt,
+    ...(stageId ? { stageId } : {}),
+    ...(skillId ? { skillId } : {}),
+    existingCourse,
+    origin: buildRequestOrigin(req),
+    ...(existingCourse ? { status: 'succeeded' as const } : {}),
+  });
+
+  return NextResponse.json(meta, { status: 202, headers: responseHeaders });
+}
+
+export async function GET(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const store = await getAgentSessionStore();
+  const sessions = await store.listSessionsByOwner(ownerId);
+  return NextResponse.json(sessions, { headers: responseHeaders });
+}

--- a/app/api/agent/sessions/route.ts
+++ b/app/api/agent/sessions/route.ts
@@ -9,9 +9,10 @@ import { NextResponse } from 'next/server';
 
 import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
+import { MAX_SESSION_TEXT_LENGTH } from '@/lib/server/agent-runtime/limits';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
-import { buildRequestOrigin } from '@/lib/server/classroom-storage';
-import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+import { buildRequestOrigin, isValidClassroomId } from '@/lib/server/classroom-storage';
 
 export const runtime = 'nodejs';
 
@@ -40,31 +41,43 @@ export async function POST(req: NextRequest) {
   if (existingCourse && !stageId) {
     return apiError('MISSING_REQUIRED_FIELD', 400, 'existingCourse requires stageId');
   }
+  if (existingCourse && stageId && !isValidClassroomId(stageId)) {
+    return apiError('INVALID_REQUEST', 400, 'existingCourse stageId has an invalid format');
+  }
 
   const prompt =
     (body.prompt ?? '').toString().trim() || (existingCourse ? (stageId ?? 'existing-course') : '');
   if (!prompt) {
     return apiError('MISSING_REQUIRED_FIELD', 400, 'prompt is required');
   }
+  if (prompt.length > MAX_SESSION_TEXT_LENGTH) {
+    return apiError(
+      'INVALID_REQUEST',
+      400,
+      `prompt exceeds the ${MAX_SESSION_TEXT_LENGTH} character limit`,
+    );
+  }
 
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
-  const skillId = (body.skill ?? '').toString().trim() || undefined;
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const skillId = (body.skill ?? '').toString().trim() || undefined;
 
-  // Upstream classrooms do not carry an owner partition, so existing-course
-  // sessions validate the required identifier but cannot enforce ownership.
-  const store = await getAgentSessionStore();
-  const meta = await store.createSession({
-    ownerId,
-    prompt,
-    ...(stageId ? { stageId } : {}),
-    ...(skillId ? { skillId } : {}),
-    existingCourse,
-    origin: buildRequestOrigin(req),
-    ...(existingCourse ? { status: 'succeeded' as const } : {}),
+    // Upstream classrooms do not carry an owner partition, so existing-course
+    // sessions validate only the identifier format here. Full existence and
+    // ownership validation is deferred until a later slice consumes stageId —
+    // the upstream document store has no owner partition yet.
+    const store = await getAgentSessionStore();
+    const meta = await store.createSession({
+      ownerId,
+      prompt,
+      ...(stageId ? { stageId } : {}),
+      ...(skillId ? { skillId } : {}),
+      existingCourse,
+      origin: buildRequestOrigin(req),
+      ...(existingCourse ? { status: 'succeeded' as const } : {}),
+    });
+
+    return NextResponse.json(meta, { status: 202, headers: responseHeaders });
   });
-
-  return NextResponse.json(meta, { status: 202, headers: responseHeaders });
 }
 
 export async function GET(req: NextRequest) {
@@ -72,9 +85,9 @@ export async function GET(req: NextRequest) {
     return new Response('Not found', { status: 404 });
   }
 
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
-  const store = await getAgentSessionStore();
-  const sessions = await store.listSessionsByOwner(ownerId);
-  return NextResponse.json(sessions, { headers: responseHeaders });
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const store = await getAgentSessionStore();
+    const sessions = await store.listSessionsByOwner(ownerId);
+    return NextResponse.json(sessions, { headers: responseHeaders });
+  });
 }

--- a/app/api/agent/sessions/status/route.ts
+++ b/app/api/agent/sessions/status/route.ts
@@ -2,8 +2,8 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
-import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
 
 export const runtime = 'nodejs';
 
@@ -11,10 +11,10 @@ export const runtime = 'nodejs';
 export async function GET(req: NextRequest) {
   if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
 
-  const responseHeaders = new Headers();
-  const ownerId = resolveRequestOwnerId(req, responseHeaders);
-  const store = await getAgentSessionStore();
-  const sessions = await store.listSessionsByOwner(ownerId);
-  const statuses = Object.fromEntries(sessions.map((session) => [session.id, session.status]));
-  return NextResponse.json(statuses, { headers: responseHeaders });
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const store = await getAgentSessionStore();
+    const sessions = await store.listSessionsByOwner(ownerId);
+    const statuses = Object.fromEntries(sessions.map((session) => [session.id, session.status]));
+    return NextResponse.json(statuses, { headers: responseHeaders });
+  });
 }

--- a/app/api/agent/sessions/status/route.ts
+++ b/app/api/agent/sessions/status/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
+
+export const runtime = 'nodejs';
+
+/** Return a sparse status map for all sessions visible to this owner. */
+export async function GET(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const store = await getAgentSessionStore();
+  const sessions = await store.listSessionsByOwner(ownerId);
+  const statuses = Object.fromEntries(sessions.map((session) => [session.id, session.status]));
+  return NextResponse.json(statuses, { headers: responseHeaders });
+}

--- a/lib/server/agent-runtime/limits.ts
+++ b/lib/server/agent-runtime/limits.ts
@@ -1,0 +1,9 @@
+/**
+ * Upper bound, in characters, for agent session prompts and follow-up messages.
+ *
+ * The upstream runtime has no credit gate and no per-identity quota, so an
+ * anonymous identity could otherwise post unbounded text and drive unbounded
+ * database bloat and unbounded LLM spend. 100k characters is generous for
+ * real course-building prompts while still bounding a single request.
+ */
+export const MAX_SESSION_TEXT_LENGTH = 100_000;

--- a/lib/server/agent-runtime/with-owner.ts
+++ b/lib/server/agent-runtime/with-owner.ts
@@ -1,0 +1,24 @@
+import { resolveRequestOwnerId } from './owner';
+
+/**
+ * Resolve the anonymous owner identity and run a handler with its response
+ * headers.
+ *
+ * The Set-Cookie minted by resolveRequestOwnerId must ride every response,
+ * including 4xx and 5xx: a client that retries after an error keeps the same
+ * owner partition, while a 500 that dropped the cookie would silently make
+ * the retry a different anonymous owner.
+ */
+export async function withRequestOwnerId(
+  req: Pick<Request, 'headers'>,
+  handler: (ownerId: string, responseHeaders: Headers) => Promise<Response>,
+): Promise<Response> {
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  try {
+    return await handler(ownerId, responseHeaders);
+  } catch (error) {
+    console.error('[agent-runtime] request failed under an anonymous owner', error);
+    return new Response('Internal Server Error', { status: 500, headers: responseHeaders });
+  }
+}

--- a/tests/agent-runtime/cancel-route.test.ts
+++ b/tests/agent-runtime/cancel-route.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  requestCancel: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({ isAgentRuntimeEnabled: () => true }));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: () => 'owner-1',
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: async () => ({
+    getSession: mocks.getSession,
+    requestCancel: mocks.requestCancel,
+  }),
+}));
+
+import { POST } from '@/app/api/agent/sessions/[id]/cancel/route';
+
+function call() {
+  return POST(new NextRequest('http://localhost/api/agent/sessions/session-1/cancel'), {
+    params: Promise.resolve({ id: 'session-1' }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-1', status: 'running' });
+});
+
+describe('POST agent session cancellation', () => {
+  it('durably requests cancellation for an owned live session', async () => {
+    const response = await call();
+
+    expect(response.status).toBe(202);
+    expect(mocks.requestCancel).toHaveBeenCalledWith('session-1');
+    await expect(response.json()).resolves.toEqual({ id: 'session-1', cancelRequested: true });
+  });
+
+  it.each(['succeeded', 'failed', 'cancelled'] as const)(
+    'returns a structured terminal conflict for %s',
+    async (status) => {
+      mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-1', status });
+
+      const response = await call();
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toEqual({
+        code: 'SESSION_ALREADY_TERMINAL',
+        status,
+        error: `session is already ${status}`,
+      });
+      expect(mocks.requestCancel).not.toHaveBeenCalled();
+    },
+  );
+
+  it('hides a foreign session', async () => {
+    mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-2', status: 'running' });
+
+    expect((await call()).status).toBe(404);
+    expect(mocks.requestCancel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/agent-runtime/messages-route.test.ts
+++ b/tests/agent-runtime/messages-route.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/server/agent-runtime/store', () => ({
 }));
 
 import { POST } from '@/app/api/agent/sessions/[id]/messages/route';
+import { MAX_SESSION_TEXT_LENGTH } from '@/lib/server/agent-runtime/limits';
 
 function call(body: unknown) {
   const request = new NextRequest('http://localhost/api/agent/sessions/session-1/messages', {
@@ -74,16 +75,37 @@ describe('POST agent session message', () => {
     expect(mocks.postUserMessage).not.toHaveBeenCalled();
   });
 
+  it('rejects a message that exceeds the text length cap', async () => {
+    const response = await call({ text: 'x'.repeat(MAX_SESSION_TEXT_LENGTH + 1) });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+    expect(mocks.postUserMessage).not.toHaveBeenCalled();
+  });
+
   it('hides an absent or foreign session', async () => {
     mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-2' });
 
-    expect((await call({ text: 'Continue' })).status).toBe(404);
+    const response = await call({ text: 'Continue' });
+    expect(response.status).toBe(404);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
     expect(mocks.postUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the minted owner cookie when the store fails', async () => {
+    mocks.getSession.mockRejectedValue(new Error('database unavailable'));
+
+    const response = await call({ text: 'Continue' });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
   });
 
   it('maps a transactional ownership race to forbidden', async () => {
     mocks.postUserMessage.mockRejectedValue(new AgentSessionAccessError('session-1'));
 
-    expect((await call({ text: 'Continue' })).status).toBe(403);
+    const response = await call({ text: 'Continue' });
+    expect(response.status).toBe(403);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
   });
 });

--- a/tests/agent-runtime/messages-route.test.ts
+++ b/tests/agent-runtime/messages-route.test.ts
@@ -1,0 +1,89 @@
+import { AgentSessionAccessError } from '@openmaic/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  postUserMessage: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({ isAgentRuntimeEnabled: () => true }));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: (_request: NextRequest, headers: Headers) => {
+    headers.append('Set-Cookie', 'anonymous_id=test; Path=/; HttpOnly');
+    return 'owner-1';
+  },
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: async () => ({
+    getSession: mocks.getSession,
+    postUserMessage: mocks.postUserMessage,
+  }),
+}));
+
+import { POST } from '@/app/api/agent/sessions/[id]/messages/route';
+
+function call(body: unknown) {
+  const request = new NextRequest('http://localhost/api/agent/sessions/session-1/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return POST(request, { params: Promise.resolve({ id: 'session-1' }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-1', status: 'succeeded' });
+  mocks.postUserMessage.mockResolvedValue({ seq: 4, delivery: 'queued', requeued: true });
+});
+
+describe('POST agent session message', () => {
+  it('posts a trimmed message with an owner fence and returns its delivery', async () => {
+    const response = await call({ text: ' Continue ' });
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+    expect(mocks.postUserMessage).toHaveBeenCalledWith(
+      'session-1',
+      { text: 'Continue' },
+      { expectedOwnerId: 'owner-1' },
+    );
+    await expect(response.json()).resolves.toEqual({
+      id: 'session-1',
+      message: { seq: 4, text: 'Continue', delivery: 'queued' },
+    });
+  });
+
+  it('accepts a follow-up for a failed session', async () => {
+    mocks.getSession.mockResolvedValue({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      status: 'failed',
+      attempt: 6,
+    });
+
+    expect((await call({ text: 'Retry' })).status).toBe(202);
+    expect(mocks.postUserMessage).toHaveBeenCalledOnce();
+  });
+
+  it('requires non-empty text', async () => {
+    const response = await call({ text: ' ' });
+
+    expect(response.status).toBe(400);
+    expect(mocks.postUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('hides an absent or foreign session', async () => {
+    mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-2' });
+
+    expect((await call({ text: 'Continue' })).status).toBe(404);
+    expect(mocks.postUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('maps a transactional ownership race to forbidden', async () => {
+    mocks.postUserMessage.mockRejectedValue(new AgentSessionAccessError('session-1'));
+
+    expect((await call({ text: 'Continue' })).status).toBe(403);
+  });
+});

--- a/tests/agent-runtime/runtime-probe.test.ts
+++ b/tests/agent-runtime/runtime-probe.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const flags = vi.hoisted(() => ({ runtime: false }));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => flags.runtime,
+}));
+
+import { GET } from '@/app/api/agent/runtime/route';
+
+beforeEach(() => {
+  flags.runtime = false;
+});
+
+describe('agent runtime probe', () => {
+  it('reports the disabled runtime', async () => {
+    await expect((await GET()).json()).resolves.toEqual({ enabled: false });
+  });
+
+  it('reports the enabled runtime without unrelated capability flags', async () => {
+    flags.runtime = true;
+    await expect((await GET()).json()).resolves.toEqual({ enabled: true });
+  });
+});

--- a/tests/agent-runtime/session-detail-route.test.ts
+++ b/tests/agent-runtime/session-detail-route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({ getSession: vi.fn() }));
+
+vi.mock('@/lib/config/feature-flags', () => ({ isAgentRuntimeEnabled: () => true }));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: () => 'owner-1',
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: async () => ({ getSession: mocks.getSession }),
+}));
+
+import { GET } from '@/app/api/agent/sessions/[id]/route';
+
+function call() {
+  return GET(new NextRequest('http://localhost/api/agent/sessions/session-1'), {
+    params: Promise.resolve({ id: 'session-1' }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-1', status: 'running' });
+});
+
+describe('GET one agent session', () => {
+  it('returns an owned session', async () => {
+    const response = await call();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ id: 'session-1', status: 'running' });
+  });
+
+  it('does not expose a foreign session', async () => {
+    mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-2' });
+    expect((await call()).status).toBe(404);
+  });
+});

--- a/tests/agent-runtime/session-detail-route.test.ts
+++ b/tests/agent-runtime/session-detail-route.test.ts
@@ -35,4 +35,18 @@ describe('GET one agent session', () => {
     mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-2' });
     expect((await call()).status).toBe(404);
   });
+
+  it.each(['not-a-real-id', 'x'.repeat(4096)])(
+    'answers a malformed or oversized session id (%s) with not found',
+    async (id) => {
+      mocks.getSession.mockResolvedValue(null);
+
+      const response = await GET(new NextRequest(`http://localhost/api/agent/sessions/${id}`), {
+        params: Promise.resolve({ id }),
+      });
+
+      expect(mocks.getSession).toHaveBeenCalledWith(id);
+      expect(response.status).toBe(404);
+    },
+  );
 });

--- a/tests/agent-runtime/session-status-route.test.ts
+++ b/tests/agent-runtime/session-status-route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  listSessionsByOwner: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: () => 'owner-1',
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: async () => ({ listSessionsByOwner: mocks.listSessionsByOwner }),
+}));
+
+import { GET } from '@/app/api/agent/sessions/status/route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.listSessionsByOwner.mockResolvedValue([
+    { id: 'session-queued', status: 'queued' },
+    { id: 'session-running', status: 'running' },
+    { id: 'session-done', status: 'succeeded' },
+  ]);
+});
+
+describe('GET agent session status map', () => {
+  it('builds an id-to-status mapping from the owner session list', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/agent/sessions/status'));
+
+    expect(response.status).toBe(200);
+    expect(mocks.listSessionsByOwner).toHaveBeenCalledWith('owner-1');
+    await expect(response.json()).resolves.toEqual({
+      'session-queued': 'queued',
+      'session-running': 'running',
+      'session-done': 'succeeded',
+    });
+  });
+
+  it('stays behind the runtime feature gate', async () => {
+    mocks.runtimeEnabled = false;
+
+    expect((await GET(new NextRequest('http://localhost/api/agent/sessions/status'))).status).toBe(
+      404,
+    );
+    expect(mocks.listSessionsByOwner).not.toHaveBeenCalled();
+  });
+});

--- a/tests/agent-runtime/sessions-route.test.ts
+++ b/tests/agent-runtime/sessions-route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  createSession: vi.fn(),
+  listSessionsByOwner: vi.fn(),
+  resolveRequestOwnerId: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: async () => ({
+    createSession: mocks.createSession,
+    listSessionsByOwner: mocks.listSessionsByOwner,
+  }),
+}));
+
+import { GET, POST } from '@/app/api/agent/sessions/route';
+
+function post(body: unknown, headers?: HeadersInit) {
+  return POST(
+    new NextRequest('http://localhost/api/agent/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockImplementation(
+    (_request: NextRequest, responseHeaders: Headers) => {
+      responseHeaders.append('Set-Cookie', 'anonymous_id=test; Path=/; HttpOnly');
+      return 'anon:test';
+    },
+  );
+  mocks.createSession.mockResolvedValue({
+    id: 'session-1',
+    ownerId: 'anon:test',
+    prompt: 'Build a course',
+    stageId: 'agent-session-1',
+    status: 'queued',
+  });
+  mocks.listSessionsByOwner.mockResolvedValue([]);
+});
+
+describe('agent session collection route', () => {
+  it('creates a queued session and propagates a newly minted owner cookie', async () => {
+    const response = await post({ prompt: ' Build a course ', skill: 'custom-skill' });
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerId: 'anon:test',
+        prompt: 'Build a course',
+        skillId: 'custom-skill',
+        existingCourse: false,
+        origin: 'http://localhost',
+      }),
+    );
+  });
+
+  it('requires a prompt for a new session', async () => {
+    const response = await post({ prompt: '  ' });
+
+    expect(response.status).toBe(400);
+    expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it('creates an idle existing-course session without a stage access dependency', async () => {
+    const response = await post({ existingCourse: true, stageId: 'stage-1' });
+
+    expect(response.status).toBe(202);
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'stage-1',
+        stageId: 'stage-1',
+        existingCourse: true,
+        status: 'succeeded',
+      }),
+    );
+  });
+
+  it('requires a stage id for an existing-course session', async () => {
+    const response = await post({ existingCourse: true });
+
+    expect(response.status).toBe(400);
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it('lists only sessions for the resolved owner', async () => {
+    mocks.listSessionsByOwner.mockResolvedValue([{ id: 'session-1', status: 'running' }]);
+    const response = await GET(new NextRequest('http://localhost/api/agent/sessions'));
+
+    expect(response.status).toBe(200);
+    expect(mocks.listSessionsByOwner).toHaveBeenCalledWith('anon:test');
+    await expect(response.json()).resolves.toEqual([{ id: 'session-1', status: 'running' }]);
+  });
+
+  it('keeps both collection methods behind the runtime gate', async () => {
+    mocks.runtimeEnabled = false;
+
+    expect((await post({ prompt: 'Build' })).status).toBe(404);
+    expect((await GET(new NextRequest('http://localhost/api/agent/sessions'))).status).toBe(404);
+    expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
+  });
+});

--- a/tests/agent-runtime/sessions-route.test.ts
+++ b/tests/agent-runtime/sessions-route.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/server/agent-runtime/store', () => ({
 }));
 
 import { GET, POST } from '@/app/api/agent/sessions/route';
+import { MAX_SESSION_TEXT_LENGTH } from '@/lib/server/agent-runtime/limits';
 
 function post(body: unknown, headers?: HeadersInit) {
   return POST(
@@ -96,6 +97,31 @@ describe('agent session collection route', () => {
 
     expect(response.status).toBe(400);
     expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects an existing-course stage id that fails the classroom id format', async () => {
+    const response = await post({ existingCourse: true, stageId: 'not a valid id!' });
+
+    expect(response.status).toBe(400);
+    expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a prompt that exceeds the text length cap', async () => {
+    const response = await post({ prompt: 'x'.repeat(MAX_SESSION_TEXT_LENGTH + 1) });
+
+    expect(response.status).toBe(400);
+    expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps the minted owner cookie when session creation fails', async () => {
+    mocks.createSession.mockRejectedValue(new Error('database unavailable'));
+
+    const response = await post({ prompt: 'Build a course' });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
   });
 
   it('lists only sessions for the resolved owner', async () => {


### PR DESCRIPTION
Fourth application-layer slice: the agent session control-plane routes (create / list / detail / cancel / message / status + the runtime probe). Consumes the landed store and owner cookie seam; no SSE (that is the sibling slice), no business tools.

- Every by-id route is owner-scoped through the resolved request owner (cross-owner access verified impossible in review); `postUserMessage`'s access error maps to 403, not 500.
- Owner identity comes from the anonymous cookie seam and its Set-Cookie is preserved on all response paths including errors, so a retry keeps the same identity.
- Live couplings removed: credit gate, material binding + id validation, skill-registry checks, and the stage-access ownership probe. Because the upstream document store has no owner partition yet, `existingCourse` validates the stageId format (rejecting malformed ids) and defers full existence/ownership validation to the slice that will consume stageId — documented in a comment, no fake 403.
- Since upstream has no credit gate or per-identity quota, prompt and message text carry a generous bounded length cap to avoid unbounded DB/LLM cost from an anonymous identity.
- The runtime probe intentionally drops the materials flag (a live coupling), returning just { enabled }.

Tests: lifecycle routes, status folding, plus new coverage for Set-Cookie on error paths, malformed ids, and oversized input. Real PostgreSQL 16 suite green locally.