### PR TITLE
feat(providers): uniform capability force-off and consistent missing-key contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -265,6 +265,9 @@ SEARXNG_BASE_URL=
 # Dedicated MiniMax web-search vars avoid conflicting with the LLM MINIMAX_* endpoint.
 WEB_SEARCH_MINIMAX_API_KEY=
 WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com
+# Dedicated Doubao web-search vars avoid conflicting with the Doubao LLM provider.
+WEB_SEARCH_DOUBAO_API_KEY=
+WEB_SEARCH_DOUBAO_BASE_URL=https://open.feedcoopapi.com
 # Claude (Anthropic) native web search. Dedicated vars avoid conflicting with
 # ANTHROPIC_* LLM provider vars. Optional WEB_SEARCH_CLAUDE_MODELS pins the
 # search model server-side (first entry wins), e.g. claude-sonnet-5.
@@ -274,6 +277,7 @@ WEB_SEARCH_CLAUDE_MODELS=
 
 # Operators can force-disable any built-in web search provider. Examples:
 # TAVILY_ENABLED=false
+# WEB_SEARCH_DOUBAO_ENABLED=false
 # SEARXNG_ENABLED=false
 
 # Server-only, default-OFF selector for the Native Child execution harness.

--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,10 @@ ASR_AZURE_BASE_URL=https://{region}.api.cognitive.microsoft.com
 # Lemonade ASR (local, WAV input only, no API key required)
 # ASR_LEMONADE_BASE_URL=http://localhost:13305/v1
 
+# Operators can force-disable any built-in ASR provider. Examples:
+# ASR_OPENAI_ENABLED=false
+# ASR_BROWSER_NATIVE_ENABLED=false
+
 
 # --- PDF Processing -----------------------------------------------------------
 
@@ -210,6 +214,11 @@ IMAGE_GROK_BASE_URL=
 # Lemonade image generation (local, no API key required)
 # IMAGE_LEMONADE_BASE_URL=http://localhost:13305/v1
 
+# Operators can force-disable any built-in image provider, including the
+# client-only ComfyUI provider (it has no credential env). Examples:
+# IMAGE_OPENAI_ENABLED=false
+# IMAGE_COMFYUI_ENABLED=false
+
 # --- Video Generation ---------------------------------------------------------
 
 VIDEO_SEEDANCE_API_KEY=
@@ -233,6 +242,10 @@ VIDEO_GROK_BASE_URL=
 
 VIDEO_HAPPYHORSE_API_KEY=
 VIDEO_HAPPYHORSE_BASE_URL=https://dashscope.aliyuncs.com
+
+# Operators can force-disable any built-in video provider. Examples:
+# VIDEO_GROK_ENABLED=false
+# VIDEO_KLING_ENABLED=false
 
 # --- Web Search ---------------------------------------------------------------
 # Note: Grok (xAI) web search is available via chat completions + search tools,
@@ -258,6 +271,10 @@ WEB_SEARCH_MINIMAX_BASE_URL=https://api.minimaxi.com
 WEB_SEARCH_CLAUDE_API_KEY=
 WEB_SEARCH_CLAUDE_BASE_URL=https://api.anthropic.com/v1
 WEB_SEARCH_CLAUDE_MODELS=
+
+# Operators can force-disable any built-in web search provider. Examples:
+# TAVILY_ENABLED=false
+# SEARXNG_ENABLED=false
 
 # Server-only, default-OFF selector for the Native Child execution harness.
 # OPENMAIC_ENABLE_PI_NATIVE_CHILD_RUNTIME=true

--- a/app/api/generate/image/route.ts
+++ b/app/api/generate/image/route.ts
@@ -24,6 +24,7 @@ import {
 } from '@/lib/media/image-providers';
 import {
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveImageApiKey,
   resolveImageBaseUrl,
   resolveImageModel,
@@ -57,6 +58,11 @@ export async function POST(request: NextRequest) {
       resolveServerImageProviderId()) as ImageProviderId;
     if (!providerId) {
       return apiError('MISSING_PROVIDER', 400, 'No image provider configured');
+    }
+    // Enforce server precedence: a force-disabled provider is off for everyone,
+    // regardless of any client key/selection — mirror the TTS contract (#665).
+    if (isServerProviderDisabled('image', providerId)) {
+      return apiError('PROVIDER_DISABLED', 403, 'This image provider is disabled by the server');
     }
     // Managed providers are admin-owned: ignore any client-sent key/baseUrl.
     const managed = isServerConfiguredProvider('image', providerId);

--- a/app/api/generate/tts/route.ts
+++ b/app/api/generate/tts/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest } from 'next/server';
 import { generateTTS, QwenTTSError, TTSRateLimitError } from '@/lib/audio/tts-providers';
+import { TTS_PROVIDERS } from '@/lib/audio/constants';
 import { recordGenerationUsage } from '@/lib/server/usage-storage';
 import {
   isServerConfiguredProvider,
@@ -102,6 +103,20 @@ export async function POST(req: NextRequest) {
 
     const apiKey = resolveTTSApiKey(ttsProviderId, managed ? undefined : ttsApiKey || undefined);
     const baseUrl = resolveTTSBaseUrl(ttsProviderId, clientBaseUrl);
+
+    // Pre-flight the same key requirement the library enforces: a keyed provider
+    // with no key (server config AND client-supplied key both absent) is a
+    // client contract violation, not a server failure. Return the image route's
+    // MISSING_API_KEY envelope instead of falling through to a 500
+    // GENERATION_FAILED. Unknown/custom providers keep their existing behavior.
+    const ttsProvider = TTS_PROVIDERS[ttsProviderId as keyof typeof TTS_PROVIDERS];
+    if (ttsProvider?.requiresApiKey && !apiKey) {
+      return apiError(
+        'MISSING_API_KEY',
+        400,
+        `No API key configured for TTS provider: ${ttsProviderId}`,
+      );
+    }
 
     // Build TTS config (managed providers may pin the model server-side)
     const qwenCloneVoice = ttsProviderId === 'qwen-tts' && isQwenCloneVoice(ttsVoice);

--- a/app/api/generate/video/route.ts
+++ b/app/api/generate/video/route.ts
@@ -21,6 +21,7 @@ import { recordGenerationUsage } from '@/lib/server/usage-storage';
 import { generateVideo, normalizeVideoOptions } from '@/lib/media/video-providers';
 import {
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveVideoApiKey,
   resolveVideoBaseUrl,
   resolveVideoModel,
@@ -49,6 +50,11 @@ export async function POST(request: NextRequest) {
       resolveServerVideoProviderId()) as VideoProviderId;
     if (!providerId) {
       return apiError('MISSING_PROVIDER', 400, 'No video provider configured');
+    }
+    // Enforce server precedence: a force-disabled provider is off for everyone,
+    // regardless of any client key/selection — mirror the TTS contract (#665).
+    if (isServerProviderDisabled('video', providerId)) {
+      return apiError('PROVIDER_DISABLED', 403, 'This video provider is disabled by the server');
     }
     // Managed providers are admin-owned: ignore any client-sent key/baseUrl.
     const managed = isServerConfiguredProvider('video', providerId);

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -13,9 +13,11 @@ export async function GET() {
     status: 'ok',
     version,
     capabilities: {
-      webSearch: Object.keys(getServerWebSearchProviders()).length > 0,
-      imageGeneration: Object.keys(getServerImageProviders()).length > 0,
-      videoGeneration: Object.keys(getServerVideoProviders()).length > 0,
+      // A capability is available only when at least one provider is enabled —
+      // force-disabled providers (disabled: true) do not count (#665).
+      webSearch: Object.values(getServerWebSearchProviders()).some((info) => !info.disabled),
+      imageGeneration: Object.values(getServerImageProviders()).some((info) => !info.disabled),
+      videoGeneration: Object.values(getServerVideoProviders()).some((info) => !info.disabled),
       tts: Object.values(getServerTTSProviders()).some((info) => !info.disabled),
     },
   });

--- a/app/api/transcription/route.ts
+++ b/app/api/transcription/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { transcribeAudio } from '@/lib/audio/asr-providers';
 import {
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveASRApiKey,
   resolveASRBaseUrl,
   resolveASRModel,
@@ -37,6 +38,12 @@ export async function POST(req: NextRequest) {
     const effectiveProviderId = providerId || ('openai-whisper' as ASRProviderId);
     resolvedProviderId = effectiveProviderId;
     resolvedModelId = modelId;
+
+    // Enforce server precedence: a force-disabled provider is off for everyone,
+    // regardless of any client key/selection — mirror the TTS contract (#665).
+    if (isServerProviderDisabled('asr', effectiveProviderId)) {
+      return apiError('PROVIDER_DISABLED', 403, 'This ASR provider is disabled by the server');
+    }
 
     // Managed providers are admin-owned: ignore any client-sent key/baseUrl.
     const managed = isServerConfiguredProvider('asr', effectiveProviderId);

--- a/app/api/transcription/route.ts
+++ b/app/api/transcription/route.ts
@@ -6,6 +6,7 @@ import {
   resolveASRApiKey,
   resolveASRBaseUrl,
   resolveASRModel,
+  resolveServerASRProviderId,
 } from '@/lib/server/provider-config';
 import type { ASRProviderId } from '@/lib/audio/types';
 import { createLogger } from '@/lib/logger';
@@ -34,8 +35,13 @@ export async function POST(req: NextRequest) {
       return apiError('MISSING_REQUIRED_FIELD', 400, 'Audio file is required');
     }
 
-    // providerId is required from the client — no server-side store to fall back to
-    const effectiveProviderId = providerId || ('openai-whisper' as ASRProviderId);
+    // Prefer an enabled operator-configured backend when the client omitted its
+    // selection. Never guess a vendor: fail loudly when no backend is enabled.
+    const effectiveProviderId =
+      providerId || (resolveServerASRProviderId() as ASRProviderId | undefined);
+    if (!effectiveProviderId) {
+      return apiError('MISSING_PROVIDER', 400, 'No enabled ASR provider is configured');
+    }
     resolvedProviderId = effectiveProviderId;
     resolvedModelId = modelId;
 

--- a/app/api/verify-image-provider/route.ts
+++ b/app/api/verify-image-provider/route.ts
@@ -18,6 +18,7 @@ import { NextRequest } from 'next/server';
 import { IMAGE_PROVIDERS, testImageConnectivity } from '@/lib/media/image-providers';
 import {
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveImageApiKey,
   resolveImageBaseUrl,
   resolveImageModel,
@@ -41,6 +42,11 @@ export async function POST(request: NextRequest) {
       resolveServerImageProviderId()) as ImageProviderId;
     if (!providerId) {
       return apiError('MISSING_PROVIDER', 400, 'No image provider configured');
+    }
+    // Enforce server precedence: a force-disabled provider is off for everyone,
+    // regardless of any client key/selection — mirror the TTS contract (#665).
+    if (isServerProviderDisabled('image', providerId)) {
+      return apiError('PROVIDER_DISABLED', 403, 'This image provider is disabled by the server');
     }
     const clientModel = request.headers.get('x-image-model')?.trim() || undefined;
     // Managed providers are admin-owned: ignore any client-sent key/baseUrl.

--- a/app/api/verify-video-provider/route.ts
+++ b/app/api/verify-video-provider/route.ts
@@ -18,6 +18,7 @@ import { NextRequest } from 'next/server';
 import { testVideoConnectivity } from '@/lib/media/video-providers';
 import {
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveVideoApiKey,
   resolveVideoBaseUrl,
   resolveVideoModel,
@@ -36,6 +37,11 @@ export async function POST(request: NextRequest) {
       resolveServerVideoProviderId()) as VideoProviderId;
     if (!providerId) {
       return apiError('MISSING_PROVIDER', 400, 'No video provider configured');
+    }
+    // Enforce server precedence: a force-disabled provider is off for everyone,
+    // regardless of any client key/selection — mirror the TTS contract (#665).
+    if (isServerProviderDisabled('video', providerId)) {
+      return apiError('PROVIDER_DISABLED', 403, 'This video provider is disabled by the server');
     }
     const clientModel = request.headers.get('x-video-model')?.trim() || undefined;
     // Managed providers are admin-owned: ignore any client-sent key/baseUrl.

--- a/app/api/web-search/route.ts
+++ b/app/api/web-search/route.ts
@@ -205,6 +205,8 @@ function getWebSearchEnvKey(providerId: WebSearchProviderId): string {
       return 'WEB_SEARCH_CLAUDE_API_KEY';
     case 'minimax':
       return 'WEB_SEARCH_MINIMAX_API_KEY';
+    case 'doubao':
+      return 'WEB_SEARCH_DOUBAO_API_KEY';
     case 'searxng':
       return 'SEARXNG_BASE_URL';
     case 'tavily':

--- a/app/api/web-search/route.ts
+++ b/app/api/web-search/route.ts
@@ -10,6 +10,7 @@ import { callLLM } from '@/lib/ai/llm';
 import { formatSearchResultsAsContext, searchWeb } from '@/lib/web-search';
 import {
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveServerWebSearchProviderId,
   resolveWebSearchApiKey,
   resolveWebSearchModel,
@@ -73,6 +74,18 @@ export async function POST(req: NextRequest) {
         `Using server-configured web search provider "${serverProviderId}" instead of "${providerId}"`,
       );
       providerId = serverProviderId;
+    }
+
+    // Enforce server precedence: a force-disabled provider is off for everyone,
+    // regardless of any client key/selection — mirror the TTS contract (#665).
+    // Checked after the server-preference override so a disabled client choice
+    // yields to the operator's enabled backend.
+    if (isServerProviderDisabled('webSearch', providerId)) {
+      return apiError(
+        'PROVIDER_DISABLED',
+        403,
+        'This web search provider is disabled by the server',
+      );
     }
 
     const provider = WEB_SEARCH_PROVIDERS[providerId];

--- a/components/generation/media-popover.tsx
+++ b/components/generation/media-popover.tsx
@@ -133,10 +133,15 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
 
   const cfgOk = useCallback(
     (
-      configs: Record<string, { apiKey?: string; isServerConfigured?: boolean }>,
+      configs: Record<
+        string,
+        { apiKey?: string; isServerConfigured?: boolean; serverDisabled?: boolean }
+      >,
       id: string,
       needsKey: boolean,
-    ) => !needsKey || !!configs[id]?.apiKey || !!configs[id]?.isServerConfigured,
+    ) =>
+      !configs[id]?.serverDisabled &&
+      (!needsKey || !!configs[id]?.apiKey || !!configs[id]?.isServerConfigured),
     [],
   );
 

--- a/components/settings/asr-settings.tsx
+++ b/components/settings/asr-settings.tsx
@@ -31,6 +31,7 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { createLogger } from '@/lib/logger';
 import { normalizeASRUploadAudio } from '@/lib/audio/wav-utils';
+import { getASRServerDisabledError } from '@/lib/audio/asr-enablement';
 
 const log = createLogger('ASRSettings');
 
@@ -84,6 +85,15 @@ export function ASRSettings({ selectedProviderId }: ASRSettingsProps) {
       setASRResult('');
       setTestStatus('testing');
       setTestMessage('');
+
+      // Browser-native tests execute wholly in the client and therefore need
+      // the same server force-off guard as the normal recorder path.
+      const serverDisabledError = getASRServerDisabledError(providerConfig);
+      if (serverDisabledError) {
+        setTestStatus('error');
+        setTestMessage(serverDisabledError);
+        return;
+      }
 
       if (selectedProviderId === 'browser-native') {
         const SpeechRecognitionCtor =

--- a/lib/audio/asr-enablement.ts
+++ b/lib/audio/asr-enablement.ts
@@ -1,0 +1,10 @@
+export interface ASRServerControl {
+  serverDisabled?: boolean;
+}
+
+export const ASR_SERVER_DISABLED_MESSAGE = 'This ASR provider is disabled by the server';
+
+/** Server force-off takes precedence even for ASR that executes entirely in the browser. */
+export function getASRServerDisabledError(config?: ASRServerControl): string | undefined {
+  return config?.serverDisabled ? ASR_SERVER_DISABLED_MESSAGE : undefined;
+}

--- a/lib/hooks/use-asr-available.ts
+++ b/lib/hooks/use-asr-available.ts
@@ -36,6 +36,7 @@ export function useASRAvailable(): boolean {
   );
 
   const builtIn = ASR_PROVIDERS[asrProviderId as BuiltInASRProviderId];
+  if (providerConfig?.serverDisabled) return false;
   const requiresKey = builtIn ? builtIn.requiresApiKey : (providerConfig?.requiresApiKey ?? true);
   // Trim to match what the recorder actually sends — a whitespace-only key is
   // dropped at request time, so it must not count as configured here.

--- a/lib/hooks/use-audio-recorder.ts
+++ b/lib/hooks/use-audio-recorder.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { ASR_PROVIDERS } from '@/lib/audio/constants';
+import { getASRServerDisabledError } from '@/lib/audio/asr-enablement';
 import { normalizeASRUploadAudio } from '@/lib/audio/wav-utils';
 import { createLogger } from '@/lib/logger';
 
@@ -102,7 +103,15 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}) {
       // Get current ASR configuration
       if (typeof window !== 'undefined') {
         const { useSettingsStore } = await import('@/lib/store/settings');
-        const { asrProviderId, asrLanguage } = useSettingsStore.getState();
+        const { asrProviderId, asrLanguage, asrProvidersConfig } = useSettingsStore.getState();
+
+        // Browser-native ASR never reaches the server route, so enforce the
+        // operator force-off locally before invoking the Web Speech API.
+        const serverDisabledError = getASRServerDisabledError(asrProvidersConfig[asrProviderId]);
+        if (serverDisabledError) {
+          onError?.(serverDisabledError);
+          return;
+        }
 
         // Use browser native ASR if configured
         if (asrProviderId === 'browser-native') {

--- a/lib/server/classroom-media-generation.ts
+++ b/lib/server/classroom-media-generation.ts
@@ -93,9 +93,14 @@ export async function generateMediaForClassroom(
   const requests = outlines.flatMap((o) => o.mediaGenerations ?? []);
   if (requests.length === 0) return {};
 
-  // Resolve providers
-  const imageProviderIds = Object.keys(getServerImageProviders());
-  const videoProviderIds = Object.keys(getServerVideoProviders());
+  // Resolve providers, excluding operator force-disabled ones (server
+  // precedence, #665 — mirror the TTS listing's disabled flag).
+  const imageProviderIds = Object.entries(getServerImageProviders())
+    .filter(([, info]) => !info.disabled)
+    .map(([id]) => id);
+  const videoProviderIds = Object.entries(getServerVideoProviders())
+    .filter(([, info]) => !info.disabled)
+    .map(([id]) => id);
 
   const mediaMap: Record<string, string> = {};
 

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -133,6 +133,8 @@ const WEB_SEARCH_ENV_MAP: Record<string, string> = {
   // WEB_SEARCH_ prefix avoids colliding with ANTHROPIC_* LLM provider vars.
   WEB_SEARCH_CLAUDE: 'claude',
   WEB_SEARCH_MINIMAX: 'minimax',
+  // Dedicated prefix avoids colliding with the Doubao LLM provider vars.
+  WEB_SEARCH_DOUBAO: 'doubao',
   SEARXNG: 'searxng',
 };
 
@@ -737,6 +739,12 @@ export function resolveASRApiKey(providerId: string, clientKey?: string): string
 
 export function resolveASRBaseUrl(providerId: string, clientBaseUrl?: string): string | undefined {
   return resolveSectionBaseUrl('asr', providerId, clientBaseUrl);
+}
+
+/** First operator-configured ASR provider that is not force-disabled. */
+export function resolveServerASRProviderId(): string | undefined {
+  const cfg = getConfig();
+  return Object.keys(cfg.asr).find((id) => !cfg.disabled.asr.has(id));
 }
 
 /**

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -34,7 +34,7 @@ interface ServerProviderEntry {
   /**
    * Admin/operator force-off switch. `false` disables the provider for ALL
    * clients regardless of the user's per-provider toggle (server precedence).
-   * Currently honored for TTS only (#665).
+   * Honored for the capability sections in {@link DISABLE_ENV_MAPS} (#665).
    */
   enabled?: boolean;
 }
@@ -47,8 +47,8 @@ interface ServerConfig {
   image: Record<string, ServerProviderEntry>;
   video: Record<string, ServerProviderEntry>;
   webSearch: Record<string, ServerProviderEntry>;
-  /** TTS provider IDs the operator force-disabled (server precedence). */
-  ttsDisabled: Set<string>;
+  /** Provider IDs the operator force-disabled per capability section (server precedence). */
+  disabled: Record<CapabilitySection, Set<string>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,16 +89,6 @@ const TTS_ENV_MAP: Record<string, string> = {
   TTS_ELEVENLABS: 'elevenlabs-tts',
   TTS_MINIMAX: 'minimax-tts',
   TTS_LEMONADE: 'lemonade-tts',
-};
-
-/**
- * Env prefixes for the TTS force-disable switch (`TTS_<PREFIX>_ENABLED=false`).
- * Superset of TTS_ENV_MAP: browser-native has no credential env (it is
- * client-only) but operators may still want to force it off fleet-wide (#665).
- */
-const TTS_DISABLE_ENV_MAP: Record<string, string> = {
-  ...TTS_ENV_MAP,
-  TTS_BROWSER_NATIVE: 'browser-native-tts',
 };
 
 const ASR_ENV_MAP: Record<string, string> = {
@@ -144,6 +134,53 @@ const WEB_SEARCH_ENV_MAP: Record<string, string> = {
   WEB_SEARCH_CLAUDE: 'claude',
   WEB_SEARCH_MINIMAX: 'minimax',
   SEARXNG: 'searxng',
+};
+
+// ---------------------------------------------------------------------------
+// Force-disable maps
+// ---------------------------------------------------------------------------
+
+/**
+ * Capability sections that support the operator force-off switch
+ * (`<CAP>_<PREFIX>_ENABLED=false`). LLM and PDF are intentionally not included:
+ * their enablement stays purely credential-driven.
+ */
+type CapabilitySection = 'tts' | 'asr' | 'image' | 'video' | 'webSearch';
+
+/**
+ * Env prefixes for each capability's force-disable switch
+ * (`<CAP>_<PREFIX>_ENABLED=false`). Built from the existing per-section env
+ * maps plus the client-only keyless providers that have no credential env
+ * (browser-native, ComfyUI) — operators may still want to force those off
+ * fleet-wide (#665). The `_ENABLED` vars can only disable; they never
+ * force-enable a provider that has no credentials configured.
+ */
+const DISABLE_ENV_MAPS: Record<CapabilitySection, Record<string, string>> = {
+  tts: {
+    ...TTS_ENV_MAP,
+    TTS_BROWSER_NATIVE: 'browser-native-tts',
+  },
+  asr: {
+    ...ASR_ENV_MAP,
+    ASR_BROWSER_NATIVE: 'browser-native',
+  },
+  image: {
+    ...IMAGE_ENV_MAP,
+    // comfyui-image lives in the client-side catalog only (no credential env),
+    // but operators may still want to force it off fleet-wide.
+    IMAGE_COMFYUI: 'comfyui-image',
+  },
+  video: { ...VIDEO_ENV_MAP },
+  webSearch: { ...WEB_SEARCH_ENV_MAP },
+};
+
+/** YAML section key per capability (web-search is hyphenated in YAML). */
+const YAML_SECTION_KEY: Record<CapabilitySection, keyof YamlData> = {
+  tts: 'tts',
+  asr: 'asr',
+  image: 'image',
+  video: 'video',
+  webSearch: 'web-search',
 };
 
 // ---------------------------------------------------------------------------
@@ -268,27 +305,36 @@ function parseBooleanEnv(raw: string): boolean {
 }
 
 /**
- * Collect TTS provider IDs the operator force-disabled, from YAML
- * (`tts.<id>.enabled: false`) and env (`TTS_<PREFIX>_ENABLED=false`). An
- * explicit env `true` overrides a YAML disable (env precedence, matching the
- * rest of this module).
+ * Collect provider IDs the operator force-disabled per capability section, from
+ * YAML (`<section>.<id>.enabled: false`) and env (`<CAP>_<PREFIX>_ENABLED`).
+ * An explicit env `true` overrides a YAML disable (env precedence, matching the
+ * rest of this module). Unset / empty values are "no opinion" — they never
+ * silently override an explicit YAML disable. The `_ENABLED` vars can only
+ * disable; they never create or force-enable a provider entry.
  */
-function collectDisabledTTS(
-  yamlTts: Record<string, Partial<ServerProviderEntry>> | undefined,
-): Set<string> {
-  const disabled = new Set<string>();
-  if (yamlTts) {
-    for (const [id, entry] of Object.entries(yamlTts)) {
-      if (entry?.enabled === false) disabled.add(id);
+function collectDisabledProviders(yamlData: YamlData): Record<CapabilitySection, Set<string>> {
+  const disabled: Record<CapabilitySection, Set<string>> = {
+    tts: new Set<string>(),
+    asr: new Set<string>(),
+    image: new Set<string>(),
+    video: new Set<string>(),
+    webSearch: new Set<string>(),
+  };
+  for (const section of Object.keys(DISABLE_ENV_MAPS) as CapabilitySection[]) {
+    const yamlSection = yamlData[YAML_SECTION_KEY[section]];
+    if (yamlSection) {
+      for (const [id, entry] of Object.entries(yamlSection)) {
+        if (entry?.enabled === false) disabled[section].add(id);
+      }
     }
-  }
-  for (const [prefix, providerId] of Object.entries(TTS_DISABLE_ENV_MAP)) {
-    const raw = process.env[`${prefix}_ENABLED`];
-    // Treat unset / empty (e.g. a blank CI-templated value) as "no opinion" so
-    // it never silently overrides an explicit YAML disable.
-    if (raw === undefined || raw.trim() === '') continue;
-    if (parseBooleanEnv(raw)) disabled.delete(providerId);
-    else disabled.add(providerId);
+    for (const [prefix, providerId] of Object.entries(DISABLE_ENV_MAPS[section])) {
+      const raw = process.env[`${prefix}_ENABLED`];
+      // Treat unset / empty (e.g. a blank CI-templated value) as "no opinion" so
+      // it never silently overrides an explicit YAML disable.
+      if (raw === undefined || raw.trim() === '') continue;
+      if (parseBooleanEnv(raw)) disabled[section].delete(providerId);
+      else disabled[section].add(providerId);
+    }
   }
   return disabled;
 }
@@ -459,7 +505,7 @@ function buildConfig(yamlData: YamlData): ServerConfig {
     webSearch: loadEnvSection(WEB_SEARCH_ENV_MAP, yamlData['web-search'], {
       keylessProviders: new Set(['brave', 'searxng']),
     }),
-    ttsDisabled: collectDisabledTTS(yamlData.tts),
+    disabled: collectDisabledProviders(yamlData),
   };
 }
 
@@ -503,11 +549,16 @@ function getConfig(): ServerConfig {
 // server config (the bug class #533 patched route-by-route).
 // ---------------------------------------------------------------------------
 
-type ProviderSection = Exclude<keyof ServerConfig, 'ttsDisabled'>;
+type ProviderSection = 'providers' | 'tts' | 'asr' | 'pdf' | 'image' | 'video' | 'webSearch';
 
 /** Whether the operator configured this provider in the given section. */
 export function isServerConfiguredProvider(section: ProviderSection, providerId: string): boolean {
   return !!getConfig()[section][providerId];
+}
+
+/** Whether the operator force-disabled this provider in the given capability section (server precedence). */
+export function isServerProviderDisabled(section: CapabilitySection, providerId: string): boolean {
+  return getConfig().disabled[section].has(providerId);
 }
 
 function resolveSectionApiKey(
@@ -578,7 +629,7 @@ export function getServerTTSProviders(): Record<string, { disabled?: boolean }> 
   const cfg = getConfig();
   const result: Record<string, { disabled?: boolean }> = {};
   for (const id of Object.keys(cfg.tts)) result[id] = {};
-  for (const id of cfg.ttsDisabled) result[id] = { disabled: true };
+  for (const id of cfg.disabled.tts) result[id] = { disabled: true };
   return result;
 }
 
@@ -588,7 +639,7 @@ export function resolveTTSApiKey(providerId: string, clientKey?: string): string
 
 /** Whether the operator force-disabled this TTS provider (server precedence, #665). */
 export function isServerTTSProviderDisabled(providerId: string): boolean {
-  return getConfig().ttsDisabled.has(providerId);
+  return isServerProviderDisabled('tts', providerId);
 }
 
 export function resolveTTSBaseUrl(providerId: string, clientBaseUrl?: string): string | undefined {
@@ -667,9 +718,17 @@ export function resolveTTSModel(
 // Public API — ASR
 // ---------------------------------------------------------------------------
 
-/** Returns server-configured ASR providers (managed flag only, no base URLs). */
-export function getServerASRProviders(): Record<string, Record<string, never>> {
-  return Object.fromEntries(Object.keys(getConfig().asr).map((id) => [id, {}]));
+/**
+ * Returns ASR providers the client must know about: server-managed providers
+ * (presence = managed flag) plus operator force-disabled providers
+ * (`{ disabled: true }`), mirroring the TTS listing — disable wins (#665).
+ */
+export function getServerASRProviders(): Record<string, { disabled?: boolean }> {
+  const cfg = getConfig();
+  const result: Record<string, { disabled?: boolean }> = {};
+  for (const id of Object.keys(cfg.asr)) result[id] = {};
+  for (const id of cfg.disabled.asr) result[id] = { disabled: true };
+  return result;
 }
 
 export function resolveASRApiKey(providerId: string, clientKey?: string): string {
@@ -715,14 +774,22 @@ export function resolvePDFBaseUrl(providerId: string, clientBaseUrl?: string): s
 // Public API — Image Generation
 // ---------------------------------------------------------------------------
 
-/** Returns server-configured image providers (allowed models only, no base URLs). */
-export function getServerImageProviders(): Record<string, { models?: string[] }> {
+/**
+ * Returns image providers the client must know about: server-managed providers
+ * (allowed models only, no base URLs) plus operator force-disabled providers
+ * (`{ disabled: true }`), mirroring the TTS listing — disable wins (#665).
+ */
+export function getServerImageProviders(): Record<
+  string,
+  { models?: string[]; disabled?: boolean }
+> {
   const cfg = getConfig();
-  const result: Record<string, { models?: string[] }> = {};
+  const result: Record<string, { models?: string[]; disabled?: boolean }> = {};
   for (const [id, entry] of Object.entries(cfg.image)) {
     result[id] = {};
     if (entry.models && entry.models.length > 0) result[id].models = entry.models;
   }
+  for (const id of cfg.disabled.image) result[id] = { disabled: true };
   return result;
 }
 
@@ -739,11 +806,13 @@ export function resolveImageBaseUrl(
 
 /**
  * Resolve the server-side default image provider, used when the client sends
- * no provider preference: the first operator-configured image provider. Returns
- * undefined when no image provider is configured at all (callers fail loud).
+ * no provider preference: the first operator-configured image provider that is
+ * not force-disabled. Returns undefined when no image provider is enabled at
+ * all (callers fail loud).
  */
 export function resolveServerImageProviderId(): string | undefined {
-  return Object.keys(getConfig().image)[0];
+  const disabled = getConfig().disabled.image;
+  return Object.keys(getConfig().image).find((id) => !disabled.has(id));
 }
 
 /**
@@ -764,9 +833,17 @@ export function resolveImageModel(providerId: string, clientModel?: string): str
 // Public API — Video Generation
 // ---------------------------------------------------------------------------
 
-/** Returns server-configured video providers (managed flag only, no base URLs). */
-export function getServerVideoProviders(): Record<string, Record<string, never>> {
-  return Object.fromEntries(Object.keys(getConfig().video).map((id) => [id, {}]));
+/**
+ * Returns video providers the client must know about: server-managed providers
+ * (presence = managed flag) plus operator force-disabled providers
+ * (`{ disabled: true }`), mirroring the TTS listing — disable wins (#665).
+ */
+export function getServerVideoProviders(): Record<string, { disabled?: boolean }> {
+  const cfg = getConfig();
+  const result: Record<string, { disabled?: boolean }> = {};
+  for (const id of Object.keys(cfg.video)) result[id] = {};
+  for (const id of cfg.disabled.video) result[id] = { disabled: true };
+  return result;
 }
 
 export function resolveVideoApiKey(providerId: string, clientKey?: string): string {
@@ -782,11 +859,13 @@ export function resolveVideoBaseUrl(
 
 /**
  * Resolve the server-side default video provider, used when the client sends
- * no provider preference: the first operator-configured video provider. Returns
- * undefined when no video provider is configured at all (callers fail loud).
+ * no provider preference: the first operator-configured video provider that is
+ * not force-disabled. Returns undefined when no video provider is enabled at
+ * all (callers fail loud).
  */
 export function resolveServerVideoProviderId(): string | undefined {
-  return Object.keys(getConfig().video)[0];
+  const disabled = getConfig().disabled.video;
+  return Object.keys(getConfig().video).find((id) => !disabled.has(id));
 }
 
 /**
@@ -807,9 +886,17 @@ export function resolveVideoModel(providerId: string, clientModel?: string): str
 // Public API — Web Search
 // ---------------------------------------------------------------------------
 
-/** Returns server-configured web search providers (managed flag only, no base URLs). */
-export function getServerWebSearchProviders(): Record<string, Record<string, never>> {
-  return Object.fromEntries(Object.keys(getConfig().webSearch).map((id) => [id, {}]));
+/**
+ * Returns web-search providers the client must know about: server-managed
+ * providers (presence = managed flag) plus operator force-disabled providers
+ * (`{ disabled: true }`), mirroring the TTS listing — disable wins (#665).
+ */
+export function getServerWebSearchProviders(): Record<string, { disabled?: boolean }> {
+  const cfg = getConfig();
+  const result: Record<string, { disabled?: boolean }> = {};
+  for (const id of Object.keys(cfg.webSearch)) result[id] = {};
+  for (const id of cfg.disabled.webSearch) result[id] = { disabled: true };
+  return result;
 }
 
 /**
@@ -851,15 +938,21 @@ export function resolveWebSearchModel(
 
 export function resolveServerWebSearchProviderId(preferredProviderId?: string): string | undefined {
   const webSearch = getConfig().webSearch;
-  if (preferredProviderId && webSearch[preferredProviderId]?.apiKey) {
+  const disabled = getConfig().disabled.webSearch;
+  const enabled = (id: string) => !disabled.has(id);
+  if (
+    preferredProviderId &&
+    enabled(preferredProviderId) &&
+    webSearch[preferredProviderId]?.apiKey
+  ) {
     return preferredProviderId;
   }
-  if (webSearch.tavily?.apiKey) return 'tavily';
-  if (webSearch.bocha?.apiKey) return 'bocha';
-  if (webSearch.baidu?.apiKey) return 'baidu';
-  if (webSearch.minimax?.apiKey) return 'minimax';
-  if (webSearch.claude?.apiKey) return 'claude';
-  return Object.keys(webSearch)[0];
+  if (enabled('tavily') && webSearch.tavily?.apiKey) return 'tavily';
+  if (enabled('bocha') && webSearch.bocha?.apiKey) return 'bocha';
+  if (enabled('baidu') && webSearch.baidu?.apiKey) return 'baidu';
+  if (enabled('minimax') && webSearch.minimax?.apiKey) return 'minimax';
+  if (enabled('claude') && webSearch.claude?.apiKey) return 'claude';
+  return Object.keys(webSearch).find(enabled);
 }
 
 /**

--- a/lib/server/web-search-config.ts
+++ b/lib/server/web-search-config.ts
@@ -1,6 +1,7 @@
 import {
   resolveServerWebSearchProviderId,
   isServerConfiguredProvider,
+  isServerProviderDisabled,
   resolveWebSearchApiKey,
   resolveWebSearchBaseUrl,
   resolveWebSearchModel,
@@ -102,8 +103,13 @@ export function resolveClassroomWebSearchConfig(input: {
   const requestedProviderId = assertWebSearchProviderId(input.webSearchProviderId)
     ? input.webSearchProviderId
     : undefined;
+  // A force-disabled requested provider yields to the operator's server default
+  // (server precedence, #665); resolveServerWebSearchProviderId already skips
+  // disabled providers internally.
   const providerId =
-    requestedProviderId ?? (resolveServerWebSearchProviderId() as WebSearchProviderId | undefined);
+    (requestedProviderId && !isServerProviderDisabled('webSearch', requestedProviderId)
+      ? requestedProviderId
+      : undefined) ?? (resolveServerWebSearchProviderId() as WebSearchProviderId | undefined);
   if (!providerId) return undefined;
 
   const provider = WEB_SEARCH_PROVIDERS[providerId];

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -128,6 +128,8 @@ export interface SettingsState {
       customModels?: Array<{ id: string; name: string }>;
       providerOptions?: Record<string, unknown>;
       isServerConfigured?: boolean;
+      /** Admin/server-level force-off (server-providers.yml / env). Overrides `enabled`. */
+      serverDisabled?: boolean;
       // Custom provider fields
       customName?: string;
       customDefaultBaseUrl?: string;
@@ -164,6 +166,8 @@ export interface SettingsState {
       baseUrl: string;
       enabled: boolean;
       isServerConfigured?: boolean;
+      /** Admin/server-level force-off (server-providers.yml / env). Overrides `enabled`. */
+      serverDisabled?: boolean;
       customModels?: Array<{ id: string; name: string }>;
       replaceBuiltInModels?: boolean;
     }
@@ -179,6 +183,8 @@ export interface SettingsState {
       baseUrl: string;
       enabled: boolean;
       isServerConfigured?: boolean;
+      /** Admin/server-level force-off (server-providers.yml / env). Overrides `enabled`. */
+      serverDisabled?: boolean;
       customModels?: Array<{ id: string; name: string }>;
       replaceBuiltInModels?: boolean;
     }
@@ -199,6 +205,8 @@ export interface SettingsState {
       enabled: boolean;
       requiresApiKey?: boolean;
       isServerConfigured?: boolean;
+      /** Admin/server-level force-off (server-providers.yml / env). Overrides `enabled`. */
+      serverDisabled?: boolean;
       /** Model-based providers only (Claude): the model that runs the search. */
       modelId?: string;
     }
@@ -1394,17 +1402,17 @@ export const useSettingsStore = create<SettingsState>()(
             const res = await fetch('/api/server-providers');
             if (!res.ok) return;
             // Managed providers expose only their allowed model list (LLM/image)
-            // and presence (the "managed" flag) — never a base URL.
+            // and presence (the "managed" flag) — never a base URL. Every
+            // capability section carries an optional `disabled` flag for
+            // admin/server-level force-off (#665).
             const data = (await res.json()) as {
               providers: Record<string, { models?: string[] }>;
-              // TTS additionally carries an optional `disabled` flag for
-              // admin/server-level force-off (#665).
               tts: Record<string, { disabled?: boolean }>;
-              asr: Record<string, Record<string, never>>;
+              asr: Record<string, { disabled?: boolean }>;
               pdf: Record<string, Record<string, never>>;
-              image: Record<string, { models?: string[] }>;
-              video: Record<string, Record<string, never>>;
-              webSearch: Record<string, Record<string, never>>;
+              image: Record<string, { models?: string[]; disabled?: boolean }>;
+              video: Record<string, { disabled?: boolean }>;
+              webSearch: Record<string, { disabled?: boolean }>;
               generation?: { parallelSceneConcurrency?: number };
             };
 
@@ -1485,7 +1493,9 @@ export const useSettingsStore = create<SettingsState>()(
                 }
               }
 
-              // Merge ASR providers
+              // Merge ASR providers. Reset both server flags first, then apply:
+              // an entry with `disabled` is force-off (server precedence) and is
+              // NOT treated as managed/configured, mirroring the TTS merge.
               const newASRConfig = { ...state.asrProvidersConfig };
               for (const pid of Object.keys(newASRConfig)) {
                 const key = pid as ASRProviderId;
@@ -1493,15 +1503,17 @@ export const useSettingsStore = create<SettingsState>()(
                   newASRConfig[key] = {
                     ...newASRConfig[key],
                     isServerConfigured: false,
+                    serverDisabled: false,
                   };
                 }
               }
-              for (const pid of Object.keys(data.asr)) {
+              for (const [pid, info] of Object.entries(data.asr)) {
                 const key = pid as ASRProviderId;
                 if (newASRConfig[key]) {
                   newASRConfig[key] = {
                     ...newASRConfig[key],
-                    isServerConfigured: true,
+                    isServerConfigured: !info.disabled,
+                    serverDisabled: info.disabled === true,
                   };
                 }
               }
@@ -1527,7 +1539,9 @@ export const useSettingsStore = create<SettingsState>()(
                 }
               }
 
-              // Merge Image providers
+              // Merge Image providers. Reset both server flags first, then
+              // apply: `disabled` is force-off (server precedence), mirroring
+              // the TTS merge.
               const newImageConfig = { ...state.imageProvidersConfig };
               for (const pid of Object.keys(newImageConfig)) {
                 const key = pid as ImageProviderId;
@@ -1535,20 +1549,24 @@ export const useSettingsStore = create<SettingsState>()(
                   newImageConfig[key] = {
                     ...newImageConfig[key],
                     isServerConfigured: false,
+                    serverDisabled: false,
                   };
                 }
               }
-              for (const pid of Object.keys(data.image)) {
+              for (const [pid, info] of Object.entries(data.image)) {
                 const key = pid as ImageProviderId;
                 if (newImageConfig[key]) {
                   newImageConfig[key] = {
                     ...newImageConfig[key],
-                    isServerConfigured: true,
+                    isServerConfigured: !info.disabled,
+                    serverDisabled: info.disabled === true,
                   };
                 }
               }
 
-              // Merge Video providers
+              // Merge Video providers. Reset both server flags first, then
+              // apply: `disabled` is force-off (server precedence), mirroring
+              // the TTS merge.
               const newVideoConfig = { ...state.videoProvidersConfig };
               for (const pid of Object.keys(newVideoConfig)) {
                 const key = pid as VideoProviderId;
@@ -1556,36 +1574,42 @@ export const useSettingsStore = create<SettingsState>()(
                   newVideoConfig[key] = {
                     ...newVideoConfig[key],
                     isServerConfigured: false,
+                    serverDisabled: false,
                   };
                 }
               }
               if (data.video) {
-                for (const pid of Object.keys(data.video)) {
+                for (const [pid, info] of Object.entries(data.video)) {
                   const key = pid as VideoProviderId;
                   if (newVideoConfig[key]) {
                     newVideoConfig[key] = {
                       ...newVideoConfig[key],
-                      isServerConfigured: true,
+                      isServerConfigured: !info.disabled,
+                      serverDisabled: info.disabled === true,
                     };
                   }
                 }
               }
 
-              // Merge Web Search config — reset all first, then mark server-configured
+              // Merge Web Search config — reset all first, then mark
+              // server-configured; `disabled` is force-off (server precedence),
+              // mirroring the TTS merge.
               const newWebSearchConfig = { ...state.webSearchProvidersConfig };
               for (const key of Object.keys(newWebSearchConfig) as WebSearchProviderId[]) {
                 newWebSearchConfig[key] = {
                   ...newWebSearchConfig[key],
                   isServerConfigured: false,
+                  serverDisabled: false,
                 };
               }
               if (data.webSearch) {
-                for (const pid of Object.keys(data.webSearch)) {
+                for (const [pid, info] of Object.entries(data.webSearch)) {
                   const key = pid as WebSearchProviderId;
                   if (newWebSearchConfig[key]) {
                     newWebSearchConfig[key] = {
                       ...newWebSearchConfig[key],
-                      isServerConfigured: true,
+                      isServerConfigured: !info.disabled,
+                      serverDisabled: info.disabled === true,
                     };
                   }
                 }
@@ -1599,7 +1623,7 @@ export const useSettingsStore = create<SettingsState>()(
                   { isServerConfigured?: boolean; apiKey?: string; serverDisabled?: boolean }
                 >,
               ): T[] => [
-                // Server-disabled providers (TTS only) are never fallback targets.
+                // Server-disabled providers are never fallback targets.
                 ...Object.entries(config)
                   .filter(([, c]) => c.isServerConfigured && !c.serverDisabled)
                   .map(([id]) => id as T),
@@ -1749,8 +1773,12 @@ export const useSettingsStore = create<SettingsState>()(
                   autoTtsEnabled = true;
                 }
 
-                // ASR: select first server provider if current is not server-configured
-                const serverAsrIds = Object.keys(data.asr) as ASRProviderId[];
+                // ASR: select first server provider if current is not
+                // server-configured. Skip server-disabled entries — they are
+                // force-off, not selectable.
+                const serverAsrIds = Object.entries(data.asr)
+                  .filter(([, info]) => !info.disabled)
+                  .map(([id]) => id) as ASRProviderId[];
                 if (
                   serverAsrIds.length > 0 &&
                   !newASRConfig[state.asrProviderId]?.isServerConfigured
@@ -1758,8 +1786,11 @@ export const useSettingsStore = create<SettingsState>()(
                   autoAsrProvider = serverAsrIds[0];
                 }
 
-                // Image: first server provider
-                const serverImageIds = Object.keys(data.image) as ImageProviderId[];
+                // Image: first server provider. Skip server-disabled entries —
+                // they are force-off, not selectable.
+                const serverImageIds = Object.entries(data.image)
+                  .filter(([, info]) => !info.disabled)
+                  .map(([id]) => id) as ImageProviderId[];
                 if (
                   serverImageIds.length > 0 &&
                   !newImageConfig[state.imageProviderId]?.isServerConfigured
@@ -1772,8 +1803,11 @@ export const useSettingsStore = create<SettingsState>()(
                   autoImageEnabled = true;
                 }
 
-                // Video: first server provider
-                const serverVideoIds = Object.keys(data.video || {}) as VideoProviderId[];
+                // Video: first server provider. Skip server-disabled entries —
+                // they are force-off, not selectable.
+                const serverVideoIds = Object.entries(data.video || {})
+                  .filter(([, info]) => !info.disabled)
+                  .map(([id]) => id) as VideoProviderId[];
                 if (
                   serverVideoIds.length > 0 &&
                   !newVideoConfig[state.videoProviderId]?.isServerConfigured

--- a/lib/web-search/constants.ts
+++ b/lib/web-search/constants.ts
@@ -89,8 +89,14 @@ export const CLAUDE_WEB_SEARCH_MODELS: ReadonlyArray<{ id: string; name: string 
 
 export function isWebSearchProviderConfigured(
   provider: WebSearchProviderConfig,
-  cfg?: { apiKey?: string; baseUrl?: string; isServerConfigured?: boolean },
+  cfg?: {
+    apiKey?: string;
+    baseUrl?: string;
+    isServerConfigured?: boolean;
+    serverDisabled?: boolean;
+  },
 ): boolean {
+  if (cfg?.serverDisabled) return false;
   if (cfg?.isServerConfigured) return true;
   // SearXNG base URLs are operator-managed only; client settings must not count.
   if (provider.id === 'searxng') return false;
@@ -106,9 +112,11 @@ function isWebSearchConfigUsable(
     baseUrl?: string;
     isServerConfigured?: boolean;
     requiresApiKey?: boolean;
+    serverDisabled?: boolean;
   },
 ): boolean {
   if (!cfg) return false;
+  if (cfg.serverDisabled) return false;
   if (cfg.isServerConfigured) return true;
 
   const provider = WEB_SEARCH_PROVIDERS[providerId];
@@ -126,7 +134,13 @@ export function buildWebSearchFallbackOrder(
   config: Partial<
     Record<
       WebSearchProviderId,
-      { apiKey?: string; baseUrl?: string; isServerConfigured?: boolean; requiresApiKey?: boolean }
+      {
+        apiKey?: string;
+        baseUrl?: string;
+        isServerConfigured?: boolean;
+        requiresApiKey?: boolean;
+        serverDisabled?: boolean;
+      }
     >
   >,
 ): WebSearchProviderId[] {

--- a/tests/audio/asr-force-off.test.ts
+++ b/tests/audio/asr-force-off.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { ASR_SERVER_DISABLED_MESSAGE, getASRServerDisabledError } from '@/lib/audio/asr-enablement';
+
+describe('ASR client-side force-off guard', () => {
+  it('blocks browser-native execution when the server disables the provider', () => {
+    expect(getASRServerDisabledError({ serverDisabled: true })).toBe(ASR_SERVER_DISABLED_MESSAGE);
+  });
+
+  it('allows providers without a server force-off', () => {
+    expect(getASRServerDisabledError()).toBeUndefined();
+    expect(getASRServerDisabledError({ serverDisabled: false })).toBeUndefined();
+  });
+});

--- a/tests/server/capability-force-off-routes.test.ts
+++ b/tests/server/capability-force-off-routes.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Force-off route guards (#665): mirror the TTS contract — a server-disabled
+// provider is rejected with 403 PROVIDER_DISABLED before any credential or
+// generation logic runs, and a disabled provider is never picked as the
+// server-side default.
+
+const mocks = vi.hoisted(() => ({
+  generateImage: vi.fn(),
+  testImageConnectivity: vi.fn(),
+  generateVideo: vi.fn(),
+  testVideoConnectivity: vi.fn(),
+  transcribeAudio: vi.fn(),
+}));
+
+vi.mock('@/lib/media/image-providers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/media/image-providers')>();
+  return {
+    ...actual,
+    generateImage: mocks.generateImage,
+    testImageConnectivity: mocks.testImageConnectivity,
+  };
+});
+
+vi.mock('@/lib/media/video-providers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/media/video-providers')>();
+  return {
+    ...actual,
+    generateVideo: mocks.generateVideo,
+    testVideoConnectivity: mocks.testVideoConnectivity,
+  };
+});
+
+vi.mock('@/lib/audio/asr-providers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/audio/asr-providers')>();
+  return { ...actual, transcribeAudio: mocks.transcribeAudio };
+});
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const CAP_ENV_PREFIXES = [
+  'IMAGE_OPENAI',
+  'IMAGE_SEEDREAM',
+  'IMAGE_QWEN_IMAGE',
+  'IMAGE_NANO_BANANA',
+  'IMAGE_MINIMAX',
+  'IMAGE_GROK',
+  'IMAGE_LEMONADE',
+  'IMAGE_COMFYUI',
+  'VIDEO_SEEDANCE',
+  'VIDEO_KLING',
+  'VIDEO_VEO',
+  'VIDEO_SORA',
+  'VIDEO_MINIMAX',
+  'VIDEO_GROK',
+  'VIDEO_HAPPYHORSE',
+  'ASR_OPENAI',
+  'ASR_QWEN',
+  'ASR_AZURE',
+  'ASR_FUNASR',
+  'ASR_LEMONADE',
+  'ASR_BROWSER_NATIVE',
+];
+
+function clearCapabilityEnv() {
+  for (const prefix of CAP_ENV_PREFIXES) {
+    delete process.env[`${prefix}_API_KEY`];
+    delete process.env[`${prefix}_BASE_URL`];
+    delete process.env[`${prefix}_MODELS`];
+    delete process.env[`${prefix}_ENABLED`];
+  }
+}
+
+function jsonRequest(
+  url: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  return new NextRequest(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function transcriptionRequest(providerId: string): NextRequest {
+  const form = new FormData();
+  form.append('audio', new File([new Uint8Array([1, 2, 3])], 'test.wav', { type: 'audio/wav' }));
+  form.append('providerId', providerId);
+  return new NextRequest('http://localhost/api/transcription', {
+    method: 'POST',
+    body: form,
+  });
+}
+
+describe('capability force-off route guards (#665)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    clearCapabilityEnv();
+    mocks.generateImage.mockReset().mockResolvedValue({ url: 'https://example.com/img.png' });
+    mocks.testImageConnectivity.mockReset().mockResolvedValue({ success: true, message: 'ok' });
+    mocks.generateVideo.mockReset().mockResolvedValue({
+      url: 'https://example.com/v.mp4',
+      width: 1920,
+      height: 1080,
+      duration: 5,
+    });
+    mocks.testVideoConnectivity.mockReset().mockResolvedValue({ success: true, message: 'ok' });
+    mocks.transcribeAudio.mockReset().mockResolvedValue({ text: 'hello' });
+  });
+
+  describe('image', () => {
+    it('POST /api/generate/image returns 403 PROVIDER_DISABLED for a force-disabled provider', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { POST } = await import('@/app/api/generate/image/route');
+
+      const res = await POST(
+        jsonRequest(
+          'http://localhost/api/generate/image',
+          { prompt: 'a cat' },
+          { 'x-image-provider': 'openai-image' },
+        ),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(mocks.generateImage).not.toHaveBeenCalled();
+    });
+
+    it('force-off beats a client key on an unmanaged provider', async () => {
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { POST } = await import('@/app/api/generate/image/route');
+
+      const res = await POST(
+        jsonRequest(
+          'http://localhost/api/generate/image',
+          { prompt: 'a cat' },
+          { 'x-image-provider': 'openai-image', 'x-api-key': 'client-key' },
+        ),
+      );
+
+      expect(res.status).toBe(403);
+      expect(mocks.generateImage).not.toHaveBeenCalled();
+    });
+
+    it('does not pick a disabled provider as the server default (MISSING_PROVIDER)', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { POST } = await import('@/app/api/generate/image/route');
+
+      // No x-image-provider header ⇒ server default resolution, which skips the
+      // disabled provider, leaving nothing configured.
+      const res = await POST(
+        jsonRequest('http://localhost/api/generate/image', { prompt: 'a cat' }),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json).toMatchObject({ success: false, errorCode: 'MISSING_PROVIDER' });
+      expect(mocks.generateImage).not.toHaveBeenCalled();
+    });
+
+    it('POST /api/verify-image-provider returns 403 for a force-disabled provider', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { POST } = await import('@/app/api/verify-image-provider/route');
+
+      const res = await POST(
+        jsonRequest(
+          'http://localhost/api/verify-image-provider',
+          {},
+          { 'x-image-provider': 'openai-image' },
+        ),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(mocks.testImageConnectivity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('video', () => {
+    it('POST /api/generate/video returns 403 PROVIDER_DISABLED for a force-disabled provider', async () => {
+      vi.stubEnv('VIDEO_GROK_API_KEY', 'xai-video');
+      vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+      const { POST } = await import('@/app/api/generate/video/route');
+
+      const res = await POST(
+        jsonRequest(
+          'http://localhost/api/generate/video',
+          { prompt: 'a cat' },
+          { 'x-video-provider': 'grok-video' },
+        ),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(mocks.generateVideo).not.toHaveBeenCalled();
+    });
+
+    it('does not pick a disabled provider as the server default (MISSING_PROVIDER)', async () => {
+      vi.stubEnv('VIDEO_GROK_API_KEY', 'xai-video');
+      vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+      const { POST } = await import('@/app/api/generate/video/route');
+
+      const res = await POST(
+        jsonRequest('http://localhost/api/generate/video', { prompt: 'a cat' }),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json).toMatchObject({ success: false, errorCode: 'MISSING_PROVIDER' });
+      expect(mocks.generateVideo).not.toHaveBeenCalled();
+    });
+
+    it('POST /api/verify-video-provider returns 403 for a force-disabled provider', async () => {
+      vi.stubEnv('VIDEO_GROK_API_KEY', 'xai-video');
+      vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+      const { POST } = await import('@/app/api/verify-video-provider/route');
+
+      const res = await POST(
+        jsonRequest(
+          'http://localhost/api/verify-video-provider',
+          {},
+          { 'x-video-provider': 'grok-video' },
+        ),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(mocks.testVideoConnectivity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('asr (transcription)', () => {
+    it('POST /api/transcription returns 403 PROVIDER_DISABLED for a force-disabled provider', async () => {
+      vi.stubEnv('ASR_OPENAI_API_KEY', 'sk-asr');
+      vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
+      const { POST } = await import('@/app/api/transcription/route');
+
+      const res = await POST(transcriptionRequest('openai-whisper'));
+      const json = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(mocks.transcribeAudio).not.toHaveBeenCalled();
+    });
+
+    it('rejects the default openai-whisper fallback when it is force-disabled', async () => {
+      vi.stubEnv('ASR_OPENAI_API_KEY', 'sk-asr');
+      vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
+      const { POST } = await import('@/app/api/transcription/route');
+
+      // No providerId in the form ⇒ the route defaults to openai-whisper, which
+      // must still be rejected when force-disabled.
+      const form = new FormData();
+      form.append(
+        'audio',
+        new File([new Uint8Array([1, 2, 3])], 'test.wav', { type: 'audio/wav' }),
+      );
+      const res = await POST(
+        new NextRequest('http://localhost/api/transcription', { method: 'POST', body: form }),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(mocks.transcribeAudio).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/server/capability-force-off-routes.test.ts
+++ b/tests/server/capability-force-off-routes.test.ts
@@ -260,13 +260,13 @@ describe('capability force-off route guards (#665)', () => {
       expect(mocks.transcribeAudio).not.toHaveBeenCalled();
     });
 
-    it('rejects the default openai-whisper fallback when it is force-disabled', async () => {
+    it('fails loudly instead of guessing a vendor when no enabled ASR backend exists', async () => {
       vi.stubEnv('ASR_OPENAI_API_KEY', 'sk-asr');
       vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
       const { POST } = await import('@/app/api/transcription/route');
 
-      // No providerId in the form ⇒ the route defaults to openai-whisper, which
-      // must still be rejected when force-disabled.
+      // No providerId in the form and no enabled server backend must not fall
+      // through to a hardcoded vendor default.
       const form = new FormData();
       form.append(
         'audio',
@@ -277,9 +277,31 @@ describe('capability force-off route guards (#665)', () => {
       );
       const json = await res.json();
 
-      expect(res.status).toBe(403);
-      expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+      expect(res.status).toBe(400);
+      expect(json).toMatchObject({ success: false, errorCode: 'MISSING_PROVIDER' });
       expect(mocks.transcribeAudio).not.toHaveBeenCalled();
+    });
+
+    it('uses an enabled server ASR backend when the client omits providerId', async () => {
+      vi.stubEnv('ASR_OPENAI_API_KEY', 'sk-openai');
+      vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
+      vi.stubEnv('ASR_QWEN_API_KEY', 'sk-qwen');
+      const { POST } = await import('@/app/api/transcription/route');
+
+      const form = new FormData();
+      form.append(
+        'audio',
+        new File([new Uint8Array([1, 2, 3])], 'test.wav', { type: 'audio/wav' }),
+      );
+      const res = await POST(
+        new NextRequest('http://localhost/api/transcription', { method: 'POST', body: form }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mocks.transcribeAudio).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: 'qwen-asr', apiKey: 'sk-qwen' }),
+        expect.any(File),
+      );
     });
   });
 });

--- a/tests/server/classroom-media-generation.test.ts
+++ b/tests/server/classroom-media-generation.test.ts
@@ -107,6 +107,36 @@ describe('generateMediaForClassroom model fallback', () => {
     vi.useRealTimers();
   });
 
+  test('gracefully skips media when every configured provider is force-disabled', async () => {
+    vi.stubEnv('IMAGE_SEEDREAM_API_KEY', 'sk-seedream');
+    vi.stubEnv('IMAGE_SEEDREAM_ENABLED', 'false');
+    vi.stubEnv('VIDEO_SEEDANCE_API_KEY', 'sk-seedance');
+    vi.stubEnv('VIDEO_SEEDANCE_ENABLED', 'false');
+    vi.resetModules();
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { generateMediaForClassroom } = await import('@/lib/server/classroom-media-generation');
+    const outlines = [
+      {
+        id: 'outline_disabled',
+        type: 'slide',
+        title: 'Scene',
+        description: 'd',
+        order: 1,
+        mediaGenerations: [
+          { type: 'image', prompt: 'image', elementId: 'gen_img_disabled' },
+          { type: 'video', prompt: 'video', elementId: 'gen_vid_disabled' },
+        ],
+      },
+    ] as unknown as SceneOutline[];
+
+    await expect(
+      generateMediaForClassroom(outlines, 'cls-disabled', 'http://localhost'),
+    ).resolves.toEqual({});
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('falls back to the first catalog image model when the server pins no models', async () => {
     // Key-only managed provider (no IMAGE_SEEDREAM_MODELS pin): the resolver
     // yields no model, so the classroom path must fall back to the first

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -752,6 +752,166 @@ video:
     });
   });
 
+  describe('per-capability force-disable (#665)', () => {
+    it('image: marks an env-configured provider as managed (no disabled flag)', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+      expect(getServerImageProviders()['openai-image']).toEqual({});
+    });
+
+    it('image: force-disables via IMAGE_<P>_ENABLED=false even when it has a key', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+      expect(getServerImageProviders()['openai-image']).toEqual({ disabled: true });
+    });
+
+    it('image: force-disables the keyless client-only ComfyUI provider via env', async () => {
+      vi.stubEnv('IMAGE_COMFYUI_ENABLED', 'false');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+      expect(getServerImageProviders()['comfyui-image']).toEqual({ disabled: true });
+    });
+
+    it('image: an _ENABLED=true value does NOT force-enable an unconfigured keyless provider', async () => {
+      vi.stubEnv('IMAGE_COMFYUI_ENABLED', 'true');
+      const { getServerImageProviders, resolveServerImageProviderId } =
+        await import('@/lib/server/provider-config');
+      // ComfyUI has no credential env, so a truthy _ENABLED must not conjure a
+      // configured/enabled entry out of thin air — it can only disable (#665).
+      expect(getServerImageProviders()['comfyui-image']).toBeUndefined();
+      expect(resolveServerImageProviderId()).toBeUndefined();
+    });
+
+    it('image: force-disables via YAML image.<id>.enabled: false', async () => {
+      yamlOverride = 'image:\n  seedream:\n    enabled: false\n';
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+      expect(getServerImageProviders()['seedream']).toEqual({ disabled: true });
+    });
+
+    it('image: env ENABLED=true overrides a YAML disable', async () => {
+      yamlOverride = 'image:\n  openai-image:\n    enabled: false\n    apiKey: sk-yaml\n';
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'true');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+      expect(getServerImageProviders()['openai-image']).toEqual({});
+    });
+
+    it('image: an empty IMAGE_<P>_ENABLED does NOT override a YAML disable', async () => {
+      yamlOverride = 'image:\n  openai-image:\n    enabled: false\n    apiKey: sk-yaml\n';
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', '');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+      expect(getServerImageProviders()['openai-image']).toEqual({ disabled: true });
+    });
+
+    it('asr: force-disables a keyed provider via ASR_<P>_ENABLED=false even when it has a key', async () => {
+      vi.stubEnv('ASR_OPENAI_API_KEY', 'sk-asr');
+      vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
+      const { getServerASRProviders } = await import('@/lib/server/provider-config');
+      expect(getServerASRProviders()['openai-whisper']).toEqual({ disabled: true });
+    });
+
+    it('asr: force-disables the client-only browser-native provider via env', async () => {
+      vi.stubEnv('ASR_BROWSER_NATIVE_ENABLED', 'false');
+      const { getServerASRProviders } = await import('@/lib/server/provider-config');
+      expect(getServerASRProviders()['browser-native']).toEqual({ disabled: true });
+    });
+
+    it('video: force-disables via VIDEO_<P>_ENABLED=false even when it has a key', async () => {
+      vi.stubEnv('VIDEO_GROK_API_KEY', 'xai-video');
+      vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+      const { getServerVideoProviders } = await import('@/lib/server/provider-config');
+      expect(getServerVideoProviders()['grok-video']).toEqual({ disabled: true });
+    });
+
+    it('video: force-disables via YAML video.<id>.enabled: false', async () => {
+      yamlOverride = 'video:\n  kling:\n    enabled: false\n    apiKey: sk-yaml\n';
+      const { getServerVideoProviders } = await import('@/lib/server/provider-config');
+      expect(getServerVideoProviders()['kling']).toEqual({ disabled: true });
+    });
+
+    it('web-search: force-disables a keyed provider via <P>_ENABLED=false even when it has a key', async () => {
+      vi.stubEnv('TAVILY_API_KEY', 'tvly-key');
+      vi.stubEnv('TAVILY_ENABLED', 'false');
+      const { getServerWebSearchProviders } = await import('@/lib/server/provider-config');
+      expect(getServerWebSearchProviders()['tavily']).toEqual({ disabled: true });
+    });
+
+    it('web-search: force-disables the keyless SearXNG provider via env', async () => {
+      vi.stubEnv('SEARXNG_BASE_URL', 'http://searxng.internal');
+      vi.stubEnv('SEARXNG_ENABLED', 'false');
+      const { getServerWebSearchProviders } = await import('@/lib/server/provider-config');
+      expect(getServerWebSearchProviders()['searxng']).toEqual({ disabled: true });
+    });
+
+    it('isServerProviderDisabled reflects the per-section force-disable set', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+      vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
+      const { isServerProviderDisabled } = await import('@/lib/server/provider-config');
+      expect(isServerProviderDisabled('image', 'openai-image')).toBe(true);
+      expect(isServerProviderDisabled('image', 'seedream')).toBe(false);
+      expect(isServerProviderDisabled('video', 'grok-video')).toBe(true);
+      expect(isServerProviderDisabled('asr', 'openai-whisper')).toBe(true);
+      expect(isServerProviderDisabled('tts', 'openai-tts')).toBe(false);
+    });
+  });
+
+  describe('server defaults skip force-disabled providers (#665)', () => {
+    it('resolveServerImageProviderId skips a disabled provider', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-1');
+      vi.stubEnv('IMAGE_GROK_API_KEY', 'sk-2');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { resolveServerImageProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerImageProviderId()).toBe('grok-image');
+    });
+
+    it('resolveServerImageProviderId returns undefined when every configured provider is disabled', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-1');
+      vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+      const { resolveServerImageProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerImageProviderId()).toBeUndefined();
+    });
+
+    it('resolveServerVideoProviderId skips a disabled provider', async () => {
+      vi.stubEnv('VIDEO_GROK_API_KEY', 'sk-1');
+      vi.stubEnv('VIDEO_KLING_API_KEY', 'sk-2');
+      vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+      const { resolveServerVideoProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerVideoProviderId()).toBe('kling');
+    });
+
+    it('web-search preference chain skips disabled providers', async () => {
+      vi.stubEnv('TAVILY_API_KEY', 'tvly');
+      vi.stubEnv('BOCHA_API_KEY', 'bocha');
+      vi.stubEnv('TAVILY_ENABLED', 'false');
+      const { resolveServerWebSearchProviderId } = await import('@/lib/server/provider-config');
+      // Tavily is the preferred default but disabled ⇒ bocha is chosen.
+      expect(resolveServerWebSearchProviderId()).toBe('bocha');
+    });
+
+    it('web-search preference chain honors an enabled preferred provider', async () => {
+      vi.stubEnv('TAVILY_API_KEY', 'tvly');
+      vi.stubEnv('BOCHA_API_KEY', 'bocha');
+      const { resolveServerWebSearchProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerWebSearchProviderId()).toBe('tavily');
+    });
+
+    it('web-search preference chain skips a disabled client-preferred provider', async () => {
+      vi.stubEnv('TAVILY_API_KEY', 'tvly');
+      vi.stubEnv('BOCHA_API_KEY', 'bocha');
+      vi.stubEnv('TAVILY_ENABLED', 'false');
+      const { resolveServerWebSearchProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerWebSearchProviderId('tavily')).toBe('bocha');
+    });
+
+    it('web-search preference chain returns undefined when every configured provider is disabled', async () => {
+      vi.stubEnv('TAVILY_API_KEY', 'tvly');
+      vi.stubEnv('TAVILY_ENABLED', 'false');
+      const { resolveServerWebSearchProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerWebSearchProviderId()).toBeUndefined();
+    });
+  });
+
   describe('Qwen TTS resolution', () => {
     it('uses the provider default base URL when none is configured or supplied', async () => {
       const { resolveTTSBaseUrl } = await import('@/lib/server/provider-config');

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -56,6 +56,7 @@ const ENV_PREFIXES_TO_CLEAR = [
   'BOCHA',
   'WEB_SEARCH_MINIMAX',
   'WEB_SEARCH_CLAUDE',
+  'WEB_SEARCH_DOUBAO',
 ];
 
 function clearProviderEnv() {
@@ -842,6 +843,12 @@ video:
       expect(getServerWebSearchProviders()['searxng']).toEqual({ disabled: true });
     });
 
+    it('web-search: force-disables the built-in Doubao provider via its dedicated env', async () => {
+      vi.stubEnv('WEB_SEARCH_DOUBAO_ENABLED', 'false');
+      const { getServerWebSearchProviders } = await import('@/lib/server/provider-config');
+      expect(getServerWebSearchProviders().doubao).toEqual({ disabled: true });
+    });
+
     it('isServerProviderDisabled reflects the per-section force-disable set', async () => {
       vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
       vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
@@ -878,6 +885,14 @@ video:
       vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
       const { resolveServerVideoProviderId } = await import('@/lib/server/provider-config');
       expect(resolveServerVideoProviderId()).toBe('kling');
+    });
+
+    it('resolveServerASRProviderId skips a disabled provider', async () => {
+      vi.stubEnv('ASR_OPENAI_API_KEY', 'sk-1');
+      vi.stubEnv('ASR_QWEN_API_KEY', 'sk-2');
+      vi.stubEnv('ASR_OPENAI_ENABLED', 'false');
+      const { resolveServerASRProviderId } = await import('@/lib/server/provider-config');
+      expect(resolveServerASRProviderId()).toBe('qwen-asr');
     });
 
     it('web-search preference chain skips disabled providers', async () => {

--- a/tests/server/tts-route-missing-key.test.ts
+++ b/tests/server/tts-route-missing-key.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock fs — only intercept server-providers.yml so a host-machine YAML config
+// can never leak into the route's provider-config (same pattern as
+// provider-config.test.ts).
+let yamlOverride: string | null = null;
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const isYaml = (p: unknown) => typeof p === 'string' && p.endsWith('server-providers.yml');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: (p: string) => (isYaml(p) ? yamlOverride !== null : actual.existsSync(p)),
+      readFileSync: (p: string, ...args: unknown[]) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        isYaml(p) ? (yamlOverride ?? '') : (actual.readFileSync as any)(p, ...args),
+    },
+    existsSync: (p: string) => (isYaml(p) ? yamlOverride !== null : actual.existsSync(p)),
+    readFileSync: (p: string, ...args: unknown[]) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      isYaml(p) ? (yamlOverride ?? '') : (actual.readFileSync as any)(p, ...args),
+  };
+});
+
+const mocks = vi.hoisted(() => ({ generateTTS: vi.fn() }));
+
+vi.mock('@/lib/audio/tts-providers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/audio/tts-providers')>();
+  return { ...actual, generateTTS: mocks.generateTTS };
+});
+
+const TTS_ENV_PREFIXES = [
+  'TTS_OPENAI',
+  'TTS_AZURE',
+  'TTS_GLM',
+  'TTS_QWEN',
+  'TTS_VOXCPM',
+  'TTS_DOUBAO',
+  'TTS_ELEVENLABS',
+  'TTS_MINIMAX',
+  'TTS_LEMONADE',
+  'TTS_BROWSER_NATIVE',
+];
+
+function clearTtsEnv() {
+  for (const prefix of TTS_ENV_PREFIXES) {
+    delete process.env[`${prefix}_API_KEY`];
+    delete process.env[`${prefix}_BASE_URL`];
+    delete process.env[`${prefix}_MODELS`];
+    delete process.env[`${prefix}_ENABLED`];
+  }
+  delete process.env.TTS_QWEN_VOICE_CLONE_MODEL;
+}
+
+function ttsRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/generate/tts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      text: 'Hello',
+      audioId: 'audio-1',
+      ...body,
+    }),
+  });
+}
+
+describe('POST /api/generate/tts missing-key contract (#665)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    clearTtsEnv();
+    yamlOverride = null;
+    mocks.generateTTS.mockReset().mockResolvedValue({ audio: new Uint8Array([1]), format: 'wav' });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns 400 MISSING_API_KEY for a keyed provider with no key (server or client)', async () => {
+    const { POST } = await import('@/app/api/generate/tts/route');
+    const res = await POST(ttsRequest({ ttsProviderId: 'openai-tts', ttsVoice: 'alloy' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json).toMatchObject({
+      success: false,
+      errorCode: 'MISSING_API_KEY',
+    });
+    expect(mocks.generateTTS).not.toHaveBeenCalled();
+  });
+
+  it('no longer falls through to a 500 GENERATION_FAILED for a missing key', async () => {
+    // Regression guard: before the pre-flight guard, the library threw
+    // "API key required for TTS provider: ..." which the route's catch mapped
+    // to 500 GENERATION_FAILED. The contract is now a client error.
+    const { POST } = await import('@/app/api/generate/tts/route');
+    const res = await POST(ttsRequest({ ttsProviderId: 'qwen-tts', ttsVoice: 'Cherry' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.errorCode).not.toBe('GENERATION_FAILED');
+    expect(mocks.generateTTS).not.toHaveBeenCalled();
+  });
+
+  it('uses a server-configured key (managed provider) so no client key is needed', async () => {
+    yamlOverride = 'tts:\n  openai-tts:\n    apiKey: sk-server\n';
+    const { POST } = await import('@/app/api/generate/tts/route');
+    const res = await POST(ttsRequest({ ttsProviderId: 'openai-tts', ttsVoice: 'alloy' }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.generateTTS).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'openai-tts', apiKey: 'sk-server' }),
+      'Hello',
+    );
+  });
+
+  it('accepts a client-supplied key for an unmanaged keyed provider', async () => {
+    const { POST } = await import('@/app/api/generate/tts/route');
+    const res = await POST(
+      ttsRequest({
+        ttsProviderId: 'openai-tts',
+        ttsVoice: 'alloy',
+        ttsApiKey: 'client-key',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.generateTTS).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'openai-tts', apiKey: 'client-key' }),
+      'Hello',
+    );
+  });
+
+  it('does not pre-empt keyless providers (e.g. voxcpm-tts) with the key guard', async () => {
+    // The local base URL is the provider's credential path; the key guard must
+    // not fire for a keyless provider (and localhost needs the self-host flag).
+    vi.stubEnv('ALLOW_LOCAL_NETWORKS', 'true');
+    const { POST } = await import('@/app/api/generate/tts/route');
+    const res = await POST(
+      ttsRequest({
+        ttsProviderId: 'voxcpm-tts',
+        ttsVoice: 'auto',
+        ttsBaseUrl: 'http://localhost:8000/v1',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.generateTTS).toHaveBeenCalled();
+  });
+
+  it('keeps the 500 GENERATION_FAILED envelope for a non-key library failure', async () => {
+    // Only the missing-key case moved to 400; genuine downstream failures keep
+    // the existing server-error contract.
+    mocks.generateTTS.mockRejectedValueOnce(new Error('upstream exploded'));
+    const { POST } = await import('@/app/api/generate/tts/route');
+    const res = await POST(
+      ttsRequest({
+        ttsProviderId: 'openai-tts',
+        ttsVoice: 'alloy',
+        ttsApiKey: 'client-key',
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json).toMatchObject({ success: false, errorCode: 'GENERATION_FAILED' });
+  });
+});

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -206,11 +206,11 @@ async function readPersistedState(): Promise<Record<string, unknown>> {
 interface MockServerResponse {
   providers?: Record<string, { models?: string[]; baseUrl?: string }>;
   tts?: Record<string, { baseUrl?: string; disabled?: boolean }>;
-  asr?: Record<string, { baseUrl?: string }>;
+  asr?: Record<string, { baseUrl?: string; disabled?: boolean }>;
   pdf?: Record<string, { baseUrl?: string }>;
-  image?: Record<string, { baseUrl?: string }>;
-  video?: Record<string, { baseUrl?: string }>;
-  webSearch?: Record<string, { baseUrl?: string }>;
+  image?: Record<string, { baseUrl?: string; disabled?: boolean }>;
+  video?: Record<string, { baseUrl?: string; disabled?: boolean }>;
+  webSearch?: Record<string, { baseUrl?: string; disabled?: boolean }>;
 }
 
 function mockServerResponse(overrides: MockServerResponse = {}) {
@@ -820,6 +820,20 @@ describe('fetchServerProviders — ASR stale selection', () => {
 
     expect(store.getState().asrProviderId).toBe('openai-whisper');
   });
+
+  it('marks a force-disabled ASR provider and re-points the stale selection', async () => {
+    const store = await getStore();
+    store.setState({ asrProviderId: 'openai-whisper' });
+    mockServerResponse({ asr: { 'openai-whisper': { disabled: true } } });
+
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().asrProvidersConfig['openai-whisper']).toMatchObject({
+      isServerConfigured: false,
+      serverDisabled: true,
+    });
+    expect(store.getState().asrProviderId).toBe('browser-native');
+  });
 });
 
 describe('fetchServerProviders — Web Search provider sync', () => {
@@ -893,6 +907,22 @@ describe('fetchServerProviders — Web Search provider sync', () => {
     });
     await store.getState().fetchServerProviders();
 
+    expect(store.getState().webSearchProviderId).toBe('bocha');
+  });
+
+  it('marks a force-disabled web-search provider and re-points the stale selection', async () => {
+    const store = await getStore();
+    store.setState({ webSearchProviderId: 'tavily' });
+    mockServerResponse({
+      webSearch: { tavily: { disabled: true }, bocha: {} },
+    });
+
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().webSearchProvidersConfig.tavily).toMatchObject({
+      isServerConfigured: false,
+      serverDisabled: true,
+    });
     expect(store.getState().webSearchProviderId).toBe('bocha');
   });
 
@@ -1042,6 +1072,20 @@ describe('fetchServerProviders — Image stale selection', () => {
     expect(store.getState().imageModelId).toBe('qwen-image-max');
   });
 
+  it('marks a force-disabled image provider and re-points the stale selection', async () => {
+    const store = await getStore();
+    store.setState({ imageProviderId: 'seedream' });
+    mockServerResponse({ image: { seedream: { disabled: true }, 'qwen-image': {} } });
+
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().imageProvidersConfig.seedream).toMatchObject({
+      isServerConfigured: false,
+      serverDisabled: true,
+    });
+    expect(store.getState().imageProviderId).toBe('qwen-image');
+  });
+
   it('auto-selects provider and model when server adds image provider after empty state', async () => {
     const store = await getStore();
 
@@ -1166,6 +1210,20 @@ describe('fetchServerProviders — Video stale selection', () => {
 
     expect(store.getState().videoProviderId).toBe('kling');
     expect(store.getState().videoModelId).toBe('kling-v2-6');
+  });
+
+  it('marks a force-disabled video provider and re-points the stale selection', async () => {
+    const store = await getStore();
+    store.setState({ videoProviderId: 'seedance' });
+    mockServerResponse({ video: { seedance: { disabled: true }, kling: {} } });
+
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().videoProvidersConfig.seedance).toMatchObject({
+      isServerConfigured: false,
+      serverDisabled: true,
+    });
+    expect(store.getState().videoProviderId).toBe('kling');
   });
 
   it('auto-selects provider and model when server adds video provider after empty state', async () => {

--- a/tests/web-search/constants.test.ts
+++ b/tests/web-search/constants.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getAllWebSearchProviders,
   getWebSearchProviderDisplayName,
+  isWebSearchProviderConfigured,
   WEB_SEARCH_PROVIDERS,
   buildWebSearchFallbackOrder,
   CLAUDE_WEB_SEARCH_DEFAULT_MODEL,
@@ -80,5 +81,15 @@ describe('web search provider constants', () => {
     expect(order[0]).toBe('searxng');
     expect(order).toContain('brave');
     expect(order.indexOf('searxng')).toBeLessThan(order.indexOf('brave'));
+  });
+
+  it('never treats a server-disabled provider as configured or a fallback', () => {
+    const cfg = {
+      apiKey: 'client-key',
+      requiresApiKey: true,
+      serverDisabled: true,
+    };
+    expect(isWebSearchProviderConfigured(WEB_SEARCH_PROVIDERS.tavily, cfg)).toBe(false);
+    expect(buildWebSearchFallbackOrder({ tavily: cfg })).not.toContain('tavily');
   });
 });

--- a/tests/web-search/route.test.ts
+++ b/tests/web-search/route.test.ts
@@ -49,18 +49,25 @@ describe('POST /api/web-search', () => {
     vi.unstubAllEnvs();
     delete process.env.TAVILY_API_KEY;
     delete process.env.TAVILY_BASE_URL;
+    delete process.env.TAVILY_ENABLED;
     delete process.env.BOCHA_API_KEY;
     delete process.env.BOCHA_BASE_URL;
+    delete process.env.BOCHA_ENABLED;
     delete process.env.BRAVE_API_KEY;
     delete process.env.BRAVE_BASE_URL;
+    delete process.env.BRAVE_ENABLED;
     delete process.env.BAIDU_API_KEY;
     delete process.env.BAIDU_BASE_URL;
+    delete process.env.BAIDU_ENABLED;
     delete process.env.WEB_SEARCH_MINIMAX_API_KEY;
     delete process.env.WEB_SEARCH_MINIMAX_BASE_URL;
+    delete process.env.WEB_SEARCH_MINIMAX_ENABLED;
     delete process.env.WEB_SEARCH_CLAUDE_API_KEY;
     delete process.env.WEB_SEARCH_CLAUDE_BASE_URL;
     delete process.env.WEB_SEARCH_CLAUDE_MODELS;
+    delete process.env.WEB_SEARCH_CLAUDE_ENABLED;
     delete process.env.SEARXNG_BASE_URL;
+    delete process.env.SEARXNG_ENABLED;
     mocks.searchWeb.mockReset();
     mocks.formatSearchResultsAsContext.mockClear();
     mocks.resolveModelFromRequest.mockReset();
@@ -335,4 +342,74 @@ describe('POST /api/web-search', () => {
       );
     },
   );
+
+  it('rejects a force-disabled provider with 403 PROVIDER_DISABLED even when it has a key', async () => {
+    vi.stubEnv('TAVILY_API_KEY', 'tvly-server-key');
+    vi.stubEnv('TAVILY_ENABLED', 'false');
+
+    const res = await postWebSearch({
+      query: 'test query',
+      providerId: 'tavily',
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json).toMatchObject({
+      success: false,
+      errorCode: 'PROVIDER_DISABLED',
+    });
+    expect(mocks.searchWeb).not.toHaveBeenCalled();
+  });
+
+  it('force-off beats a client key: a disabled unmanaged provider still 403s', async () => {
+    vi.stubEnv('TAVILY_ENABLED', 'false');
+
+    const res = await postWebSearch({
+      query: 'test query',
+      providerId: 'tavily',
+      apiKey: 'tvly-client-key',
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+    expect(mocks.searchWeb).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the operator backend when the client picks a disabled provider', async () => {
+    // Server has Bocha (enabled); the client asks for Tavily which is
+    // force-disabled and NOT server-configured. The server-preference override
+    // points at the enabled backend instead of failing the request.
+    vi.stubEnv('BOCHA_API_KEY', 'bocha-server-key');
+    vi.stubEnv('TAVILY_ENABLED', 'false');
+
+    const res = await postWebSearch({
+      query: 'test query',
+      providerId: 'tavily',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.searchWeb).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'bocha', apiKey: 'bocha-server-key' }),
+    );
+  });
+
+  it('403s a force-disabled server-configured provider even when the server has an enabled backend', async () => {
+    // Tavily is server-configured (key present) but force-disabled, so the
+    // server-preference override does NOT apply — the disabled provider itself
+    // is rejected rather than silently swapped.
+    vi.stubEnv('BOCHA_API_KEY', 'bocha-server-key');
+    vi.stubEnv('TAVILY_API_KEY', 'tvly-server-key');
+    vi.stubEnv('TAVILY_ENABLED', 'false');
+
+    const res = await postWebSearch({
+      query: 'test query',
+      providerId: 'tavily',
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json).toMatchObject({ success: false, errorCode: 'PROVIDER_DISABLED' });
+    expect(mocks.searchWeb).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

Capability enable/disable was inconsistent across providers:

- Only TTS had an explicit operator force-off (`TTS_<PREFIX>_ENABLED=false`); image, video, ASR, and web search were purely "key present ⇒ enabled" with no way to turn a capability off without deleting credentials.
- A keyed TTS provider with no key failed as **500 GENERATION_FAILED** (library throw into the generic catch), while the image route returns a clean **400 MISSING_API_KEY** — two contracts in the same repo.

## Change

- **Force-off generalized to image, video, ASR, and web search**, mirroring the TTS semantics exactly (only an explicit `false` disables; unset is no opinion; an env `true` overrides a YAML disable; the flag can never enable a keyless provider). Implemented as one per-section disable map derived from the existing env maps rather than four copies; client-only keyless providers (browser-native ASR/TTS, ComfyUI image) are coverable too.
- Disabled providers are skipped by server-default selection (including the web-search preference chain and classroom media generation), rejected with **403 PROVIDER_DISABLED** by the generate/verify/transcription/web-search routes, reported `{disabled: true}` by `/api/server-providers`, and excluded from client availability, fallback re-pointing, and first-run auto-select.
- **TTS missing-key is now a 400 MISSING_API_KEY pre-guard** matching the image route; keyless providers are never pre-empted and unknown providers keep their existing path.
- Review-pass hardening: the built-in Doubao web-search provider is now mapped (previously it could not be disabled at all), browser-native ASR honors the server force-off on the client (it never reaches the transcription route), and a request with no ASR provider now selects the first enabled server backend — or fails 400 MISSING_PROVIDER — instead of hard-defaulting to a vendor.
- `.env.example` documents the new `<CAP>_<PREFIX>_ENABLED` knobs per section.

Backward compatible: with no new env set, behavior is unchanged except the TTS missing-key contract fix and the removal of the ASR vendor default.

## Tests

1,373 tests across the affected suites (server/media/web-search/store/audio/settings), including per-section force-off semantics, route 403s, disabled-skipping server defaults, client re-pointing, and the classroom only-provider-disabled degradation. tsc/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)