### PR TITLE
feat(agent): register a web_search tool on the session runner

### DIFF
--- a/lib/server/agent-runtime/runner-contract.ts
+++ b/lib/server/agent-runtime/runner-contract.ts
@@ -10,5 +10,6 @@ export function assembleRunnerTools(
 // NOTE: `buildRunnerCoursePrompt` (the DSL-compatibility prompt block) is
 // intentionally not ported in this slice — it imports `courseSystemPrompt` /
 // `DSL_TOOLS_PROMPT` from `./course-tools`, which belongs to a later slice of
-// the agent-tool foundations wave. The runner will call `assembleRunnerTools`
-// and its own prompt construction once the course toolset lands.
+// the agent-tool foundations wave. The runner already calls
+// `assembleRunnerTools` and builds its own (capability-conditional) prompt;
+// the course prompt block will layer on top once the course toolset lands.

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -23,6 +23,8 @@ import { createLogger } from '@/lib/logger';
 import { resolveAgentDriverModel } from './agent-driver-model';
 import { buildAskUserTool } from './ask-user';
 import { agentRuntimeConfig as config } from './config';
+import { assembleRunnerTools } from './runner-contract';
+import { buildWebSearchTool, resolveWebSearchCapability, searchPromptBlock } from './web-search';
 import {
   AgentSessionEntryStorage,
   loadSessionEntryHistory,
@@ -42,17 +44,20 @@ const WORKER_ID = `${randomUUID().slice(0, 8)}:${process.pid}`;
 const SESSION_WAKEUP_FALLBACK_MS = 5_000;
 const MESSAGE_UPDATE_MIN_INTERVAL_MS = 150;
 
-/** The runner starts with one capability and no product-specific tools. */
+/** The runner's always-registered tool; additional tools are capability-gated. */
 export const MINIMAL_AGENT_TOOL_NAMES = new Set(['ask_user']);
 
-/** Product-neutral prompt for the zero-tool runtime slice. */
-export const AGENT_RUNTIME_SYSTEM_PROMPT = [
+/**
+ * Shared prompt lines for every registered toolset. The ask_user-only claim is
+ * conditional: it is true only while web_search is not registered, so it lives
+ * in `AGENT_RUNTIME_SYSTEM_PROMPT` (the unregistered form) rather than here.
+ */
+const AGENT_RUNTIME_SYSTEM_PROMPT_LINES = [
   'You are a capable assistant working in a durable background session.',
   'Complete the user request carefully and explain the result clearly.',
   'The conversation may pause, restart on another worker, or receive follow-up messages.',
   'Treat earlier conversation messages as durable context.',
   'Do not claim access to tools or data that are not present in this session.',
-  'Your only available tool is ask_user.',
   'Use ask_user only when a decision genuinely belongs to the user.',
   'Make every question self-contained and concise.',
   'Offer stable, unique option ids when choices are useful.',
@@ -62,7 +67,24 @@ export const AGENT_RUNTIME_SYSTEM_PROMPT = [
   'Follow later user messages as updates to the same conversation.',
   'Be honest about uncertainty and unavailable capabilities.',
   "Reply in the user's language unless the user requests another language.",
+];
+
+/** Product-neutral prompt for the ask_user-only runtime slice. */
+export const AGENT_RUNTIME_SYSTEM_PROMPT = [
+  ...AGENT_RUNTIME_SYSTEM_PROMPT_LINES.slice(0, 5),
+  'Your only available tool is ask_user.',
+  ...AGENT_RUNTIME_SYSTEM_PROMPT_LINES.slice(5),
 ].join('\n');
+
+/**
+ * System prompt for a run with the given registered toolset. When web_search is
+ * registered the ask_user-only claim is dropped (it would be false) and the
+ * capability prompt block is appended in its place.
+ */
+export function buildRunnerSystemPrompt(webSearchRegistered: boolean): string {
+  if (!webSearchRegistered) return AGENT_RUNTIME_SYSTEM_PROMPT;
+  return [...AGENT_RUNTIME_SYSTEM_PROMPT_LINES, searchPromptBlock()].join('\n');
+}
 
 function isLeaseLostError(error: unknown): boolean {
   let current = error;
@@ -672,15 +694,20 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
     const askUserTool = buildAskUserTool({
       onUserQuestion: (question) => emit(LIFECYCLE.userQuestion, question),
     });
-    const tools = [askUserTool];
+    // web_search is capability-registered: the tool exists in the toolset
+    // exactly when this deployment has a working web-search backend. An
+    // unconfigured deployment gets no tool, so the model never sees a dead one.
+    const search = resolveWebSearchCapability();
+    const webSearchTools = search ? [buildWebSearchTool(search)] : [];
+    const tools = assembleRunnerTools([askUserTool], webSearchTools);
     const askUserLatch = createAskUserTerminateLatch();
     let toolCalls = 0;
     const agent = buildAgent({
       streamFn,
-      systemPrompt: AGENT_RUNTIME_SYSTEM_PROMPT,
+      systemPrompt: buildRunnerSystemPrompt(search !== null),
       model: driver.piModel,
       tools,
-      allowedToolNames: MINIMAL_AGENT_TOOL_NAMES,
+      allowedToolNames: new Set([...MINIMAL_AGENT_TOOL_NAMES, ...(search ? ['web_search'] : [])]),
       ...(plan.kind === 'start' ? {} : { history: modelMessages }),
       afterToolCall: (toolContext) => {
         toolCalls += 1;
@@ -958,7 +985,9 @@ export function startAgentRunner(): AgentRunnerHandle {
       `heartbeat=${config.heartbeatIntervalMs}ms, leaseTtl=${config.leaseTtlMs}ms, ` +
       `maxConcurrent=${config.maxConcurrent}, maxAttempts=${config.maxAttempts})`,
   );
-  log.info('minimal tool set enabled: ask_user');
+  log.info(
+    'agent runner toolset: ask_user always; web_search when a web-search backend is configured',
+  );
 
   return {
     workerId: WORKER_ID,

--- a/lib/server/agent-runtime/web-search.ts
+++ b/lib/server/agent-runtime/web-search.ts
@@ -1,0 +1,96 @@
+/**
+ * `web_search` for the agent runtime — capability-registered.
+ *
+ * The tool exists in the toolset exactly when this deployment has a working
+ * web-search provider (the app's own server-side resolution: server-providers.yml
+ * / WEB_SEARCH_* env). There is no per-session switch: a modern agent decides
+ * for itself when a search is worth calling, and an unconfigured deployment
+ * simply does not register the tool — the only form of "unavailable" a model
+ * cannot misread.
+ */
+import { Type, type Static } from 'typebox';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+
+import { formatSearchResultsAsContext, searchWeb } from '@/lib/web-search';
+import { resolveClassroomWebSearchConfig } from '@/lib/server/web-search-config';
+
+export interface WebSearchCapability {
+  providerId: Parameters<typeof searchWeb>[0]['providerId'];
+  apiKey: string;
+  baseUrl?: string;
+}
+
+/** This deployment's web-search capability, or null when unconfigured. */
+export function resolveWebSearchCapability(): WebSearchCapability | null {
+  // The resolver's own per-provider rules decide usability — including
+  // keyless providers (brave/searxng carry no apiKey by definition) and the
+  // capability force-off plumbing (a disabled-only config resolves to nothing).
+  // An extra non-empty-key check here would silently unregister web_search on
+  // exactly the keyless deployments.
+  const config = resolveClassroomWebSearchConfig({});
+  if (!config) return null;
+  return {
+    providerId: config.providerId,
+    apiKey: config.apiKey,
+    ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+  };
+}
+
+const SEARCH_SCHEMA = Type.Object({
+  query: Type.String({ description: 'The search query, in the language of the course.' }),
+});
+
+export function buildWebSearchTool(capability: WebSearchCapability): AgentTool<never, never> {
+  const tool: AgentTool<typeof SEARCH_SCHEMA, unknown> = {
+    name: 'web_search',
+    label: 'Search the web',
+    description:
+      'Search the web for current or factual information. Use it when the course topic needs facts ' +
+      'you cannot be sure of (recent events, exact figures, product details), not for things you ' +
+      'already know. Prefer one precise query over several vague ones.',
+    parameters: SEARCH_SCHEMA,
+    async execute(_id, params: Static<typeof SEARCH_SCHEMA>, signal) {
+      // The abort signal is the pi loop's per-run signal (the same one
+      // agent.abort() fires); the provider fetch below carries it too, so an
+      // in-flight request is cut short rather than merely abandoned.
+      if (signal?.aborted) throw new Error('aborted');
+      const result = await searchWeb({
+        providerId: capability.providerId,
+        query: params.query,
+        apiKey: capability.apiKey,
+        ...(capability.baseUrl ? { baseUrl: capability.baseUrl } : {}),
+        ...(signal ? { signal } : {}),
+      });
+      if (signal?.aborted) throw new Error('aborted');
+      // NOTE: URL observation attaches at this seam in a later slice — every
+      // result URL is registered with the session's durable session-urls store
+      // before the tool result is returned. The store is not ported here, so
+      // nothing is recorded yet.
+      const context = formatSearchResultsAsContext(result);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: context || `No results for "${params.query}".`,
+          },
+        ],
+        details: { query: params.query, sources: result.sources.length },
+      };
+    },
+  };
+  return tool as unknown as AgentTool<never, never>;
+}
+
+/**
+ * The prompt block, present exactly when the tool is. Guidance on WHEN to
+ * search, not a report that somebody asked for it.
+ */
+export function searchPromptBlock(): string {
+  return [
+    '## Web search',
+    '',
+    'You have `web_search`. Use it when the topic needs facts you cannot be sure of — recent',
+    'developments, exact figures, version-specific behaviour — and skip it for timeless material.',
+    'Cite what you use in the page content naturally; do not dump raw URLs at the learner.',
+  ].join('\n');
+}

--- a/tests/agent-runtime/runner-web-search-registration.test.ts
+++ b/tests/agent-runtime/runner-web-search-registration.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Runner-level pins for capability-registered `web_search` wiring.
+ *
+ * The tool-level tests in web-search.test.ts exercise the tool itself. This
+ * file drives the actual `runSession` loop through a fake agent (mocked
+ * `buildAgent`) so the RUNNER WIRING is observable: the toolset the agent
+ * receives, the allowlist it is given, and the system prompt it is built with
+ * all depend on whether a web-search backend is configured:
+ *
+ * - configured: both ask_user and web_search are registered and the prompt
+ *   carries the web-search capability block (and no ask_user-only claim);
+ * - unconfigured: the toolset is ask_user-only, the allowlist matches, and the
+ *   prompt never mentions web_search — the model never sees a dead tool.
+ */
+import type { AgentEvent, AgentMessage } from '@earendil-works/pi-agent-core';
+import { InMemorySessionRepo, Session } from '@earendil-works/pi-agent-core';
+import type { ClaimedAgentSession } from '@openmaic/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  randomUUID: vi.fn(() => 'runner-test-uuid'),
+  getAgentSessionStore: vi.fn(),
+  openEntryStorage: vi.fn(),
+  resolveAgentDriverModel: vi.fn(),
+  createCallLlmStreamFn: vi.fn(),
+  buildAgent: vi.fn(),
+  resolveWebSearchCapability: vi.fn(),
+}));
+
+vi.mock('node:crypto', async (importActual) => {
+  const actual = await importActual<typeof import('node:crypto')>();
+  return { ...actual, randomUUID: mocks.randomUUID };
+});
+
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: mocks.getAgentSessionStore,
+}));
+
+vi.mock('@/lib/server/agent-runtime/entry-tree-storage', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@/lib/server/agent-runtime/entry-tree-storage')>();
+  return {
+    ...actual,
+    AgentSessionEntryStorage: {
+      open: mocks.openEntryStorage,
+    },
+  };
+});
+
+vi.mock('@/lib/server/agent-runtime/agent-driver-model', () => ({
+  resolveAgentDriverModel: mocks.resolveAgentDriverModel,
+}));
+
+vi.mock('@/lib/agent/runtime/stream-fn', () => ({
+  createCallLlmStreamFn: mocks.createCallLlmStreamFn,
+}));
+
+vi.mock('@/lib/agent/runtime/build-agent', () => ({
+  buildAgent: mocks.buildAgent,
+}));
+
+// Keep the real tool builder and prompt block; only the capability resolution
+// is faked, so the assertions observe the actual registered tool and prompt.
+vi.mock('@/lib/server/agent-runtime/web-search', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/server/agent-runtime/web-search')>();
+  return {
+    ...actual,
+    resolveWebSearchCapability: mocks.resolveWebSearchCapability,
+  };
+});
+
+import { runSession } from '@/lib/server/agent-runtime/runner';
+
+const SESSION_ID = 'session-1';
+/** Mirrors the runner's `WORKER_ID` derivation with the fixed mock uuid. */
+const WORKER_ID = `runner-t:${process.pid}`;
+
+function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSession {
+  return {
+    id: SESSION_ID,
+    ownerId: 'owner-1',
+    prompt: 'Help me',
+    stageId: 'stage-1',
+    existingCourse: false,
+    status: 'running',
+    attempt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    claimReason: 'queued',
+    claimSeq: 0,
+    ...overrides,
+  };
+}
+
+function makeStore(meta: ClaimedAgentSession) {
+  let seq = 0;
+  return {
+    appendRunEvent: vi.fn(
+      async (
+        _id: string,
+        _workerId: string,
+        _event: { type: string; data?: Record<string, unknown> },
+      ) => {
+        seq += 1;
+        return seq;
+      },
+    ),
+    clearCancel: vi.fn(async () => undefined),
+    finishSession: vi.fn(async () => true),
+    getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
+    hasSessionRunHistory: vi.fn(async () => false),
+    heartbeat: vi.fn(async () => true),
+    isCancelRequested: vi.fn(async () => false),
+    listUserMessages: vi.fn(async () => []),
+    releaseLease: vi.fn(async () => undefined),
+    requeueForRetry: vi.fn(async () => false),
+    requeueSession: vi.fn(async () => false),
+  };
+}
+
+async function makeEntryTree(): Promise<Session> {
+  const repo = new InMemorySessionRepo();
+  return repo.create({ id: SESSION_ID });
+}
+
+interface FakeAgent {
+  subscribe(listener: (event: AgentEvent, signal?: AbortSignal) => void): () => void;
+  prompt(text: string): Promise<void>;
+  continue(): Promise<void>;
+  waitForIdle(): Promise<void>;
+  steer(message: AgentMessage): void;
+  abort(): void;
+  readonly state: { messages: AgentMessage[]; errorMessage?: string };
+}
+
+function makeFakeAgent(): FakeAgent {
+  const messages: AgentMessage[] = [];
+  const listeners = new Set<(event: AgentEvent, signal?: AbortSignal) => void>();
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    prompt: async () => {},
+    continue: async () => {},
+    waitForIdle: async () => {},
+    steer: () => {},
+    abort: () => {},
+    state: {
+      get messages() {
+        return messages;
+      },
+      errorMessage: undefined,
+    },
+  };
+}
+
+interface BuildAgentOptions {
+  systemPrompt: string;
+  tools: Array<{ name: string }>;
+  allowedToolNames?: ReadonlySet<string>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveAgentDriverModel.mockResolvedValue({
+    connection: { model: undefined, thinkingConfig: undefined },
+    piModel: undefined,
+    wireMaxOutputTokens: undefined,
+    reservedOutputTokens: 8192,
+  });
+  mocks.createCallLlmStreamFn.mockReturnValue((() => {}) as never);
+  mocks.buildAgent.mockReturnValue(makeFakeAgent() as never);
+});
+
+async function runToBuildAgent(): Promise<BuildAgentOptions> {
+  const meta = makeMeta();
+  const session = await makeEntryTree();
+  const store = makeStore(meta);
+  mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+  mocks.getAgentSessionStore.mockResolvedValue(store);
+
+  let options: BuildAgentOptions | undefined;
+  mocks.buildAgent.mockImplementation((agentOptions: BuildAgentOptions) => {
+    options = agentOptions;
+    return makeFakeAgent();
+  });
+
+  await runSession({ running: new Map(), shuttingDown: false }, meta);
+
+  expect(options, 'buildAgent must be called with the run options').toBeDefined();
+  expect(store.finishSession).toHaveBeenCalledWith(
+    SESSION_ID,
+    WORKER_ID,
+    expect.objectContaining({ status: 'succeeded' }),
+  );
+  return options!;
+}
+
+describe('web_search runner registration', () => {
+  it('registers both tools and the web-search prompt block when a backend is configured', async () => {
+    mocks.resolveWebSearchCapability.mockReturnValue({
+      providerId: 'searxng',
+      apiKey: '',
+      baseUrl: 'https://search.example',
+    });
+
+    const options = await runToBuildAgent();
+
+    expect(options.tools.map((tool) => tool.name)).toEqual(['ask_user', 'web_search']);
+    expect([...(options.allowedToolNames ?? [])].sort()).toEqual(['ask_user', 'web_search']);
+    expect(options.systemPrompt).toContain('## Web search');
+    expect(options.systemPrompt).toContain('web_search');
+    // The capability is registered: the ask_user-only claim would be false.
+    expect(options.systemPrompt).not.toContain('Your only available tool is ask_user');
+  });
+
+  it('registers ask_user only and no web-search prompt when nothing is configured', async () => {
+    mocks.resolveWebSearchCapability.mockReturnValue(null);
+
+    const options = await runToBuildAgent();
+
+    expect(options.tools.map((tool) => tool.name)).toEqual(['ask_user']);
+    expect([...(options.allowedToolNames ?? [])]).toEqual(['ask_user']);
+    expect(options.systemPrompt).not.toContain('web_search');
+    expect(options.systemPrompt).not.toContain('## Web search');
+    // In this state the ask_user-only claim is accurate and stays in place.
+    expect(options.systemPrompt).toContain('Your only available tool is ask_user');
+  });
+});

--- a/tests/agent-runtime/web-search.test.ts
+++ b/tests/agent-runtime/web-search.test.ts
@@ -1,0 +1,99 @@
+/**
+ * resolveWebSearchCapability — capability registration must follow the
+ * resolver's own per-provider usability rules, including keyless providers
+ * (brave/searxng carry no API key by definition) and the capability force-off
+ * plumbing (a disabled-only config must count as not configured). An
+ * extra non-empty-key check on top would silently unregister web_search on
+ * exactly the keyless deployments.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { searchWebMock } = vi.hoisted(() => ({ searchWebMock: vi.fn() }));
+
+vi.mock('@/lib/server/web-search-config', () => ({
+  resolveClassroomWebSearchConfig: vi.fn(),
+}));
+vi.mock('@/lib/web-search', () => ({
+  searchWeb: searchWebMock,
+  formatSearchResultsAsContext: vi.fn(() => 'search context'),
+}));
+
+import { resolveClassroomWebSearchConfig } from '@/lib/server/web-search-config';
+import {
+  buildWebSearchTool,
+  resolveWebSearchCapability,
+  type WebSearchCapability,
+} from '@/lib/server/agent-runtime/web-search';
+
+const mocked = vi.mocked(resolveClassroomWebSearchConfig);
+
+afterEach(() => {
+  mocked.mockReset();
+  searchWebMock.mockReset();
+});
+
+describe('resolveWebSearchCapability', () => {
+  it('registers when a keyed provider resolves', () => {
+    mocked.mockReturnValue({
+      providerId: 'tavily',
+      apiKey: 'tvly-test',
+      baseUrl: 'https://api.tavily.com',
+    });
+    expect(resolveWebSearchCapability()).toEqual({
+      providerId: 'tavily',
+      apiKey: 'tvly-test',
+      baseUrl: 'https://api.tavily.com',
+    });
+  });
+
+  it('registers a KEYLESS provider (empty apiKey is a valid configuration)', () => {
+    mocked.mockReturnValue({
+      providerId: 'searxng',
+      apiKey: '',
+      baseUrl: 'https://searx.example',
+    });
+    const capability = resolveWebSearchCapability();
+    expect(capability).not.toBeNull();
+    expect(capability?.providerId).toBe('searxng');
+  });
+
+  it('stays unregistered when the resolver finds nothing usable', () => {
+    mocked.mockReturnValue(undefined);
+    expect(resolveWebSearchCapability()).toBeNull();
+  });
+});
+
+describe('web_search abort handling', () => {
+  const capability: WebSearchCapability = {
+    providerId: 'searxng',
+    apiKey: '',
+    baseUrl: 'https://search.example',
+  };
+
+  it('fails fast without calling the provider when the run signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const tool = buildWebSearchTool(capability);
+    await expect(
+      tool.execute('call_1', { query: 'q' } as never, controller.signal),
+    ).rejects.toThrow('aborted');
+    expect(searchWebMock).not.toHaveBeenCalled();
+  });
+
+  it('throws aborted when the signal fires after the provider fetch resolves', async () => {
+    const controller = new AbortController();
+    searchWebMock.mockImplementation(async () => {
+      controller.abort();
+      return {
+        answer: '',
+        query: 'q',
+        responseTime: 0.1,
+        sources: [{ title: 'A', url: 'https://a.example/', content: 'a', score: 1 }],
+      };
+    });
+    const tool = buildWebSearchTool(capability);
+    await expect(
+      tool.execute('call_1', { query: 'q' } as never, controller.signal),
+    ).rejects.toThrow('aborted');
+  });
+});


### PR DESCRIPTION
Second slice of the tools wave, and the first real use of the slice-1184 assembly seam: the session runner now registers a `web_search` tool when the deployment has a usable web-search backend.

- `resolveWebSearchCapability()` resolves through the shared classroom web-search config, so provider usability, keyless providers, and the capability force-off plumbing are all honored — a disabled-only config resolves to nothing and the model never sees a dead tool.
- The system prompt is now state-accurate: the ask_user-only claim stays when nothing else is registered, and the ported web-search guidance block is appended when the tool is.
- URL observation (the session-urls trust gate) belongs to the next slice; the attach point carries a NOTE.
- Tests pin both registration states at the runner level (tool list, allowlist, prompt content) plus tool-level abort handling.

638 tests green across agent-runtime/server/web-search; tsc/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)