### PR TITLE
feat(agent): add neutral tool foundation libraries

### DIFF
--- a/lib/agent-runtime/stage-writer-tools.ts
+++ b/lib/agent-runtime/stage-writer-tools.ts
@@ -1,0 +1,38 @@
+/**
+ * The single source of truth for "which agent tools WRITE a stage document".
+ *
+ * Three consumers, one list:
+ *  - the server scheduler (`DOCUMENT_WRITING_TOOLS` in course-tools.ts) marks
+ *    these tools `executionMode: 'sequential'` so parallel writers cannot
+ *    clobber each other (a consistency test pins the relation);
+ *  - the workbench fold arms write ownership (veto + realtime sync) the moment
+ *    one of these tools STARTS (`tool_execution_start` carries the target
+ *    stageId in its args) — and deliberately NOT for reader tools:
+ *    ownership's side effect is dropping the user's own pending edits, so a
+ *    `read_stage` must never take it;
+ *  - `rename_stage` is a writer for ownership purposes even though it is not
+ *    part of the course toolset's sequential scheduling (it rewrites stage
+ *    identity, not scene content, and runs from the curriculum toolset).
+ *
+ * This module is shared between server and client code: keep it free of any
+ * server-only imports.
+ */
+export const STAGE_WRITER_TOOL_NAMES: ReadonlySet<string> = new Set([
+  // course generation writers
+  'set_roster',
+  'generate_scene',
+  'generate_actions',
+  'duplicate_scene',
+  'import_pptx',
+  // course audio and page-list writers
+  'generate_tts',
+  'edit_deck',
+  // generic stage-document writer
+  'patch_stage',
+  // curriculum writer (stage identity)
+  'rename_stage',
+]);
+
+export function isStageWriterTool(toolName: string): boolean {
+  return STAGE_WRITER_TOOL_NAMES.has(toolName);
+}

--- a/lib/media/image-providers.ts
+++ b/lib/media/image-providers.ts
@@ -222,3 +222,24 @@ export function aspectRatioToDimensions(
   if (!w || !h) return { width: maxWidth, height: Math.round((maxWidth * 9) / 16) };
   return { width: maxWidth, height: Math.round((maxWidth * h) / w) };
 }
+
+/**
+ * Scale a width/height pair up to a minimum pixel area while preserving the
+ * aspect ratio, rounding both edges up to a multiple of 8 (common provider
+ * alignment). A no-op for a non-positive floor or degenerate dimensions.
+ */
+export function applyMinPixelFloor(
+  width: number,
+  height: number,
+  minPixels: number,
+): { width: number; height: number } {
+  if (!(minPixels > 0) || width <= 0 || height <= 0) return { width, height };
+  const area = width * height;
+  if (area >= minPixels) return { width, height };
+
+  const scale = Math.sqrt(minPixels / area);
+  return {
+    width: Math.ceil((width * scale) / 8) * 8,
+    height: Math.ceil((height * scale) / 8) * 8,
+  };
+}

--- a/lib/server/agent-runtime/course-outline-union.ts
+++ b/lib/server/agent-runtime/course-outline-union.ts
@@ -1,0 +1,187 @@
+/**
+ * The single shared union view over a stage's planned outline and its
+ * persisted scenes.
+ *
+ * Two agent tools answer the same "what does this course look like right now"
+ * question and must answer it identically:
+ *
+ *  - `read_stage_outline` (curriculum-tools.ts) renders the page list;
+ *  - `generate_actions` (course-tools.ts) builds the course-context slot
+ *    (`allTitles` "Title: brief" entries + the current page's position).
+ *
+ * The page list's order truth is the REAL scenes: a mid-deck insert
+ * (import_pptx atOrder, edit_deck insert, duplicate_scene) can never leave
+ * the readout with stale, duplicated or missing page numbers. But a stage
+ * whose generation is still IN PROGRESS (outline complete, scenes landing one
+ * by one) must not read as truncated either: snapshot entries that no
+ * persisted scene carries are kept as PLANNED pages. A COMPLETED snapshot is
+ * pure scenes — its stale entries must never resurface.
+ *
+ * Matching — pairing each real scene with the outline entry it was built from:
+ *  - by `outlineId` when the scene carries one AND the id still resolves to an
+ *    unconsumed entry. An outlineId duplicated across the plan only ever
+ *    consumes its FIRST occurrence; the remaining same-id entries stay
+ *    planned or re-pair by order (a Set-membership union would swallow them).
+ *  - otherwise by `order`: a real scene at order N occupies plan slot N
+ *    (pre-existing / inserted scenes have no outlineId).
+ *  - otherwise the scene is an inserted page with no plan slot at all.
+ * Each outline entry is consumed at most once.
+ *
+ * Merging — display order: entries merge BY ORDER instead of being
+ * tail-appended, so planned-only pages sit at their planned position. When a
+ * real page and a planned entry share an order, the real page comes first and
+ * the planned entry defers. Display sequence numbers are the merged
+ * consecutive positions; every entry keeps its ORIGINAL `order` (the
+ * structured page list reports it, so no duplicated page numbers appear).
+ *
+ * Briefs: matched real pages carry the snapshot's `description` (brief),
+ * which is what lets `generate_actions` render "Title: brief" — `scene.title`
+ * is only the fallback when no snapshot entry was matched.
+ */
+import type { SceneOutline } from '@/lib/types/generation';
+
+/** A real scene reduced to the fields the union matching needs. */
+export interface OutlineSceneLike {
+  id: string;
+  order: number;
+  title: string;
+  type: string;
+  outlineId?: string;
+}
+
+/** One page of the union view. */
+export interface OutlineUnionEntry {
+  /** The page's original order: scene order for real pages, plan order for planned ones. */
+  order: number;
+  title: string;
+  type: SceneOutline['type'];
+  /** True only for planned-only pages (no persisted scene yet). */
+  planned?: boolean;
+  /** Real pages: the persisted scene id. */
+  sceneId?: string;
+  /** Real pages: the snapshot outline id they were matched to, when one exists. */
+  outlineId?: string;
+  /** The page brief: the snapshot description for matched pages, scene.title otherwise. */
+  description?: string;
+  keyPoints?: string[];
+}
+
+export interface OutlineUnionInput {
+  scenes: readonly OutlineSceneLike[];
+  planned: readonly SceneOutline[];
+  /**
+   * `false` keeps the still-planned pages in the union; `true` or `undefined`
+   * (a client-minted course never marks progress) means finished intent —
+   * pure scenes, stale planned entries never resurface.
+   */
+  generationComplete?: boolean;
+}
+
+const OUTLINE_TYPES = new Set<SceneOutline['type']>(['slide', 'quiz', 'interactive', 'pbl']);
+
+function outlineTypeFromScene(type: string): SceneOutline['type'] {
+  return OUTLINE_TYPES.has(type as SceneOutline['type']) ? (type as SceneOutline['type']) : 'slide';
+}
+
+/**
+ * Pair every real scene with the outline entry it was built from: by
+ * `outlineId` (identity, consuming only the FIRST occurrence of an id
+ * duplicated across the plan), else by `order`. Returns scene id → planned
+ * index; scenes with no match are absent. This is the one matching rule for
+ * outline↔scene pairing — `mergeStageOutline` renders with it, and the agent
+ * runtime's order-renumbering helpers (course-tools.ts) keep the snapshot
+ * outline in lockstep with reordered scenes using it, so the rules cannot
+ * drift between the readout and the writers.
+ */
+export function matchOutlineEntries(
+  scenes: readonly OutlineSceneLike[],
+  planned: readonly SceneOutline[],
+): Map<string, number> {
+  const idCount = new Map<string, number>();
+  const firstIndexOfId = new Map<string, number>();
+  planned.forEach((o, i) => {
+    idCount.set(o.id, (idCount.get(o.id) ?? 0) + 1);
+    if (!firstIndexOfId.has(o.id)) firstIndexOfId.set(o.id, i);
+  });
+  const consumed = new Array<boolean>(planned.length).fill(false);
+  const matchIndex = new Map<string, number>(); // scene id → planned index
+  for (const scene of scenes) {
+    let index = -1;
+    if (scene.outlineId) {
+      const count = idCount.get(scene.outlineId) ?? 0;
+      if (count <= 1) {
+        index = planned.findIndex((o, i) => o.id === scene.outlineId && !consumed[i]);
+      } else {
+        const first = firstIndexOfId.get(scene.outlineId) ?? -1;
+        index = first >= 0 && !consumed[first] ? first : -1;
+      }
+    }
+    if (index < 0) {
+      index = planned.findIndex((o, i) => o.order === scene.order && !consumed[i]);
+    }
+    if (index >= 0) {
+      consumed[index] = true;
+      matchIndex.set(scene.id, index);
+    }
+  }
+  return matchIndex;
+}
+
+/**
+ * Merge the planned outline and the persisted scenes into one display-order
+ * page list (see the module doc for the exact matching/merging rules).
+ */
+export function mergeStageOutline(input: OutlineUnionInput): OutlineUnionEntry[] {
+  const scenes = [...input.scenes].sort((a, b) => a.order - b.order);
+  const planned = input.planned;
+
+  // ── Phase 1: pair every real scene with the outline entry it was built from.
+  // For an outlineId duplicated across the plan only its FIRST occurrence is
+  // consumable by identity; every other scene falls back to order pairing.
+  const matchIndex = matchOutlineEntries(scenes, planned);
+
+  // ── Phase 2: build the entries. Real pages first (they carry the snapshot
+  // brief they were matched to), then the still-planned pages — only while
+  // generation is in progress.
+  const entries: OutlineUnionEntry[] = scenes.map((scene) => {
+    const index = matchIndex.get(scene.id);
+    const outline = index !== undefined ? planned[index] : undefined;
+    return {
+      order: scene.order,
+      title: scene.title,
+      type: outlineTypeFromScene(scene.type),
+      sceneId: scene.id,
+      ...(scene.outlineId ? { outlineId: scene.outlineId } : {}),
+      ...(outline
+        ? {
+            description: outline.description || scene.title,
+            keyPoints: [...(outline.keyPoints ?? [])],
+          }
+        : { description: scene.title, keyPoints: [] }),
+    };
+  });
+  if (input.generationComplete === false) {
+    const consumed = new Array<boolean>(planned.length).fill(false);
+    for (const index of matchIndex.values()) consumed[index] = true;
+    for (let i = 0; i < planned.length; i += 1) {
+      if (consumed[i]) continue;
+      const outline = planned[i];
+      entries.push({
+        order: outline.order,
+        title: outline.title,
+        type: outline.type,
+        planned: true,
+        description: outline.description,
+        keyPoints: [...(outline.keyPoints ?? [])],
+      });
+    }
+  }
+
+  // ── Phase 3: merge by order. Real pages come first at each order and
+  // planned entries defer to the next display position; the sort is stable,
+  // so same-key entries keep the construction order above.
+  entries.sort(
+    (a, b) => a.order - b.order || Number(Boolean(a.planned)) - Number(Boolean(b.planned)),
+  );
+  return entries;
+}

--- a/lib/server/agent-runtime/course-stage.ts
+++ b/lib/server/agent-runtime/course-stage.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto';
+
+/** Model-visible wording shared by every course-scoped tool schema. */
+export const COURSE_STAGE_ID_DESCRIPTION =
+  'Target stage id obtained from create_stage or list_folder_stages.';
+
+/**
+ * Deterministic stage id for one create-style tool call.
+ *
+ * A replay of the same durable call reuses its stage while a genuinely new
+ * call gets a new id. `create_stage` uses this seam before the owner-bound
+ * DocumentStore claims the document.
+ */
+export function stageIdForCall(sessionId: string, callId: string): string {
+  const digest = createHash('sha256').update(`${sessionId}:${callId}`, 'utf-8').digest('base64url');
+  return `stage-${digest.slice(0, 10)}`;
+}

--- a/lib/server/agent-runtime/generation-content.ts
+++ b/lib/server/agent-runtime/generation-content.ts
@@ -1,0 +1,33 @@
+import type {
+  GeneratedInteractiveContent,
+  GeneratedPBLContent,
+  GeneratedQuizContent,
+  GeneratedSlideContent,
+} from '@/lib/types/generation';
+import type { SceneContent } from '@/lib/types/stage';
+import { normalizeLegacyPBLContent } from '@/lib/pbl/legacy/read';
+
+/**
+ * Adapt persisted runtime content to the generation-time content shapes used
+ * by action generation. Slides are the only structural mismatch: their
+ * elements live under `canvas` at runtime but at the top level while
+ * generating. Legacy PBL documents are normalized at the same boundary.
+ */
+export function toGenerationContent(
+  content: SceneContent,
+):
+  | GeneratedSlideContent
+  | GeneratedQuizContent
+  | GeneratedInteractiveContent
+  | GeneratedPBLContent {
+  if (content.type === 'slide') {
+    return {
+      elements: content.canvas.elements ?? [],
+      background: content.canvas.background,
+    } satisfies GeneratedSlideContent;
+  }
+  if (content.type === 'pbl') {
+    return normalizeLegacyPBLContent(content) as GeneratedPBLContent;
+  }
+  return content as GeneratedQuizContent | GeneratedInteractiveContent;
+}

--- a/lib/server/agent-runtime/runner-contract.ts
+++ b/lib/server/agent-runtime/runner-contract.ts
@@ -1,0 +1,14 @@
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+
+/** Pure runner assembly seam: tests can pin the exact registered name set. */
+export function assembleRunnerTools(
+  ...groups: ReadonlyArray<ReadonlyArray<AgentTool>>
+): AgentTool[] {
+  return groups.flat();
+}
+
+// NOTE: `buildRunnerCoursePrompt` (the DSL-compatibility prompt block) is
+// intentionally not ported in this slice — it imports `courseSystemPrompt` /
+// `DSL_TOOLS_PROMPT` from `./course-tools`, which belongs to a later slice of
+// the agent-tool foundations wave. The runner will call `assembleRunnerTools`
+// and its own prompt construction once the course toolset lands.

--- a/lib/server/bounded-download.ts
+++ b/lib/server/bounded-download.ts
@@ -1,0 +1,94 @@
+export const MAX_REMOTE_IMAGE_BYTES = 20 * 1024 * 1024;
+export const MAX_REMOTE_IMAGE_BATCH_BYTES = 100 * 1024 * 1024;
+
+export class DownloadSizeLimitError extends Error {
+  constructor(
+    readonly scope: 'response' | 'aggregate',
+    readonly maxBytes: number,
+  ) {
+    super(
+      scope === 'response'
+        ? `Download exceeded the ${maxBytes}-byte response limit`
+        : `Downloads exceeded the ${maxBytes}-byte aggregate limit`,
+    );
+    this.name = 'DownloadSizeLimitError';
+  }
+}
+
+export class DownloadByteBudget {
+  private consumedBytes = 0;
+
+  constructor(readonly maxBytes: number) {}
+
+  get remainingBytes(): number {
+    return this.maxBytes - this.consumedBytes;
+  }
+
+  consume(bytes: number): boolean {
+    if (bytes > this.remainingBytes) return false;
+    this.consumedBytes += bytes;
+    return true;
+  }
+}
+
+async function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
+  await body?.cancel().catch(() => {});
+}
+
+/** Read a response body without ever buffering beyond the configured byte limits. */
+export async function readResponseBodyWithLimit(
+  response: Response,
+  options: {
+    maxBytes: number;
+    aggregateBudget?: DownloadByteBudget;
+  },
+): Promise<Buffer> {
+  const { maxBytes, aggregateBudget } = options;
+  const declaredLength = Number(response.headers.get('content-length'));
+
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await cancelBody(response.body);
+    throw new DownloadSizeLimitError('response', maxBytes);
+  }
+  if (
+    aggregateBudget &&
+    Number.isFinite(declaredLength) &&
+    declaredLength > aggregateBudget.remainingBytes
+  ) {
+    await cancelBody(response.body);
+    throw new DownloadSizeLimitError('aggregate', aggregateBudget.maxBytes);
+  }
+
+  const body = response.body;
+  if (!body) throw new Error('Download response has no body');
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new DownloadSizeLimitError('response', maxBytes);
+      }
+      if (aggregateBudget && !aggregateBudget.consume(value.byteLength)) {
+        await reader.cancel().catch(() => {});
+        throw new DownloadSizeLimitError('aggregate', aggregateBudget.maxBytes);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(
+    chunks.map((chunk) => Buffer.from(chunk)),
+    totalBytes,
+  );
+}

--- a/lib/server/image-sizing.ts
+++ b/lib/server/image-sizing.ts
@@ -1,0 +1,59 @@
+/**
+ * Server-side sizing of an image generation request.
+ *
+ * Two steps that every server-issued image request needs, in this order:
+ *
+ * 1. **aspect ratio → pixels**, when the caller only expressed a ratio.
+ * 2. **minimum-area floor** (`IMAGE_MIN_PIXELS`), scaling the request up while
+ *    preserving the ratio. Some models reject outputs below a minimum area —
+ *    seedream 5.0 requires >= 3,686,400 px and returns HTTP 400 otherwise, so
+ *    the 1024-wide sizes callers ask for would always fail. Unset (the
+ *    default) changes nothing.
+ *
+ * This lives here rather than in `lib/media/image-providers.ts` because it reads
+ * `process.env`; the pure geometry it builds on (`applyMinPixelFloor`,
+ * `aspectRatioToDimensions`) stays in that browser-bundled module.
+ *
+ * Both server paths that generate images must call this — `/api/generate/image`
+ * and the classroom generator. The classroom path skipping it is what made
+ * seedream reject every server-side course illustration for being too small.
+ */
+import { applyMinPixelFloor, aspectRatioToDimensions } from '@/lib/media/image-providers';
+import { createLogger } from '@/lib/logger';
+import type { ImageGenerationOptions } from '@/lib/media/types';
+
+const log = createLogger('ImageSizing');
+
+/** Edge the adapters fall back to when a request carries no explicit size. */
+export const DEFAULT_IMAGE_EDGE = 1024;
+
+/**
+ * Return a copy of `options` with `width`/`height` resolved and raised to the
+ * configured minimum area. Never mutates the input.
+ */
+export function resolveImageSize<T extends ImageGenerationOptions>(options: T): T {
+  const resolved = { ...options };
+
+  if (!resolved.width && !resolved.height && resolved.aspectRatio) {
+    const dims = aspectRatioToDimensions(resolved.aspectRatio);
+    resolved.width = dims.width;
+    resolved.height = dims.height;
+  }
+
+  const minPixels = Number(process.env.IMAGE_MIN_PIXELS || 0);
+  if (minPixels > 0) {
+    const width = resolved.width || DEFAULT_IMAGE_EDGE;
+    const height = resolved.height || DEFAULT_IMAGE_EDGE;
+    const scaled = applyMinPixelFloor(width, height, minPixels);
+    if (scaled.width !== width || scaled.height !== height) {
+      resolved.width = scaled.width;
+      resolved.height = scaled.height;
+      log.info(
+        `Image size ${width}x${height} below IMAGE_MIN_PIXELS=${minPixels}; ` +
+          `scaled to ${resolved.width}x${resolved.height}`,
+      );
+    }
+  }
+
+  return resolved;
+}

--- a/lib/server/media-origin.ts
+++ b/lib/server/media-origin.ts
@@ -1,0 +1,72 @@
+/**
+ * One resolver for the base origin used to build classroom media serving
+ * URLs (`mediaServingUrl` in `classroom-media-generation.ts`).
+ *
+ * Providers that hand back a hosted URL are stored directly and never touch
+ * this resolver. It exists for the BYTE-FALLBACK branch only: byte-only
+ * providers (raw audio/image data, no URL) are still written locally and
+ * served through THIS app's own `/api/classroom-media/...` route, so those
+ * serving URLs must be same-origin with the app instance the caller is
+ * talking to, never with a different product's origin.
+ *
+ * ACCEPTED LIMITATION: URL-direct storage trades away the deletion-revocation
+ * gate and the `Cache-Control: private` posture of /api/classroom-media; the
+ * route REMAINS for legacy records (old courses still reference it), so its
+ * tombstone veto stays in place.
+ *
+ * The old code fell back to `NEXT_PUBLIC_MAIN_SITE_ORIGIN` when no origin
+ * was threaded; that env is the MAIN SITE origin (a different product), where
+ * the classroom-media route does not exist and every request is rejected.
+ * That env stays available for its other legitimate uses (auth redirects
+ * etc.) — it must simply never be used to build media URLs.
+ */
+import type { NextRequest } from 'next/server';
+
+/**
+ * Final fallback origin when nothing is threaded and no request exists.
+ *
+ * Deliberately a local dev origin, NOT `NEXT_PUBLIC_MAIN_SITE_ORIGIN`: in a
+ * background/agent-runner context with no origin captured yet, the only
+ * same-origin-safe guess is this app's own localhost. Production deployments
+ * always thread a real origin (request-derived, or persisted at session
+ * creation), so this fallback only ever fires in dev/tests.
+ */
+export const LOCAL_MEDIA_ORIGIN = 'http://localhost:3000';
+
+/** Strip trailing slashes so `${origin}/api/...` never double-slashes. */
+export function normalizeOrigin(origin: string): string {
+  return origin.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Resolve the origin classroom media URLs should be built from.
+ *
+ * Precedence:
+ *  1. an explicitly threaded origin (`deps.baseUrl`, a request-derived
+ *     origin passed by API routes, or the session-creation origin the agent
+ *     runner threads);
+ *  2. the incoming request origin, when a request is available;
+ *  3. {@link LOCAL_MEDIA_ORIGIN}.
+ *
+ * Never consults `NEXT_PUBLIC_MAIN_SITE_ORIGIN` — see the module comment.
+ */
+export function resolveMediaServingOrigin(
+  threadedOrigin?: string | null,
+  request?: NextRequest | null,
+): string {
+  if (threadedOrigin && threadedOrigin.trim()) return normalizeOrigin(threadedOrigin);
+  if (request) return normalizeOrigin(requestOrigin(request));
+  return LOCAL_MEDIA_ORIGIN;
+}
+
+/**
+ * The origin this app instance is reachable at for the given request:
+ * proxy-forwarded host when present, else the request URL's own origin.
+ */
+export function requestOrigin(req: NextRequest): string {
+  const forwardedHost = req.headers.get('x-forwarded-host');
+  if (forwardedHost) {
+    return `${req.headers.get('x-forwarded-proto') || 'http'}://${forwardedHost}`;
+  }
+  return req.nextUrl.origin;
+}

--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -6,6 +6,17 @@
  */
 import { promises as dns } from 'node:dns';
 import { isIP } from 'node:net';
+import ipaddr from 'ipaddr.js';
+
+const CLOUD_METADATA_HOSTNAMES = new Set(['metadata.google.internal']);
+const CLOUD_METADATA_ADDRESSES = new Set(['169.254.169.254', '100.100.100.200', 'fd00:ec2::254']);
+
+export class UnsafeNetworkTargetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsafeNetworkTargetError';
+  }
+}
 
 function normalizeAddress(value: string): string {
   let normalized = value.trim().toLowerCase();
@@ -13,6 +24,58 @@ function normalizeAddress(value: string): string {
     normalized = normalized.slice(1, -1);
   }
   return normalized.replace(/\.+$/, '');
+}
+
+/**
+ * Assert that a connection address is globally routable unicast.
+ * IPv4-mapped IPv6 is classified as IPv4 so ::ffff:127.0.0.1 cannot hide.
+ */
+export function assertSafeIp(value: string): void {
+  const normalized = normalizeAddress(value);
+  let address: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    address = ipaddr.parse(normalized);
+  } catch {
+    throw new UnsafeNetworkTargetError(`Unable to classify network address: ${value}`);
+  }
+  if (address.kind() === 'ipv6' && (address as ipaddr.IPv6).isIPv4MappedAddress()) {
+    address = (address as ipaddr.IPv6).toIPv4Address();
+  }
+  const canonical = address.toString().toLowerCase();
+  if (CLOUD_METADATA_ADDRESSES.has(canonical) || address.range() !== 'unicast') {
+    throw new UnsafeNetworkTargetError('Local/private/reserved network URLs are not allowed');
+  }
+}
+
+/** Strict URL-layer validation for outbound material fetches (no DNS side effects). */
+export function normalizeUrlForStrictFetch(value: string): URL {
+  let parsed: URL;
+  try {
+    // WHATWG parsing canonicalizes legacy decimal/octal IPv4 spellings before checks.
+    parsed = new URL(value);
+  } catch {
+    throw new UnsafeNetworkTargetError('Invalid URL');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new UnsafeNetworkTargetError('Only HTTP(S) URLs are allowed');
+  }
+  if (parsed.username || parsed.password) {
+    throw new UnsafeNetworkTargetError('URLs containing userinfo are not allowed');
+  }
+  if (parsed.port && parsed.port !== '80' && parsed.port !== '443') {
+    throw new UnsafeNetworkTargetError('Only ports 80 and 443 are allowed');
+  }
+  const hostname = normalizeAddress(parsed.hostname);
+  if (
+    CLOUD_METADATA_HOSTNAMES.has(hostname) ||
+    hostname === 'localhost' ||
+    hostname.endsWith('.local')
+  ) {
+    throw new UnsafeNetworkTargetError('Local/private/reserved network URLs are not allowed');
+  }
+  // IP literals never invoke lookup in Node/undici, so this branch is mandatory.
+  if (isIP(hostname)) assertSafeIp(hostname);
+  return parsed;
 }
 
 function parseIPv4(ip: string): number[] | null {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "i18next": "^26.0.1",
     "i18next-resources-to-backend": "^1.2.1",
     "immer": "^11.1.3",
+    "ipaddr.js": "^2.5.0",
     "js-yaml": "^4.1.1",
     "jsonrepair": "^3.13.2",
     "jszip": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       immer:
         specifier: ^11.1.3
         version: 11.1.4
+      ipaddr.js:
+        specifier: ^2.5.0
+        version: 2.5.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -9500,6 +9503,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.5.0:
+    resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
+    engines: {node: '>= 10'}
 
   is-absolute@1.0.0:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
@@ -24013,6 +24020,8 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.5.0: {}
 
   is-absolute@1.0.0:
     dependencies:

--- a/tests/agent-runtime/course-outline-union.test.ts
+++ b/tests/agent-runtime/course-outline-union.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The shared outline/scene union merge (`mergeStageOutline`) — the single
+ * algorithm behind `read_stage_outline` and `generate_actions`' course
+ * context. Every boundary the review probed is pinned here as a semantics
+ * table (input → output), so a future edit of one consumer cannot silently
+ * diverge from the other.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  mergeStageOutline,
+  type OutlineSceneLike,
+  type OutlineUnionEntry,
+} from '@/lib/server/agent-runtime/course-outline-union';
+import type { SceneOutline } from '@/lib/types/generation';
+
+function scene(
+  overrides: Partial<OutlineSceneLike> & Pick<OutlineSceneLike, 'id' | 'order' | 'title'>,
+): OutlineSceneLike {
+  return { type: 'slide', ...overrides };
+}
+
+function outline(
+  overrides: Partial<SceneOutline> & Pick<SceneOutline, 'id' | 'order' | 'title'>,
+): SceneOutline {
+  return { type: 'slide', description: `brief-of-${overrides.title}`, keyPoints: [], ...overrides };
+}
+
+const rows = (
+  entries: OutlineUnionEntry[],
+): { order: number; title: string; planned?: boolean; description?: string }[] =>
+  entries.map(({ order, title, planned, description }) => ({ order, title, planned, description }));
+
+describe('mergeStageOutline — the shared outline/scene union', () => {
+  it('empty scenes + incomplete plan → every plan entry as planned', () => {
+    const merged = mergeStageOutline({
+      scenes: [],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+      ],
+      generationComplete: false,
+    });
+    expect(rows(merged)).toEqual([
+      { order: 1, title: 'A', planned: true, description: 'brief-of-A' },
+      { order: 2, title: 'B', planned: true, description: 'brief-of-B' },
+    ]);
+  });
+
+  it('empty scenes + completed → pure scenes (empty), stale plan never resurface', () => {
+    const merged = mergeStageOutline({
+      scenes: [],
+      planned: [outline({ id: 'p1', order: 1, title: 'A' })],
+      generationComplete: true,
+    });
+    expect(merged).toEqual([]);
+  });
+
+  it('no plan (imported course) + scenes → real pages only, title fallback brief', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's2', order: 2, title: 'Second' })],
+      planned: [],
+      generationComplete: false,
+    });
+    expect(rows(merged)).toEqual([{ order: 2, title: 'Second', description: 'Second' }]);
+  });
+
+  it('scenes [1] + plan [1,2,3] incomplete → [real 1, planned 2, planned 3]', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's1', order: 1, title: 'A', outlineId: 'p1' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+        outline({ id: 'p3', order: 3, title: 'C' }),
+      ],
+      generationComplete: false,
+    });
+    expect(rows(merged)).toEqual([
+      { order: 1, title: 'A', description: 'brief-of-A' },
+      { order: 2, title: 'B', planned: true, description: 'brief-of-B' },
+      { order: 3, title: 'C', planned: true, description: 'brief-of-C' },
+    ]);
+  });
+
+  it('scenes [2] + plan [1,2,3] incomplete → [planned 1, real 2, planned 3] — order pairing', () => {
+    const merged = mergeStageOutline({
+      // No outlineId: a pre-existing scene must pair with plan slot 2 BY ORDER.
+      scenes: [scene({ id: 's2', order: 2, title: 'Second' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+        outline({ id: 'p3', order: 3, title: 'C' }),
+      ],
+      generationComplete: false,
+    });
+    expect(rows(merged)).toEqual([
+      { order: 1, title: 'A', planned: true, description: 'brief-of-A' },
+      // The real page is the middle of the merged course and carries the
+      // matched slot's brief (the ORDER pairing attached p2 to it).
+      { order: 2, title: 'Second', description: 'brief-of-B' },
+      { order: 3, title: 'C', planned: true, description: 'brief-of-C' },
+    ]);
+  });
+
+  it('scenes [2,3] + plan [1,2,3] incomplete → [planned 1, real 2, real 3] — no FIRST mislabel', () => {
+    const merged = mergeStageOutline({
+      scenes: [
+        scene({ id: 's2', order: 2, title: 'Second' }),
+        scene({ id: 's3', order: 3, title: 'Third' }),
+      ],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+        outline({ id: 'p3', order: 3, title: 'C' }),
+      ],
+      generationComplete: false,
+    });
+    const entries = rows(merged);
+    expect(entries.map((e) => e.title)).toEqual(['A', 'Second', 'Third']);
+    expect(entries.map((e) => e.order)).toEqual([1, 2, 3]);
+    expect(entries.map((e) => e.planned)).toEqual([true, undefined, undefined]);
+    // Real page 2 would render "Position: Page 2 of 3".
+    expect(entries[1]?.description).toBe('brief-of-B');
+  });
+
+  it('scene@1 without outlineId + plan [1,2] incomplete → [real 1, planned 2], no [1,1,2] duplicate', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's1', order: 1, title: 'A' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+      ],
+      generationComplete: false,
+    });
+    const entries = rows(merged);
+    expect(entries.map((e) => e.order)).toEqual([1, 2]);
+    expect(entries.map((e) => e.title)).toEqual(['A', 'B']);
+    expect(entries.map((e) => e.planned)).toEqual([undefined, true]);
+  });
+
+  it('duplicated outlineId consumes only the FIRST plan entry — the twin stays planned', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's1', order: 1, title: 'One', outlineId: 'dup' })],
+      planned: [
+        outline({ id: 'dup', order: 1, title: 'One' }),
+        outline({ id: 'dup', order: 2, title: 'Two' }),
+      ],
+      generationComplete: false,
+    });
+    const entries = rows(merged);
+    expect(entries.map((e) => e.title)).toEqual(['One', 'Two']);
+    expect(entries.map((e) => e.planned)).toEqual([undefined, true]);
+    expect(entries[1]?.description).toBe('brief-of-Two');
+  });
+
+  it('two scenes sharing a duplicated outlineId: only the first consumes by id, the second re-pairs by order', () => {
+    const merged = mergeStageOutline({
+      scenes: [
+        scene({ id: 's1', order: 1, title: 'One', outlineId: 'dup' }),
+        scene({ id: 's2', order: 2, title: 'Two', outlineId: 'dup' }),
+      ],
+      planned: [
+        outline({ id: 'dup', order: 1, title: 'One' }),
+        outline({ id: 'dup', order: 2, title: 'Two' }),
+      ],
+      generationComplete: false,
+    });
+    const entries = rows(merged);
+    expect(entries.map((e) => e.title)).toEqual(['One', 'Two']);
+    // Both real pages matched (the second by order), so nothing stays planned.
+    expect(entries.map((e) => e.planned)).toEqual([undefined, undefined]);
+    expect(entries.map((e) => e.description)).toEqual(['brief-of-One', 'brief-of-Two']);
+  });
+
+  it('real page wins the shared order; the planned entry defers — display stays 1..N (conflict merge)', () => {
+    // Drifted plan [A@1, B@2, C@2, D@3] with a real page X@2 matched to C by
+    // id: the unpaired B@2 defers AFTER the real page, display never repeats.
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 'sx', order: 2, title: 'X', outlineId: 'p3' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+        outline({ id: 'p3', order: 2, title: 'C' }),
+        outline({ id: 'p4', order: 3, title: 'D' }),
+      ],
+      generationComplete: false,
+    });
+    const entries = rows(merged);
+    // Display order: A(planned), X(real, matched to C), B(deferred planned), D.
+    expect(entries.map((e) => e.title)).toEqual(['A', 'X', 'B', 'D']);
+    // Entries keep their ORIGINAL order (2 appears twice) but the display
+    // positions are consecutive 1..4 — no duplicated page numbers.
+    expect(entries.map((e) => e.order)).toEqual([1, 2, 2, 3]);
+    expect(entries.map((e) => e.planned)).toEqual([true, undefined, true, true]);
+    expect(entries[1]?.description).toBe('brief-of-C');
+  });
+
+  it('a completed snapshot is pure scenes — but matched real pages keep the snapshot brief', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's1', order: 1, title: 'A', outlineId: 'p1' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+      ],
+      generationComplete: true,
+    });
+    const entries = rows(merged);
+    expect(entries.map((e) => e.title)).toEqual(['A']);
+    expect(entries.map((e) => e.planned)).toEqual([undefined]);
+    expect(entries[0]?.description).toBe('brief-of-A');
+  });
+
+  it('an outlineId that exists nowhere in the plan falls back to order pairing', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's2', order: 2, title: 'Second', outlineId: 'ghost' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+      ],
+      generationComplete: false,
+    });
+    const entries = rows(merged);
+    expect(entries.map((e) => e.title)).toEqual(['A', 'Second']);
+    expect(entries.map((e) => e.planned)).toEqual([true, undefined]);
+    expect(entries[1]?.description).toBe('brief-of-B');
+  });
+
+  it('generationComplete undefined (client-minted course) is finished intent: pure scenes', () => {
+    const merged = mergeStageOutline({
+      scenes: [scene({ id: 's1', order: 1, title: 'A' })],
+      planned: [
+        outline({ id: 'p1', order: 1, title: 'A' }),
+        outline({ id: 'p2', order: 2, title: 'B' }),
+      ],
+    });
+    expect(merged.map((e) => e.title)).toEqual(['A']);
+    expect(merged.every((e) => e.planned === undefined)).toBe(true);
+  });
+});

--- a/tests/agent-runtime/course-stage.test.ts
+++ b/tests/agent-runtime/course-stage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COURSE_STAGE_ID_DESCRIPTION,
+  stageIdForCall,
+} from '@/lib/server/agent-runtime/course-stage';
+
+describe('stageIdForCall', () => {
+  it('is deterministic for the same session/call pair', () => {
+    expect(stageIdForCall('session-1', 'call-1')).toBe(stageIdForCall('session-1', 'call-1'));
+  });
+
+  it('differs across calls and sessions', () => {
+    expect(stageIdForCall('session-1', 'call-1')).not.toBe(stageIdForCall('session-1', 'call-2'));
+    expect(stageIdForCall('session-1', 'call-1')).not.toBe(stageIdForCall('session-2', 'call-1'));
+  });
+
+  it('produces a stable, prefixed id shape', () => {
+    const id = stageIdForCall('session-1', 'call-1');
+    expect(id).toMatch(/^stage-[A-Za-z0-9_-]{10}$/);
+  });
+});
+
+describe('COURSE_STAGE_ID_DESCRIPTION', () => {
+  it('is the shared model-visible wording', () => {
+    expect(COURSE_STAGE_ID_DESCRIPTION).toContain('create_stage');
+    expect(COURSE_STAGE_ID_DESCRIPTION).toContain('list_folder_stages');
+  });
+});

--- a/tests/agent-runtime/generation-content.test.ts
+++ b/tests/agent-runtime/generation-content.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { PPTElement, Slide } from '@openmaic/dsl';
+import { toGenerationContent } from '@/lib/server/agent-runtime/generation-content';
+import type { SlideContent } from '@/lib/types/stage';
+import { legacyPBLSceneFixture } from '@/tests/fixtures/pbl-v1-scene';
+
+describe('toGenerationContent', () => {
+  it('flattens runtime slide canvas content for action generation', () => {
+    const content: SlideContent = {
+      type: 'slide',
+      canvas: {
+        id: 'slide-1',
+        viewportSize: 1000,
+        viewportRatio: 0.5625,
+        elements: [{ id: 'element-1', type: 'text', content: 'Hello' } as unknown as PPTElement],
+        background: { type: 'solid', color: '#ffffff' },
+      } as unknown as Slide,
+    };
+
+    const result = toGenerationContent(content);
+
+    expect(result).toMatchObject({
+      elements: [{ id: 'element-1' }],
+      background: { type: 'solid', color: '#ffffff' },
+    });
+    expect(result).not.toHaveProperty('canvas');
+    expect(result).not.toHaveProperty('type');
+  });
+
+  it('normalizes legacy PBL content at the server-runtime boundary', () => {
+    const content = structuredClone(legacyPBLSceneFixture.content);
+    if (content.type !== 'pbl') throw new Error('expected PBL fixture');
+
+    expect(toGenerationContent(content)).toHaveProperty('projectV2');
+  });
+});

--- a/tests/agent-runtime/runner-contract.test.ts
+++ b/tests/agent-runtime/runner-contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { assembleRunnerTools } from '@/lib/server/agent-runtime/runner-contract';
+
+function tool(name: string): AgentTool {
+  return { name, description: `tool-${name}` } as unknown as AgentTool;
+}
+
+describe('assembleRunnerTools', () => {
+  it('flattens tool groups into a single runner tool list, preserving order', () => {
+    const tools = assembleRunnerTools([tool('a'), tool('b')], [], [tool('c')]);
+    expect(tools.map((t) => t.name)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty list when no groups are given', () => {
+    expect(assembleRunnerTools()).toEqual([]);
+  });
+});

--- a/tests/agent-runtime/stage-writer-registry.test.ts
+++ b/tests/agent-runtime/stage-writer-registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { STAGE_WRITER_TOOL_NAMES, isStageWriterTool } from '@/lib/agent-runtime/stage-writer-tools';
+
+/**
+ * The stage-writer registry is the single source of truth for "which agent
+ * tools WRITE a stage document". The cross-module consistency assertions
+ * against the server scheduler (`DOCUMENT_WRITING_TOOLS`) and the per-toolset
+ * writer lists live in this suite once those modules land in a later slice;
+ * here the registry's own contents and the reader/writer split are pinned.
+ */
+describe('stage writer registry is the single source', () => {
+  it('every registered name is recognized as a writer', () => {
+    for (const name of STAGE_WRITER_TOOL_NAMES) {
+      expect(isStageWriterTool(name)).toBe(true);
+    }
+  });
+
+  it('pins the exact writer set so scheduling/ownership cannot drift silently', () => {
+    expect([...STAGE_WRITER_TOOL_NAMES].sort()).toEqual(
+      [
+        // course generation writers
+        'set_roster',
+        'generate_scene',
+        'generate_actions',
+        'duplicate_scene',
+        'import_pptx',
+        // course audio and page-list writers
+        'generate_tts',
+        'edit_deck',
+        // generic stage-document writer
+        'patch_stage',
+        // curriculum writer (stage identity)
+        'rename_stage',
+      ].sort(),
+    );
+  });
+
+  it('reader tools are NOT writers — ownership must never arm on them', () => {
+    for (const reader of [
+      'read_stage',
+      'grep_stage',
+      'list_scenes',
+      'read_stage_outline',
+      'list_folder_stages',
+      'render_scene_preview',
+      'generate_image',
+      'use_material_media',
+      'generate_video',
+    ]) {
+      expect(isStageWriterTool(reader)).toBe(false);
+    }
+  });
+});

--- a/tests/media/min-pixel-floor.test.ts
+++ b/tests/media/min-pixel-floor.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { applyMinPixelFloor, aspectRatioToDimensions } from '@/lib/media/image-providers';
+
+/**
+ * seedream 5.0 rejects outputs below 3,686,400 px outright (HTTP 400), while
+ * the app's callers ask for 1024-wide sizes. IMAGE_MIN_PIXELS scales those up.
+ */
+const SEEDREAM_MIN = 3_686_400;
+
+describe('applyMinPixelFloor', () => {
+  it('leaves dimensions that already meet the floor untouched', () => {
+    // Exactly on the boundary must not be scaled (2560*1440 === the floor).
+    expect(applyMinPixelFloor(2560, 1440, SEEDREAM_MIN)).toEqual({ width: 2560, height: 1440 });
+    expect(applyMinPixelFloor(2560, 1600, SEEDREAM_MIN)).toEqual({ width: 2560, height: 1600 });
+  });
+
+  it('scales small requests above the floor while preserving aspect ratio', () => {
+    const { width, height } = applyMinPixelFloor(1024, 576, SEEDREAM_MIN);
+
+    expect(width * height).toBeGreaterThanOrEqual(SEEDREAM_MIN);
+    // 16:9 in, 16:9 out (allow a little slack from the round-up to /8).
+    expect(width / height).toBeCloseTo(1024 / 576, 1);
+  });
+
+  it('keeps every real caller size above the floor after rounding', () => {
+    // The ratios the app actually requests, via aspectRatioToDimensions.
+    for (const ratio of ['16:9', '4:3', '1:1', '3:4', '9:16']) {
+      const { width, height } = aspectRatioToDimensions(ratio);
+      const scaled = applyMinPixelFloor(width, height, SEEDREAM_MIN);
+
+      expect(scaled.width * scaled.height).toBeGreaterThanOrEqual(SEEDREAM_MIN);
+      // Rounded up to a multiple of 8 on both edges.
+      expect(scaled.width % 8).toBe(0);
+      expect(scaled.height % 8).toBe(0);
+    }
+  });
+
+  it('is a no-op when no floor is configured', () => {
+    // IMAGE_MIN_PIXELS unset/0 must not change historical behaviour.
+    expect(applyMinPixelFloor(1024, 576, 0)).toEqual({ width: 1024, height: 576 });
+    expect(applyMinPixelFloor(1024, 576, Number.NaN)).toEqual({ width: 1024, height: 576 });
+  });
+
+  it('does not divide by zero on degenerate dimensions', () => {
+    expect(applyMinPixelFloor(0, 576, SEEDREAM_MIN)).toEqual({ width: 0, height: 576 });
+    expect(applyMinPixelFloor(1024, 0, SEEDREAM_MIN)).toEqual({ width: 1024, height: 0 });
+  });
+});

--- a/tests/server/bounded-download.test.ts
+++ b/tests/server/bounded-download.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DownloadByteBudget,
+  DownloadSizeLimitError,
+  readResponseBodyWithLimit,
+} from '@/lib/server/bounded-download';
+
+describe('readResponseBodyWithLimit', () => {
+  it('rejects an oversized Content-Length without reading the body', async () => {
+    const getReader = vi.fn();
+    const cancel = vi.fn(async () => undefined);
+    const response = {
+      headers: new Headers({ 'content-length': '11' }),
+      body: { getReader, cancel },
+    } as unknown as Response;
+
+    await expect(readResponseBodyWithLimit(response, { maxBytes: 10 })).rejects.toMatchObject({
+      name: 'DownloadSizeLimitError',
+      scope: 'response',
+    });
+    expect(getReader).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('cancels a streaming overflow while another download in the batch succeeds', async () => {
+    let oversizedReads = 0;
+    const oversizedCancel = vi.fn();
+    const oversizedBody = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          oversizedReads += 1;
+          controller.enqueue(new Uint8Array([1, 2]));
+          if (oversizedReads === 4) controller.close();
+        },
+        cancel: oversizedCancel,
+      },
+      { highWaterMark: 0 },
+    );
+    const smallBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([7, 8]));
+        controller.close();
+      },
+    });
+    const budget = new DownloadByteBudget(10);
+
+    const results = await Promise.all([
+      readResponseBodyWithLimit(new Response(oversizedBody), {
+        maxBytes: 5,
+        aggregateBudget: budget,
+      }).catch((error: unknown) => error),
+      readResponseBodyWithLimit(new Response(smallBody), {
+        maxBytes: 5,
+        aggregateBudget: budget,
+      }),
+    ]);
+
+    expect(results[0]).toBeInstanceOf(DownloadSizeLimitError);
+    expect(results[1]).toEqual(Buffer.from([7, 8]));
+    expect(oversizedReads).toBe(3);
+    expect(oversizedCancel).toHaveBeenCalledOnce();
+  });
+
+  it('enforces one aggregate budget across downloads', async () => {
+    const budget = new DownloadByteBudget(3);
+    await expect(
+      readResponseBodyWithLimit(new Response(new Uint8Array([1, 2])), {
+        maxBytes: 10,
+        aggregateBudget: budget,
+      }),
+    ).resolves.toEqual(Buffer.from([1, 2]));
+
+    await expect(
+      readResponseBodyWithLimit(
+        new Response(new Uint8Array([3, 4]), {
+          headers: { 'content-length': '2' },
+        }),
+        { maxBytes: 10, aggregateBudget: budget },
+      ),
+    ).rejects.toMatchObject({ scope: 'aggregate' });
+  });
+});

--- a/tests/server/image-sizing.test.ts
+++ b/tests/server/image-sizing.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveImageSize } from '@/lib/server/image-sizing';
+import type { ImageGenerationOptions } from '@/lib/media/types';
+
+const originalMinPixels = process.env.IMAGE_MIN_PIXELS;
+
+function options(overrides: Partial<ImageGenerationOptions> = {}): ImageGenerationOptions {
+  return { prompt: 'a prompt', ...overrides };
+}
+
+describe('resolveImageSize', () => {
+  beforeEach(() => {
+    delete process.env.IMAGE_MIN_PIXELS;
+  });
+
+  afterEach(() => {
+    if (originalMinPixels === undefined) {
+      delete process.env.IMAGE_MIN_PIXELS;
+    } else {
+      process.env.IMAGE_MIN_PIXELS = originalMinPixels;
+    }
+  });
+
+  it('resolves an aspect ratio to pixels when no explicit size is given', () => {
+    const result = resolveImageSize(options({ aspectRatio: '16:9' }));
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(576);
+  });
+
+  it('leaves explicit width/height untouched (ratio ignored)', () => {
+    const result = resolveImageSize(options({ width: 512, height: 768, aspectRatio: '16:9' }));
+    expect(result).toMatchObject({ width: 512, height: 768 });
+  });
+
+  it('is a no-op when no minimum area is configured', () => {
+    const input = options({ width: 1024, height: 576 });
+    expect(resolveImageSize(input)).toMatchObject({ width: 1024, height: 576 });
+  });
+
+  it('scales a request up to the configured minimum area, preserving the ratio', () => {
+    process.env.IMAGE_MIN_PIXELS = '3686400'; // seedream 5.0 floor
+    const result = resolveImageSize(options({ width: 1024, height: 576 }));
+    expect(result.width! * result.height!).toBeGreaterThanOrEqual(3_686_400);
+    expect(result.width! / result.height!).toBeCloseTo(1024 / 576, 1);
+    expect(result.width! % 8).toBe(0);
+    expect(result.height! % 8).toBe(0);
+  });
+
+  it('never mutates the input options object', () => {
+    const input = options({ aspectRatio: '4:3' });
+    resolveImageSize(input);
+    expect(input).toMatchObject({ prompt: 'a prompt', aspectRatio: '4:3' });
+    expect(input.width).toBeUndefined();
+    expect(input.height).toBeUndefined();
+  });
+
+  it('falls back to the default edge only inside the minimum-area branch', () => {
+    // No explicit size: the floor computation starts from the default 1024
+    // edge and scales it up (1024x1024 -> 1920x1920 hits the seedream floor).
+    process.env.IMAGE_MIN_PIXELS = '3686400';
+    expect(resolveImageSize(options({}))).toMatchObject({ width: 1920, height: 1920 });
+  });
+});

--- a/tests/server/media-origin.test.ts
+++ b/tests/server/media-origin.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  LOCAL_MEDIA_ORIGIN,
+  normalizeOrigin,
+  resolveMediaServingOrigin,
+} from '@/lib/server/media-origin';
+
+const MAIN_SITE_ORIGIN = 'https://main-site.example';
+
+describe('resolveMediaServingOrigin', () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_MAIN_SITE_ORIGIN;
+  });
+
+  it('prefers the explicitly threaded origin', () => {
+    expect(resolveMediaServingOrigin('https://app.example.com')).toBe('https://app.example.com');
+  });
+
+  it('normalizes a threaded origin with a trailing slash', () => {
+    expect(resolveMediaServingOrigin('https://app.example.com/')).toBe('https://app.example.com');
+  });
+
+  it('prefers the threaded origin over a request origin', () => {
+    const req = new NextRequest('http://app.internal/api/agent/sessions', {
+      headers: { 'x-forwarded-host': 'app.public.example', 'x-forwarded-proto': 'https' },
+    });
+    expect(resolveMediaServingOrigin('https://threaded.example', req)).toBe(
+      'https://threaded.example',
+    );
+  });
+
+  it('uses the incoming request origin when nothing is threaded', () => {
+    const req = new NextRequest('http://app.internal/api/agent/sessions', {
+      headers: { 'x-forwarded-host': 'app.public.example', 'x-forwarded-proto': 'https' },
+    });
+    expect(resolveMediaServingOrigin(undefined, req)).toBe('https://app.public.example');
+  });
+
+  it('falls back to a local dev origin when nothing is threaded and no request exists', () => {
+    expect(resolveMediaServingOrigin()).toBe(LOCAL_MEDIA_ORIGIN);
+    expect(resolveMediaServingOrigin('')).toBe(LOCAL_MEDIA_ORIGIN);
+    expect(resolveMediaServingOrigin(null)).toBe(LOCAL_MEDIA_ORIGIN);
+    expect(resolveMediaServingOrigin('   ')).toBe(LOCAL_MEDIA_ORIGIN);
+  });
+
+  // The regression this file exists for: classroom media is served by THIS
+  // app's /api/classroom-media route, so the serving origin must NEVER be the
+  // main site, no matter what NEXT_PUBLIC_MAIN_SITE_ORIGIN says (it points at
+  // a different product whose media route rejects every request).
+  it('never returns NEXT_PUBLIC_MAIN_SITE_ORIGIN, even when it is set', () => {
+    process.env.NEXT_PUBLIC_MAIN_SITE_ORIGIN = MAIN_SITE_ORIGIN;
+    expect(resolveMediaServingOrigin()).not.toContain('main-site.example');
+    expect(resolveMediaServingOrigin()).toBe(LOCAL_MEDIA_ORIGIN);
+    const req = new NextRequest('http://app.internal/api/agent/sessions', {
+      headers: { 'x-forwarded-host': 'app.public.example', 'x-forwarded-proto': 'https' },
+    });
+    expect(resolveMediaServingOrigin(undefined, req)).not.toContain('main-site.example');
+  });
+
+  it('normalizeOrigin strips trailing slashes and whitespace', () => {
+    expect(normalizeOrigin('  https://app.example.com/// ')).toBe('https://app.example.com');
+  });
+});

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -267,3 +267,126 @@ describe('validateUrlForSSRF', () => {
     );
   });
 });
+
+const STRICT_BLOCK_MESSAGE = 'Local/private/reserved network URLs are not allowed';
+
+describe('assertSafeIp', () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  it('accepts globally routable unicast addresses', async () => {
+    const { assertSafeIp } = await import('@/lib/server/ssrf-guard');
+    expect(() => assertSafeIp('8.8.8.8')).not.toThrow();
+    expect(() => assertSafeIp('1.1.1.1')).not.toThrow();
+    expect(() => assertSafeIp('2606:4700:4700::1111')).not.toThrow();
+  });
+
+  it('rejects private and reserved IPv4 addresses', async () => {
+    const { assertSafeIp } = await import('@/lib/server/ssrf-guard');
+    for (const ip of [
+      '127.0.0.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '192.168.1.1',
+      '169.254.169.254',
+      '0.0.0.0',
+      '100.100.100.200',
+      '255.255.255.255',
+    ]) {
+      expect(() => assertSafeIp(ip)).toThrow(STRICT_BLOCK_MESSAGE);
+    }
+  });
+
+  it('rejects private, link-local and metadata IPv6 addresses', async () => {
+    const { assertSafeIp } = await import('@/lib/server/ssrf-guard');
+    for (const ip of [
+      '::1',
+      '::',
+      'fd00::1',
+      'fe80::1',
+      'fec0::1',
+      'fd00:ec2::254',
+      '2002:7f00:0001::', // 6to4 embedding 127.0.0.1
+    ]) {
+      expect(() => assertSafeIp(ip)).toThrow(STRICT_BLOCK_MESSAGE);
+    }
+  });
+
+  it('classifies IPv4-mapped IPv6 as IPv4 so ::ffff:127.0.0.1 cannot hide', async () => {
+    const { assertSafeIp } = await import('@/lib/server/ssrf-guard');
+    expect(() => assertSafeIp('::ffff:127.0.0.1')).toThrow(STRICT_BLOCK_MESSAGE);
+    expect(() => assertSafeIp('::ffff:8.8.8.8')).not.toThrow();
+  });
+
+  it('throws a classified error for unparseable input', async () => {
+    const { assertSafeIp, UnsafeNetworkTargetError } = await import('@/lib/server/ssrf-guard');
+    expect(() => assertSafeIp('not-an-ip')).toThrow(UnsafeNetworkTargetError);
+  });
+});
+
+describe('normalizeUrlForStrictFetch', () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  it('returns a parsed URL for a safe http(s) URL', async () => {
+    const { normalizeUrlForStrictFetch } = await import('@/lib/server/ssrf-guard');
+    expect(normalizeUrlForStrictFetch('https://example.com/a?b=1').toString()).toBe(
+      'https://example.com/a?b=1',
+    );
+    expect(normalizeUrlForStrictFetch('http://example.com:80/').port).toBe('');
+  });
+
+  it('rejects non-http protocols, userinfo and unusual ports', async () => {
+    const { normalizeUrlForStrictFetch, UnsafeNetworkTargetError } =
+      await import('@/lib/server/ssrf-guard');
+    expect(() => normalizeUrlForStrictFetch('ftp://example.com')).toThrow(UnsafeNetworkTargetError);
+    expect(() => normalizeUrlForStrictFetch('file:///etc/passwd')).toThrow(
+      UnsafeNetworkTargetError,
+    );
+    expect(() => normalizeUrlForStrictFetch('https://user:pass@example.com')).toThrow(
+      UnsafeNetworkTargetError,
+    );
+    expect(() => normalizeUrlForStrictFetch('https://example.com:8443')).toThrow(
+      UnsafeNetworkTargetError,
+    );
+  });
+
+  it('rejects local and private IP literals without any DNS lookup', async () => {
+    const { normalizeUrlForStrictFetch } = await import('@/lib/server/ssrf-guard');
+    for (const url of [
+      'http://127.0.0.1',
+      'http://10.0.0.1',
+      'http://192.168.1.1',
+      'http://[::1]',
+      'http://[fd00::1]',
+      'http://[::ffff:127.0.0.1]',
+      // WHATWG parsing canonicalizes legacy decimal IPv4 spellings.
+      'http://2130706433',
+      'http://0x7f000001',
+    ]) {
+      expect(() => normalizeUrlForStrictFetch(url)).toThrow(STRICT_BLOCK_MESSAGE);
+    }
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects local hostnames and cloud-metadata hosts', async () => {
+    const { normalizeUrlForStrictFetch } = await import('@/lib/server/ssrf-guard');
+    for (const url of [
+      'http://localhost',
+      'http://printer.local',
+      'http://metadata.google.internal',
+    ]) {
+      expect(() => normalizeUrlForStrictFetch(url)).toThrow(STRICT_BLOCK_MESSAGE);
+    }
+  });
+
+  it('accepts public hostnames and IP literals without DNS', async () => {
+    const { normalizeUrlForStrictFetch } = await import('@/lib/server/ssrf-guard');
+    expect(() => normalizeUrlForStrictFetch('https://example.com')).not.toThrow();
+    expect(() => normalizeUrlForStrictFetch('https://8.8.8.8')).not.toThrow();
+    expect(() => normalizeUrlForStrictFetch('https://[2606:4700:4700::1111]')).not.toThrow();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
First slice of the agent-runtime tools wave: pure library files the upcoming tool slices consume. No runner wiring in this slice — the modules are inert until later slices import them.

- `runner-contract` (tool assembly seam — `assembleRunnerTools`; the prompt builder half follows with the course toolset), `course-stage` (deterministic stage ids), `stage-writer-tools` (the sequential-marking registry for write tools), `generation-content`, `course-outline-union`
- Media plumbing: `media-origin`, `image-sizing` (+ `applyMinPixelFloor` in image-providers), `bounded-download` (byte caps + budgets)
- SSRF strict helpers: `assertSafeIp` / `normalizeUrlForStrictFetch` added to the existing guard for the future material-fetch path — globally-routable-unicast-only via ipaddr.js, IPv4-mapped unwrap, cloud-metadata denylist, no DNS side effects; deliberately independent of `ALLOW_LOCAL_NETWORKS` so the strict path has no escape hatch. Existing `validateUrlForSSRF` behavior untouched.

Tests: ported suites plus new minimal suites for the files that lacked them; the security-adjacent pieces (bounded-download caps, private-IP rejection incl. `::ffff:` mapping and legacy IPv4 spellings) are covered. 957 tests green across server/agent-runtime/media; tsc/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)