### PR TITLE
fix(‎middleware): Rename middleware to proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -41,7 +41,7 @@ async function verifyToken(token: string, accessCode: string): Promise<boolean> 
   return mismatch === 0;
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const accessCode = process.env.ACCESS_CODE;
   if (!accessCode) {
     return NextResponse.next();


### PR DESCRIPTION
Fixes https://github.com/THU-MAIC/OpenMAIC/issues/1177

Next warning: The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy