### PR TITLE
docs: document the agent runtime configuration surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -295,6 +295,51 @@ WEB_SEARCH_CLAUDE_MODELS=
 # blank defaults to open.maic.chat; set to "off" to omit it.
 # NEXT_PUBLIC_VIDEO_EXPORT_CTA_DESTINATION=open.maic.chat
 
+# --- Agent Runtime (experimental) ---------------------------------------------
+
+# Server-only gate for durable background agent sessions: the /api/agent
+# session and owner-event control-plane routes plus the in-process session
+# runner. Default OFF — while disabled, every /api/agent/sessions* and
+# /api/agent/owner-events route answers 404. Truthy values are "true" or "1";
+# anything else (including unset) is treated as disabled.
+# OPENMAIC_AGENT_RUNTIME_ENABLED=true
+
+# The runtime is server-backed and requires the PostgreSQL connection from the
+# "Server-backed Persistence" section below: without a non-empty DATABASE_URL
+# the runner never starts and the session store rejects requests, even with the
+# flag above enabled.
+# DATABASE_URL=postgres://openmaic:password@postgres:5432/openmaic
+
+# REQUIRED while the runtime is enabled: MODEL_ROUTES must explicitly route the
+# "maic-agent-driver" stage to a provider-prefixed model id. There is
+# intentionally no fallback — without this route every agent session fails at
+# run start. The route object must set api (or its alias dialect) to
+# "openai-completions" or "openai-responses"; any other value is rejected, and
+# a bare model id without a provider prefix is rejected too. Optional fields:
+# contextWindow pins the effective context window below the provider catalog
+# value (used by compaction thresholds), and thinking must never set effort
+# (the tool-using driver cannot combine reasoning_effort with function tools on
+# this transport).
+# MODEL_ROUTES='{"maic-agent-driver":{"model":"openai:gpt-5.5","api":"openai-completions"}}'
+
+# Runner tuning. Defaults are shown; only relevant once the runtime is enabled.
+# OPENMAIC_AGENT_RUNTIME_SCAN_INTERVAL_MS=1000
+# OPENMAIC_AGENT_RUNTIME_HEARTBEAT_MS=2000
+# OPENMAIC_AGENT_RUNTIME_LEASE_TTL_MS=10000
+# OPENMAIC_AGENT_RUNTIME_MAX_CONCURRENT=2
+# OPENMAIC_AGENT_RUNTIME_MAX_ATTEMPTS=5
+
+# Conversation compaction is reserved and OFF by default. The reusable
+# compaction runtime is not implemented yet — it lands in a later slice of
+# work — and until then the runner runs without context transformation, so
+# these knobs are inert placeholders.
+# OPENMAIC_AGENT_COMPACTION_ENABLED=true
+# OPENMAIC_AGENT_COMPACTION_RESERVE_TOKENS=0
+# OPENMAIC_AGENT_COMPACTION_KEEP_RECENT_TOKENS=0
+
+# Session prompts and follow-up messages are capped server-side at a fixed
+# 100,000 characters; this limit is a constant and is not configurable.
+
 # --- Proxy (optional) --------------------------------------------------------
 
 # HTTP_PROXY=
@@ -325,13 +370,19 @@ DEFAULT_MODEL=
 # route to an unconfigured/invalid model fails at request time for that stage,
 # the same way a bad DEFAULT_MODEL would (no startup validation).
 # Routable stages: scene-outlines-stream, scene-content, scene-actions,
-# agent-profiles, quiz-grade, pbl-chat, chat-adapter, generate-classroom,
-# web-search-query-rewrite.
+# agent-profiles, quiz-grade, pbl-chat, pbl-v2-runtime, chat-adapter,
+# generate-classroom, web-search-query-rewrite, maic-agent,
+# maic-agent-driver.
 # scene-content can also be routed per scene type with composite keys:
 # scene-content:slide, scene-content:quiz, scene-content:interactive,
 # scene-content:pbl. A type falls back to the base scene-content route when it
 # has no key of its own (so scene-content:<type> > scene-content > x-model >
 # DEFAULT_MODEL).
+# pbl-v2-runtime follows the same composite fallback pattern with
+# pbl-v2-runtime:instructor, pbl-v2-runtime:open-task, pbl-v2-runtime:evaluate
+# and pbl-v2-runtime:simulator, falling back to the base pbl-v2-runtime route.
+# maic-agent-driver is REQUIRED when the agent runtime is enabled; see the
+# "Agent runtime (experimental)" section for its api/dialect constraints.
 # A route value can be a model string, OR an object {"model","thinking"} where
 # `thinking` is the full ThinkingConfig: mode (default|disabled|enabled|auto),
 # effort (none|minimal|low|medium|high|xhigh|max), level (minimal|low|medium|

--- a/README.md
+++ b/README.md
@@ -409,6 +409,28 @@ and
 Leave `NEXT_PUBLIC_PERSISTENCE` unset to retain the existing browser-only
 behavior.
 
+### Optional: Agent runtime (experimental)
+
+Background agent sessions — the `/api/agent/*` control-plane routes plus an
+in-process session runner — are experimental and off by default. To enable
+them, set the server-side flag and provide the same PostgreSQL connection used
+by server-backed persistence:
+
+```env
+OPENMAIC_AGENT_RUNTIME_ENABLED=true
+DATABASE_URL=postgres://openmaic:openmaic-dev@postgres:5432/openmaic
+```
+
+While the flag is off, the `/api/agent/sessions*` and `/api/agent/owner-events`
+routes answer `404`. Enabling it
+without a `DATABASE_URL` never starts the runner and makes the session routes
+error, so the runtime is server-backed by design. While enabled, `MODEL_ROUTES`
+must explicitly route the `maic-agent-driver` stage to a provider-prefixed
+model with an `openai-completions` or `openai-responses` `api`/`dialect`; there
+is intentionally no fallback. Runner cadence (scan interval, heartbeat, lease
+TTL, concurrency, attempts) and the reserved compaction knobs are listed in
+`.env.example` under **Agent runtime (experimental)**.
+
 ### Optional: MP4 Video Export (Render Service)
 
 The "Export Video" menu builds a self-contained [Hyperframes](https://www.npmjs.com/package/@hyperframes/producer) project entirely in the browser. Turning that into an MP4 needs Chromium + FFmpeg on Node 22, so it runs in an isolated `render-service` container rather than the app.


### PR DESCRIPTION
The integration branch introduced the agent runtime's configuration surface with no operator documentation: the `OPENMAIC_AGENT_RUNTIME_ENABLED` gate, the DATABASE_URL requirement, the mandatory `maic-agent-driver` MODEL_ROUTES stage (which has intentionally no fallback and fails every session at run start when missing), the runner tuning envs, and the reserved compaction placeholders. The `.env.example` routable-stages list was also stale (missing `maic-agent`, `maic-agent-driver`, and the `pbl-v2-runtime*` stages).

- New "Agent Runtime (experimental)" section in `.env.example`, every entry verified against the code (flag truthiness, 404 behavior, driver route constraints, tuning defaults)
- Compaction knobs documented honestly as inert placeholders until the compaction runtime lands
- Routable-stages list regenerated from `LLM_STAGES`
- Matching short section in README

Docs only — no code changes. prettier + eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)