### PR TITLE
fix(agent): repair orphaned and late tool results across interruption boundaries

### DIFF
--- a/lib/server/agent-runtime/resume.ts
+++ b/lib/server/agent-runtime/resume.ts
@@ -22,14 +22,14 @@
  *                                   its own question)
  *   ends with `assistant` + calls-> we died DURING tool execution. The calls have
  *                                   no results, so the transcript is not a legal
- *                                   continuation point. We synthesize an error
- *                                   tool result per dangling call telling the
- *                                   model the step was interrupted, then continue.
+ *                                   continuation point. We report the dangling
+ *                                   ids; the shared read-boundary repair adds
+ *                                   provider-safe interrupted results.
  *   ends with non-empty
  *   `assistant`, none            -> the model had already stopped calling tools;
  *                                   the run was effectively complete.
  *
- * The synthesized-error branch is what makes tool execution AT-LEAST-ONCE: a
+ * The interrupted-result repair is what makes tool execution AT-LEAST-ONCE: a
  * tool that ran but whose result never got persisted will be re-issued by the
  * model. Every tool in this system must therefore be idempotent — `putScene` is,
  * on (stageId, sceneId), and `generate_scene` derives its scene id from the
@@ -44,10 +44,6 @@ export type ResumeAction =
   | { kind: 'start' }
   | { kind: 'continue'; messages: AgentMessage[]; repairedToolCalls: string[] }
   | { kind: 'already-complete'; messages: AgentMessage[] };
-
-const INTERRUPTED_TEXT =
-  'This tool call was interrupted by a worker restart and produced no recorded result. ' +
-  'The underlying store is idempotent, so re-issue the same call if the step is still needed.';
 
 function isEmptyAssistantMessage(message: AgentMessage): boolean {
   if (message.role !== 'assistant') return false;
@@ -154,16 +150,9 @@ export function planResume(transcript: AgentMessage[] | null): ResumeAction {
       // assistant message; treat as a normal continuation point.
       return { kind: 'continue', messages, repairedToolCalls: [] };
     }
-    for (const call of dangling) {
-      messages.push({
-        role: 'toolResult',
-        toolCallId: call.id,
-        toolName: call.name,
-        content: [{ type: 'text', text: INTERRUPTED_TEXT }],
-        isError: true,
-        timestamp: Date.now(),
-      } as unknown as AgentMessage);
-    }
+    // Keep planResume deterministic and limited to durable-tail
+    // classification. The shared read-boundary normalizer owns synthetic
+    // receipts for both tail and middle-of-history orphans.
     return { kind: 'continue', messages, repairedToolCalls: dangling.map((c) => c.id) };
   }
 

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -29,6 +29,12 @@ import {
   type SessionEntryHistory,
 } from './entry-tree-storage';
 import { planResume, type ResumeAction } from './resume';
+import {
+  appendInterruptedToolCallResults,
+  repairOrphanedToolCalls,
+  trackToolCallMessage,
+  type PendingToolCall,
+} from './tool-call-integrity';
 import { getAgentSessionStore } from './store';
 
 const log = createLogger('AgentRunner');
@@ -575,24 +581,32 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
     const recovery = await loadEntryHistory();
     const historyMessages = recovery.messages;
     const plan = planResume(historyMessages);
-    const repairedCount = plan.kind === 'continue' ? plan.repairedToolCalls.length : 0;
     const plannedMessages = plan.kind === 'start' ? [] : plan.messages;
-    const retainedCount = plannedMessages.length - repairedCount;
+    // planResume now contains durable messages only; synthetic receipts are a
+    // read-time provider view owned by repairOrphanedToolCalls.
+    const retainedCount = plannedMessages.length;
 
-    // planResume may strip an incomplete suffix and synthesize missing tool
-    // results. Reflect both changes in the append-only tree before execution.
+    // planResume may strip an incomplete suffix. Reflect the truncation in the
+    // append-only tree before execution; missing tool results are repaired at
+    // the read boundary and are deliberately never persisted.
     if (retainedCount < historyMessages.length) {
       const targetId = retainedCount > 0 ? recovery.contextEntryIds[retainedCount - 1]! : null;
       await writeRequiredSessionEntry(async () => {
         await entrySession!.moveTo(targetId);
       }, markLeaseLost);
     }
-    for (const repaired of plannedMessages.slice(retainedCount)) {
-      await writeRequiredSessionEntry(async () => {
-        await entrySession!.appendMessage(repaired);
-      }, markLeaseLost);
-    }
     if (leaseLost) throw new AgentSessionLeaseLostError(id, WORKER_ID, attempt);
+    // planResume still owns tail classification/truncation, but its synthetic
+    // results are a read-time view only. The general repair below also covers
+    // old middle-of-history orphans without mutating the entry tree.
+    const contextRepair = repairOrphanedToolCalls(plannedMessages);
+    const modelMessages = contextRepair.messages;
+    const repairedToolCallIds = [
+      ...new Set([
+        ...(plan.kind === 'continue' ? plan.repairedToolCalls : []),
+        ...contextRepair.repairedToolCalls,
+      ]),
+    ];
 
     const loggedMessages = await store.listUserMessages(id);
     const historyUsers = recovery.cursorMessages.filter((message) => message.role === 'user');
@@ -634,8 +648,8 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         pid: process.pid,
         attempt,
         reason: plan.kind === 'start' || meta.claimReason === 'queued' ? 'follow_up' : 'crash',
-        transcriptMessages: plan.kind === 'start' ? 0 : plan.messages.length,
-        repairedToolCalls: plan.kind === 'continue' ? plan.repairedToolCalls : [],
+        transcriptMessages: modelMessages.length,
+        repairedToolCalls: repairedToolCallIds,
       });
     }
 
@@ -667,7 +681,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       model: driver.piModel,
       tools,
       allowedToolNames: MINIMAL_AGENT_TOOL_NAMES,
-      ...(plan.kind === 'start' ? {} : { history: plan.messages }),
+      ...(plan.kind === 'start' ? {} : { history: modelMessages }),
       afterToolCall: (toolContext) => {
         toolCalls += 1;
         if (askUserLatch.shouldTerminate(toolContext.toolCall.name, toolContext.isError)) {
@@ -677,14 +691,47 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       },
     });
 
+    // Every finalized pi message is inserted into the only history source on
+    // the same ordered chain as its event. The INSERT is a critical write: a
+    // failure aborts the loop and prevents a successful settlement.
+    const inFlightToolCalls = new Map<string, PendingToolCall>();
     const unsubscribe = agent.subscribe((event: AgentEvent) => {
       emit(event.type, event);
       if (event.type === 'message_end') {
+        // A tool call becomes pending as soon as its assistant frame is
+        // emitted, so an abort can queue its receipt even while that frame is
+        // still waiting on the ordered write chain. A result stops being
+        // pending only AFTER its fenced append succeeds; clearing it at event
+        // time would reopen the orphan race during write-chain drain.
+        if (event.message.role === 'assistant') {
+          trackToolCallMessage(inFlightToolCalls, event.message);
+        }
         enqueue(async () => {
           await entrySession!.appendMessage(event.message);
+          if (event.message.role === 'toolResult') {
+            trackToolCallMessage(inFlightToolCalls, event.message);
+          }
         }, true);
       }
     });
+    let interruptedResultsQueued = false;
+    const queueInterruptedToolResults = (): void => {
+      if (interruptedResultsQueued || inFlightToolCalls.size === 0) return;
+      interruptedResultsQueued = true;
+      enqueue(async () => {
+        // Resolve the set only after all preceding message appends have
+        // drained. Successfully persisted results remove themselves above;
+        // calls still present here are the genuinely orphaned durable set.
+        const calls = [...inFlightToolCalls.values()];
+        inFlightToolCalls.clear();
+        await appendInterruptedToolCallResults(calls, {
+          append: async (message) => {
+            await entrySession!.appendMessage(message);
+          },
+          onFenceLost: markLeaseLost,
+        });
+      }, true);
+    };
     const abortAgent = () => agent.abort();
     abort.signal.addEventListener('abort', abortAgent);
 
@@ -767,6 +814,12 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         if (abort.signal.aborted) break;
         if (delivered === 0 || steeredThisAttempt === before) break;
       }
+
+      // A tool call that was still in flight when the loop wound down has no
+      // durable receipt yet. Append its interrupted result before the terminal
+      // flush so the tree is provider-safe for the next claim, and so a
+      // shutdown/lease-loss park leaves no orphaned call behind.
+      queueInterruptedToolResults();
       await flushAll();
 
       const loopError = terminalLoopError(agent.state.messages, agent.state.errorMessage);
@@ -806,6 +859,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       }
       log.info(`session ${id} -> ${status} (attempt ${attempt}, ${toolCalls} tool calls)`);
     } catch (error) {
+      queueInterruptedToolResults();
       if (isLeaseLostError(error)) markLeaseLost();
       const message = error instanceof Error ? error.message : String(error);
       if (ctx.shuttingDown || leaseLost || tripwireViolated) {

--- a/lib/server/agent-runtime/tool-call-integrity.ts
+++ b/lib/server/agent-runtime/tool-call-integrity.ts
@@ -1,0 +1,236 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { AssistantMessage, ToolCall, ToolResultMessage } from '@earendil-works/pi-ai';
+import { AgentSessionLeaseLostError } from '@openmaic/storage';
+
+export interface PendingToolCall {
+  id: string;
+  name: string;
+}
+
+export interface ToolCallRepair {
+  messages: AgentMessage[];
+  repairedToolCalls: string[];
+}
+
+export type AgentContextTransform = (
+  messages: AgentMessage[],
+  signal?: AbortSignal,
+) => Promise<AgentMessage[]>;
+
+const INTERRUPTED_DETAILS = { ok: false, error: 'interrupted' } as const;
+const INTERRUPTED_TEXT = JSON.stringify({
+  ...INTERRUPTED_DETAILS,
+  message: 'This tool call was interrupted before a result was recorded.',
+});
+
+/**
+ * The entry-tree adapter surfaces a lease/attempt fence loss as a storage
+ * error whose cause chain bottoms out in `AgentSessionLeaseLostError`. Walk
+ * the chain so the write-time settlement treats it exactly like the runner's
+ * other critical writes instead of re-throwing it as an ordinary failure.
+ */
+function isLeaseLostError(error: unknown): boolean {
+  let current = error;
+  const visited = new Set<unknown>();
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    if (current instanceof AgentSessionLeaseLostError) return true;
+    visited.add(current);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+function toolCalls(message: AgentMessage): ToolCall[] {
+  if (message.role !== 'assistant') return [];
+  const content = (message as Partial<AssistantMessage>).content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(
+    (part): part is ToolCall =>
+      part?.type === 'toolCall' && typeof part.id === 'string' && typeof part.name === 'string',
+  );
+}
+
+function isInterruptedAssistantFrame(message: AgentMessage): boolean {
+  if (message.role !== 'assistant' || toolCalls(message).length > 0) return false;
+  const frame = message as { stopReason?: unknown; errorMessage?: unknown };
+  return (
+    frame.stopReason === 'aborted' ||
+    frame.stopReason === 'length' ||
+    frame.stopReason === 'error' ||
+    (typeof frame.errorMessage === 'string' && frame.errorMessage.trim().length > 0)
+  );
+}
+
+export function interruptedToolResult(call: PendingToolCall, timestamp = Date.now()): AgentMessage {
+  return {
+    role: 'toolResult',
+    toolCallId: call.id,
+    toolName: call.name,
+    content: [{ type: 'text', text: INTERRUPTED_TEXT }],
+    details: INTERRUPTED_DETAILS,
+    isError: true,
+    timestamp,
+  } as ToolResultMessage;
+}
+
+/** Return every tool call id that has no result anywhere in the materialized context. */
+export function orphanedToolCalls(messages: readonly AgentMessage[]): PendingToolCall[] {
+  const answered = new Set(
+    messages.flatMap((message) =>
+      message.role === 'toolResult' && typeof message.toolCallId === 'string'
+        ? [message.toolCallId]
+        : [],
+    ),
+  );
+  return messages.flatMap((message) =>
+    toolCalls(message)
+      .filter((call) => !answered.has(call.id))
+      .map((call) => ({ id: call.id, name: call.name })),
+  );
+}
+
+/**
+ * Enforce the provider tool-call invariant at the read boundary.
+ *
+ * Parallel tools may finish while pi is unwinding an aborted assistant frame.
+ * Their durable order can then be:
+ *
+ *   assistant(tool A, tool B), result(A), assistant(aborted), result(B)
+ *
+ * Although result(B) exists, strict providers reject that history because all
+ * results for one assistant tool-call frame must be contiguous. For an invalid
+ * transcript we materialize a provider-safe view: existing results move next
+ * to their owning assistant (in call order), incomplete assistant unwind frames
+ * are omitted, and only genuinely missing results are synthesized. The entry
+ * tree itself remains an immutable audit trail.
+ * A healthy transcript is returned by reference so its serialized bytes are
+ * necessarily unchanged.
+ */
+export function repairOrphanedToolCalls(
+  messages: AgentMessage[],
+  now: () => number = Date.now,
+): ToolCallRepair {
+  const callGroups = new Map<number, ToolCall[]>();
+  const knownCallIds = new Set<string>();
+  const resultIndexes = new Map<string, number[]>();
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const calls = toolCalls(messages[index]!);
+    if (calls.length > 0) {
+      callGroups.set(index, calls);
+      for (const call of calls) knownCallIds.add(call.id);
+    }
+    const message = messages[index]!;
+    if (message.role === 'toolResult' && typeof message.toolCallId === 'string') {
+      resultIndexes.set(message.toolCallId, [
+        ...(resultIndexes.get(message.toolCallId) ?? []),
+        index,
+      ]);
+    }
+  }
+
+  const repairedToolCalls: string[] = [];
+  let needsRepair = false;
+
+  for (const [index, calls] of callGroups) {
+    const expected = new Set(calls.map((call) => call.id));
+    const contiguous: string[] = [];
+    for (let cursor = index + 1; messages[cursor]?.role === 'toolResult'; cursor += 1) {
+      contiguous.push((messages[cursor] as ToolResultMessage).toolCallId);
+    }
+    if (
+      contiguous.length !== expected.size ||
+      contiguous.some((id) => !expected.has(id)) ||
+      [...expected].some((id) => !contiguous.includes(id))
+    ) {
+      needsRepair = true;
+    }
+
+    for (const call of calls) {
+      if ((resultIndexes.get(call.id) ?? []).length === 0) repairedToolCalls.push(call.id);
+    }
+  }
+
+  if (!needsRepair && repairedToolCalls.length === 0) return { messages, repairedToolCalls };
+
+  // Every result owned by a known call is emitted with that call below. This
+  // also drops duplicate receipts from the model view while preserving the
+  // first durable receipt verbatim.
+  const ownedResultIndexes = new Set(
+    [...resultIndexes.entries()]
+      .filter(([id]) => knownCallIds.has(id))
+      .flatMap(([, indexes]) => indexes),
+  );
+  const repaired: AgentMessage[] = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    if (ownedResultIndexes.has(index)) continue;
+    // Once late results move in front of the abort frame, that frame becomes
+    // the tail again. It is not a completed model turn and planResume would
+    // have discarded it had the race not hidden it in the middle originally.
+    if (isInterruptedAssistantFrame(messages[index]!)) continue;
+    repaired.push(messages[index]!);
+    for (const call of callGroups.get(index) ?? []) {
+      const existingIndex = resultIndexes.get(call.id)?.[0];
+      repaired.push(
+        existingIndex === undefined
+          ? interruptedToolResult({ id: call.id, name: call.name }, now())
+          : messages[existingIndex]!,
+      );
+    }
+  }
+  return { messages: repaired, repairedToolCalls };
+}
+
+/**
+ * Keep the final model-facing context legal even when an intermediate
+ * transform re-materializes the raw durable tree.
+ *
+ * A transform that rebuilds context from the raw entry tree on every turn can
+ * replace an already-repaired initial state with the original orphan, because
+ * read-time synthetic receipts are deliberately not persisted. Applying the
+ * same normalizer after the transform makes this the last context boundary
+ * before the model conversion and also fixes late parallel results that the
+ * durable order split with an abort frame.
+ */
+export function withToolCallIntegrityRepair(
+  transform: AgentContextTransform,
+): AgentContextTransform {
+  return async (messages, signal) =>
+    repairOrphanedToolCalls(await transform(messages, signal)).messages;
+}
+
+/** Track calls whose durable assistant frame exists but whose result does not yet exist. */
+export function trackToolCallMessage(
+  inFlight: Map<string, PendingToolCall>,
+  message: AgentMessage,
+): void {
+  if (message.role === 'assistant') {
+    for (const call of toolCalls(message)) inFlight.set(call.id, { id: call.id, name: call.name });
+    return;
+  }
+  if (message.role === 'toolResult') inFlight.delete(message.toolCallId);
+}
+
+interface AppendInterruptedOptions {
+  append: (message: AgentMessage) => Promise<void>;
+  onFenceLost: () => void;
+  now?: () => number;
+}
+
+/** Append abort receipts through the same attempt-fenced storage as normal messages. */
+export async function appendInterruptedToolCallResults(
+  calls: readonly PendingToolCall[],
+  options: AppendInterruptedOptions,
+): Promise<void> {
+  for (const call of calls) {
+    try {
+      await options.append(interruptedToolResult(call, (options.now ?? Date.now)()));
+    } catch (error) {
+      if (isLeaseLostError(error)) {
+        options.onFenceLost();
+        return;
+      }
+      throw error;
+    }
+  }
+}

--- a/tests/agent-runtime/resume.test.ts
+++ b/tests/agent-runtime/resume.test.ts
@@ -149,7 +149,7 @@ describe('planResume', () => {
     if (plan.kind === 'continue') expect(plan.repairedToolCalls).toEqual([]);
   });
 
-  it('synthesizes error results for dangling tool calls (died DURING tool execution)', () => {
+  it('reports dangling tool calls without mutating the durable recovery view', () => {
     const transcript = [
       user('build a course'),
       assistantWithCalls([
@@ -165,16 +165,7 @@ describe('planResume', () => {
     expect(plan.kind).toBe('continue');
     if (plan.kind !== 'continue') throw new Error('unreachable');
     expect(plan.repairedToolCalls).toEqual(['c3']);
-    const repaired = plan.messages[plan.messages.length - 1] as unknown as {
-      role: string;
-      toolCallId: string;
-      isError: boolean;
-      content: { text: string }[];
-    };
-    expect(repaired.role).toBe('toolResult');
-    expect(repaired.toolCallId).toBe('c3');
-    expect(repaired.isError).toBe(true);
-    expect(repaired.content[0].text).toMatch(/interrupted/);
+    expect(plan.messages).toEqual(transcript);
   });
 
   it('reports already-complete when the tail assistant message has no tool calls', () => {
@@ -291,11 +282,7 @@ describe('planResume', () => {
     if (plan.kind !== 'continue') throw new Error('unreachable');
     expect(plan.repairedToolCalls).toEqual(['c1']);
     expect(plan.messages).not.toContain(transcript[2]);
-    expect(plan.messages.at(-1)).toMatchObject({
-      role: 'toolResult',
-      toolCallId: 'c1',
-      isError: true,
-    });
+    expect(plan.messages).toEqual(transcript.slice(0, -1));
   });
 
   it('preserves a successful terminal side effect exposed by stripping an empty tail', () => {

--- a/tests/agent-runtime/runner-tool-call-integrity.test.ts
+++ b/tests/agent-runtime/runner-tool-call-integrity.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Runner-level pins for the tool-call-integrity wiring.
+ *
+ * The module-level tests in tool-call-integrity.test.ts exercise the repair and
+ * settlement functions directly. This file drives the actual `runSession` loop
+ * through a fake agent (mocked `buildAgent`) so the RUNNER WIRING is observable:
+ *
+ * - write-time settlement: an assistant tool-call frame emitted mid-run leaves
+ *   the call tracked as in-flight; before the terminal flush (normal wind-down,
+ *   catch path, or shutdown park) the runner appends an interrupted-result
+ *   receipt for it through the fenced entry-tree write chain;
+ * - read-time repair: resuming a session whose durable tail contains an orphaned
+ *   tool call hands the agent a repaired history (synthetic receipt included)
+ *   while leaving the durable tree untouched, and reports the repaired id on
+ *   the session_resumed event.
+ */
+import type { AgentEvent, AgentMessage } from '@earendil-works/pi-agent-core';
+import { InMemorySessionRepo, Session } from '@earendil-works/pi-agent-core';
+import type { ClaimedAgentSession } from '@openmaic/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  randomUUID: vi.fn(() => 'runner-test-uuid'),
+  getAgentSessionStore: vi.fn(),
+  openEntryStorage: vi.fn(),
+  resolveAgentDriverModel: vi.fn(),
+  createCallLlmStreamFn: vi.fn(),
+  buildAgent: vi.fn(),
+}));
+
+vi.mock('node:crypto', async (importActual) => {
+  const actual = await importActual<typeof import('node:crypto')>();
+  return { ...actual, randomUUID: mocks.randomUUID };
+});
+
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: mocks.getAgentSessionStore,
+}));
+
+vi.mock('@/lib/server/agent-runtime/entry-tree-storage', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@/lib/server/agent-runtime/entry-tree-storage')>();
+  return {
+    ...actual,
+    AgentSessionEntryStorage: {
+      open: mocks.openEntryStorage,
+    },
+  };
+});
+
+vi.mock('@/lib/server/agent-runtime/agent-driver-model', () => ({
+  resolveAgentDriverModel: mocks.resolveAgentDriverModel,
+}));
+
+vi.mock('@/lib/agent/runtime/stream-fn', () => ({
+  createCallLlmStreamFn: mocks.createCallLlmStreamFn,
+}));
+
+vi.mock('@/lib/agent/runtime/build-agent', () => ({
+  buildAgent: mocks.buildAgent,
+}));
+
+import { runSession } from '@/lib/server/agent-runtime/runner';
+
+const SESSION_ID = 'session-1';
+const TOOL_CALL_ID = 'call_1';
+const TOOL_NAME = 'generate_scene';
+/** Mirrors the runner's `WORKER_ID` derivation with the fixed mock uuid. */
+const WORKER_ID = `runner-t:${process.pid}`;
+
+const userMessage = (text: string, timestamp: number): AgentMessage =>
+  ({ role: 'user', content: text, timestamp }) as unknown as AgentMessage;
+
+const assistantCallMessage = (timestamp: number): AgentMessage =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'toolCall', id: TOOL_CALL_ID, name: TOOL_NAME, arguments: {} }],
+    stopReason: 'toolUse',
+    timestamp,
+  }) as unknown as AgentMessage;
+
+function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSession {
+  return {
+    id: SESSION_ID,
+    ownerId: 'owner-1',
+    prompt: 'Build a lesson',
+    stageId: 'stage-1',
+    existingCourse: false,
+    status: 'running',
+    attempt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    claimReason: 'queued',
+    claimSeq: 0,
+    ...overrides,
+  };
+}
+
+function makeStore(meta: ClaimedAgentSession, options: { hasSessionRunHistory?: boolean } = {}) {
+  let seq = 0;
+  return {
+    appendRunEvent: vi.fn(
+      async (
+        _id: string,
+        _workerId: string,
+        _event: { type: string; data?: Record<string, unknown> },
+      ) => {
+        seq += 1;
+        return seq;
+      },
+    ),
+    clearCancel: vi.fn(async () => undefined),
+    finishSession: vi.fn(async () => true),
+    getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
+    hasSessionRunHistory: vi.fn(async () => options.hasSessionRunHistory ?? false),
+    heartbeat: vi.fn(async () => true),
+    isCancelRequested: vi.fn(async () => false),
+    listUserMessages: vi.fn(async () => []),
+    releaseLease: vi.fn(async () => undefined),
+    requeueForRetry: vi.fn(async () => false),
+    requeueSession: vi.fn(async () => false),
+  };
+}
+
+type FakeStore = ReturnType<typeof makeStore>;
+
+const runEvents = (store: FakeStore): Array<{ type: string; data?: Record<string, unknown> }> =>
+  store.appendRunEvent.mock.calls.map((call) => call[2]);
+
+async function makeEntryTree(seed: AgentMessage[] = []): Promise<Session> {
+  const repo = new InMemorySessionRepo();
+  const session = await repo.create({ id: SESSION_ID });
+  for (const message of seed) await session.appendMessage(message);
+  return session;
+}
+
+interface FakeAgent {
+  subscribe(listener: (event: AgentEvent, signal?: AbortSignal) => void): () => void;
+  prompt(text: string): Promise<void>;
+  continue(): Promise<void>;
+  waitForIdle(): Promise<void>;
+  steer(message: AgentMessage): void;
+  abort(): void;
+  readonly state: { messages: AgentMessage[]; errorMessage?: string };
+}
+
+function makeFakeAgent(options: {
+  messages?: AgentMessage[];
+  onPrompt?: (emit: (event: AgentEvent) => void) => void | Promise<void>;
+  onContinue?: (emit: (event: AgentEvent) => void) => void | Promise<void>;
+}): FakeAgent {
+  const messages = [...(options.messages ?? [])];
+  const listeners = new Set<(event: AgentEvent, signal?: AbortSignal) => void>();
+  const emit = (event: AgentEvent): void => {
+    if (event.type === 'message_end') messages.push(event.message);
+    for (const listener of [...listeners]) listener(event, undefined);
+  };
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    prompt: async (_text) => {
+      await options.onPrompt?.(emit);
+    },
+    continue: async () => {
+      await options.onContinue?.(emit);
+    },
+    waitForIdle: async () => {},
+    steer: () => {},
+    abort: () => {},
+    state: {
+      get messages() {
+        return messages;
+      },
+      errorMessage: undefined,
+    },
+  };
+}
+
+/** Emit a complete pi turn: user prompt + assistant frame with one tool call, no result. */
+function emitToolCallTurn(emit: (event: AgentEvent) => void): void {
+  const user = userMessage('Build a lesson', 1);
+  const assistant = assistantCallMessage(2);
+  emit({ type: 'agent_start' });
+  emit({ type: 'turn_start' });
+  emit({ type: 'message_start', message: user });
+  emit({ type: 'message_end', message: user });
+  emit({ type: 'message_start', message: assistant });
+  emit({ type: 'message_end', message: assistant });
+  emit({ type: 'turn_end', message: assistant, toolResults: [] });
+  emit({ type: 'agent_end', messages: [user, assistant] });
+}
+
+/** The runner's settlement must leave exactly user + assistant + interrupted receipt. */
+function expectInterruptedReceipt(messages: readonly AgentMessage[]): void {
+  expect(messages.map((message) => message.role)).toEqual(['user', 'assistant', 'toolResult']);
+  expect(messages[2]).toMatchObject({
+    role: 'toolResult',
+    toolCallId: TOOL_CALL_ID,
+    toolName: TOOL_NAME,
+    isError: true,
+  });
+  expect(JSON.stringify((messages[2] as { content?: unknown }).content ?? [])).toContain(
+    'interrupted',
+  );
+  expect(typeof (messages[2] as { timestamp?: unknown }).timestamp).toBe('number');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveAgentDriverModel.mockResolvedValue({
+    connection: { model: undefined, thinkingConfig: undefined },
+    piModel: undefined,
+    wireMaxOutputTokens: undefined,
+    reservedOutputTokens: 8192,
+  });
+  mocks.createCallLlmStreamFn.mockReturnValue((() => {}) as never);
+});
+
+describe('write-time settlement of interrupted tool calls', () => {
+  it('persists an interrupted receipt through the fenced chain when a call is in flight at wind-down', async () => {
+    const meta = makeMeta();
+    const session = await makeEntryTree();
+    const store = makeStore(meta);
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+    mocks.buildAgent.mockImplementation(() =>
+      makeFakeAgent({
+        onPrompt: (emit) => emitToolCallTurn(emit),
+      }),
+    );
+
+    await runSession({ running: new Map(), shuttingDown: false }, meta);
+
+    expectInterruptedReceipt((await session.buildContext()).messages);
+    expect(store.finishSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      WORKER_ID,
+      expect.objectContaining({ status: 'succeeded' }),
+    );
+    // The receipt is appended to the entry tree only: no toolResult frame ever
+    // reached the runner's event log.
+    const toolResultEvents = runEvents(store).filter(
+      (event) =>
+        event.type === 'message_end' &&
+        (event.data?.message as { role?: string } | undefined)?.role === 'toolResult',
+    );
+    expect(toolResultEvents).toEqual([]);
+  });
+
+  it('parks a shutdown-interrupted run with a durable receipt for the orphaned call', async () => {
+    const meta = makeMeta();
+    const session = await makeEntryTree();
+    const store = makeStore(meta);
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+    mocks.buildAgent.mockImplementation(() =>
+      makeFakeAgent({
+        onPrompt: async (emit) => {
+          emitToolCallTurn(emit);
+          throw new Error('worker draining before result');
+        },
+      }),
+    );
+
+    await runSession({ running: new Map(), shuttingDown: true }, meta);
+
+    expectInterruptedReceipt((await session.buildContext()).messages);
+    const events = runEvents(store);
+    expect(events.at(-1)?.type).toBe('session_interrupted');
+    expect(events.at(-1)?.data).toMatchObject({ reason: 'runner shutdown', attempt: 1 });
+    expect(store.releaseLease).toHaveBeenCalledWith(SESSION_ID, WORKER_ID);
+    expect(store.finishSession).not.toHaveBeenCalled();
+  });
+
+  it('appends the receipt on the catch path when the run fails before the result lands', async () => {
+    const meta = makeMeta();
+    const session = await makeEntryTree();
+    const store = makeStore(meta);
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+    mocks.buildAgent.mockImplementation(() =>
+      makeFakeAgent({
+        onPrompt: async (emit) => {
+          emitToolCallTurn(emit);
+          throw new Error('provider disconnected');
+        },
+      }),
+    );
+
+    await runSession({ running: new Map(), shuttingDown: false }, meta);
+
+    expectInterruptedReceipt((await session.buildContext()).messages);
+    expect(store.finishSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      WORKER_ID,
+      expect.objectContaining({ status: 'failed' }),
+    );
+    expect(runEvents(store).at(-1)?.type).toBe('session_end');
+  });
+});
+
+describe('read-time repair of an orphaned durable tool call', () => {
+  it('hands the resumed agent the repaired history, reports the repair, and leaves the tree untouched', async () => {
+    const meta = makeMeta({ claimReason: 'orphaned', attempt: 2 });
+    const seedUser = userMessage('Build a lesson', 1);
+    const seedAssistant = assistantCallMessage(2);
+    const session = await makeEntryTree([seedUser, seedAssistant]);
+    const store = makeStore(meta, { hasSessionRunHistory: true });
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+
+    let history: AgentMessage[] | undefined;
+    mocks.buildAgent.mockImplementation((options: { history?: AgentMessage[] }) => {
+      history = options.history;
+      return makeFakeAgent({ messages: options.history ?? [] });
+    });
+
+    await runSession({ running: new Map(), shuttingDown: false }, meta);
+
+    // The model history seeded into the agent contains the synthetic receipt...
+    expect(history).toHaveLength(3);
+    expect(history?.[0]).toBe(seedUser);
+    expect(history?.[1]).toBe(seedAssistant);
+    expect(history?.[2]).toMatchObject({
+      role: 'toolResult',
+      toolCallId: TOOL_CALL_ID,
+      isError: true,
+    });
+    expect(JSON.stringify(history?.[2])).toContain('interrupted');
+
+    // ...the session_resumed event reports the repaired id...
+    const resumed = runEvents(store).find((event) => event.type === 'session_resumed');
+    expect(resumed?.data).toMatchObject({
+      repairedToolCalls: [TOOL_CALL_ID],
+      transcriptMessages: 3,
+    });
+
+    // ...and the durable tree was never mutated.
+    const after = await session.buildContext();
+    expect(after.messages.map((message) => message.role)).toEqual(['user', 'assistant']);
+    expect(after.messages[0]).toBe(seedUser);
+    expect(after.messages[1]).toBe(seedAssistant);
+  });
+});

--- a/tests/agent-runtime/tool-call-integrity.test.ts
+++ b/tests/agent-runtime/tool-call-integrity.test.ts
@@ -1,0 +1,308 @@
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import { AgentSessionLeaseLostError } from '@openmaic/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  appendInterruptedToolCallResults,
+  orphanedToolCalls,
+  repairOrphanedToolCalls,
+  trackToolCallMessage,
+  withToolCallIntegrityRepair,
+  type PendingToolCall,
+} from '@/lib/server/agent-runtime/tool-call-integrity';
+
+const user = (text: string, timestamp: number): AgentMessage => ({
+  role: 'user',
+  content: text,
+  timestamp,
+});
+
+const assistantText = (text: string, timestamp: number) =>
+  ({
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    timestamp,
+  }) as unknown as AgentMessage;
+
+const assistantCalls = (calls: { id: string; name?: string }[], timestamp: number): AgentMessage =>
+  ({
+    role: 'assistant',
+    content: calls.map((call) => ({
+      type: 'toolCall',
+      id: call.id,
+      name: call.name ?? 'generate_scene',
+      arguments: { sceneId: call.id },
+    })),
+    stopReason: 'toolUse',
+    timestamp,
+  }) as unknown as AgentMessage;
+
+const toolResult = (id: string, timestamp: number): AgentMessage => ({
+  role: 'toolResult',
+  toolCallId: id,
+  toolName: 'generate_scene',
+  content: [{ type: 'text', text: `result:${id}` }],
+  details: { id },
+  isError: false,
+  timestamp,
+});
+
+function expectIntegrity(messages: AgentMessage[]): void {
+  expect(orphanedToolCalls(messages)).toEqual([]);
+}
+
+function expectOriginalSubsequence(original: AgentMessage[], repaired: AgentMessage[]): void {
+  let cursor = 0;
+  for (const message of repaired) {
+    if (message === original[cursor]) cursor += 1;
+  }
+  expect(cursor).toBe(original.length);
+}
+
+describe('read-time tool-call integrity repair', () => {
+  it.each([
+    ['a trailing orphan', () => [user('start', 1), assistantCalls([{ id: 'tail' }], 2)], ['tail']],
+    [
+      'a middle-of-history orphan',
+      () => [user('start', 1), assistantCalls([{ id: 'middle' }], 2), assistantText('more', 3)],
+      ['middle'],
+    ],
+    [
+      'multiple consecutive orphans',
+      () => [
+        user('start', 1),
+        assistantCalls([{ id: 'first' }], 2),
+        assistantCalls([{ id: 'second' }], 3),
+        assistantCalls([{ id: 'third' }], 4),
+      ],
+      ['first', 'second', 'third'],
+    ],
+    [
+      'an orphan followed by a new user message',
+      () => [
+        user('first message', 1),
+        assistantCalls([{ id: 'before-user' }], 2),
+        user('a new user message must be preserved', 3),
+      ],
+      ['before-user'],
+    ],
+  ] as const)(
+    'repairs %s without reordering or rewriting the original messages',
+    (_name, build, ids) => {
+      const original = build();
+      const bytesBefore = original.map((message) => JSON.stringify(message));
+      const repaired = repairOrphanedToolCalls(original, () => 99);
+
+      expect(repaired.repairedToolCalls).toEqual(ids);
+      expectIntegrity(repaired.messages);
+      expectOriginalSubsequence(original, repaired.messages);
+      expect(original.map((message) => JSON.stringify(message))).toEqual(bytesBefore);
+    },
+  );
+
+  it('repairs partial parallel results by call id within one assistant frame', () => {
+    const assistant = assistantCalls([{ id: 'done' }, { id: 'missing-a' }, { id: 'missing-b' }], 2);
+    const done = toolResult('done', 3);
+    const nextUser = user('continue', 4);
+    const original = [user('start', 1), assistant, done, nextUser];
+
+    const repaired = repairOrphanedToolCalls(original, () => 99);
+
+    expect(repaired.repairedToolCalls).toEqual(['missing-a', 'missing-b']);
+    expect(repaired.messages.slice(1, 5).map((message) => message.role)).toEqual([
+      'assistant',
+      'toolResult',
+      'toolResult',
+      'toolResult',
+    ]);
+    expect(repaired.messages[2]).toBe(done);
+    expect(repaired.messages[5]).toBe(nextUser);
+    expectIntegrity(repaired.messages);
+  });
+
+  it('moves a late parallel result back before the aborted assistant frame', () => {
+    const calls = assistantCalls(
+      [
+        { id: 'fast', name: 'generate_actions' },
+        { id: 'slow', name: 'generate_scene' },
+      ],
+      2,
+    );
+    const fast = toolResult('fast', 3);
+    const aborted = {
+      role: 'assistant',
+      content: [{ type: 'text', text: '' }],
+      stopReason: 'aborted',
+      errorMessage: 'worker aborted before flush',
+      timestamp: 4,
+    } as unknown as AgentMessage;
+    const slow = toolResult('slow', 5);
+    const original = [user('start', 1), calls, fast, aborted, slow];
+
+    const repaired = repairOrphanedToolCalls(original, () => 99);
+
+    expect(repaired.repairedToolCalls).toEqual([]);
+    expect(repaired.messages).toEqual([user('start', 1), calls, fast, slow]);
+    expect(repaired.messages[2]).toBe(fast);
+    expect(repaired.messages[3]).toBe(slow);
+    expectIntegrity(repaired.messages);
+  });
+
+  it('synthesizes receipts only for genuinely missing calls when late results coexist', () => {
+    const calls = assistantCalls([{ id: 'done' }, { id: 'late' }, { id: 'missing' }], 2);
+    const done = toolResult('done', 3);
+    const barrier = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'interrupted tail' }],
+      stopReason: 'aborted',
+      errorMessage: 'worker stopped',
+      timestamp: 4,
+    } as unknown as AgentMessage;
+    const late = toolResult('late', 5);
+
+    const repaired = repairOrphanedToolCalls(
+      [user('start', 1), calls, done, barrier, late],
+      () => 99,
+    );
+
+    expect(repaired.repairedToolCalls).toEqual(['missing']);
+    expect(repaired.messages.slice(1).map((message) => message.role)).toEqual([
+      'assistant',
+      'toolResult',
+      'toolResult',
+      'toolResult',
+    ]);
+    expect(repaired.messages[2]).toBe(done);
+    expect(repaired.messages[3]).toBe(late);
+    expect(repaired.messages[4]).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'missing',
+      isError: true,
+    });
+    expectIntegrity(repaired.messages);
+  });
+
+  it('returns a healthy transcript by reference, byte-identical', () => {
+    const history = [
+      user('start', 1),
+      assistantCalls([{ id: 'done' }], 2),
+      toolResult('done', 3),
+      assistantText('done', 4),
+    ];
+    const bytesBefore = JSON.stringify(history);
+
+    const repaired = repairOrphanedToolCalls(history);
+
+    expect(repaired.messages).toBe(history);
+    expect(JSON.stringify(repaired.messages)).toBe(bytesBefore);
+    expect(repaired.repairedToolCalls).toEqual([]);
+  });
+});
+
+describe('model-boundary repair after a re-materializing transform', () => {
+  it('keeps a synthetic result when a transform re-materializes a missing receipt', async () => {
+    const call = assistantCalls([{ id: 'call_00_orphan' }], 2);
+    const raw = [user('import slide deck', 1), call];
+    // Simulate a context transform that rebuilds the raw durable tree: it
+    // replaces the repaired view with the raw orphan, exactly what a durable
+    // context rebuild would do.
+    const transform = async () => raw;
+    const initialState = repairOrphanedToolCalls(raw, () => 99).messages;
+
+    const transformed = await withToolCallIntegrityRepair(transform)(initialState);
+
+    expect(transformed).toHaveLength(3);
+    expect(transformed[1]).toBe(call);
+    expect(transformed[2]).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'call_00_orphan',
+      isError: true,
+    });
+    expectIntegrity(transformed);
+  });
+
+  it('reorders a late parallel result when a transform restores the raw durable order', async () => {
+    const calls = assistantCalls([{ id: 'fast' }, { id: 'late' }], 2);
+    const fast = toolResult('fast', 3);
+    const aborted = {
+      role: 'assistant',
+      content: [],
+      stopReason: 'aborted',
+      timestamp: 4,
+    } as unknown as AgentMessage;
+    const late = toolResult('late', 5);
+    const raw = [user('generate course', 1), calls, fast, aborted, late];
+    const transform = async () => raw;
+    const initialState = repairOrphanedToolCalls(raw, () => 99).messages;
+
+    const transformed = await withToolCallIntegrityRepair(transform)(initialState);
+
+    expect(transformed).toEqual([user('generate course', 1), calls, fast, late]);
+  });
+});
+
+describe('write-time interrupted tool-call settlement', () => {
+  it('abort settlement writes an interrupted result for every in-flight call', async () => {
+    const inFlight = new Map<string, PendingToolCall>();
+    trackToolCallMessage(
+      inFlight,
+      assistantCalls([{ id: 'done' }, { id: 'aborted-a' }, { id: 'aborted-b' }], 1),
+    );
+    trackToolCallMessage(inFlight, toolResult('done', 2));
+    const appended: AgentMessage[] = [];
+
+    await appendInterruptedToolCallResults([...inFlight.values()], {
+      append: async (message) => {
+        appended.push(message);
+      },
+      onFenceLost: vi.fn(),
+      now: () => 3,
+    });
+
+    expect(appended).toMatchObject([
+      { role: 'toolResult', toolCallId: 'aborted-a', isError: true },
+      { role: 'toolResult', toolCallId: 'aborted-b', isError: true },
+    ]);
+    expect(appended.every((message) => JSON.stringify(message).includes('interrupted'))).toBe(true);
+  });
+
+  it('does not write results for a zombie run whose attempt fence was lost', async () => {
+    const durableWrites: AgentMessage[] = [];
+    const onFenceLost = vi.fn();
+    const append = vi.fn(async (message: AgentMessage) => {
+      const currentAttempt: number = Number('2');
+      const zombieAttempt = 1;
+      if (currentAttempt !== zombieAttempt) {
+        throw new AgentSessionLeaseLostError('session-1', 'old-worker', zombieAttempt);
+      }
+      durableWrites.push(message);
+    });
+
+    await appendInterruptedToolCallResults([{ id: 'zombie', name: 'generate_scene' }], {
+      append,
+      onFenceLost,
+      now: () => 3,
+    });
+
+    expect(append).toHaveBeenCalledOnce();
+    expect(durableWrites).toEqual([]);
+    expect(onFenceLost).toHaveBeenCalledOnce();
+  });
+
+  it('treats a wrapped fence loss (storage error carrying the lease error) as lost', async () => {
+    const onFenceLost = vi.fn();
+    const cause = new AgentSessionLeaseLostError('session-1', 'old-worker', 1);
+    const wrapped = new Error('entry append rejected', { cause });
+    const append = vi.fn(async () => {
+      throw wrapped;
+    });
+
+    await appendInterruptedToolCallResults([{ id: 'wrapped', name: 'generate_scene' }], {
+      append,
+      onFenceLost,
+      now: () => 3,
+    });
+
+    expect(onFenceLost).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Three related failure modes in the durable runner around interrupted tool calls:

1. **Orphaned interrupted tool calls permanently wedge a session.** When a run is interrupted after an assistant frame with a tool call but before the result lands, the durable tail is provider-invalid and every subsequent resume fails the same way. Fixed with a two-layer guard in the new `lib/server/agent-runtime/tool-call-integrity.ts`: write-time settlement (the runner tracks in-flight calls and appends an interrupted-result receipt through the attempt-fenced write chain on wind-down, shutdown park, and the catch path) plus read-time repair (`repairOrphanedToolCalls` builds a provider-safe model view without mutating the durable tree).
2. **Late parallel tool results arriving on resume** are moved back before the aborted assistant frame, and receipts are synthesized only for genuinely missing calls.
3. **Interrupted tool repair is preserved at the model boundary**: `planResume` now only classifies the durable tail and reports dangling call ids; the shared read-boundary normalizer owns synthetic receipts, so a re-materializing context transform cannot strip them (`withToolCallIntegrityRepair`).

Fence-loss detection walks the error cause chain (the storage package surfaces lease/attempt fence loss wrapped), matching the runner's existing pattern.

**Tests:** 17 module-level cases (`tool-call-integrity.test.ts`, updated `resume.test.ts`) plus 4 runner-loop tests (`runner-tool-call-integrity.test.ts`) that pin each wiring point individually — mutation-checked: removing the read-time repair fails 1, removing the write-time call sites fails 3, removing all fails 4, restored all green. Full suite: 5452 passed, no regressions. tsc/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)