### PR TITLE
feat(server): validate model routing config at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -321,9 +321,11 @@ DEFAULT_MODEL=
 # model as x-model. Unset = identical to today (everything uses DEFAULT_MODEL).
 # Unlisted stages fall back to x-model then DEFAULT_MODEL, so you can override
 # just one or two and leave the rest to the client/default.
-# Point a stage only at a server-configured provider (its key resolvable); a
-# route to an unconfigured/invalid model fails at request time for that stage,
-# the same way a bad DEFAULT_MODEL would (no startup validation).
+# At boot the server validates MODEL_ROUTES / DEFAULT_MODEL / <PREFIX>_MODELS
+# and prints [config] warnings for unknown stages, unregistered providers,
+# providers with no API key, and bare model ids (which still default to openai
+# but are deprecated — write provider:model). Warnings only: the server starts
+# regardless, so a bad value is caught here instead of at request time.
 # Routable stages: scene-outlines-stream, scene-content, scene-actions,
 # agent-profiles, quiz-grade, pbl-chat, chat-adapter, generate-classroom,
 # web-search-query-rewrite.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -19,4 +19,12 @@ export async function register(): Promise<void> {
   const { startAssetCollectorSchedule } =
     await import('@/lib/persistence/asset-collector-schedule');
   startAssetCollectorSchedule();
+
+  // Warn-first boot-time validation of model routing config (MODEL_ROUTES,
+  // DEFAULT_MODEL, <PREFIX>_MODELS). Cheap and non-throwing: broken config
+  // surfaces here as [config] warnings instead of failing at request time.
+  // Imported dynamically so the Edge bundle never pulls in the fs/js-yaml
+  // backed provider config it reads.
+  const { validateServerConfig } = await import('@/lib/server/config-validation');
+  validateServerConfig();
 }

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -2307,6 +2307,34 @@ export function getModel(config: ModelConfig): ModelWithInfo {
 }
 
 /**
+ * Deprecation notice for bare model ids (no `provider:` prefix). parseModelString
+ * keeps defaulting them to `openai` for backward compatibility, but that fallback
+ * is deprecated: configs should write `provider:model` explicitly. Emitted by
+ * parseModelString at runtime and by the boot-time config validation, exactly
+ * once per unique bare id per process.
+ */
+export const BARE_MODEL_ID_DEPRECATION_MSG =
+  'bare model ids default to openai for backward compatibility; this fallback is deprecated — write provider:model';
+
+/** Bare model ids already surfaced, so the deprecation fires once per unique id. */
+const warnedBareModelIds = new Set<string>();
+
+/**
+ * Warn once per unique bare model id. `where` names the config site (e.g.
+ * `DEFAULT_MODEL` or a MODEL_ROUTES stage) when the warning comes from the
+ * boot-time validation; the runtime call from parseModelString omits it. The
+ * shared dedupe set means a bare id that boot already flagged never re-warns
+ * at request time.
+ */
+export function warnBareModelIdDeprecation(bareModelId: string, where?: string): boolean {
+  if (warnedBareModelIds.has(bareModelId)) return false;
+  warnedBareModelIds.add(bareModelId);
+  const context = where ? `${where}: ` : '';
+  console.warn(`[config] ${context}${BARE_MODEL_ID_DEPRECATION_MSG} (bare id "${bareModelId}")`);
+  return true;
+}
+
+/**
  * Parse model string in format "providerId:modelId" or just "modelId" (defaults to OpenAI)
  */
 export function parseModelString(modelString: string): {
@@ -2323,7 +2351,8 @@ export function parseModelString(modelString: string): {
     };
   }
 
-  // Default to OpenAI for backward compatibility
+  // Default to OpenAI for backward compatibility (deprecated, warn-first)
+  warnBareModelIdDeprecation(modelString);
   return {
     providerId: 'openai',
     modelId: modelString,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -2309,9 +2309,9 @@ export function getModel(config: ModelConfig): ModelWithInfo {
 /**
  * Deprecation notice for bare model ids (no `provider:` prefix). parseModelString
  * keeps defaulting them to `openai` for backward compatibility, but that fallback
- * is deprecated: configs should write `provider:model` explicitly. Emitted by
- * parseModelString at runtime and by the boot-time config validation, exactly
- * once per unique bare id per process.
+ * is deprecated: configs should write `provider:model` explicitly. Emitted only
+ * by the boot-time config validation for config-derived sites — never for
+ * request-derived strings, which would let clients drive log volume.
  */
 export const BARE_MODEL_ID_DEPRECATION_MSG =
   'bare model ids default to openai for backward compatibility; this fallback is deprecated — write provider:model';
@@ -2321,10 +2321,9 @@ const warnedBareModelIds = new Set<string>();
 
 /**
  * Warn once per unique bare model id. `where` names the config site (e.g.
- * `DEFAULT_MODEL` or a MODEL_ROUTES stage) when the warning comes from the
- * boot-time validation; the runtime call from parseModelString omits it. The
- * shared dedupe set means a bare id that boot already flagged never re-warns
- * at request time.
+ * `DEFAULT_MODEL` or a MODEL_ROUTES stage). Callers must pass only
+ * config-derived ids (the config surface is finite, so the dedupe set is
+ * bounded); request-derived strings must never reach this function.
  */
 export function warnBareModelIdDeprecation(bareModelId: string, where?: string): boolean {
   if (warnedBareModelIds.has(bareModelId)) return false;
@@ -2351,8 +2350,10 @@ export function parseModelString(modelString: string): {
     };
   }
 
-  // Default to OpenAI for backward compatibility (deprecated, warn-first)
-  warnBareModelIdDeprecation(modelString);
+  // Default to OpenAI for backward compatibility (deprecated; boot-time config
+  // validation warns for config-derived bare ids). Deliberately no warning
+  // here: this path is reachable with request-controlled strings, which must
+  // not drive logging or dedupe-set growth.
   return {
     providerId: 'openai',
     modelId: modelString,

--- a/lib/server/config-validation.ts
+++ b/lib/server/config-validation.ts
@@ -55,8 +55,11 @@ function routeModel(value: unknown): string | undefined {
  * Check one model string the way parseModelString would resolve it: a bare id
  * gets the shared deprecation warning; a prefixed id is checked for a
  * registered provider and (for key-requiring providers) a configured key.
+ * `routed` distinguishes MODEL_ROUTES entries — where the server key is the
+ * only key that can be used — from unrouted sites like DEFAULT_MODEL, where a
+ * client-supplied key still works and a missing server key is only a note.
  */
-function checkModelString(model: string, where: string): void {
+function checkModelString(model: string, where: string, routed: boolean): void {
   const colonIndex = model.indexOf(':');
   if (colonIndex <= 0) {
     warnBareModelIdDeprecation(model, where);
@@ -69,9 +72,15 @@ function checkModelString(model: string, where: string): void {
     return;
   }
   if (provider.requiresApiKey && !resolveApiKey(providerId)) {
-    warn(
-      `Provider "${providerId}" in ${where} has no API key configured — add a <PREFIX>_API_KEY env var (or server-providers.yml), or requests using it will fail.`,
-    );
+    if (routed) {
+      warn(
+        `Provider "${providerId}" in ${where} has no API key configured — add a <PREFIX>_API_KEY env var (or server-providers.yml), or requests using it will fail.`,
+      );
+    } else {
+      warn(
+        `Provider "${providerId}" in ${where} has no server API key configured — requests will only work when the client supplies its own key.`,
+      );
+    }
   }
 }
 
@@ -102,14 +111,14 @@ function validateModelRoutes(): void {
     }
     const model = routeModel(value);
     if (!model) continue; // no model string; model-routes warns about bad values at request time
-    checkModelString(model, `MODEL_ROUTES stage "${key}"`);
+    checkModelString(model, `MODEL_ROUTES stage "${key}"`, true);
   }
 }
 
 function validateDefaultModel(): void {
   const model = process.env.DEFAULT_MODEL?.trim();
   if (!model) return;
-  checkModelString(model, 'DEFAULT_MODEL');
+  checkModelString(model, 'DEFAULT_MODEL', false);
 }
 
 /**
@@ -129,7 +138,7 @@ function validateModelsEnvPins(): void {
     }
     const configured = provider.requiresApiKey
       ? !!resolveApiKey(providerId)
-      : isServerConfiguredProvider('providers', providerId);
+      : isServerConfiguredProvider('providers', providerId) || !!provider.defaultBaseUrl;
     if (!configured) {
       const missing = provider.requiresApiKey ? `${prefix}_API_KEY` : `${prefix}_BASE_URL`;
       warn(

--- a/lib/server/config-validation.ts
+++ b/lib/server/config-validation.ts
@@ -1,0 +1,156 @@
+/**
+ * Boot-time validation of model routing configuration (warn-first).
+ *
+ * Runs once at startup (see instrumentation.ts). Misconfiguration is otherwise
+ * discovered only at request time — or worse, per-session. At boot we surface,
+ * as `[config]` warnings:
+ *
+ *  - `MODEL_ROUTES` that does not parse as JSON;
+ *  - a route key that is not a routable stage (typo detection);
+ *  - a route / `DEFAULT_MODEL` whose provider prefix is not registered, or
+ *    whose provider requires an API key that is not configured (keyless
+ *    providers like Ollama pass);
+ *  - a bare model id (no `provider:` prefix) — it still defaults to `openai`
+ *    for backward compatibility, but that fallback is deprecated;
+ *  - a `<PREFIX>_MODELS` env set for a provider whose key env is absent
+ *    (pinned models on an unconfigured provider — probably a typo).
+ *
+ * Everything here is a warning, never a throw: operators with partial config
+ * still get a running app, and the warnings name exactly what is broken.
+ */
+
+import { getProvider, warnBareModelIdDeprecation } from '@/lib/ai/providers';
+import { LLM_STAGES } from '@/lib/server/model-routes';
+import {
+  isServerConfiguredProvider,
+  LLM_ENV_MAP,
+  resolveApiKey,
+} from '@/lib/server/provider-config';
+import type { ProviderId } from '@/lib/types/provider';
+
+/** Consistent prefix for boot-time config warnings. */
+const WARN_PREFIX = '[config]';
+
+function warn(message: string): void {
+  console.warn(`${WARN_PREFIX} ${message}`);
+}
+
+/** Extract the model string from a MODEL_ROUTES route value (string or `{model}`). */
+function routeModel(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const model = (value as Record<string, unknown>).model;
+    if (typeof model === 'string') {
+      const trimmed = model.trim();
+      return trimmed || undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Check one model string the way parseModelString would resolve it: a bare id
+ * gets the shared deprecation warning; a prefixed id is checked for a
+ * registered provider and (for key-requiring providers) a configured key.
+ */
+function checkModelString(model: string, where: string): void {
+  const colonIndex = model.indexOf(':');
+  if (colonIndex <= 0) {
+    warnBareModelIdDeprecation(model, where);
+    return;
+  }
+  const providerId = model.slice(0, colonIndex);
+  const provider = getProvider(providerId as ProviderId);
+  if (!provider) {
+    warn(`Unknown provider "${providerId}" in ${where} — not a registered provider (typo?).`);
+    return;
+  }
+  if (provider.requiresApiKey && !resolveApiKey(providerId)) {
+    warn(
+      `Provider "${providerId}" in ${where} has no API key configured — add a <PREFIX>_API_KEY env var (or server-providers.yml), or requests using it will fail.`,
+    );
+  }
+}
+
+function validateModelRoutes(): void {
+  const raw = process.env.MODEL_ROUTES?.trim();
+  if (!raw) return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    warn(
+      'MODEL_ROUTES is not valid JSON — check the value (model routing falls back to DEFAULT_MODEL).',
+    );
+    return;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    warn('MODEL_ROUTES must be a JSON object mapping stage -> model; ignoring it.');
+    return;
+  }
+
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!(LLM_STAGES as readonly string[]).includes(key)) {
+      warn(
+        `Unknown stage "${key}" in MODEL_ROUTES — not a routable stage (typo?). Valid stages: ${LLM_STAGES.join(', ')}`,
+      );
+      continue;
+    }
+    const model = routeModel(value);
+    if (!model) continue; // no model string; model-routes warns about bad values at request time
+    checkModelString(model, `MODEL_ROUTES stage "${key}"`);
+  }
+}
+
+function validateDefaultModel(): void {
+  const model = process.env.DEFAULT_MODEL?.trim();
+  if (!model) return;
+  checkModelString(model, 'DEFAULT_MODEL');
+}
+
+/**
+ * A `<PREFIX>_MODELS` pin only takes effect when the provider is actually
+ * configured (its key env, or a base URL for keyless providers). A pin on an
+ * unconfigured provider is dead config — usually a typo.
+ */
+function validateModelsEnvPins(): void {
+  for (const [prefix, providerId] of Object.entries(LLM_ENV_MAP)) {
+    if (!process.env[`${prefix}_MODELS`]) continue;
+    const provider = getProvider(providerId as ProviderId);
+    if (!provider) {
+      warn(
+        `${prefix}_MODELS is set for provider "${providerId}" — not a registered provider (typo?).`,
+      );
+      continue;
+    }
+    const configured = provider.requiresApiKey
+      ? !!resolveApiKey(providerId)
+      : isServerConfiguredProvider('providers', providerId);
+    if (!configured) {
+      const missing = provider.requiresApiKey ? `${prefix}_API_KEY` : `${prefix}_BASE_URL`;
+      warn(
+        `${prefix}_MODELS is set for provider "${providerId}" but ${missing} is not — pinned models on an unconfigured provider (probably a typo).`,
+      );
+    }
+  }
+}
+
+/**
+ * Validate server model-routing config at boot. Warn-only, cheap, and
+ * non-throwing: a broken config never prevents the server from starting.
+ */
+export function validateServerConfig(): void {
+  try {
+    validateModelRoutes();
+    validateDefaultModel();
+    validateModelsEnvPins();
+  } catch (err) {
+    // Boot-time validation must never take the server down.
+    const detail = err instanceof Error ? err.message : String(err);
+    warn(`Unexpected error during config validation: ${detail}`);
+  }
+}

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -55,7 +55,12 @@ interface ServerConfig {
 // Env-var prefix mappings
 // ---------------------------------------------------------------------------
 
-const LLM_ENV_MAP: Record<string, string> = {
+/**
+ * Env-var prefix → LLM provider-id mapping (e.g. `DEEPSEEK_API_KEY` configures
+ * the `deepseek` provider). Exported for boot-time config validation, which
+ * checks `<PREFIX>_MODELS` pins against the provider's key env.
+ */
+export const LLM_ENV_MAP: Record<string, string> = {
   OPENAI: 'openai',
   AZURE_OPENAI: 'azure',
   ATLASCLOUD: 'atlascloud',

--- a/tests/server/config-validation.test.ts
+++ b/tests/server/config-validation.test.ts
@@ -157,12 +157,14 @@ describe('validateServerConfig — warning matrix', () => {
     expect(String(warnSpy.mock.calls[0][0])).toContain(BARE_MODEL_ID_DEPRECATION_MSG);
   });
 
-  it('warns when DEFAULT_MODEL points at a provider with no key', async () => {
+  it('warns softly when DEFAULT_MODEL points at a provider with no server key (client keys still work)', async () => {
     vi.stubEnv('DEFAULT_MODEL', 'deepseek:deepseek-v4-pro');
     const { validateServerConfig } = await import('@/lib/server/config-validation');
     validateServerConfig();
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(String(warnSpy.mock.calls[0][0])).toContain('deepseek');
+    // Unrouted sites honor client-supplied keys, so the message must not claim requests will fail.
+    expect(String(warnSpy.mock.calls[0][0])).toContain('client supplies its own key');
   });
 
   it('warns when <PREFIX>_MODELS is set without the provider key env', async () => {
@@ -194,9 +196,8 @@ describe('validateServerConfig — warning matrix', () => {
     vi.stubEnv('OLLAMA_MODELS', 'llama3.3');
     const { validateServerConfig } = await import('@/lib/server/config-validation');
     validateServerConfig();
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(String(warnSpy.mock.calls[0][0])).toContain('OLLAMA_MODELS');
-    expect(String(warnSpy.mock.calls[0][0])).toContain('OLLAMA_BASE_URL');
+    // Ollama ships a default base URL, so a bare _MODELS pin is functional — no warning.
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('does not throw on garbage config (warn-only)', async () => {
@@ -230,28 +231,38 @@ describe('validateServerConfig — warning matrix', () => {
   });
 });
 
-describe('parseModelString — bare-id deprecation dedup', () => {
-  it('warns once per unique bare model id, never for prefixed ids', async () => {
+describe('parseModelString — request-derived strings never warn', () => {
+  it('resolves bare and prefixed ids without logging (client input must not drive log volume)', async () => {
     vi.resetModules();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const { parseModelString } = await import('@/lib/ai/providers');
 
       expect(parseModelString('gpt-5.5')).toEqual({ providerId: 'openai', modelId: 'gpt-5.5' });
+      expect(parseModelString('anthropic:claude-sonnet-4')).toEqual({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warnBareModelIdDeprecation dedupes per unique config-site id', async () => {
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { warnBareModelIdDeprecation } = await import('@/lib/ai/providers');
+
+      expect(warnBareModelIdDeprecation('gpt-5.5', 'DEFAULT_MODEL')).toBe(true);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(String(warnSpy.mock.calls[0][0])).toContain(BARE_MODEL_ID_DEPRECATION_MSG);
 
-      // Same bare id again — deduped, no new warning.
-      expect(parseModelString('gpt-5.5')).toEqual({ providerId: 'openai', modelId: 'gpt-5.5' });
+      expect(warnBareModelIdDeprecation('gpt-5.5', 'DEFAULT_MODEL')).toBe(false);
       expect(warnSpy).toHaveBeenCalledTimes(1);
 
-      // A different bare id warns again.
-      parseModelString('gpt-4.1');
-      expect(warnSpy).toHaveBeenCalledTimes(2);
-
-      // Prefixed ids never warn.
-      parseModelString('anthropic:claude-sonnet-4');
-      parseModelString('openai:gpt-5.5');
+      expect(warnBareModelIdDeprecation('gpt-4.1', 'MODEL_ROUTES stage "pbl-chat"')).toBe(true);
       expect(warnSpy).toHaveBeenCalledTimes(2);
     } finally {
       warnSpy.mockRestore();

--- a/tests/server/config-validation.test.ts
+++ b/tests/server/config-validation.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BARE_MODEL_ID_DEPRECATION_MSG } from '@/lib/ai/providers';
+
+// config-validation reads env directly and imports provider-config, whose
+// module-level getConfig() cache must be reset between cases (mirrors the
+// model-routes / provider-config conventions). fs is mocked so a host-machine
+// server-providers.yml can never leak into tests.
+let yamlOverride: string | null = null;
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const isYaml = (p: unknown) => typeof p === 'string' && p.endsWith('server-providers.yml');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: (p: string) => (isYaml(p) ? yamlOverride !== null : actual.existsSync(p)),
+      readFileSync: (p: string, ...args: unknown[]) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        isYaml(p) ? (yamlOverride ?? '') : (actual.readFileSync as any)(p, ...args),
+    },
+    existsSync: (p: string) => (isYaml(p) ? yamlOverride !== null : actual.existsSync(p)),
+    readFileSync: (p: string, ...args: unknown[]) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      isYaml(p) ? (yamlOverride ?? '') : (actual.readFileSync as any)(p, ...args),
+  };
+});
+
+/** LLM env prefixes that provider-config reads for the `providers` section. */
+const LLM_ENV_PREFIXES = [
+  'OPENAI',
+  'AZURE_OPENAI',
+  'ATLASCLOUD',
+  'ANTHROPIC',
+  'GOOGLE',
+  'DEEPSEEK',
+  'QWEN',
+  'KIMI',
+  'MINIMAX',
+  'GLM',
+  'SILICONFLOW',
+  'DOUBAO',
+  'OPENROUTER',
+  'GROK',
+  'TENCENT',
+  'TENCENT_HUNYUAN',
+  'XIAOMI',
+  'MIMO',
+  'OLLAMA',
+  'LEMONADE',
+  'BEDROCK',
+];
+
+function clearConfigEnv() {
+  delete process.env.MODEL_ROUTES;
+  delete process.env.DEFAULT_MODEL;
+  for (const prefix of LLM_ENV_PREFIXES) {
+    delete process.env[`${prefix}_API_KEY`];
+    delete process.env[`${prefix}_BASE_URL`];
+    delete process.env[`${prefix}_MODELS`];
+  }
+  delete process.env.BEDROCK_REGION;
+}
+
+describe('validateServerConfig — warning matrix', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    clearConfigEnv();
+    yamlOverride = null;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    clearConfigEnv();
+  });
+
+  it('emits no warnings when nothing is configured', async () => {
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits no warnings on a fully valid config', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-test');
+    vi.stubEnv('DEFAULT_MODEL', 'openai:gpt-5.4-mini');
+    vi.stubEnv(
+      'MODEL_ROUTES',
+      JSON.stringify({
+        'scene-content': 'openai:gpt-5.4',
+        'pbl-chat': { model: 'anthropic:claude-sonnet-4', thinking: { enabled: false } },
+      }),
+    );
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when MODEL_ROUTES is not valid JSON', async () => {
+    vi.stubEnv('MODEL_ROUTES', '{not valid json');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('MODEL_ROUTES');
+    expect(String(warnSpy.mock.calls[0][0])).toContain('JSON');
+  });
+
+  it('warns naming an unknown stage key (typo detection)', async () => {
+    vi.stubEnv('MODEL_ROUTES', JSON.stringify({ 'scene-contnet': 'openai:gpt-5.4' }));
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('scene-contnet');
+  });
+
+  it('warns for an unknown provider prefix in a route', async () => {
+    vi.stubEnv('MODEL_ROUTES', JSON.stringify({ 'scene-content': 'anhtropic:claude-sonnet-4' }));
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('anhtropic');
+  });
+
+  it('warns when a routed provider has no API key configured', async () => {
+    vi.stubEnv('MODEL_ROUTES', JSON.stringify({ 'scene-content': 'deepseek:deepseek-v4-pro' }));
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('deepseek');
+    expect(String(warnSpy.mock.calls[0][0])).toContain('API key');
+  });
+
+  it('does not warn about a keyless provider (ollama)', async () => {
+    vi.stubEnv('MODEL_ROUTES', JSON.stringify({ 'scene-content': 'ollama:llama3.3' }));
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits the deprecation warning for a bare model id in a route', async () => {
+    vi.stubEnv('MODEL_ROUTES', JSON.stringify({ 'scene-content': 'gpt-5.4' }));
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain(BARE_MODEL_ID_DEPRECATION_MSG);
+  });
+
+  it('emits the deprecation warning for a bare DEFAULT_MODEL', async () => {
+    vi.stubEnv('DEFAULT_MODEL', 'gpt-5.4');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain(BARE_MODEL_ID_DEPRECATION_MSG);
+  });
+
+  it('warns when DEFAULT_MODEL points at a provider with no key', async () => {
+    vi.stubEnv('DEFAULT_MODEL', 'deepseek:deepseek-v4-pro');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('deepseek');
+  });
+
+  it('warns when <PREFIX>_MODELS is set without the provider key env', async () => {
+    vi.stubEnv('DEEPSEEK_MODELS', 'deepseek-v4-pro');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('DEEPSEEK_MODELS');
+    expect(String(warnSpy.mock.calls[0][0])).toContain('DEEPSEEK_API_KEY');
+  });
+
+  it('does not warn when <PREFIX>_MODELS is set with the key present', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'sk-test');
+    vi.stubEnv('DEEPSEEK_MODELS', 'deepseek-v4-pro');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when <PREFIX>_MODELS is set for a keyless provider with a base URL', async () => {
+    vi.stubEnv('OLLAMA_BASE_URL', 'http://localhost:11434/v1');
+    vi.stubEnv('OLLAMA_MODELS', 'llama3.3');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when <PREFIX>_MODELS is set for a keyless provider without a base URL', async () => {
+    vi.stubEnv('OLLAMA_MODELS', 'llama3.3');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('OLLAMA_MODELS');
+    expect(String(warnSpy.mock.calls[0][0])).toContain('OLLAMA_BASE_URL');
+  });
+
+  it('does not throw on garbage config (warn-only)', async () => {
+    vi.stubEnv('MODEL_ROUTES', '{{{');
+    vi.stubEnv('DEFAULT_MODEL', ':::::');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    expect(() => validateServerConfig()).not.toThrow();
+  });
+
+  it('does not warn when a provider is configured via server-providers.yml', async () => {
+    yamlOverride = 'providers:\n  deepseek:\n    apiKey: sk-yaml\n';
+    vi.stubEnv('MODEL_ROUTES', JSON.stringify({ 'scene-content': 'deepseek:deepseek-v4-pro' }));
+    vi.stubEnv('DEEPSEEK_MODELS', 'deepseek-v4-pro');
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns once per distinct problem when a config has several', async () => {
+    vi.stubEnv(
+      'MODEL_ROUTES',
+      JSON.stringify({
+        'scene-contnet': 'openai:gpt-5.4', // unknown stage
+        'scene-content': 'anhtropic:claude-sonnet-4', // unknown provider
+        'pbl-chat': 'claude-sonnet-4', // bare id
+      }),
+    );
+    const { validateServerConfig } = await import('@/lib/server/config-validation');
+    validateServerConfig();
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('parseModelString — bare-id deprecation dedup', () => {
+  it('warns once per unique bare model id, never for prefixed ids', async () => {
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { parseModelString } = await import('@/lib/ai/providers');
+
+      expect(parseModelString('gpt-5.5')).toEqual({ providerId: 'openai', modelId: 'gpt-5.5' });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain(BARE_MODEL_ID_DEPRECATION_MSG);
+
+      // Same bare id again — deduped, no new warning.
+      expect(parseModelString('gpt-5.5')).toEqual({ providerId: 'openai', modelId: 'gpt-5.5' });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // A different bare id warns again.
+      parseModelString('gpt-4.1');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+
+      // Prefixed ids never warn.
+      parseModelString('anthropic:claude-sonnet-4');
+      parseModelString('openai:gpt-5.5');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The repo has no startup validation (`.env.example` says so explicitly): a typo'd MODEL_ROUTES stage, an unregistered provider prefix, a route whose provider has no key, or a stray `<PREFIX>_MODELS` pin is discovered at request time — or, for the agent driver stage, as a per-session failure.

## Change

- New `lib/server/config-validation.ts` with `validateServerConfig()`, wired into `instrumentation.ts` (nodejs runtime only, dynamically imported so nothing new reaches the edge bundle). **Warn-only and provably non-throwing** — a broken config never prevents boot; `[config]`-prefixed warnings name exactly what is wrong.
- Warning matrix: MODEL_ROUTES JSON validity and shape; unknown stage keys (typo detection, lists valid stages); unknown provider prefixes; routed providers without a configured key (fatal at request time since routed stages ignore client keys); DEFAULT_MODEL checks with softer wording (unrouted resolution still honors client-supplied keys); `<PREFIX>_MODELS` pins on unconfigured providers (keyless providers with a default base URL are fine and not flagged).
- **Deprecation, warn-first**: a bare model id (no `provider:` prefix) in MODEL_ROUTES or DEFAULT_MODEL warns that the silent `openai` fallback is deprecated. The fallback behavior is unchanged this release; removal can follow after a deprecation period. The warning fires only for config-derived sites — deliberately never from `parseModelString` itself, where request-controlled strings could drive log volume.

## Tests

19 cases pinning the full warning matrix (including the no-warnings-on-valid-config and never-throws-on-garbage properties, YAML-configured providers, keyless defaults) plus the request-path never-warns contract. Full `tests/server/` suite green; tsc/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)