### PR TITLE
feat(whiteboard): add destructive runtime operations

### DIFF
--- a/.github/workflows/storage-pg-contract.yml
+++ b/.github/workflows/storage-pg-contract.yml
@@ -62,3 +62,6 @@ jobs:
             --outputFile.json="$STORAGE_VITEST_RESULTS"
           node scripts/assert-pg-contract-suites.mjs "$STORAGE_VITEST_RESULTS" \
             --baseline "$STORAGE_PG_BASELINE"
+
+      - name: Whiteboard RuntimeStore PostgreSQL app-domain contract
+        run: pnpm exec vitest run tests/lib/whiteboard/runtime-store.pg.test.ts

--- a/lib/chat/pi/tools/native-whiteboard.ts
+++ b/lib/chat/pi/tools/native-whiteboard.ts
@@ -181,6 +181,9 @@ const SafeWhiteboardIdentifier = Type.String({
   maxLength: 512,
   pattern: '^[^\\x00-\\x1f\\x7f\\u2028\\u2029]+$',
 });
+// CodeLine.id is a plain string in the persisted DSL contract. Keep target IDs compatible with
+// every readable legacy line while retaining strict host-owned IDs for newly written lines.
+const ExistingWhiteboardCodeLineId = Type.String();
 const NativeWhiteboardDeleteParams = Type.Object(
   {
     expectedLastSeq: ExpectedLastSeq,
@@ -199,7 +202,7 @@ const NativeWhiteboardEditCodeParams = Type.Union(
         expectedLastSeq: ExpectedLastSeq,
         elementId: SafeWhiteboardIdentifier,
         operation: Type.Literal('insert_after'),
-        lineId: SafeWhiteboardIdentifier,
+        lineId: ExistingWhiteboardCodeLineId,
         content: Type.String({ minLength: 1 }),
       },
       { additionalProperties: false },
@@ -209,7 +212,7 @@ const NativeWhiteboardEditCodeParams = Type.Union(
         expectedLastSeq: ExpectedLastSeq,
         elementId: SafeWhiteboardIdentifier,
         operation: Type.Literal('insert_before'),
-        lineId: SafeWhiteboardIdentifier,
+        lineId: ExistingWhiteboardCodeLineId,
         content: Type.String({ minLength: 1 }),
       },
       { additionalProperties: false },
@@ -219,7 +222,7 @@ const NativeWhiteboardEditCodeParams = Type.Union(
         expectedLastSeq: ExpectedLastSeq,
         elementId: SafeWhiteboardIdentifier,
         operation: Type.Literal('delete_lines'),
-        lineIds: Type.Array(SafeWhiteboardIdentifier, { minItems: 1, uniqueItems: true }),
+        lineIds: Type.Array(ExistingWhiteboardCodeLineId, { minItems: 1, uniqueItems: true }),
       },
       { additionalProperties: false },
     ),
@@ -228,7 +231,7 @@ const NativeWhiteboardEditCodeParams = Type.Union(
         expectedLastSeq: ExpectedLastSeq,
         elementId: SafeWhiteboardIdentifier,
         operation: Type.Literal('replace_lines'),
-        lineIds: Type.Array(SafeWhiteboardIdentifier, { minItems: 1, uniqueItems: true }),
+        lineIds: Type.Array(ExistingWhiteboardCodeLineId, { minItems: 1, uniqueItems: true }),
         content: Type.String({ minLength: 1 }),
       },
       { additionalProperties: false },
@@ -577,10 +580,18 @@ function codeLines(
   invocationDigest: string,
   reusableLineIds: readonly string[] = [],
 ): CodeLine[] {
-  return content.split('\n').map((lineContent, index) => ({
-    id: reusableLineIds[index] ?? `native-wb-code-line:${invocationDigest}:${index}`,
-    content: lineContent,
-  }));
+  return content.split('\n').map((lineContent, index) => {
+    const reusableLineId = reusableLineIds[index];
+    const canReuse =
+      reusableLineId !== undefined &&
+      reusableLineId.length > 0 &&
+      reusableLineId.length <= 512 &&
+      !/[\u0000-\u001f\u007f\u2028\u2029]/u.test(reusableLineId);
+    return {
+      id: canReuse ? reusableLineId : `native-wb-code-line:${invocationDigest}:${index}`,
+      content: lineContent,
+    };
+  });
 }
 
 function codeEditAffected(elementId: string, edit: WhiteboardCodeLinesEdit): MutationAffected {

--- a/lib/chat/pi/tools/native-whiteboard.ts
+++ b/lib/chat/pi/tools/native-whiteboard.ts
@@ -1,4 +1,5 @@
 import type {
+  CodeLine,
   PPTChartElement,
   PPTCodeElement,
   PPTElement,
@@ -23,6 +24,14 @@ import {
 } from '@/lib/whiteboard/runtime/store';
 import {
   WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
+  WhiteboardRuntimeCodeLineIdConflictError,
+  WhiteboardRuntimeCodeLineNotFoundError,
+  WhiteboardRuntimeElementNotFoundError,
+  WhiteboardRuntimeElementTypeMismatchError,
+  WhiteboardRuntimeNoChangeError,
+  type FoldedWhiteboardRuntimeState,
+  type WhiteboardCodeLinesEdit,
+  type WhiteboardRuntimeOperationV1,
   type WhiteboardRuntimePayloadV1,
 } from '@/lib/whiteboard/runtime/types';
 import { queryWhiteboardVisibility } from '../whiteboard-visibility';
@@ -167,6 +176,66 @@ const NativeWhiteboardDrawCodeParams = Type.Object(
   },
   { additionalProperties: false },
 );
+const SafeWhiteboardIdentifier = Type.String({
+  minLength: 1,
+  maxLength: 512,
+  pattern: '^[^\\x00-\\x1f\\x7f\\u2028\\u2029]+$',
+});
+const NativeWhiteboardDeleteParams = Type.Object(
+  {
+    expectedLastSeq: ExpectedLastSeq,
+    elementId: SafeWhiteboardIdentifier,
+  },
+  { additionalProperties: false },
+);
+const NativeWhiteboardClearParams = Type.Object(
+  { expectedLastSeq: ExpectedLastSeq },
+  { additionalProperties: false },
+);
+const NativeWhiteboardEditCodeParams = Type.Union(
+  [
+    Type.Object(
+      {
+        expectedLastSeq: ExpectedLastSeq,
+        elementId: SafeWhiteboardIdentifier,
+        operation: Type.Literal('insert_after'),
+        lineId: SafeWhiteboardIdentifier,
+        content: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        expectedLastSeq: ExpectedLastSeq,
+        elementId: SafeWhiteboardIdentifier,
+        operation: Type.Literal('insert_before'),
+        lineId: SafeWhiteboardIdentifier,
+        content: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        expectedLastSeq: ExpectedLastSeq,
+        elementId: SafeWhiteboardIdentifier,
+        operation: Type.Literal('delete_lines'),
+        lineIds: Type.Array(SafeWhiteboardIdentifier, { minItems: 1, uniqueItems: true }),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        expectedLastSeq: ExpectedLastSeq,
+        elementId: SafeWhiteboardIdentifier,
+        operation: Type.Literal('replace_lines'),
+        lineIds: Type.Array(SafeWhiteboardIdentifier, { minItems: 1, uniqueItems: true }),
+        content: Type.String({ minLength: 1 }),
+      },
+      { additionalProperties: false },
+    ),
+  ],
+  { type: 'object' },
+);
 
 type EmptyParams = Static<typeof EmptyParams>;
 type NativeWhiteboardDrawTextParams = Static<typeof NativeWhiteboardDrawTextParams>;
@@ -176,6 +245,9 @@ type NativeWhiteboardDrawLatexParams = Static<typeof NativeWhiteboardDrawLatexPa
 type NativeWhiteboardDrawTableParams = Static<typeof NativeWhiteboardDrawTableParams>;
 type NativeWhiteboardDrawLineParams = Static<typeof NativeWhiteboardDrawLineParams>;
 type NativeWhiteboardDrawCodeParams = Static<typeof NativeWhiteboardDrawCodeParams>;
+type NativeWhiteboardDeleteParams = Static<typeof NativeWhiteboardDeleteParams>;
+type NativeWhiteboardClearParams = Static<typeof NativeWhiteboardClearParams>;
+type NativeWhiteboardEditCodeParams = Static<typeof NativeWhiteboardEditCodeParams>;
 
 const DRAW_TEXT_KEYS = new Set([
   'expectedLastSeq',
@@ -238,6 +310,16 @@ const DRAW_CODE_KEYS = new Set([
   'height',
   'fileName',
 ]);
+const DELETE_KEYS = new Set(['expectedLastSeq', 'elementId']);
+const CLEAR_KEYS = new Set(['expectedLastSeq']);
+const EDIT_CODE_KEYS = new Set([
+  'expectedLastSeq',
+  'elementId',
+  'operation',
+  'lineId',
+  'lineIds',
+  'content',
+]);
 
 const SHAPE_PATHS = {
   rectangle: 'M 0 0 L 1000 0 L 1000 1000 L 0 1000 Z',
@@ -256,6 +338,9 @@ export const NATIVE_WHITEBOARD_ACTION_NAMES = [
   'wb_draw_table',
   'wb_draw_line',
   'wb_draw_code',
+  'wb_delete',
+  'wb_clear',
+  'wb_edit_code',
   'wb_close',
 ] as const;
 const NATIVE_WHITEBOARD_ACTION_SET = new Set<string>(NATIVE_WHITEBOARD_ACTION_NAMES);
@@ -358,30 +443,26 @@ type NativeWhiteboardToolOptions = {
 };
 
 type ElementMutationParams = { expectedLastSeq: number | null };
+type MutationAffected = Record<string, unknown>;
 
-async function commitElementMutation(
+async function settleWhiteboardMutation(
   opts: NativeWhiteboardToolOptions,
   expectedLastSeq: number | null,
-  element: PPTElement,
-  invocationDigest: string,
+  payload: WhiteboardRuntimePayloadV1,
+  affectedFromCommittedState: (
+    state: FoldedWhiteboardRuntimeState,
+    replayed: boolean,
+  ) => MutationAffected | null,
   signal?: AbortSignal,
 ): Promise<AgentToolResult<unknown>> {
-  const payload: WhiteboardRuntimePayloadV1 = {
-    payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
-    operationId: `native-wb-operation:${invocationDigest}`,
-    operation: { kind: 'element_added', element },
-  };
-
   const committedResult = async (
     committedSeq: number,
-    state: Awaited<ReturnType<WhiteboardRuntimeService['read']>>,
+    state: FoldedWhiteboardRuntimeState,
     replayed: boolean,
   ): Promise<AgentToolResult<unknown>> => {
     if (signal?.aborted) throw abortReason(signal);
-    const affected = state.whiteboard?.elements.find(
-      (candidate) => candidate.id === element.id && candidate.type === element.type,
-    );
-    if (!affected || state.lastSeq === null) {
+    const affected = affectedFromCommittedState(state, replayed);
+    if (affected === null || state.lastSeq === null) {
       return failedResult(
         'WHITEBOARD_RUNTIME_POST_COMMIT_VERIFICATION_FAILED',
         'Whiteboard commit verification failed; the commit outcome may be uncertain. Read before any further mutation.',
@@ -399,7 +480,7 @@ async function commitElementMutation(
       committedSeq,
       lastSeq: state.lastSeq,
       replayed,
-      affected: { element: affected },
+      affected,
     };
     return textResult(JSON.stringify(result), { ...result, dispatchedAction: true });
   };
@@ -432,6 +513,38 @@ async function commitElementMutation(
         'Whiteboard session state violates the runtime invariant.',
       );
     }
+    if (error instanceof WhiteboardRuntimeElementNotFoundError) {
+      return failedResult('WHITEBOARD_ELEMENT_NOT_FOUND', error.message, {
+        elementId: error.elementId,
+      });
+    }
+    if (error instanceof WhiteboardRuntimeElementTypeMismatchError) {
+      return failedResult('WHITEBOARD_ELEMENT_TYPE_MISMATCH', error.message, {
+        elementId: error.elementId,
+        expectedType: error.expectedType,
+        actualType: error.actualType,
+      });
+    }
+    if (error instanceof WhiteboardRuntimeCodeLineNotFoundError) {
+      return failedResult('WHITEBOARD_CODE_LINE_NOT_FOUND', error.message, {
+        elementId: error.elementId,
+        lineId: error.lineId,
+      });
+    }
+    if (error instanceof WhiteboardRuntimeCodeLineIdConflictError) {
+      return failedResult('WHITEBOARD_CODE_LINE_ID_CONFLICT', error.message, {
+        elementId: error.elementId,
+        lineId: error.lineId,
+      });
+    }
+    if (error instanceof WhiteboardRuntimeNoChangeError) {
+      const result = {
+        noOp: true,
+        lastSeq: error.state?.lastSeq ?? expectedLastSeq,
+        affected: { cleared: false },
+      };
+      return textResult(JSON.stringify(result), result);
+    }
     try {
       const reconciled = await opts.service.reconcileOperation(opts.stageId, payload);
       if (signal?.aborted) throw abortReason(signal);
@@ -442,10 +555,43 @@ async function commitElementMutation(
       if (isAbort(reconciliationError, signal)) throw abortReason(signal);
     }
     return failedResult(
-      'WHITEBOARD_MUTATION_FAILED',
-      'Whiteboard mutation outcome could not be confirmed. Read before any further mutation.',
+      'WHITEBOARD_MUTATION_UNCERTAIN',
+      'Whiteboard mutation outcome could not be confirmed. Call wb_read before any further mutation.',
     );
   }
+}
+
+function runtimePayload(
+  invocationDigest: string,
+  operation: WhiteboardRuntimeOperationV1,
+): WhiteboardRuntimePayloadV1 {
+  return {
+    payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
+    operationId: `native-wb-operation:${invocationDigest}`,
+    operation,
+  };
+}
+
+function codeLines(
+  content: string,
+  invocationDigest: string,
+  reusableLineIds: readonly string[] = [],
+): CodeLine[] {
+  return content.split('\n').map((lineContent, index) => ({
+    id: reusableLineIds[index] ?? `native-wb-code-line:${invocationDigest}:${index}`,
+    content: lineContent,
+  }));
+}
+
+function codeEditAffected(elementId: string, edit: WhiteboardCodeLinesEdit): MutationAffected {
+  const targetLineIds = 'lineId' in edit ? [edit.lineId] : edit.lineIds;
+  const resultLineIds = 'lines' in edit ? edit.lines.map((line) => line.id) : [];
+  return {
+    elementId,
+    operation: edit.kind,
+    targetLineIds,
+    resultLineIds,
+  };
 }
 
 function elementMutationTool<TParams extends ElementMutationParams>(
@@ -479,7 +625,19 @@ function elementMutationTool<TParams extends ElementMutationParams>(
           'Whiteboard element construction failed; no mutation was accepted.',
         );
       }
-      return commitElementMutation(opts, params.expectedLastSeq, element, invocationDigest, signal);
+      const payload = runtimePayload(invocationDigest, { kind: 'element_added', element });
+      return settleWhiteboardMutation(
+        opts,
+        params.expectedLastSeq,
+        payload,
+        (state) => {
+          const affected = state.whiteboard?.elements.find(
+            (candidate) => candidate.id === element.id && candidate.type === element.type,
+          );
+          return affected ? { element: affected } : null;
+        },
+        signal,
+      );
     },
   };
 }
@@ -830,6 +988,112 @@ export function buildNativeWhiteboardTools(opts: NativeWhiteboardToolOptions): A
         }),
       }),
     );
+  }
+
+  if (allowed.has('wb_delete')) {
+    tools.push({
+      name: 'wb_delete',
+      label: 'Delete whiteboard element',
+      description:
+        'Delete exactly one element selected by elementId from the latest wb_read result. Copy nextMutation.expectedLastSeq exactly. This durable mutation works while the whiteboard is closed and never changes visibility.',
+      parameters: NativeWhiteboardDeleteParams,
+      executionMode: 'sequential',
+      prepareArguments: (args) =>
+        strictArguments<NativeWhiteboardDeleteParams>(
+          NativeWhiteboardDeleteParams,
+          args,
+          DELETE_KEYS,
+        ),
+      execute: async (toolCallId, rawParams, signal) => {
+        if (signal?.aborted) throw abortReason(signal);
+        const params = rawParams as NativeWhiteboardDeleteParams;
+        const invocationDigest = logicalInvocationDigest(opts.messageId, toolCallId);
+        return settleWhiteboardMutation(
+          opts,
+          params.expectedLastSeq,
+          runtimePayload(invocationDigest, {
+            kind: 'element_deleted',
+            elementId: params.elementId,
+          }),
+          () => ({ elementId: params.elementId }),
+          signal,
+        );
+      },
+    });
+  }
+
+  if (allowed.has('wb_clear')) {
+    tools.push({
+      name: 'wb_clear',
+      label: 'Clear whiteboard elements',
+      description:
+        'Remove all elements while preserving the authoritative whiteboard and its metadata. Copy nextMutation.expectedLastSeq exactly. A missing or already-empty board is a successful no-op with no projection, and this tool never changes visibility.',
+      parameters: NativeWhiteboardClearParams,
+      executionMode: 'sequential',
+      prepareArguments: (args) =>
+        strictArguments<NativeWhiteboardClearParams>(NativeWhiteboardClearParams, args, CLEAR_KEYS),
+      execute: async (toolCallId, rawParams, signal) => {
+        if (signal?.aborted) throw abortReason(signal);
+        const params = rawParams as NativeWhiteboardClearParams;
+        const invocationDigest = logicalInvocationDigest(opts.messageId, toolCallId);
+        return settleWhiteboardMutation(
+          opts,
+          params.expectedLastSeq,
+          runtimePayload(invocationDigest, { kind: 'elements_cleared' }),
+          () => ({ cleared: true }),
+          signal,
+        );
+      },
+    });
+  }
+
+  if (allowed.has('wb_edit_code')) {
+    tools.push({
+      name: 'wb_edit_code',
+      label: 'Edit whiteboard code lines',
+      description:
+        'Insert, delete, or replace lines in one code element using element and line IDs from the latest wb_read result. Copy nextMutation.expectedLastSeq exactly. Content may contain blank lines. This durable mutation works while closed and never changes visibility.',
+      parameters: NativeWhiteboardEditCodeParams,
+      executionMode: 'sequential',
+      prepareArguments: (args) =>
+        strictArguments<NativeWhiteboardEditCodeParams>(
+          NativeWhiteboardEditCodeParams,
+          args,
+          EDIT_CODE_KEYS,
+        ),
+      execute: async (toolCallId, rawParams, signal) => {
+        if (signal?.aborted) throw abortReason(signal);
+        const params = rawParams as NativeWhiteboardEditCodeParams;
+        const invocationDigest = logicalInvocationDigest(opts.messageId, toolCallId);
+        let edit: WhiteboardCodeLinesEdit;
+        if (params.operation === 'insert_after' || params.operation === 'insert_before') {
+          edit = {
+            kind: params.operation,
+            lineId: params.lineId,
+            lines: codeLines(params.content, invocationDigest),
+          };
+        } else if (params.operation === 'delete_lines') {
+          edit = { kind: params.operation, lineIds: params.lineIds };
+        } else {
+          edit = {
+            kind: params.operation,
+            lineIds: params.lineIds,
+            lines: codeLines(params.content, invocationDigest, params.lineIds),
+          };
+        }
+        return settleWhiteboardMutation(
+          opts,
+          params.expectedLastSeq,
+          runtimePayload(invocationDigest, {
+            kind: 'code_lines_edited',
+            elementId: params.elementId,
+            edit,
+          }),
+          () => codeEditAffected(params.elementId, edit),
+          signal,
+        );
+      },
+    });
   }
 
   if (hasMutation || allowed.has('wb_close')) tools.push(effectTool('wb_close'));

--- a/lib/chat/pi/tools/native-whiteboard.ts
+++ b/lib/chat/pi/tools/native-whiteboard.ts
@@ -630,7 +630,8 @@ function elementMutationTool<TParams extends ElementMutationParams>(
         opts,
         params.expectedLastSeq,
         payload,
-        (state) => {
+        (state, replayed) => {
+          if (replayed) return { element };
           const affected = state.whiteboard?.elements.find(
             (candidate) => candidate.id === element.id && candidate.type === element.type,
           );

--- a/lib/whiteboard/runtime/fold.ts
+++ b/lib/whiteboard/runtime/fold.ts
@@ -113,8 +113,23 @@ export async function applyWhiteboardRuntimeOperation(
     throw new WhiteboardRuntimeCodeLineNotFoundError(snapshot.elementId, missingLineId);
   }
 
+  const assertIntroducedLineIdsDoNotConflict = (
+    retainedLines: readonly CodeLine[],
+    introducedLines: readonly CodeLine[],
+  ): void => {
+    const retainedIds = new Set(retainedLines.map((line) => line.id));
+    const introducedIds = new Set<string>();
+    for (const line of introducedLines) {
+      if (retainedIds.has(line.id) || introducedIds.has(line.id)) {
+        throw new WhiteboardRuntimeCodeLineIdConflictError(snapshot.elementId, line.id);
+      }
+      introducedIds.add(line.id);
+    }
+  };
+
   let editedLines: CodeLine[];
   if ('lineId' in edit) {
+    assertIntroducedLineIdsDoNotConflict(lines, edit.lines);
     editedLines = [...lines];
     const referenceIndex = editedLines.findIndex((line) => line.id === edit.lineId);
     editedLines.splice(
@@ -131,15 +146,8 @@ export async function applyWhiteboardRuntimeOperation(
     const firstIndex = lines.findIndex((line) => line.id === edit.lineIds[0]);
     const replaced = new Set(edit.lineIds);
     editedLines = lines.filter((line) => !replaced.has(line.id));
+    assertIntroducedLineIdsDoNotConflict(editedLines, edit.lines);
     editedLines.splice(firstIndex, 0, ...edit.lines);
-  }
-
-  const resultingIds = new Set<string>();
-  for (const line of editedLines) {
-    if (resultingIds.has(line.id)) {
-      throw new WhiteboardRuntimeCodeLineIdConflictError(snapshot.elementId, line.id);
-    }
-    resultingIds.add(line.id);
   }
   const editedElement = { ...element, lines: editedLines };
   const normalizedElement = normalizeAndValidateWhiteboardElement(editedElement);

--- a/lib/whiteboard/runtime/fold.ts
+++ b/lib/whiteboard/runtime/fold.ts
@@ -1,13 +1,29 @@
-import { validateRuntimeRecord, type RuntimeRecord, type Whiteboard } from '@openmaic/dsl';
+import {
+  validateRuntimeRecord,
+  type CodeLine,
+  type RuntimeRecord,
+  type Whiteboard,
+} from '@openmaic/dsl';
 
 import {
+  WhiteboardRuntimeCodeLineIdConflictError,
+  WhiteboardRuntimeCodeLineNotFoundError,
+  WhiteboardRuntimeElementNotFoundError,
+  WhiteboardRuntimeElementTypeMismatchError,
+  WhiteboardRuntimeNoChangeError,
   type FoldedWhiteboardRuntimeDetails,
   type FoldedWhiteboardRuntimeState,
   type Sha256Digest,
   type WhiteboardRuntimeOperationV1,
   type WhiteboardRuntimePayloadV1,
 } from './types';
-import { assertWhiteboardRuntimePayload, cloneCanonicalJson, sha256Canonical } from './validate';
+import {
+  assertWhiteboardRuntimePayload,
+  canonicalJson,
+  cloneCanonicalJson,
+  normalizeAndValidateWhiteboardElement,
+  sha256Canonical,
+} from './validate';
 
 function immutableClone<T>(value: T): T {
   const cloned = cloneCanonicalJson(value);
@@ -41,23 +57,98 @@ export async function applyWhiteboardRuntimeOperation(
     return immutableClone(snapshot.whiteboard);
   }
 
-  if (current?.elements.some((element) => element.id === snapshot.element.id)) {
-    throw new Error('WHITEBOARD_RUNTIME_ELEMENT_ALREADY_EXISTS');
-  }
-  if (current === null) {
+  if (snapshot.kind === 'element_added') {
+    if (current?.elements.some((element) => element.id === snapshot.element.id)) {
+      throw new Error('WHITEBOARD_RUNTIME_ELEMENT_ALREADY_EXISTS');
+    }
+    if (current === null) {
+      return immutableClone({
+        id: await deriveRuntimeWhiteboardId(sessionId),
+        viewportSize: 1000,
+        viewportRatio: 0.5625,
+        elements: [snapshot.element],
+        background: { type: 'solid', color: '#ffffff' },
+        animations: [],
+      });
+    }
     return immutableClone({
-      id: await deriveRuntimeWhiteboardId(sessionId),
-      viewportSize: 1000,
-      viewportRatio: 0.5625,
-      elements: [snapshot.element],
-      background: { type: 'solid', color: '#ffffff' },
-      animations: [],
+      ...current,
+      elements: [...current.elements, snapshot.element],
     });
   }
-  return immutableClone({
-    ...current,
-    elements: [...current.elements, snapshot.element],
-  });
+
+  if (snapshot.kind === 'elements_cleared') {
+    if (current === null) throw new WhiteboardRuntimeNoChangeError('whiteboard_missing');
+    if (current.elements.length === 0) {
+      throw new WhiteboardRuntimeNoChangeError('whiteboard_empty');
+    }
+    return immutableClone({ ...current, elements: [] });
+  }
+
+  if (current === null) {
+    throw new WhiteboardRuntimeElementNotFoundError(snapshot.elementId);
+  }
+  const elementIndex = current.elements.findIndex((element) => element.id === snapshot.elementId);
+  if (elementIndex === -1) {
+    throw new WhiteboardRuntimeElementNotFoundError(snapshot.elementId);
+  }
+
+  if (snapshot.kind === 'element_deleted') {
+    return immutableClone({
+      ...current,
+      elements: current.elements.filter((_element, index) => index !== elementIndex),
+    });
+  }
+
+  const element = current.elements[elementIndex]!;
+  if (element.type !== 'code') {
+    throw new WhiteboardRuntimeElementTypeMismatchError(snapshot.elementId, element.type);
+  }
+  const lines = [...element.lines];
+  const edit = snapshot.edit;
+  const targetLineIds = 'lineId' in edit ? [edit.lineId] : edit.lineIds;
+  const knownLineIds = new Set(lines.map((line) => line.id));
+  const missingLineId = targetLineIds.find((lineId) => !knownLineIds.has(lineId));
+  if (missingLineId !== undefined) {
+    throw new WhiteboardRuntimeCodeLineNotFoundError(snapshot.elementId, missingLineId);
+  }
+
+  let editedLines: CodeLine[];
+  if ('lineId' in edit) {
+    editedLines = [...lines];
+    const referenceIndex = editedLines.findIndex((line) => line.id === edit.lineId);
+    editedLines.splice(
+      edit.kind === 'insert_after' ? referenceIndex + 1 : referenceIndex,
+      0,
+      ...edit.lines,
+    );
+  } else if (edit.kind === 'delete_lines') {
+    const deleted = new Set(edit.lineIds);
+    editedLines = lines.filter((line) => !deleted.has(line.id));
+  } else {
+    // Match the Legacy transition: anchor replacement at the first supplied target ID,
+    // remove all targets, then insert the host-supplied replacement lines exactly.
+    const firstIndex = lines.findIndex((line) => line.id === edit.lineIds[0]);
+    const replaced = new Set(edit.lineIds);
+    editedLines = lines.filter((line) => !replaced.has(line.id));
+    editedLines.splice(firstIndex, 0, ...edit.lines);
+  }
+
+  const resultingIds = new Set<string>();
+  for (const line of editedLines) {
+    if (resultingIds.has(line.id)) {
+      throw new WhiteboardRuntimeCodeLineIdConflictError(snapshot.elementId, line.id);
+    }
+    resultingIds.add(line.id);
+  }
+  const editedElement = { ...element, lines: editedLines };
+  const normalizedElement = normalizeAndValidateWhiteboardElement(editedElement);
+  if (canonicalJson(normalizedElement) !== canonicalJson(editedElement)) {
+    throw new Error('WHITEBOARD_RUNTIME_CODE_ELEMENT_NOT_CANONICAL');
+  }
+  const elements = [...current.elements];
+  elements[elementIndex] = editedElement;
+  return immutableClone({ ...current, elements });
 }
 
 export async function foldWhiteboardRuntimeRecords(

--- a/lib/whiteboard/runtime/store.ts
+++ b/lib/whiteboard/runtime/store.ts
@@ -14,6 +14,7 @@ import {
 } from './fold';
 import {
   WHITEBOARD_RUNTIME_KIND,
+  WhiteboardRuntimeNoChangeError,
   type AppendWhiteboardRecordInput,
   type AppendWhiteboardRecordResult,
   type FoldedWhiteboardRuntimeDetails,
@@ -219,7 +220,17 @@ export function createWhiteboardRuntimeService(
       if (payload.operation.kind === 'legacy_snapshot_imported' && before.lastSeq !== null) {
         throw new Error('WHITEBOARD_RUNTIME_IMPORT_AFTER_STATE');
       }
-      await applyWhiteboardRuntimeOperation(session.id, before.whiteboard, payload.operation);
+      try {
+        await applyWhiteboardRuntimeOperation(session.id, before.whiteboard, payload.operation);
+      } catch (error) {
+        if (error instanceof WhiteboardRuntimeNoChangeError) {
+          throw new WhiteboardRuntimeNoChangeError(
+            error.reason,
+            publicWhiteboardRuntimeState(before),
+          );
+        }
+        throw error;
+      }
 
       let appended: RuntimeRecord;
       try {

--- a/lib/whiteboard/runtime/types.ts
+++ b/lib/whiteboard/runtime/types.ts
@@ -1,4 +1,4 @@
-import type { PPTElement, RuntimeRecord, Whiteboard } from '@openmaic/dsl';
+import type { CodeLine, PPTElement, RuntimeRecord, Whiteboard } from '@openmaic/dsl';
 
 export const WHITEBOARD_RUNTIME_KIND = 'whiteboard';
 export const WHITEBOARD_RUNTIME_PAYLOAD_VERSION = 1;
@@ -21,9 +21,43 @@ export interface WhiteboardElementAddedOperation {
   element: PPTElement;
 }
 
+export interface WhiteboardElementDeletedOperation {
+  kind: 'element_deleted';
+  elementId: string;
+}
+
+export interface WhiteboardElementsClearedOperation {
+  kind: 'elements_cleared';
+}
+
+export type WhiteboardCodeLinesEdit =
+  | {
+      kind: 'insert_after' | 'insert_before';
+      lineId: string;
+      lines: CodeLine[];
+    }
+  | {
+      kind: 'delete_lines';
+      lineIds: string[];
+    }
+  | {
+      kind: 'replace_lines';
+      lineIds: string[];
+      lines: CodeLine[];
+    };
+
+export interface WhiteboardCodeLinesEditedOperation {
+  kind: 'code_lines_edited';
+  elementId: string;
+  edit: WhiteboardCodeLinesEdit;
+}
+
 export type WhiteboardRuntimeOperationV1 =
   | LegacySnapshotImportedOperation
-  | WhiteboardElementAddedOperation;
+  | WhiteboardElementAddedOperation
+  | WhiteboardElementDeletedOperation
+  | WhiteboardElementsClearedOperation
+  | WhiteboardCodeLinesEditedOperation;
 
 export interface WhiteboardRuntimePayloadV1 {
   payloadVersion: typeof WHITEBOARD_RUNTIME_PAYLOAD_VERSION;
@@ -59,6 +93,72 @@ export interface AppendWhiteboardRecordResult {
   committedSeq: number;
   state: FoldedWhiteboardRuntimeState;
   replayed: boolean;
+}
+
+export class WhiteboardRuntimeElementNotFoundError extends Error {
+  override readonly name = 'WhiteboardRuntimeElementNotFoundError';
+  readonly code = 'WHITEBOARD_RUNTIME_ELEMENT_NOT_FOUND';
+
+  constructor(readonly elementId: string) {
+    super(`Whiteboard element ${JSON.stringify(elementId)} was not found`);
+  }
+}
+
+export class WhiteboardRuntimeElementTypeMismatchError extends Error {
+  override readonly name = 'WhiteboardRuntimeElementTypeMismatchError';
+  readonly code = 'WHITEBOARD_RUNTIME_ELEMENT_TYPE_MISMATCH';
+  readonly expectedType = 'code';
+
+  constructor(
+    readonly elementId: string,
+    readonly actualType: PPTElement['type'],
+  ) {
+    super(
+      `Whiteboard element ${JSON.stringify(elementId)} has type ${JSON.stringify(actualType)}; expected code`,
+    );
+  }
+}
+
+export class WhiteboardRuntimeCodeLineNotFoundError extends Error {
+  override readonly name = 'WhiteboardRuntimeCodeLineNotFoundError';
+  readonly code = 'WHITEBOARD_RUNTIME_CODE_LINE_NOT_FOUND';
+
+  constructor(
+    readonly elementId: string,
+    readonly lineId: string,
+  ) {
+    super(
+      `Code line ${JSON.stringify(lineId)} was not found in whiteboard element ${JSON.stringify(elementId)}`,
+    );
+  }
+}
+
+export class WhiteboardRuntimeCodeLineIdConflictError extends Error {
+  override readonly name = 'WhiteboardRuntimeCodeLineIdConflictError';
+  readonly code = 'WHITEBOARD_RUNTIME_CODE_LINE_ID_CONFLICT';
+
+  constructor(
+    readonly elementId: string,
+    readonly lineId: string,
+  ) {
+    super(
+      `Code line ID ${JSON.stringify(lineId)} conflicts in whiteboard element ${JSON.stringify(elementId)}`,
+    );
+  }
+}
+
+export type WhiteboardRuntimeNoChangeReason = 'whiteboard_missing' | 'whiteboard_empty';
+
+export class WhiteboardRuntimeNoChangeError extends Error {
+  override readonly name = 'WhiteboardRuntimeNoChangeError';
+  readonly code = 'WHITEBOARD_RUNTIME_NO_CHANGE';
+
+  constructor(
+    readonly reason: WhiteboardRuntimeNoChangeReason,
+    readonly state?: FoldedWhiteboardRuntimeState,
+  ) {
+    super(`Whiteboard mutation made no change: ${reason}`);
+  }
 }
 
 export type WhiteboardRuntimeRecord = RuntimeRecord<WhiteboardRuntimePayloadV1>;

--- a/lib/whiteboard/runtime/validate.ts
+++ b/lib/whiteboard/runtime/validate.ts
@@ -245,11 +245,13 @@ function validateElement(element: PPTElement): string | null {
   return schema ? validateSchema(element, schema, 'element') : 'unknown element type';
 }
 
-function validateIdentifierArray(value: unknown, label: string): asserts value is string[] {
+function validateCodeLineTargetIds(value: unknown, label: string): asserts value is string[] {
   if (!Array.isArray(value) || value.length === 0) throw new Error(`${label} must be non-empty`);
   const ids = new Set<string>();
   for (const id of value) {
-    if (!isSafeIdentifier(id)) throw new Error(`${label} contains an invalid id`);
+    // Existing CodeLine.id values are plain strings in the frozen DSL contract. Targets must
+    // remain able to address every line accepted by legacy import, including an empty ID.
+    if (typeof id !== 'string') throw new Error(`${label} contains an invalid id`);
     if (ids.has(id)) throw new Error(`${label} contains a duplicate id`);
     ids.add(id);
   }
@@ -480,18 +482,18 @@ export function validateWhiteboardRuntimePayload(
         if (!hasExactOwnKeys(edit, CODE_LINES_INSERT_EDIT_KEYS)) {
           throw new Error('edit is invalid');
         }
-        if (!isSafeIdentifier(edit.lineId)) throw new Error('lineId is invalid');
+        if (typeof edit.lineId !== 'string') throw new Error('lineId is invalid');
         validateCodeLines(edit.lines, 'edit.lines', { nonEmpty: true });
       } else if (edit.kind === 'delete_lines') {
         if (!hasExactOwnKeys(edit, CODE_LINES_DELETE_EDIT_KEYS)) {
           throw new Error('edit is invalid');
         }
-        validateIdentifierArray(edit.lineIds, 'edit.lineIds');
+        validateCodeLineTargetIds(edit.lineIds, 'edit.lineIds');
       } else if (edit.kind === 'replace_lines') {
         if (!hasExactOwnKeys(edit, CODE_LINES_REPLACE_EDIT_KEYS)) {
           throw new Error('edit is invalid');
         }
-        validateIdentifierArray(edit.lineIds, 'edit.lineIds');
+        validateCodeLineTargetIds(edit.lineIds, 'edit.lineIds');
         validateCodeLines(edit.lines, 'edit.lines', { nonEmpty: true });
       } else {
         throw new Error('edit kind is invalid');

--- a/lib/whiteboard/runtime/validate.ts
+++ b/lib/whiteboard/runtime/validate.ts
@@ -1,4 +1,4 @@
-import { normalizeElement, type PPTElement, type Whiteboard } from '@openmaic/dsl';
+import { normalizeElement, type CodeLine, type PPTElement, type Whiteboard } from '@openmaic/dsl';
 import sceneSchemaJson from '@openmaic/dsl/schema/scene.schema.json';
 import type { RuntimePayloadValidator } from '@openmaic/storage';
 
@@ -26,6 +26,13 @@ const REQUIRED_WHITEBOARD_KEYS = new Set(['id', 'viewportSize', 'viewportRatio',
 const PAYLOAD_KEYS = new Set(['payloadVersion', 'operationId', 'operation']);
 const LEGACY_OPERATION_KEYS = new Set(['kind', 'source', 'whiteboard']);
 const ELEMENT_ADDED_OPERATION_KEYS = new Set(['kind', 'element']);
+const ELEMENT_DELETED_OPERATION_KEYS = new Set(['kind', 'elementId']);
+const ELEMENTS_CLEARED_OPERATION_KEYS = new Set(['kind']);
+const CODE_LINES_EDITED_OPERATION_KEYS = new Set(['kind', 'elementId', 'edit']);
+const CODE_LINE_KEYS = new Set(['id', 'content']);
+const CODE_LINES_INSERT_EDIT_KEYS = new Set(['kind', 'lineId', 'lines']);
+const CODE_LINES_DELETE_EDIT_KEYS = new Set(['kind', 'lineIds']);
+const CODE_LINES_REPLACE_EDIT_KEYS = new Set(['kind', 'lineIds', 'lines']);
 const SOURCE_KEYS = new Set(['kind', 'fingerprint']);
 
 type JsonSchema = {
@@ -238,7 +245,38 @@ function validateElement(element: PPTElement): string | null {
   return schema ? validateSchema(element, schema, 'element') : 'unknown element type';
 }
 
-function normalizeAndValidateWhiteboardElement(value: unknown): PPTElement {
+function validateIdentifierArray(value: unknown, label: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.length === 0) throw new Error(`${label} must be non-empty`);
+  const ids = new Set<string>();
+  for (const id of value) {
+    if (!isSafeIdentifier(id)) throw new Error(`${label} contains an invalid id`);
+    if (ids.has(id)) throw new Error(`${label} contains a duplicate id`);
+    ids.add(id);
+  }
+}
+
+function validateCodeLines(
+  value: unknown,
+  label: string,
+  options: { nonEmpty: boolean },
+): asserts value is CodeLine[] {
+  if (!Array.isArray(value) || (options.nonEmpty && value.length === 0)) {
+    throw new Error(`${label} must be ${options.nonEmpty ? 'a non-empty array' : 'an array'}`);
+  }
+  const ids = new Set<string>();
+  for (const candidate of value) {
+    const line = objectValue(candidate);
+    if (!line || !hasExactOwnKeys(line, CODE_LINE_KEYS)) {
+      throw new Error(`${label} contains an invalid code line`);
+    }
+    if (!isSafeIdentifier(line.id)) throw new Error(`${label} contains an invalid line id`);
+    if (ids.has(line.id)) throw new Error(`${label} contains a duplicate line id`);
+    if (typeof line.content !== 'string') throw new Error(`${label} contains invalid content`);
+    ids.add(line.id);
+  }
+}
+
+export function normalizeAndValidateWhiteboardElement(value: unknown): PPTElement {
   assertLosslessJson(value, '$');
   const normalized = normalizeElement(value as PPTElement);
   if (!isSafeIdentifier(normalized.id)) throw new Error('invalid element id');
@@ -276,7 +314,7 @@ function assertLosslessJson(value: unknown, path: string, seen = new Set<object>
           throw new Error(`${path} has a non-index array property`);
         }
         const descriptor = Object.getOwnPropertyDescriptor(value, key);
-        if (descriptor?.get || descriptor?.set) {
+        if (!descriptor?.enumerable || descriptor.get || descriptor.set) {
           throw new Error(`${path}[${String(key)}] is not a plain data property`);
         }
       }
@@ -421,6 +459,42 @@ export function validateWhiteboardRuntimePayload(
       const normalized = normalizeAndValidateWhiteboardElement(operation.element);
       if (canonicalJson(normalized) !== canonicalJson(operation.element)) {
         throw new Error('element payload is not canonical');
+      }
+    } else if (operation.kind === 'element_deleted') {
+      if (!hasExactOwnKeys(operation, ELEMENT_DELETED_OPERATION_KEYS)) {
+        throw new Error('operation is invalid');
+      }
+      if (!isSafeIdentifier(operation.elementId)) throw new Error('elementId is invalid');
+    } else if (operation.kind === 'elements_cleared') {
+      if (!hasExactOwnKeys(operation, ELEMENTS_CLEARED_OPERATION_KEYS)) {
+        throw new Error('operation is invalid');
+      }
+    } else if (operation.kind === 'code_lines_edited') {
+      if (!hasExactOwnKeys(operation, CODE_LINES_EDITED_OPERATION_KEYS)) {
+        throw new Error('operation is invalid');
+      }
+      if (!isSafeIdentifier(operation.elementId)) throw new Error('elementId is invalid');
+      const edit = objectValue(operation.edit);
+      if (!edit) throw new Error('edit is invalid');
+      if (edit.kind === 'insert_after' || edit.kind === 'insert_before') {
+        if (!hasExactOwnKeys(edit, CODE_LINES_INSERT_EDIT_KEYS)) {
+          throw new Error('edit is invalid');
+        }
+        if (!isSafeIdentifier(edit.lineId)) throw new Error('lineId is invalid');
+        validateCodeLines(edit.lines, 'edit.lines', { nonEmpty: true });
+      } else if (edit.kind === 'delete_lines') {
+        if (!hasExactOwnKeys(edit, CODE_LINES_DELETE_EDIT_KEYS)) {
+          throw new Error('edit is invalid');
+        }
+        validateIdentifierArray(edit.lineIds, 'edit.lineIds');
+      } else if (edit.kind === 'replace_lines') {
+        if (!hasExactOwnKeys(edit, CODE_LINES_REPLACE_EDIT_KEYS)) {
+          throw new Error('edit is invalid');
+        }
+        validateIdentifierArray(edit.lineIds, 'edit.lineIds');
+        validateCodeLines(edit.lines, 'edit.lines', { nonEmpty: true });
+      } else {
+        throw new Error('edit kind is invalid');
       }
     } else {
       throw new Error('operation kind is invalid');

--- a/tests/lib/chat/pi/native-child-route-wiring.test.ts
+++ b/tests/lib/chat/pi/native-child-route-wiring.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextRequest } from 'next/server';
+import type { RuntimeRecord } from '@openmaic/dsl';
 import { BrowserRuntimeStore } from '@openmaic/storage';
 import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
 
@@ -315,7 +316,7 @@ describe('PR2 Native Child route production wiring', () => {
               persona: 'Use the whiteboard directly.',
               avatar: '',
               color: '#3366ff',
-              allowedActions: ['wb_draw_text'],
+              allowedActions: ['wb_draw_text', 'wb_delete', 'wb_clear', 'wb_edit_code'],
               priority: 10,
             },
           ],
@@ -333,28 +334,37 @@ describe('PR2 Native Child route production wiring', () => {
     expect(childPayloads[0]?.options.tools).toHaveProperty('wb_read');
     expect(childPayloads[0]?.options.tools).toHaveProperty('wb_open');
     expect(childPayloads[0]?.options.tools).toHaveProperty('wb_draw_text');
+    expect(childPayloads[0]?.options.tools).toHaveProperty('wb_delete');
+    expect(childPayloads[0]?.options.tools).toHaveProperty('wb_clear');
+    expect(childPayloads[0]?.options.tools).toHaveProperty('wb_edit_code');
     expect(childPayloads[0]?.options.tools).toHaveProperty('wb_close');
-    const providerDrawTool = (
-      childPayloads[0]?.options.tools as
-        | Record<
-            string,
-            {
-              inputSchema?: {
-                jsonSchema?: {
-                  required?: string[];
-                  properties?: {
-                    expectedLastSeq?: {
-                      type?: string[];
-                      minimum?: number;
-                      description?: string;
-                    };
+    const providerTools = childPayloads[0]?.options.tools as
+      | Record<
+          string,
+          {
+            inputSchema?: {
+              jsonSchema?: {
+                type?: string;
+                anyOf?: unknown[];
+                required?: string[];
+                properties?: {
+                  expectedLastSeq?: {
+                    type?: string[];
+                    minimum?: number;
+                    description?: string;
                   };
                 };
               };
-            }
-          >
-        | undefined
-    )?.wb_draw_text;
+            };
+          }
+        >
+      | undefined;
+    for (const [toolName, tool] of Object.entries(providerTools ?? {})) {
+      expect(tool.inputSchema?.jsonSchema?.type, toolName).toBe('object');
+    }
+    const providerDrawTool = providerTools?.wb_draw_text;
+    const providerEditTool = providerTools?.wb_edit_code;
+    expect(providerEditTool?.inputSchema?.jsonSchema?.anyOf).toHaveLength(4);
     expect(providerDrawTool?.inputSchema?.jsonSchema?.required).toContain('expectedLastSeq');
     expect(
       providerDrawTool?.inputSchema?.jsonSchema?.properties?.expectedLastSeq?.description,
@@ -389,9 +399,124 @@ describe('PR2 Native Child route production wiring', () => {
     const provider = await mocks.getServerPersistenceProvider.mock.results[0]?.value;
     const sessions = await provider.runtimeStore.listSessions('stage-1', 'learner-route-test');
     expect(sessions).toHaveLength(1);
-    const records = await provider.runtimeStore.listRecords(sessions[0]!.id);
+    const records: RuntimeRecord[] = await provider.runtimeStore.listRecords(sessions[0]!.id);
     expect(records).toHaveLength(1);
     expect(records[0]?.seq).toBe(0);
+  }, 15_000);
+
+  it('executes wb_draw_text → wb_delete through the production route in one Child', async () => {
+    process.env.NEXT_PUBLIC_PERSISTENCE = '1';
+    process.env.DATABASE_URL = 'postgres://shared-provider-test';
+    process.env.PERSISTENCE_DEV_TOKEN = 'persistence-test-token';
+    const directorResponses = [
+      [toolCall('read-1', 'read_scene', { sceneId: 'scene-current' }), finish('tool-calls')],
+      [
+        toolCall('delegate-1', 'call_agent', {
+          agentId: 'teacher-1',
+          instruction: 'Draw one temporary label, then delete that exact label.',
+        }),
+        finish('tool-calls'),
+      ],
+      [toolCall('cue-1', 'cue_user', { prompt: 'Continue?' }), finish('tool-calls')],
+    ];
+    const payloads: Array<{ source: string; options: Record<string, unknown> }> = [];
+    let childTransport = 0;
+    mocks.streamLLM.mockImplementation((options, source) => {
+      payloads.push({ source, options });
+      if (source !== 'pi-chat-native-child') {
+        return resultFrom(directorResponses.shift() ?? [finish('stop')]);
+      }
+      childTransport += 1;
+      if (childTransport === 1) {
+        return resultFrom([toolCall('wb-read-1', 'wb_read', {}), finish('tool-calls')]);
+      }
+      if (childTransport === 2) {
+        return resultFrom([
+          toolCall('wb-draw-1', 'wb_draw_text', {
+            expectedLastSeq: null,
+            content: 'Temporary Runtime label',
+            x: 80,
+            y: 100,
+          }),
+          finish('tool-calls'),
+        ]);
+      }
+      if (childTransport === 3) {
+        const elementId = JSON.stringify(options.messages).match(
+          /native-wb-element:[0-9a-f]{64}/u,
+        )?.[0];
+        expect(elementId).toBeDefined();
+        return resultFrom([
+          toolCall('wb-delete-1', 'wb_delete', {
+            expectedLastSeq: 0,
+            elementId,
+          }),
+          finish('tool-calls'),
+        ]);
+      }
+      return resultFrom([finish('stop')]);
+    });
+
+    const { POST } = await import('@/app/api/chat/pi/route');
+    const response = await POST(
+      makeRequest({
+        config: {
+          agentIds: ['teacher-1'],
+          piEnableWhiteboardTools: true,
+          agentConfigs: [
+            {
+              id: 'teacher-1',
+              name: 'Teacher',
+              role: 'teacher',
+              persona: 'Use the whiteboard directly.',
+              avatar: '',
+              color: '#3366ff',
+              allowedActions: ['wb_draw_text', 'wb_delete'],
+              priority: 10,
+            },
+          ],
+        },
+      }),
+    );
+    const events = await readSseEvents(response);
+
+    expect(response.status).toBe(200);
+    const childPayloads = payloads.filter((payload) => payload.source === 'pi-chat-native-child');
+    expect(childPayloads).toHaveLength(4);
+    expect(JSON.stringify(childPayloads[2]?.options.messages)).toContain('wb-draw-1');
+    expect(JSON.stringify(childPayloads[2]?.options.messages)).toContain('committedSeq');
+    expect(JSON.stringify(childPayloads[3]?.options.messages)).toContain('wb-delete-1');
+    expect(JSON.stringify(childPayloads[3]?.options.messages)).toContain('elementId');
+
+    expect(
+      events.filter((event) => event.type === 'whiteboard' && event.data?.kind === 'projection'),
+    ).toEqual([
+      {
+        type: 'whiteboard',
+        data: { kind: 'projection', stageId: 'stage-1', lastSeq: 0 },
+      },
+      {
+        type: 'whiteboard',
+        data: { kind: 'projection', stageId: 'stage-1', lastSeq: 1 },
+      },
+    ]);
+    expect(events.filter((event) => event.type === 'action')).toHaveLength(0);
+    expect(events.filter((event) => event.type === 'agent_start')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'agent_end')).toHaveLength(1);
+    expect(events.find((event) => event.type === 'done')).toMatchObject({
+      data: { totalAgents: 1, totalActions: 2, agentHadContent: true },
+    });
+
+    const provider = await mocks.getServerPersistenceProvider.mock.results[0]?.value;
+    const sessions = await provider.runtimeStore.listSessions('stage-1', 'learner-route-test');
+    expect(sessions).toHaveLength(1);
+    const records: RuntimeRecord[] = await provider.runtimeStore.listRecords(sessions[0]!.id);
+    expect(records.map((record) => record.seq)).toEqual([0, 1]);
+    expect(
+      records.map(
+        (record) => (record.payload as { operation?: { kind?: string } }).operation?.kind,
+      ),
+    ).toEqual(['element_added', 'element_deleted']);
   }, 15_000);
 
   it.each([

--- a/tests/lib/chat/pi/native-whiteboard.test.ts
+++ b/tests/lib/chat/pi/native-whiteboard.test.ts
@@ -11,6 +11,8 @@ import {
   type WhiteboardRuntimeService,
 } from '@/lib/whiteboard/runtime/store';
 import {
+  LEGACY_WHITEBOARD_SOURCE_KIND,
+  WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
   WhiteboardRuntimeCodeLineIdConflictError,
   WhiteboardRuntimeCodeLineNotFoundError,
   WhiteboardRuntimeElementTypeMismatchError,
@@ -829,6 +831,26 @@ describe('Native RuntimeStore whiteboard tools', () => {
         lineIds: ['L1'],
         content: 'replacement',
       },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'insert_after',
+        lineId: '',
+        content: 'after legacy empty ID',
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'delete_lines',
+        lineIds: [''],
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'replace_lines',
+        lineIds: [''],
+        content: 'replace legacy empty IDs',
+      },
     ];
     for (const edit of validEdits) expect(editTool.prepareArguments?.(edit)).toBe(edit);
 
@@ -876,6 +898,128 @@ describe('Native RuntimeStore whiteboard tools', () => {
       expect(() => tool.prepareArguments?.(invalid)).toThrow('strict schema');
     }
     expect(runtime.append).not.toHaveBeenCalled();
+  });
+
+  it('edits a readable legacy code block whose persisted line IDs are empty', async () => {
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    try {
+      const store = new BrowserRuntimeStore({
+        indexedDB: new IDBFactory(),
+        payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+      });
+      const runtime = createWhiteboardRuntimeService({
+        store,
+        resolveLearnerKey: () => 'learner-1',
+        withMaintenanceLock: (work) => work(),
+      });
+      await runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: null,
+        payload: {
+          payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
+          operationId: 'legacy-import:empty-code-line-ids',
+          operation: {
+            kind: 'legacy_snapshot_imported',
+            source: {
+              kind: LEGACY_WHITEBOARD_SOURCE_KIND,
+              fingerprint: `sha256:${'1'.repeat(64)}`,
+            },
+            whiteboard: {
+              id: 'legacy-board',
+              viewportSize: 1000,
+              viewportRatio: 0.5625,
+              elements: [
+                {
+                  id: 'legacy-code',
+                  type: 'code',
+                  language: 'python',
+                  lines: [
+                    { id: '', content: 'first' },
+                    { id: '', content: 'second' },
+                  ],
+                  fileName: 'legacy.py',
+                  showLineNumbers: true,
+                  fontSize: 14,
+                  left: 10,
+                  top: 20,
+                  width: 480,
+                  height: 240,
+                  rotate: 0,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const edit = build(runtime).tools.find((tool) => tool.name === 'wb_edit_code')!;
+      await expect(
+        edit.execute('edit-after-empty-line-id', {
+          expectedLastSeq: 0,
+          elementId: 'legacy-code',
+          operation: 'insert_after',
+          lineId: '',
+          content: 'inserted',
+        }),
+      ).resolves.toMatchObject({
+        details: {
+          committedSeq: 1,
+          affected: {
+            targetLineIds: [''],
+            resultLineIds: [expect.stringMatching(/^native-wb-code-line:[0-9a-f]{64}:0$/u)],
+          },
+        },
+      });
+      await expect(runtime.read('stage-1')).resolves.toMatchObject({
+        lastSeq: 1,
+        whiteboard: {
+          elements: [
+            {
+              id: 'legacy-code',
+              lines: [
+                { id: '', content: 'first' },
+                { id: expect.stringMatching(/^native-wb-code-line:/u), content: 'inserted' },
+                { id: '', content: 'second' },
+              ],
+            },
+          ],
+        },
+      });
+
+      const replaceResult = await edit.execute('edit-replace-empty-line-ids', {
+        expectedLastSeq: 1,
+        elementId: 'legacy-code',
+        operation: 'replace_lines',
+        lineIds: [''],
+        content: 'replacement',
+      });
+      expect(replaceResult).toMatchObject({
+        details: {
+          committedSeq: 2,
+          affected: {
+            targetLineIds: [''],
+            resultLineIds: [expect.stringMatching(/^native-wb-code-line:[0-9a-f]{64}:0$/u)],
+          },
+        },
+      });
+      const final = await runtime.read('stage-1');
+      const finalCode = final.whiteboard?.elements[0];
+      expect(finalCode).toMatchObject({
+        id: 'legacy-code',
+        type: 'code',
+        lines: [
+          { id: expect.stringMatching(/^native-wb-code-line:/u), content: 'replacement' },
+          { id: expect.stringMatching(/^native-wb-code-line:/u), content: 'inserted' },
+        ],
+      });
+      if (finalCode?.type !== 'code') throw new Error('expected code element');
+      expect(finalCode.lines.every((line) => line.id.length > 0)).toBe(true);
+
+      const sessions = await store.listSessions('stage-1', 'learner-1');
+      await expect(store.listRecords(sessions[0]!.id)).resolves.toHaveLength(3);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('commits every code-line edit with stable host IDs and supports late exact replay', async () => {

--- a/tests/lib/chat/pi/native-whiteboard.test.ts
+++ b/tests/lib/chat/pi/native-whiteboard.test.ts
@@ -1077,6 +1077,58 @@ describe('Native RuntimeStore whiteboard tools', () => {
     }
   });
 
+  it('reports an exact draw replay after deletion without restoring the deleted element', async () => {
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    try {
+      const store = new BrowserRuntimeStore({
+        indexedDB: new IDBFactory(),
+        payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+      });
+      const runtime = createWhiteboardRuntimeService({
+        store,
+        resolveLearnerKey: () => 'learner-1',
+        withMaintenanceLock: (work) => work(),
+      });
+      const tools = build(runtime).tools;
+      const draw = tools.find((tool) => tool.name === 'wb_draw_text')!;
+      const deleteTool = tools.find((tool) => tool.name === 'wb_delete')!;
+      const drawParams = {
+        expectedLastSeq: null,
+        content: 'draw once',
+        x: 1,
+        y: 2,
+      };
+
+      const firstDraw = await draw.execute('draw-before-delete', drawParams);
+      expect(firstDraw).toMatchObject({
+        details: { committedSeq: 0, lastSeq: 0, replayed: false },
+      });
+      const element = (firstDraw.details as { affected: { element: { id: string; type: string } } })
+        .affected.element;
+      await deleteTool.execute('delete-drawn-element', {
+        expectedLastSeq: 0,
+        elementId: element.id,
+      });
+
+      await expect(draw.execute('draw-before-delete', drawParams)).resolves.toMatchObject({
+        details: {
+          committedSeq: 0,
+          lastSeq: 1,
+          replayed: true,
+          affected: { element: { id: element.id, type: element.type } },
+        },
+      });
+      await expect(runtime.read('stage-1')).resolves.toMatchObject({
+        lastSeq: 1,
+        whiteboard: { elements: [] },
+      });
+      const sessions = await store.listSessions('stage-1', 'learner-1');
+      await expect(store.listRecords(sessions[0]!.id)).resolves.toHaveLength(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('keeps missing and empty clear as zero-append, zero-projection successful no-ops', async () => {
     vi.stubGlobal('IDBKeyRange', IDBKeyRange);
     try {

--- a/tests/lib/chat/pi/native-whiteboard.test.ts
+++ b/tests/lib/chat/pi/native-whiteboard.test.ts
@@ -10,6 +10,11 @@ import {
   createWhiteboardRuntimeService,
   type WhiteboardRuntimeService,
 } from '@/lib/whiteboard/runtime/store';
+import {
+  WhiteboardRuntimeCodeLineIdConflictError,
+  WhiteboardRuntimeCodeLineNotFoundError,
+  WhiteboardRuntimeElementTypeMismatchError,
+} from '@/lib/whiteboard/runtime/types';
 
 const teacher: AgentConfig = {
   id: 'teacher-1',
@@ -27,6 +32,9 @@ const teacher: AgentConfig = {
     'wb_draw_table',
     'wb_draw_line',
     'wb_draw_code',
+    'wb_delete',
+    'wb_clear',
+    'wb_edit_code',
     'wb_close',
   ],
   priority: 10,
@@ -93,6 +101,9 @@ describe('Native RuntimeStore whiteboard tools', () => {
       'wb_draw_table',
       'wb_draw_line',
       'wb_draw_code',
+      'wb_delete',
+      'wb_clear',
+      'wb_edit_code',
       'wb_close',
     ]);
 
@@ -108,9 +119,9 @@ describe('Native RuntimeStore whiteboard tools', () => {
     expect(readOnly).toEqual([]);
   });
 
-  it('injects the complete read/open/close control plane for an allowed mutation', () => {
+  it('injects the PR #1156 read/open/close control plane for a destructive-only inventory', () => {
     const tools = buildNativeWhiteboardTools({
-      agent: { ...teacher, allowedActions: ['wb_draw_shape'] },
+      agent: { ...teacher, allowedActions: ['wb_delete'] },
       messageId: 'message-1',
       send: vi.fn(),
       service: service(),
@@ -119,12 +130,7 @@ describe('Native RuntimeStore whiteboard tools', () => {
       requestStartManualVisibilityRevision: 0,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual([
-      'wb_read',
-      'wb_open',
-      'wb_draw_shape',
-      'wb_close',
-    ]);
+    expect(tools.map((tool) => tool.name)).toEqual(['wb_read', 'wb_open', 'wb_delete', 'wb_close']);
   });
 
   it('tells every mutation tool to open first for a user-visible drawing', () => {
@@ -778,6 +784,472 @@ describe('Native RuntimeStore whiteboard tools', () => {
     }
   });
 
+  it('exposes strict destructive/edit schemas without model-owned authority or identity', () => {
+    const runtime = service();
+    const tools = build(runtime).tools;
+    const deleteTool = tools.find((tool) => tool.name === 'wb_delete')!;
+    const clearTool = tools.find((tool) => tool.name === 'wb_clear')!;
+    const editTool = tools.find((tool) => tool.name === 'wb_edit_code')!;
+    expect(editTool.parameters).toMatchObject({
+      type: 'object',
+      anyOf: expect.arrayContaining([expect.objectContaining({ type: 'object' })]),
+    });
+    expect((editTool.parameters as { anyOf?: unknown[] }).anyOf).toHaveLength(4);
+
+    const validDelete = { expectedLastSeq: 0, elementId: 'element-1' };
+    const validClear = { expectedLastSeq: 0 };
+    expect(deleteTool.prepareArguments?.(validDelete)).toBe(validDelete);
+    expect(clearTool.prepareArguments?.(validClear)).toBe(validClear);
+
+    const validEdits = [
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'insert_after',
+        lineId: 'L1',
+        content: '\n',
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'insert_before',
+        lineId: 'L1',
+        content: 'before',
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'delete_lines',
+        lineIds: ['L1'],
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'replace_lines',
+        lineIds: ['L1'],
+        content: 'replacement',
+      },
+    ];
+    for (const edit of validEdits) expect(editTool.prepareArguments?.(edit)).toBe(edit);
+
+    for (const invalid of [
+      { elementId: 'element-1' },
+      { ...validDelete, boardId: 'model-board' },
+      { ...validDelete, element: { id: 'model-element' } },
+      { expectedLastSeq: 0, stageId: 'model-stage' },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'insert_after',
+        lineId: 'L1',
+        lineIds: ['L1'],
+        content: 'x',
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'delete_lines',
+        lineIds: ['L1', 'L1'],
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'delete_lines',
+        lineIds: ['L1'],
+        content: 'irrelevant',
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'replace_lines',
+        lineIds: ['L1'],
+        content: '',
+      },
+      {
+        expectedLastSeq: 0,
+        elementId: 'code-1\n',
+        operation: 'delete_lines',
+        lineIds: ['L1'],
+      },
+    ]) {
+      const tool = Object.hasOwn(invalid, 'operation') ? editTool : deleteTool;
+      expect(() => tool.prepareArguments?.(invalid)).toThrow('strict schema');
+    }
+    expect(runtime.append).not.toHaveBeenCalled();
+  });
+
+  it('commits every code-line edit with stable host IDs and supports late exact replay', async () => {
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    try {
+      const store = new BrowserRuntimeStore({
+        indexedDB: new IDBFactory(),
+        payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+      });
+      const runtime = createWhiteboardRuntimeService({
+        store,
+        resolveLearnerKey: () => 'learner-1',
+        withMaintenanceLock: (work) => work(),
+      });
+      const tools = build(runtime).tools;
+      const draw = tools.find((tool) => tool.name === 'wb_draw_code')!;
+      const edit = tools.find((tool) => tool.name === 'wb_edit_code')!;
+
+      await draw.execute('draw-code-for-edit', {
+        expectedLastSeq: null,
+        language: 'python',
+        code: 'x = 1\nprint(x)',
+        fileName: 'example.py',
+        x: 10,
+        y: 20,
+        width: 480,
+        height: 240,
+      });
+      const initial = await runtime.read('stage-1');
+      const code = initial.whiteboard?.elements[0];
+      expect(code?.type).toBe('code');
+      if (code?.type !== 'code') throw new Error('expected code element');
+      const [firstLine, secondLine] = code.lines;
+
+      const insertResult = await edit.execute('edit-insert', {
+        expectedLastSeq: 0,
+        elementId: code.id,
+        operation: 'insert_after',
+        lineId: firstLine!.id,
+        content: 'doubled = x * 2\n',
+      });
+      expect(insertResult).toMatchObject({
+        details: {
+          committedSeq: 1,
+          affected: {
+            elementId: code.id,
+            operation: 'insert_after',
+            targetLineIds: [firstLine!.id],
+            resultLineIds: [
+              expect.stringMatching(/^native-wb-code-line:[0-9a-f]{64}:0$/u),
+              expect.stringMatching(/^native-wb-code-line:[0-9a-f]{64}:1$/u),
+            ],
+          },
+        },
+      });
+      const afterInsert = await runtime.read('stage-1');
+      const inserted = afterInsert.whiteboard?.elements[0];
+      if (inserted?.type !== 'code') throw new Error('expected code element');
+      const insertedIds = inserted.lines.slice(1, 3).map((line) => line.id);
+      expect(inserted.lines.map((line) => line.content)).toEqual([
+        'x = 1',
+        'doubled = x * 2',
+        '',
+        'print(x)',
+      ]);
+
+      const beforeResult = await edit.execute('edit-insert-before', {
+        expectedLastSeq: 1,
+        elementId: code.id,
+        operation: 'insert_before',
+        lineId: secondLine!.id,
+        content: '# display result',
+      });
+      const beforeLineId = (beforeResult.details as { affected: { resultLineIds: string[] } })
+        .affected.resultLineIds[0]!;
+      expect(beforeResult).toMatchObject({
+        details: {
+          committedSeq: 2,
+          affected: {
+            operation: 'insert_before',
+            targetLineIds: [secondLine!.id],
+            resultLineIds: [expect.stringMatching(/^native-wb-code-line:[0-9a-f]{64}:0$/u)],
+          },
+        },
+      });
+
+      const replaceParams = {
+        expectedLastSeq: 2,
+        elementId: code.id,
+        operation: 'replace_lines' as const,
+        lineIds: insertedIds,
+        content: 'doubled = x * 2',
+      };
+      await expect(edit.execute('edit-replace', replaceParams)).resolves.toMatchObject({
+        details: {
+          committedSeq: 3,
+          affected: {
+            operation: 'replace_lines',
+            targetLineIds: insertedIds,
+            resultLineIds: [insertedIds[0]],
+          },
+        },
+      });
+      await edit.execute('edit-delete', {
+        expectedLastSeq: 3,
+        elementId: code.id,
+        operation: 'delete_lines',
+        lineIds: [secondLine!.id],
+      });
+
+      const finalState = await runtime.read('stage-1');
+      const finalCode = finalState.whiteboard?.elements[0];
+      expect(finalCode).toMatchObject({
+        id: code.id,
+        type: 'code',
+        language: 'python',
+        fileName: 'example.py',
+        left: 10,
+        top: 20,
+        width: 480,
+        height: 240,
+        lines: [
+          { id: firstLine!.id, content: 'x = 1' },
+          { id: insertedIds[0], content: 'doubled = x * 2' },
+          { id: beforeLineId, content: '# display result' },
+        ],
+      });
+
+      await expect(edit.execute('edit-replace', replaceParams)).resolves.toMatchObject({
+        details: {
+          committedSeq: 3,
+          lastSeq: 4,
+          replayed: true,
+          affected: {
+            operation: 'replace_lines',
+            targetLineIds: insertedIds,
+            resultLineIds: [insertedIds[0]],
+          },
+        },
+      });
+      const sessions = await store.listSessions('stage-1', 'learner-1');
+      await expect(store.listRecords(sessions[0]!.id)).resolves.toHaveLength(5);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('settles delete replay before current-target validation and maps fresh target errors', async () => {
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    try {
+      const store = new BrowserRuntimeStore({
+        indexedDB: new IDBFactory(),
+        payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+      });
+      const runtime = createWhiteboardRuntimeService({
+        store,
+        resolveLearnerKey: () => 'learner-1',
+        withMaintenanceLock: (work) => work(),
+      });
+      const tools = build(runtime).tools;
+      const draw = tools.find((tool) => tool.name === 'wb_draw_text')!;
+      const deleteTool = tools.find((tool) => tool.name === 'wb_delete')!;
+      await draw.execute('draw-delete-target', {
+        expectedLastSeq: null,
+        content: 'delete me',
+        x: 1,
+        y: 2,
+      });
+      const elementId = (await runtime.read('stage-1')).whiteboard!.elements[0]!.id;
+      const params = { expectedLastSeq: 0, elementId };
+
+      await expect(deleteTool.execute('delete-target', params)).resolves.toMatchObject({
+        details: {
+          committedSeq: 1,
+          replayed: false,
+          affected: { elementId },
+          dispatchedAction: true,
+        },
+      });
+      await expect(deleteTool.execute('delete-target', params)).resolves.toMatchObject({
+        details: { committedSeq: 1, replayed: true, affected: { elementId } },
+      });
+      await expect(
+        deleteTool.execute('delete-stale-missing', { expectedLastSeq: 0, elementId }),
+      ).resolves.toMatchObject({
+        isError: true,
+        details: { code: 'STALE_STATE', actualLastSeq: 1 },
+      });
+      await expect(
+        deleteTool.execute('delete-fresh-missing', { expectedLastSeq: 1, elementId }),
+      ).resolves.toMatchObject({
+        isError: true,
+        details: { code: 'WHITEBOARD_ELEMENT_NOT_FOUND', elementId },
+      });
+      const sessions = await store.listSessions('stage-1', 'learner-1');
+      await expect(store.listRecords(sessions[0]!.id)).resolves.toHaveLength(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('keeps missing and empty clear as zero-append, zero-projection successful no-ops', async () => {
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    try {
+      const store = new BrowserRuntimeStore({
+        indexedDB: new IDBFactory(),
+        payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+      });
+      const runtime = createWhiteboardRuntimeService({
+        store,
+        resolveLearnerKey: () => 'learner-1',
+        withMaintenanceLock: (work) => work(),
+      });
+      const { tools, send } = build(runtime);
+      const clear = tools.find((tool) => tool.name === 'wb_clear')!;
+      const draw = tools.find((tool) => tool.name === 'wb_draw_text')!;
+
+      await expect(
+        clear.execute('clear-missing', { expectedLastSeq: null }),
+      ).resolves.toMatchObject({
+        details: { noOp: true, lastSeq: null, affected: { cleared: false } },
+      });
+      expect(send).not.toHaveBeenCalled();
+
+      await draw.execute('draw-before-clear', {
+        expectedLastSeq: null,
+        content: 'temporary',
+        x: 1,
+        y: 2,
+      });
+      const clearParams = { expectedLastSeq: 0 };
+      await expect(clear.execute('clear-committed', clearParams)).resolves.toMatchObject({
+        details: {
+          committedSeq: 1,
+          replayed: false,
+          affected: { cleared: true },
+          dispatchedAction: true,
+        },
+      });
+      await expect(clear.execute('clear-committed', clearParams)).resolves.toMatchObject({
+        details: { committedSeq: 1, replayed: true, affected: { cleared: true } },
+      });
+      const beforeNoOpProjectionCount = vi.mocked(send).mock.calls.length;
+      const emptyNoOp = await clear.execute('clear-empty', { expectedLastSeq: 1 });
+      expect(emptyNoOp).toMatchObject({
+        details: { noOp: true, lastSeq: 1, affected: { cleared: false } },
+      });
+      expect(emptyNoOp.details).not.toHaveProperty('dispatchedAction');
+      expect(send).toHaveBeenCalledTimes(beforeNoOpProjectionCount);
+
+      const state = await runtime.read('stage-1');
+      expect(state).toMatchObject({ lastSeq: 1, whiteboard: { elements: [] } });
+      const sessions = await store.listSessions('stage-1', 'learner-1');
+      await expect(store.listRecords(sessions[0]!.id)).resolves.toHaveLength(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('maps edit target failures without reconciliation or projection', async () => {
+    const append = vi.fn(async () => {
+      throw new WhiteboardRuntimeCodeLineNotFoundError('code-1', 'missing-line');
+    });
+    const reconcileOperation = vi.fn();
+    const runtime = service({ append, reconcileOperation });
+    const { tools, send } = build(runtime);
+    const edit = tools.find((tool) => tool.name === 'wb_edit_code')!;
+
+    await expect(
+      edit.execute('edit-missing-line', {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'delete_lines',
+        lineIds: ['missing-line'],
+      }),
+    ).resolves.toMatchObject({
+      isError: true,
+      details: {
+        code: 'WHITEBOARD_CODE_LINE_NOT_FOUND',
+        elementId: 'code-1',
+        lineId: 'missing-line',
+      },
+    });
+    expect(append).toHaveBeenCalledOnce();
+    expect(reconcileOperation).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      error: new WhiteboardRuntimeElementTypeMismatchError('not-code', 'text'),
+      expected: {
+        code: 'WHITEBOARD_ELEMENT_TYPE_MISMATCH',
+        elementId: 'not-code',
+        expectedType: 'code',
+        actualType: 'text',
+      },
+    },
+    {
+      error: new WhiteboardRuntimeCodeLineIdConflictError('code-1', 'duplicate-line'),
+      expected: {
+        code: 'WHITEBOARD_CODE_LINE_ID_CONFLICT',
+        elementId: 'code-1',
+        lineId: 'duplicate-line',
+      },
+    },
+  ])('maps $expected.code as a definitive pre-commit edit error', async ({ error, expected }) => {
+    const append = vi.fn(async () => {
+      throw error;
+    });
+    const reconcileOperation = vi.fn();
+    const runtime = service({ append, reconcileOperation });
+    const { tools, send } = build(runtime);
+    const edit = tools.find((tool) => tool.name === 'wb_edit_code')!;
+
+    await expect(
+      edit.execute('edit-domain-error', {
+        expectedLastSeq: 0,
+        elementId: 'code-1',
+        operation: 'insert_after',
+        lineId: 'L1',
+        content: 'new line',
+      }),
+    ).resolves.toMatchObject({ isError: true, details: expected });
+    expect(append).toHaveBeenCalledOnce();
+    expect(reconcileOperation).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('uses the shared one-append/one-reconcile settlement for destructive mutations', async () => {
+    const append = vi.fn(async () => {
+      throw new Error('append response lost');
+    });
+    const reconcileOperation = vi.fn(async () => ({
+      status: 'exact' as const,
+      committedSeq: 7,
+      state: {
+        sessionId: 'runtime-session-1',
+        lastSeq: 9,
+        whiteboard: {
+          id: 'runtime-board-1',
+          viewportSize: 1000,
+          viewportRatio: 0.5625,
+          elements: [],
+        },
+      },
+    }));
+    const runtime = service({ append, reconcileOperation });
+    const { tools, send } = build(runtime);
+    const deleteTool = tools.find((tool) => tool.name === 'wb_delete')!;
+
+    await expect(
+      deleteTool.execute('delete-response-lost', {
+        expectedLastSeq: 6,
+        elementId: 'deleted-before-response',
+      }),
+    ).resolves.toMatchObject({
+      details: {
+        committedSeq: 7,
+        lastSeq: 9,
+        replayed: true,
+        affected: { elementId: 'deleted-before-response' },
+        dispatchedAction: true,
+      },
+    });
+    expect(append).toHaveBeenCalledOnce();
+    expect(reconcileOperation).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith({
+      type: 'whiteboard',
+      data: { kind: 'projection', stageId: 'stage-1', lastSeq: 9 },
+    });
+  });
+
   it('rejects stale null when the authoritative sequence is zero', async () => {
     vi.stubGlobal('IDBKeyRange', IDBKeyRange);
     try {
@@ -953,7 +1425,7 @@ describe('Native RuntimeStore whiteboard tools', () => {
     expect(reconcileOperation).toHaveBeenCalledOnce();
     expect(result).toMatchObject({
       isError: true,
-      details: { code: 'WHITEBOARD_MUTATION_FAILED' },
+      details: { code: 'WHITEBOARD_MUTATION_UNCERTAIN' },
       content: [
         expect.objectContaining({ text: expect.stringContaining('could not be confirmed') }),
       ],

--- a/tests/lib/whiteboard/runtime-contract.test.ts
+++ b/tests/lib/whiteboard/runtime-contract.test.ts
@@ -224,6 +224,25 @@ describe('whiteboard RuntimeStore payload contract', () => {
           ],
         },
       }),
+      operationPayload('edit:legacy-empty-insert-target', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'insert_after', lineId: '', lines: [{ id: 'host-empty-1', content: '' }] },
+      }),
+      operationPayload('edit:legacy-empty-delete-target', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'delete_lines', lineIds: [''] },
+      }),
+      operationPayload('edit:legacy-empty-replace-target', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: {
+          kind: 'replace_lines',
+          lineIds: [''],
+          lines: [{ id: 'host-empty-2', content: 'replacement' }],
+        },
+      }),
     ]) {
       expect(validateWhiteboardRuntimePayload(candidate)).toEqual({ valid: true });
     }

--- a/tests/lib/whiteboard/runtime-contract.test.ts
+++ b/tests/lib/whiteboard/runtime-contract.test.ts
@@ -7,6 +7,7 @@ import {
   WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
   type LegacySnapshotImportedOperation,
   type WhiteboardElementAddedOperation,
+  type WhiteboardRuntimeOperationV1,
   type WhiteboardRuntimePayloadV1,
 } from '@/lib/whiteboard/runtime/types';
 import {
@@ -62,6 +63,31 @@ function textElement(id = 'text-added', content = 'learner text'): PPTElement {
   };
 }
 
+function codeElement(
+  id = 'code-1',
+  lines = [
+    { id: 'L1', content: 'const one = 1;' },
+    { id: 'L2', content: 'const two = 2;' },
+    { id: 'L3', content: 'return one + two;' },
+    { id: 'L4', content: '' },
+  ],
+): PPTElement {
+  return {
+    id,
+    type: 'code',
+    language: 'typescript',
+    lines,
+    fileName: 'example.ts',
+    showLineNumbers: true,
+    fontSize: 14,
+    left: 100,
+    top: 120,
+    width: 500,
+    height: 300,
+    rotate: 0,
+  };
+}
+
 function payload(overrides: Partial<LegacyPayload> = {}): LegacyPayload {
   return {
     payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
@@ -87,6 +113,13 @@ function elementPayload(
     operationId,
     operation: { kind: 'element_added', element },
   };
+}
+
+function operationPayload(
+  operationId: string,
+  operation: WhiteboardRuntimeOperationV1,
+): WhiteboardRuntimePayloadV1 {
+  return { payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION, operationId, operation };
 }
 
 function record(seq: number, value: WhiteboardRuntimePayloadV1 = payload()): RuntimeRecord {
@@ -136,6 +169,182 @@ describe('whiteboard RuntimeStore payload contract', () => {
             rotate: 0,
           },
         },
+      }).valid,
+    ).toBe(false);
+  });
+
+  it('does not narrow the frozen code-line contract for existing add/import operations', () => {
+    const legacyCode = codeElement('legacy-code', [
+      { id: '', content: 'first' },
+      { id: '', content: 'second' },
+    ]);
+    expect(
+      validateWhiteboardRuntimePayload(elementPayload('element-add:legacy-code', legacyCode)),
+    ).toEqual({ valid: true });
+    expect(
+      validateWhiteboardRuntimePayload(
+        payload({
+          operation: {
+            ...payload().operation,
+            whiteboard: board({ elements: [legacyCode] }),
+          },
+        }),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it('accepts only exact destructive and line-edit operation shapes', () => {
+    for (const candidate of [
+      operationPayload('delete:one', { kind: 'element_deleted', elementId: 'text-1' }),
+      operationPayload('clear:one', { kind: 'elements_cleared' }),
+      operationPayload('edit:after', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'insert_after', lineId: 'L1', lines: [{ id: 'L1.5', content: '' }] },
+      }),
+      operationPayload('edit:before', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'insert_before', lineId: 'L2', lines: [{ id: 'L1.9', content: ' ' }] },
+      }),
+      operationPayload('edit:delete', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'delete_lines', lineIds: ['L1', 'L3'] },
+      }),
+      operationPayload('edit:replace', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: {
+          kind: 'replace_lines',
+          lineIds: ['L3', 'L1'],
+          lines: [
+            { id: 'host-1', content: '' },
+            { id: 'host-2', content: 'replacement' },
+          ],
+        },
+      }),
+    ]) {
+      expect(validateWhiteboardRuntimePayload(candidate)).toEqual({ valid: true });
+    }
+
+    for (const candidate of [
+      operationPayload('delete:extra', {
+        kind: 'element_deleted',
+        elementId: 'text-1',
+        whiteboard: board(),
+      } as never),
+      operationPayload('clear:extra', { kind: 'elements_cleared', elementId: 'text-1' } as never),
+      operationPayload('edit:empty-targets', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'delete_lines', lineIds: [] },
+      }),
+      operationPayload('edit:duplicate-targets', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'delete_lines', lineIds: ['L1', 'L1'] },
+      }),
+      operationPayload('edit:empty-lines', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'insert_after', lineId: 'L1', lines: [] },
+      }),
+      operationPayload('edit:duplicate-lines', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: {
+          kind: 'replace_lines',
+          lineIds: ['L1'],
+          lines: [
+            { id: 'new', content: 'one' },
+            { id: 'new', content: 'two' },
+          ],
+        },
+      }),
+      operationPayload('edit:extra-line-key', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: {
+          kind: 'insert_before',
+          lineId: 'L1',
+          lines: [{ id: 'new', content: 'one', extra: true } as never],
+        },
+      }),
+      operationPayload('edit:unsafe-line', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'delete_lines', lineIds: ['unsafe\u0000line'] },
+      }),
+      operationPayload('edit:unsafe-new-line', {
+        kind: 'code_lines_edited',
+        elementId: 'code-1',
+        edit: { kind: 'insert_after', lineId: 'L1', lines: [{ id: '', content: 'new' }] },
+      }),
+    ]) {
+      expect(validateWhiteboardRuntimePayload(candidate).valid).toBe(false);
+    }
+  });
+
+  it('rejects non-enumerable line and target array entries instead of laundering them', () => {
+    const hiddenLines = [{ id: 'host-line', content: 'new' }];
+    Object.defineProperty(hiddenLines, '0', {
+      value: hiddenLines[0],
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    expect(
+      validateWhiteboardRuntimePayload(
+        operationPayload('edit:hidden-lines', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: { kind: 'insert_after', lineId: 'L1', lines: hiddenLines },
+        }),
+      ).valid,
+    ).toBe(false);
+
+    const hiddenLineIds = ['L1'];
+    Object.defineProperty(hiddenLineIds, '0', {
+      value: hiddenLineIds[0],
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    expect(
+      validateWhiteboardRuntimePayload(
+        operationPayload('edit:hidden-targets', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: { kind: 'delete_lines', lineIds: hiddenLineIds },
+        }),
+      ).valid,
+    ).toBe(false);
+  });
+
+  it('rejects inherited and symbol-key line edit fields', () => {
+    const inheritedEdit = Object.create({ kind: 'delete_lines', lineIds: ['L1'] });
+    expect(
+      validateWhiteboardRuntimePayload({
+        ...operationPayload('edit:inherited', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: { kind: 'delete_lines', lineIds: ['L1'] },
+        }),
+        operation: { kind: 'code_lines_edited', elementId: 'code-1', edit: inheritedEdit },
+      }).valid,
+    ).toBe(false);
+
+    const symbolEdit = { kind: 'delete_lines', lineIds: ['L1'] };
+    Object.defineProperty(symbolEdit, Symbol('hidden'), { value: true, enumerable: true });
+    expect(
+      validateWhiteboardRuntimePayload({
+        ...operationPayload('edit:symbol', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: { kind: 'delete_lines', lineIds: ['L1'] },
+        }),
+        operation: { kind: 'code_lines_edited', elementId: 'code-1', edit: symbolEdit },
       }).valid,
     ).toBe(false);
   });
@@ -437,6 +646,128 @@ describe('whiteboard RuntimeStore fold', () => {
         record(1, elementPayload('element-add:two')),
       ]),
     ).rejects.toThrow('WHITEBOARD_RUNTIME_ELEMENT_ALREADY_EXISTS');
+  });
+
+  it('deletes one element and clears all elements without changing board metadata', async () => {
+    const imported = payload({
+      operation: {
+        ...payload().operation,
+        whiteboard: board({
+          elements: [textElement('text-1'), codeElement()],
+          background: { type: 'solid', color: '#123456' },
+          script: 'preserve me',
+        }),
+      },
+    });
+    const deleted = await foldWhiteboardRuntimeRecords('session-1', [
+      record(0, imported),
+      record(1, operationPayload('delete:text', { kind: 'element_deleted', elementId: 'text-1' })),
+    ]);
+    expect(deleted.whiteboard).toMatchObject({
+      id: 'board-1',
+      background: { type: 'solid', color: '#123456' },
+      script: 'preserve me',
+      elements: [{ id: 'code-1' }],
+    });
+
+    const cleared = await foldWhiteboardRuntimeRecords('session-1', [
+      record(0, imported),
+      record(1, operationPayload('clear:all', { kind: 'elements_cleared' })),
+    ]);
+    expect(cleared.whiteboard).toEqual({ ...imported.operation.whiteboard, elements: [] });
+    expect(cleared.whiteboard).not.toBeNull();
+  });
+
+  it('matches Legacy line-edit ordering while preserving host replacement IDs and code metadata', async () => {
+    const imported = payload({
+      operation: {
+        ...payload().operation,
+        whiteboard: board({ elements: [codeElement()] }),
+      },
+    });
+    const edited = await foldWhiteboardRuntimeRecords('session-1', [
+      record(0, imported),
+      record(
+        1,
+        operationPayload('edit:noncontiguous', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: {
+            kind: 'replace_lines',
+            lineIds: ['L3', 'L1'],
+            lines: [
+              { id: 'host-A', content: '' },
+              { id: 'host-B', content: 'two' },
+              { id: 'host-C', content: 'three' },
+            ],
+          },
+        }),
+      ),
+    ]);
+    expect(edited.whiteboard?.elements[0]).toMatchObject({
+      id: 'code-1',
+      type: 'code',
+      language: 'typescript',
+      fileName: 'example.ts',
+      showLineNumbers: true,
+      fontSize: 14,
+      lines: [
+        { id: 'L2', content: 'const two = 2;' },
+        { id: 'L4', content: '' },
+        { id: 'host-A', content: '' },
+        { id: 'host-B', content: 'two' },
+        { id: 'host-C', content: 'three' },
+      ],
+    });
+  });
+
+  it('supports insert-before/after, delete-all, and fewer replacement lines', async () => {
+    const imported = payload({
+      operation: { ...payload().operation, whiteboard: board({ elements: [codeElement()] }) },
+    });
+    const result = await foldWhiteboardRuntimeRecords('session-1', [
+      record(0, imported),
+      record(
+        1,
+        operationPayload('edit:before', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: { kind: 'insert_before', lineId: 'L2', lines: [{ id: 'B', content: 'before' }] },
+        }),
+      ),
+      record(
+        2,
+        operationPayload('edit:after', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: { kind: 'insert_after', lineId: 'L2', lines: [{ id: 'A', content: 'after' }] },
+        }),
+      ),
+      record(
+        3,
+        operationPayload('edit:fewer', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: {
+            kind: 'replace_lines',
+            lineIds: ['L1', 'L2'],
+            lines: [{ id: 'replacement-only', content: '' }],
+          },
+        }),
+      ),
+      record(
+        4,
+        operationPayload('edit:delete-all', {
+          kind: 'code_lines_edited',
+          elementId: 'code-1',
+          edit: {
+            kind: 'delete_lines',
+            lineIds: ['replacement-only', 'B', 'A', 'L3', 'L4'],
+          },
+        }),
+      ),
+    ]);
+    expect(result.whiteboard?.elements[0]).toMatchObject({ type: 'code', lines: [] });
   });
 
   it('fails closed on conflicting duplicate, sequence, and session identity', async () => {

--- a/tests/lib/whiteboard/runtime-store.pg.test.ts
+++ b/tests/lib/whiteboard/runtime-store.pg.test.ts
@@ -1,0 +1,254 @@
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import type { PPTCodeElement } from '@openmaic/dsl';
+import { BrowserRuntimeStore, type RuntimeStore } from '@openmaic/storage';
+import {
+  PgRuntimeStore,
+  ensureSchema,
+  type Queryable,
+  type WithTransaction,
+} from '@openmaic/storage/runtime/pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Pool } from 'pg';
+
+import { APP_RUNTIME_PAYLOAD_VALIDATORS } from '@/lib/runtime/payload-validators';
+import { createWhiteboardRuntimeService } from '@/lib/whiteboard/runtime/store';
+import {
+  WhiteboardRuntimeNoChangeError,
+  type WhiteboardRuntimeOperationV1,
+  type WhiteboardRuntimePayloadV1,
+} from '@/lib/whiteboard/runtime/types';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+if (process.env.STORAGE_PG_CONTRACT_REQUIRED === '1' && !contractUrl) {
+  throw new Error(
+    'whiteboard RuntimeStore: STORAGE_PG_CONTRACT_REQUIRED=1 requires PG_CONTRACT_URL; ' +
+      'refusing to skip the PostgreSQL app-domain suite',
+  );
+}
+
+function transactionFor(pool: Pool): WithTransaction {
+  return async (body) => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client as Queryable);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the transaction body's original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+function operationPayload(
+  operationId: string,
+  operation: WhiteboardRuntimeOperationV1,
+): WhiteboardRuntimePayloadV1 {
+  return { payloadVersion: 1, operationId, operation };
+}
+
+function codeElement(): PPTCodeElement {
+  return {
+    id: 'code-1',
+    type: 'code',
+    language: 'typescript',
+    lines: [
+      { id: 'L1', content: 'const one = 1;' },
+      { id: 'L2', content: 'const two = 2;' },
+      { id: 'L3', content: '' },
+    ],
+    fileName: 'example.ts',
+    showLineNumbers: true,
+    fontSize: 14,
+    left: 100,
+    top: 120,
+    width: 500,
+    height: 300,
+    rotate: 0,
+  };
+}
+
+async function runDestructiveScenario(store: RuntimeStore) {
+  const runtime = createWhiteboardRuntimeService({
+    store,
+    resolveLearnerKey: () => 'learner-1',
+    now: () => '2026-08-21T00:00:00.000Z',
+    withMaintenanceLock: (work) => work(),
+  });
+  const states = [];
+  states.push(
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: null,
+      payload: operationPayload('add:code', { kind: 'element_added', element: codeElement() }),
+    }),
+  );
+  const edited = operationPayload('edit:code', {
+    kind: 'code_lines_edited',
+    elementId: 'code-1',
+    edit: {
+      kind: 'replace_lines',
+      lineIds: ['L3', 'L1'],
+      lines: [
+        { id: 'host-A', content: '' },
+        { id: 'host-B', content: 'replacement' },
+      ],
+    },
+  });
+  states.push(await runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: edited }));
+  states.push(
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: 1,
+      payload: operationPayload('add:text', {
+        kind: 'element_added',
+        element: {
+          id: 'text-1',
+          type: 'text',
+          left: 10,
+          top: 20,
+          width: 200,
+          height: 60,
+          rotate: 0,
+          content: 'delete me',
+          defaultFontName: 'Inter',
+          defaultColor: '#000000',
+        },
+      }),
+    }),
+  );
+  states.push(
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: 2,
+      payload: operationPayload('delete:text', {
+        kind: 'element_deleted',
+        elementId: 'text-1',
+      }),
+    }),
+  );
+  const clear = operationPayload('clear:all', { kind: 'elements_cleared' });
+  states.push(await runtime.append({ stageId: 'stage-1', expectedLastSeq: 3, payload: clear }));
+  const editReplay = await runtime.append({
+    stageId: 'stage-1',
+    expectedLastSeq: 0,
+    payload: edited,
+  });
+  const noChange = await runtime
+    .append({
+      stageId: 'stage-1',
+      expectedLastSeq: 4,
+      payload: operationPayload('clear:empty', { kind: 'elements_cleared' }),
+    })
+    .catch((error: unknown) => error);
+  expect(noChange).toBeInstanceOf(WhiteboardRuntimeNoChangeError);
+
+  return {
+    states,
+    editReplay,
+    noChange: {
+      code: (noChange as WhiteboardRuntimeNoChangeError).code,
+      reason: (noChange as WhiteboardRuntimeNoChangeError).reason,
+      state: (noChange as WhiteboardRuntimeNoChangeError).state,
+    },
+    records: await store.listRecords('whiteboard:stage-1:learner-1'),
+  };
+}
+
+async function rejectMalformedWhiteboardRecord(store: RuntimeStore) {
+  const sessionId = 'whiteboard:stage-1:learner-1';
+  const before = await store.listRecords(sessionId);
+  const outcome = await store
+    .appendRecord(
+      {
+        id: 'invalid:authority-extra',
+        sessionId,
+        createdAt: '2026-08-21T00:00:00.000Z',
+        payload: {
+          payloadVersion: 1,
+          operationId: 'invalid:authority-extra',
+          operation: { kind: 'elements_cleared', stageId: 'model-owned-stage' },
+        },
+      },
+      { expectedLastSeq: 4 },
+    )
+    .then(
+      () => ({ accepted: true as const }),
+      (error: unknown) => ({ accepted: false as const, error }),
+    );
+
+  expect(outcome.accepted).toBe(false);
+  if (outcome.accepted) throw new Error('malformed whiteboard payload was accepted');
+  expect(outcome.error).toBeInstanceOf(Error);
+  const after = await store.listRecords(sessionId);
+  expect(after).toEqual(before);
+  expect(after).toHaveLength(5);
+  expect(after.at(-1)?.seq).toBe(4);
+  return {
+    name: (outcome.error as Error).name,
+    message: (outcome.error as Error).message,
+  };
+}
+
+describe.skipIf(!contractUrl)('whiteboard app-domain contract with PostgreSQL 16', () => {
+  let pool: Pool;
+  let pgStore: PgRuntimeStore;
+
+  beforeAll(async () => {
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    pool = new Pool({ connectionString: contractUrl, max: 8 });
+    await ensureSchema(pool as Queryable);
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE runtime_records, runtime_sessions');
+    pgStore = new PgRuntimeStore(pool as Queryable, {
+      withTransaction: transactionFor(pool),
+      payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+    });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+    vi.unstubAllGlobals();
+  });
+
+  it('matches BrowserRuntimeStore for delete/edit/clear, replay, and zero-append no-op', async () => {
+    const browserStore = new BrowserRuntimeStore({
+      indexedDB: new IDBFactory(),
+      dbName: 'whiteboard-pg-comparison',
+      payloadValidators: APP_RUNTIME_PAYLOAD_VALIDATORS,
+    });
+    const browser = await runDestructiveScenario(browserStore);
+    const postgres = await runDestructiveScenario(pgStore);
+
+    expect(postgres).toEqual(browser);
+    expect(postgres.records).toHaveLength(5);
+    expect(postgres.states.at(-1)).toMatchObject({
+      committedSeq: 4,
+      state: { lastSeq: 4, whiteboard: { elements: [] } },
+    });
+    expect(postgres.editReplay).toMatchObject({
+      committedSeq: 1,
+      replayed: true,
+      state: { lastSeq: 4, whiteboard: { elements: [] } },
+    });
+    expect(postgres.noChange).toMatchObject({
+      code: 'WHITEBOARD_RUNTIME_NO_CHANGE',
+      reason: 'whiteboard_empty',
+      state: { lastSeq: 4, whiteboard: { elements: [] } },
+    });
+
+    const browserRejection = await rejectMalformedWhiteboardRecord(browserStore);
+    const postgresRejection = await rejectMalformedWhiteboardRecord(pgStore);
+    expect(postgresRejection).toEqual(browserRejection);
+  });
+});

--- a/tests/lib/whiteboard/runtime-store.test.ts
+++ b/tests/lib/whiteboard/runtime-store.test.ts
@@ -19,8 +19,14 @@ import {
 import {
   LEGACY_WHITEBOARD_SOURCE_KIND,
   WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
+  WhiteboardRuntimeCodeLineIdConflictError,
+  WhiteboardRuntimeCodeLineNotFoundError,
+  WhiteboardRuntimeElementNotFoundError,
+  WhiteboardRuntimeElementTypeMismatchError,
+  WhiteboardRuntimeNoChangeError,
   type LegacySnapshotImportedOperation,
   type WhiteboardElementAddedOperation,
+  type WhiteboardRuntimeOperationV1,
   type WhiteboardRuntimePayloadV1,
 } from '@/lib/whiteboard/runtime/types';
 
@@ -55,6 +61,30 @@ function textElement(id = 'text-added', content = 'learner text'): PPTElement {
   };
 }
 
+function codeElement(
+  id = 'code-1',
+  lines = [
+    { id: 'L1', content: 'const one = 1;' },
+    { id: 'L2', content: 'const two = 2;' },
+    { id: 'L3', content: '' },
+  ],
+): PPTElement {
+  return {
+    id,
+    type: 'code',
+    language: 'typescript',
+    lines,
+    fileName: 'example.ts',
+    showLineNumbers: true,
+    fontSize: 14,
+    left: 100,
+    top: 120,
+    width: 500,
+    height: 300,
+    rotate: 0,
+  };
+}
+
 function payload(id = 'operation-1', boardId = 'board-1'): LegacyPayload {
   return {
     payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION,
@@ -76,6 +106,13 @@ function elementPayload(id = 'element-operation-1', element = textElement()): El
     operationId: id,
     operation: { kind: 'element_added', element },
   };
+}
+
+function operationPayload(
+  operationId: string,
+  operation: WhiteboardRuntimeOperationV1,
+): WhiteboardRuntimePayloadV1 {
+  return { payloadVersion: WHITEBOARD_RUNTIME_PAYLOAD_VERSION, operationId, operation };
 }
 
 function runtimeStore(): BrowserRuntimeStore {
@@ -248,6 +285,373 @@ describe('whiteboard RuntimeStore service', () => {
       'legacy-text',
       'text-added',
     ]);
+  });
+
+  it('deletes exactly one element and exact replay cannot delete a later reused ID', async () => {
+    const store = runtimeStore();
+    const runtime = service(store);
+    const imported = payload();
+    imported.operation.whiteboard = {
+      ...board(),
+      elements: [textElement('reused-id', 'first'), codeElement()],
+      script: 'keep metadata',
+    };
+    await runtime.append({ stageId: 'stage-1', expectedLastSeq: null, payload: imported });
+
+    const deletion = operationPayload('delete:reused', {
+      kind: 'element_deleted',
+      elementId: 'reused-id',
+    });
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: deletion }),
+    ).resolves.toMatchObject({ committedSeq: 1, replayed: false });
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: 1,
+      payload: elementPayload('add:reused', textElement('reused-id', 'second')),
+    });
+
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: deletion }),
+    ).resolves.toMatchObject({
+      committedSeq: 1,
+      replayed: true,
+      state: { lastSeq: 2, whiteboard: { script: 'keep metadata' } },
+    });
+    await expect(
+      runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: 2,
+        payload: operationPayload('delete:reused', {
+          kind: 'element_deleted',
+          elementId: 'code-1',
+        }),
+      }),
+    ).rejects.toThrow('WHITEBOARD_RUNTIME_OPERATION_CONFLICT');
+    expect((await runtime.read('stage-1')).whiteboard?.elements).toEqual([
+      codeElement(),
+      textElement('reused-id', 'second'),
+    ]);
+    expect(
+      await store.listRecords(whiteboardRuntimeSessionId('stage-1', 'learner-1')),
+    ).toHaveLength(3);
+  });
+
+  it('reports missing delete targets before append while stale CAS wins first', async () => {
+    const backing = runtimeStore();
+    const appendRecord = vi.fn(backing.appendRecord.bind(backing));
+    const tracked = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'appendRecord') return appendRecord;
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as RuntimeStore;
+    const runtime = service(tracked);
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: null,
+      payload: elementPayload(),
+    });
+    const missing = operationPayload('delete:missing', {
+      kind: 'element_deleted',
+      elementId: 'not-there',
+    });
+
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: null, payload: missing }),
+    ).rejects.toBeInstanceOf(RuntimeAppendConflictError);
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: missing }),
+    ).rejects.toMatchObject({
+      name: WhiteboardRuntimeElementNotFoundError.name,
+      code: 'WHITEBOARD_RUNTIME_ELEMENT_NOT_FOUND',
+      elementId: 'not-there',
+    });
+    expect(appendRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats clear missing/empty state as an atomic typed no-op with zero appends', async () => {
+    const backing = runtimeStore();
+    const appendRecord = vi.fn(backing.appendRecord.bind(backing));
+    const tracked = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'appendRecord') return appendRecord;
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as RuntimeStore;
+    const runtime = service(tracked);
+    const missingClear = operationPayload('clear:missing', { kind: 'elements_cleared' });
+    const missingError = await runtime
+      .append({ stageId: 'stage-1', expectedLastSeq: null, payload: missingClear })
+      .catch((error: unknown) => error);
+    expect(missingError).toMatchObject({
+      name: WhiteboardRuntimeNoChangeError.name,
+      code: 'WHITEBOARD_RUNTIME_NO_CHANGE',
+      reason: 'whiteboard_missing',
+      state: {
+        sessionId: whiteboardRuntimeSessionId('stage-1', 'learner-1'),
+        whiteboard: null,
+        lastSeq: null,
+      },
+    });
+    expect(appendRecord).not.toHaveBeenCalled();
+
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: null,
+      payload: elementPayload(),
+    });
+    const committedClear = operationPayload('clear:committed', { kind: 'elements_cleared' });
+    const cleared = await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: 0,
+      payload: committedClear,
+    });
+    expect(cleared).toMatchObject({
+      committedSeq: 1,
+      replayed: false,
+      state: { lastSeq: 1, whiteboard: { elements: [] } },
+    });
+
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 99, payload: committedClear }),
+    ).resolves.toMatchObject({ committedSeq: 1, replayed: true });
+    const distinctClear = operationPayload('clear:already-empty', { kind: 'elements_cleared' });
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: distinctClear }),
+    ).rejects.toBeInstanceOf(RuntimeAppendConflictError);
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 1, payload: distinctClear }),
+    ).rejects.toMatchObject({
+      name: WhiteboardRuntimeNoChangeError.name,
+      code: 'WHITEBOARD_RUNTIME_NO_CHANGE',
+      reason: 'whiteboard_empty',
+      state: { lastSeq: 1, whiteboard: { elements: [] } },
+    });
+    expect(appendRecord).toHaveBeenCalledTimes(2);
+    expect(
+      await backing.listRecords(whiteboardRuntimeSessionId('stage-1', 'learner-1')),
+    ).toHaveLength(2);
+  });
+
+  it('clears elements while preserving the materialized board identity and metadata', async () => {
+    const runtime = service(runtimeStore());
+    const imported = payload();
+    imported.operation.whiteboard = {
+      id: 'metadata-board',
+      viewportSize: 2048,
+      viewportRatio: 0.75,
+      elements: [textElement(), codeElement()],
+      background: { type: 'solid', color: '#123456' },
+      animations: [],
+      script: 'preserve this script',
+    };
+    await runtime.append({ stageId: 'stage-1', expectedLastSeq: null, payload: imported });
+    const result = await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: 0,
+      payload: operationPayload('clear:metadata', { kind: 'elements_cleared' }),
+    });
+    expect(result.state.whiteboard).toEqual({ ...imported.operation.whiteboard, elements: [] });
+    expect(result.state.whiteboard).not.toBeNull();
+  });
+
+  it.each([
+    {
+      label: 'delete',
+      payload: operationPayload('delete:lost-response', {
+        kind: 'element_deleted',
+        elementId: 'text-added',
+      }),
+    },
+    {
+      label: 'clear',
+      payload: operationPayload('clear:lost-response', { kind: 'elements_cleared' }),
+    },
+  ])('recovers a lost $label response with exactly one underlying append', async ({ payload }) => {
+    const backing = runtimeStore();
+    await service(backing).append({
+      stageId: 'stage-1',
+      expectedLastSeq: null,
+      payload: elementPayload(),
+    });
+    const appendRecord = vi.fn(async (...args: Parameters<RuntimeStore['appendRecord']>) => {
+      await backing.appendRecord(...args);
+      throw new Error('response lost');
+    });
+    const lossy = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'appendRecord') return appendRecord;
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as RuntimeStore;
+
+    await expect(
+      service(lossy).append({ stageId: 'stage-1', expectedLastSeq: 0, payload }),
+    ).resolves.toMatchObject({
+      committedSeq: 1,
+      replayed: true,
+      state: { lastSeq: 1, whiteboard: { elements: [] } },
+    });
+    expect(appendRecord).toHaveBeenCalledTimes(1);
+    expect(
+      await backing.listRecords(whiteboardRuntimeSessionId('stage-1', 'learner-1')),
+    ).toHaveLength(2);
+  });
+
+  it('returns distinct typed code target, type, line, and ID-conflict failures pre-append', async () => {
+    const backing = runtimeStore();
+    const appendRecord = vi.fn(backing.appendRecord.bind(backing));
+    const tracked = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'appendRecord') return appendRecord;
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as RuntimeStore;
+    const runtime = service(tracked);
+    const imported = payload();
+    imported.operation.whiteboard = {
+      ...board(),
+      elements: [textElement('text-target'), codeElement()],
+    };
+    await runtime.append({ stageId: 'stage-1', expectedLastSeq: null, payload: imported });
+
+    const edit = (operationId: string, elementId: string, lineId: string, newLineId: string) =>
+      operationPayload(operationId, {
+        kind: 'code_lines_edited',
+        elementId,
+        edit: {
+          kind: 'insert_after',
+          lineId,
+          lines: [{ id: newLineId, content: 'new' }],
+        },
+      });
+    await expect(
+      runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: 0,
+        payload: edit('edit:missing-element', 'missing', 'L1', 'new-1'),
+      }),
+    ).rejects.toBeInstanceOf(WhiteboardRuntimeElementNotFoundError);
+    await expect(
+      runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: 0,
+        payload: edit('edit:wrong-type', 'text-target', 'L1', 'new-2'),
+      }),
+    ).rejects.toMatchObject({
+      name: WhiteboardRuntimeElementTypeMismatchError.name,
+      code: 'WHITEBOARD_RUNTIME_ELEMENT_TYPE_MISMATCH',
+      expectedType: 'code',
+      actualType: 'text',
+    });
+    await expect(
+      runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: 0,
+        payload: edit('edit:missing-line', 'code-1', 'L99', 'new-3'),
+      }),
+    ).rejects.toMatchObject({
+      name: WhiteboardRuntimeCodeLineNotFoundError.name,
+      code: 'WHITEBOARD_RUNTIME_CODE_LINE_NOT_FOUND',
+      elementId: 'code-1',
+      lineId: 'L99',
+    });
+    await expect(
+      runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: null,
+        payload: edit('edit:stale-before-line', 'code-1', 'L99', 'new-4'),
+      }),
+    ).rejects.toBeInstanceOf(RuntimeAppendConflictError);
+    await expect(
+      runtime.append({
+        stageId: 'stage-1',
+        expectedLastSeq: 0,
+        payload: edit('edit:line-conflict', 'code-1', 'L1', 'L2'),
+      }),
+    ).rejects.toBeInstanceOf(WhiteboardRuntimeCodeLineIdConflictError);
+    expect(appendRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers a lost code-edit response with one append and exact replay survives target deletion', async () => {
+    const backing = runtimeStore();
+    const initial = service(backing);
+    const imported = payload();
+    imported.operation.whiteboard = { ...board(), elements: [codeElement()] };
+    await initial.append({ stageId: 'stage-1', expectedLastSeq: null, payload: imported });
+
+    let loseResponse = true;
+    const appendRecord = vi.fn(async (...args: Parameters<RuntimeStore['appendRecord']>) => {
+      const committed = await backing.appendRecord(...args);
+      if (loseResponse) {
+        loseResponse = false;
+        throw new Error('response lost');
+      }
+      return committed;
+    });
+    const lossy = new Proxy(backing, {
+      get(target, property) {
+        if (property === 'appendRecord') return appendRecord;
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as RuntimeStore;
+    const runtime = service(lossy);
+    const edited = operationPayload('edit:lost-response', {
+      kind: 'code_lines_edited',
+      elementId: 'code-1',
+      edit: {
+        kind: 'replace_lines',
+        lineIds: ['L3', 'L1'],
+        lines: [
+          { id: 'host-A', content: '' },
+          { id: 'host-B', content: 'replacement' },
+        ],
+      },
+    });
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: edited }),
+    ).resolves.toMatchObject({
+      committedSeq: 1,
+      replayed: true,
+      state: {
+        whiteboard: {
+          elements: [
+            {
+              id: 'code-1',
+              lines: [
+                { id: 'L2', content: 'const two = 2;' },
+                { id: 'host-A', content: '' },
+                { id: 'host-B', content: 'replacement' },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(appendRecord).toHaveBeenCalledTimes(1);
+
+    await runtime.append({
+      stageId: 'stage-1',
+      expectedLastSeq: 1,
+      payload: operationPayload('delete:code-after-edit', {
+        kind: 'element_deleted',
+        elementId: 'code-1',
+      }),
+    });
+    await expect(
+      runtime.append({ stageId: 'stage-1', expectedLastSeq: 0, payload: edited }),
+    ).resolves.toMatchObject({
+      committedSeq: 1,
+      replayed: true,
+      state: { lastSeq: 2, whiteboard: { elements: [] } },
+    });
+    expect(appendRecord).toHaveBeenCalledTimes(2);
   });
 
   it('detaches a learner element before the first async boundary', async () => {

--- a/tests/runtime/whiteboard-payload-wiring.test.ts
+++ b/tests/runtime/whiteboard-payload-wiring.test.ts
@@ -11,6 +11,10 @@ import { createStorageHttpHandler } from '@openmaic/storage/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { APP_RUNTIME_PAYLOAD_VALIDATORS } from '@/lib/runtime/payload-validators';
+import type {
+  WhiteboardRuntimeOperationV1,
+  WhiteboardRuntimePayloadV1,
+} from '@/lib/whiteboard/runtime/types';
 
 const NOW = '2026-08-06T00:00:00.000Z';
 
@@ -54,6 +58,13 @@ function validElementPayload(operationId = 'element-add:valid') {
       },
     },
   } as const;
+}
+
+function operationPayload(
+  operationId: string,
+  operation: WhiteboardRuntimeOperationV1,
+): WhiteboardRuntimePayloadV1 {
+  return { payloadVersion: 1, operationId, operation };
 }
 
 function handlerFetch(handler: RequestListener): typeof globalThis.fetch {
@@ -161,6 +172,53 @@ describe('default BrowserRuntimeStore app payload wiring', () => {
     await expect(
       store.appendRecord(
         {
+          id: 'code-edit:valid',
+          sessionId: 'whiteboard-session',
+          createdAt: now,
+          payload: operationPayload('code-edit:valid', {
+            kind: 'code_lines_edited',
+            elementId: 'code-1',
+            edit: {
+              kind: 'replace_lines',
+              lineIds: ['L2', 'L1'],
+              lines: [
+                { id: 'host-A', content: '' },
+                { id: 'host-B', content: 'replacement' },
+              ],
+            },
+          }),
+        },
+        { expectedLastSeq: 0 },
+      ),
+    ).resolves.toMatchObject({ seq: 1 });
+    await expect(
+      store.appendRecord(
+        {
+          id: 'element-delete:valid',
+          sessionId: 'whiteboard-session',
+          createdAt: now,
+          payload: operationPayload('element-delete:valid', {
+            kind: 'element_deleted',
+            elementId: 'text-added',
+          }),
+        },
+        { expectedLastSeq: 1 },
+      ),
+    ).resolves.toMatchObject({ seq: 2 });
+    await expect(
+      store.appendRecord(
+        {
+          id: 'elements-clear:valid',
+          sessionId: 'whiteboard-session',
+          createdAt: now,
+          payload: operationPayload('elements-clear:valid', { kind: 'elements_cleared' }),
+        },
+        { expectedLastSeq: 2 },
+      ),
+    ).resolves.toMatchObject({ seq: 3 });
+    await expect(
+      store.appendRecord(
+        {
           id: 'element-add:invalid-target',
           sessionId: 'whiteboard-session',
           createdAt: now,
@@ -172,7 +230,22 @@ describe('default BrowserRuntimeStore app payload wiring', () => {
             },
           },
         },
-        { expectedLastSeq: 0 },
+        { expectedLastSeq: 3 },
+      ),
+    ).rejects.toThrow('invalid runtime record');
+    await expect(
+      store.appendRecord(
+        {
+          id: 'code-edit:invalid-lines',
+          sessionId: 'whiteboard-session',
+          createdAt: now,
+          payload: operationPayload('code-edit:invalid-lines', {
+            kind: 'code_lines_edited',
+            elementId: 'code-1',
+            edit: { kind: 'delete_lines', lineIds: [] },
+          }),
+        },
+        { expectedLastSeq: 3 },
       ),
     ).rejects.toThrow('invalid runtime record');
   });
@@ -251,6 +324,50 @@ describe('default BrowserRuntimeStore app payload wiring', () => {
     await expect(
       client.appendRecord(
         {
+          id: 'code-edit:http',
+          sessionId: 'http-whiteboard-element',
+          createdAt: NOW,
+          payload: operationPayload('code-edit:http', {
+            kind: 'code_lines_edited',
+            elementId: 'code-1',
+            edit: {
+              kind: 'insert_after',
+              lineId: 'L1',
+              lines: [{ id: 'host-line', content: '' }],
+            },
+          }),
+        },
+        { expectedLastSeq: 0 },
+      ),
+    ).resolves.toMatchObject({ seq: 1 });
+    await expect(
+      client.appendRecord(
+        {
+          id: 'element-delete:http',
+          sessionId: 'http-whiteboard-element',
+          createdAt: NOW,
+          payload: operationPayload('element-delete:http', {
+            kind: 'element_deleted',
+            elementId: 'text-added',
+          }),
+        },
+        { expectedLastSeq: 1 },
+      ),
+    ).resolves.toMatchObject({ seq: 2 });
+    await expect(
+      client.appendRecord(
+        {
+          id: 'elements-clear:http',
+          sessionId: 'http-whiteboard-element',
+          createdAt: NOW,
+          payload: operationPayload('elements-clear:http', { kind: 'elements_cleared' }),
+        },
+        { expectedLastSeq: 2 },
+      ),
+    ).resolves.toMatchObject({ seq: 3 });
+    await expect(
+      client.appendRecord(
+        {
           id: 'element-add:http-invalid',
           sessionId: 'http-whiteboard-element',
           createdAt: NOW,
@@ -262,7 +379,30 @@ describe('default BrowserRuntimeStore app payload wiring', () => {
             },
           },
         },
-        { expectedLastSeq: 0 },
+        { expectedLastSeq: 3 },
+      ),
+    ).rejects.toMatchObject({
+      name: HttpRuntimeStoreError.name,
+      status: 400,
+      code: 'VALIDATION_FAILED',
+    });
+    await expect(
+      client.appendRecord(
+        {
+          id: 'code-edit:http-invalid',
+          sessionId: 'http-whiteboard-element',
+          createdAt: NOW,
+          payload: operationPayload('code-edit:http-invalid', {
+            kind: 'code_lines_edited',
+            elementId: 'code-1',
+            edit: {
+              kind: 'replace_lines',
+              lineIds: ['L1', 'L1'],
+              lines: [{ id: 'host-line', content: 'replacement' }],
+            },
+          }),
+        },
+        { expectedLastSeq: 3 },
       ),
     ).rejects.toMatchObject({
       name: HttpRuntimeStoreError.name,


### PR DESCRIPTION
## Summary

Add RuntimeStore-backed destructive and incremental code-edit operations to the Native Child whiteboard tool set, building on the read/visibility composition from #1156.

The mutation path keeps RuntimeStore as commit authority: exact replay is resolved before CAS and transition, each fresh operation appends at most once, uncertain append outcomes receive at most one read-only reconciliation, and projection is emitted only for confirmed commits.

## Related Issues

Related to #1049

Builds on #1152 and #1156

## Changes

- Add versioned Runtime whiteboard operations for element deletion, clearing all elements, and code-line insert/delete/replace edits.
- Add strict payload validation and deterministic folding for the new operation vocabulary.
- Add `wb_delete`, `wb_clear`, and `wb_edit_code` to the existing Native whiteboard inventory.
- Share operation-agnostic mutation settlement across additive and destructive Native tools.
- Preserve exact replay, CAS, definitive transition errors, one reconciliation at most, and confirmed-commit-only projection.
- Keep missing/already-empty clear as a successful zero-append, zero-projection no-op.
- Expose `wb_edit_code` as a root object JSON Schema while retaining strict operation-specific branches for provider portability.
- Add Browser/Pg RuntimeStore parity coverage and production-route integration coverage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run the focused Native/RuntimeStore suites listed below.
2. Run the PostgreSQL contract suite through the `storage-pg-contract` workflow.
3. In a classroom Q&A, create two elements, delete exactly one, then create a code block and perform line replacement/insertion/deletion without redrawing the block.

### What I personally verified

- Focused suites: 109 passed; the PostgreSQL suite was collected and skipped locally when `PG_CONTRACT_URL` was absent.
- Native tool and production-route suites passed, including the production-shaped additive replay regression.
- PostgreSQL 16 storage contract passed in CI.
- ESLint passed for every changed TypeScript source/test file.
- Prettier and `git diff --check` passed.
- Browser production path manually verified clear, exact element deletion, nonexistent-target handling, and code-line replace/insert/delete while preserving unrelated board content.
- Full Vitest in the physical validation copy reached 5204 passing tests. Eight unrelated publish-shell cases require Git metadata unavailable in that copy; two unrelated timeout cases passed when rerun in isolation (42/42).
- Full workspace typecheck retains existing renderer package-export diagnostics; no changed-file diagnostic appeared.

### Cross-review

- Independent read-only full-diff review found one reachable P2: replaying an additive operation after a later delete/clear could misreport a confirmed historical commit as failed.
- Fixed at `6b1556b9`: exact additive replay now derives its affected result from the exact operation payload while preserving the current authoritative state and record tail.
- Production-shaped regression covers draw → delete → replay: original `committedSeq`, current `lastSeq`, no additional append, and no element restoration.
- Full-diff re-review at `6b1556b9` reported no actionable P0–P3 findings and approved the change.
- A separate `WHITEBOARD_RUNTIME_CODE_ELEMENT_NOT_CANONICAL` candidate was withdrawn after tracing production reachability: Legacy elements are normalized before append and non-canonical Runtime snapshots are rejected by payload validation.

### Browser E2E evidence

<img width="689" height="732" alt="1 Codex Image Aug 24, 2026, 03_39_39 PM" src="https://github.com/user-attachments/assets/c5972c5a-d559-494f-859c-0785e3260b7d" />

<img width="703" height="560" alt="2Codex Image Aug 24, 2026, 03_40_01 PM" src="https://github.com/user-attachments/assets/2175a7fd-c16a-4bd5-a88e-1a31521251e2" />


In-place code-line replacement and insertion preserve the code block's identity, position, and style.

<img width="714" height="770" alt="3 Codex Image Aug 24, 2026, 03_40_12 PM" src="https://github.com/user-attachments/assets/2187244d-05e3-487e-99e9-00eb12c6c595" />

Before/after element deletion: the selected blue circle is removed while the code block, red rectangle, labels, and other board content remain.

Deleting the two inserted code lines restores the original four-line code block without redrawing or moving it.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
