### PR TITLE
fix(build): scope Next typecheck to production sources

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: process.env.VERCEL ? undefined : 'standalone',
+  typescript: {
+    tsconfigPath: process.env.NODE_ENV === 'production' ? 'tsconfig.build.json' : 'tsconfig.json',
+  },
   transpilePackages: ['mathml2omml', 'pptxgenjs', '@openmaic/importer'],
   // These agent packages do a runtime `import(specifier)` with a computed
   // specifier (to lazily load node:fs/os/path without breaking browser/Vite

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  // `exclude` replaces the inherited list; keep shared entries in sync with tsconfig.json.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "packages/*/src",
+    "packages/docs",
+    "openclaw",
+    "e2e",
+    "render-service",
+    "tests",
+    "eval",
+    "packages/@openmaic/*/test"
+  ]
+}


### PR DESCRIPTION
## Summary

A clean Docker production build aborts during the Next.js TypeScript-checking phase (#1157). The optimized compile succeeds, then the type-check worker reaches the builder image's default V8 heap limit (~2,096 MiB) and dies with `SIGABRT`.

This scopes the production type-check to production sources. `next build` now reads a `tsconfig.build.json` that extends the root config and additionally excludes the test and eval trees. The saving comes less from the test files themselves than from the test-only `node_modules` type declarations they pull into the program (vitest, testing-library and friends): the type-check program drops from 7,960 to 6,915 files and from 410k to 253k lines of TypeScript.

No Dockerfile or `NODE_OPTIONS` change is included. Raising the heap ceiling would relocate the failure rather than detect it, and it is a build-resource policy decision independent of this fix.

## Related Issues

Fixes #1157

## Changes

- `next.config.ts`: point `typescript.tsconfigPath` at `tsconfig.build.json` when `NODE_ENV` is `production`, and at the root `tsconfig.json` otherwise.
- `tsconfig.build.json`: new config extending the root one, additionally excluding `tests`, `eval` and `packages/@openmaic/*/test`. TypeScript replaces an inherited `exclude` instead of merging into it, so the root entries are repeated and carry a comment saying they must stay in sync.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. On the parent commit `9b54baa6`, run `docker build --no-cache --progress=plain -t openmaic-1157:baseline .` — the build dies during `Running TypeScript ...`.
2. On this branch, run `docker build --no-cache --progress=plain -t openmaic-1157:final .` — the build completes and exports the image.
3. Start a container from that image and request `/api/health`.

### What you personally verified

Environment: Docker (aarch64), 18 CPU, 8,319,213,568 B VM memory; builder stage `node:22-alpine` (Node 22). The default V8 heap limit inside that image is 2,197,815,296 B (~2,096 MiB), as measured in #1157.

| Source | Builder heap | Result |
| --- | --- | --- |
| `9b54baa6` (pre-fix `main`) | default | **FAIL** — `FATAL ERROR: Ineffective mark-compacts near heap limit` + `SIGABRT` during `Running TypeScript ...` |
| this branch | 1536 MiB | **FAIL** — identical signature, identical build phase |
| this branch | 1792 MiB | PASS — 44/44 static pages, image exported |
| this branch | default | PASS — 44/44 static pages, image exported |

The baseline and final builds used `--no-cache`; no `RUN` step was reused. The 1536/1792 boundary probes reused dependency layers, while the `pnpm build` layer reran under each heap limit. Those probes drove the heap limit through a temporary `ARG`-based `NODE_OPTIONS` wrapper in the builder stage — experiment harness only, not part of this diff, which leaves the builder stage as a plain `RUN pnpm build`.

The 1536/1792 pair brackets the production type-check's requirement between those two values against a ~2,096 MiB default ceiling, i.e. roughly 15–27% measured headroom. That is real headroom but not a generous margin, so the numbers are recorded here: a future report of the same OOM on a build host with less RAM can be diagnosed against a known requirement instead of being re-bisected. Node's default heap limit scales with host memory, so that ceiling is a property of the build machine rather than of this commit.

CI type coverage is unchanged. The root `npx tsc --noEmit` job still runs the full `tsconfig.json`, so `tests/`, `eval/` and `packages/@openmaic/*/test` stay type-checked, and the storage package keeps its dedicated `typecheck` job. `next build` selects the scoped config, while `next dev` and CI's root type-check continue using `tsconfig.json`.

Not verified: any platform other than the aarch64 environment described above.

### Evidence

Runtime check against the image produced by the final build:

```text
container_status=running
GET /api/health -> {"success":true,"status":"ok","version":"0.1.0","capabilities":{"webSearch":false,"imageGeneration":false,"videoGeneration":false,"tts":false}}
```

`pnpm check` and `pnpm lint` pass locally with 0 errors. The root `npx tsc --noEmit` is left to CI: this PR does not touch `tsconfig.json`, so the root type-check program is identical to `main`'s.

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
