### PR TITLE
feat(media): convert inline base64 images to pool assets on load (#1153 part 4)

### DIFF
--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -275,9 +275,10 @@ export async function fetchClassroomFromApi(
   // degrades to the app's lock-free route instead of silently no-op'ing the
   // cold load; the degraded pass still keeps its ledger+rollback discipline,
   // so a failed unlocked attempt leaves nothing behind.
-  const [{ mutateDocument }, converter] = await Promise.all([
+  const [{ mutateDocument }, converter, inlineConverter] = await Promise.all([
     import('@/lib/document-store'),
     import('@/lib/media/convert-legacy-asset-refs'),
+    import('@/lib/media/convert-inline-image-assets'),
   ]);
   try {
     return await mutateDocument(
@@ -300,19 +301,30 @@ export async function fetchClassroomFromApi(
             shouldConvert,
             allocated,
           );
+          // The inline base64 image converter (#1153 part 4) runs AFTER the
+          // legacy converter — the two are independent, and this order lets
+          // the gen-placeholder converter see its expected shapes first. Both
+          // share one allocation ledger, so a superseded or failed load rolls
+          // every fresh allocation back through the single rollback call.
+          const inlined = await inlineConverter.convertInlineImageAssets(
+            converted.document,
+            undefined,
+            shouldConvert,
+            allocated,
+          );
           // The converter rechecks liveness at its commit boundaries; this is
           // the final gate before the document write, so a load superseded in
           // the last window never commits side effects it cannot hand over.
           if (!shouldConvert()) {
             throw new converter.LegacyConversionAbortedError(allocated);
           }
-          if (converter.containsClassroomMediaUrls(converted.document)) {
+          if (converter.containsClassroomMediaUrls(inlined.document)) {
             throw new Error('server classroom media conversion was incomplete');
           }
-          await store.saveDocument(converted.document);
+          await store.saveDocument(inlined.document);
           return {
-            stage: converted.document.stage,
-            scenes: converted.document.scenes,
+            stage: inlined.document.stage,
+            scenes: inlined.document.scenes,
           };
         } catch (error) {
           // Every failure mode -- a liveness abort or an ordinary converter

--- a/lib/classroom/load-classroom.ts
+++ b/lib/classroom/load-classroom.ts
@@ -286,11 +286,45 @@ export async function fetchClassroomFromApi(
       async (existing, store) => {
         if (existing) {
           // The document already owns its media (a concurrent cold load, or a
-          // prior open). Reuse it verbatim; if it still carries transport
-          // URLs, conversion could not complete and the load must fail rather
-          // than apply or persist raw addresses.
+          // prior open). If it still carries transport URLs, conversion could
+          // not complete and the load must fail rather than apply or persist
+          // raw addresses.
           if (converter.containsClassroomMediaUrls(existing)) return null;
-          return { stage: existing.stage, scenes: existing.scenes };
+          // Kept inline images (budget expiry, a transient digest failure, an
+          // oversized payload on the birth pass) retry on the NEXT open: the
+          // inline pass re-runs here exactly like the migration path's
+          // every-access semantics. It is idempotent and near-free when no
+          // data URLs remain (one enumeration, no allocations), and a
+          // `changed` result persists through the same save/rollback
+          // machinery the birth path uses.
+          const allocated: string[] = [];
+          try {
+            const inlined = await inlineConverter.convertInlineImageAssets(
+              existing,
+              undefined,
+              shouldConvert,
+              allocated,
+            );
+            if (!inlined.changed) {
+              return { stage: existing.stage, scenes: existing.scenes };
+            }
+            // Same final liveness gate as the birth path: a load superseded in
+            // the last window must not commit side effects it cannot hand over.
+            if (!shouldConvert()) {
+              throw new converter.LegacyConversionAbortedError(allocated);
+            }
+            await store.saveDocument(inlined.document);
+            return {
+              stage: inlined.document.stage,
+              scenes: inlined.document.scenes,
+            };
+          } catch (error) {
+            // Same compensation as the birth path: every failure mode rolls
+            // back the pass's fresh allocations; the already-committed
+            // document itself is untouched.
+            await converter.rollbackConvertedAllocations(payload.stage.id, allocated);
+            throw error;
+          }
         }
 
         const allocated: string[] = [];

--- a/lib/document-store/migration.ts
+++ b/lib/document-store/migration.ts
@@ -121,7 +121,26 @@ async function convertLoadedDocument(
       deps.convertAssetRefs ??
       (async (value: AppDocument) => {
         const { convertDocumentAssetRefs } = await import('@/lib/media/convert-legacy-asset-refs');
-        return (await convertDocumentAssetRefs(value, undefined, undefined, ledger)).document;
+        const converted = await convertDocumentAssetRefs(value, undefined, undefined, ledger);
+        // The inline base64 image converter (#1153 part 4) runs AFTER the
+        // legacy converter: the two are independent, and this order lets the
+        // gen-placeholder converter see its expected shapes first. A failure
+        // here degrades to the legacy-converted document rather than
+        // discarding the legacy pass's work — each converter is best-effort
+        // on its own.
+        try {
+          const { convertInlineImageAssets } =
+            await import('@/lib/media/convert-inline-image-assets');
+          return (await convertInlineImageAssets(converted.document, undefined, undefined, ledger))
+            .document;
+        } catch (inlineError) {
+          log.warn(
+            `Inline image conversion failed for document ${JSON.stringify(value.stage.id)}; ` +
+              'keeping the legacy-converted document',
+            inlineError,
+          );
+          return converted.document;
+        }
       });
     return await convert(document, ledger);
   } catch (error) {

--- a/lib/media/convert-inline-image-assets.ts
+++ b/lib/media/convert-inline-image-assets.ts
@@ -28,11 +28,13 @@
  *   an ASCII case-insensitive `base64` (the marker must be the FINAL
  *   parameter). The converter is CONSERVATIVE by design — when the grammar
  *   is anything but unambiguous it leaves the slot inline (`kept`) and never
- *   guesses a decode path: a `;base64` that is not the final parameter, a
- *   payload that decodes to zero bytes, or a payload whose raw text exceeds
- *   the 50 MB decode bound is kept, because the browser treats those shapes
- *   as percent-encoded or broken and converting them would rewrite a broken
- *   image into stored bytes.
+ *   guesses a decode path. A non-final `;base64` is not a broken image: the
+ *   browser still renders it (it percent-decodes the body and ignores the
+ *   stray parameter), so the slot stays inline because this converter never
+ *   guesses a decode path, not because the image is broken. The other kept
+ *   shapes have concrete reasons: zero decoded bytes are not an image, and a
+ *   payload whose ESTIMATED DECODED size exceeds the 50 MB decode bound is
+ *   pathological, not the target corpus.
  * - One allocation per unique decoded content, shared across every slot that
  *   names identical bytes. Two different encodings of the same bytes (base64
  *   vs percent-encoded, different MIME casing) also collapse: the memo key is
@@ -100,13 +102,16 @@ export const INLINE_IMAGE_CONVERSION_BUDGET_MS = DEFAULT_INGEST_AWAIT_TIMEOUT_MS
 export const INLINE_IMAGE_SLIDE_CONCURRENCY = 4;
 
 /**
- * Per-payload decode bound: an inline data URL whose raw payload text exceeds
- * the shared 50 MB extract cap (`MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES`) is
- * pathological, not the target corpus. It is kept inline WITHOUT decoding —
- * the gate is a pre-decode length check — so an oversized payload never
- * allocates multi-megabyte decode buffers.
+ * Per-payload decode bound, in DECODED BYTES: an inline data URL whose
+ * payload would decode past the shared 50 MB extract cap
+ * (`MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES`) is pathological, not the target
+ * corpus. It is kept inline WITHOUT decoding — the gate is a pre-decode size
+ * ESTIMATE — so an oversized payload never allocates multi-megabyte decode
+ * buffers. The same constant bounds the extract route's accepted bytes, so
+ * the converter's keep/convert decision and the generation route's
+ * accept/reject decision agree on the same quantity.
  */
-export const MAX_INLINE_IMAGE_PAYLOAD_BYTES = MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES;
+export const MAX_INLINE_IMAGE_DECODED_BYTES = MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES;
 
 /** Whether a slide media slot value is an inline image data URL — the only shape this converter rewrites. */
 export function isInlineImageDataUrl(ref: string | undefined): ref is string {
@@ -119,16 +124,42 @@ export interface DecodedInlineImage {
   readonly mimeType: string;
 }
 
+/** Parsed parts of an inline image data URL (the fetch-spec mediatype split). */
+interface ParsedInlineImageDataUrl {
+  mimeType: string;
+  params: string;
+  payload: string;
+}
+
+/** Split an inline image data URL into its mediatype parts and raw payload text. */
+function parseInlineImageDataUrl(src: string): ParsedInlineImageDataUrl | null {
+  const match = /^data:image\/([^;,]+)(?:;([^,]*))?,([\s\S]*)$/i.exec(src);
+  if (!match) return null;
+  return {
+    mimeType: `image/${match[1].toLowerCase()}`,
+    params: match[2] ?? '',
+    payload: match[3] ?? '',
+  };
+}
+
 /**
- * Raw payload text of an inline image data URL — everything after the first
- * comma, un-decoded. The pre-decode size gate measures this so an oversized
- * payload is kept before any decoding work happens. Returns `null` when the
- * value is not an inline image data URL.
+ * Estimated DECODED size of an inline image data URL's payload, computed
+ * before any decoding work so an oversized payload is kept without
+ * allocating decode buffers. A base64 payload scales the text length by 3/4
+ * (each quartet encodes three bytes; trailing padding encodes none and is
+ * excluded). A percent-encoded payload uses the raw text length as a safe
+ * upper bound (every `%XX` triple decodes to one byte). Returns `null` when
+ * the value is not an inline image data URL.
  */
-export function inlineImageDataUrlPayload(src: string): string | null {
-  const comma = src.indexOf(',');
-  if (!isInlineImageDataUrl(src) || comma < 0) return null;
-  return src.slice(comma + 1);
+export function estimateInlineImageDecodedBytes(src: string): number | null {
+  const parsed = parseInlineImageDataUrl(src);
+  if (!parsed) return null;
+  const mediatype = parsed.params ? `${parsed.mimeType};${parsed.params}` : parsed.mimeType;
+  if (/; *base64$/i.test(mediatype)) {
+    const padding = /=+$/.exec(parsed.payload)?.[0].length ?? 0;
+    return Math.floor(((parsed.payload.length - padding) * 3) / 4);
+  }
+  return parsed.payload.length;
 }
 
 /**
@@ -140,17 +171,16 @@ export function inlineImageDataUrlPayload(src: string): string | null {
  * The base64 marker follows the fetch spec's data-URL grammar: the body is
  * base64 exactly when the mediatype ends with `;` + zero or more SPACE + an
  * ASCII case-insensitive `base64`. The marker must be the FINAL parameter —
- * a `;base64` anywhere else is not a marker: the browser treats the body as
- * percent-encoded and the image is broken either way, so such a value is
- * conservatively kept (this converter slims, it never guesses a decode path
- * or converts a broken image).
+ * a `;base64` anywhere else is not a marker. Such a value is conservatively
+ * kept even though the browser still renders it (it percent-decodes the body
+ * and ignores the stray parameter): this converter slims data URLs it can
+ * decode unambiguously and never guesses a decode path — the slot stays
+ * inline because the marker is ambiguous, not because the image is broken.
  */
 export function decodeInlineImageDataUrl(src: string): DecodedInlineImage | null {
-  const match = /^data:image\/([^;,]+)(?:;([^,]*))?,([\s\S]*)$/i.exec(src);
-  if (!match) return null;
-  const mimeType = `image/${match[1].toLowerCase()}`;
-  const params = match[2] ?? '';
-  const payload = match[3] ?? '';
+  const parsed = parseInlineImageDataUrl(src);
+  if (!parsed) return null;
+  const { mimeType, params, payload } = parsed;
   try {
     const mediatype = params ? `${mimeType};${params}` : mimeType;
     // Fetch-spec marker (case-insensitive, space-tolerant, FINAL parameter).
@@ -315,6 +345,10 @@ export async function convertInlineImageAssets(
   const allocationByDigest = new Map<string, Promise<string | null>>();
   const report: InlineImageConversionReport = { converted: 0, ingested: 0, kept: 0 };
   let changed = false;
+  // Oversized payloads are counted per pass and reported with ONE aggregate
+  // warn (the old per-payload warn repeated on every open of a document that
+  // keeps them).
+  let oversizedPayloads = 0;
 
   /**
    * Probe whether a content digest can be computed at all. `crypto.subtle` —
@@ -346,17 +380,23 @@ export async function convertInlineImageAssets(
   /**
    * Allocate (once) for a content digest. Returns the allocated id, or `null`
    * when the ingest failed — the slot then stays inline. A failed attempt
-   * releases what it allocated and forgets the digest's memo entry, so a
-   * sibling slot naming the same bytes can retry rather than inheriting the
-   * failure forever.
+   * forgets the digest's memo entry — so a sibling slot naming the same
+   * bytes can retry rather than inheriting the failure forever — and
+   * releases anything the attempt allocated (a failed pool write allocated
+   * nothing; a failed mirror write releases the just-allocated id).
    */
   const allocateImage = (digest: string, blob: Blob, src: string): Promise<string | null> => {
     const inFlight = allocationByDigest.get(digest);
     if (inFlight) return inFlight;
     const pending = (async (): Promise<string | null> => {
-      const assetId = await resolvedDeps.putAsset(blob, imageMeta(blob));
-      allocatedIds.push(assetId);
+      let assetId: string | null = null;
       try {
+        // The pool write is inside the guarded region too: a transient pool
+        // error must clear the memo entry exactly like a mirror-write
+        // failure, so the NEXT slot naming the same bytes retries instead of
+        // inheriting the rejected promise for the rest of the pass.
+        assetId = await resolvedDeps.putAsset(blob, imageMeta(blob));
+        allocatedIds.push(assetId);
         // Liveness is rechecked at the commit boundary: an abort between the
         // allocation and its mirror compensates the allocation, exactly like
         // a mirror-write failure.
@@ -367,9 +407,11 @@ export async function convertInlineImageAssets(
           compatRecord(stageId, assetId, blob, src),
         );
       } catch (error) {
-        // Do not strand an allocation nothing references.
+        // Do not strand a memo entry (or an allocation) nothing references.
         allocationByDigest.delete(digest);
-        await resolvedDeps.removeAsset(assetId).catch(() => undefined);
+        if (assetId !== null) {
+          await resolvedDeps.removeAsset(assetId).catch(() => undefined);
+        }
         throw error;
       }
       report.ingested += 1;
@@ -396,16 +438,18 @@ export async function convertInlineImageAssets(
         report.kept += 1;
         continue;
       }
-      // Per-payload decode bound: a data URL whose raw payload text exceeds
-      // the shared 50 MB cap is pathological, not the target corpus. The gate
-      // is a pre-decode length check — the decoder is never invoked for it.
-      const payload = inlineImageDataUrlPayload(ref);
-      if (payload !== null && payload.length > MAX_INLINE_IMAGE_PAYLOAD_BYTES) {
+      // Per-payload decode bound, measured in DECODED bytes: a data URL whose
+      // payload would decode past the shared 50 MB cap is pathological, not
+      // the target corpus. The gate is a pre-decode size ESTIMATE — the
+      // decoder is never invoked for it — so an oversized payload never
+      // allocates multi-megabyte decode buffers.
+      const estimatedDecodedBytes = estimateInlineImageDecodedBytes(ref);
+      if (
+        estimatedDecodedBytes !== null &&
+        estimatedDecodedBytes > MAX_INLINE_IMAGE_DECODED_BYTES
+      ) {
+        oversizedPayloads += 1;
         report.kept += 1;
-        log.warn(
-          `Skipping oversized inline image payload for ${JSON.stringify(stageId)} ` +
-            `(${payload.length} chars > ${MAX_INLINE_IMAGE_PAYLOAD_BYTES}); staying inline`,
-        );
         continue;
       }
       if (!(await ensureDigestAvailable())) {
@@ -502,6 +546,17 @@ export async function convertInlineImageAssets(
       }
     }
     scenes.push(nextScene);
+  }
+
+  // One aggregate warn per pass for oversized payloads — the kept payloads
+  // never convert, so a per-payload warn would repeat on every open. A later
+  // open re-warns only while oversized payloads actually remain.
+  if (oversizedPayloads > 0) {
+    log.warn(
+      `Skipping ${oversizedPayloads} oversized inline image payload` +
+        `${oversizedPayloads === 1 ? '' : 's'} for ${JSON.stringify(stageId)} ` +
+        `(estimated decoded bytes > ${MAX_INLINE_IMAGE_DECODED_BYTES}); keeping them inline`,
+    );
   }
 
   if (!changed) return { document, changed: false, report, allocatedIds };

--- a/lib/media/convert-inline-image-assets.ts
+++ b/lib/media/convert-inline-image-assets.ts
@@ -1,0 +1,390 @@
+/**
+ * Inline base64 image converter (RFC #1153 part 4).
+ *
+ * Pre-part-2 documents carry source-document images as inline base64 data URLs
+ * in `PPTImageElement.src` (written by `resolveImageIds` before the
+ * id-addressed mode existed) — the same image on five slides is stored five
+ * times, and every document load/save moves those bytes through the document
+ * store instead of the byte layer. This module is a lazy converter in the
+ * #1101 mold: given a loaded document it rewrites every inline `data:image/*`
+ * slot value into a pool-backed allocated asset id, ingesting each unique
+ * image exactly once per pass (memoized by sha256 of the decoded bytes, so
+ * identical base64 on N slides collapses to ONE registry entry referenced N
+ * times).
+ *
+ * No DSL version bump: the slot's type already admits both shapes — data URLs
+ * are concrete addresses, allocated ids resolve through the pool (part 2
+ * established this) — so an unconverted document remains fully valid and the
+ * converter is a pure slimming pass over documents the id-addressed mode
+ * predates.
+ *
+ * Conversion rules, per reference:
+ *
+ * - Only `data:image/*` values convert. Every other shape (allocated ids,
+ *   `gen_*` placeholders, http(s), classroom-media transport URLs) is left
+ *   untouched — the #1101 converter owns those.
+ * - One allocation per unique decoded content, shared across every slot that
+ *   names identical bytes. Two different encodings of the same bytes (base64
+ *   vs percent-encoded, different MIME casing) also collapse: the memo key is
+ *   the digest of the DECODED bytes.
+ * - The rewritten slot holds the allocated id; the bytes live in the pool
+ *   under that id, and a Dexie `mediaFiles` compatibility row is mirrored
+ *   under the compound key (the part-2 double-write discipline), so stage
+ *   deletion reclaims converted images and export resolves them exactly like
+ *   part-2's id-addressed images. The original data URL is retained on
+ *   `placeholderRef` for reload reconciliation, like #1101 does.
+ * - Budgeted and partial-safe: an aggregate wall-clock budget bounds the pass
+ *   (the 15 s constant family — the same family the ingest path uses). When
+ *   it expires, the conversions made so far are kept and the rest stay inline;
+ *   idempotency makes the partial progress safe — the next open continues.
+ * - A failed ingest (undecodable value, pool failure, compatibility-write
+ *   failure) leaves that slot inline and releases what the failed attempt
+ *   allocated, then continues with the next slot. Allocations a caller ends
+ *   up discarding are released through the shared ledger/rollback accounting
+ *   (the same `rollbackConvertedAllocations` the #1101 pass uses).
+ *
+ * Idempotent: a converted document holds pool-backed allocated ids and no
+ * `data:image/*` values, so re-running is a no-op that returns the input by
+ * identity.
+ *
+ * The pure DSL migration ladder deliberately does none of this: it cannot
+ * decode local bytes. It covers only documents this converter never reached.
+ */
+
+import type { AssetMeta, Slide } from '@openmaic/dsl';
+import { createLogger } from '@/lib/logger';
+import { DEFAULT_INGEST_AWAIT_TIMEOUT_MS } from '@/lib/document/extract-source';
+import type { AppDocument } from '@/lib/document-store/persistence-types';
+import type { AppScene, Stage } from '@/lib/types/stage';
+import { makeScene } from '@/lib/types/stage';
+import type { MediaFileRecord } from '@/lib/utils/database';
+import { slideMediaReferenceSlots } from './slide-media-slots';
+
+const log = createLogger('InlineImageConversion');
+
+/**
+ * Aggregate wall-clock budget for one inline-image conversion pass. The
+ * budget family is the ingest path's 15 s constant: a pass must not hold the
+ * document lock for an unbounded decoding/ingest run on a document full of
+ * heavy base64 payloads. What does not convert within the budget stays inline
+ * and converts on a later open.
+ */
+export const INLINE_IMAGE_CONVERSION_BUDGET_MS = DEFAULT_INGEST_AWAIT_TIMEOUT_MS;
+
+/** Whether a slide media slot value is an inline image data URL — the only shape this converter rewrites. */
+export function isInlineImageDataUrl(ref: string | undefined): ref is string {
+  return !!ref && /^data:image\//i.test(ref);
+}
+
+/** Decoded payload of an inline image data URL. */
+export interface DecodedInlineImage {
+  readonly bytes: Uint8Array<ArrayBuffer>;
+  readonly mimeType: string;
+}
+
+/**
+ * Decode a `data:image/*` URL to bytes. Handles both base64 payloads and
+ * percent-encoded (UTF-8) payloads; returns `null` when the value is not
+ * decodable, so a malformed value stays inline and retries on a later open
+ * instead of being lost or allocated as garbage.
+ */
+export function decodeInlineImageDataUrl(src: string): DecodedInlineImage | null {
+  const match = /^data:image\/([^;,]+)(?:;([^,]*))?,([\s\S]*)$/i.exec(src);
+  if (!match) return null;
+  const mimeType = `image/${match[1].toLowerCase()}`;
+  const params = match[2] ?? '';
+  const payload = match[3] ?? '';
+  try {
+    if (params.split(';').includes('base64')) {
+      // Base64 payload: atob yields one binary character per byte. Whitespace
+      // is legal inside base64 data URLs (line-wrapped payloads) and must be
+      // stripped before decoding.
+      const binary = atob(payload.replace(/\s+/g, ''));
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      return { bytes, mimeType };
+    }
+    // Percent-encoded payload (commonly UTF-8 SVG). TextEncoder re-encodes
+    // the decoded string to its exact UTF-8 bytes, so the digest covers the
+    // true byte content and two encodings of one image collapse.
+    return { bytes: new TextEncoder().encode(decodeURIComponent(payload)), mimeType };
+  } catch {
+    return null;
+  }
+}
+
+export interface InlineImageConversionDeps {
+  /** Ingest decoded bytes into the asset pool; resolves to the allocated asset id. */
+  putAsset(blob: Blob, meta: AssetMeta): Promise<string>;
+  /** Remove an allocation nothing references (the failed-attempt release). */
+  removeAsset(ref: string): Promise<void>;
+  /**
+   * Write the post-conversion Dexie compatibility copy, keyed by the id the
+   * document now names — the part-2 double-write discipline that makes stage
+   * deletion reclaim the pool entry and export/import resolve it like any
+   * id-addressed image.
+   */
+  putMediaRecord(stageId: string, ref: string, record: MediaFileRecord): Promise<void>;
+  /**
+   * Content digest of the decoded bytes — the within-run memo key. Defaults
+   * to sha256; injectable so tests can pin what is hashed.
+   */
+  digest(bytes: Uint8Array<ArrayBuffer>): Promise<string>;
+}
+
+/** Thrown when the caller's liveness check fails mid-conversion (the classroom fetch path). */
+export class InlineImageConversionAbortedError extends Error {
+  override readonly name = 'InlineImageConversionAbortedError';
+  constructor(readonly allocatedIds: readonly string[]) {
+    super('inline image conversion aborted');
+  }
+}
+
+export interface InlineImageConversionReport {
+  /** Slots rewritten to an allocated pool asset id. */
+  converted: number;
+  /** Unique images ingested this pass (dedup collapses repeated base64). */
+  ingested: number;
+  /** Inline slots left untouched for a later open (budget expiry or failed ingest). */
+  kept: number;
+}
+
+export interface InlineImageConversionResult {
+  document: AppDocument;
+  /** False when nothing was rewritten — the input is returned by identity. */
+  changed: boolean;
+  report: InlineImageConversionReport;
+  /**
+   * Ids this pass freshly allocated. A caller that ends up rejecting the
+   * converted document (a superseded classroom load) rolls these back through
+   * the shared `rollbackConvertedAllocations` accounting.
+   */
+  allocatedIds: string[];
+}
+
+/** The default production wiring: the browser-wide asset pool plus Dexie. */
+async function defaultDeps(): Promise<InlineImageConversionDeps> {
+  const [{ db, mediaFileKey }, { putAsset, removeAsset }] = await Promise.all([
+    import('@/lib/utils/database'),
+    import('./asset-pool'),
+  ]);
+  return {
+    putAsset: (blob, meta) => putAsset(blob, meta),
+    removeAsset: (ref) => removeAsset(ref),
+    putMediaRecord: (stageId, ref, record) =>
+      db.mediaFiles
+        .put({ ...record, id: mediaFileKey(stageId, ref), stageId })
+        .then(() => undefined),
+    digest: async (bytes) => {
+      const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
+      return [...new Uint8Array(hashBuffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
+    },
+  };
+}
+
+function imageMeta(blob: Blob): AssetMeta {
+  return {
+    contentType: blob.type || 'image/png',
+    mediaType: 'image',
+    origin: 'inline-data-url',
+  };
+}
+
+function compatRecord(stageId: string, assetId: string, blob: Blob, src: string): MediaFileRecord {
+  return {
+    id: `${stageId}:${assetId}`,
+    stageId,
+    type: 'image',
+    blob,
+    mimeType: blob.type || 'image/png',
+    size: blob.size,
+    prompt: '',
+    params: '{}',
+    placeholderRef: src,
+    createdAt: Date.now(),
+  };
+}
+
+type SlideLike = Pick<Slide, 'background' | 'elements'>;
+
+/**
+ * Convert every inline `data:image/*` slot value in a loaded document to an
+ * allocated asset id. The input document is never mutated; the side effects
+ * are pool ingests and Dexie compatibility mirror writes.
+ *
+ * Crash-safety ordering mirrors the generation write paths and #1101: pool
+ * bytes first, the Dexie compatibility copy second, and the in-memory
+ * document rewrite last, so a failure mid-conversion never leaves the
+ * persisted document pointing at bytes that were never stored.
+ */
+export async function convertInlineImageAssets(
+  document: AppDocument,
+  deps?: InlineImageConversionDeps,
+  shouldContinue?: () => boolean,
+  ledger?: string[],
+): Promise<InlineImageConversionResult> {
+  const resolvedDeps = deps ?? (await defaultDeps());
+  const stageId = document.stage.id;
+  const budgetEndsAt = Date.now() + INLINE_IMAGE_CONVERSION_BUDGET_MS;
+  const withinBudget = (): boolean => Date.now() <= budgetEndsAt;
+  /**
+   * Ids this pass freshly allocated. A caller may share the array to own the
+   * rollback itself: any failure path — liveness abort or a discarded result
+   * — then still compensates what the pass committed.
+   */
+  const allocatedIds = ledger ?? [];
+  // Liveness probe for callers whose own work can be superseded mid-flight (a
+  // classroom load): a stale conversion must stop producing side effects as
+  // soon as its result is known to be unwanted.
+  const assertContinuing = (): void => {
+    if (shouldContinue && !shouldContinue()) {
+      throw new InlineImageConversionAbortedError(allocatedIds);
+    }
+  };
+  // One allocation per unique DECODED content, shared across every slot that
+  // names identical bytes. The map holds the in-flight promise, not just the
+  // settled value: whiteboard slides convert concurrently, and caching only
+  // completed allocations would let two slides naming one image each allocate
+  // their own asset.
+  const allocationByDigest = new Map<string, Promise<string | null>>();
+  const report: InlineImageConversionReport = { converted: 0, ingested: 0, kept: 0 };
+  let changed = false;
+
+  /**
+   * Allocate (once) for a content digest. Returns the allocated id, or `null`
+   * when the ingest failed — the slot then stays inline. A failed attempt
+   * releases what it allocated and forgets the digest's memo entry, so a
+   * sibling slot naming the same bytes can retry rather than inheriting the
+   * failure forever.
+   */
+  const allocateImage = (digest: string, blob: Blob, src: string): Promise<string | null> => {
+    const inFlight = allocationByDigest.get(digest);
+    if (inFlight) return inFlight;
+    const pending = (async (): Promise<string | null> => {
+      const assetId = await resolvedDeps.putAsset(blob, imageMeta(blob));
+      allocatedIds.push(assetId);
+      try {
+        // Liveness is rechecked at the commit boundary: an abort between the
+        // allocation and its mirror compensates the allocation, exactly like
+        // a mirror-write failure.
+        assertContinuing();
+        await resolvedDeps.putMediaRecord(
+          stageId,
+          assetId,
+          compatRecord(stageId, assetId, blob, src),
+        );
+      } catch (error) {
+        // Do not strand an allocation nothing references.
+        allocationByDigest.delete(digest);
+        await resolvedDeps.removeAsset(assetId).catch(() => undefined);
+        throw error;
+      }
+      report.ingested += 1;
+      return assetId;
+    })();
+    allocationByDigest.set(digest, pending);
+    return pending;
+  };
+
+  const convertSlide = async <T extends SlideLike>(slide: T): Promise<T> => {
+    assertContinuing();
+    const slots = [...slideMediaReferenceSlots(slide)];
+    const rewrites: Array<{ index: number; assetId: string }> = [];
+    let budgetExhausted = false;
+    for (let index = 0; index < slots.length; index += 1) {
+      // Budget expiry mid-run keeps the conversions made so far and leaves
+      // the rest inline: the next open continues from here (idempotency makes
+      // the partial progress safe). Once expired, every remaining inline
+      // value is counted as kept rather than converted.
+      if (!withinBudget()) budgetExhausted = true;
+      const ref = slots[index].read();
+      if (!isInlineImageDataUrl(ref)) continue;
+      if (budgetExhausted) {
+        report.kept += 1;
+        continue;
+      }
+      const decoded = decodeInlineImageDataUrl(ref);
+      if (!decoded) {
+        report.kept += 1;
+        continue;
+      }
+      const digest = await resolvedDeps.digest(decoded.bytes);
+      let assetId: string | null;
+      try {
+        assetId = await allocateImage(
+          digest,
+          new Blob([decoded.bytes], { type: decoded.mimeType }),
+          ref,
+        );
+      } catch {
+        // A failed ingest leaves the slot inline; the attempt released what
+        // it allocated. Continue with the next slot — one pool hiccup must
+        // not stop the rest of the pass.
+        assetId = null;
+      }
+      if (!assetId) {
+        report.kept += 1;
+        continue;
+      }
+      rewrites.push({ index, assetId });
+      report.converted += 1;
+    }
+    if (rewrites.length === 0) return slide;
+    // Rewrite on a clone so the caller's document is never mutated. Slot
+    // iteration order is deterministic, so the clone's slots align by index.
+    const clone = structuredClone(slide);
+    const cloneSlots = [...slideMediaReferenceSlots(clone)];
+    for (const { index, assetId } of rewrites) cloneSlots[index].write(assetId);
+    changed = true;
+    return clone;
+  };
+
+  const stage = document.stage;
+  let whiteboard = stage.whiteboard;
+  if (whiteboard) {
+    const converted = await Promise.all(whiteboard.map((slide) => convertSlide(slide)));
+    if (converted.some((slide, index) => slide !== whiteboard![index])) {
+      whiteboard = converted;
+    }
+  }
+
+  const scenes: AppScene[] = [];
+  for (const scene of document.scenes) {
+    let nextScene = scene;
+    if (scene.content.type === 'slide') {
+      const canvas = await convertSlide(scene.content.canvas);
+      if (canvas !== scene.content.canvas) {
+        // Rebuild through makeScene so the discriminated union stays bound:
+        // a plain spread cannot prove the canvas lands on the slide member.
+        const { type: _type, content: _content, ...core } = nextScene;
+        void _type;
+        void _content;
+        nextScene = makeScene(core, { ...scene.content, canvas });
+      }
+    }
+    if (scene.whiteboards) {
+      const converted = await Promise.all(scene.whiteboards.map((slide) => convertSlide(slide)));
+      if (converted.some((slide, index) => slide !== scene.whiteboards![index])) {
+        nextScene = { ...nextScene, whiteboards: converted };
+      }
+    }
+    scenes.push(nextScene);
+  }
+
+  if (!changed) return { document, changed: false, report, allocatedIds };
+
+  const nextStage: Stage = whiteboard !== stage.whiteboard ? { ...stage, whiteboard } : stage;
+
+  log.info(
+    `Converted inline base64 images for ${stageId}: ${report.converted} slots rewritten, ` +
+      `${report.ingested} unique images ingested, ${report.kept} left inline`,
+  );
+  return {
+    document: { ...document, stage: nextStage, scenes },
+    changed: true,
+    report,
+    allocatedIds,
+  };
+}

--- a/lib/media/convert-inline-image-assets.ts
+++ b/lib/media/convert-inline-image-assets.ts
@@ -23,6 +23,16 @@
  * - Only `data:image/*` values convert. Every other shape (allocated ids,
  *   `gen_*` placeholders, http(s), classroom-media transport URLs) is left
  *   untouched — the #1101 converter owns those.
+ * - Payload decoding follows the fetch spec's data-URL grammar: the body is
+ *   base64 exactly when the mediatype ends with `;` + zero or more SPACE +
+ *   an ASCII case-insensitive `base64` (the marker must be the FINAL
+ *   parameter). The converter is CONSERVATIVE by design — when the grammar
+ *   is anything but unambiguous it leaves the slot inline (`kept`) and never
+ *   guesses a decode path: a `;base64` that is not the final parameter, a
+ *   payload that decodes to zero bytes, or a payload whose raw text exceeds
+ *   the 50 MB decode bound is kept, because the browser treats those shapes
+ *   as percent-encoded or broken and converting them would rewrite a broken
+ *   image into stored bytes.
  * - One allocation per unique decoded content, shared across every slot that
  *   names identical bytes. Two different encodings of the same bytes (base64
  *   vs percent-encoded, different MIME casing) also collapse: the memo key is
@@ -37,11 +47,20 @@
  *   (the 15 s constant family — the same family the ingest path uses). When
  *   it expires, the conversions made so far are kept and the rest stay inline;
  *   idempotency makes the partial progress safe — the next open continues.
+ * - Bounded concurrency: whiteboard slides convert through the part-1
+ *   `mapWithConcurrency` at batch 4, so the decoded buffers of N slides never
+ *   coexist.
  * - A failed ingest (undecodable value, pool failure, compatibility-write
  *   failure) leaves that slot inline and releases what the failed attempt
  *   allocated, then continues with the next slot. Allocations a caller ends
  *   up discarding are released through the shared ledger/rollback accounting
  *   (the same `rollbackConvertedAllocations` the #1101 pass uses).
+ * - A content digest that is unavailable (a non-secure context or older
+ *   webview lacks `crypto.subtle`) degrades the whole pass to a no-op: the
+ *   document is returned unchanged and every inline slot is kept, with one
+ *   warn — a load that succeeded before this converter existed must keep
+ *   succeeding. A digest that fails mid-run on one image keeps that slot
+ *   inline and continues, exactly like a failed ingest.
  *
  * Idempotent: a converted document holds pool-backed allocated ids and no
  * `data:image/*` values, so re-running is a no-op that returns the input by
@@ -51,13 +70,15 @@
  * decode local bytes. It covers only documents this converter never reached.
  */
 
-import type { AssetMeta, Slide } from '@openmaic/dsl';
+import type { AssetMeta, Slide, Whiteboard } from '@openmaic/dsl';
 import { createLogger } from '@/lib/logger';
+import { MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES } from '@/lib/constants/generation';
 import { DEFAULT_INGEST_AWAIT_TIMEOUT_MS } from '@/lib/document/extract-source';
 import type { AppDocument } from '@/lib/document-store/persistence-types';
 import type { AppScene, Stage } from '@/lib/types/stage';
 import { makeScene } from '@/lib/types/stage';
 import type { MediaFileRecord } from '@/lib/utils/database';
+import { mapWithConcurrency } from '@/lib/utils/concurrency';
 import { slideMediaReferenceSlots } from './slide-media-slots';
 
 const log = createLogger('InlineImageConversion');
@@ -71,6 +92,22 @@ const log = createLogger('InlineImageConversion');
  */
 export const INLINE_IMAGE_CONVERSION_BUDGET_MS = DEFAULT_INGEST_AWAIT_TIMEOUT_MS;
 
+/**
+ * Concurrency bound for converting whiteboard slides (the part-1
+ * `mapWithConcurrency` batch): at most this many slides decode/ingest at
+ * once, so the decoded buffers of N slides never coexist.
+ */
+export const INLINE_IMAGE_SLIDE_CONCURRENCY = 4;
+
+/**
+ * Per-payload decode bound: an inline data URL whose raw payload text exceeds
+ * the shared 50 MB extract cap (`MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES`) is
+ * pathological, not the target corpus. It is kept inline WITHOUT decoding —
+ * the gate is a pre-decode length check — so an oversized payload never
+ * allocates multi-megabyte decode buffers.
+ */
+export const MAX_INLINE_IMAGE_PAYLOAD_BYTES = MAX_EXTRACT_DOCUMENT_FILE_SIZE_BYTES;
+
 /** Whether a slide media slot value is an inline image data URL — the only shape this converter rewrites. */
 export function isInlineImageDataUrl(ref: string | undefined): ref is string {
   return !!ref && /^data:image\//i.test(ref);
@@ -83,10 +120,30 @@ export interface DecodedInlineImage {
 }
 
 /**
+ * Raw payload text of an inline image data URL — everything after the first
+ * comma, un-decoded. The pre-decode size gate measures this so an oversized
+ * payload is kept before any decoding work happens. Returns `null` when the
+ * value is not an inline image data URL.
+ */
+export function inlineImageDataUrlPayload(src: string): string | null {
+  const comma = src.indexOf(',');
+  if (!isInlineImageDataUrl(src) || comma < 0) return null;
+  return src.slice(comma + 1);
+}
+
+/**
  * Decode a `data:image/*` URL to bytes. Handles both base64 payloads and
  * percent-encoded (UTF-8) payloads; returns `null` when the value is not
  * decodable, so a malformed value stays inline and retries on a later open
  * instead of being lost or allocated as garbage.
+ *
+ * The base64 marker follows the fetch spec's data-URL grammar: the body is
+ * base64 exactly when the mediatype ends with `;` + zero or more SPACE + an
+ * ASCII case-insensitive `base64`. The marker must be the FINAL parameter —
+ * a `;base64` anywhere else is not a marker: the browser treats the body as
+ * percent-encoded and the image is broken either way, so such a value is
+ * conservatively kept (this converter slims, it never guesses a decode path
+ * or converts a broken image).
  */
 export function decodeInlineImageDataUrl(src: string): DecodedInlineImage | null {
   const match = /^data:image\/([^;,]+)(?:;([^,]*))?,([\s\S]*)$/i.exec(src);
@@ -95,7 +152,14 @@ export function decodeInlineImageDataUrl(src: string): DecodedInlineImage | null
   const params = match[2] ?? '';
   const payload = match[3] ?? '';
   try {
-    if (params.split(';').includes('base64')) {
+    const mediatype = params ? `${mimeType};${params}` : mimeType;
+    // Fetch-spec marker (case-insensitive, space-tolerant, FINAL parameter).
+    const isBase64Payload = /; *base64$/i.test(mediatype);
+    // A `;base64` token that is not the final parameter is not a marker: keep
+    // the slot inline rather than decoding on a guess.
+    const hasStrayBase64Token = !isBase64Payload && /;\s*base64/i.test(mediatype);
+    if (hasStrayBase64Token) return null;
+    if (isBase64Payload) {
       // Base64 payload: atob yields one binary character per byte. Whitespace
       // is legal inside base64 data URLs (line-wrapped payloads) and must be
       // stripped before decoding.
@@ -253,6 +317,33 @@ export async function convertInlineImageAssets(
   let changed = false;
 
   /**
+   * Probe whether a content digest can be computed at all. `crypto.subtle` —
+   * and so the default sha-256 digest — exists only in secure contexts;
+   * non-secure contexts and older webviews lack it. Without a digest the
+   * within-run memo cannot be computed, so the pass degrades to a no-op (the
+   * document is returned unchanged and every inline slot is kept) instead of
+   * throwing where a pre-part-4 load succeeded. Probed lazily on the first
+   * inline slot; one warn covers the whole pass.
+   */
+  let digestProbed = false;
+  let digestUnavailable = false;
+  const ensureDigestAvailable = async (): Promise<boolean> => {
+    if (digestProbed) return !digestUnavailable;
+    digestProbed = true;
+    try {
+      await resolvedDeps.digest(new Uint8Array(0));
+      return true;
+    } catch {
+      digestUnavailable = true;
+      log.warn(
+        `Content digest unavailable for ${JSON.stringify(stageId)} (non-secure context or ` +
+          'older webview); keeping inline images inline for a later open',
+      );
+      return false;
+    }
+  };
+
+  /**
    * Allocate (once) for a content digest. Returns the allocated id, or `null`
    * when the ingest failed — the slot then stays inline. A failed attempt
    * releases what it allocated and forgets the digest's memo entry, so a
@@ -305,23 +396,48 @@ export async function convertInlineImageAssets(
         report.kept += 1;
         continue;
       }
-      const decoded = decodeInlineImageDataUrl(ref);
-      if (!decoded) {
+      // Per-payload decode bound: a data URL whose raw payload text exceeds
+      // the shared 50 MB cap is pathological, not the target corpus. The gate
+      // is a pre-decode length check — the decoder is never invoked for it.
+      const payload = inlineImageDataUrlPayload(ref);
+      if (payload !== null && payload.length > MAX_INLINE_IMAGE_PAYLOAD_BYTES) {
+        report.kept += 1;
+        log.warn(
+          `Skipping oversized inline image payload for ${JSON.stringify(stageId)} ` +
+            `(${payload.length} chars > ${MAX_INLINE_IMAGE_PAYLOAD_BYTES}); staying inline`,
+        );
+        continue;
+      }
+      if (!(await ensureDigestAvailable())) {
         report.kept += 1;
         continue;
       }
-      const digest = await resolvedDeps.digest(decoded.bytes);
-      let assetId: string | null;
+      const decoded = decodeInlineImageDataUrl(ref);
+      if (!decoded || decoded.bytes.length === 0) {
+        // Undecodable values, and payloads that decode to zero bytes (an
+        // empty data URL), are not usable bytes: keep the slot inline,
+        // allocate nothing, mirror no row.
+        report.kept += 1;
+        continue;
+      }
+      let assetId: string | null = null;
       try {
+        const digest = await resolvedDeps.digest(decoded.bytes);
         assetId = await allocateImage(
           digest,
           new Blob([decoded.bytes], { type: decoded.mimeType }),
           ref,
         );
-      } catch {
-        // A failed ingest leaves the slot inline; the attempt released what
-        // it allocated. Continue with the next slot — one pool hiccup must
-        // not stop the rest of the pass.
+      } catch (error) {
+        if (error instanceof InlineImageConversionAbortedError) {
+          // A superseded pass stops NOW: the abort is not a per-slot failure —
+          // digesting/allocating the remaining slots would defeat the
+          // liveness probe's purpose.
+          throw error;
+        }
+        // A failed digest or ingest leaves the slot inline; a failed attempt
+        // released what it allocated. Continue with the next slot — one
+        // hiccup must not stop the rest of the pass.
         assetId = null;
       }
       if (!assetId) {
@@ -344,9 +460,15 @@ export async function convertInlineImageAssets(
   const stage = document.stage;
   let whiteboard = stage.whiteboard;
   if (whiteboard) {
-    const converted = await Promise.all(whiteboard.map((slide) => convertSlide(slide)));
-    if (converted.some((slide, index) => slide !== whiteboard![index])) {
-      whiteboard = converted;
+    // Bounded concurrency (batch 4): decoded buffers for at most
+    // INLINE_IMAGE_SLIDE_CONCURRENCY slides coexist at once.
+    const converted = await mapWithConcurrency(
+      whiteboard,
+      INLINE_IMAGE_SLIDE_CONCURRENCY,
+      (slide) => convertSlide(slide),
+    );
+    if (converted.some((slide, index) => slide !== undefined && slide !== whiteboard![index])) {
+      whiteboard = converted.filter((slide): slide is Whiteboard => slide !== undefined);
     }
   }
 
@@ -365,9 +487,18 @@ export async function convertInlineImageAssets(
       }
     }
     if (scene.whiteboards) {
-      const converted = await Promise.all(scene.whiteboards.map((slide) => convertSlide(slide)));
-      if (converted.some((slide, index) => slide !== scene.whiteboards![index])) {
-        nextScene = { ...nextScene, whiteboards: converted };
+      const converted = await mapWithConcurrency(
+        scene.whiteboards,
+        INLINE_IMAGE_SLIDE_CONCURRENCY,
+        (slide) => convertSlide(slide),
+      );
+      if (
+        converted.some((slide, index) => slide !== undefined && slide !== scene.whiteboards![index])
+      ) {
+        nextScene = {
+          ...nextScene,
+          whiteboards: converted.filter((slide): slide is Slide => slide !== undefined),
+        };
       }
     }
     scenes.push(nextScene);

--- a/tests/media/convert-inline-image-assets-wiring.test.ts
+++ b/tests/media/convert-inline-image-assets-wiring.test.ts
@@ -369,6 +369,89 @@ describe('inline image conversion with production wiring', () => {
     warnSpy.mockRestore();
   });
 
+  it('a classroom persisted with kept inline images converts them on the next open', async () => {
+    // First open: the content digest is unavailable (a non-secure context /
+    // older webview), so the birth pass keeps the inline image and persists
+    // the document with the data URL still inline — the exact state a
+    // transient digest failure, budget expiry, or oversized payload leaves.
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      randomUUID: originalCrypto.randomUUID.bind(originalCrypto),
+    } as unknown as Crypto);
+    const payload = {
+      stage: { id: 'classroom-1', name: 'Server Course', createdAt: 1, updatedAt: 2 },
+      scenes: [
+        {
+          id: 'scene-1',
+          stageId: 'classroom-1',
+          type: 'slide',
+          title: 'S',
+          order: 0,
+          content: {
+            type: 'slide',
+            canvas: {
+              id: 'c1',
+              elements: [
+                {
+                  id: 'el1',
+                  type: 'image',
+                  src: dataUrl('inline'),
+                  left: 0,
+                  top: 0,
+                  width: 100,
+                  height: 100,
+                },
+              ],
+            },
+          },
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        if (String(input) === '/api/classroom?id=classroom-1') {
+          return new Response(JSON.stringify({ success: true, classroom: payload }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`);
+      }),
+    );
+    const store = await documentStore();
+    const { fetchClassroomFromApi } = await import('@/lib/classroom/load-classroom');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { db } = await import('@/lib/utils/database');
+    const pool = getAssetPool();
+
+    const first = await fetchClassroomFromApi('classroom-1', () => true, accessDeps(store));
+    expect(first).not.toBeNull();
+    let committed = await store.loadDocument('classroom-1');
+    let src = (committed?.scenes[0].content as { canvas: { elements: { src: string }[] } }).canvas
+      .elements[0].src;
+    expect(src).toBe(dataUrl('inline'));
+    expect(await pool.exists?.(src as never)).toBe(false);
+
+    // Second open: the digest works again. The kept inline image must convert
+    // through the EXISTING-document path (the birth-only pass would have
+    // returned the committed document verbatim, forever), and the converted
+    // document must persist through the same save machinery.
+    vi.stubGlobal('crypto', originalCrypto);
+    const second = await fetchClassroomFromApi('classroom-1', () => true, accessDeps(store));
+    expect(second).not.toBeNull();
+    committed = await store.loadDocument('classroom-1');
+    src = (committed?.scenes[0].content as { canvas: { elements: { src: string }[] } }).canvas
+      .elements[0].src;
+    expect(src).toMatch(/^ast_/);
+    expect(await pool.exists?.(src as never)).toBe(true);
+    const row = await db.mediaFiles.get(`classroom-1:${src}`);
+    expect(await row?.blob.text()).toBe('inline');
+  });
+
   it('a superseded classroom load rolls the shared ledger back through the real helper', async () => {
     const { db } = await import('@/lib/utils/database');
     // The payload carries BOTH a legacy gen placeholder (owned by the #1101

--- a/tests/media/convert-inline-image-assets-wiring.test.ts
+++ b/tests/media/convert-inline-image-assets-wiring.test.ts
@@ -293,6 +293,82 @@ describe('inline image conversion with production wiring', () => {
     expect(again?.scenes[0]).toEqual(committed?.scenes[0]);
   });
 
+  it('a classroom load still returns the document when the content digest is unavailable', async () => {
+    // A non-secure context / older webview: `crypto.subtle` is undefined, so
+    // the default sha-256 digest cannot run. The inline pass must degrade to a
+    // no-op (everything kept, one warn) instead of throwing — a load that
+    // succeeded before the inline converter existed must keep succeeding.
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      randomUUID: originalCrypto.randomUUID.bind(originalCrypto),
+    } as unknown as Crypto);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const payload = {
+      stage: { id: 'classroom-1', name: 'Server Course', createdAt: 1, updatedAt: 2 },
+      scenes: [
+        {
+          id: 'scene-1',
+          stageId: 'classroom-1',
+          type: 'slide',
+          title: 'S',
+          order: 0,
+          content: {
+            type: 'slide',
+            canvas: {
+              id: 'c1',
+              elements: [
+                {
+                  id: 'el1',
+                  type: 'image',
+                  src: dataUrl('inline'),
+                  left: 0,
+                  top: 0,
+                  width: 100,
+                  height: 100,
+                },
+              ],
+            },
+          },
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        if (String(input) === '/api/classroom?id=classroom-1') {
+          return new Response(JSON.stringify({ success: true, classroom: payload }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`);
+      }),
+    );
+    const store = await documentStore();
+    const { fetchClassroomFromApi } = await import('@/lib/classroom/load-classroom');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const pool = getAssetPool();
+
+    const result = await fetchClassroomFromApi('classroom-1', () => true, accessDeps(store));
+
+    // The load succeeds (null would be the pre-fix hard regression) and the
+    // document is persisted with the data URL still inline — nothing was
+    // converted, nothing was allocated.
+    expect(result).not.toBeNull();
+    const committed = await store.loadDocument('classroom-1');
+    const src = (committed?.scenes[0].content as { canvas: { elements: { src: string }[] } }).canvas
+      .elements[0].src;
+    expect(src).toBe(dataUrl('inline'));
+    expect(await pool.exists?.(src as never)).toBe(false);
+    expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('digest unavailable'))).toBe(
+      true,
+    );
+    warnSpy.mockRestore();
+  });
+
   it('a superseded classroom load rolls the shared ledger back through the real helper', async () => {
     const { db } = await import('@/lib/utils/database');
     // The payload carries BOTH a legacy gen placeholder (owned by the #1101

--- a/tests/media/convert-inline-image-assets-wiring.test.ts
+++ b/tests/media/convert-inline-image-assets-wiring.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { DSL_VERSION } from '@openmaic/dsl';
+import type { KVScope } from '@openmaic/storage';
+
+// Drives the inline-image converter through its production dependency graph:
+// the real Dexie tables, the real browser asset pool, and the real
+// document-store load path — not injected in-memory maps.
+describe('inline image conversion with production wiring', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubGlobal('indexedDB', new IDBFactory());
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    // The document-store path imports the stage store, whose module body
+    // registers visibility/unload listeners; a minimal window/document keeps
+    // it loadable without dragging in a full DOM.
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as Window);
+    vi.stubGlobal('document', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      visibilityState: 'visible',
+    } as unknown as Document);
+    vi.stubGlobal('location', { origin: 'http://localhost' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function dataUrl(payload: string): string {
+    return `data:image/png;base64,${btoa(payload)}`;
+  }
+
+  function documentWithInlineImage(src: string, stageId = 'stage-1') {
+    return {
+      dslVersion: DSL_VERSION,
+      stage: { id: stageId, name: 'Course', createdAt: 1, updatedAt: 2 },
+      scenes: [
+        {
+          id: 'scene-1',
+          stageId,
+          type: 'slide',
+          title: 'S',
+          order: 0,
+          content: {
+            type: 'slide',
+            canvas: {
+              id: 'c1',
+              elements: [
+                { id: 'el1', type: 'image', src, left: 0, top: 0, width: 100, height: 100 },
+              ],
+            },
+          },
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    } as never;
+  }
+
+  async function documentStore(dbName = 'maic-documents') {
+    const { BrowserDocumentStore } = await import('@openmaic/storage');
+    return new BrowserDocumentStore({
+      indexedDB: globalThis.indexedDB as unknown as IDBFactory,
+      dbName,
+      validateScene: () => ({ valid: true }),
+    });
+  }
+
+  function accessDeps(store: unknown) {
+    return {
+      store: store as never,
+      kv: new MemoryKv(),
+      legacyStore: { read: async () => null, listStages: async () => [] },
+      lockManager: lockManager(),
+    };
+  }
+
+  it('converts inline data URLs through the real pool and real Dexie on access, then stays a no-op', async () => {
+    const store = await documentStore();
+    await store.saveDocument(documentWithInlineImage(dataUrl('first')));
+    const { accessDocument } = await import('@/lib/document-store/migration');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { db } = await import('@/lib/utils/database');
+    const pool = getAssetPool();
+    const saveSpy = vi.spyOn(store, 'saveDocument');
+
+    const first = await accessDocument('stage-1', accessDeps(store));
+
+    const src = (first.document?.scenes[0].content as { canvas: { elements: { src: string }[] } })
+      .canvas.elements[0].src;
+    expect(src).toMatch(/^ast_/);
+    expect(await pool.exists?.(src as never)).toBe(true);
+    const row = await db.mediaFiles.get(`stage-1:${src}`);
+    expect(row?.type).toBe('image');
+    expect(row?.placeholderRef).toBe(dataUrl('first'));
+    expect(await row?.blob.text()).toBe('first');
+    // The converted document was saved back once.
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // Second open is a no-op: nothing inline remains, so nothing is written.
+    saveSpy.mockClear();
+    const second = await accessDocument('stage-1', accessDeps(store));
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(
+      (second.document?.scenes[0].content as { canvas: { elements: { src: string }[] } }).canvas
+        .elements[0].src,
+    ).toBe(src);
+  });
+
+  it('the narrowed save window re-converts newer content observed during conversion', async () => {
+    // Conversion runs under the per-stage lock but the lock does not
+    // coordinate independent browsers: a concurrent write during conversion
+    // must be reconciled — the save path reloads, converts on top of the
+    // newer content, and persists that, never the stale pre-concurrency
+    // snapshot.
+    const store = await documentStore();
+    await store.saveDocument(documentWithInlineImage(dataUrl('old')));
+    const { accessDocument } = await import('@/lib/document-store/migration');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { db } = await import('@/lib/utils/database');
+    const pool = getAssetPool();
+    let loads = 0;
+    const racingStore = new Proxy(store, {
+      get(target, property) {
+        if (property === 'loadDocument') {
+          return async (id: string) => {
+            loads += 1;
+            const doc = await target.loadDocument(id);
+            if (loads === 2 && doc) {
+              // A concurrent editor swapped the image bytes while conversion ran.
+              return documentWithInlineImage(dataUrl('newer'));
+            }
+            return doc;
+          };
+        }
+        return Reflect.get(target, property);
+      },
+    });
+
+    const result = await accessDocument('stage-1', accessDeps(racingStore));
+
+    const src = (result.document?.scenes[0].content as { canvas: { elements: { src: string }[] } })
+      .canvas.elements[0].src;
+    expect(src).toMatch(/^ast_/);
+    // The persisted bytes are the NEWER image, converted on top of the
+    // concurrent edit — the stale snapshot was not saved.
+    const persisted = await store.loadDocument('stage-1');
+    const persistedSrc = (
+      persisted?.scenes[0].content as { canvas: { elements: { src: string }[] } }
+    ).canvas.elements[0].src;
+    expect(persistedSrc).toBe(src);
+    expect(await pool.exists?.(src as never)).toBe(true);
+    const row = await db.mediaFiles.get(`stage-1:${src}`);
+    expect(await row?.blob.text()).toBe('newer');
+  });
+
+  it('a failed save-back rolls every fresh allocation back through the real helper', async () => {
+    const store = await documentStore();
+    await store.saveDocument(documentWithInlineImage(dataUrl('bytes')));
+    const flakyStore = new Proxy(store, {
+      get(target, property) {
+        if (property === 'saveDocument') return () => Promise.reject(new Error('quota'));
+        return Reflect.get(target, property);
+      },
+    });
+    const { accessDocument } = await import('@/lib/document-store/migration');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { db } = await import('@/lib/utils/database');
+    const pool = getAssetPool();
+    const removeSpy = vi.spyOn(pool, 'remove');
+
+    const result = await accessDocument('stage-1', accessDeps(flakyStore));
+
+    // The opened document is unconverted (the save never landed).
+    const src = (result.document?.scenes[0].content as { canvas: { elements: { src: string }[] } })
+      .canvas.elements[0].src;
+    expect(src).toBe(dataUrl('bytes'));
+    // Every fresh allocation was rolled back through the real helper: pool
+    // entry and compatibility row are gone.
+    const rolledBack = new Set(removeSpy.mock.calls.map((args) => String(args[0])));
+    expect(rolledBack.size).toBe(1);
+    for (const id of rolledBack) {
+      expect(await pool.exists?.(id as never)).toBe(false);
+      expect(await db.mediaFiles.get(`stage-1:${id}`)).toBeUndefined();
+    }
+  });
+
+  it('deleting the stage reclaims the converted pool bytes through the real flow', async () => {
+    const store = await documentStore();
+    await store.saveDocument(documentWithInlineImage(dataUrl('reclaim-me')));
+    const { accessDocument } = await import('@/lib/document-store/migration');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const pool = getAssetPool();
+
+    const result = await accessDocument('stage-1', accessDeps(store));
+    const src = (result.document?.scenes[0].content as { canvas: { elements: { src: string }[] } })
+      .canvas.elements[0].src;
+    expect(src).toMatch(/^ast_/);
+    expect(await pool.exists?.(src as never)).toBe(true);
+
+    // The deletion flow: prepare the reclamation plan from the document and
+    // its compatibility rows, delete the authoritative document, then
+    // execute — exactly the ordering stage deletion uses.
+    const {
+      loadStageAssetInventory,
+      buildStageAssetReclamationPlan,
+      executeStageAssetReclamation,
+    } = await import('@/lib/media/reclaim-stage-assets');
+    const inventory = await loadStageAssetInventory(result.document!);
+    const plan = buildStageAssetReclamationPlan(
+      'stage-1',
+      inventory.refs,
+      inventory.mediaRows,
+      inventory.audioRows,
+    );
+    expect(plan.poolRefs).toContain(src);
+    await store.deleteDocument('stage-1');
+    await executeStageAssetReclamation(plan, null);
+
+    expect(await pool.exists?.(src as never)).toBe(false);
+  });
+
+  it('the classroom fetch path converts inline images in a server payload and persists the ids', async () => {
+    const payload = {
+      stage: { id: 'classroom-1', name: 'Server Course', createdAt: 1, updatedAt: 2 },
+      scenes: [
+        {
+          id: 'scene-1',
+          stageId: 'classroom-1',
+          type: 'slide',
+          title: 'S',
+          order: 0,
+          content: {
+            type: 'slide',
+            canvas: {
+              id: 'c1',
+              elements: [
+                {
+                  id: 'el1',
+                  type: 'image',
+                  src: dataUrl('classroom-image'),
+                  left: 0,
+                  top: 0,
+                  width: 100,
+                  height: 100,
+                },
+              ],
+            },
+          },
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        if (String(input) === '/api/classroom?id=classroom-1') {
+          return new Response(JSON.stringify({ success: true, classroom: payload }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`);
+      }),
+    );
+    const store = await documentStore();
+    const { fetchClassroomFromApi } = await import('@/lib/classroom/load-classroom');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const { db } = await import('@/lib/utils/database');
+    const pool = getAssetPool();
+
+    const result = await fetchClassroomFromApi('classroom-1', () => true, accessDeps(store));
+
+    const committed = await store.loadDocument('classroom-1');
+    const src = (committed?.scenes[0].content as { canvas: { elements: { src: string }[] } }).canvas
+      .elements[0].src;
+    expect(src).toMatch(/^ast_/);
+    expect(result?.scenes[0]).toEqual(committed?.scenes[0]);
+    // The inline bytes never entered storage: they live in the pool and the
+    // compatibility row only.
+    expect(await pool.exists?.(src as never)).toBe(true);
+    const row = await db.mediaFiles.get(`classroom-1:${src}`);
+    expect(await row?.blob.text()).toBe('classroom-image');
+
+    // A second cold load reuses the committed document (no re-allocation).
+    const again = await fetchClassroomFromApi('classroom-1', () => true, accessDeps(store));
+    expect(again?.scenes[0]).toEqual(committed?.scenes[0]);
+  });
+
+  it('a superseded classroom load rolls the shared ledger back through the real helper', async () => {
+    const { db } = await import('@/lib/utils/database');
+    // The payload carries BOTH a legacy gen placeholder (owned by the #1101
+    // converter) and an inline data URL (owned by this converter). A liveness
+    // abort after the legacy allocation must roll BOTH back through the
+    // shared ledger — one rollback call covers both converters' allocations.
+    await db.mediaFiles.put({
+      id: 'classroom-1:gen_img_1',
+      stageId: 'classroom-1',
+      type: 'image',
+      blob: new Blob(['gen-bytes'], { type: 'image/png' }),
+      mimeType: 'image/png',
+      size: 9,
+      prompt: 'p',
+      params: '{}',
+      createdAt: 1,
+    });
+    const payload = {
+      stage: { id: 'classroom-1', name: 'Server Course', createdAt: 1, updatedAt: 2 },
+      scenes: [
+        {
+          id: 'scene-1',
+          stageId: 'classroom-1',
+          type: 'slide',
+          title: 'S',
+          order: 0,
+          content: {
+            type: 'slide',
+            canvas: {
+              id: 'c1',
+              elements: [
+                {
+                  id: 'el1',
+                  type: 'image',
+                  src: 'gen_img_1',
+                  left: 0,
+                  top: 0,
+                  width: 100,
+                  height: 100,
+                },
+                {
+                  id: 'el2',
+                  type: 'image',
+                  src: dataUrl('inline'),
+                  left: 0,
+                  top: 0,
+                  width: 100,
+                  height: 100,
+                },
+              ],
+            },
+          },
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string) => {
+        if (String(input) === '/api/classroom?id=classroom-1') {
+          return new Response(JSON.stringify({ success: true, classroom: payload }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`);
+      }),
+    );
+    const store = await documentStore();
+    const { fetchClassroomFromApi } = await import('@/lib/classroom/load-classroom');
+    const { getAssetPool } = await import('@/lib/media/asset-pool');
+    const pool = getAssetPool();
+    const removeSpy = vi.spyOn(pool, 'remove');
+    // Entry (1) and the legacy pass's commit-boundary checks stay live; the
+    // inline pass's first liveness check turns the load stale.
+    let calls = 0;
+    const shouldConvert = () => ++calls < 4;
+
+    const result = await fetchClassroomFromApi('classroom-1', shouldConvert, accessDeps(store));
+
+    expect(result).toBeNull();
+    // BOTH converters' fresh allocations were rolled back through the real
+    // helper: nothing is stranded in the pool, and the document was never
+    // committed.
+    const rolledBack = new Set(removeSpy.mock.calls.map((args) => String(args[0])));
+    expect(rolledBack.size).toBeGreaterThan(0);
+    for (const id of rolledBack) {
+      expect(await pool.exists?.(id as never)).toBe(false);
+      expect(await db.mediaFiles.get(`classroom-1:${id}`)).toBeUndefined();
+    }
+    expect(await store.loadDocument('classroom-1')).toBeNull();
+  });
+});
+
+class MemoryKv {
+  readonly values = new Map<string, unknown>();
+
+  async get<T>(key: string, scope: KVScope = 'account'): Promise<T | null> {
+    return (this.values.get(`${scope}:${key}`) as T | undefined) ?? null;
+  }
+
+  async set<T>(key: string, value: T, scope: KVScope = 'account'): Promise<void> {
+    this.values.set(`${scope}:${key}`, structuredClone(value));
+  }
+
+  async remove(key: string, scope: KVScope = 'account'): Promise<void> {
+    this.values.delete(`${scope}:${key}`);
+  }
+
+  async keys(prefix = '', scope: KVScope = 'account'): Promise<string[]> {
+    const fullPrefix = `${scope}:${prefix}`;
+    return [...this.values.keys()]
+      .filter((key) => key.startsWith(fullPrefix))
+      .map((key) => key.slice(scope.length + 1));
+  }
+}
+
+function lockManager(): LockManager {
+  let tail = Promise.resolve();
+  return {
+    request: vi.fn((_name, _options, callback) => {
+      const result = tail.then(() => callback({ name: _name, mode: 'exclusive' } as Lock));
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    }),
+    query: vi.fn(),
+  } as unknown as LockManager;
+}

--- a/tests/media/convert-inline-image-assets.test.ts
+++ b/tests/media/convert-inline-image-assets.test.ts
@@ -1,0 +1,542 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { AssetMeta } from '@openmaic/dsl';
+
+import {
+  convertInlineImageAssets,
+  decodeInlineImageDataUrl,
+  type InlineImageConversionDeps,
+} from '@/lib/media/convert-inline-image-assets';
+import { buildStageAssetReclamationPlan } from '@/lib/media/reclaim-stage-assets';
+import { collectStageAssetRefs } from '@/lib/media/collect-stage-asset-refs';
+import type { AppDocument } from '@/lib/document-store/persistence-types';
+import type { Action } from '@/lib/types/action';
+import type { AppScene, Stage } from '@/lib/types/stage';
+import type { MediaFileRecord } from '@/lib/utils/database';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let allocationCounter = 0;
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function makeHarness() {
+  const pool = new Map<string, { blob: Blob; meta: AssetMeta }>();
+  const mediaRows = new Map<string, MediaFileRecord>();
+
+  const deps: InlineImageConversionDeps = {
+    putAsset: async (blob, meta) => {
+      const id = `ast_test_${(allocationCounter += 1)}`;
+      pool.set(id, { blob, meta });
+      return id;
+    },
+    removeAsset: async (ref) => {
+      pool.delete(ref);
+    },
+    putMediaRecord: async (stageId, ref, record) => {
+      mediaRows.set(`${stageId}:${ref}`, { ...record, id: `${stageId}:${ref}`, stageId });
+    },
+    // Deterministic digest over the DECODED bytes, so the dedup behavior is
+    // directly observable (identical bytes in different encodings collapse).
+    digest: async (bytes) => bytesToHex(bytes),
+  };
+
+  return { pool, mediaRows, deps };
+}
+
+function pngDataUrl(payload: string): string {
+  return `data:image/png;base64,${btoa(payload)}`;
+}
+
+function imageElement(src: string, id = 'el'): Record<string, unknown> {
+  return { id, type: 'image', src, left: 0, top: 0, width: 100, height: 100, rotate: 0 };
+}
+
+function stage(partial: Partial<Stage> = {}): Stage {
+  return { id: 'stage-1', name: 'Course', createdAt: 1, updatedAt: 2, ...partial };
+}
+
+function slideScene(actions: Action[] = [], elements: unknown[] = []): AppScene {
+  return {
+    id: 'scene-1',
+    stageId: 'stage-1',
+    type: 'slide',
+    title: 'Scene',
+    order: 0,
+    content: { type: 'slide', canvas: { id: 'canvas-1', elements } },
+    actions,
+    createdAt: 1,
+    updatedAt: 2,
+  } as AppScene;
+}
+
+function document(partial: Partial<AppDocument> = {}): AppDocument {
+  return { stage: stage(), scenes: [], ...partial };
+}
+
+function canvasElements(doc: AppDocument): Array<{ src: string }> {
+  return (
+    (doc.scenes[0].content as { canvas: { elements: { src: string }[] } }).canvas.elements ?? []
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Data URL decoding
+// ---------------------------------------------------------------------------
+
+describe('decodeInlineImageDataUrl', () => {
+  test('decodes a base64 payload to its exact bytes and MIME type', () => {
+    const decoded = decodeInlineImageDataUrl(pngDataUrl('hello'));
+    expect(decoded).not.toBeNull();
+    expect(decoded?.mimeType).toBe('image/png');
+    expect(new TextDecoder().decode(decoded?.bytes)).toBe('hello');
+  });
+
+  test('decodes a percent-encoded UTF-8 payload to its exact bytes', () => {
+    // Non-ASCII text proves the bytes are the true UTF-8 encoding, not the
+    // UTF-16 code units of the decoded string.
+    const src = `data:image/svg+xml,${encodeURIComponent('<text>中文</text>')}`;
+    const decoded = decodeInlineImageDataUrl(src);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.mimeType).toBe('image/svg+xml');
+    expect(new TextDecoder().decode(decoded?.bytes)).toBe('<text>中文</text>');
+    // The byte length is the UTF-8 length (2 CJK chars = 6 bytes).
+    expect(decoded?.bytes.length).toBe('<text>'.length + 6 + '</text>'.length);
+  });
+
+  test('tolerates whitespace inside a base64 payload', () => {
+    const wrapped = `data:image/png;base64,${btoa('abc').slice(0, 2)}\n${btoa('abc').slice(2)}`;
+    const decoded = decodeInlineImageDataUrl(wrapped);
+    expect(new TextDecoder().decode(decoded?.bytes)).toBe('abc');
+  });
+
+  test('returns null for non-image data URLs and malformed payloads', () => {
+    expect(decodeInlineImageDataUrl('data:text/plain;base64,AAAA')).toBeNull();
+    expect(decodeInlineImageDataUrl('data:image/png;base64,!!!not-base64!!!')).toBeNull();
+    expect(decodeInlineImageDataUrl('https://example.com/i.png')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline image conversion
+// ---------------------------------------------------------------------------
+
+describe('inline base64 image conversion', () => {
+  test('a canvas image data URL is rewritten to an allocated pool id', async () => {
+    const { pool, deps } = makeHarness();
+    const doc = document({
+      scenes: [slideScene([], [imageElement(pngDataUrl('bytes'))])],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(true);
+    const src = canvasElements(result.document)[0].src;
+    expect(src).toMatch(/^ast_test_/);
+    expect(pool.has(src)).toBe(true);
+    expect(pool.get(src)?.meta).toMatchObject({
+      contentType: 'image/png',
+      mediaType: 'image',
+      origin: 'inline-data-url',
+    });
+    expect(await pool.get(src)?.blob.text()).toBe('bytes');
+    expect(result.report.converted).toBe(1);
+    expect(result.report.ingested).toBe(1);
+    // The input document is never mutated.
+    expect(canvasElements(doc)[0].src).toBe(pngDataUrl('bytes'));
+  });
+
+  test('identical base64 on N slides collapses to one id with N references', async () => {
+    const { pool, deps } = makeHarness();
+    const dataUrl = pngDataUrl('same-bytes');
+    const doc = document({
+      stage: stage({
+        whiteboard: [
+          { id: 'wb1', elements: [imageElement(dataUrl, 'wb1-el')] },
+          { id: 'wb2', elements: [imageElement(dataUrl, 'wb2-el')] },
+        ] as unknown as Stage['whiteboard'],
+      }),
+      scenes: [
+        slideScene([], [imageElement(dataUrl, 'canvas-el'), imageElement(dataUrl, 'canvas-el-2')]),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(pool.size).toBe(1);
+    const [assetId] = [...pool.keys()];
+    expect(result.report.converted).toBe(4);
+    expect(result.report.ingested).toBe(1);
+    const canvas = (
+      result.document.scenes[0].content as {
+        canvas: { elements: { src: string }[] };
+      }
+    ).canvas;
+    expect(canvas.elements[0].src).toBe(assetId);
+    expect(canvas.elements[1].src).toBe(assetId);
+    expect(result.document.stage.whiteboard?.[0].elements[0]).toMatchObject({ src: assetId });
+    expect(result.document.stage.whiteboard?.[1].elements[0]).toMatchObject({ src: assetId });
+  });
+
+  test('identical decoded bytes in different encodings collapse to one id', async () => {
+    const { pool, deps } = makeHarness();
+    const base64Encoded = `data:image/svg+xml;base64,${btoa('<svg/>')}`;
+    const percentEncoded = `data:image/svg+xml,${encodeURIComponent('<svg/>')}`;
+    const doc = document({
+      scenes: [
+        slideScene([], [imageElement(base64Encoded, 'a'), imageElement(percentEncoded, 'b')]),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(pool.size).toBe(1);
+    const [assetId] = [...pool.keys()];
+    expect(canvasElements(result.document).map((el) => el.src)).toEqual([assetId, assetId]);
+    expect(result.report.ingested).toBe(1);
+    expect(result.report.converted).toBe(2);
+  });
+
+  test('concurrent slides naming one image share a single in-flight allocation', async () => {
+    const { pool, deps } = makeHarness();
+    const dataUrl = pngDataUrl('shared');
+    const slowPut: InlineImageConversionDeps['putAsset'] = async (blob, meta) => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const id = `ast_test_${(allocationCounter += 1)}`;
+      pool.set(id, { blob, meta });
+      return id;
+    };
+    const doc = document({
+      stage: stage({
+        whiteboard: [
+          { id: 'wb1', elements: [imageElement(dataUrl)] },
+          { id: 'wb2', elements: [imageElement(dataUrl)] },
+          { id: 'wb3', elements: [imageElement(dataUrl)] },
+        ] as unknown as Stage['whiteboard'],
+      }),
+    });
+
+    const result = await convertInlineImageAssets(doc, { ...deps, putAsset: slowPut });
+
+    expect(pool.size).toBe(1);
+    const [assetId] = [...pool.keys()];
+    for (const slide of result.document.stage.whiteboard ?? []) {
+      expect(slide.elements[0]).toMatchObject({ src: assetId });
+    }
+  });
+
+  test('whiteboard and background slots convert, not just canvas images', async () => {
+    const { deps } = makeHarness();
+    const bgUrl = pngDataUrl('background');
+    const wbUrl = pngDataUrl('whiteboard');
+    const doc = document({
+      stage: stage({
+        whiteboard: [
+          {
+            id: 'wb',
+            background: { type: 'image', image: { src: bgUrl, size: 'cover' } },
+            elements: [imageElement(wbUrl, 'wb-el')],
+          },
+        ] as unknown as Stage['whiteboard'],
+      }),
+      scenes: [
+        {
+          ...slideScene(),
+          content: {
+            type: 'slide',
+            canvas: {
+              id: 'canvas-1',
+              background: { type: 'image', image: { src: bgUrl, size: 'cover' } },
+              elements: [],
+            },
+          },
+        } as unknown as AppScene,
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.report.converted).toBe(3);
+    const canvas = (
+      result.document.scenes[0].content as {
+        canvas: { background: { image: { src: string } } };
+      }
+    ).canvas;
+    const wb = result.document.stage.whiteboard?.[0];
+    expect(canvas.background.image.src).toMatch(/^ast_test_/);
+    expect((wb?.background as { image: { src: string } }).image.src).toMatch(/^ast_test_/);
+    // Same bytes on the canvas background and the whiteboard background → one id.
+    expect(canvas.background.image.src).toBe(
+      (wb?.background as { image: { src: string } }).image.src,
+    );
+    expect((wb?.elements[0] as { src: string }).src).toMatch(/^ast_test_/);
+  });
+
+  test('video poster data URLs convert like image srcs', async () => {
+    const { deps } = makeHarness();
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          [
+            {
+              id: 'v1',
+              type: 'video',
+              src: 'ast_existing_video',
+              mediaRef: 'ast_existing_video',
+              poster: pngDataUrl('poster-bytes'),
+            },
+          ],
+        ),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(true);
+    const video = (
+      result.document.scenes[0].content as {
+        canvas: { elements: Array<{ src: string; poster: string }> };
+      }
+    ).canvas.elements[0];
+    expect(video.src).toBe('ast_existing_video'); // untouched
+    expect(video.poster).toMatch(/^ast_test_/);
+    expect(result.report.converted).toBe(1);
+  });
+
+  test('second run is a no-op (idempotency)', async () => {
+    const { pool, deps } = makeHarness();
+    const doc = document({
+      scenes: [slideScene([], [imageElement(pngDataUrl('bytes'))])],
+    });
+
+    const once = await convertInlineImageAssets(doc, deps);
+    expect(once.changed).toBe(true);
+    const allocationsAfterFirst = pool.size;
+    const twice = await convertInlineImageAssets(once.document, deps);
+
+    expect(twice.changed).toBe(false);
+    expect(twice.document).toBe(once.document);
+    expect(twice.report.converted).toBe(0);
+    expect(pool.size).toBe(allocationsAfterFirst);
+  });
+
+  test('non-data-URL shapes are untouched (ids, gen_*, http, classroom-media, blob)', async () => {
+    const { pool, deps } = makeHarness();
+    const shapes = [
+      'ast_allocated',
+      'gen_img_alpha_001',
+      'https://example.com/i.png',
+      '/api/classroom-media/c1/i.png',
+      'blob:http://localhost/abc',
+    ];
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          shapes.map((src, index) => imageElement(src, `el${index}`)),
+        ),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(result.report.converted).toBe(0);
+    expect(result.report.kept).toBe(0);
+    expect(pool.size).toBe(0);
+    expect(canvasElements(result.document).map((el) => el.src)).toEqual(shapes);
+  });
+
+  test('a malformed data URL stays inline and counts as kept', async () => {
+    const { pool, deps } = makeHarness();
+    const malformed = 'data:image/png;base64,!!!not-base64!!!';
+    const doc = document({ scenes: [slideScene([], [imageElement(malformed)])] });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(result.report.kept).toBe(1);
+    expect(pool.size).toBe(0);
+  });
+
+  test('a failed ingest leaves that slot inline and does not stop the pass', async () => {
+    const { pool, deps } = makeHarness();
+    let calls = 0;
+    const flakyPut: InlineImageConversionDeps['putAsset'] = async (blob, meta) => {
+      calls += 1;
+      if (calls === 1) throw new Error('pool down');
+      const id = `ast_test_${(allocationCounter += 1)}`;
+      pool.set(id, { blob, meta });
+      return id;
+    };
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          [imageElement(pngDataUrl('one'), 'a'), imageElement(pngDataUrl('two'), 'b')],
+        ),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, { ...deps, putAsset: flakyPut });
+
+    expect(result.changed).toBe(true);
+    expect(result.report.converted).toBe(1);
+    expect(result.report.kept).toBe(1);
+    expect(canvasElements(result.document)[0].src).toBe(pngDataUrl('one')); // failed stays inline
+    expect(canvasElements(result.document)[1].src).toMatch(/^ast_test_/); // pass continued
+    expect(pool.size).toBe(1);
+  });
+
+  test('a compatibility-write failure releases the allocated id and leaves the slot inline', async () => {
+    const { pool, deps } = makeHarness();
+    const failingPutMedia: InlineImageConversionDeps['putMediaRecord'] = async () => {
+      throw new Error('dexie down');
+    };
+    const doc = document({ scenes: [slideScene([], [imageElement(pngDataUrl('bytes'))])] });
+
+    const result = await convertInlineImageAssets(doc, {
+      ...deps,
+      putMediaRecord: failingPutMedia,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(result.report.kept).toBe(1);
+    // The failed attempt released its allocation: no stranded pool entry.
+    expect(pool.size).toBe(0);
+  });
+
+  test('fresh allocations are reported on the ledger for caller rollback', async () => {
+    const { pool, deps } = makeHarness();
+    const ledger: string[] = [];
+    const doc = document({
+      scenes: [
+        slideScene([], [imageElement(pngDataUrl('a'), 'a'), imageElement(pngDataUrl('b'), 'b')]),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps, undefined, ledger);
+
+    expect(result.changed).toBe(true);
+    expect(ledger).toHaveLength(2);
+    expect(pool.size).toBe(2);
+    // A caller that discards the converted document releases every fresh
+    // allocation — the accounting the shared rollback helper is built on.
+    for (const id of ledger) await deps.removeAsset(id);
+    expect(pool.size).toBe(0);
+  });
+
+  test('converted ids are stage-referenced assets: counted and reclaimed like part-2 images', async () => {
+    const { pool, mediaRows, deps } = makeHarness();
+    const dataUrl = pngDataUrl('same');
+    const doc = document({
+      stage: stage({
+        whiteboard: [
+          { id: 'wb', elements: [imageElement(dataUrl, 'wb-el')] },
+        ] as unknown as Stage['whiteboard'],
+      }),
+      scenes: [slideScene([], [imageElement(dataUrl, 'canvas-el')])],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+    const [assetId] = [...pool.keys()];
+
+    const stageRows = [...mediaRows.values()].map(({ id, stageId }) => ({ id, stageId }));
+    const refs = collectStageAssetRefs(result.document, {
+      mediaRows: stageRows,
+      audioRows: [],
+    });
+
+    // Counted exactly like a part-2 id-addressed image: referenced by the
+    // document, and pool-owned through the compatibility row.
+    expect(refs.document.has(assetId)).toBe(true);
+    expect(refs.referenced.has(assetId)).toBe(true);
+    expect(refs.referenceCounts.get(assetId)).toBe(2);
+    expect(refs.poolOwned.has(assetId)).toBe(true);
+
+    // Stage deletion builds a reclamation plan that includes the converted id.
+    const plan = buildStageAssetReclamationPlan('stage-1', refs, stageRows, []);
+    expect(plan.poolRefs).toContain(assetId);
+  });
+
+  test('a converted document converts the whole traversal, including scene whiteboards', async () => {
+    const { deps } = makeHarness();
+    const scene = slideScene([], [imageElement(pngDataUrl('canvas'), 'c')]);
+    scene.whiteboards = [{ id: 'swb', elements: [imageElement(pngDataUrl('swb'), 's')] }] as never;
+    const doc = document({ scenes: [scene] });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.report.converted).toBe(2);
+    const convertedScene = result.document.scenes[0] as AppScene;
+    expect(
+      (convertedScene.content as { canvas: { elements: { src: string }[] } }).canvas.elements[0]
+        .src,
+    ).toMatch(/^ast_test_/);
+    expect((convertedScene.whiteboards?.[0].elements[0] as { src: string }).src).toMatch(
+      /^ast_test_/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Time budget
+// ---------------------------------------------------------------------------
+
+describe('conversion time budget', () => {
+  test('budget expiry mid-run keeps progress and the next open continues', async () => {
+    vi.useFakeTimers();
+    try {
+      const { pool, deps } = makeHarness();
+      let releaseFirst!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const slowPut: InlineImageConversionDeps['putAsset'] = async (blob, meta) => {
+        await gate;
+        const id = `ast_test_${(allocationCounter += 1)}`;
+        pool.set(id, { blob, meta });
+        return id;
+      };
+      const doc = document({
+        scenes: [
+          slideScene(
+            [],
+            [imageElement(pngDataUrl('one'), 'a'), imageElement(pngDataUrl('two'), 'b')],
+          ),
+        ],
+      });
+
+      const pending = convertInlineImageAssets(doc, { ...deps, putAsset: slowPut });
+      // Exhaust the 15-second aggregate budget while the first ingest is still
+      // pending (a stalled pool write).
+      vi.advanceTimersByTime(16_000);
+      releaseFirst();
+      const first = await pending;
+
+      // The conversions made before expiry are kept; the rest stay inline.
+      expect(first.changed).toBe(true);
+      expect(first.report.converted).toBe(1);
+      expect(first.report.ingested).toBe(1);
+      expect(first.report.kept).toBe(1);
+      expect(canvasElements(first.document)[0].src).toMatch(/^ast_test_/);
+      expect(canvasElements(first.document)[1].src).toBe(pngDataUrl('two'));
+
+      // The next open continues from where the budget stopped it.
+      const second = await convertInlineImageAssets(first.document, deps);
+      expect(second.changed).toBe(true);
+      expect(second.report.converted).toBe(1);
+      expect(canvasElements(second.document)[1].src).toMatch(/^ast_test_/);
+      expect(pool.size).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/media/convert-inline-image-assets.test.ts
+++ b/tests/media/convert-inline-image-assets.test.ts
@@ -4,10 +4,11 @@ import type { AssetMeta } from '@openmaic/dsl';
 import {
   convertInlineImageAssets,
   decodeInlineImageDataUrl,
+  estimateInlineImageDecodedBytes,
   INLINE_IMAGE_SLIDE_CONCURRENCY,
   InlineImageConversionAbortedError,
   type InlineImageConversionDeps,
-  MAX_INLINE_IMAGE_PAYLOAD_BYTES,
+  MAX_INLINE_IMAGE_DECODED_BYTES,
 } from '@/lib/media/convert-inline-image-assets';
 import { buildStageAssetReclamationPlan } from '@/lib/media/reclaim-stage-assets';
 import { collectStageAssetRefs } from '@/lib/media/collect-stage-asset-refs';
@@ -101,13 +102,15 @@ describe('decodeInlineImageDataUrl', () => {
   test('decodes a percent-encoded UTF-8 payload to its exact bytes', () => {
     // Non-ASCII text proves the bytes are the true UTF-8 encoding, not the
     // UTF-16 code units of the decoded string.
-    const src = `data:image/svg+xml,${encodeURIComponent('<text>中文</text>')}`;
+    const src = `data:image/svg+xml,${encodeURIComponent('<text>déjà-vu ☃</text>')}`;
     const decoded = decodeInlineImageDataUrl(src);
     expect(decoded).not.toBeNull();
     expect(decoded?.mimeType).toBe('image/svg+xml');
-    expect(new TextDecoder().decode(decoded?.bytes)).toBe('<text>中文</text>');
-    // The byte length is the UTF-8 length (2 CJK chars = 6 bytes).
-    expect(decoded?.bytes.length).toBe('<text>'.length + 6 + '</text>'.length);
+    expect(new TextDecoder().decode(decoded?.bytes)).toBe('<text>déjà-vu ☃</text>');
+    // The byte length is the UTF-8 length, not the character count: 'é'/'à'
+    // are 2 bytes each and '☃' is 3, so the multi-byte payload proves the
+    // percent path preserves UTF-8 exactly.
+    expect(decoded?.bytes.length).toBe(new TextEncoder().encode('<text>déjà-vu ☃</text>').length);
   });
 
   test('tolerates whitespace inside a base64 payload', () => {
@@ -142,6 +145,19 @@ describe('decodeInlineImageDataUrl', () => {
     );
     expect(percent).not.toBeNull();
     expect(new TextDecoder().decode(percent?.bytes)).toBe('<svg/>');
+  });
+
+  test('estimateInlineImageDecodedBytes measures DECODED bytes, not text length', () => {
+    // Base64: text × 3/4, padding excluded (each quartet encodes 3 bytes).
+    expect(estimateInlineImageDecodedBytes(pngDataUrl('hello'))).toBe(5);
+    expect(estimateInlineImageDecodedBytes(`data:image/png;base64,${btoa('hello')}`)).toBe(5);
+    // 'AA==' is 4 text chars, 2 padding → 1 decoded byte.
+    expect(estimateInlineImageDecodedBytes('data:image/png;base64,AA==')).toBe(1);
+    // Percent-encoded: the raw text length is a safe upper bound on the
+    // decoded size (each `%XX` triple decodes to one byte).
+    expect(estimateInlineImageDecodedBytes('data:image/svg+xml,%3Csvg%2F%3E')).toBe(12);
+    // Non-inline values have no estimate.
+    expect(estimateInlineImageDecodedBytes('https://example.com/i.png')).toBeNull();
   });
 });
 
@@ -419,6 +435,35 @@ describe('inline base64 image conversion', () => {
     expect(pool.size).toBe(1);
   });
 
+  test('a failed putAsset forgets the memo entry so a sibling slot with the same bytes retries and converts', async () => {
+    const { pool, deps } = makeHarness();
+    let calls = 0;
+    const flakyPut: InlineImageConversionDeps['putAsset'] = async (blob, meta) => {
+      calls += 1;
+      if (calls === 1) throw new Error('pool down');
+      const id = `ast_test_${(allocationCounter += 1)}`;
+      pool.set(id, { blob, meta });
+      return id;
+    };
+    const src = pngDataUrl('same-bytes');
+    const doc = document({
+      scenes: [slideScene([], [imageElement(src, 'a'), imageElement(src, 'b')])],
+    });
+
+    const result = await convertInlineImageAssets(doc, { ...deps, putAsset: flakyPut });
+
+    // Slot 1's pool write failed; the memo entry was forgotten, so slot 2
+    // (identical bytes) retried instead of inheriting the rejected promise
+    // for the rest of the pass.
+    expect(result.changed).toBe(true);
+    expect(result.report.converted).toBe(1);
+    expect(result.report.ingested).toBe(1);
+    expect(result.report.kept).toBe(1);
+    expect(canvasElements(result.document)[0].src).toBe(src); // failed stays inline
+    expect(canvasElements(result.document)[1].src).toMatch(/^ast_test_/); // sibling retried
+    expect(pool.size).toBe(1);
+  });
+
   test('a compatibility-write failure releases the allocated id and leaves the slot inline', async () => {
     const { pool, deps } = makeHarness();
     const failingPutMedia: InlineImageConversionDeps['putMediaRecord'] = async () => {
@@ -553,6 +598,45 @@ describe('inline base64 image conversion', () => {
     expect(result.document).toBe(doc);
     expect(result.report.kept).toBe(1);
     expect(pool.size).toBe(0);
+  });
+
+  test('safe-direction marker shapes stay inline: never rewritten into a guessed decode', async () => {
+    const { pool, deps } = makeHarness();
+    const payload = btoa('never-decoded');
+    // Shapes whose fetch-spec handling differs from a naive base64 guess. The
+    // converter must leave each inline (the safe direction) rather than
+    // decode a body the browser treats differently:
+    // - leading space after `data:` (the spec strips it → base64; the
+    //   converter does not even recognize the value as an inline data URL);
+    // - trailing space after the `;base64` marker (the spec strips it →
+    //   base64; the converter's stray-token guard keeps it);
+    // - NBSP inside the marker (the spec percent-decodes; the stray-token
+    //   guard keeps it — never a base64 guess).
+    const shapes = [
+      `data: image/png;base64,${payload}`,
+      `data:image/png;base64 ,${payload}`,
+      `data:image/png;\u00a0base64,${payload}`,
+    ];
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          shapes.map((src, index) => imageElement(src, `el${index}`)),
+        ),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(pool.size).toBe(0);
+    expect(canvasElements(result.document).map((el) => el.src)).toEqual(shapes);
+    // The two shapes the converter recognizes as inline are counted as kept;
+    // the leading-space shape is not even recognized as inline and is left
+    // untouched, uncounted.
+    expect(result.report.converted).toBe(0);
+    expect(result.report.kept).toBe(2);
   });
 
   test('an unavailable content digest degrades the pass to a no-op with one warn', async () => {
@@ -699,7 +783,11 @@ describe('inline base64 image conversion', () => {
         return bytesToHex(bytes);
       },
     };
-    const oversized = `data:image/png;base64,${'A'.repeat(MAX_INLINE_IMAGE_PAYLOAD_BYTES + 1)}`;
+    // Base64 text long enough that its DECODED size exceeds the 50 MB cap
+    // (the estimate scales text by 3/4, so the text must be ~4/3 × the cap).
+    const oversized = `data:image/png;base64,${'A'.repeat(
+      Math.ceil(((MAX_INLINE_IMAGE_DECODED_BYTES + 1) * 4) / 3),
+    )}`;
     const doc = document({ scenes: [slideScene([], [imageElement(oversized)])] });
 
     const result = await convertInlineImageAssets(doc, countingDeps);
@@ -710,6 +798,63 @@ describe('inline base64 image conversion', () => {
     expect(pool.size).toBe(0);
     // The pre-decode gate fired: no digest — and so no decode — was attempted.
     expect(digestCalls).toBe(0);
+  });
+
+  test('a payload whose raw text exceeds the cap but DECODES under it converts', async () => {
+    const { pool, deps } = makeHarness();
+    // Base64 text longer than MAX_INLINE_IMAGE_DECODED_BYTES (the old gate
+    // compared TEXT length, so it kept this) decodes to only ~3/4 of that —
+    // under the 50 MB byte cap — so the pre-decode DECODED-size estimate
+    // lets it through. The length is a multiple of 4 so atob accepts it.
+    const textLength = MAX_INLINE_IMAGE_DECODED_BYTES + 4;
+    const src = `data:image/png;base64,${'A'.repeat(textLength)}`;
+    const doc = document({ scenes: [slideScene([], [imageElement(src)])] });
+
+    const result = await convertInlineImageAssets(doc, {
+      ...deps,
+      // One unique payload: a length-addressed digest avoids hex-encoding the
+      // ~39 MB buffer the harness's byte digest would materialize.
+      digest: async (bytes) => `len:${bytes.length}`,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.report.converted).toBe(1);
+    expect(result.report.ingested).toBe(1);
+    expect(result.report.kept).toBe(0);
+    expect(pool.size).toBe(1);
+    const [assetId] = [...pool.keys()];
+    expect(canvasElements(result.document)[0].src).toBe(assetId);
+    // 'A' is the base64 encoding of a zero byte: decoded size = text × 3/4.
+    expect(pool.get(assetId)?.blob.size).toBe((textLength * 3) / 4);
+  }, 30_000);
+
+  test('oversized payloads are reported with ONE aggregate warn per pass', async () => {
+    const { pool, deps } = makeHarness();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const oversized = `data:image/png;base64,${'A'.repeat(
+        Math.ceil(((MAX_INLINE_IMAGE_DECODED_BYTES + 1) * 4) / 3),
+      )}`;
+      const doc = document({
+        scenes: [slideScene([], [imageElement(oversized, 'a'), imageElement(oversized, 'b')])],
+      });
+
+      const result = await convertInlineImageAssets(doc, deps);
+
+      expect(result.changed).toBe(false);
+      expect(result.report.kept).toBe(2);
+      expect(pool.size).toBe(0);
+      // The old per-payload warn repeated once per oversized payload per open;
+      // the fix reports the whole pass in one aggregate message.
+      const oversizedWarns = warnSpy.mock.calls.filter((args) =>
+        String(args[0]).includes('oversized'),
+      );
+      expect(oversizedWarns).toHaveLength(1);
+      expect(String(oversizedWarns[0][0])).toContain('2 oversized inline image payloads');
+      expect(String(oversizedWarns[0][0])).toContain(String(MAX_INLINE_IMAGE_DECODED_BYTES));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test('whiteboard slides convert with bounded concurrency (batch 4)', async () => {

--- a/tests/media/convert-inline-image-assets.test.ts
+++ b/tests/media/convert-inline-image-assets.test.ts
@@ -4,7 +4,10 @@ import type { AssetMeta } from '@openmaic/dsl';
 import {
   convertInlineImageAssets,
   decodeInlineImageDataUrl,
+  INLINE_IMAGE_SLIDE_CONCURRENCY,
+  InlineImageConversionAbortedError,
   type InlineImageConversionDeps,
+  MAX_INLINE_IMAGE_PAYLOAD_BYTES,
 } from '@/lib/media/convert-inline-image-assets';
 import { buildStageAssetReclamationPlan } from '@/lib/media/reclaim-stage-assets';
 import { collectStageAssetRefs } from '@/lib/media/collect-stage-asset-refs';
@@ -117,6 +120,28 @@ describe('decodeInlineImageDataUrl', () => {
     expect(decodeInlineImageDataUrl('data:text/plain;base64,AAAA')).toBeNull();
     expect(decodeInlineImageDataUrl('data:image/png;base64,!!!not-base64!!!')).toBeNull();
     expect(decodeInlineImageDataUrl('https://example.com/i.png')).toBeNull();
+  });
+
+  test('the ;base64 marker follows the fetch spec: case- and space-tolerant, final parameter only', () => {
+    const payload = btoa('round-trip');
+    // Every casing/space variant the fetch spec accepts decodes as base64 and
+    // round-trips byte-exact.
+    for (const marker of [';base64', ';BASE64', ';BaSe64', '; base64', ';  base64']) {
+      const decoded = decodeInlineImageDataUrl(`data:image/png${marker},${payload}`);
+      expect(decoded).not.toBeNull();
+      expect(decoded?.mimeType).toBe('image/png');
+      expect(new TextDecoder().decode(decoded?.bytes)).toBe('round-trip');
+    }
+    // A ;base64 that is NOT the final parameter is not a marker: the browser
+    // percent-decodes the body and the image is broken either way, so the
+    // value is conservatively kept rather than decoded on a guess.
+    expect(decodeInlineImageDataUrl(`data:image/png;base64;charset=utf-8,${payload}`)).toBeNull();
+    // Percent-encoded without a marker still converts via the percent path.
+    const percent = decodeInlineImageDataUrl(
+      `data:image/png;charset=utf-8,${encodeURIComponent('<svg/>')}`,
+    );
+    expect(percent).not.toBeNull();
+    expect(new TextDecoder().decode(percent?.bytes)).toBe('<svg/>');
   });
 });
 
@@ -483,6 +508,235 @@ describe('inline base64 image conversion', () => {
     expect((convertedScene.whiteboards?.[0].elements[0] as { src: string }).src).toMatch(
       /^ast_test_/,
     );
+  });
+
+  test('fetch-spec ;base64 marker variants convert and round-trip byte-exact', async () => {
+    const { pool, deps } = makeHarness();
+    const payload = 'round-trip-bytes';
+    const variants = [
+      `data:image/png;base64,${btoa(payload)}`,
+      `data:image/png;BASE64,${btoa(payload)}`,
+      `data:image/png;BaSe64,${btoa(payload)}`,
+      `data:image/png; base64,${btoa(payload)}`,
+      `data:image/png;  base64,${btoa(payload)}`,
+    ];
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          variants.map((src, index) => imageElement(src, `el${index}`)),
+        ),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    // All five variants decode the same bytes → one allocation, five refs.
+    expect(result.changed).toBe(true);
+    expect(pool.size).toBe(1);
+    const [assetId] = [...pool.keys()];
+    expect(await pool.get(assetId)?.blob.text()).toBe(payload);
+    expect(canvasElements(result.document).map((el) => el.src)).toEqual(
+      variants.map(() => assetId),
+    );
+    expect(result.report.converted).toBe(5);
+  });
+
+  test('a ;base64 that is not the final parameter is kept, never converted', async () => {
+    const { pool, deps } = makeHarness();
+    const src = `data:image/png;base64;charset=utf-8,${btoa('not-this')}`;
+    const doc = document({ scenes: [slideScene([], [imageElement(src)])] });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(result.report.kept).toBe(1);
+    expect(pool.size).toBe(0);
+  });
+
+  test('an unavailable content digest degrades the pass to a no-op with one warn', async () => {
+    const { pool, deps } = makeHarness();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      // A non-secure context / older webview: crypto.subtle is undefined and
+      // the default digest throws TypeError on first use.
+      const unavailableDeps: InlineImageConversionDeps = {
+        ...deps,
+        digest: async () => {
+          throw new TypeError('crypto.subtle is undefined');
+        },
+      };
+      const doc = document({
+        scenes: [
+          slideScene([], [imageElement(pngDataUrl('a'), 'a'), imageElement(pngDataUrl('b'), 'b')]),
+        ],
+      });
+
+      const result = await convertInlineImageAssets(doc, unavailableDeps);
+
+      expect(result.changed).toBe(false);
+      expect(result.document).toBe(doc);
+      expect(result.report.converted).toBe(0);
+      expect(result.report.ingested).toBe(0);
+      expect(result.report.kept).toBe(2);
+      expect(result.allocatedIds).toEqual([]);
+      expect(pool.size).toBe(0);
+      const digestWarns = warnSpy.mock.calls.filter((args) =>
+        String(args[0]).includes('digest unavailable'),
+      );
+      expect(digestWarns).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('a mid-run digest failure keeps that slot inline and the pass continues', async () => {
+    const { pool, deps } = makeHarness();
+    const failingDigest: InlineImageConversionDeps['digest'] = async (bytes) => {
+      const hex = bytesToHex(bytes);
+      if (hex === bytesToHex(new TextEncoder().encode('boom'))) throw new Error('digest hiccup');
+      return hex;
+    };
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          [
+            imageElement(pngDataUrl('ok-1'), 'a'),
+            imageElement(pngDataUrl('boom'), 'b'),
+            imageElement(pngDataUrl('ok-2'), 'c'),
+          ],
+        ),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, { ...deps, digest: failingDigest });
+
+    expect(result.changed).toBe(true);
+    expect(result.report.converted).toBe(2);
+    expect(result.report.kept).toBe(1);
+    const srcs = canvasElements(result.document).map((el) => el.src);
+    expect(srcs[0]).toMatch(/^ast_test_/);
+    expect(srcs[1]).toBe(pngDataUrl('boom'));
+    expect(srcs[2]).toMatch(/^ast_test_/);
+    expect(pool.size).toBe(2);
+  });
+
+  test('zero-byte payloads stay inline: no allocation, no compatibility row', async () => {
+    const { pool, mediaRows, deps } = makeHarness();
+    const doc = document({
+      scenes: [
+        slideScene([], [imageElement('data:image/png;base64,'), imageElement('data:image/png,')]),
+      ],
+    });
+
+    const result = await convertInlineImageAssets(doc, deps);
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(result.report.kept).toBe(2);
+    expect(pool.size).toBe(0);
+    expect(mediaRows.size).toBe(0);
+  });
+
+  test('an abort mid-pass stops the pass immediately and the ledger carries exactly the pre-abort allocations', async () => {
+    const { pool, deps } = makeHarness();
+    const ledger: string[] = [];
+    let digestCalls = 0;
+    let putAssetCalls = 0;
+    const countingDeps: InlineImageConversionDeps = {
+      ...deps,
+      digest: async (bytes) => {
+        digestCalls += 1;
+        return bytesToHex(bytes);
+      },
+      putAsset: async (blob, meta) => {
+        putAssetCalls += 1;
+        const id = `ast_test_${(allocationCounter += 1)}`;
+        pool.set(id, { blob, meta });
+        return id;
+      },
+    };
+    // Liveness holds for the slide-start check and slot 1's commit boundary,
+    // then fails at slot 2's commit boundary — after slot 2's bytes were
+    // ingested but before its mirror write.
+    let livenessCalls = 0;
+    const shouldContinue = () => ++livenessCalls < 3;
+    const doc = document({
+      scenes: [
+        slideScene(
+          [],
+          [
+            imageElement(pngDataUrl('one'), 'a'),
+            imageElement(pngDataUrl('two'), 'b'),
+            imageElement(pngDataUrl('three'), 'c'),
+          ],
+        ),
+      ],
+    });
+
+    await expect(
+      convertInlineImageAssets(doc, countingDeps, shouldContinue, ledger),
+    ).rejects.toThrow(InlineImageConversionAbortedError);
+
+    // Slot 3 was never touched: the abort stopped the pass immediately.
+    expect(digestCalls).toBe(3); // availability probe + slot 1 + slot 2
+    expect(putAssetCalls).toBe(2); // slot 1 + slot 2 (slot 2's putAsset precedes its commit check)
+    expect(ledger).toHaveLength(2); // exactly the pre-abort allocations
+    expect(pool.size).toBe(1); // slot 2's allocation was compensated on abort
+    // The input document is never mutated even by the aborted pass.
+    expect(canvasElements(doc)[0].src).toBe(pngDataUrl('one'));
+  });
+
+  test('an oversized inline payload is kept without decoding', async () => {
+    const { pool, deps } = makeHarness();
+    let digestCalls = 0;
+    const countingDeps: InlineImageConversionDeps = {
+      ...deps,
+      digest: async (bytes) => {
+        digestCalls += 1;
+        return bytesToHex(bytes);
+      },
+    };
+    const oversized = `data:image/png;base64,${'A'.repeat(MAX_INLINE_IMAGE_PAYLOAD_BYTES + 1)}`;
+    const doc = document({ scenes: [slideScene([], [imageElement(oversized)])] });
+
+    const result = await convertInlineImageAssets(doc, countingDeps);
+
+    expect(result.changed).toBe(false);
+    expect(result.document).toBe(doc);
+    expect(result.report.kept).toBe(1);
+    expect(pool.size).toBe(0);
+    // The pre-decode gate fired: no digest — and so no decode — was attempted.
+    expect(digestCalls).toBe(0);
+  });
+
+  test('whiteboard slides convert with bounded concurrency (batch 4)', async () => {
+    const { pool, deps } = makeHarness();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const slowDigest: InlineImageConversionDeps['digest'] = async (bytes) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return bytesToHex(bytes);
+    };
+    const slides = Array.from({ length: 9 }, (_, index) => ({
+      id: `wb-${index}`,
+      elements: [imageElement(pngDataUrl(`img-${index}`), `el-${index}`)],
+    }));
+    const doc = document({
+      stage: stage({ whiteboard: slides as unknown as Stage['whiteboard'] }),
+    });
+
+    const result = await convertInlineImageAssets(doc, { ...deps, digest: slowDigest });
+
+    expect(result.changed).toBe(true);
+    expect(result.report.converted).toBe(9);
+    expect(pool.size).toBe(9);
+    expect(maxInFlight).toBeLessThanOrEqual(INLINE_IMAGE_SLIDE_CONCURRENCY);
   });
 });
 


### PR DESCRIPTION
## Summary

Part 4 of RFC #1153 — the last delivery-plan item: a lazy converter in the #1101 mold that, on document load, rewrites inline base64 image `src` values into pool-backed allocated ids. Pre-part-2 documents carry source images as inline data URLs (the same image on five slides is stored five times, and every load/save moves those bytes through the document store); after conversion the bytes live once in the asset pool and the document carries ids. Pure slimming: no DSL version bump is needed because the slot type already admits both shapes — data URLs are concrete addresses, ids resolve through the pool (part 2's model) — so an unconverted document stays fully valid.

## Related Issues

Part 4 of #1153 (delivery plan). Mirrors the #1101 converter's structure and reuses its narrowed load+save window, orphan-rollback ledger, and load-path hooks (migration + classroom fetch, running after the reference converter).

## Changes

- **`lib/media/convert-inline-image-assets.ts`** (new): enumerates every slide media slot via `slideMediaReferenceSlots` (canvas images, whiteboards, backgrounds, video posters); converts only unambiguous `data:image/*` values — the `;base64` marker is detected per the fetch spec (case-insensitive, space-tolerant, final-parameter-only), and the converter's accept set is a proven strict subset of the browser's, so every divergence lands on "keep inline", never on a wrong decode path. Zero-byte and oversized payloads (estimated decoded bytes over the shared 50 MB bound, checked before decoding) stay inline.
- **Dedup and accounting**: one allocation per sha256 of the decoded bytes (identical images across slides — even across encodings — collapse to one registry entry); pool write → Dexie compatibility mirror → document rewrite, with each failure point releasing exactly what it allocated and clearing the in-flight memo so sibling slots retry; fresh allocations ride the shared conversion ledger so a failed save-back or superseded load rolls everything back through the existing helper.
- **Bounded work**: a 15 s aggregate budget per pass (expiry keeps progress; the next open continues — including for classroom documents, which now re-run the pass on every open like the migration path), bounded whiteboard concurrency, and immediate abort propagation when a load is superseded.
- **Degradation**: `crypto.subtle` unavailable (non-secure contexts) → the pass is a no-op with one warning, per-pass, never a failed load.
- **Reclaim parity**: converted ids are stage-referenced assets — enumerated, reference-counted, and reclaimed on stage deletion exactly like part-2's id-addressed images (the Dexie mirror row carries the reclamation).
- **Tests**: 40 across a unit suite (fetch-spec marker matrix incl. safe-direction shapes, dedup/encoding collapse, budget, abort, failure accounting, idempotency, non-target shapes untouched) and a wiring suite against the real pool + real Dexie (save-back window, rollback, deletion reclaim, classroom birth + retry paths).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Verification

### Steps to reproduce / test

1. `pnpm check` / `pnpm lint` (0 errors) / `tsc --noEmit` / full vitest (5290 passed) / `pnpm build` — all green (Node 22).
2. Open a pre-part-2 document with repeated inline images: after load, `PPTImageElement.src` values are allocated ids, the pool holds one entry per unique image, and a second open is a no-op (no save).
3. Kill the pool mid-conversion: the document keeps its inline values for the failed slots and converts them on the next open.

### Review notes (verified during an adversarial pass, recorded to save re-derivation)

- Two-tab concurrent conversion is safe: id spaces are disjoint, the reload-before-save re-converts on top of the winner, and a losing tab's rollback can only touch its own allocations.
- Converting an SVG data URL does not change its security context (both shapes feed the same `<img src>` sink, scripts inert either way).
- Slot pairs (video src/mediaRef/poster) cannot half-convert; `shape.pattern` is not enumerated and deliberately stays inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
