### PR TITLE
refactor(storage): drop the unused active-stage API from the agent-session contract

### DIFF
--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -232,7 +232,6 @@ interface SessionRow extends Record<string, unknown> {
   owner_id: string;
   prompt: string;
   stage_id: string;
-  active_stage_id: string | null;
   skill_id: string | null;
   origin: string | null;
   existing_course: boolean;
@@ -246,7 +245,7 @@ interface SessionRow extends Record<string, unknown> {
   updated_at: Date | string;
 }
 
-const SESSION_COLUMNS = `id, owner_id, prompt, stage_id, active_stage_id, skill_id, origin,
+const SESSION_COLUMNS = `id, owner_id, prompt, stage_id, skill_id, origin,
   existing_course, status, attempt, lease_worker_id, lease_worker_pid,
   lease_heartbeat_at, error, created_at, updated_at`;
 
@@ -260,7 +259,6 @@ function sessionMeta(row: SessionRow): AgentSessionMeta {
     ownerId: row.owner_id,
     prompt: row.prompt,
     stageId: row.stage_id,
-    ...(row.active_stage_id ? { activeStageId: row.active_stage_id } : {}),
     ...(row.skill_id ? { skillId: row.skill_id } : {}),
     ...(row.origin ? { origin: row.origin } : {}),
     existingCourse: row.existing_course,
@@ -419,41 +417,6 @@ export class PgAgentSessionStore
       );
       if (!result.rows[0]) return false;
       await this.appendProjection({ type: 'session_deleted', sessionId, ts: this.clock() }, tx);
-      return true;
-    });
-  }
-
-  async resolveActiveStage(sessionId: string): Promise<string> {
-    const result = await this.queryable.query<{ stage_id: string; active_stage_id: string | null }>(
-      `SELECT stage_id, active_stage_id FROM ${this.table('sessions')}
-       WHERE id = $1 AND deleted_at IS NULL`,
-      [sessionId],
-    );
-    const row = result.rows[0];
-    if (!row) throw new Error(`@openmaic/storage: unknown session ${JSON.stringify(sessionId)}`);
-    return row.active_stage_id ?? row.stage_id;
-  }
-
-  async setActiveStage(sessionId: string, stageId: string): Promise<boolean> {
-    return this.transaction(async (tx) => {
-      const locked = await tx.query<{ active_stage_id: string | null }>(
-        `SELECT active_stage_id FROM ${this.table('sessions')}
-         WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
-        [sessionId],
-      );
-      const prior = locked.rows[0];
-      if (!prior) return false;
-      await tx.query(
-        `UPDATE ${this.table('sessions')} SET active_stage_id = $2, updated_at = now()
-         WHERE id = $1 AND deleted_at IS NULL`,
-        [sessionId, stageId],
-      );
-      if (prior.active_stage_id !== stageId) {
-        await this.appendProjection(
-          { type: 'session_active_stage', sessionId, ts: this.clock(), activeStageId: stageId },
-          tx,
-        );
-      }
       return true;
     });
   }
@@ -1021,8 +984,7 @@ export class PgAgentSessionStore
       if (!counter) throw new Error(`cannot allocate owner event id for ${session.owner_id}`);
       const status = 'status' in event ? event.status : null;
       const attempt = 'attempt' in event ? event.attempt : null;
-      const data =
-        event.type === 'session_active_stage' ? { activeStageId: event.activeStageId } : {};
+      const data = {};
       await transaction.query(
         `INSERT INTO ${this.table('ownerEvents')}
           (owner_id, id, ts, session_id, type, status, attempt, data)
@@ -1083,13 +1045,6 @@ export class PgAgentSessionStore
         sessionId: row.session_id,
         ts: Number(row.ts),
       };
-      if (row.type === 'session_active_stage') {
-        return {
-          ...base,
-          type: row.type,
-          activeStageId: String(decodedObject(row.data).activeStageId ?? ''),
-        };
-      }
       if (row.type === 'session_created' || row.type === 'session_status') {
         return {
           ...base,

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -29,7 +29,6 @@ export const AGENT_SESSION_LIFECYCLE = {
   thinkingEnd: 'thinking_end',
   materialExtraction: 'material_extraction',
   userQuestion: 'user_question',
-  activeStageChanged: 'active_stage_changed',
   libraryChanged: 'library_changed',
 } as const;
 
@@ -48,8 +47,6 @@ export interface AgentSessionMeta {
   prompt: string;
   /** The immutable stage with which the conversation was created. */
   stageId: string;
-  /** The current tool target; absence means that {@link stageId} is active. */
-  activeStageId?: string;
   skillId?: string;
   origin?: string;
   existingCourse: boolean;
@@ -228,8 +225,6 @@ export interface AgentSessionStore {
   listSessionsByOwner(ownerId: string): Promise<AgentSessionMeta[]>;
   /** Tombstone a visible session while deliberately preserving every child row. */
   softDeleteSession(sessionId: string, ownerId: string): Promise<boolean>;
-  resolveActiveStage(sessionId: string): Promise<string>;
-  setActiveStage(sessionId: string, stageId: string): Promise<boolean>;
   /**
    * Scan optimistically, then lock and recheck one candidate. The second
    * check is the authority: candidate snapshots are stale as soon as read.
@@ -347,7 +342,6 @@ export const OWNER_SESSION_EVENT_TYPES = [
   'session_created',
   'session_status',
   'session_deleted',
-  'session_active_stage',
   'session_cancel_requested',
 ] as const;
 
@@ -364,8 +358,7 @@ export type NewOwnerSessionEvent =
       status: AgentSessionStatus;
       attempt: number;
     })
-  | (OwnerSessionEventBase & { type: 'session_deleted' | 'session_cancel_requested' })
-  | (OwnerSessionEventBase & { type: 'session_active_stage'; activeStageId: string });
+  | (OwnerSessionEventBase & { type: 'session_deleted' | 'session_cancel_requested' });
 
 export type PersistedOwnerSessionEvent = NewOwnerSessionEvent & {
   /** Decimal bigint text avoids rounding a replay cursor in JavaScript. */

--- a/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-concurrency-contract.ts
@@ -120,11 +120,10 @@ export function runAgentSessionConcurrencyContract(
         const store = makeStore();
         await store.createSession(makeAgentSessionInput());
         await Promise.all([
-          store.setActiveStage('session-1', 'stage-2'),
           store.postUserMessage('session-1', { text: 'Concurrent message' }),
           store.requestCancel('session-1'),
         ]);
-        expect(await store.readMaxId('owner-a')).toBe(BigInt(4));
+        expect(await store.readMaxId('owner-a')).toBe(BigInt(3));
       },
     );
 
@@ -147,16 +146,15 @@ export function runAgentSessionConcurrencyContract(
         // Deadlock freedom follows from that invariant, which this free-running
         // race cannot falsify. What it does verify deterministically: the
         // session-row locks serialize each projection against the merge, so all
-        // four transactions commit, and the assertions below pin the merged
+        // three transactions commit, and the assertions below pin the merged
         // result (duplicate-free stream, durable counter == highest allocated
         // id, source counter deleted, owner rosters).
         await Promise.all([
           store.mergeOwner('owner-a', 'owner-b'),
-          store.setActiveStage('session-1', 'stage-1b'),
           store.requestCancel('session-2'),
           store.postUserMessage('session-3', { text: 'Concurrent message' }),
         ]);
-        // All four committed: the merged owner stream is duplicate-free and
+        // All three committed: the merged owner stream is duplicate-free and
         // its durable counter matches the highest allocated id.
         const targetEvents = await store.readAfter('owner-b', BigInt(0));
         const ids = targetEvents.map((event) => Number(event.id));

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -39,7 +39,7 @@ export function runAgentSessionStoreContract(
   makeStore: () => AgentSessionContractStore,
 ): void {
   describe(`AgentSessionStore contract: ${name}`, () => {
-    test('creates, reads, lists, and resolves an active stage', async () => {
+    test('creates, reads, and lists sessions', async () => {
       const store = makeStore();
       const created = await store.createSession(
         makeAgentSessionInput({ skillId: 'skill-a', origin: 'https://example.test' }),
@@ -55,9 +55,6 @@ export function runAgentSessionStoreContract(
       });
       expect(await store.getSession('session-1')).toEqual(created);
       expect(await store.listSessionsByOwner('owner-a')).toEqual([created]);
-      expect(await store.resolveActiveStage('session-1')).toBe('stage-1');
-      expect(await store.setActiveStage('session-1', 'stage-2')).toBe(true);
-      expect(await store.resolveActiveStage('session-1')).toBe('stage-2');
     });
 
     test('tombstones only through the owner and hides all public child reads', async () => {
@@ -318,16 +315,14 @@ export function runAgentSessionStoreContract(
     test('maintains a sparse per-owner projection and its durable counter', async () => {
       const store = makeStore();
       await store.createSession(makeAgentSessionInput());
-      await store.setActiveStage('session-1', 'stage-2');
       await store.requestCancel('session-1');
       const events = await store.readAfter('owner-a', BigInt(0));
       expect(events.map((event) => event.type)).toEqual([
         'session_created',
-        'session_active_stage',
         'session_cancel_requested',
       ]);
-      expect(events.map((event) => event.id)).toEqual(['1', '2', '3']);
-      expect(await store.readMaxId('owner-a')).toBe(BigInt(3));
+      expect(events.map((event) => event.id)).toEqual(['1', '2']);
+      expect(await store.readMaxId('owner-a')).toBe(BigInt(2));
       expect(await store.readRetirement('owner-a')).toBeNull();
     });
 


### PR DESCRIPTION
The agent-session store exposed `resolveActiveStage` / `setActiveStage` plus the `active_stage_changed` lifecycle event and the `session_active_stage` owner-event variant, with contract tests pinning them — but nothing in the runtime consumes any of it. The intended contract is that every tool call addresses its stage explicitly, so a session carries no mutable default target.

Removing the API now, while it still has zero consumers, keeps the store contract from accreting a concept the runtime does not want. The `active_stage_id` column and its DDL check-constraint entry stay untouched for schema compatibility.

- Store interface, PG implementation, owner-event encode/decode paths, and the lifecycle event name removed
- Contract tests covering the API removed
- `tsc`, lint, and the storage + agent-runtime suites pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)