### PR TITLE
feat(storage): add an ownership scope to stage documents

### DIFF
--- a/packages/@openmaic/storage/README.md
+++ b/packages/@openmaic/storage/README.md
@@ -88,6 +88,10 @@ a browser.
   (`validateStage` / `validateScene`) so schema drift fails loud. The outline is
   an opaque, app-owned snapshot carried alongside — persisted verbatim, neither
   validated nor migrated.
+- **Server document ownership.** `PgDocumentStore` without an owner remains the
+  historical client-owned partition (`owner_id IS NULL`). Server features bind
+  the same complete contract to a trusted identity with `store.forOwner(ownerId)`;
+  owned stages are invisible and immutable across owner boundaries.
 - **Generic over scene type.** `DocumentStore<TScene>` defaults to the DSL
   `Scene` (universal `slide` / `quiz`). An app that widens `Scene` with its own
   kinds (`interactive` / `pbl`, content the DSL does not own) parameterizes the

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/document/pg.ts
+++ b/packages/@openmaic/storage/src/document/pg.ts
@@ -46,6 +46,11 @@ export interface PgDocumentStoreOptions {
   validateScene?: SceneValidator;
   /** Stage write-boundary validator. Defaults to the DSL validateStage. */
   validateStage?: StageValidator;
+  /**
+   * Restrict every read and write to this owner. Omit this for the historical
+   * client-owned partition, whose rows have a null `owner_id`.
+   */
+  ownerId?: string;
 }
 
 /** Idempotent schema for the PostgreSQL document backend. */
@@ -58,8 +63,15 @@ CREATE TABLE IF NOT EXISTS document_stages (
   task_engine_mode BOOLEAN,
   created_at DOUBLE PRECISION NOT NULL,
   updated_at DOUBLE PRECISION NOT NULL,
+  owner_id TEXT,
   data JSONB NOT NULL
 );
+
+ALTER TABLE document_stages
+  ADD COLUMN IF NOT EXISTS owner_id TEXT;
+
+CREATE INDEX IF NOT EXISTS document_stages_owner_idx
+  ON document_stages (owner_id, id) WHERE owner_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS document_scenes (
   stage_id TEXT NOT NULL REFERENCES document_stages(id) ON DELETE CASCADE,
@@ -191,6 +203,8 @@ export class PgDocumentStore<
   private readonly transactionHook: WithTransaction;
   private readonly validateScene: SceneValidator;
   private readonly validateStage: StageValidator;
+  private readonly ownerId: string | null;
+  private readonly options: PgDocumentStoreOptions;
 
   constructor(queryable: Queryable, options: PgDocumentStoreOptions) {
     if (typeof options?.withTransaction !== 'function') {
@@ -204,6 +218,31 @@ export class PgDocumentStore<
     this.transactionHook = options.withTransaction;
     this.validateScene = options.validateScene ?? validateScene;
     this.validateStage = options.validateStage ?? validateStage;
+    if (options.ownerId !== undefined && !isPgQueryableKey(options.ownerId)) {
+      throw new Error('@openmaic/storage: PgDocumentStore ownerId must be lossless JSON text');
+    }
+    this.ownerId = options.ownerId ?? null;
+    this.options = options;
+  }
+
+  /** Bind the complete document contract to one trusted owner identity. */
+  forOwner(ownerId: string): PgDocumentStore<TScene, TStage> {
+    return new PgDocumentStore(this.queryable, { ...this.options, ownerId });
+  }
+
+  private scopePredicate(alias = '', ownerParameter = 1): string {
+    const column = alias === '' ? 'owner_id' : `${alias}.owner_id`;
+    return this.ownerId === null ? `${column} IS NULL` : `${column} = $${ownerParameter}`;
+  }
+
+  private scopeParams(stageId?: string): unknown[] {
+    return this.ownerId === null
+      ? stageId === undefined
+        ? []
+        : [stageId]
+      : stageId === undefined
+        ? [this.ownerId]
+        : [stageId, this.ownerId];
   }
 
   private async transaction<T>(body: (queryable: Queryable) => Promise<T>): Promise<T> {
@@ -219,8 +258,8 @@ export class PgDocumentStore<
     const result = await queryable.query<StoredJsonRow>(
       `SELECT data
          FROM document_stages
-        WHERE id = $1${suffix}`,
-      [stageId],
+        WHERE id = $1 AND ${this.scopePredicate('', 2)}${suffix}`,
+      this.scopeParams(stageId),
     );
     const storedRow = result.rows[0];
     if (!storedRow) return undefined;
@@ -307,10 +346,11 @@ export class PgDocumentStore<
   }
 
   private async persistStage(queryable: Queryable, stageRow: StageRow<TStage>): Promise<void> {
-    await queryable.query(
+    const result = await queryable.query<{ id: string }>(
       `INSERT INTO document_stages
-         (id, name, description, interactive_mode, task_engine_mode, created_at, updated_at, data)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+         (id, name, description, interactive_mode, task_engine_mode, created_at, updated_at,
+          owner_id, data)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
        ON CONFLICT (id) DO UPDATE
          SET name = EXCLUDED.name,
              description = EXCLUDED.description,
@@ -318,7 +358,9 @@ export class PgDocumentStore<
              task_engine_mode = EXCLUDED.task_engine_mode,
              created_at = EXCLUDED.created_at,
              updated_at = EXCLUDED.updated_at,
-             data = EXCLUDED.data`,
+             data = EXCLUDED.data
+       WHERE document_stages.owner_id IS NOT DISTINCT FROM EXCLUDED.owner_id
+       RETURNING id`,
       [
         stageRow.id,
         stageRow.name,
@@ -327,9 +369,16 @@ export class PgDocumentStore<
         stageRow.taskEngineMode ?? null,
         stageRow.createdAt,
         stageRow.updatedAt,
+        this.ownerId,
         encodeJson(stageRow, `document stage ${JSON.stringify(stageRow.id)}`),
       ],
     );
+    if (result.rows.length === 0) {
+      throw new DocumentNotFoundError(
+        stageRow.id,
+        `@openmaic/storage: document ${JSON.stringify(stageRow.id)} belongs to another scope`,
+      );
+    }
   }
 
   async saveDocument(doc: MaicDocument<TScene, TStage>): Promise<void> {
@@ -424,8 +473,10 @@ export class PgDocumentStore<
               COUNT(scenes.id)::text AS scene_count
          FROM document_stages AS stages
          LEFT JOIN document_scenes AS scenes ON scenes.stage_id = stages.id
+        WHERE ${this.scopePredicate('stages')}
         GROUP BY stages.id
         ORDER BY stages.id ASC`,
+      this.scopeParams(),
     );
     return result.rows.map((row) => ({
       id: row.id,
@@ -442,7 +493,10 @@ export class PgDocumentStore<
   async deleteDocument(stageId: string): Promise<void> {
     if (!isPgQueryableKey(stageId)) return;
     // One statement; both child tables are removed by their FK cascades.
-    await this.queryable.query('DELETE FROM document_stages WHERE id = $1', [stageId]);
+    await this.queryable.query(
+      `DELETE FROM document_stages WHERE id = $1 AND ${this.scopePredicate('', 2)}`,
+      this.scopeParams(stageId),
+    );
   }
 
   async putStage(stageId: string, stage: TStage): Promise<void> {

--- a/packages/@openmaic/storage/test/pg-document-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.test.ts
@@ -56,6 +56,27 @@ describe('PgDocumentStore with PGlite', () => {
   }));
 });
 
+describe('owner-scoped PgDocumentStore contract', () => {
+  let db: PGlite;
+  let store: DocumentStore;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureDocumentSchema(db);
+    store = new PgDocumentStore(db, transactionOptions(db)).forOwner('anon:contract-owner');
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  runDocumentStoreContract('Postgres owner scope (PGlite)', () => ({
+    store,
+    seedStoredVersion: (stageId, version) => restamp(db, stageId, version),
+  }));
+});
+
 describe('PgDocumentStore Postgres behavior', () => {
   let db: PGlite;
   let store: PgDocumentStore;
@@ -87,6 +108,82 @@ describe('PgDocumentStore Postgres behavior', () => {
       'document_scenes',
       'document_stages',
     ]);
+  });
+
+  test('ensureDocumentSchema adds the nullable owner column to an existing stage table', async () => {
+    const legacy = new PGlite();
+    await legacy.waitReady;
+    try {
+      await legacy.query(`CREATE TABLE document_stages (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        interactive_mode BOOLEAN,
+        task_engine_mode BOOLEAN,
+        created_at DOUBLE PRECISION NOT NULL,
+        updated_at DOUBLE PRECISION NOT NULL,
+        data JSONB NOT NULL
+      )`);
+      await ensureDocumentSchema(legacy);
+      const columns = await legacy.query<{ column_name: string; is_nullable: string }>(
+        `SELECT column_name, is_nullable
+           FROM information_schema.columns
+          WHERE table_name = 'document_stages' AND column_name = 'owner_id'`,
+      );
+      expect(columns.rows).toEqual([{ column_name: 'owner_id', is_nullable: 'YES' }]);
+    } finally {
+      await legacy.close();
+    }
+  });
+
+  test('owner scopes isolate the full contract and cannot claim an existing stage id', async () => {
+    const alice = store.forOwner('anon:alice');
+    const bob = store.forOwner('anon:bob');
+    await alice.saveDocument(makeDocument('alice-stage'));
+    await bob.saveDocument(makeDocument('bob-stage'));
+
+    await expect(alice.loadDocument('bob-stage')).resolves.toBeNull();
+    await expect(bob.getScene('alice-stage', 'scene-a')).resolves.toBeNull();
+    await expect(alice.listDocuments()).resolves.toEqual([
+      expect.objectContaining({ id: 'alice-stage' }),
+    ]);
+    await expect(bob.saveDocument(makeDocument('alice-stage'))).rejects.toBeInstanceOf(
+      DocumentNotFoundError,
+    );
+
+    await bob.deleteDocument('alice-stage');
+    await expect(alice.loadDocument('alice-stage')).resolves.not.toBeNull();
+  });
+
+  test('the historical unowned path remains byte-identical beside owned documents', async () => {
+    const legacyDocument = makeDocument('legacy-stage');
+    await store.saveDocument(legacyDocument);
+    const beforeDocument = JSON.stringify(await store.loadDocument('legacy-stage'));
+    const beforeList = JSON.stringify(await store.listDocuments());
+    const beforeRows = JSON.stringify(
+      (
+        await db.query<{ data: unknown }>(
+          'SELECT data FROM document_stages WHERE id = $1 AND owner_id IS NULL',
+          ['legacy-stage'],
+        )
+      ).rows,
+    );
+
+    await store.forOwner('anon:agent').saveDocument(makeDocument('agent-stage'));
+
+    expect(JSON.stringify(await store.loadDocument('legacy-stage'))).toBe(beforeDocument);
+    expect(JSON.stringify(await store.listDocuments())).toBe(beforeList);
+    expect(
+      JSON.stringify(
+        (
+          await db.query<{ data: unknown }>(
+            'SELECT data FROM document_stages WHERE id = $1 AND owner_id IS NULL',
+            ['legacy-stage'],
+          )
+        ).rows,
+      ),
+    ).toBe(beforeRows);
+    await expect(store.loadDocument('agent-stage')).resolves.toBeNull();
   });
 
   test('requires a transaction hook at construction time', () => {

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -45,8 +45,15 @@ CREATE TABLE IF NOT EXISTS document_stages (
   task_engine_mode BOOLEAN,
   created_at DOUBLE PRECISION NOT NULL,
   updated_at DOUBLE PRECISION NOT NULL,
+  owner_id TEXT,
   data JSONB NOT NULL
 );
+
+ALTER TABLE document_stages
+  ADD COLUMN IF NOT EXISTS owner_id TEXT;
+
+CREATE INDEX IF NOT EXISTS document_stages_owner_idx
+  ON document_stages (owner_id, id) WHERE owner_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS document_scenes (
   stage_id TEXT NOT NULL REFERENCES document_stages(id) ON DELETE CASCADE,
@@ -333,8 +340,9 @@ describe.each(schemas)('$name is a pinned contract', ({ name, actual, expected, 
     expect(statements.length).toBeGreaterThan(0);
     for (const statement of statements) {
       expect(
-        /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(statement),
-        `${name} statement is not an IF NOT EXISTS create: ${statement}`,
+        /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(statement) ||
+          /^ALTER TABLE [a-z_]+\s+ADD COLUMN IF NOT EXISTS /.test(statement),
+        `${name} statement is not an idempotent create or additive migration: ${statement}`,
       ).toBe(true);
     }
   });


### PR DESCRIPTION
Prerequisite for the agent course toolset: the PostgreSQL document store had no owner dimension — every load, list, edit, and delete was keyed only by the globally unique stage id, because the browser/HTTP document surfaces are client-owned and supply no trusted server principal. Agent-created stages therefore had nowhere to record who owns them.

## Design

A **nullable `owner_id` column** on `document_stages`, with the full `DocumentStore` contract bindable to one owner via `store.forOwner(ownerId)` (or the constructor option). A store built without an owner is exactly the historical `owner_id IS NULL` partition.

This keeps a stage a durable owner-level resource rather than session state: multiple sessions of the same owner can work on one course, and the later folder slice gets a stable `(owner_id, stage_id)` attachment key without touching these tables again.

**Rejected alternative**: a session→stage association in the agent-session store. It would leave the document tables untouched, but a stage would only be reachable by first selecting a session, every course operation would need session joins, and folders would either attach to sessions incorrectly or force a second ownership model. Good for session-only artifacts, wrong for owner-level courses.

Soft deletion was deliberately not added — `deleteDocument` promises a physical cascade, and changing that would not be additive.

## Compatibility (the property that must not regress)

- The shared `DocumentStore` contract suite runs against **both** the unowned and the owner-scoped store.
- A migration test provisions the pre-change table and proves `ensureDocumentSchema` adds the nullable column idempotently (plus a partial index on owned rows only).
- Cross-owner tests prove load / scene read / list / conflicting save / delete cannot cross the boundary; a cross-scope id collision raises `DocumentNotFoundError` before any child row changes.
- A byte-compatibility test serializes an unowned document result, its list result, and its raw JSONB stage row before adding an owned neighbour, and proves all three byte sequences are unchanged afterwards.

Package 0.10.0 → 0.11.0. Storage suite 960 green; server + persistence 428 green; tsc/prettier/eslint clean; version gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)