### PR TITLE
feat(agent): add stage read and patch tools

### DIFF
--- a/lib/document-store/persistence-types.ts
+++ b/lib/document-store/persistence-types.ts
@@ -7,10 +7,38 @@ import type { AppScene } from '@/lib/types/stage';
 /** App-owned stage shape. Device playback position is not document metadata. */
 export type AppStage = Stage;
 
+/**
+ * Who produces the scenes of this course.
+ *
+ * `'client'` (the default, and what an absent field means) is the historical
+ * app: the browser drives `useSceneGenerator` against the user's own model
+ * config, so an interrupted deck must be resumed by whichever tab opens it.
+ * `'server-job'` is the agent runtime (`lib/server/agent-runtime/`): a
+ * long-lived agent job owns the course and the browser is an observer that
+ * must never produce a scene, however incomplete the deck looks.
+ *
+ * This is a separate axis from `generationComplete`, and separating them is the
+ * point. "Is this course finished" and "may this browser generate the missing
+ * pages" are different questions; conflating them forces a server-owned course
+ * to claim it is complete from its very first write just to keep the browser
+ * out.
+ */
+export type DocumentProducer = 'client' | 'server-job';
+
 /** Generation intent stored opaquely with the document aggregate. */
 export interface AppDocumentOutline {
   outlines: SceneOutline[];
+  /**
+   * The requirement text the plan was generated from (agent runtime only).
+   * Doubles as the replan idempotency key: a `generate_outline` replan
+   * carrying the same requirement is a retry, not a new plan.
+   */
+  requirement?: string;
   generationComplete?: boolean;
+  /** Absent = `'client'`, i.e. every course written before the agent runtime. */
+  producer?: DocumentProducer;
+  /** Opaque handle of the producing job, when one owns the course. */
+  producerRef?: string;
   createdAt: number;
   updatedAt: number;
 }

--- a/lib/document-store/validators.ts
+++ b/lib/document-store/validators.ts
@@ -1,4 +1,10 @@
-import { validateScene, validateStage, type ValidationIssue } from '@openmaic/dsl';
+import {
+  isActionType,
+  validateAction,
+  validateScene,
+  validateStage,
+  type ValidationIssue,
+} from '@openmaic/dsl';
 import type { SceneValidator, StageValidator } from '@openmaic/storage';
 import { hasPBLProjectV2Containers } from '@/lib/pbl/v2/types';
 import { isEmptyLegacyPBLConfig, type PBLProjectConfig } from '@/lib/pbl/legacy/read';
@@ -100,6 +106,52 @@ export const validateAppScene: SceneValidator = (scene) => {
       path: '/content/projectV2',
       message: '`projectV2` must contain milestones, roles and threads arrays',
     });
+  }
+
+  // The app-only branch historically never looked at `actions`, so a
+  // `patch_stage set /actions = "not-an-array"` persisted a string that
+  // crashed the tool's own return-value construction and playback
+  // (`(scene.actions ?? []).map is not a function` — R5-P2-2). Every element
+  // must be action-shaped (a string `id` and a string `type`), and an element
+  // whose type IS in the DSL action registry additionally runs the DSL's own
+  // per-variant required-field validation — `{id, type:'speech'}` without a
+  // string `text` crashes the playback engine's `speechAction.text.trim()`
+  // (R6-P2-3), so persisting it is persisting corruption. Elements with types
+  // OUTSIDE the registry stay lenient beyond the id/type shape: the legacy
+  // corpus holds hundreds of invented types that must keep saving — the write
+  // barrier is for corruption, not canon. (Legacy actions missing only an
+  // `id` are completed by `canonicalizeLegacyScene` before they ever reach
+  // this barrier — R6-P2-2.)
+  if (value.actions !== undefined) {
+    if (!Array.isArray(value.actions)) {
+      errors.push({ path: '/actions', message: '`actions` must be an array' });
+    } else {
+      value.actions.forEach((action, index) => {
+        if (action === null || typeof action !== 'object' || Array.isArray(action)) {
+          errors.push({ path: `/actions/${index}`, message: 'action must be an object' });
+          return;
+        }
+        const record = action as Record<string, unknown>;
+        if (typeof record.id !== 'string') {
+          errors.push({ path: `/actions/${index}/id`, message: 'expected string `id`' });
+        }
+        if (typeof record.type !== 'string') {
+          errors.push({ path: `/actions/${index}/type`, message: 'expected string `type`' });
+          return;
+        }
+        if (isActionType(record.type)) {
+          const variant = validateAction(record);
+          if (!variant.valid) {
+            for (const issue of variant.errors ?? []) {
+              errors.push({
+                path: `/actions/${index}${issue.path === '/' ? '' : issue.path}`,
+                message: issue.message,
+              });
+            }
+          }
+        }
+      });
+    }
   }
 
   return errors.length === 0 ? { valid: true } : { valid: false, errors };

--- a/lib/edit/slide-edit-elements.ts
+++ b/lib/edit/slide-edit-elements.ts
@@ -1,3 +1,4 @@
+import katex from 'katex';
 import type {
   ChartType,
   PPTChartElement,
@@ -114,6 +115,26 @@ export function createDefaultLatexElement(id: string, result: LatexEditorResult)
     align: 'center',
     fixedRatio: true,
   };
+}
+
+/**
+ * Render LaTeX source to the KaTeX HTML snapshot a latex element persists in
+ * `html`. Mirrors the prod generation path (processLatexElements) and the
+ * whiteboard draw action (lib/action/engine.ts): display-mode block markup,
+ * never throw on bad TeX (KaTeX emits error markup instead). Returns null only
+ * on an unexpected renderer throw, so a write boundary can drop the snapshot
+ * rather than persist a stale one.
+ */
+export function renderLatexElementHtml(latex: string): string | null {
+  try {
+    return katex.renderToString(latex, {
+      throwOnError: false,
+      displayMode: true,
+      output: 'html',
+    });
+  } catch {
+    return null;
+  }
 }
 
 /** Create a renderer-editor chart with data that is valid for every chart type. */

--- a/lib/server/agent-runtime/course-edit/apply.ts
+++ b/lib/server/agent-runtime/course-edit/apply.ts
@@ -1,0 +1,666 @@
+/** Shared scene projections and generic JSON/slide transforms for stage tools. */
+import { nanoid } from 'nanoid';
+import { renderLatexElementHtml } from '@/lib/edit/slide-edit-elements';
+import { validateElementInput, validateSlideCanvas } from './element-schema';
+import type { PBLProjectV2, PBLRole } from '@/lib/pbl/v2/types';
+import type { Action } from '@/lib/types/action';
+import type { QuizContent, Scene, SlideContent } from '@/lib/types/stage';
+import type { WidgetConfig } from '@/lib/types/widgets';
+import type { PPTElement } from '@openmaic/dsl';
+import {
+  containsReadSceneMediaPlaceholder,
+  containsReadScenePlaceholderFragment,
+} from './media-byte-omission';
+
+export type ApplyResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function ok<T>(value: T): ApplyResult<T> {
+  return { ok: true, value };
+}
+function fail(error: string): ApplyResult<never> {
+  return { ok: false, error };
+}
+
+export function stripTags(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function findElement(content: SlideContent, elementId: string): PPTElement | undefined {
+  return content.canvas.elements.find((el) => el.id === elementId);
+}
+
+export function inventorySlide(content: SlideContent) {
+  return content.canvas.elements.map((el) => {
+    const rec = el as PPTElement & {
+      content?: string;
+      text?: { content?: string };
+      src?: string;
+      mediaRef?: string;
+      poster?: string;
+      latex?: string;
+      lines?: { content?: string }[];
+      data?: { text?: string }[][];
+    };
+    let text = '';
+    if (rec.type === 'text') text = stripTags(rec.content ?? '');
+    else if (rec.type === 'shape') text = stripTags(rec.text?.content ?? '');
+    else if (rec.type === 'latex') text = rec.latex ?? '';
+    else if (rec.type === 'code') text = (rec.lines ?? []).map((l) => l.content).join('\n');
+    else if (rec.type === 'table')
+      text = (rec.data ?? [])
+        .flat()
+        .map((c) => c.text ?? '')
+        .filter(Boolean)
+        .join(' | ');
+    return {
+      id: rec.id,
+      type: rec.type,
+      text,
+      left: rec.left,
+      top: rec.top,
+      width: 'width' in rec ? rec.width : undefined,
+      height: 'height' in rec ? rec.height : undefined,
+      src: rec.src,
+      ...(rec.mediaRef !== undefined ? { mediaRef: rec.mediaRef } : {}),
+      ...(rec.poster !== undefined ? { poster: rec.poster } : {}),
+    };
+  });
+}
+
+/** Whole-page visible-text view used to prove old copy has no residue. */
+export function textSlide(content: SlideContent) {
+  const inventory = inventorySlide(content);
+  const elements = inventory
+    .map((element, index) => ({
+      path: `/canvas/elements/${index}`,
+      id: element.id,
+      type: element.type,
+      text: element.text,
+    }))
+    .filter((element) => element.text.length > 0);
+  const media: {
+    path: string;
+    id: string;
+    type: string;
+    src?: string;
+    mediaRef?: string;
+    poster?: string;
+  }[] = inventory.flatMap((element, index) => {
+    const path = `/canvas/elements/${index}`;
+    return (['src', 'mediaRef', 'poster'] as const).flatMap((field) =>
+      typeof element[field] === 'string'
+        ? [
+            {
+              path: `${path}/${field}`,
+              id: element.id,
+              type: element.type,
+              [field]: element[field],
+            },
+          ]
+        : [],
+    );
+  });
+  const background = content.canvas.background;
+  if (background?.type === 'image' && background.image?.src) {
+    media.unshift({
+      path: '/canvas/background/image/src',
+      id: content.canvas.id,
+      type: 'background',
+      src: background.image.src,
+    });
+  }
+  return {
+    elements,
+    combinedText: elements.map((element) => element.text).join('\n'),
+    media,
+  };
+}
+
+/**
+ * Server course-agent surface only. The classroom/browser editor uses the
+ * lower-level `SlideEditOperation` union in `lib/edit/slide-ops.ts` directly;
+ * keep that UI contract independent from which sugar ops the agent exposes.
+ */
+export type SlideEditOp =
+  | {
+      op: 'patch';
+      action: 'set' | 'remove';
+      path: string;
+      value?: unknown;
+    }
+  | {
+      op: 'add_element';
+      element: Record<string, unknown>;
+      afterId?: string;
+      index?: number;
+    }
+  | { op: 'delete_element'; elementId: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function decodePointer(path: string): ApplyResult<string[]> {
+  if (!path.startsWith('/') || path === '/') {
+    return fail('patch path must be a non-root JSON Pointer beginning with /');
+  }
+  const encoded = path.slice(1).split('/');
+  const decoded: string[] = [];
+  for (const token of encoded) {
+    if (/~(?:[^01]|$)/.test(token)) {
+      return fail(`bad JSON pointer escape in path ${JSON.stringify(path)}`);
+    }
+    decoded.push(token.replace(/~1/g, '/').replace(/~0/g, '~'));
+  }
+  return ok(decoded);
+}
+
+function arrayIndex(token: string, length: number): ApplyResult<number> {
+  if (!/^(0|[1-9]\d*)$/.test(token)) {
+    return fail(`array path segment ${JSON.stringify(token)} is not a canonical index`);
+  }
+  const index = Number(token);
+  if (index >= length) return fail(`array index ${index} is out of bounds (length ${length})`);
+  return ok(index);
+}
+
+function applyPointer(
+  root: Record<string, unknown>,
+  tokens: string[],
+  action: 'set' | 'remove',
+  value: unknown,
+): ApplyResult<void> {
+  let parent: unknown = root;
+  for (const token of tokens.slice(0, -1)) {
+    if (Array.isArray(parent)) {
+      const parsed = arrayIndex(token, parent.length);
+      if (!parsed.ok) return parsed;
+      parent = parent[parsed.value];
+    } else if (isRecord(parent)) {
+      if (!Object.prototype.hasOwnProperty.call(parent, token)) {
+        return fail(`patch path does not exist at ${JSON.stringify(token)}`);
+      }
+      parent = parent[token];
+    } else {
+      return fail(`patch path crosses a non-container at ${JSON.stringify(token)}`);
+    }
+  }
+  const key = tokens.at(-1);
+  if (key === undefined) return fail('patch path must address a field');
+  if (Array.isArray(parent)) {
+    const parsed = arrayIndex(key, parent.length);
+    if (!parsed.ok) return parsed;
+    if (action === 'remove') parent.splice(parsed.value, 1);
+    else parent[parsed.value] = structuredClone(value);
+    return ok(undefined);
+  }
+  if (!isRecord(parent)) return fail('patch path parent is not an object or array');
+  if (action === 'remove') {
+    if (!Object.prototype.hasOwnProperty.call(parent, key)) {
+      return fail(`patch remove path does not exist: ${JSON.stringify(key)}`);
+    }
+    delete parent[key];
+  } else {
+    Object.defineProperty(parent, key, {
+      value: structuredClone(value),
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return ok(undefined);
+}
+
+/** Read-side media omission placeholders are never persisted data. */
+const READ_PLACEHOLDER_REJECTION =
+  'patch rejected: that is a read-time placeholder, not a real src; write a new media src/URL instead of writing the placeholder text back into the document';
+
+/**
+ * Shared JSON Pointer primitive for the course DSL spike. It deliberately has
+ * the same bounded-array, missing-parent, deep-clone, and media-placeholder
+ * semantics as the stage DSL slide path. Domain identity and resulting-document validation
+ * remain the caller's responsibility.
+ */
+export function applyJsonPointerEdit<T>(
+  root: T,
+  input: { action: 'set' | 'remove'; path: string; value?: unknown },
+): ApplyResult<T> {
+  if (input.action === 'set' && input.value === undefined) {
+    return fail('patch set needs value (use action:"remove" to delete an optional field)');
+  }
+  if (input.action === 'remove' && input.value !== undefined) {
+    return fail('patch remove must not include value');
+  }
+  if (input.action === 'set' && containsReadSceneMediaPlaceholder(input.value)) {
+    return fail(READ_PLACEHOLDER_REJECTION);
+  }
+  const decoded = decodePointer(input.path);
+  if (!decoded.ok) return decoded;
+  const next = structuredClone(root);
+  const applied = applyPointer(
+    next as unknown as Record<string, unknown>,
+    decoded.value,
+    input.action,
+    input.value,
+  );
+  return applied.ok ? ok(next) : applied;
+}
+
+export interface StrReplaceInput {
+  path: string;
+  oldText: string;
+  newText: string;
+  replaceAll?: boolean;
+}
+
+export type StrReplaceResult<T> =
+  | { ok: true; value: T; occurrences: number }
+  | { ok: false; error: string };
+
+function failStr(error: string): StrReplaceResult<never> {
+  return { ok: false as const, error };
+}
+
+function strReplaceMissing(path: string): StrReplaceResult<never> {
+  return failStr(`str_replace requires a string field; ${path} is missing`);
+}
+
+function strReplaceTypeName(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
+ * Exact-text ("str_replace") replacement inside ONE string field, aligned with
+ * Claude Code Edit semantics. The anchor must occur exactly once in the stored
+ * value (or every occurrence with `replaceAll`), counting non-overlapping
+ * exact matches. Read-side media omission placeholders are rejected in both
+ * the anchor and the replacement so a read projection can never leak into
+ * persisted data. The input is never mutated; the caller's clone discipline
+ * matches `applyJsonPointerEdit`.
+ */
+export function applyStrReplace<T>(root: T, input: StrReplaceInput): StrReplaceResult<T> {
+  if (input.oldText === '') return failStr('str_replace needs a non-empty oldText');
+  const decoded = decodePointer(input.path);
+  if (!decoded.ok) return decoded;
+  const next = structuredClone(root);
+  let parent: unknown = next;
+  const tokens = decoded.value;
+  for (const token of tokens.slice(0, -1)) {
+    if (Array.isArray(parent)) {
+      const parsed = arrayIndex(token, parent.length);
+      if (!parsed.ok) return parsed;
+      parent = parent[parsed.value];
+    } else if (isRecord(parent)) {
+      if (!Object.prototype.hasOwnProperty.call(parent, token)) {
+        return strReplaceMissing(input.path);
+      }
+      parent = parent[token];
+    } else {
+      return strReplaceMissing(input.path);
+    }
+  }
+  const key = tokens.at(-1);
+  if (key === undefined) return failStr('patch path must address a field');
+  let current: unknown;
+  if (Array.isArray(parent)) {
+    const parsed = arrayIndex(key, parent.length);
+    if (!parsed.ok) return parsed;
+    current = parent[parsed.value];
+  } else if (isRecord(parent)) {
+    if (!Object.prototype.hasOwnProperty.call(parent, key)) {
+      return strReplaceMissing(input.path);
+    }
+    current = parent[key];
+  } else {
+    return strReplaceMissing(input.path);
+  }
+  if (typeof current !== 'string') {
+    return failStr(
+      `str_replace requires a string field; ${input.path} is ${strReplaceTypeName(current)}`,
+    );
+  }
+  if (containsReadScenePlaceholderFragment(input.oldText)) {
+    return failStr(
+      'anchor contains an omitted-bytes placeholder from read_stage; it does not exist in the stored value — choose an anchor outside omitted regions',
+    );
+  }
+  if (containsReadSceneMediaPlaceholder(input.newText)) {
+    return failStr(READ_PLACEHOLDER_REJECTION);
+  }
+  let occurrences = 0;
+  let fromIndex = 0;
+  for (;;) {
+    const found = current.indexOf(input.oldText, fromIndex);
+    if (found < 0) break;
+    occurrences += 1;
+    fromIndex = found + input.oldText.length;
+  }
+  if (occurrences === 0) {
+    return failStr(`anchor text not found in ${input.path} (0 occurrences)`);
+  }
+  if (!input.replaceAll && occurrences > 1) {
+    return failStr(`anchor text occurs ${occurrences} times; extend the anchor or set replaceAll`);
+  }
+  const replaced = input.replaceAll
+    ? current.split(input.oldText).join(input.newText)
+    : current.replace(input.oldText, input.newText);
+  Object.defineProperty(parent, key, {
+    value: replaced,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  return { ok: true, value: next, occurrences };
+}
+
+function elementIdentityIssue(before: SlideContent, after: SlideContent): string | null {
+  if (before.canvas.id !== after.canvas.id) return 'patch cannot change canvas id';
+  const oldTypes = new Map(before.canvas.elements.map((element) => [element.id, element.type]));
+  const nextIds = after.canvas.elements.map((element) => element.id);
+  if (new Set(nextIds).size !== nextIds.length) return 'patch produced duplicate element ids';
+  if (oldTypes.size !== nextIds.length || nextIds.some((id) => !oldTypes.has(id))) {
+    return 'patch cannot add, remove, or change element ids; use add_element/delete_element';
+  }
+  for (const element of after.canvas.elements) {
+    if (oldTypes.get(element.id) !== element.type) {
+      return `patch cannot change type for element ${element.id}`;
+    }
+  }
+  return null;
+}
+
+function applyJsonPointerPatch(
+  content: SlideContent,
+  input: Extract<SlideEditOp, { op: 'patch' }>,
+): ApplyResult<SlideContent> {
+  if (!input.path.startsWith('/canvas/')) {
+    return fail(
+      'slide patch path must start with /canvas/ after removing the scene /content prefix',
+    );
+  }
+  if (input.action === 'set' && input.value === undefined) {
+    return fail('patch set needs value (use action:"remove" to delete an optional field)');
+  }
+  if (input.action === 'remove' && input.value !== undefined) {
+    return fail('patch remove must not include value');
+  }
+  if (input.action === 'set' && containsReadSceneMediaPlaceholder(input.value)) {
+    return fail(READ_PLACEHOLDER_REJECTION);
+  }
+  const decoded = decodePointer(input.path);
+  if (!decoded.ok) return decoded;
+  const next = structuredClone(content);
+  const applied = applyPointer(
+    next as unknown as Record<string, unknown>,
+    decoded.value,
+    input.action,
+    input.value,
+  );
+  if (!applied.ok) return applied;
+  const identityIssue = elementIdentityIssue(content, next);
+  if (identityIssue) return fail(`patch rejected: ${identityIssue}`);
+  const schemaIssues = validateSlideCanvas(next.canvas);
+  if (schemaIssues.length > 0) return fail(`patch rejected: ${schemaIssues.join('; ')}`);
+  const beforeLatex = new Map(
+    content.canvas.elements
+      .filter((element) => element.type === 'latex')
+      .map((element) => [element.id, element.latex]),
+  );
+  for (const element of next.canvas.elements) {
+    if (element.type !== 'latex' || beforeLatex.get(element.id) === element.latex) continue;
+    const html = renderLatexElementHtml(element.latex);
+    if (html !== null) element.html = html;
+    else delete element.html;
+  }
+  return ok(next);
+}
+
+export function applySlideEdit(
+  content: SlideContent,
+  input: SlideEditOp,
+): ApplyResult<SlideContent> {
+  switch (input.op) {
+    case 'patch':
+      return applyJsonPointerPatch(content, input);
+    case 'add_element': {
+      if (!isRecord(input.element)) return fail('add_element needs element as an object');
+      if ('id' in input.element) {
+        return fail(
+          'add_element element must not include id (the server assigns element identity)',
+        );
+      }
+      const issues = validateElementInput(input.element);
+      if (issues.length > 0) return fail(`add_element rejected: ${issues.join('; ')}`);
+      if (input.afterId !== undefined && input.index !== undefined) {
+        return fail('add_element accepts either afterId or index, not both');
+      }
+      let index: number | undefined;
+      if (input.afterId !== undefined) {
+        const afterIndex = content.canvas.elements.findIndex((item) => item.id === input.afterId);
+        if (afterIndex < 0) return fail(`no element ${input.afterId}`);
+        index = afterIndex + 1;
+      } else if (input.index !== undefined) {
+        if (
+          !Number.isInteger(input.index) ||
+          input.index < 0 ||
+          input.index > content.canvas.elements.length
+        ) {
+          return fail(
+            `add_element index must be an integer from 0 to ${content.canvas.elements.length}`,
+          );
+        }
+        index = input.index;
+      }
+      let id = `el-${nanoid(8)}`;
+      while (findElement(content, id)) id = `el-${nanoid(8)}`;
+      const element = { ...structuredClone(input.element), id } as unknown as PPTElement;
+      const next = structuredClone(content);
+      next.canvas.elements.splice(index ?? next.canvas.elements.length, 0, element);
+      return ok(next);
+    }
+    case 'delete_element': {
+      if (!findElement(content, input.elementId)) return fail(`no element ${input.elementId}`);
+      const next = structuredClone(content);
+      next.canvas.elements = next.canvas.elements.filter(
+        (element) => element.id !== input.elementId,
+      );
+      return ok(next);
+    }
+    default:
+      return fail(`unknown slide op`);
+  }
+}
+
+function emptyPblThread(roleId: string): PBLProjectV2['threads'][number] {
+  return { agentId: roleId, messages: [] };
+}
+
+export function createStubProjectV2(title: string, description = ''): PBLProjectV2 {
+  const roleId = `role-${nanoid(8)}`;
+  const now = new Date().toISOString();
+  return {
+    uiPhase: 'hero',
+    title,
+    description,
+    proficiency: '',
+    language: 'zh-CN',
+    tags: [],
+    status: 'designing',
+    roles: [{ id: roleId, type: 'instructor', name: 'Instructor' }],
+    milestones: [],
+    submissions: [],
+    evaluations: [],
+    threads: [emptyPblThread(roleId)],
+    engagementEvents: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function emptySlideContent(): SlideContent {
+  return {
+    type: 'slide',
+    canvas: {
+      id: `slide-${nanoid(8)}`,
+      viewportSize: 1000,
+      viewportRatio: 0.5625,
+      theme: {
+        backgroundColor: '#ffffff',
+        themeColors: ['#2563eb'],
+        fontColor: '#111827',
+        fontName: 'Inter',
+      },
+      elements: [],
+    },
+  };
+}
+
+export function emptyQuizContent(): QuizContent {
+  return { type: 'quiz', questions: [] };
+}
+
+export function createBlankScene(input: {
+  id: string;
+  stageId: string;
+  order: number;
+  title: string;
+  type: 'slide' | 'quiz' | 'interactive' | 'pbl';
+}): Scene {
+  if (input.type === 'quiz') {
+    return {
+      id: input.id,
+      stageId: input.stageId,
+      order: input.order,
+      title: input.title,
+      type: 'quiz',
+      content: emptyQuizContent(),
+      actions: [],
+    } as Scene;
+  }
+  if (input.type === 'interactive') {
+    return {
+      id: input.id,
+      stageId: input.stageId,
+      order: input.order,
+      title: input.title,
+      type: 'interactive',
+      content: { type: 'interactive', url: '', html: '<!DOCTYPE html><html><body></body></html>' },
+      actions: [],
+    } as Scene;
+  }
+  if (input.type === 'pbl') {
+    const project = createStubProjectV2(input.title);
+    return {
+      id: input.id,
+      stageId: input.stageId,
+      order: input.order,
+      title: input.title,
+      type: 'pbl',
+      content: {
+        type: 'pbl',
+        projectV2: project,
+      },
+      actions: [],
+    } as Scene;
+  }
+  return {
+    id: input.id,
+    stageId: input.stageId,
+    order: input.order,
+    title: input.title,
+    type: 'slide',
+    content: emptySlideContent(),
+    actions: [],
+  } as Scene;
+}
+
+export function inventoryScene(scene: Scene) {
+  const content = scene.content as {
+    type?: string;
+    questions?: { id: string; question: string; type: string; options?: { label: string }[] }[];
+    widgetType?: string;
+    widgetConfig?: WidgetConfig;
+    html?: string;
+    projectV2?: PBLProjectV2;
+  };
+  // Shallow-copy each action so read_stage surfaces every writable field
+  // (spotlight elementId/dimOpacity, speech text/voice/speed/audioId, wb_*
+  // geometry, discussion topic, widget state, ...) instead of an id/type/text
+  // projection — the agent verifies persisted edits through this inventory.
+  const actions = ((scene.actions ?? []) as Action[]).map((action) => ({ ...action }));
+  if (content.type === 'slide') {
+    return {
+      sceneId: scene.id,
+      order: scene.order,
+      title: scene.title,
+      type: 'slide',
+      elements: inventorySlide(scene.content as SlideContent),
+      actions,
+    };
+  }
+  if (content.type === 'quiz') {
+    return {
+      sceneId: scene.id,
+      order: scene.order,
+      title: scene.title,
+      type: 'quiz',
+      questions: (content.questions ?? []).map((q) => ({
+        id: q.id,
+        type: q.type,
+        question: q.question,
+        options: q.options?.map((o) => o.label) ?? [],
+      })),
+      actions,
+    };
+  }
+  if (content.type === 'interactive') {
+    return {
+      sceneId: scene.id,
+      order: scene.order,
+      title: scene.title,
+      type: 'interactive',
+      widgetType: content.widgetType ?? content.widgetConfig?.type,
+      widgetConfig: content.widgetConfig ?? null,
+      htmlChars: content.html?.length ?? 0,
+      actions,
+    };
+  }
+  if (content.type === 'pbl') {
+    const project = content.projectV2;
+    return {
+      sceneId: scene.id,
+      order: scene.order,
+      title: scene.title,
+      type: 'pbl',
+      project: project
+        ? {
+            title: project.title,
+            description: project.description,
+            roles: project.roles.map((role: PBLRole) => ({
+              id: role.id,
+              type: role.type,
+              name: role.name,
+            })),
+            milestones: project.milestones.map((ms) => ({
+              id: ms.id,
+              title: ms.title,
+              microtasks: ms.microtasks.map((mt) => ({ id: mt.id, title: mt.title })),
+            })),
+          }
+        : null,
+      actions,
+    };
+  }
+  return {
+    sceneId: scene.id,
+    order: scene.order,
+    title: scene.title,
+    type: scene.type,
+    actions,
+  };
+}

--- a/lib/server/agent-runtime/course-edit/element-schema.ts
+++ b/lib/server/agent-runtime/course-edit/element-schema.ts
@@ -1,0 +1,694 @@
+/**
+ * Closed TypeBox schemas for the slide DSL JSON exposed by `read_stage` and
+ * written by `patch_stage`.
+ *
+ * A patch is a PARTIAL element JSON: every field optional, `additionalProperties`
+ * closed at every level so an unknown or out-of-contract field fails loud
+ * instead of silently landing in a document. Nested objects are themselves
+ * partial patches (deep-merge semantics); arrays are validated against their
+ * element types (array fields are replaced wholesale, never merged).
+ *
+ * Patch schemas omit `id` and `type` because identity is not patchable. The
+ * insertion schema adds the discriminating `type`, still omits `id` (the
+ * server owns identity), and restores every DSL-required field.
+ *
+ * Field sets mirror `@openmaic/dsl` `slides.ts` exactly (the 10-element union).
+ */
+import { Type, type TSchema } from 'typebox';
+import { Check, Errors } from 'typebox/value';
+import { ElementTypes } from '@openmaic/dsl';
+
+const optionalString = () => Type.Optional(Type.String());
+const optionalNumber = () => Type.Optional(Type.Number());
+const optionalBoolean = () => Type.Optional(Type.Boolean());
+
+const LineStyleType = Type.Union([
+  Type.Literal('solid'),
+  Type.Literal('dashed'),
+  Type.Literal('dotted'),
+]);
+const TextAlign = Type.Union([
+  Type.Literal('left'),
+  Type.Literal('center'),
+  Type.Literal('right'),
+  Type.Literal('justify'),
+]);
+const VAlign = Type.Union([Type.Literal('top'), Type.Literal('middle'), Type.Literal('bottom')]);
+const TextType = Type.Union([
+  Type.Literal('title'),
+  Type.Literal('subtitle'),
+  Type.Literal('content'),
+  Type.Literal('item'),
+  Type.Literal('itemTitle'),
+  Type.Literal('notes'),
+  Type.Literal('header'),
+  Type.Literal('footer'),
+  Type.Literal('partNumber'),
+  Type.Literal('itemNumber'),
+]);
+const ImageType = Type.Union([
+  Type.Literal('pageFigure'),
+  Type.Literal('itemFigure'),
+  Type.Literal('background'),
+]);
+const ChartType = Type.Union([
+  Type.Literal('bar'),
+  Type.Literal('column'),
+  Type.Literal('line'),
+  Type.Literal('pie'),
+  Type.Literal('ring'),
+  Type.Literal('area'),
+  Type.Literal('radar'),
+  Type.Literal('scatter'),
+]);
+const LinePoint = Type.Union([Type.Literal(''), Type.Literal('arrow'), Type.Literal('dot')]);
+const ShapePathFormulas = Type.Union([
+  Type.Literal('roundRect'),
+  Type.Literal('roundRectDiagonal'),
+  Type.Literal('roundRectSingle'),
+  Type.Literal('roundRectSameSide'),
+  Type.Literal('cutRectDiagonal'),
+  Type.Literal('cutRectSingle'),
+  Type.Literal('cutRectSameSide'),
+  Type.Literal('cutRoundRect'),
+  Type.Literal('message'),
+  Type.Literal('roundMessage'),
+  Type.Literal('L'),
+  Type.Literal('ringRect'),
+  Type.Literal('plus'),
+  Type.Literal('triangle'),
+  Type.Literal('parallelogramLeft'),
+  Type.Literal('parallelogramRight'),
+  Type.Literal('trapezoid'),
+  Type.Literal('bullet'),
+  Type.Literal('indicator'),
+  Type.Literal('donut'),
+  Type.Literal('diagStripe'),
+]);
+
+const Point = Type.Tuple([Type.Number(), Type.Number()]);
+
+const Link = Type.Object(
+  {
+    type: Type.Union([Type.Literal('web'), Type.Literal('slide')]),
+    target: Type.String(),
+  },
+  { additionalProperties: false },
+);
+const Outline = Type.Object(
+  {
+    style: Type.Optional(LineStyleType),
+    width: optionalNumber(),
+    color: optionalString(),
+  },
+  { additionalProperties: false },
+);
+const Shadow = Type.Object(
+  {
+    h: optionalNumber(),
+    v: optionalNumber(),
+    blur: optionalNumber(),
+    color: optionalString(),
+  },
+  { additionalProperties: false },
+);
+const FullShadow = Type.Object(
+  {
+    h: Type.Number(),
+    v: Type.Number(),
+    blur: Type.Number(),
+    color: Type.String(),
+  },
+  { additionalProperties: false },
+);
+const GradientColor = Type.Object(
+  {
+    pos: Type.Number(),
+    color: Type.String(),
+  },
+  { additionalProperties: false },
+);
+const Gradient = Type.Object(
+  {
+    type: Type.Union([Type.Literal('linear'), Type.Literal('radial')]),
+    colors: Type.Array(GradientColor),
+    rotate: Type.Number(),
+  },
+  { additionalProperties: false },
+);
+const ShapeText = Type.Object(
+  {
+    content: optionalString(),
+    defaultFontName: optionalString(),
+    defaultColor: optionalString(),
+    align: Type.Optional(VAlign),
+    lineHeight: optionalNumber(),
+    wordSpace: optionalNumber(),
+    paragraphSpace: optionalNumber(),
+    type: Type.Optional(TextType),
+  },
+  { additionalProperties: false },
+);
+const FullShapeText = Type.Object(
+  {
+    content: Type.String(),
+    defaultFontName: Type.String(),
+    defaultColor: Type.String(),
+    align: VAlign,
+    lineHeight: optionalNumber(),
+    wordSpace: optionalNumber(),
+    paragraphSpace: optionalNumber(),
+    type: Type.Optional(TextType),
+  },
+  { additionalProperties: false },
+);
+const ImageFilters = Type.Object(
+  {
+    blur: optionalString(),
+    brightness: optionalString(),
+    contrast: optionalString(),
+    grayscale: optionalString(),
+    saturate: optionalString(),
+    'hue-rotate': optionalString(),
+    sepia: optionalString(),
+    invert: optionalString(),
+    opacity: optionalString(),
+  },
+  { additionalProperties: false },
+);
+const ImageClip = Type.Object(
+  {
+    range: Type.Tuple([Point, Point]),
+    shape: Type.String(),
+  },
+  { additionalProperties: false },
+);
+const ChartData = Type.Object(
+  {
+    labels: Type.Array(Type.String()),
+    legends: Type.Array(Type.String()),
+    series: Type.Array(Type.Array(Type.Number())),
+  },
+  { additionalProperties: false },
+);
+const ChartOptions = Type.Object(
+  {
+    lineSmooth: optionalBoolean(),
+    stack: optionalBoolean(),
+  },
+  { additionalProperties: false },
+);
+const TableCellStyle = Type.Object(
+  {
+    bold: optionalBoolean(),
+    em: optionalBoolean(),
+    underline: optionalBoolean(),
+    strikethrough: optionalBoolean(),
+    color: optionalString(),
+    backcolor: optionalString(),
+    fontsize: optionalString(),
+    fontname: optionalString(),
+    align: Type.Optional(TextAlign),
+  },
+  { additionalProperties: false },
+);
+const TableCellBorder = Type.Object(
+  {
+    width: Type.Number(),
+    style: LineStyleType,
+    color: Type.String(),
+  },
+  { additionalProperties: false },
+);
+const TableCell = Type.Object(
+  {
+    id: Type.String(),
+    colspan: Type.Number(),
+    rowspan: Type.Number(),
+    text: Type.String(),
+    style: Type.Optional(TableCellStyle),
+    padding: optionalString(),
+    vAlign: Type.Optional(VAlign),
+    borders: Type.Optional(
+      Type.Object(
+        {
+          top: Type.Optional(TableCellBorder),
+          bottom: Type.Optional(TableCellBorder),
+          left: Type.Optional(TableCellBorder),
+          right: Type.Optional(TableCellBorder),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+const TableTheme = Type.Object(
+  {
+    color: Type.String(),
+    rowHeader: Type.Boolean(),
+    rowFooter: Type.Boolean(),
+    colHeader: Type.Boolean(),
+    colFooter: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+const CodeLine = Type.Object(
+  {
+    id: Type.String(),
+    content: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+/**
+ * Fields shared by every element kind (from `PPTBaseElement`), minus `id` —
+ * identity is rejected before validation.
+ */
+const Common = {
+  left: optionalNumber(),
+  top: optionalNumber(),
+  lock: optionalBoolean(),
+  groupId: optionalString(),
+  width: optionalNumber(),
+  height: optionalNumber(),
+  rotate: optionalNumber(),
+  link: Type.Optional(Link),
+  name: optionalString(),
+};
+
+const TextElementPatch = Type.Object(
+  {
+    ...Common,
+    content: optionalString(),
+    defaultFontName: optionalString(),
+    defaultColor: optionalString(),
+    outline: Type.Optional(Outline),
+    fill: optionalString(),
+    lineHeight: optionalNumber(),
+    wordSpace: optionalNumber(),
+    opacity: optionalNumber(),
+    shadow: Type.Optional(Shadow),
+    paragraphSpace: optionalNumber(),
+    vertical: optionalBoolean(),
+    textType: Type.Optional(TextType),
+    vAlign: Type.Optional(VAlign),
+  },
+  { additionalProperties: false },
+);
+const ImageElementPatch = Type.Object(
+  {
+    ...Common,
+    fixedRatio: optionalBoolean(),
+    src: optionalString(),
+    outline: Type.Optional(Outline),
+    filters: Type.Optional(ImageFilters),
+    clip: Type.Optional(ImageClip),
+    flipH: optionalBoolean(),
+    flipV: optionalBoolean(),
+    shadow: Type.Optional(Shadow),
+    radius: optionalNumber(),
+    colorMask: optionalString(),
+    imageType: Type.Optional(ImageType),
+    softEdge: optionalNumber(),
+  },
+  { additionalProperties: false },
+);
+const ShapeElementPatch = Type.Object(
+  {
+    ...Common,
+    viewBox: Type.Optional(Point),
+    path: optionalString(),
+    fixedRatio: optionalBoolean(),
+    fill: optionalString(),
+    gradient: Type.Optional(Gradient),
+    pattern: optionalString(),
+    outline: Type.Optional(Outline),
+    opacity: optionalNumber(),
+    flipH: optionalBoolean(),
+    flipV: optionalBoolean(),
+    shadow: Type.Optional(Shadow),
+    special: optionalBoolean(),
+    text: Type.Optional(ShapeText),
+    pathFormula: Type.Optional(ShapePathFormulas),
+    keypoints: Type.Optional(Type.Array(Type.Number())),
+  },
+  { additionalProperties: false },
+);
+const LineElementPatch = Type.Object(
+  {
+    left: optionalNumber(),
+    top: optionalNumber(),
+    lock: optionalBoolean(),
+    groupId: optionalString(),
+    width: optionalNumber(),
+    link: Type.Optional(Link),
+    name: optionalString(),
+    start: Type.Optional(Point),
+    end: Type.Optional(Point),
+    style: Type.Optional(LineStyleType),
+    color: optionalString(),
+    points: Type.Optional(Type.Tuple([LinePoint, LinePoint])),
+    shadow: Type.Optional(Shadow),
+    broken: Type.Optional(Point),
+    broken2: Type.Optional(Point),
+    curve: Type.Optional(Point),
+    cubic: Type.Optional(Type.Tuple([Point, Point])),
+  },
+  { additionalProperties: false },
+);
+const ChartElementPatch = Type.Object(
+  {
+    ...Common,
+    fill: optionalString(),
+    chartType: Type.Optional(ChartType),
+    data: Type.Optional(ChartData),
+    options: Type.Optional(ChartOptions),
+    outline: Type.Optional(Outline),
+    themeColors: Type.Optional(Type.Array(Type.String())),
+    textColor: optionalString(),
+    lineColor: optionalString(),
+  },
+  { additionalProperties: false },
+);
+const TableElementPatch = Type.Object(
+  {
+    ...Common,
+    outline: Type.Optional(Outline),
+    theme: Type.Optional(TableTheme),
+    colWidths: Type.Optional(Type.Array(Type.Number())),
+    cellMinHeight: optionalNumber(),
+    rowHeights: Type.Optional(Type.Array(Type.Number())),
+    data: Type.Optional(Type.Array(Type.Array(TableCell))),
+  },
+  { additionalProperties: false },
+);
+const LatexElementPatch = Type.Object(
+  {
+    ...Common,
+    latex: optionalString(),
+    html: optionalString(),
+    path: optionalString(),
+    color: optionalString(),
+    strokeWidth: optionalNumber(),
+    viewBox: Type.Optional(Point),
+    fixedRatio: optionalBoolean(),
+    align: Type.Optional(
+      Type.Union([Type.Literal('left'), Type.Literal('center'), Type.Literal('right')]),
+    ),
+  },
+  { additionalProperties: false },
+);
+const VideoElementPatch = Type.Object(
+  {
+    ...Common,
+    src: optionalString(),
+    mediaRef: optionalString(),
+    autoplay: optionalBoolean(),
+    poster: optionalString(),
+    ext: optionalString(),
+  },
+  { additionalProperties: false },
+);
+const AudioElementPatch = Type.Object(
+  {
+    ...Common,
+    fixedRatio: optionalBoolean(),
+    color: optionalString(),
+    loop: optionalBoolean(),
+    autoplay: optionalBoolean(),
+    src: optionalString(),
+    ext: optionalString(),
+  },
+  { additionalProperties: false },
+);
+const CodeElementPatch = Type.Object(
+  {
+    ...Common,
+    language: optionalString(),
+    lines: Type.Optional(Type.Array(CodeLine)),
+    fileName: optionalString(),
+    showLineNumbers: optionalBoolean(),
+    fontSize: optionalNumber(),
+  },
+  { additionalProperties: false },
+);
+
+const ELEMENT_PATCH_SCHEMAS: Record<string, TSchema> = {
+  [ElementTypes.TEXT]: TextElementPatch,
+  [ElementTypes.IMAGE]: ImageElementPatch,
+  [ElementTypes.SHAPE]: ShapeElementPatch,
+  [ElementTypes.LINE]: LineElementPatch,
+  [ElementTypes.CHART]: ChartElementPatch,
+  [ElementTypes.TABLE]: TableElementPatch,
+  [ElementTypes.LATEX]: LatexElementPatch,
+  [ElementTypes.VIDEO]: VideoElementPatch,
+  [ElementTypes.AUDIO]: AudioElementPatch,
+  [ElementTypes.CODE]: CodeElementPatch,
+};
+
+const BASE_REQUIRED = ['left', 'top', 'width', 'height', 'rotate'];
+
+/**
+ * Build a creation schema from the matching patch schema so both operations
+ * accept exactly the same field vocabulary. `required` restores the fields
+ * that are mandatory on the full DSL element; nested objects that are partial
+ * during a deep merge are tightened through `overrides` for creation.
+ */
+function fullElementSchema(
+  type: string,
+  patch: { properties: Record<string, TSchema> },
+  required: string[],
+  overrides: Record<string, TSchema> = {},
+): TSchema {
+  const schema = Type.Object(
+    {
+      type: Type.Literal(type),
+      ...patch.properties,
+      ...overrides,
+    },
+    { additionalProperties: false },
+  );
+  return { ...schema, required: ['type', ...required] };
+}
+
+const TextElementInput = fullElementSchema(
+  ElementTypes.TEXT,
+  TextElementPatch,
+  [...BASE_REQUIRED, 'content', 'defaultFontName', 'defaultColor'],
+  { shadow: Type.Optional(FullShadow) },
+);
+const ImageElementInput = fullElementSchema(
+  ElementTypes.IMAGE,
+  ImageElementPatch,
+  [...BASE_REQUIRED, 'fixedRatio', 'src'],
+  { shadow: Type.Optional(FullShadow) },
+);
+const ShapeElementInput = fullElementSchema(
+  ElementTypes.SHAPE,
+  ShapeElementPatch,
+  [...BASE_REQUIRED, 'viewBox', 'path', 'fixedRatio', 'fill'],
+  { shadow: Type.Optional(FullShadow), text: Type.Optional(FullShapeText) },
+);
+const LineElementInput = fullElementSchema(
+  ElementTypes.LINE,
+  LineElementPatch,
+  ['left', 'top', 'width', 'start', 'end', 'style', 'color', 'points'],
+  { shadow: Type.Optional(FullShadow) },
+);
+const ChartElementInput = fullElementSchema(ElementTypes.CHART, ChartElementPatch, [
+  ...BASE_REQUIRED,
+  'chartType',
+  'data',
+  'themeColors',
+]);
+const TableElementInput = fullElementSchema(ElementTypes.TABLE, TableElementPatch, [
+  ...BASE_REQUIRED,
+  'outline',
+  'colWidths',
+  'cellMinHeight',
+  'data',
+]);
+const LatexElementInput = fullElementSchema(ElementTypes.LATEX, LatexElementPatch, [
+  ...BASE_REQUIRED,
+  'latex',
+]);
+const VideoElementInput = fullElementSchema(ElementTypes.VIDEO, VideoElementPatch, [
+  ...BASE_REQUIRED,
+  'autoplay',
+]);
+const AudioElementInput = fullElementSchema(ElementTypes.AUDIO, AudioElementPatch, [
+  ...BASE_REQUIRED,
+  'fixedRatio',
+  'color',
+  'loop',
+  'autoplay',
+  'src',
+]);
+const CodeElementInput = fullElementSchema(ElementTypes.CODE, CodeElementPatch, [
+  ...BASE_REQUIRED,
+  'language',
+  'lines',
+]);
+
+/** Complete element JSON accepted by `add_element`; `id` is server-assigned. */
+export const SlideElementInputSchema = Type.Union(
+  [
+    TextElementInput,
+    ImageElementInput,
+    ShapeElementInput,
+    LineElementInput,
+    ChartElementInput,
+    TableElementInput,
+    LatexElementInput,
+    VideoElementInput,
+    AudioElementInput,
+    CodeElementInput,
+  ],
+  {
+    description:
+      'One COMPLETE slide element JSON without id. The server validates it and assigns id.',
+  },
+);
+
+function persistedElementSchema(schema: TSchema): TSchema {
+  const object = schema as TSchema & {
+    properties: Record<string, TSchema>;
+    required?: string[];
+  };
+  const persisted = Type.Object(
+    {
+      id: Type.String(),
+      ...object.properties,
+    },
+    { additionalProperties: false },
+  );
+  return { ...persisted, required: ['id', ...(object.required ?? [])] };
+}
+
+/** Complete persisted element JSON, including the server-owned id. */
+const PersistedSlideElementSchema = Type.Union([
+  persistedElementSchema(TextElementInput),
+  persistedElementSchema(ImageElementInput),
+  persistedElementSchema(ShapeElementInput),
+  persistedElementSchema(LineElementInput),
+  persistedElementSchema(ChartElementInput),
+  persistedElementSchema(TableElementInput),
+  persistedElementSchema(LatexElementInput),
+  persistedElementSchema(VideoElementInput),
+  persistedElementSchema(AudioElementInput),
+  persistedElementSchema(CodeElementInput),
+]);
+
+const SlideThemeSchema = Type.Object(
+  {
+    backgroundColor: Type.String(),
+    themeColors: Type.Array(Type.String()),
+    fontColor: Type.String(),
+    fontName: Type.String(),
+    outline: Type.Optional(Outline),
+    shadow: Type.Optional(FullShadow),
+  },
+  { additionalProperties: false },
+);
+const SlideBackgroundSchema = Type.Object(
+  {
+    type: Type.Union([Type.Literal('solid'), Type.Literal('image'), Type.Literal('gradient')]),
+    color: Type.Optional(Type.String()),
+    image: Type.Optional(
+      Type.Object(
+        {
+          src: Type.String(),
+          size: Type.Union([
+            Type.Literal('cover'),
+            Type.Literal('contain'),
+            Type.Literal('repeat'),
+          ]),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    gradient: Type.Optional(Gradient),
+  },
+  { additionalProperties: false },
+);
+const SlideAnimationSchema = Type.Object(
+  {
+    id: Type.String(),
+    elId: Type.String(),
+    effect: Type.String(),
+    type: Type.Union([Type.Literal('in'), Type.Literal('out'), Type.Literal('attention')]),
+    duration: Type.Number(),
+    trigger: Type.Union([Type.Literal('click'), Type.Literal('meantime'), Type.Literal('auto')]),
+  },
+  { additionalProperties: false },
+);
+const SlideCanvasSchema = Type.Object(
+  {
+    id: Type.String(),
+    viewportSize: Type.Number(),
+    viewportRatio: Type.Number(),
+    theme: SlideThemeSchema,
+    elements: Type.Array(PersistedSlideElementSchema),
+    background: Type.Optional(SlideBackgroundSchema),
+    animations: Type.Optional(Type.Array(SlideAnimationSchema)),
+    turningMode: Type.Optional(
+      Type.Union(
+        [
+          'no',
+          'fade',
+          'slideX',
+          'slideY',
+          'random',
+          'slideX3D',
+          'slideY3D',
+          'rotate',
+          'scaleY',
+          'scaleX',
+          'scale',
+          'scaleReverse',
+        ].map((mode) => Type.Literal(mode)),
+      ),
+    ),
+    sectionTag: Type.Optional(
+      Type.Object(
+        { id: Type.String(), title: Type.Optional(Type.String()) },
+        { additionalProperties: false },
+      ),
+    ),
+    type: Type.Optional(
+      Type.Union(
+        ['cover', 'contents', 'transition', 'content', 'end'].map((type) => Type.Literal(type)),
+      ),
+    ),
+    script: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+/**
+ * Validate a patch against the resolved element's type schema. Returns a list
+ * of human-readable issues (empty when the patch is in contract).
+ */
+export function validateElementPatch(type: string, patch: Record<string, unknown>): string[] {
+  const schema = ELEMENT_PATCH_SCHEMAS[type];
+  if (!schema) return [`element type ${JSON.stringify(type)} is out of contract`];
+  if (Check(schema, patch)) return [];
+  return Errors(schema, patch).map((error) => `patch${error.instancePath || ''}: ${error.message}`);
+}
+
+/** Validate a complete, id-less element before the server assigns identity. */
+export function validateElementInput(element: unknown): string[] {
+  if (Check(SlideElementInputSchema, element)) return [];
+  return Errors(SlideElementInputSchema, element).map(
+    (error) => `element${error.instancePath || ''}: ${error.message}`,
+  );
+}
+
+/** Validate the entire patched canvas, rejecting unknown fields at every level. */
+export function validateSlideCanvas(canvas: unknown): string[] {
+  if (Check(SlideCanvasSchema, canvas)) return [];
+  return Errors(SlideCanvasSchema, canvas).map(
+    (error) => `canvas${error.instancePath || ''}: ${error.message}`,
+  );
+}

--- a/lib/server/agent-runtime/course-edit/media-byte-omission.ts
+++ b/lib/server/agent-runtime/course-edit/media-byte-omission.ts
@@ -1,0 +1,384 @@
+/**
+ * Inline media below this decoded-byte limit stays visible to the model. Small
+ * icons are cheap and occasionally useful; larger payloads are opaque token
+ * waste and are represented by a read-only placeholder instead.
+ */
+export const READ_SCENE_INLINE_MEDIA_BYTE_LIMIT = 2 * 1024;
+
+export const PLACEHOLDER_PREFIX = '<';
+export const PLACEHOLDER_MARKER = ' bytes omitted:';
+export const PLACEHOLDER_SUFFIX =
+  'read-only placeholder; to replace it, write a new media src/URL at this path>';
+
+export interface OmittedMediaBytes {
+  path: string;
+  placeholder: string;
+}
+
+interface InlineMedia {
+  mime: string;
+  /** Decoded byte length, computed arithmetically — never a full decode. */
+  byteLength: number;
+  /**
+   * Pixel dimensions read from a FIXED header prefix (PNG/GIF) when the
+   * format and payload allow; null when unavailable (e.g. JPEG's variable
+   * marker walk, or a non-image mime).
+   */
+  dimensions: [number, number] | null;
+}
+
+function escapePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+function isHexDigit(code: number): boolean {
+  return (
+    (code >= 0x30 && code <= 0x39) || // 0-9
+    (code >= 0x41 && code <= 0x46) || // A-F
+    (code >= 0x61 && code <= 0x66) // a-f
+  );
+}
+
+function hexValue(code: number): number {
+  if (code >= 0x30 && code <= 0x39) return code - 0x30;
+  if (code >= 0x41 && code <= 0x46) return code - 0x41 + 10;
+  return code - 0x61 + 10; // a-f
+}
+
+/**
+ * Arithmetic decoded-byte length of a base64 payload, WITHOUT decoding it.
+ * Valid base64 encodes 3 bytes per 4 chars; each trailing `=` pads 0 bytes,
+ * so the length is `floor(chars * 3 / 4) - padding` — exactly what
+ * `Buffer.from(payload, 'base64').byteLength` returns, minus the full-buffer
+ * allocation (cr#7 R7-P2-3: the grep/read projection previously decoded every
+ * inline media byte before its budget check even started).
+ *
+ * The regex validity scan is kept verbatim from the old decoder: it is a pure
+ * string scan with no large allocation. Whitespace is stripped only when
+ * actually present, so a whitespace-free megabyte payload stays zero-copy.
+ */
+function base64ByteLength(payload: string): number | null {
+  const compact = /\s/.test(payload) ? payload.replace(/\s/g, '') : payload;
+  if (compact.length === 0 || !/^[A-Za-z0-9+/_-]*={0,2}$/.test(compact)) return null;
+  let padding = 0;
+  for (let i = compact.length - 1; i >= 0 && compact.charCodeAt(i) === 0x3d; i--) padding += 1;
+  return Math.floor((compact.length * 3) / 4) - padding;
+}
+
+/**
+ * Arithmetic UTF-8 byte length of a percent-encoded (non-base64) data-URI
+ * payload, WITHOUT materializing the decoded string: each `%XX` escape is one
+ * byte, every other code point counts its UTF-8 length (surrogate pairs count
+ * the 4 bytes they encode to).
+ *
+ * The `%XX` escapes must ALSO decode to valid UTF-8, exactly as
+ * `decodeURIComponent` verifies them before the old decoder saw the string:
+ * the old implementation fell back to the raw length when that call threw,
+ * and counting `%FF`/truncated/overlong escapes as 1 byte each would
+ * undercount by up to 3× and silently bypass the omission limit (cr#8 P2).
+ * An allocation-free UTF-8 state machine therefore validates the decoded
+ * percent byte stream — consecutive escapes form one run, a literal character
+ * ends it — and ANY violation (orphan continuation byte, overlong encoding,
+ * surrogate encoding, > U+10FFFF, or a sequence truncated at a literal or the
+ * end of the payload) returns the raw UTF-8 length immediately: the exact
+ * old catch-fallback, conservative because it can only overestimate.
+ */
+export function percentDecodedUtf8Length(payload: string): number {
+  let length = 0;
+  // In-flight multi-byte sequence state: continuation bytes still expected,
+  // and the per-sequence bounds of its first continuation byte (stricter than
+  // 0x80-0xbf for E0/F0 overlongs and ED/F4 surrogate/out-of-range guards).
+  let need = 0;
+  let secondMin = 0x80;
+  let secondMax = 0xbf;
+
+  function feedPercentByte(byte: number): boolean {
+    if (need > 0) {
+      // The per-sequence bounds apply ONLY to the first continuation byte;
+      // reset them right after, so later continuations use the plain
+      // 0x80-0xbf range.
+      if ((byte & 0xc0) !== 0x80 || byte < secondMin || byte > secondMax) return false;
+      need -= 1;
+      secondMin = 0x80;
+      secondMax = 0xbf;
+      return true;
+    }
+    if (byte < 0x80) return true; // ASCII
+    if (byte >= 0xc2 && byte <= 0xdf) {
+      need = 1;
+      return true;
+    }
+    if (byte >= 0xe0 && byte <= 0xef) {
+      need = 2;
+      if (byte === 0xe0)
+        secondMin = 0xa0; // reject overlong U+0000..U+07FF
+      else if (byte === 0xed) secondMax = 0x9f; // reject surrogates U+D800..U+DFFF
+      return true;
+    }
+    if (byte >= 0xf0 && byte <= 0xf4) {
+      need = 3;
+      if (byte === 0xf0)
+        secondMin = 0x90; // reject overlong U+0000..U+FFFF
+      else if (byte === 0xf4) secondMax = 0x8f; // reject > U+10FFFF
+      return true;
+    }
+    return false; // orphan continuation 0x80-0xbf, overlong 0xc0/0xc1, 0xf5+
+  }
+
+  for (let i = 0; i < payload.length; i++) {
+    const code = payload.charCodeAt(i);
+    if (code === 0x25) {
+      if (
+        i + 2 < payload.length &&
+        isHexDigit(payload.charCodeAt(i + 1)) &&
+        isHexDigit(payload.charCodeAt(i + 2))
+      ) {
+        const byte =
+          (hexValue(payload.charCodeAt(i + 1)) << 4) | hexValue(payload.charCodeAt(i + 2));
+        if (!feedPercentByte(byte)) {
+          // decodeURIComponent would throw URIError: mirror the old
+          // catch-fallback to the raw string. Buffer.byteLength allocates
+          // nothing.
+          return Buffer.byteLength(payload, 'utf8');
+        }
+        length += 1;
+        i += 2;
+        continue;
+      }
+      // Malformed escape: decodeURIComponent would throw; mirror the old
+      // catch-fallback to the raw string. Buffer.byteLength allocates nothing.
+      return Buffer.byteLength(payload, 'utf8');
+    }
+    // A literal character ends the percent byte run; an in-flight sequence at
+    // that point is the truncated error decodeURIComponent raises for
+    // e.g. '%E4%B8a'.
+    if (need > 0) return Buffer.byteLength(payload, 'utf8');
+    if (code < 0x80) length += 1;
+    else if (code < 0x800) length += 2;
+    else if (code < 0xd800 || code > 0xdfff) length += 3;
+    else if (code < 0xdc00 && i + 1 < payload.length) {
+      const next = payload.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        length += 4;
+        i += 1;
+      } else {
+        length += 3; // lone high surrogate
+      }
+    } else {
+      length += 3; // lone low surrogate
+    }
+  }
+  // Truncated multi-byte sequence at the end of the payload: '%E4%B8'.
+  if (need > 0) return Buffer.byteLength(payload, 'utf8');
+  return length;
+}
+
+/**
+ * Decode only a FIXED header prefix of a base64 payload (≤ 32 chars → 24
+ * bytes) — enough for the PNG/GIF dimension fields without materializing the
+ * whole payload. The caller has already validated the payload; the prefix is
+ * chunk-aligned (a multiple of 4 chars), so the slice is always well-formed.
+ */
+function decodeBase64Prefix(payload: string, byteCount: number): Uint8Array | null {
+  const chars = Math.ceil(byteCount / 3) * 4;
+  if (payload.length < chars) return null;
+  return Buffer.from(payload.slice(0, chars), 'base64').subarray(0, byteCount);
+}
+
+function decodedDataUri(value: string): InlineMedia | null {
+  const match = /^data:([^;,]+)?((?:;[^,]*)*),([\s\S]*)$/i.exec(value);
+  if (!match) return null;
+  const mime = match[1] || 'application/octet-stream';
+  const metadata = match[2] ?? '';
+  const payload = match[3] ?? '';
+  if (/;base64(?:;|$)/i.test(metadata)) {
+    const byteLength = base64ByteLength(payload);
+    return byteLength === null
+      ? null
+      : { mime, byteLength, dimensions: mediaDimensions(mime, payload) };
+  }
+  return { mime, byteLength: percentDecodedUtf8Length(payload), dimensions: null };
+}
+
+function pngDimensions(bytes: Uint8Array | null): [number, number] | null {
+  if (
+    !bytes ||
+    bytes.length < 24 ||
+    bytes[0] !== 0x89 ||
+    bytes[1] !== 0x50 ||
+    bytes[2] !== 0x4e ||
+    bytes[3] !== 0x47
+  ) {
+    return null;
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return [view.getUint32(16), view.getUint32(20)];
+}
+
+function gifDimensions(bytes: Uint8Array | null): [number, number] | null {
+  if (!bytes || bytes.length < 10 || String.fromCharCode(...bytes.slice(0, 3)) !== 'GIF') {
+    return null;
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return [view.getUint16(6, true), view.getUint16(8, true)];
+}
+
+/**
+ * Pixel dimensions of an image payload, reading ONLY fixed-offset headers:
+ * PNG (24-byte header, dimensions at 16–23) and GIF (10-byte header,
+ * dimensions at 6–9). The JPEG marker walk needs a VARIABLE-length header
+ * read, so JPEG dimensions are omitted — the placeholder carries mime and the
+ * byte count either way (cr#7 R7-P2-3 ruling: read a fixed header, omit the
+ * dimensions when they cannot be obtained from one).
+ */
+function mediaDimensions(mime: string, payload: string): [number, number] | null {
+  if (!mime.toLowerCase().startsWith('image/')) return null;
+  return (
+    pngDimensions(decodeBase64Prefix(payload, 24)) ?? gifDimensions(decodeBase64Prefix(payload, 10))
+  );
+}
+
+function mediaKind(mime: string): string {
+  const kind = mime.split('/', 1)[0]?.toLowerCase();
+  return kind === 'image' || kind === 'video' || kind === 'audio' ? kind : 'media';
+}
+
+function placeholderFor(media: InlineMedia): string {
+  const parts = [media.mime];
+  if (media.dimensions) parts.push(`${media.dimensions[0]}×${media.dimensions[1]}`);
+  parts.push(`${media.byteLength} bytes`);
+  return `${PLACEHOLDER_PREFIX}${mediaKind(media.mime)}${PLACEHOLDER_MARKER} ${parts.join(
+    ', ',
+  )}; ${PLACEHOLDER_SUFFIX}`;
+}
+
+function inferredMime(key: string | undefined, parentType: unknown, path: string): string {
+  if (key === 'poster' || /\/background\/image\/src$/.test(path)) return 'image/unknown';
+  if (parentType === 'image' || /image(?:Data|Bytes|Base64)/i.test(key ?? '')) {
+    return 'image/unknown';
+  }
+  if (parentType === 'video' || key === 'mediaRef') return 'video/unknown';
+  if (parentType === 'audio') return 'audio/unknown';
+  return 'application/octet-stream';
+}
+
+function isMediaByteField(key: string | undefined, parentType: unknown, path: string): boolean {
+  if (/\/background\/image\/src$/.test(path)) return true;
+  if (['src', 'mediaRef', 'poster'].includes(key ?? '')) {
+    return ['image', 'video', 'audio'].includes(String(parentType)) || key === 'poster';
+  }
+  return /(?:base64|b64|bytesBase64Encoded|imageData|imageBytes|videoData|audioData)/i.test(
+    key ?? '',
+  );
+}
+
+const EMBEDDED_BASE64_DATA_URI =
+  /data:([a-z]+\/[a-z0-9.+-]+)((?:;[^,;\s"')}]*)*;base64),([A-Za-z0-9+/_=-]+)/gi;
+
+function omitString(
+  value: string,
+  key: string | undefined,
+  parentType: unknown,
+  path: string,
+  omitted: OmittedMediaBytes[],
+): string {
+  const exactDataUri = decodedDataUri(value);
+  if (exactDataUri && exactDataUri.byteLength > READ_SCENE_INLINE_MEDIA_BYTE_LIMIT) {
+    const placeholder = placeholderFor(exactDataUri);
+    omitted.push({ path, placeholder });
+    return placeholder;
+  }
+
+  if (isMediaByteField(key, parentType, path)) {
+    const byteLength = base64ByteLength(value);
+    if (byteLength !== null && byteLength > READ_SCENE_INLINE_MEDIA_BYTE_LIMIT) {
+      const mime = inferredMime(key, parentType, path);
+      const placeholder = placeholderFor({
+        mime,
+        byteLength,
+        dimensions: mediaDimensions(mime, value),
+      });
+      omitted.push({ path, placeholder });
+      return placeholder;
+    }
+  }
+
+  return value.replace(
+    EMBEDDED_BASE64_DATA_URI,
+    (match, mime: string, _metadata: string, payload: string) => {
+      const byteLength = base64ByteLength(payload);
+      if (byteLength === null || byteLength <= READ_SCENE_INLINE_MEDIA_BYTE_LIMIT) return match;
+      const placeholder = placeholderFor({
+        mime,
+        byteLength,
+        dimensions: mediaDimensions(mime, payload),
+      });
+      omitted.push({ path, placeholder });
+      return placeholder;
+    },
+  );
+}
+
+/**
+ * Build a read-only JSON projection with large inline media bytes omitted.
+ * The input is never mutated, so persisted scenes and their JSON Pointer
+ * address space remain byte-for-byte unchanged.
+ */
+export function omitReadSceneMediaBytes<T>(input: T): {
+  value: T;
+  omitted: OmittedMediaBytes[];
+} {
+  const omitted: OmittedMediaBytes[] = [];
+
+  function visit(value: unknown, path: string, key?: string, parentType?: unknown): unknown {
+    if (typeof value === 'string') return omitString(value, key, parentType, path, omitted);
+    if (Array.isArray(value)) {
+      return value.map((item, index) => visit(item, `${path}/${index}`, String(index)));
+    }
+    if (value === null || typeof value !== 'object') return value;
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(record).map(([childKey, childValue]) => [
+        childKey,
+        visit(
+          childValue,
+          `${path}/${escapePointerToken(childKey)}`,
+          childKey,
+          record.type ?? parentType,
+        ),
+      ]),
+    );
+  }
+
+  return { value: visit(input, '') as T, omitted };
+}
+
+/** Reject copying any read-only omission placeholder into a persisted patch. */
+export function containsReadSceneMediaPlaceholder(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return (
+      value.includes(PLACEHOLDER_PREFIX) &&
+      value.includes(PLACEHOLDER_MARKER) &&
+      value.includes(PLACEHOLDER_SUFFIX)
+    );
+  }
+  if (Array.isArray(value)) return value.some(containsReadSceneMediaPlaceholder);
+  if (value === null || typeof value !== 'object') return false;
+  return Object.values(value as Record<string, unknown>).some(containsReadSceneMediaPlaceholder);
+}
+
+/**
+ * Detect the `<… bytes omitted` signature of a read-side media omission
+ * placeholder even when only a fragment of the placeholder text is present.
+ * An anchor built from a placeholder fragment cannot exist in the stored
+ * value; flag it before the generic occurrence check so the model gets the
+ * actionable "choose an anchor outside omitted regions" error.
+ */
+export function containsReadScenePlaceholderFragment(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.includes(PLACEHOLDER_PREFIX) && value.includes(PLACEHOLDER_MARKER);
+  }
+  if (Array.isArray(value)) return value.some(containsReadScenePlaceholderFragment);
+  if (value === null || typeof value !== 'object') return false;
+  return Object.values(value as Record<string, unknown>).some(containsReadScenePlaceholderFragment);
+}

--- a/lib/server/agent-runtime/course-tools.ts
+++ b/lib/server/agent-runtime/course-tools.ts
@@ -1,0 +1,186 @@
+/**
+ * The stage read/patch toolset — the agent's document-level DSL surface.
+ *
+ * This slice wires the three generic stage tools (`read_stage`, `patch_stage`,
+ * `grep_stage` from `./dsl-tools`) and the stage-level CRUD they need
+ * (`create_stage`, `read_stage_outline` from `./curriculum-tools`) into the
+ * background runner. Generation, media, page-list and folder tools belong to
+ * later slices and are deliberately NOT registered here.
+ *
+ * What this layer owns:
+ *
+ *  - **Owner-scoped writes.** Every tool receives ONE store bound to the run's
+ *    session owner (`pgDocuments.forOwner(ownerId)` in `runner.ts`). The owner
+ *    never appears in a model-visible parameter; a stage owned by another
+ *    owner reads as missing and cannot be written.
+ *  - **Sequential scheduling for document writers.** `patch_stage` loads the
+ *    whole document, applies its change in memory and writes the scene back.
+ *    The agent routinely emits several writers as PARALLEL tool calls in one
+ *    turn, and then they all load the same snapshot and overwrite each other —
+ *    the last writer wins, every sibling op is lost while still reporting
+ *    success. The write set is derived from the shared
+ *    `STAGE_WRITER_TOOL_NAMES` registry (the same list that arms client-side
+ *    write ownership) and declared `executionMode: 'sequential'` to pi, so a
+ *    batch containing a writer runs entirely sequentially and reads next to a
+ *    write observe committed state.
+ *  - **The DSL compatibility prompt block.** `DSL_TOOLS_PROMPT` teaches the
+ *    model the current tool names (legacy transcripts named the retired
+ *    per-type editors) and is layered into every runner prompt by
+ *    `buildRunnerCoursePrompt` (runner-contract.ts).
+ */
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { DocumentStore, MaicDocument } from '@openmaic/storage';
+import type { Stage } from '@openmaic/dsl';
+
+import type { Scene } from '@/lib/types/stage';
+import { STAGE_WRITER_TOOL_NAMES } from '@/lib/agent-runtime/stage-writer-tools';
+import { buildDslCourseTools, DSL_COURSE_TOOL_NAMES } from './dsl-tools';
+import { CURRICULUM_ALLOWLIST } from './curriculum-tools';
+
+export type CourseDocument = MaicDocument<Scene, Stage>;
+export type CourseStore = DocumentStore<Scene, Stage>;
+
+/** Progress metadata emitted on the durable `checkpoint` channel after a write. */
+export interface CheckpointInfo {
+  tool: string;
+  detail: string;
+  /** The stage the checkpoint wrote to — unlocks the workbench's real-time
+   * sync for courses that were opened, not minted, by this session. */
+  stageId?: string;
+  sceneId?: string;
+  order?: number;
+  title?: string;
+  sceneType?: string;
+}
+
+export interface CourseToolDeps {
+  /** The owner-bound document store of the run's session owner. */
+  store: CourseStore;
+  /** Emitted after a successful document write (the durable `checkpoint` event). */
+  onCheckpoint: (info: CheckpointInfo) => void;
+  /** The session id, recorded on the document as the producer reference. */
+  sessionId?: string;
+}
+
+/**
+ * Every tool in this toolset that is a read-modify-write of the persisted
+ * course document: it loads the document (or one scene), applies its change in
+ * memory, and writes a whole scene or the whole document back.
+ *
+ * Derived from the shared `STAGE_WRITER_TOOL_NAMES` (the same list that arms
+ * client-side write ownership) so the scheduler and the workbench can never
+ * disagree about who writes. `rename_stage` is excluded here only because it
+ * belongs to the curriculum toolset and never runs through this toolset's
+ * scheduler.
+ */
+export const DOCUMENT_WRITING_TOOLS: ReadonlySet<string> = new Set<string>(
+  [...STAGE_WRITER_TOOL_NAMES].filter((name) => name !== 'rename_stage'),
+);
+
+/**
+ * Declare the document writers as `executionMode: 'sequential'`.
+ *
+ * None of them takes a lock: each is `load whole document → apply one op in
+ * memory → write the whole scene back`. The agent routinely emits several of
+ * them for one page as PARALLEL tool calls in a single turn, and then they all
+ * load the same snapshot and overwrite each other. The damage is silent — the
+ * last writer wins, every sibling op is lost while still reporting success, and
+ * an element added by one call is erased by a sibling whose snapshot predates
+ * it.
+ *
+ * pi is the scheduler, so the requirement is declared to pi rather than
+ * hand-rolled here: in `executeToolCalls` (pi-agent-core agent-loop.js) a batch
+ * containing ANY call to a `sequential` tool runs entirely through
+ * `executeToolCallsSequential`. That is deliberately stronger than serializing
+ * only the writers against each other — it also orders the READS in the same
+ * batch, so a `read_stage` next to an edit observes committed state instead of
+ * the pre-write snapshot, which is the other half of what made the agent loop.
+ *
+ * The cost is that a batch mixing a write with otherwise-parallel reads loses
+ * that parallelism. That is the intended trade: a lost write is not
+ * self-correcting, a slower turn is.
+ */
+export function markDocumentWritersSequential(
+  tools: AgentTool<never, never>[],
+): AgentTool<never, never>[] {
+  return tools.map((tool) => {
+    const named = tool as unknown as { name: string };
+    if (!DOCUMENT_WRITING_TOOLS.has(named.name)) return tool;
+    return { ...tool, executionMode: 'sequential' } as unknown as AgentTool<never, never>;
+  });
+}
+
+/**
+ * The stage read/patch toolset registered on the runner: the three generic DSL
+ * tools, with `patch_stage` marked sequential through the shared writer
+ * registry.
+ */
+export function buildDslCourseToolset(deps: CourseToolDeps): AgentTool<never, never>[] {
+  return markDocumentWritersSequential(buildDslCourseTools(deps));
+}
+
+/** The exact registered tool names of this slice's toolset. */
+export function buildCourseAllowlist(): ReadonlySet<string> {
+  return new Set([...DSL_COURSE_TOOL_NAMES, ...CURRICULUM_ALLOWLIST]);
+}
+
+export const DSL_TOOLS_PROMPT = [
+  'Some installed skills and older transcripts were written for earlier tool names. Translate on sight: read_scene → read_stage (path=/scenes/<order|id>); edit_slide / edit_quiz / edit_widget / edit_actions / edit_pbl → patch_stage (same JSON-pointer ops, target the scene); read_course → read_stage; patch_course → patch_stage; grep_course → grep_stage. Never call the legacy names.',
+  'The generic DSL tools replace read_scene and the per-type edit tools.',
+  'Every read_stage, patch_stage and grep_stage call requires an explicit stageId obtained from create_stage.',
+  'Example: read_stage {"stageId":"stage-...","path":"/scenes/1","detail":"source"}. Use paths "", /outline, /scenes/<1-based order|sceneId>, and /scenes/<...>/actions.',
+  'Before patching a structure you have not touched, read the stage-dsl skill and its matching reference chapter.',
+  'Always read_stage detail:"source" for the target, patch_stage with the smallest /content/... or /actions/... JSON Pointer, then read_stage again to verify.',
+  'For one targeted change inside a large HTML or long text field, use patch_stage op "str_replace" (path, oldText, newText; set replaceAll only when the anchor repeats) instead of rewriting the whole field with set.',
+  'Use grep_stage for literal stage-wide text/source search.',
+  'Start with detail:"tree" to see structure; read source only for the subtree you will edit; for long content, prefer grep_stage over paging with offset.',
+].join(' ');
+
+/** Base runner identity/environment lines, shared by every runner prompt. */
+export const COURSE_SYSTEM_PROMPT = [
+  'You are a capable assistant working in a durable background session.',
+  'Complete the user request carefully and explain the result clearly.',
+  'The conversation may pause, restart on another worker, or receive follow-up messages.',
+  'Treat earlier conversation messages as durable context.',
+  'Do not claim access to tools or data that are not present in this session.',
+  'Use ask_user only when a decision genuinely belongs to the user.',
+  'Make every question self-contained and concise.',
+  'Offer stable, unique option ids when choices are useful.',
+  'After ask_user succeeds, stop and wait for the next user message.',
+  'Do not answer your own question or invent the user decision.',
+  'If no clarification is needed, answer directly without calling a tool.',
+  'Follow later user messages as updates to the same conversation.',
+  'Be honest about uncertainty and unavailable capabilities.',
+  "Reply in the user's language unless the user requests another language.",
+].join('\n');
+
+interface CoursePromptBlocks {
+  /** Pi's native `<available_skills>` discovery block. */
+  availableSkills?: string;
+  /** Multi-stage workflow guidance (explicit stage ids and folders). */
+  curriculum?: string;
+  /** Present exactly when the web_search tool is registered. */
+  search?: string;
+  /** Policy boundary for content fetched from session-observed URLs. */
+  untrustedContent?: string;
+  /** fetch_url usage guidance (the tool is always registered). */
+  fetch?: string;
+  /** Compatibility guidance for installed legacy skills and resumed transcripts. */
+  dslTools?: string;
+}
+
+/**
+ * The agent's system prompt, assembled from the capabilities this session
+ * actually has. The DSL compatibility block is always present; every other
+ * block is included only when the corresponding capability is registered.
+ */
+export function courseSystemPrompt(blocks: CoursePromptBlocks): string {
+  const parts = [COURSE_SYSTEM_PROMPT];
+  if (blocks.availableSkills) parts.push('', blocks.availableSkills);
+  if (blocks.curriculum) parts.push('', blocks.curriculum);
+  if (blocks.search) parts.push('', blocks.search);
+  if (blocks.dslTools) parts.push('', blocks.dslTools);
+  if (blocks.fetch) parts.push('', blocks.fetch);
+  if (blocks.untrustedContent) parts.push('', blocks.untrustedContent);
+  return parts.join('\n');
+}

--- a/lib/server/agent-runtime/curriculum-tools.ts
+++ b/lib/server/agent-runtime/curriculum-tools.ts
@@ -1,0 +1,268 @@
+/**
+ * Multi-stage curriculum tools — the backend half of "user says '7 days of
+ * python', ONE agent session runs start to finish": create stages (one class
+ * per unit/day) and read cross-stage outlines for chaining.
+ *
+ * This slice ports ONLY `create_stage` and `read_stage_outline` from the
+ * reference curriculum toolset. The folder tools (`create_folder`,
+ * `move_to_folder`), `rename_stage` and `list_folder_stages` belong to the
+ * folder slice and are deliberately absent here, so `create_stage` never takes
+ * a `folderId` (a stage is always created ungrouped until the folder slice
+ * lands).
+ *
+ * Every tool is scoped to the run's owner: the store handed to these tools is
+ * the owner-bound `PgDocumentStore` (`documentStore.forOwner(ownerId)`), so a
+ * foreign stage is indistinguishable from a missing one — fail-closed, never
+ * confirming another tenant's id. Every execute takes pi's 3rd `signal`
+ * argument and re-checks it at each IO boundary.
+ */
+import { Type, type Static } from 'typebox';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { StageLinkLifecycleData } from '@/lib/agent-runtime/lifecycle';
+
+import type { AppDocumentOutline } from '@/lib/document-store/persistence-types';
+import type { CourseDocument, CourseStore } from './course-tools';
+import { stageIdForCall } from './course-stage';
+import { mergeStageOutline } from './course-outline-union';
+
+export { stageIdForCall } from './course-stage';
+
+// ── Tool deps ─────────────────────────────────────────────────────────────────
+
+export interface CurriculumToolDeps {
+  /** The owner-bound document store of the run's session owner. */
+  store: CourseStore;
+  /** The session owner; every stage access is scoped to it by the store. */
+  ownerId: string;
+  sessionId: string;
+  /** Fired whenever a tool produces or returns a classroom link. */
+  onStageLink?: (course: StageLinkLifecycleData) => void;
+  /**
+   * Fired after a successful WRITE to the owner's course library: a stage
+   * created. The runner turns it into the durable `library_changed` event and
+   * the workspace refetches its course list — the same refresh sink the first
+   * committed page already uses.
+   *
+   * Fired ONLY after the persist succeeded: a refused or failed call changed
+   * nothing, and asking the client to refetch a tree that did not move is a
+   * request for the same bytes back.
+   */
+  onLibraryChanged?: (change: LibraryChange) => void;
+}
+
+/**
+ * What moved in the library. The client refetches the whole list either way, so
+ * this rides along for the log and for debugging rather than for a diff — see
+ * `LIFECYCLE.libraryChanged`. The folder-shaped variants land with the folder
+ * slice.
+ */
+export type LibraryChange = { change: 'stage_created'; stageId: string; title: string };
+
+// ── Params ────────────────────────────────────────────────────────────────────
+
+const CreateStageParams = Type.Object({
+  title: Type.String({
+    description:
+      'Stage title (e.g. "Day 1 — Python basics"); becomes the stage name and the `/classroom/<stageId>` title.',
+  }),
+  brief: Type.Optional(
+    Type.String({ description: 'Optional one-line brief, stored as the stage description.' }),
+  ),
+});
+
+const ReadStageOutlineParams = Type.Object({
+  stageId: Type.String({
+    description:
+      'An owner stage id. Returns the stage title and its page list (order/title/type) — the summary level, not page content.',
+  }),
+});
+
+// ── Toolset ───────────────────────────────────────────────────────────────────
+
+function toolResult(text: string, details: Record<string, unknown>, isError = false) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    details,
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+/**
+ * The single refusal every owner-scoped tool maps a non-owned stage to. The
+ * tool text never echoes whether the stage is foreign or missing — a stranger
+ * probing another tenant's id must get the same answer they would have got
+ * while it was alive.
+ */
+function notYoursResult(subject: string) {
+  return toolResult(
+    `${subject} was not found, or does not belong to this session user. You can only read and write stages this session created.`,
+    { refused: true },
+    true,
+  );
+}
+
+export function buildCurriculumTools(deps: CurriculumToolDeps): AgentTool<never, never>[] {
+  const createStage: AgentTool<typeof CreateStageParams, unknown> = {
+    name: 'create_stage',
+    label: 'Create stage',
+    description:
+      'Create a NEW stage document owned by this session user and return its stageId and classroom url. Pass that stageId explicitly to every later stage tool. Use for multi-stage series: one stage per unit/day.',
+    parameters: CreateStageParams,
+    async execute(callId, params: Static<typeof CreateStageParams>, signal) {
+      if (signal?.aborted) throw new Error('aborted');
+      const title = params.title?.trim();
+      if (!title) {
+        return toolResult('create_stage needs a non-empty title.', { error: 'empty-title' }, true);
+      }
+      // Idempotent by construction: the SAME tool call (same call id, replayed
+      // after a crash between the save and the result checkpoint) derives the
+      // SAME stage id, so the retry lands on the stage the original already
+      // minted instead of casting a second orphan course. The store is
+      // owner-bound, so `loadDocument` only ever returns a stage this owner
+      // owns — a foreign document at the same id reads as absent and the
+      // `saveDocument` below refuses it (the owner scope is enforced inside
+      // the write transaction).
+      const stageId = stageIdForCall(deps.sessionId, callId);
+      const existing = await deps.store.loadDocument(stageId);
+      if (signal?.aborted) throw new Error('aborted');
+      if (existing) {
+        const producerRef = (existing.outline as AppDocumentOutline | undefined)?.producerRef;
+        // `producerRef` is this session's id when the agent created the stage
+        // (set below; absent for an empty sessionId). Only a stage this session
+        // minted may be treated as a committed retry — a document this session
+        // did not mint at the same id is a collision and must not be confirmed.
+        const ours = deps.sessionId ? producerRef === deps.sessionId : producerRef === undefined;
+        if (!ours) {
+          return toolResult(
+            `A stage document already exists at this id and was not created by this session; refusing to overwrite it.`,
+            { refused: true },
+            true,
+          );
+        }
+        deps.onStageLink?.({
+          stageId,
+          title: existing.stage.name,
+          url: `/classroom/${stageId}`,
+        });
+        return toolResult(
+          `Stage "${existing.stage.name}" was already created — this create_stage call was a retry, returning the existing stage.`,
+          {
+            stageId,
+            title: existing.stage.name,
+            url: `/classroom/${stageId}`,
+            reused: true,
+          },
+        );
+      }
+      const now = Date.now();
+      const document: CourseDocument = {
+        stage: {
+          id: stageId,
+          name: title,
+          ...(params.brief?.trim() ? { description: params.brief.trim() } : {}),
+          createdAt: now,
+          updatedAt: now,
+        },
+        scenes: [],
+        // The same outline envelope the server-side generate_outline writes,
+        // with producer semantics intact: this course is owned by the agent
+        // runtime job, and the browser must never generate into it. An
+        // agent-minted stage has NO generation-pipeline lifecycle — planning
+        // happens in the conversation and each page lands through the page
+        // tools of the generation slice — so it is born complete
+        // (`generationComplete: true`).
+        outline: {
+          outlines: [],
+          requirement: title,
+          generationComplete: true,
+          producer: 'server-job',
+          ...(deps.sessionId ? { producerRef: deps.sessionId } : {}),
+          createdAt: now,
+          updatedAt: now,
+        } satisfies AppDocumentOutline,
+      };
+      if (signal?.aborted) throw new Error('aborted');
+      // `saveDocument` on the owner-bound store mints the document AND claims
+      // the owner scope in one transaction. A concurrent mint of the same id
+      // is refused by the store's owner scope; the replay is sequential, so
+      // the loadDocument pre-check above is the ordering guarantee.
+      await deps.store.saveDocument(document);
+      if (signal?.aborted) throw new Error('aborted');
+      // The owner's library gained a course — the left rail's tree is stale
+      // until it refetches. Fired exactly once per mint.
+      deps.onLibraryChanged?.({ change: 'stage_created', stageId, title });
+      deps.onStageLink?.({ stageId, title, url: `/classroom/${stageId}` });
+      return toolResult(
+        `Created stage "${title}" — open it at /classroom/${stageId}. Pass stageId=${stageId} explicitly to every stage tool for this stage.`,
+        {
+          stageId,
+          title,
+          url: `/classroom/${stageId}`,
+        },
+      );
+    },
+  };
+
+  const readStageOutline: AgentTool<typeof ReadStageOutlineParams, unknown> = {
+    name: 'read_stage_outline',
+    label: 'Read stage outline',
+    description:
+      'Read the OUTLINE of any stage this session user owns (title + page list with order/title/type — not page content). Use to chain stages in a series: see what a previous day covered before planning the next.',
+    parameters: ReadStageOutlineParams,
+    async execute(_id, params: Static<typeof ReadStageOutlineParams>, signal) {
+      if (signal?.aborted) throw new Error('aborted');
+      // The owner-bound store is the fail-closed probe: a foreign or missing
+      // stage reads as absent, so the refusal below never confirms another
+      // tenant's id.
+      const doc = await deps.store.loadDocument(params.stageId);
+      if (signal?.aborted) throw new Error('aborted');
+      if (!doc) return notYoursResult(`Stage "${params.stageId}"`);
+      const snapshot = doc.outline as AppDocumentOutline | undefined;
+      const planned = snapshot && Array.isArray(snapshot.outlines) ? snapshot.outlines : [];
+      const scenes = doc.scenes ?? [];
+      // UNION view: real scenes pair with the outline entries they were built
+      // from (outlineId, then order) and planned-only pages stay visible at
+      // their planned position while generation is in progress; a COMPLETED
+      // snapshot is pure scenes. See course-outline-union.ts.
+      const entries = mergeStageOutline({
+        scenes,
+        planned,
+        generationComplete: snapshot?.generationComplete,
+      });
+      // `details.pages` keeps the historical {order,title,type} shape; the
+      // planned/pending marker and the display sequence ride the
+      // human-readable text only (display numbers are the merged consecutive
+      // positions — entries keep their original order).
+      const pages = entries.map(({ order, title, type }) => ({ order, title, type }));
+      const title = doc.stage?.name ?? '';
+      const text =
+        pages.length === 0
+          ? `Stage "${title}" has no planned pages yet.`
+          : `Stage "${title}" (${pages.length} page(s)):\n${entries
+              .map((p, i) => `- ${i + 1}. ${p.title} [${p.type}]${p.planned ? ' (planned)' : ''}`)
+              .join('\n')}`;
+      return toolResult(text, { stageId: params.stageId, title, pages, pageCount: pages.length });
+    },
+  };
+
+  return [createStage, readStageOutline] as unknown as AgentTool<never, never>[];
+}
+
+export const CURRICULUM_ALLOWLIST: ReadonlySet<string> = new Set([
+  'create_stage',
+  'read_stage_outline',
+]);
+
+/**
+ * Prompt block teaching the multi-stage workflow (appended to the system
+ * prompt). Folder guidance (create_folder / move_to_folder / list_folder_stages
+ * / rename_stage) lands with the folder slice.
+ */
+export const CURRICULUM_TOOLS_PROMPT = [
+  'Multi-stage series: to build a series in one session, call `create_stage`',
+  'once per unit/day. `create_stage` returns a stageId; pass that',
+  'stageId explicitly to every later stage tool. There is no active/current stage.',
+  'Use different stageIds to work on several stages in parallel.',
+  "`read_stage_outline` reads a stage's page list (not content) so you can",
+  'chain a series (e.g. day 2 builds on what day 1 covered).',
+].join(' ');

--- a/lib/server/agent-runtime/dsl-tools.ts
+++ b/lib/server/agent-runtime/dsl-tools.ts
@@ -1,0 +1,990 @@
+import { Type, type Static } from 'typebox';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { Action } from '@/lib/types/action';
+import type { Scene, SlideContent } from '@/lib/types/stage';
+import { validateAppScene } from '@/lib/document-store/validators';
+import type { CourseDocument, CourseToolDeps } from './course-tools';
+import {
+  applyJsonPointerEdit,
+  applySlideEdit,
+  applyStrReplace,
+  inventoryScene,
+  textSlide,
+  type SlideEditOp,
+} from './course-edit/apply';
+import {
+  containsReadSceneMediaPlaceholder,
+  omitReadSceneMediaBytes,
+} from './course-edit/media-byte-omission';
+import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
+
+const READ_PAGE_CHARS = 12_000;
+const SEARCH_CONTEXT_CHARS = 200;
+const MAX_SEARCH_SNIPPET_CHARS = SEARCH_CONTEXT_CHARS * 2;
+const MAX_SEARCH_HITS_PER_SCENE = 10;
+const MAX_SEARCH_HITS_TOTAL = 30;
+const MAX_SEARCH_CHARS_PER_EXEC = 1_000_000;
+const SEARCH_TIME_BUDGET_MS = 100;
+const LEGAL_PATHS =
+  'Legal paths: "" (whole stage), /outline, /scenes/<1-based order|scene_id>, /scenes/<...>/actions.';
+
+export const READ_COURSE_SCHEMA = Type.Object({
+  stageId: Type.String({ description: COURSE_STAGE_ID_DESCRIPTION }),
+  path: Type.Optional(
+    Type.String({
+      description:
+        'Stage path: "", /outline, /scenes/<1-based order|scene id>, or /scenes/<...>/actions.',
+    }),
+  ),
+  detail: Type.Optional(
+    Type.Union([Type.Literal('tree'), Type.Literal('source'), Type.Literal('text')], {
+      description:
+        "'tree' (default) is a compact structure inventory; 'source' is exact JSON; 'text' is a visible-text projection.",
+    }),
+  ),
+  offset: Type.Optional(
+    Type.Integer({ minimum: 0, description: 'Character offset for source/text pagination.' }),
+  ),
+});
+
+const PATCH_OP_SCHEMA = Type.Object({
+  op: Type.Union([
+    Type.Literal('set'),
+    Type.Literal('remove'),
+    Type.Literal('add_element'),
+    Type.Literal('delete_element'),
+    Type.Literal('str_replace'),
+  ]),
+  path: Type.Optional(
+    Type.String({
+      description:
+        'For set/remove/str_replace: JSON Pointer rooted at the exact scene source returned by read_stage.',
+    }),
+  ),
+  value: Type.Optional(Type.Unknown({ description: 'For set only: exact JSON value to store.' })),
+  oldText: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description: 'For str_replace: exact text to find within the string field value at path.',
+    }),
+  ),
+  newText: Type.Optional(
+    Type.String({
+      description: 'For str_replace: replacement text (empty string deletes the anchor).',
+    }),
+  ),
+  replaceAll: Type.Optional(
+    Type.Boolean({
+      description:
+        'For str_replace: replace every occurrence (default false, which requires exactly one).',
+    }),
+  ),
+  element: Type.Optional(
+    Type.Unknown({ description: 'For add_element: complete id-less slide element JSON.' }),
+  ),
+  elementId: Type.Optional(
+    Type.String({ description: 'For delete_element: persisted element id.' }),
+  ),
+  afterId: Type.Optional(Type.String()),
+  index: Type.Optional(Type.Integer({ minimum: 0 })),
+});
+
+export const PATCH_COURSE_SCHEMA = Type.Object({
+  stageId: Type.String({ description: COURSE_STAGE_ID_DESCRIPTION }),
+  target: Type.String({
+    minLength: 1,
+    description:
+      'Scene target /scenes/<1-based order|scene id>. Stage/deck writes remain on edit_deck.',
+  }),
+  intent: Type.String({
+    minLength: 1,
+    description: 'One-sentence human summary of the intended change, shown in the UI.',
+  }),
+  ops: Type.Array(PATCH_OP_SCHEMA, {
+    minItems: 1,
+    description: 'Atomic operations: every op succeeds or the scene is not persisted.',
+  }),
+});
+
+export const GREP_COURSE_SCHEMA = Type.Object({
+  query: Type.String({
+    minLength: 1,
+    maxLength: 200,
+    description: 'Case-insensitive NFKC-normalized literal text. Not a regular expression.',
+  }),
+  stageId: Type.String({ description: COURSE_STAGE_ID_DESCRIPTION }),
+  scope: Type.Optional(
+    Type.Union([Type.Literal('text'), Type.Literal('source')], {
+      description:
+        "'text' (default) searches visible text; 'source' searches serialized scene JSON.",
+    }),
+  ),
+  cursor: Type.Optional(
+    Type.String({ description: 'Opaque continuation cursor returned by a truncated search.' }),
+  ),
+});
+
+type ReadParams = Static<typeof READ_COURSE_SCHEMA>;
+type PatchParams = Static<typeof PATCH_COURSE_SCHEMA>;
+type GrepParams = Static<typeof GREP_COURSE_SCHEMA>;
+
+function toolResult(text: string, details: Record<string, unknown>, isError = false) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    details,
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+async function loadCourse(
+  deps: CourseToolDeps,
+  stageId: string,
+): Promise<{ stageId: string; doc: CourseDocument } | { error: string }> {
+  try {
+    const doc = await deps.store.loadDocument(stageId);
+    if (!doc)
+      return { error: `Stage ${JSON.stringify(stageId)} was not found or is not accessible.` };
+    return { stageId, doc };
+  } catch (error) {
+    return {
+      error: `Stage is not accessible: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+type ResolvedPath =
+  | { kind: 'course'; path: '' }
+  | { kind: 'outline'; path: '/outline' }
+  | { kind: 'scene'; path: string; scene: Scene }
+  | { kind: 'actions'; path: string; scene: Scene };
+
+function decodePathToken(token: string): string | null {
+  if (/~(?:[^01]|$)/.test(token)) return null;
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function resolveCoursePath(doc: CourseDocument, rawPath?: string): ResolvedPath | string {
+  const path = rawPath ?? '';
+  if (path === '') return { kind: 'course', path: '' };
+  if (path === '/outline') return { kind: 'outline', path };
+  const match = /^\/scenes\/([^/]+)(\/actions)?$/.exec(path);
+  if (!match) return `Invalid stage path ${JSON.stringify(path)}. ${LEGAL_PATHS}`;
+  const token = decodePathToken(match[1]!);
+  if (!token) return `Invalid JSON Pointer escape in ${JSON.stringify(path)}. ${LEGAL_PATHS}`;
+  let scene: Scene | undefined;
+  if (/^[1-9]\d*$/.test(token)) {
+    scene = doc.scenes.find((item) => item.order === Number(token));
+  } else if (/^scene[-_]/.test(token)) {
+    scene = doc.scenes.find((item) => item.id === token);
+  } else {
+    return `Scene selector ${JSON.stringify(token)} must be a 1-based order or scene_/scene- id. ${LEGAL_PATHS}`;
+  }
+  if (!scene) return `Scene ${JSON.stringify(token)} was not found. ${LEGAL_PATHS}`;
+  return match[2] ? { kind: 'actions', path, scene } : { kind: 'scene', path, scene };
+}
+
+function actionTypeCounts(actions: readonly Action[]) {
+  const counts: Record<string, number> = {};
+  for (const action of actions) counts[action.type] = (counts[action.type] ?? 0) + 1;
+  return counts;
+}
+
+function sceneTree(scene: Scene) {
+  const inventory = inventoryScene(scene) as Record<string, unknown>;
+  const summary: Record<string, unknown> = {
+    id: scene.id,
+    order: scene.order,
+    type: scene.type,
+    title: scene.title,
+  };
+  if (scene.content.type === 'slide') {
+    const counts: Record<string, number> = {};
+    for (const element of scene.content.canvas.elements) {
+      counts[element.type] = (counts[element.type] ?? 0) + 1;
+    }
+    summary.elements = { total: scene.content.canvas.elements.length, types: counts };
+  } else if (scene.content.type === 'quiz') {
+    summary.questions = scene.content.questions.length;
+  } else if (scene.content.type === 'interactive') {
+    summary.widgetType = scene.content.widgetConfig?.type ?? scene.content.widgetType ?? null;
+    summary.htmlChars = typeof scene.content.html === 'string' ? scene.content.html.length : 0;
+  } else if (scene.content.type === 'pbl') {
+    const project = scene.content.projectV2;
+    summary.project = project
+      ? {
+          roles: project.roles.length,
+          milestones: project.milestones.length,
+          microtasks: project.milestones.reduce((sum, item) => sum + item.microtasks.length, 0),
+        }
+      : null;
+  } else {
+    Object.assign(summary, inventory);
+  }
+  const actions = (scene.actions ?? []) as Action[];
+  summary.actions = { total: actions.length, types: actionTypeCounts(actions) };
+  return summary;
+}
+
+function treeAt(doc: CourseDocument, resolved: ResolvedPath): unknown {
+  if (resolved.kind === 'course') {
+    return {
+      stage: {
+        id: doc.stage.id,
+        name: doc.stage.name,
+        description: doc.stage.description,
+      },
+      outline: doc.outline
+        ? {
+            present: true,
+            entries: Array.isArray((doc.outline as { outlines?: unknown[] }).outlines)
+              ? ((doc.outline as { outlines: unknown[] }).outlines.length ?? 0)
+              : undefined,
+          }
+        : { present: false },
+      scenes: [...doc.scenes].sort((a, b) => a.order - b.order).map(sceneTree),
+    };
+  }
+  if (resolved.kind === 'outline') {
+    const outline = doc.outline as { outlines?: Array<Record<string, unknown>> } | undefined;
+    return {
+      entries: (outline?.outlines ?? []).map((item) => ({
+        id: item.id,
+        order: item.order,
+        type: item.type,
+        title: item.title,
+      })),
+    };
+  }
+  if (resolved.kind === 'actions') {
+    const actions = (resolved.scene.actions ?? []) as Action[];
+    return { sceneId: resolved.scene.id, total: actions.length, types: actionTypeCounts(actions) };
+  }
+  return sceneTree(resolved.scene);
+}
+
+function sourceAt(doc: CourseDocument, resolved: ResolvedPath): unknown {
+  if (resolved.kind === 'course') return doc;
+  if (resolved.kind === 'outline') return doc.outline ?? null;
+  if (resolved.kind === 'actions') return resolved.scene.actions ?? [];
+  return resolved.scene;
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function visibleActionText(action: Action): string[] {
+  const common = [action.title, action.description].filter(
+    (value): value is string => typeof value === 'string',
+  );
+  switch (action.type) {
+    case 'speech':
+      return [...common, action.text];
+    case 'discussion':
+      return [...common, action.topic, ...(action.prompt ? [action.prompt] : [])];
+    case 'wb_draw_text':
+      return [...common, action.content];
+    case 'wb_draw_code':
+      return [...common, action.code, ...(action.fileName ? [action.fileName] : [])];
+    case 'widget_highlight':
+    case 'widget_annotation':
+    case 'widget_reveal':
+      return [...common, action.target, ...(action.content ? [action.content] : [])];
+    case 'widget_setState':
+      return [...common, ...(action.content ? [action.content] : [])];
+    default:
+      return common;
+  }
+}
+
+function textScene(scene: Scene) {
+  const entries: Array<{ path: string; text: string }> = [];
+  const add = (path: string, value: unknown) => {
+    if (typeof value === 'string' && value.trim()) entries.push({ path, text: value });
+  };
+  add('/title', scene.title);
+  if (scene.content.type === 'slide') {
+    for (const entry of textSlide(scene.content as SlideContent).elements) {
+      add(`/content${entry.path}`, entry.text);
+    }
+  } else if (scene.content.type === 'quiz') {
+    scene.content.questions.forEach((question, questionIndex) => {
+      const base = `/content/questions/${questionIndex}`;
+      add(`${base}/question`, question.question);
+      question.options?.forEach((option, optionIndex) =>
+        add(`${base}/options/${optionIndex}/label`, option.label),
+      );
+      add(`${base}/analysis`, question.analysis);
+      add(`${base}/commentPrompt`, question.commentPrompt);
+    });
+  } else if (scene.content.type === 'interactive') {
+    add('/content/html', scene.content.html ? stripHtml(scene.content.html) : undefined);
+    const config = scene.content.widgetConfig as Record<string, unknown> | undefined;
+    if (config) {
+      for (const field of ['title', 'label', 'description', 'concept', 'task'] as const) {
+        add(`/content/widgetConfig/${field}`, config[field]);
+      }
+      for (const field of ['hints', 'successCriteria'] as const) {
+        const values = config[field];
+        if (Array.isArray(values)) {
+          values.forEach((value, index) => add(`/content/widgetConfig/${field}/${index}`, value));
+        }
+      }
+    }
+  } else if (scene.content.type === 'pbl' && scene.content.projectV2) {
+    const project = scene.content.projectV2;
+    for (const field of ['title', 'description', 'learningObjective'] as const) {
+      add(`/content/projectV2/${field}`, project[field]);
+    }
+    project.gains?.forEach((value, index) => add(`/content/projectV2/gains/${index}`, value));
+    project.roles.forEach((role, index) => {
+      add(`/content/projectV2/roles/${index}/name`, role.name);
+      add(`/content/projectV2/roles/${index}/description`, role.description);
+    });
+    project.milestones.forEach((milestone, milestoneIndex) => {
+      const base = `/content/projectV2/milestones/${milestoneIndex}`;
+      for (const field of ['title', 'description', 'briefing', 'debrief'] as const) {
+        add(`${base}/${field}`, milestone[field]);
+      }
+      milestone.microtasks.forEach((task, taskIndex) => {
+        const taskBase = `${base}/microtasks/${taskIndex}`;
+        for (const field of ['title', 'description', 'learnerBrief'] as const) {
+          add(`${taskBase}/${field}`, task[field]);
+        }
+        task.hints.forEach((hint, hintIndex) => add(`${taskBase}/hints/${hintIndex}`, hint));
+      });
+    });
+  }
+  ((scene.actions ?? []) as Action[]).forEach((action, index) => {
+    visibleActionText(action).forEach((value, valueIndex) =>
+      add(`/actions/${index}/visible/${valueIndex}`, value),
+    );
+  });
+  return { entries, combinedText: entries.map((entry) => entry.text).join('\n') };
+}
+
+function textAt(doc: CourseDocument, resolved: ResolvedPath): unknown {
+  if (resolved.kind === 'scene') return textScene(resolved.scene);
+  if (resolved.kind === 'actions') {
+    const entries = ((resolved.scene.actions ?? []) as Action[]).flatMap((action, index) =>
+      visibleActionText(action).map((text, part) => ({ path: `/${index}/visible/${part}`, text })),
+    );
+    return { entries, combinedText: entries.map((entry) => entry.text).join('\n') };
+  }
+  if (resolved.kind === 'outline') {
+    const outlines =
+      (doc.outline as { outlines?: Array<Record<string, unknown>> } | undefined)?.outlines ?? [];
+    const entries = outlines.flatMap((item, index) =>
+      ['title', 'description', 'teachingObjective'].flatMap((field) =>
+        typeof item[field] === 'string'
+          ? [{ path: `/outlines/${index}/${field}`, text: item[field] as string }]
+          : [],
+      ),
+    );
+    return { entries, combinedText: entries.map((entry) => entry.text).join('\n') };
+  }
+  const scenes = [...doc.scenes]
+    .sort((a, b) => a.order - b.order)
+    .map((scene) => ({
+      scenePath: `/scenes/${scene.id}`,
+      order: scene.order,
+      ...textScene(scene),
+    }));
+  return { scenes, combinedText: scenes.map((scene) => scene.combinedText).join('\n') };
+}
+
+function pagedResult(value: unknown, path: string, detail: 'tree' | 'source' | 'text', offset = 0) {
+  const projected = detail === 'source' ? omitReadSceneMediaBytes(value).value : value;
+  const serialized = JSON.stringify(projected, null, 2);
+  if (detail === 'tree') {
+    return toolResult(serialized, { path, detail, totalChars: serialized.length });
+  }
+  if (offset > serialized.length) {
+    return toolResult(
+      `offset ${offset} is beyond totalChars ${serialized.length}`,
+      { path, detail, totalChars: serialized.length },
+      true,
+    );
+  }
+  const text = serialized.slice(offset, offset + READ_PAGE_CHARS);
+  const nextOffset = offset + text.length < serialized.length ? offset + text.length : undefined;
+  const truncatedText =
+    nextOffset === undefined
+      ? text
+      : `${text}\n\nOutput truncated at ${READ_PAGE_CHARS} chars (${serialized.length} total). Continue with offset=${nextOffset}, jump to a specific string with grep_stage, or narrow the path (e.g. /scenes/3/actions).`;
+  return toolResult(truncatedText, {
+    path,
+    detail,
+    totalChars: serialized.length,
+    ...(nextOffset !== undefined ? { nextOffset } : {}),
+  });
+}
+
+function validationError(scene: Scene): string | null {
+  const validation = validateAppScene(scene);
+  if (!validation.valid) {
+    return validation.errors.map((issue) => `${issue.path}: ${issue.message}`).join('; ');
+  }
+  if (scene.content.type === 'quiz') {
+    const content = scene.content as unknown as Record<string, unknown>;
+    const unknownContent = Object.keys(content).filter(
+      (key) => !['type', 'questions'].includes(key),
+    );
+    if (unknownContent.length) return `/content: unknown field(s) ${unknownContent.join(', ')}`;
+    for (let index = 0; index < scene.content.questions.length; index += 1) {
+      const question = scene.content.questions[index] as unknown as Record<string, unknown>;
+      const allowed = [
+        'id',
+        'type',
+        'question',
+        'options',
+        'answer',
+        'analysis',
+        'commentPrompt',
+        'hasAnswer',
+        'points',
+      ];
+      const unknown = Object.keys(question).filter((key) => !allowed.includes(key));
+      if (unknown.length)
+        return `/content/questions/${index}: unknown field(s) ${unknown.join(', ')}`;
+      if (!['single', 'multiple', 'short_answer'].includes(String(question.type))) {
+        return `/content/questions/${index}/type: unknown quiz question type`;
+      }
+      if (typeof question.id !== 'string' || typeof question.question !== 'string') {
+        return `/content/questions/${index}: id and question must be strings`;
+      }
+      if (question.options !== undefined) {
+        if (!Array.isArray(question.options))
+          return `/content/questions/${index}/options: expected array`;
+        for (let optionIndex = 0; optionIndex < question.options.length; optionIndex += 1) {
+          const option = question.options[optionIndex];
+          if (option === null || typeof option !== 'object' || Array.isArray(option)) {
+            return `/content/questions/${index}/options/${optionIndex}: expected object`;
+          }
+          const record = option as Record<string, unknown>;
+          const unknownOption = Object.keys(record).filter(
+            (key) => !['label', 'value'].includes(key),
+          );
+          if (unknownOption.length) {
+            return `/content/questions/${index}/options/${optionIndex}: unknown field(s) ${unknownOption.join(', ')}`;
+          }
+          if (typeof record.label !== 'string' || typeof record.value !== 'string') {
+            return `/content/questions/${index}/options/${optionIndex}: label and value must be strings`;
+          }
+        }
+      }
+      if (
+        question.answer !== undefined &&
+        (!Array.isArray(question.answer) ||
+          question.answer.some((answer) => typeof answer !== 'string'))
+      ) {
+        return `/content/questions/${index}/answer: expected string array`;
+      }
+      for (const field of ['analysis', 'commentPrompt'] as const) {
+        if (question[field] !== undefined && typeof question[field] !== 'string') {
+          return `/content/questions/${index}/${field}: expected string`;
+        }
+      }
+      if (question.hasAnswer !== undefined && typeof question.hasAnswer !== 'boolean') {
+        return `/content/questions/${index}/hasAnswer: expected boolean`;
+      }
+      if (question.points !== undefined && typeof question.points !== 'number') {
+        return `/content/questions/${index}/points: expected number`;
+      }
+    }
+  }
+  if (scene.content.type === 'interactive') {
+    const unknown = Object.keys(scene.content).filter(
+      (key) => !['type', 'url', 'html', 'widgetType', 'widgetConfig'].includes(key),
+    );
+    if (unknown.length) return `/content: unknown field(s) ${unknown.join(', ')}`;
+  }
+  if (scene.content.type === 'pbl') {
+    const unknown = Object.keys(scene.content).filter(
+      (key) => !['type', 'projectConfig', 'projectV2'].includes(key),
+    );
+    if (unknown.length) return `/content: unknown field(s) ${unknown.join(', ')}`;
+  }
+  return null;
+}
+
+function clearStaleSpeechAudio(before: Scene, after: Scene): void {
+  const beforeById = new Map(
+    ((before.actions ?? []) as Action[])
+      .filter((action): action is Extract<Action, { type: 'speech' }> => action.type === 'speech')
+      .map((action) => [action.id, action]),
+  );
+  for (const action of (after.actions ?? []) as Action[]) {
+    if (action.type !== 'speech') continue;
+    const previous = beforeById.get(action.id);
+    if (!previous || previous.text === action.text) continue;
+    const legacy = action as typeof action & { audioUrl?: string };
+    delete legacy.audioId;
+    delete legacy.audioUrl;
+  }
+}
+
+function slideOperation(op: PatchParams['ops'][number], _scene: Scene): SlideEditOp | string {
+  if (op.op === 'add_element') {
+    if (op.element === undefined) return 'add_element needs element';
+    if (containsReadSceneMediaPlaceholder(op.element))
+      return 'add_element rejected: media placeholder cannot be written back';
+    return {
+      op: 'add_element',
+      element: op.element as Record<string, unknown>,
+      afterId: op.afterId,
+      index: op.index,
+    };
+  }
+  if (op.op === 'delete_element') {
+    return op.elementId
+      ? { op: 'delete_element', elementId: op.elementId }
+      : 'delete_element needs elementId';
+  }
+  if (op.op === 'str_replace') {
+    return 'str_replace is a generic string-field op; it is not routed through the slide canvas';
+  }
+  if (!op.path) return `${op.op} needs path`;
+  if (!op.path.startsWith('/content/canvas/')) {
+    return `slide content pointer must start /content/canvas/ (actions use /actions/...)`;
+  }
+  return {
+    op: 'patch',
+    action: op.op,
+    path: op.path.slice('/content'.length),
+    value: op.value,
+  };
+}
+
+type PatchOpResult =
+  | { ok: true; value: Scene; details?: { op: string; path?: string; occurrences?: number } }
+  | { ok: false; error: string };
+
+function applyPatchOp(scene: Scene, op: PatchParams['ops'][number]): PatchOpResult {
+  if (op.op === 'add_element' || op.op === 'delete_element') {
+    if (scene.content.type !== 'slide')
+      return { ok: false as const, error: `${op.op} is only valid for slide scenes` };
+    const parsed = slideOperation(op, scene);
+    if (typeof parsed === 'string') return { ok: false as const, error: parsed };
+    const applied = applySlideEdit(scene.content, parsed);
+    return applied.ok
+      ? { ok: true as const, value: { ...scene, content: applied.value } as Scene }
+      : applied;
+  }
+  if (op.op === 'str_replace') {
+    if (!op.path) return { ok: false as const, error: 'str_replace needs path' };
+    if (!op.oldText) return { ok: false as const, error: 'str_replace needs oldText' };
+    if (op.newText === undefined) return { ok: false as const, error: 'str_replace needs newText' };
+    if (
+      !op.path.startsWith('/content/') &&
+      op.path !== '/actions' &&
+      !op.path.startsWith('/actions/')
+    ) {
+      return {
+        ok: false as const,
+        error:
+          'str_replace path must start /content/ or /actions/; use edit_deck for scene metadata',
+      };
+    }
+    const applied = applyStrReplace(scene, {
+      path: op.path,
+      oldText: op.oldText,
+      newText: op.newText,
+      replaceAll: op.replaceAll ?? false,
+    });
+    if (!applied.ok) return applied;
+    const next = applied.value as Scene;
+    clearStaleSpeechAudio(scene, next);
+    return {
+      ok: true as const,
+      value: next,
+      details: { op: 'str_replace', path: op.path, occurrences: applied.occurrences },
+    };
+  }
+  if (!op.path) return { ok: false as const, error: `${op.op} needs path` };
+  if (
+    !op.path.startsWith('/content/') &&
+    op.path !== '/actions' &&
+    !op.path.startsWith('/actions/')
+  ) {
+    return {
+      ok: false as const,
+      error: 'set/remove path must start /content/ or /actions/; use edit_deck for scene metadata',
+    };
+  }
+  if (scene.content.type === 'slide' && op.path.startsWith('/content/')) {
+    const parsed = slideOperation(op, scene);
+    if (typeof parsed === 'string') return { ok: false as const, error: parsed };
+    const applied = applySlideEdit(scene.content, parsed);
+    return applied.ok
+      ? { ok: true as const, value: { ...scene, content: applied.value } as Scene }
+      : applied;
+  }
+  const applied = applyJsonPointerEdit(scene, { action: op.op, path: op.path, value: op.value });
+  if (!applied.ok) return applied;
+  clearStaleSpeechAudio(scene, applied.value as Scene);
+  return { ok: true as const, value: applied.value as Scene };
+}
+
+interface FoldedText {
+  value: string;
+  originalStarts: number[];
+  originalEnds: number[];
+}
+
+/**
+ * Grapheme segmentation is what makes NFKC folding compose: normalization and
+ * case folding apply to a whole user-perceived character, so splitting the
+ * input by code point first would break a combining sequence (e.g. decomposed
+ * `e\u0301` never becomes precomposed `é`) and canonically-equivalent text
+ * would not search. `'und'` = language-neutral segmentation.
+ */
+const graphemeSegmenter = new Intl.Segmenter('und', { granularity: 'grapheme' });
+
+/**
+ * Case-fold a cluster to the SEARCH-CANONICAL form (Unicode case folding
+ * semantics): Σ (U+03A3), ς (U+03C2) and σ (U+03C3) must all fold to σ, so
+ * `"ΟΣ"` and `"ος"` search as the same literal. Per-cluster `toLowerCase()`
+ * alone cannot do this — Greek final sigma ς is only produced by lowercasing
+ * a whole word, and a single grapheme never sees its word-final context, so
+ * the per-cluster fold keeps the ς of an uppercase input as-is and the query's
+ * ς never matches. Normalizing ς → σ after the per-cluster lowercase folds
+ * both sides identically, independent of word context.
+ */
+function caseFoldCluster(cluster: string): string {
+  return cluster
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/\u03c2/g, '\u03c3');
+}
+
+/**
+ * NFKC + case fold with a source UTF-16 span for every resulting code unit.
+ *
+ * Folding is per GRAPHEME CLUSTER, not per code point: a cluster is
+ * normalized as a whole, so decomposed and precomposed forms fold to the same
+ * value. When a cluster expands or contracts under folding, every folded code
+ * unit maps to the span of the WHOLE original cluster, so an offset-based hit
+ * in `value` always slices the original text at cluster boundaries.
+ */
+export function foldNfkcCaseWithOffsets(text: string): FoldedText {
+  let value = '';
+  const originalStarts: number[] = [];
+  const originalEnds: number[] = [];
+  let originalIndex = 0;
+  for (const segment of graphemeSegmenter.segment(text)) {
+    const cluster = segment.segment;
+    const originalEnd = originalIndex + cluster.length;
+    const folded = caseFoldCluster(cluster);
+    value += folded;
+    for (let index = 0; index < folded.length; index += 1) {
+      originalStarts.push(originalIndex);
+      originalEnds.push(originalEnd);
+    }
+    originalIndex = originalEnd;
+  }
+  return { value, originalStarts, originalEnds };
+}
+
+function boundedSnippet(text: string, start: number, end: number) {
+  const desiredStart = Math.max(0, start - SEARCH_CONTEXT_CHARS);
+  const desiredEnd = Math.min(text.length, end + SEARCH_CONTEXT_CHARS);
+  if (desiredEnd - desiredStart <= MAX_SEARCH_SNIPPET_CHARS) {
+    return { snippetStart: desiredStart, snippetEnd: desiredEnd };
+  }
+  const midpoint = start + (end - start) / 2;
+  const snippetStart = Math.min(
+    Math.max(0, text.length - MAX_SEARCH_SNIPPET_CHARS),
+    Math.max(0, Math.floor(midpoint - MAX_SEARCH_SNIPPET_CHARS / 2)),
+  );
+  return { snippetStart, snippetEnd: snippetStart + MAX_SEARCH_SNIPPET_CHARS };
+}
+
+interface SearchCursor {
+  v: 1;
+  stageId: string;
+  query: string;
+  scope: 'text' | 'source';
+  sceneIndex: number;
+  offset: number;
+}
+
+function encodeCursor(cursor: SearchCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeCursor(raw: string): SearchCursor | null {
+  try {
+    const value = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as SearchCursor;
+    return value.v === 1 && Number.isInteger(value.sceneIndex) && Number.isInteger(value.offset)
+      ? value
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function grepText(scene: Scene, scope: 'text' | 'source'): string {
+  // Source searches run over the SAME bounded projection `read_stage
+  // detail:"source"` serves — large inline media bytes replaced by their
+  // placeholder BEFORE serialization. Serializing the raw scene first would
+  // materialize every inline data-URL (historical/imported pages carry tens
+  // of MB) before any time/char budget could apply, blocking the event loop
+  // on a string the budget then throws away (cr#6 R6-P2-6). Searching the
+  // projection also matches what the model actually reads back.
+  return scope === 'source'
+    ? JSON.stringify(omitReadSceneMediaBytes(scene).value)
+    : textScene(scene).combinedText;
+}
+
+export function buildDslCourseTools(deps: CourseToolDeps): AgentTool<never, never>[] {
+  const readCourse: AgentTool<typeof READ_COURSE_SCHEMA, unknown> = {
+    name: 'read_stage',
+    label: 'Read stage',
+    description:
+      'Read a stage or one addressable subtree. Prefer tree first; paths are "", /outline, /scenes/<order|sceneId>, and /scenes/<...>/actions. tree is compact; source is exact JSON with large media bytes omitted; text is visible text. Source/text paginate after 12000 characters with nextOffset.',
+    parameters: READ_COURSE_SCHEMA,
+    async execute(_id, params: ReadParams) {
+      const loaded = await loadCourse(deps, params.stageId);
+      if ('error' in loaded) return toolResult(loaded.error, {}, true);
+      const resolved = resolveCoursePath(loaded.doc, params.path);
+      if (typeof resolved === 'string') return toolResult(resolved, {}, true);
+      const detail = params.detail ?? 'tree';
+      const value =
+        detail === 'tree'
+          ? treeAt(loaded.doc, resolved)
+          : detail === 'source'
+            ? sourceAt(loaded.doc, resolved)
+            : textAt(loaded.doc, resolved);
+      return pagedResult(value, resolved.path, detail, params.offset ?? 0);
+    },
+  };
+
+  const patchCourse: AgentTool<typeof PATCH_COURSE_SCHEMA, unknown> = {
+    name: 'patch_stage',
+    label: 'Patch stage',
+    description:
+      'Atomically patch ONE scene at /scenes/<order|sceneId>. Read source first. set/remove use JSON Pointers rooted at that exact scene source (/content/... or /actions/...); str_replace swaps one exact occurrence of oldText inside a string field at a pointer (all occurrences with replaceAll); add_element/delete_element preserve server-owned slide element identity. Any failed op or resulting validation error rejects the whole batch. Stage/page-list operations remain on edit_deck.',
+    parameters: PATCH_COURSE_SCHEMA,
+    async execute(_id, params: PatchParams) {
+      if (!params.intent.trim()) return toolResult('intent must not be blank', {}, true);
+      const loaded = await loadCourse(deps, params.stageId);
+      if ('error' in loaded) return toolResult(loaded.error, {}, true);
+      const resolved = resolveCoursePath(loaded.doc, params.target);
+      if (typeof resolved === 'string')
+        return toolResult(resolved, { intent: params.intent }, true);
+      if (resolved.kind !== 'scene') {
+        return toolResult(
+          `patch_stage target must be /scenes/<order|sceneId>. ${LEGAL_PATHS}`,
+          { intent: params.intent },
+          true,
+        );
+      }
+      let next = structuredClone(resolved.scene);
+      const opDetails: unknown[] = [];
+      for (let index = 0; index < params.ops.length; index += 1) {
+        const applied = applyPatchOp(next, params.ops[index]!);
+        if (!applied.ok) {
+          return toolResult(
+            `patch_stage rejected at op ${index + 1}: ${applied.error}`,
+            { intent: params.intent, failedOp: index + 1 },
+            true,
+          );
+        }
+        next = applied.value;
+        const op = params.ops[index]!;
+        opDetails.push(
+          applied.details ?? {
+            op: op.op,
+            ...(typeof op.path === 'string' ? { path: op.path } : {}),
+          },
+        );
+      }
+      // Final-state placeholder guard. The per-op checks above are the friendly
+      // errors for a model that copies a placeholder verbatim, but they inspect
+      // each op's payload in ISOLATION — a batch can assemble a complete
+      // read-only placeholder across several ops (e.g. two str_replace calls
+      // that each carry only a fragment). That bypasses every per-op check, so
+      // the whole batch is re-checked HERE, against the SERIALIZED final scene,
+      // before anything is persisted. This is the primary guard: a hit rejects
+      // the entire batch and never reaches putScene.
+      const finalSerialized = JSON.stringify(next);
+      if (containsReadSceneMediaPlaceholder(finalSerialized)) {
+        return toolResult(
+          `patch_stage rejected: the resulting scene still contains a read-only media placeholder (it was assembled across ops); write a real media src/URL instead`,
+          { intent: params.intent, failedOp: params.ops.length },
+          true,
+        );
+      }
+      const issue = validationError(next);
+      if (issue) {
+        return toolResult(
+          `patch_stage rejected after op ${params.ops.length}: resulting scene fails structure validation (${issue})`,
+          { intent: params.intent, failedOp: params.ops.length },
+          true,
+        );
+      }
+      try {
+        await deps.store.putScene(loaded.stageId, next);
+      } catch (error) {
+        return toolResult(
+          `patch_stage could not persist the scene: ${error instanceof Error ? error.message : String(error)}`,
+          { intent: params.intent },
+          true,
+        );
+      }
+      deps.onCheckpoint({
+        tool: 'patch_stage',
+        stageId: loaded.stageId,
+        sceneId: next.id,
+        order: next.order,
+        title: next.title,
+        sceneType: next.type,
+        detail: params.intent,
+      });
+      return toolResult(`Updated scene "${next.title}": ${params.intent}`, {
+        intent: params.intent,
+        updated: { sceneId: next.id, order: next.order, type: next.type, ops: params.ops.length },
+        ops: opDetails,
+        tree: sceneTree(next),
+      });
+    },
+  };
+
+  const grepCourse: AgentTool<typeof GREP_COURSE_SCHEMA, unknown> = {
+    name: 'grep_stage',
+    label: 'Search stage',
+    description:
+      'Search case-insensitive, NFKC-normalized literal text across stage scenes. text searches the visible-text projection; source searches serialized scene JSON. Returns at most 10 hits per scene and 30 total; truncated results always include a continuation cursor.',
+    parameters: GREP_COURSE_SCHEMA,
+    async execute(_id, params: GrepParams) {
+      const loaded = await loadCourse(deps, params.stageId);
+      if ('error' in loaded) return toolResult(loaded.error, {}, true);
+      const scope = params.scope ?? 'text';
+      const scenes = [...loaded.doc.scenes].sort((a, b) => a.order - b.order);
+      let sceneIndex = 0;
+      let offset = 0;
+      if (params.cursor) {
+        const cursor = decodeCursor(params.cursor);
+        if (
+          !cursor ||
+          cursor.stageId !== loaded.stageId ||
+          cursor.query !== params.query ||
+          cursor.scope !== scope ||
+          cursor.sceneIndex < 0 ||
+          cursor.sceneIndex > scenes.length ||
+          cursor.offset < 0
+        ) {
+          return toolResult('Invalid or mismatched grep_stage cursor.', {}, true);
+        }
+        sceneIndex = cursor.sceneIndex;
+        offset = cursor.offset;
+      }
+      const needle = foldNfkcCaseWithOffsets(params.query).value;
+      const deadline = performance.now() + SEARCH_TIME_BUDGET_MS;
+      let scannedChars = 0;
+      const hits: Array<{
+        scenePath: string;
+        order: number;
+        start: number;
+        end: number;
+        snippet: string;
+      }> = [];
+      let continuation: SearchCursor | undefined;
+
+      for (; sceneIndex < scenes.length; sceneIndex += 1, offset = 0) {
+        const scene = scenes[sceneIndex]!;
+        const source = grepText(scene, scope);
+        if (offset > source.length)
+          return toolResult('grep_stage cursor offset is out of range.', {}, true);
+        if (performance.now() >= deadline || scannedChars >= MAX_SEARCH_CHARS_PER_EXEC) {
+          continuation = {
+            v: 1,
+            stageId: loaded.stageId,
+            query: params.query,
+            scope,
+            sceneIndex,
+            offset,
+          };
+          break;
+        }
+        const remaining = MAX_SEARCH_CHARS_PER_EXEC - scannedChars;
+        const bodyEnd = Math.min(source.length, offset + remaining);
+        const overlapEnd = Math.min(source.length, bodyEnd + params.query.length * 4);
+        const folded = foldNfkcCaseWithOffsets(source.slice(offset, overlapEnd));
+        let fromIndex = 0;
+        let sceneHits = 0;
+        let resumeOffset = offset;
+        for (;;) {
+          const local = folded.value.indexOf(needle, fromIndex);
+          if (local < 0) break;
+          const start = offset + folded.originalStarts[local]!;
+          if (start >= bodyEnd) break;
+          const endFolded = local + needle.length - 1;
+          const end = offset + folded.originalEnds[endFolded]!;
+          const { snippetStart, snippetEnd } = boundedSnippet(source, start, end);
+          hits.push({
+            scenePath: `/scenes/${scene.id}`,
+            order: scene.order,
+            start,
+            end,
+            snippet: source.slice(snippetStart, snippetEnd),
+          });
+          sceneHits += 1;
+          resumeOffset = Math.max(end, start + 1);
+          fromIndex = local + Math.max(needle.length, 1);
+          if (
+            sceneHits >= MAX_SEARCH_HITS_PER_SCENE ||
+            hits.length >= MAX_SEARCH_HITS_TOTAL ||
+            performance.now() >= deadline
+          ) {
+            continuation = {
+              v: 1,
+              stageId: loaded.stageId,
+              query: params.query,
+              scope,
+              sceneIndex,
+              offset: resumeOffset,
+            };
+            break;
+          }
+        }
+        scannedChars += bodyEnd - offset;
+        if (continuation) break;
+        if (bodyEnd < source.length) {
+          continuation = {
+            v: 1,
+            stageId: loaded.stageId,
+            query: params.query,
+            scope,
+            sceneIndex,
+            offset: bodyEnd,
+          };
+          break;
+        }
+      }
+      const truncated = continuation !== undefined;
+      const cursor = continuation ? encodeCursor(continuation) : undefined;
+      const details = {
+        query: params.query,
+        scope,
+        hits,
+        scannedChars,
+        truncated,
+        ...(cursor ? { cursor } : {}),
+      };
+      return toolResult(JSON.stringify(details, null, 2), details);
+    },
+  };
+
+  return [readCourse, patchCourse, grepCourse] as unknown as AgentTool<never, never>[];
+}
+
+export const DSL_COURSE_TOOL_NAMES = ['read_stage', 'patch_stage', 'grep_stage'] as const;
+export const DSL_COURSE_WRITE_TOOLS = ['patch_stage'] as const;

--- a/lib/server/agent-runtime/runner-contract.ts
+++ b/lib/server/agent-runtime/runner-contract.ts
@@ -1,4 +1,7 @@
 import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { courseSystemPrompt, DSL_TOOLS_PROMPT } from './course-tools';
+
+type PromptBlocks = Parameters<typeof courseSystemPrompt>[0];
 
 /** Pure runner assembly seam: tests can pin the exact registered name set. */
 export function assembleRunnerTools(
@@ -7,9 +10,7 @@ export function assembleRunnerTools(
   return groups.flat();
 }
 
-// NOTE: `buildRunnerCoursePrompt` (the DSL-compatibility prompt block) is
-// intentionally not ported in this slice — it imports `courseSystemPrompt` /
-// `DSL_TOOLS_PROMPT` from `./course-tools`, which belongs to a later slice of
-// the agent-tool foundations wave. The runner already calls
-// `assembleRunnerTools` and builds its own (capability-conditional) prompt;
-// the course prompt block will layer on top once the course toolset lands.
+/** The DSL compatibility block is part of every runner prompt. */
+export function buildRunnerCoursePrompt(blocks: Omit<PromptBlocks, 'dslTools'>): string {
+  return courseSystemPrompt({ ...blocks, dslTools: DSL_TOOLS_PROMPT });
+}

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -19,17 +19,29 @@ import { buildAgent } from '@/lib/agent/runtime/build-agent';
 import { createCallLlmStreamFn } from '@/lib/agent/runtime/stream-fn';
 import { HOST_AGENT_LIFECYCLE as LIFECYCLE } from '@/lib/agent-runtime/lifecycle';
 import { createLogger } from '@/lib/logger';
+import { withPlainJsonDocumentWrites } from '@/lib/document-store/plain-json-store';
+import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
+import type { AppScene } from '@/lib/types/stage';
+import type { AppStage } from '@/lib/document-store/persistence-types';
+import type { DocumentStore } from '@openmaic/storage';
 
 import { resolveAgentDriverModel } from './agent-driver-model';
 import { buildAskUserTool } from './ask-user';
 import { agentRuntimeConfig as config } from './config';
 import { buildCreateSkillTool } from './create-skill';
+import { buildDslCourseToolset, type CourseStore } from './course-tools';
+import {
+  buildCurriculumTools,
+  CURRICULUM_ALLOWLIST,
+  CURRICULUM_TOOLS_PROMPT,
+} from './curriculum-tools';
+import { DSL_COURSE_TOOL_NAMES } from './dsl-tools';
 import {
   buildFetchUrlTool,
   fetchPromptBlock,
   untrustedContentPolicyPromptBlock,
 } from './fetch-url';
-import { assembleRunnerTools } from './runner-contract';
+import { assembleRunnerTools, buildRunnerCoursePrompt } from './runner-contract';
 import { buildSkillEditTools, SKILL_EDIT_TOOL_NAMES } from './skill-edit-tools';
 import { buildWebSearchTool, resolveWebSearchCapability, searchPromptBlock } from './web-search';
 import { buildSkillPreload, preloadUserMessage } from './skill-preload';
@@ -63,60 +75,14 @@ const MESSAGE_UPDATE_MIN_INTERVAL_MS = 150;
 export const MINIMAL_AGENT_TOOL_NAMES = new Set(['ask_user']);
 
 /**
- * Shared prompt lines for every registered toolset.
- *
- * The ask_user-only claim no longer exists as a runner form: the skill tools
- * (create_skill / read_skill / patch_skill) are registered unconditionally on
- * every run, so "your only available tool is ask_user" is never true.
+ * System prompt for a run with the given registered toolset, assembled by
+ * `buildRunnerCoursePrompt` (runner-contract.ts): the shared base lines from
+ * course-tools.ts, the DSL compatibility block (always present), and every
+ * capability block that is actually registered — the web-search block only
+ * when a web-search backend is configured, the curriculum block always, the
+ * skill discovery block when skills are installed, and the fetch_url guidance
+ * and untrusted-content policy always (fetch_url is always registered).
  */
-const AGENT_RUNTIME_SYSTEM_PROMPT_LINES = [
-  'You are a capable assistant working in a durable background session.',
-  'Complete the user request carefully and explain the result clearly.',
-  'The conversation may pause, restart on another worker, or receive follow-up messages.',
-  'Treat earlier conversation messages as durable context.',
-  'Do not claim access to tools or data that are not present in this session.',
-  'Use ask_user only when a decision genuinely belongs to the user.',
-  'Make every question self-contained and concise.',
-  'Offer stable, unique option ids when choices are useful.',
-  'After ask_user succeeds, stop and wait for the next user message.',
-  'Do not answer your own question or invent the user decision.',
-  'If no clarification is needed, answer directly without calling a tool.',
-  'Follow later user messages as updates to the same conversation.',
-  'Be honest about uncertainty and unavailable capabilities.',
-  "Reply in the user's language unless the user requests another language.",
-];
-
-/**
- * Product-neutral prompt for the minimal ask_user-only runtime slice.
- *
- * Retained for callers that build a deliberately minimal agent; the background
- * runner no longer uses it because the skill tools are always registered.
- */
-export const AGENT_RUNTIME_SYSTEM_PROMPT = [
-  ...AGENT_RUNTIME_SYSTEM_PROMPT_LINES.slice(0, 5),
-  'Your only available tool is ask_user.',
-  ...AGENT_RUNTIME_SYSTEM_PROMPT_LINES.slice(5),
-].join('\n');
-
-/**
- * System prompt for a run with the given registered toolset. When web_search is
- * registered the web-search capability block is appended; when skills are
- * installed, pi's standard `<available_skills>` discovery block is appended
- * too. The untrusted-content policy and fetch_url guidance are always present,
- * because `fetch_url` is always registered (reference semantics: the material
- * tools are unconditional, only web_search is capability-gated).
- */
-export function buildRunnerSystemPrompt(
-  webSearchRegistered: boolean,
-  availableSkills?: string,
-): string {
-  const base = webSearchRegistered
-    ? [...AGENT_RUNTIME_SYSTEM_PROMPT_LINES, searchPromptBlock()].join('\n')
-    : AGENT_RUNTIME_SYSTEM_PROMPT_LINES.join('\n');
-  const withFetch = [base, fetchPromptBlock(), untrustedContentPolicyPromptBlock()].join('\n\n');
-  return availableSkills ? `${withFetch}\n\n${availableSkills}` : withFetch;
-}
-
 function isLeaseLostError(error: unknown): boolean {
   let current = error;
   const visited = new Set<unknown>();
@@ -760,6 +726,34 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
           ),
         ]
       : [];
+    // The owner-bound document store: ONE store per run, bound to the claimed
+    // session's owner (`forOwner`), shared by every stage tool. The owner id is
+    // deliberately absent from every model-visible parameter — the model cannot
+    // forge a target owner, and a stage owned by another owner reads as missing
+    // and cannot be written. `withPlainJsonDocumentWrites` strips
+    // undefined-valued members at the write boundary so a JSON pointer `set`
+    // that carries them never persists a JSON-null key (reference semantics).
+    // `getAgentSessionStore` above already guards on DATABASE_URL, so the
+    // provider can only be reached with a configured connection string.
+    const { documentStore } = await getServerPersistenceProvider(process.env.DATABASE_URL ?? '');
+    const ownerScopedStore: CourseStore = withPlainJsonDocumentWrites(
+      documentStore.forOwner(meta.ownerId) as unknown as DocumentStore<AppScene, AppStage>,
+    );
+    // The stage read/patch toolset and the stage-level CRUD it needs. All of
+    // them write through `ownerScopedStore`; patch_stage is marked sequential
+    // by the shared STAGE_WRITER_TOOL_NAMES registry (course-tools.ts).
+    const dslTools = buildDslCourseToolset({
+      store: ownerScopedStore,
+      onCheckpoint: (info) => emit(LIFECYCLE.checkpoint, info),
+      sessionId: id,
+    });
+    const curriculumTools = buildCurriculumTools({
+      store: ownerScopedStore,
+      ownerId: meta.ownerId,
+      sessionId: id,
+      onStageLink: (course) => emit(LIFECYCLE.stageLink, course),
+      onLibraryChanged: (change) => emit(LIFECYCLE.libraryChanged, change),
+    });
     const tools = assembleRunnerTools(
       [askUserTool],
       webSearchTools,
@@ -782,15 +776,20 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       // fetch inside the session's observed origins, and it is the tool's core
       // security property.
       [buildFetchUrlTool({ sessionId: id })],
+      dslTools,
+      curriculumTools,
     );
     const askUserLatch = createAskUserTerminateLatch();
     let toolCalls = 0;
     const agent = buildAgent({
       streamFn,
-      systemPrompt: buildRunnerSystemPrompt(
-        search !== null,
-        availableSkillsPromptBlock(installedSkills),
-      ),
+      systemPrompt: buildRunnerCoursePrompt({
+        availableSkills: availableSkillsPromptBlock(installedSkills),
+        curriculum: CURRICULUM_TOOLS_PROMPT,
+        ...(search ? { search: searchPromptBlock() } : {}),
+        fetch: fetchPromptBlock(),
+        untrustedContent: untrustedContentPolicyPromptBlock(),
+      }),
       model: driver.piModel,
       tools,
       allowedToolNames: new Set([
@@ -800,6 +799,8 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         ...SKILL_EDIT_TOOL_NAMES,
         ...(skillReadTool ? ['read'] : []),
         'fetch_url',
+        ...DSL_COURSE_TOOL_NAMES,
+        ...CURRICULUM_ALLOWLIST,
       ]),
       ...(plan.kind === 'start' ? {} : { history: modelMessages }),
       afterToolCall: (toolContext) => {
@@ -1164,7 +1165,8 @@ export function startAgentRunner(): AgentRunnerHandle {
   log.info(
     'agent runner toolset: ask_user always; web_search when a web-search backend is configured; ' +
       'create_skill/read_skill/patch_skill and the skill-scoped read when skills are installed; ' +
-      'fetch_url always (URL trust gate enforced per call)',
+      'fetch_url always (URL trust gate enforced per call); ' +
+      'read_stage/patch_stage/grep_stage and create_stage/read_stage_outline always (owner-scoped store)',
   );
 
   return {

--- a/tests/agent-runtime/curriculum-tools.test.ts
+++ b/tests/agent-runtime/curriculum-tools.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Multi-stage curriculum tools in this slice: create_stage and
+ * read_stage_outline (folders / rename / list land with the folder slice).
+ *
+ * Pins:
+ *  - create_stage is idempotent by construction: the SAME call id replays onto
+ *    the stage it already minted (nothing re-minted), a different call id mints
+ *    a different stage, and a document at the derived id this session did NOT
+ *    mint is refused fail-closed;
+ *  - create_stage mints the document skeleton through the store with
+ *    server-job producer semantics;
+ *  - every tool is OWNER-scoped: through the owner-bound store a foreign or
+ *    missing stage reads as absent and is refused (never confirmed);
+ *  - every execute takes pi's 3rd `signal` argument and re-checks it at each
+ *    IO boundary: a pre-aborted signal throws before any work;
+ *  - read_stage_outline renders the outline/scene UNION view (planned pages
+ *    while generation is incomplete, pure scenes once complete).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildCurriculumTools,
+  CURRICULUM_ALLOWLIST,
+  CURRICULUM_TOOLS_PROMPT,
+  type CurriculumToolDeps,
+} from '@/lib/server/agent-runtime/curriculum-tools';
+import type { CourseDocument, CourseStore } from '@/lib/server/agent-runtime/course-tools';
+import type { Scene } from '@/lib/types/stage';
+
+interface ToolResultShape {
+  isError?: boolean;
+  content: { type: string; text: string }[];
+  details?: Record<string, unknown>;
+}
+
+function makeStore(initial: CourseDocument | null = null): CourseStore {
+  let doc = initial;
+  const store = {
+    async loadDocument() {
+      return doc;
+    },
+    async saveDocument(next: CourseDocument) {
+      doc = next;
+    },
+    async putScene(_stageId: string, scene: Scene) {
+      if (!doc) throw new Error('no document');
+      const scenes = doc.scenes.filter((s) => s.id !== scene.id);
+      scenes.push(scene);
+      scenes.sort((a, b) => a.order - b.order);
+      doc = { ...doc, scenes };
+    },
+  };
+  return store as unknown as CourseStore;
+}
+
+/**
+ * A store keyed by stage id (the naive `makeStore` ignores the stage id, which
+ * is exactly right for most tests but cannot tell a replay of the same stage
+ * from a genuinely different one).
+ */
+function makeKeyedStore(): CourseStore & { docs: Map<string, CourseDocument> } {
+  const docs = new Map<string, CourseDocument>();
+  const store = {
+    docs,
+    async loadDocument(stageId: string) {
+      return docs.get(stageId) ?? null;
+    },
+    async saveDocument(next: CourseDocument) {
+      docs.set(next.stage.id, next);
+    },
+    async putScene(stageId: string, scene: Scene) {
+      const doc = docs.get(stageId);
+      if (!doc) throw new Error('no document');
+      const scenes = doc.scenes.filter((s) => s.id !== scene.id);
+      scenes.push(scene);
+      scenes.sort((a, b) => a.order - b.order);
+      docs.set(stageId, { ...doc, scenes });
+    },
+  };
+  return store as unknown as CourseStore & { docs: Map<string, CourseDocument> };
+}
+
+function ownedDoc(stageId: string, name: string): CourseDocument {
+  return {
+    stage: { id: stageId, name, createdAt: 1, updatedAt: 1 },
+    scenes: [],
+    outline: {
+      outlines: [
+        { id: 'p1', order: 1, title: 'Intro', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'p2', order: 2, title: 'Deep Dive', description: 'd', keyPoints: [], type: 'quiz' },
+      ],
+      requirement: 'a course',
+      generationComplete: false,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    },
+  };
+}
+
+function makeDeps(overrides: Partial<CurriculumToolDeps> = {}): CurriculumToolDeps {
+  return {
+    store: makeStore(ownedDoc('stage-b', 'Course B')),
+    ownerId: 'user:u1',
+    sessionId: 'session-1',
+    ...overrides,
+  } as CurriculumToolDeps;
+}
+
+async function runTool(
+  deps: CurriculumToolDeps,
+  name: string,
+  params: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<ToolResultShape> {
+  const tools = buildCurriculumTools(deps);
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`${name} not registered`);
+  return (await tool.execute('call-1', params as never, signal)) as ToolResultShape;
+}
+
+describe('create_stage', () => {
+  it('emits courseLink after creating the stage', async () => {
+    const onStageLink = vi.fn();
+    const result = await runTool(makeDeps({ store: makeStore(), onStageLink }), 'create_stage', {
+      title: 'Day 1',
+    });
+    expect(result.isError).toBeUndefined();
+    expect(onStageLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stageId: result.details?.stageId,
+        url: expect.stringMatching(/^\/classroom\//),
+      }),
+    );
+  });
+
+  it('mints a server-job document skeleton and returns the classroom url', async () => {
+    const store = makeStore();
+    const deps = makeDeps({ store });
+    const result = await runTool(deps, 'create_stage', {
+      title: 'Day 1 — Python',
+      brief: 'basics',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.details?.url).toMatch(/^\/classroom\/stage-/);
+    expect(result.details?.title).toBe('Day 1 — Python');
+
+    const doc = (
+      store as unknown as { loadDocument(): Promise<CourseDocument | null> }
+    ).loadDocument();
+    const saved = await doc;
+    expect(saved?.stage.name).toBe('Day 1 — Python');
+    expect(saved?.stage.description).toBe('basics');
+    expect(saved?.scenes).toEqual([]);
+    expect(saved?.outline).toMatchObject({
+      outlines: [],
+      requirement: 'Day 1 — Python',
+      generationComplete: true,
+      producer: 'server-job',
+      producerRef: 'session-1',
+    });
+  });
+
+  it('omits description and producerRef when not provided', async () => {
+    const store = makeStore();
+    const deps = makeDeps({ store, sessionId: '' });
+    const result = await runTool(deps, 'create_stage', { title: 'Course' });
+    expect(result.isError).toBeUndefined();
+    const saved = await (
+      store as unknown as { loadDocument(): Promise<CourseDocument | null> }
+    ).loadDocument();
+    expect(saved?.stage.description).toBeUndefined();
+    expect((saved?.outline as { producerRef?: string }).producerRef).toBeUndefined();
+  });
+
+  it('rejects an empty title', async () => {
+    const deps = makeDeps();
+    const result = await runTool(deps, 'create_stage', { title: '   ' });
+    expect(result.isError).toBe(true);
+    expect(result.details?.error).toBe('empty-title');
+  });
+
+  it('throws before any work when the run signal is already aborted', async () => {
+    const store = makeStore();
+    const save = vi.spyOn(store as unknown as { saveDocument(): Promise<void> }, 'saveDocument');
+    const controller = new AbortController();
+    controller.abort();
+    const deps = makeDeps({ store });
+    await expect(
+      runTool(deps, 'create_stage', { title: 'Course' }, controller.signal),
+    ).rejects.toThrow('aborted');
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('replaying the SAME call id is idempotent: same stage id, existing stage returned, nothing re-minted', async () => {
+    // A crash between saveDocument and the result checkpoint makes the resume
+    // path re-issue the same tool call. The stage id derives from
+    // (sessionId, callId), so the retry lands on the stage the original minted
+    // instead of casting a second orphan course.
+    const store = makeKeyedStore();
+    const save = vi.spyOn(store, 'saveDocument');
+    const deps = makeDeps({ store });
+    const tools = buildCurriculumTools(deps);
+    const createStage = tools.find((t) => t.name === 'create_stage');
+    if (!createStage) throw new Error('create_stage not registered');
+
+    const first = (await createStage.execute('call-9', {
+      title: 'Day 1 — Python',
+    } as never)) as ToolResultShape;
+    expect(first.isError).toBeUndefined();
+    expect(save).toHaveBeenCalledTimes(1);
+
+    const second = (await createStage.execute('call-9', {
+      title: 'Day 1 — Python',
+    } as never)) as ToolResultShape;
+    expect(second.isError).toBeUndefined();
+    expect(second.details?.stageId).toBe(first.details?.stageId);
+    expect(second.details?.reused).toBe(true);
+    expect(second.details?.url).toBe(first.details?.url);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(store.docs.size).toBe(1);
+  });
+
+  it('a DIFFERENT call id derives a DIFFERENT stage id (a genuinely new create)', async () => {
+    const store = makeKeyedStore();
+    const deps = makeDeps({ store });
+    const createStage = buildCurriculumTools(deps).find((t) => t.name === 'create_stage');
+    if (!createStage) throw new Error('create_stage not registered');
+
+    const a = (await createStage.execute('call-a', {
+      title: 'Day 1',
+    } as never)) as ToolResultShape;
+    const b = (await createStage.execute('call-b', {
+      title: 'Day 1',
+    } as never)) as ToolResultShape;
+    expect(a.isError).toBeUndefined();
+    expect(b.isError).toBeUndefined();
+    expect(a.details?.stageId).not.toBe(b.details?.stageId);
+    expect(store.docs.size).toBe(2);
+    expect(a.details?.stageId).toMatch(/^stage-[A-Za-z0-9_-]{10}$/);
+  });
+
+  it('refuses to confirm a stage at the derived id that this session did NOT mint', async () => {
+    // Same call id but the existing document carries a foreign producer ref:
+    // fail-closed — never confirm or overwrite a document that is not this
+    // session's own mint.
+    const foreign = ownedDoc('stage-whatever', 'Someone else');
+    foreign.outline = {
+      outlines: [],
+      requirement: 'x',
+      generationComplete: false,
+      producer: 'server-job',
+      producerRef: 'other-session',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const deps = makeDeps({ store: makeStore(foreign) });
+    const result = await runTool(deps, 'create_stage', { title: 'Day 1' });
+    expect(result.isError).toBe(true);
+    expect(result.details?.refused).toBe(true);
+  });
+});
+
+describe('read_stage_outline', () => {
+  it('returns the title and page-list summary of an owned course (not content)', async () => {
+    const deps = makeDeps();
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.isError).toBeUndefined();
+    expect(result.details).toMatchObject({
+      stageId: 'stage-b',
+      title: 'Course B',
+      pageCount: 2,
+      pages: [
+        { order: 1, title: 'Intro', type: 'slide' },
+        { order: 2, title: 'Deep Dive', type: 'quiz' },
+      ],
+    });
+  });
+
+  it('refuses a stage the owner does not own (owner-bound store reads it as absent)', async () => {
+    // Through the owner-scoped store a foreign or missing stage loads as null,
+    // so the tool refuses fail-closed without ever confirming the id.
+    const deps = makeDeps({ store: makeStore(null) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-x' });
+    expect(result.isError).toBe(true);
+    expect(result.details?.refused).toBe(true);
+    expect(result.content[0].text).toContain('does not belong to this session user');
+  });
+
+  it('falls back to the persisted scene list when there is no outline snapshot', async () => {
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.outline = undefined;
+    doc.scenes = [
+      { id: 's1', stageId: 'stage-b', order: 1, title: 'Scene 1', type: 'slide' } as Scene,
+    ];
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.details?.pages).toEqual([{ order: 1, title: 'Scene 1', type: 'slide' }]);
+  });
+
+  it('derives the page list from REAL scenes when pages exist, ignoring a drifted outline snapshot', async () => {
+    // The reviewer scenario: an import at order 2 shifts scenes 2/3 to 3/4
+    // but the outline snapshot keeps [1,2,2,3]. Deriving from the scenes must
+    // yield [1,2,3,4] with no duplicated page numbers.
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.scenes = [
+      { id: 's1', stageId: 'stage-b', order: 1, title: 'Page one', type: 'slide' } as Scene,
+      { id: 's2', stageId: 'stage-b', order: 2, title: 'Inserted', type: 'slide' } as Scene,
+      { id: 's3', stageId: 'stage-b', order: 3, title: 'Page two', type: 'slide' } as Scene,
+      { id: 's4', stageId: 'stage-b', order: 4, title: 'Page three', type: 'quiz' } as Scene,
+    ];
+    doc.outline = {
+      outlines: [
+        { id: 'p1', order: 1, title: 'Page one', description: 'd', keyPoints: [], type: 'slide' },
+        {
+          id: 'p2',
+          order: 2,
+          title: 'Page two',
+          description: 'd',
+          keyPoints: [],
+          type: 'slide',
+        },
+        { id: 'p3', order: 2, title: 'Inserted', description: 'd', keyPoints: [], type: 'slide' },
+        {
+          id: 'p4',
+          order: 3,
+          title: 'Page three',
+          description: 'd',
+          keyPoints: [],
+          type: 'quiz',
+        },
+      ],
+      requirement: 'a course',
+      generationComplete: true,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.isError).toBeUndefined();
+    const pages = result.details?.pages as { order: number; title: string }[];
+    expect(pages.map((p) => p.order)).toEqual([1, 2, 3, 4]);
+    expect(new Set(pages.map((p) => p.order)).size).toBe(4);
+    expect(pages.map((p) => p.title)).toEqual(['Page one', 'Inserted', 'Page two', 'Page three']);
+    expect(result.details?.pageCount).toBe(4);
+  });
+
+  it('union view: while generation is incomplete, planned pages without a scene are appended as a planned tail (R2-P2-3)', async () => {
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.outline = {
+      outlines: [
+        { id: 'p1', order: 1, title: 'Intro', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'p2', order: 2, title: 'Deep Dive', description: 'd', keyPoints: [], type: 'quiz' },
+        { id: 'p3', order: 3, title: 'Wrap-up', description: 'd', keyPoints: [], type: 'slide' },
+      ],
+      requirement: 'a course',
+      generationComplete: false,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    doc.scenes = [
+      {
+        id: 's1',
+        stageId: 'stage-b',
+        order: 1,
+        title: 'Intro',
+        type: 'slide',
+        outlineId: 'p1',
+      } as Scene,
+    ];
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.isError).toBeUndefined();
+    expect(result.details?.pageCount).toBe(3);
+    expect(result.details?.pages).toEqual([
+      { order: 1, title: 'Intro', type: 'slide' },
+      { order: 2, title: 'Deep Dive', type: 'quiz' },
+      { order: 3, title: 'Wrap-up', type: 'slide' },
+    ]);
+    // The human-readable text marks the not-yet-landed pages as planned.
+    const text = result.content[0].text;
+    expect(text).toContain('- 1. Intro [slide]');
+    expect(text).not.toContain('- 1. Intro [slide] (planned)');
+    expect(text).toContain('- 2. Deep Dive [quiz] (planned)');
+    expect(text).toContain('- 3. Wrap-up [slide] (planned)');
+  });
+
+  it('a COMPLETED outline is pure scenes: the planned tail can never resurface (R2-P2-3)', async () => {
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.outline = {
+      outlines: [
+        { id: 'p1', order: 1, title: 'Intro', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'p2', order: 2, title: 'Deep Dive', description: 'd', keyPoints: [], type: 'quiz' },
+        { id: 'p3', order: 3, title: 'Wrap-up', description: 'd', keyPoints: [], type: 'slide' },
+      ],
+      requirement: 'a course',
+      generationComplete: true,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    doc.scenes = [
+      {
+        id: 's1',
+        stageId: 'stage-b',
+        order: 1,
+        title: 'Intro',
+        type: 'slide',
+        outlineId: 'p1',
+      } as Scene,
+    ];
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.details?.pageCount).toBe(1);
+    expect(result.details?.pages).toEqual([{ order: 1, title: 'Intro', type: 'slide' }]);
+    expect(result.content[0].text).not.toContain('(planned)');
+  });
+
+  it('a real page WITHOUT outlineId pairs by order — the plan is not duplicated (R3-P2-2)', async () => {
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.scenes = [
+      { id: 's1', stageId: 'stage-b', order: 1, title: 'Intro', type: 'slide' } as Scene,
+    ];
+    doc.outline = {
+      outlines: [
+        { id: 'p1', order: 1, title: 'Intro', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'p2', order: 2, title: 'Deep Dive', description: 'd', keyPoints: [], type: 'quiz' },
+      ],
+      requirement: 'a course',
+      generationComplete: false,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.isError).toBeUndefined();
+    expect(result.details?.pageCount).toBe(2);
+    expect(result.details?.pages).toEqual([
+      { order: 1, title: 'Intro', type: 'slide' },
+      { order: 2, title: 'Deep Dive', type: 'quiz' },
+    ]);
+    const text = result.content[0].text;
+    // Page 1 appears exactly once, as the REAL page (not planned).
+    expect(text).toContain('- 1. Intro [slide]');
+    expect(text).not.toContain('- 1. Intro [slide] (planned)');
+    expect(text).toContain('- 2. Deep Dive [quiz] (planned)');
+  });
+
+  it('a duplicated outlineId consumes only the FIRST plan entry — the twin is not swallowed (R3-P2-2)', async () => {
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.scenes = [
+      {
+        id: 's1',
+        stageId: 'stage-b',
+        order: 1,
+        title: 'Page one',
+        type: 'slide',
+        outlineId: 'dup',
+      } as Scene,
+    ];
+    doc.outline = {
+      outlines: [
+        { id: 'dup', order: 1, title: 'Page one', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'dup', order: 2, title: 'Page two', description: 'd', keyPoints: [], type: 'slide' },
+      ],
+      requirement: 'a course',
+      generationComplete: false,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.isError).toBeUndefined();
+    expect(result.details?.pageCount).toBe(2);
+    expect(result.details?.pages).toEqual([
+      { order: 1, title: 'Page one', type: 'slide' },
+      { order: 2, title: 'Page two', type: 'slide' },
+    ]);
+    expect(result.content[0].text).toContain('- 2. Page two [slide] (planned)');
+  });
+
+  it('merges a mid-deck scene by order: scenes [2] + plan [1,2,3] read [planned 1, real 2, planned 3] (R3-P2-3)', async () => {
+    const doc = ownedDoc('stage-b', 'Course B');
+    doc.scenes = [{ id: 's2', stageId: 'stage-b', order: 2, title: 'Mid', type: 'slide' } as Scene];
+    doc.outline = {
+      outlines: [
+        { id: 'p1', order: 1, title: 'Intro', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'p2', order: 2, title: 'Mid', description: 'd', keyPoints: [], type: 'slide' },
+        { id: 'p3', order: 3, title: 'Wrap-up', description: 'd', keyPoints: [], type: 'slide' },
+      ],
+      requirement: 'a course',
+      generationComplete: false,
+      producer: 'server-job',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const deps = makeDeps({ store: makeStore(doc) });
+    const result = await runTool(deps, 'read_stage_outline', { stageId: 'stage-b' });
+    expect(result.isError).toBeUndefined();
+    expect(result.details?.pageCount).toBe(3);
+    expect(result.details?.pages).toEqual([
+      { order: 1, title: 'Intro', type: 'slide' },
+      { order: 2, title: 'Mid', type: 'slide' },
+      { order: 3, title: 'Wrap-up', type: 'slide' },
+    ]);
+    const text = result.content[0].text;
+    expect(text).toContain('- 1. Intro [slide] (planned)');
+    expect(text).toContain('- 2. Mid [slide]');
+    expect(text).not.toContain('- 2. Mid [slide] (planned)');
+    expect(text).toContain('- 3. Wrap-up [slide] (planned)');
+  });
+});
+
+describe('curriculum allowlist', () => {
+  it('registers exactly the two tools of this slice and no folder tools yet', () => {
+    for (const name of ['create_stage', 'read_stage_outline']) {
+      expect(CURRICULUM_ALLOWLIST).toContain(name);
+    }
+    expect(CURRICULUM_ALLOWLIST.size).toBe(2);
+    for (const name of ['create_folder', 'move_to_folder', 'rename_stage', 'list_folder_stages']) {
+      expect(CURRICULUM_ALLOWLIST).not.toContain(name);
+    }
+  });
+
+  it('exposes both tools from the toolset', () => {
+    const tools = buildCurriculumTools(makeDeps());
+    expect(tools.map((t) => t.name)).toEqual(['create_stage', 'read_stage_outline']);
+  });
+
+  it('prompt block teaches explicit stage ids and outline chaining without folder tools', () => {
+    expect(CURRICULUM_TOOLS_PROMPT).toContain('`create_stage`');
+    expect(CURRICULUM_TOOLS_PROMPT).toContain('`read_stage_outline`');
+    expect(CURRICULUM_TOOLS_PROMPT).not.toContain('create_folder');
+    expect(CURRICULUM_TOOLS_PROMPT).not.toContain('list_folder_stages');
+  });
+});

--- a/tests/agent-runtime/dsl-tools.test.ts
+++ b/tests/agent-runtime/dsl-tools.test.ts
@@ -1,0 +1,1356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Check } from 'typebox/value';
+import { PGlite } from '@electric-sql/pglite';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { PPTTextElement } from '@openmaic/dsl';
+import { PgDocumentStore, ensureDocumentSchema } from '@openmaic/storage/document/pg';
+import type { DocumentStore } from '@openmaic/storage';
+import {
+  buildCourseAllowlist,
+  buildDslCourseToolset,
+  DSL_TOOLS_PROMPT,
+  type CourseDocument,
+  type CourseStore,
+} from '@/lib/server/agent-runtime/course-tools';
+import {
+  buildDslCourseTools,
+  foldNfkcCaseWithOffsets,
+  GREP_COURSE_SCHEMA,
+  PATCH_COURSE_SCHEMA,
+  READ_COURSE_SCHEMA,
+} from '@/lib/server/agent-runtime/dsl-tools';
+import { buildCurriculumTools } from '@/lib/server/agent-runtime/curriculum-tools';
+import { buildRunnerCoursePrompt } from '@/lib/server/agent-runtime/runner-contract';
+import { withPlainJsonDocumentWrites } from '@/lib/document-store/plain-json-store';
+import type {
+  InteractiveContent,
+  PBLContent,
+  QuizContent,
+  Scene,
+  SlideContent,
+} from '@/lib/types/stage';
+import type { AppStage } from '@/lib/document-store/persistence-types';
+import type { AppScene } from '@/lib/types/stage';
+
+function slideScene(order = 1, id = 'scene_slide'): Scene {
+  return {
+    id,
+    stageId: 'stage-test',
+    order,
+    title: 'ＡＩ 开场',
+    type: 'slide',
+    content: {
+      type: 'slide',
+      canvas: {
+        id: 'canvas-1',
+        viewportSize: 1000,
+        viewportRatio: 0.5625,
+        theme: {
+          backgroundColor: '#fff',
+          themeColors: ['#2563eb'],
+          fontColor: '#111',
+          fontName: 'Inter',
+        },
+        elements: [
+          {
+            id: 'el-title',
+            type: 'text',
+            left: 10,
+            top: 10,
+            width: 400,
+            height: 80,
+            rotate: 0,
+            content: '<p>Hello AI</p>',
+            defaultFontName: 'Inter',
+            defaultColor: '#111',
+            fill: '#fff',
+          } as PPTTextElement,
+        ],
+      },
+    },
+    actions: [{ id: 'act-1', type: 'speech', text: 'Welcome', audioId: 'asset-old' }],
+  } as Scene;
+}
+
+function quizScene(): Scene {
+  return {
+    id: 'scene_quiz',
+    stageId: 'stage-test',
+    order: 2,
+    title: 'Quiz',
+    type: 'quiz',
+    content: {
+      type: 'quiz',
+      questions: [
+        {
+          id: 'q1',
+          type: 'single',
+          question: 'Which answer?',
+          options: [
+            { label: 'Alpha', value: 'A' },
+            { label: 'Beta', value: 'B' },
+          ],
+          answer: ['A'],
+          analysis: 'Because Alpha.',
+        },
+      ],
+    },
+    actions: [],
+  } as Scene;
+}
+
+function interactiveScene(): Scene {
+  return {
+    id: 'scene_widget',
+    stageId: 'stage-test',
+    order: 3,
+    title: 'Widget',
+    type: 'interactive',
+    content: {
+      type: 'interactive',
+      html: '<html><style>.hidden{}</style><body>Visible widget words</body></html>',
+      widgetType: 'simulation',
+      widgetConfig: {
+        type: 'simulation',
+        concept: 'gravity',
+        description: 'Change the mass',
+        variables: [{ name: 'mass', label: 'Mass', min: 1, max: 10, default: 2 }],
+      },
+    },
+    actions: [],
+  } as Scene;
+}
+
+function pblScene(): Scene {
+  return {
+    id: 'scene_pbl',
+    stageId: 'stage-test',
+    order: 4,
+    title: 'Project',
+    type: 'pbl',
+    content: {
+      type: 'pbl',
+      projectV2: {
+        uiPhase: 'hero',
+        title: 'Build a bridge',
+        description: 'Make a model',
+        proficiency: '',
+        language: 'en',
+        tags: [],
+        status: 'designing',
+        roles: [{ id: 'role-1', type: 'instructor', name: 'Instructor' }],
+        milestones: [
+          {
+            id: 'ms-1',
+            title: 'Plan',
+            status: 'locked',
+            order: 1,
+            microtasks: [
+              {
+                id: 'mt-1',
+                title: 'Sketch',
+                status: 'todo',
+                assignee: 'user',
+                hints: ['Use triangles'],
+                order: 1,
+              },
+            ],
+          },
+        ],
+        submissions: [],
+        evaluations: [],
+        threads: [{ agentId: 'role-1', messages: [] }],
+        engagementEvents: [],
+        createdAt: '2026-08-22T00:00:00.000Z',
+        updatedAt: '2026-08-22T00:00:00.000Z',
+      },
+    },
+    actions: [],
+  } as Scene;
+}
+
+function course(scenes: Scene[] = [slideScene(), quizScene(), interactiveScene(), pblScene()]) {
+  return {
+    stage: {
+      id: 'stage-test',
+      name: 'Test course',
+      description: 'Course description',
+      createdAt: 1,
+      updatedAt: 1,
+    },
+    outline: {
+      outlines: scenes.map((scene) => ({
+        id: `outline-${scene.id}`,
+        order: scene.order,
+        type: scene.type,
+        title: scene.title,
+        description: `Outline ${scene.title}`,
+        keyPoints: [],
+      })),
+    },
+    scenes,
+  } as unknown as CourseDocument;
+}
+
+function state(initial = course()) {
+  let doc = structuredClone(initial);
+  const putScene = vi.fn(async (_stageId: string, scene: Scene) => {
+    doc = {
+      ...doc,
+      scenes: doc.scenes.map((item) => (item.id === scene.id ? scene : item)),
+    };
+  });
+  const loadDocument = vi.fn(async (stageId: string) => (stageId === doc.stage.id ? doc : null));
+  return {
+    store: { loadDocument, putScene } as unknown as CourseStore,
+    get: () => doc,
+    putScene,
+    loadDocument,
+  };
+}
+
+function dslTools(store: CourseStore) {
+  return buildDslCourseTools({
+    store,
+    onCheckpoint: () => undefined,
+  });
+}
+
+function tool(tools: AgentTool<never, never>[], name: string) {
+  const found = tools.find((item) => item.name === name);
+  if (!found) throw new Error(`missing tool ${name}`);
+  return {
+    ...found,
+    execute(callId: string, params: Record<string, unknown>, signal?: AbortSignal) {
+      return found.execute(callId, { stageId: 'stage-test', ...params } as never, signal);
+    },
+  };
+}
+
+function textOf(result: unknown): string {
+  return (result as { content: Array<{ text: string }> }).content[0]!.text;
+}
+
+describe('read_stage', () => {
+  it('reads tree/source/text and resolves both order and scene id', async () => {
+    const current = state();
+    const read = tool(dslTools(current.store), 'read_stage');
+
+    const tree = await read.execute('tree', {} as never);
+    const parsedTree = JSON.parse(textOf(tree));
+    expect(parsedTree.stage).toMatchObject({ id: 'stage-test' });
+    expect(parsedTree.scenes[0]).toMatchObject({
+      id: 'scene_slide',
+      elements: { total: 1, types: { text: 1 } },
+      actions: { total: 1 },
+    });
+
+    const byOrder = await read.execute('source-order', {
+      path: '/scenes/2',
+      detail: 'source',
+    } as never);
+    expect(JSON.parse(textOf(byOrder))).toMatchObject({ id: 'scene_quiz', type: 'quiz' });
+
+    const byId = await read.execute('source-id', {
+      path: '/scenes/scene_widget',
+      detail: 'source',
+    } as never);
+    expect(JSON.parse(textOf(byId))).toMatchObject({
+      id: 'scene_widget',
+      content: { widgetType: 'simulation' },
+    });
+
+    const text = await read.execute('text', {
+      path: '/scenes/scene_slide',
+      detail: 'text',
+    } as never);
+    expect(JSON.parse(textOf(text)).combinedText).toContain('Hello AI');
+    expect(JSON.parse(textOf(text)).combinedText).toContain('Welcome');
+  });
+
+  it('returns an error with legal forms for bad paths and inaccessible explicit stages', async () => {
+    const current = state();
+    const read = tool(dslTools(current.store), 'read_stage');
+    const missing = await read.execute('missing', {
+      path: '/scenes/99',
+      detail: 'source',
+    } as never);
+    expect(missing).toMatchObject({ isError: true });
+    expect(textOf(missing)).toContain('Legal paths');
+
+    const foreign = await read.execute('foreign', { stageId: 'stage-foreign' } as never);
+    expect(foreign).toMatchObject({ isError: true });
+    expect(textOf(foreign)).toContain('not accessible');
+    expect(current.loadDocument).toHaveBeenLastCalledWith('stage-foreign');
+  });
+
+  it('omits large media bytes and paginates source/text at 12000 characters', async () => {
+    const scene = slideScene();
+    const imageBytes = Buffer.alloc(5_000, 0x61).toString('base64');
+    (scene.content as SlideContent).canvas.elements.unshift({
+      id: 'image-1',
+      type: 'image',
+      left: 0,
+      top: 100,
+      width: 100,
+      height: 100,
+      rotate: 0,
+      fixedRatio: true,
+      src: `data:image/png;base64,${imageBytes}`,
+    });
+    ((scene.content as SlideContent).canvas.elements[1] as PPTTextElement).content =
+      `<p>${'x'.repeat(25_000)}</p>`;
+    const current = state(course([scene]));
+    const read = tool(dslTools(current.store), 'read_stage');
+    const first = await read.execute('first', {
+      path: '/scenes/1',
+      detail: 'source',
+    } as never);
+    expect(textOf(first)).toContain('bytes omitted');
+    expect(textOf(first)).not.toContain(imageBytes);
+    expect(textOf(first)).toContain('grep_stage');
+    expect(textOf(first)).toContain('Output truncated at 12000 chars');
+    expect(textOf(first)).toContain('offset=12000');
+    expect(first.details).toMatchObject({ totalChars: expect.any(Number), nextOffset: 12_000 });
+    const nextOffset = (first.details as { nextOffset: number }).nextOffset;
+    const second = await read.execute('second', {
+      path: '/scenes/1',
+      detail: 'source',
+      offset: nextOffset,
+    } as never);
+    expect((second.details as { totalChars: number }).totalChars).toBe(
+      (first.details as { totalChars: number }).totalChars,
+    );
+    const textPage = await read.execute('text-page', {
+      path: '/scenes/1',
+      detail: 'text',
+    } as never);
+    expect(textPage.details).toMatchObject({ nextOffset: 12_000 });
+    expect(textOf(textPage)).toContain('grep_stage');
+    expect((current.get().scenes[0]!.content as SlideContent).canvas.elements[0]).toMatchObject({
+      src: `data:image/png;base64,${imageBytes}`,
+    });
+  });
+
+  it('leaves untruncated results free of the pagination hint', async () => {
+    const current = state();
+    const read = tool(dslTools(current.store), 'read_stage');
+    const source = await read.execute('source-small', {
+      path: '/scenes/1',
+      detail: 'source',
+    } as never);
+    expect(textOf(source)).not.toContain('Output truncated');
+    const text = await read.execute('text-small', {
+      path: '/scenes/1',
+      detail: 'text',
+    } as never);
+    expect(textOf(text)).not.toContain('Output truncated');
+    const tree = await read.execute('tree-small', {} as never);
+    expect(textOf(tree)).not.toContain('Output truncated');
+  });
+});
+
+describe('patch_stage', () => {
+  it.each(['scene_widget', 'scene_pbl'] as const)(
+    'rejects set /actions to a non-array on %s and never persists (R5-P2-2)',
+    async (target) => {
+      const current = state();
+      const patch = tool(dslTools(current.store), 'patch_stage');
+      const result = await patch.execute('bad-actions', {
+        target: `/scenes/${target}`,
+        intent: 'Set actions to garbage',
+        ops: [{ op: 'set', path: '/actions', value: 'not-an-action-array' }],
+      } as never);
+      expect(result).toMatchObject({ isError: true });
+      expect(textOf(result)).toContain('structure validation');
+      // The corrupted actions value never reaches the store.
+      expect(current.putScene).not.toHaveBeenCalled();
+      const scene = current.get().scenes.find((item) => item.id === target);
+      expect(scene?.actions).toEqual([]);
+    },
+  );
+
+  it.each(['scene_widget', 'scene_pbl'] as const)(
+    'accepts a valid actions array on %s (R5-P2-2)',
+    async (target) => {
+      const current = state();
+      const patch = tool(dslTools(current.store), 'patch_stage');
+      const actions = [{ id: 'a1', type: 'speech', text: '说明' }];
+      const result = await patch.execute('good-actions', {
+        target: `/scenes/${target}`,
+        intent: 'Set narration',
+        ops: [{ op: 'set', path: '/actions', value: actions }],
+      } as never);
+      expect(result).not.toHaveProperty('isError');
+      expect(current.putScene).toHaveBeenCalledTimes(1);
+      expect(current.get().scenes.find((item) => item.id === target)?.actions).toEqual(actions);
+    },
+  );
+
+  it('applies set/remove atomically and clears stale speech audio', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/scene_slide',
+      intent: 'Update title color and narration',
+      ops: [
+        { op: 'set', path: '/content/canvas/elements/0/defaultColor', value: '#f00' },
+        { op: 'set', path: '/actions/0/text', value: 'New narration' },
+        { op: 'remove', path: '/content/canvas/elements/0/fill' },
+      ],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    const scene = current.get().scenes[0]!;
+    expect(
+      ((scene.content as SlideContent).canvas.elements[0] as PPTTextElement).defaultColor,
+    ).toBe('#f00');
+    expect((scene.content as SlideContent).canvas.elements[0]).not.toHaveProperty('fill');
+    expect(scene.actions?.[0]).toMatchObject({ text: 'New narration' });
+    expect(scene.actions?.[0]).not.toHaveProperty('audioId');
+    expect(result.details).toMatchObject({
+      intent: 'Update title color and narration',
+      updated: { ops: 3 },
+      tree: { id: 'scene_slide' },
+    });
+  });
+
+  it('a later patch_stage call keeps an earlier long HTML element change (no sibling loss)', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    // >2KiB HTML, larger than the read-side media-byte-omission cutoff — the
+    // value the next call must not drop.
+    const longHtml = `<p>${'深'.repeat(2400)}</p>`;
+
+    const first = await patch.execute('patch', {
+      target: '/scenes/scene_slide',
+      intent: 'Set a long opening line',
+      ops: [{ op: 'set', path: '/content/canvas/elements/0/content', value: longHtml }],
+    } as never);
+    expect(first).not.toHaveProperty('isError');
+
+    // A second, independent call patches a DIFFERENT sibling (the narration).
+    const second = await patch.execute('patch', {
+      target: '/scenes/1',
+      intent: 'Fix the narration',
+      ops: [{ op: 'set', path: '/actions/0/text', value: 'New narration' }],
+    } as never);
+    expect(second).not.toHaveProperty('isError');
+
+    const scene = current.get().scenes[0]!;
+    expect((scene.content as SlideContent).canvas.elements[0]).toMatchObject({
+      content: longHtml,
+    });
+    expect(scene.actions?.[0]).toMatchObject({ text: 'New narration' });
+  });
+
+  it('emits the resolved course stageId on the patch_stage checkpoint', async () => {
+    const current = state();
+    const checkpoints: { tool: string; stageId?: string; sceneId?: string }[] = [];
+    const tools = buildDslCourseTools({
+      store: current.store,
+      onCheckpoint: (info) => checkpoints.push(info),
+    });
+    const patch = tool(tools, 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/scene_slide',
+      intent: 'Update title color',
+      ops: [{ op: 'set', path: '/content/canvas/elements/0/defaultColor', value: '#f00' }],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    expect(checkpoints).toHaveLength(1);
+    expect(checkpoints[0]).toMatchObject({
+      tool: 'patch_stage',
+      stageId: 'stage-test',
+      sceneId: 'scene_slide',
+    });
+  });
+
+  it('rolls back the entire batch when a middle op fails', async () => {
+    const current = state();
+    const before = JSON.stringify(current.get());
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/1',
+      intent: 'Try an atomic batch',
+      ops: [
+        { op: 'set', path: '/content/canvas/elements/0/defaultColor', value: '#f00' },
+        { op: 'remove', path: '/content/canvas/nope' },
+        { op: 'set', path: '/content/canvas/elements/0/content', value: '<p>Never</p>' },
+      ],
+    } as never);
+    expect(result).toMatchObject({ isError: true, details: { failedOp: 2 } });
+    expect(current.putScene).not.toHaveBeenCalled();
+    expect(JSON.stringify(current.get())).toBe(before);
+  });
+
+  it('loud-fails unknown fields and rejects media omission placeholders', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const unknown = await patch.execute('unknown', {
+      target: '/scenes/1',
+      intent: 'Misspell a field',
+      ops: [{ op: 'set', path: '/content/canvas/elements/0/defaultColour', value: '#f00' }],
+    } as never);
+    expect(unknown).toMatchObject({ isError: true });
+    expect(textOf(unknown)).toContain('additional properties');
+
+    const placeholder =
+      '<image bytes omitted: image/png, 5000 bytes; read-only placeholder; to replace it, write a new media src/URL at this path>';
+    const rejected = await patch.execute('placeholder', {
+      target: '/scenes/1',
+      intent: 'Copy a read placeholder',
+      ops: [
+        {
+          op: 'set',
+          path: '/content/canvas/elements/0/content',
+          value: `<p><img src="${placeholder}"></p>`,
+        },
+      ],
+    } as never);
+    expect(rejected).toMatchObject({ isError: true });
+    expect(textOf(rejected)).toContain('read-time placeholder');
+    expect(current.putScene).not.toHaveBeenCalled();
+  });
+
+  it('rejects wrong optional quiz field types at the final validation barrier', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('wrong-quiz-type', {
+      target: '/scenes/2',
+      intent: 'Try an invalid quiz score',
+      ops: [{ op: 'set', path: '/content/questions/0/points', value: 'one' }],
+    } as never);
+    expect(result).toMatchObject({ isError: true });
+    expect(textOf(result)).toContain('/content/questions/0/points: expected number');
+    expect(current.putScene).not.toHaveBeenCalled();
+  });
+
+  it('keeps add_element/delete_element semantics aligned with edit_slide', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const add = await patch.execute('add', {
+      target: '/scenes/1',
+      intent: 'Add a supporting label',
+      ops: [
+        {
+          op: 'add_element',
+          afterId: 'el-title',
+          element: {
+            type: 'text',
+            left: 20,
+            top: 120,
+            width: 300,
+            height: 60,
+            rotate: 0,
+            content: '<p>Added</p>',
+            defaultFontName: 'Inter',
+            defaultColor: '#111',
+          },
+        },
+      ],
+    } as never);
+    expect(add).not.toHaveProperty('isError');
+    const added = (current.get().scenes[0]!.content as SlideContent).canvas.elements[1]!;
+    expect(added).toMatchObject({ type: 'text', content: '<p>Added</p>' });
+    expect(added.id).toMatch(/^el-/);
+
+    const remove = await patch.execute('remove', {
+      target: '/scenes/1',
+      intent: 'Remove the supporting label',
+      ops: [{ op: 'delete_element', elementId: added.id }],
+    } as never);
+    expect(remove).not.toHaveProperty('isError');
+    expect((current.get().scenes[0]!.content as SlideContent).canvas.elements).toHaveLength(1);
+  });
+
+  it('patches quiz, widget and PBL through the same scene-root pointers', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    for (const call of [
+      {
+        target: '/scenes/2',
+        intent: 'Update quiz wording',
+        ops: [{ op: 'set', path: '/content/questions/0/question', value: 'Updated quiz?' }],
+      },
+      {
+        target: '/scenes/scene_widget',
+        intent: 'Update widget guidance',
+        ops: [{ op: 'set', path: '/content/widgetConfig/description', value: 'Move the slider' }],
+      },
+      {
+        target: '/scenes/4',
+        intent: 'Update project milestone',
+        ops: [{ op: 'set', path: '/content/projectV2/milestones/0/title', value: 'Research' }],
+      },
+    ]) {
+      const result = await patch.execute('generic', call as never);
+      expect(result).not.toHaveProperty('isError');
+    }
+    expect((current.get().scenes[1]!.content as QuizContent).questions[0]!.question).toBe(
+      'Updated quiz?',
+    );
+    expect((current.get().scenes[2]!.content as InteractiveContent).widgetConfig).toMatchObject({
+      description: 'Move the slider',
+    });
+    expect((current.get().scenes[3]!.content as PBLContent).projectV2?.milestones[0]!.title).toBe(
+      'Research',
+    );
+  });
+
+  it('adds a quiz question by setting the complete /content/questions array (caller-owned ids)', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('add-question', {
+      target: '/scenes/2',
+      intent: 'Add a second question',
+      ops: [
+        {
+          op: 'set',
+          path: '/content/questions',
+          value: [
+            {
+              id: 'q1',
+              type: 'single',
+              question: 'Which answer?',
+              options: [
+                { label: 'Alpha', value: 'A' },
+                { label: 'Beta', value: 'B' },
+              ],
+              answer: ['A'],
+              analysis: 'Because Alpha.',
+            },
+            {
+              id: 'q2',
+              type: 'single',
+              question: 'Which is larger?',
+              options: [
+                { label: '1', value: 'A' },
+                { label: '2', value: 'B' },
+              ],
+              answer: ['B'],
+            },
+          ],
+        },
+      ],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    expect(current.putScene).toHaveBeenCalledTimes(1);
+    const questions = (current.get().scenes[1]!.content as QuizContent).questions;
+    expect(questions).toHaveLength(2);
+    expect(questions[0]).toMatchObject({ id: 'q1', answer: ['A'] });
+    expect(questions[1]).toMatchObject({
+      id: 'q2',
+      type: 'single',
+      question: 'Which is larger?',
+      answer: ['B'],
+    });
+  });
+
+  it('adds an option by setting /content/questions/0/options and re-points answer atomically', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('add-option', {
+      target: '/scenes/2',
+      intent: 'Add a third option and make it the correct one',
+      ops: [
+        {
+          op: 'set',
+          path: '/content/questions/0/options',
+          value: [
+            { label: 'Alpha', value: 'A' },
+            { label: 'Beta', value: 'B' },
+            { label: 'Gamma', value: 'C' },
+          ],
+        },
+        { op: 'set', path: '/content/questions/0/answer', value: ['C'] },
+      ],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    expect(current.putScene).toHaveBeenCalledTimes(1);
+    const question = (current.get().scenes[1]!.content as QuizContent).questions[0]!;
+    expect(question.options).toEqual([
+      { label: 'Alpha', value: 'A' },
+      { label: 'Beta', value: 'B' },
+      { label: 'Gamma', value: 'C' },
+    ]);
+    // value/answer stay coupled: the answer points at a value that exists.
+    expect(question.answer).toEqual(['C']);
+    expect(question.options?.some((option) => option.value === question.answer?.[0])).toBe(true);
+  });
+
+  it('adds a milestone and microtask by setting the complete /content/projectV2/milestones array (caller-owned order)', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('add-milestone', {
+      target: '/scenes/4',
+      intent: 'Add a test milestone and a second microtask',
+      ops: [
+        {
+          op: 'set',
+          path: '/content/projectV2/milestones',
+          value: [
+            {
+              id: 'ms-1',
+              title: 'Plan',
+              status: 'locked',
+              order: 1,
+              microtasks: [
+                {
+                  id: 'mt-1',
+                  title: 'Sketch',
+                  status: 'todo',
+                  assignee: 'user',
+                  hints: ['Use triangles'],
+                  order: 1,
+                },
+                {
+                  id: 'mt-2',
+                  title: 'Prototype',
+                  status: 'todo',
+                  assignee: 'user',
+                  hints: ['Build the model'],
+                  order: 2,
+                },
+              ],
+            },
+            {
+              id: 'ms-2',
+              title: 'Test',
+              status: 'locked',
+              order: 2,
+              microtasks: [
+                {
+                  id: 'mt-3',
+                  title: 'Verify',
+                  status: 'todo',
+                  assignee: 'user',
+                  hints: [],
+                  order: 1,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    expect(current.putScene).toHaveBeenCalledTimes(1);
+    const milestones = (current.get().scenes[3]!.content as PBLContent).projectV2!.milestones;
+    expect(milestones).toHaveLength(2);
+    // Order is caller-managed: exactly what was written is persisted, with no
+    // server-side renumbering.
+    expect(milestones.map((milestone) => milestone.order)).toEqual([1, 2]);
+    expect(milestones[0]!.microtasks.map((microtask) => microtask.order)).toEqual([1, 2]);
+    expect(milestones[1]).toMatchObject({ id: 'ms-2', title: 'Test', status: 'locked' });
+    expect(milestones[0]!.microtasks[1]).toMatchObject({ id: 'mt-2', title: 'Prototype' });
+  });
+
+  it('str_replace swaps one exact anchor inside a long HTML field and leaves siblings byte-identical', async () => {
+    const scene = interactiveScene();
+    const head =
+      '<!doctype html><html><head><style>/*' +
+      'x'.repeat(24_000) +
+      '*/</style></head><body><script>';
+    const tail = '</script><p>Visible widget words</p></body></html>';
+    (scene.content as InteractiveContent).html = head + 'const speed = 0.015 * dt' + tail;
+    const current = state(course([scene]));
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/scene_widget',
+      intent: 'Slow the gravity simulation',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/html',
+          oldText: 'const speed = 0.015 * dt',
+          newText: 'const speed = 0.006 * dt',
+        },
+      ],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    const html = (current.get().scenes[0]!.content as InteractiveContent).html!;
+    expect(html).toBe(head + 'const speed = 0.006 * dt' + tail);
+    expect(html).not.toContain('0.015 * dt');
+    expect(result.details).toMatchObject({
+      ops: [{ op: 'str_replace', path: '/content/html', occurrences: 1 }],
+    });
+  });
+
+  it('str_replace loud-fails with a 0-occurrence count when the anchor is absent', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/scene_widget',
+      intent: 'Edit a missing anchor',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/html',
+          oldText: 'const speed = 0.015 * dt',
+          newText: 'const speed = 0.006 * dt',
+        },
+      ],
+    } as never);
+    expect(result).toMatchObject({ isError: true, details: { failedOp: 1 } });
+    expect(textOf(result)).toContain('anchor text not found in /content/html (0 occurrences)');
+    expect(current.putScene).not.toHaveBeenCalled();
+  });
+
+  it('str_replace rejects a repeated anchor with its count, then replaceAll swaps every occurrence', async () => {
+    const scene = interactiveScene();
+    (scene.content as InteractiveContent).html =
+      '<script>a(0.015); b(0.015); c(0.015);</script><p>Visible widget words</p>';
+    const current = state(course([scene]));
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const ambiguous = await patch.execute('ambiguous', {
+      target: '/scenes/scene_widget',
+      intent: 'Edit a repeated anchor',
+      ops: [{ op: 'str_replace', path: '/content/html', oldText: '0.015', newText: '0.006' }],
+    } as never);
+    expect(ambiguous).toMatchObject({ isError: true, details: { failedOp: 1 } });
+    expect(textOf(ambiguous)).toContain(
+      'anchor text occurs 3 times; extend the anchor or set replaceAll',
+    );
+    expect(current.putScene).not.toHaveBeenCalled();
+
+    const all = await patch.execute('all', {
+      target: '/scenes/scene_widget',
+      intent: 'Replace every occurrence',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/html',
+          oldText: '0.015',
+          newText: '0.006',
+          replaceAll: true,
+        },
+      ],
+    } as never);
+    expect(all).not.toHaveProperty('isError');
+    expect((current.get().scenes[0]!.content as InteractiveContent).html).toBe(
+      '<script>a(0.006); b(0.006); c(0.006);</script><p>Visible widget words</p>',
+    );
+    expect(all.details).toMatchObject({
+      ops: [{ op: 'str_replace', path: '/content/html', occurrences: 3 }],
+    });
+  });
+
+  it('str_replace rejects omitted-bytes placeholder fragments in oldText and newText', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const placeholder =
+      '<image bytes omitted: image/png, 5000 bytes; read-only placeholder; to replace it, write a new media src/URL at this path>';
+    const anchored = await patch.execute('anchor', {
+      target: '/scenes/scene_widget',
+      intent: 'Anchor on an omitted region',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/html',
+          oldText: `src="${placeholder}"`,
+          newText: 'src="https://example.com/new.png"',
+        },
+      ],
+    } as never);
+    expect(anchored).toMatchObject({ isError: true });
+    expect(textOf(anchored)).toContain(
+      'anchor contains an omitted-bytes placeholder from read_stage; it does not exist in the stored value',
+    );
+    expect(current.putScene).not.toHaveBeenCalled();
+
+    const written = await patch.execute('write', {
+      target: '/scenes/scene_widget',
+      intent: 'Write a placeholder back',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/html',
+          oldText: 'Visible widget words',
+          newText: `<p><img src="${placeholder}"></p>`,
+        },
+      ],
+    } as never);
+    expect(written).toMatchObject({ isError: true });
+    expect(textOf(written)).toContain('read-time placeholder');
+    expect(current.putScene).not.toHaveBeenCalled();
+  });
+
+  it('str_replace requires a string field and reports the resolved type', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const number = await patch.execute('number', {
+      target: '/scenes/scene_widget',
+      intent: 'Replace inside a number field',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/widgetConfig/variables/0/max',
+          oldText: '10',
+          newText: '20',
+        },
+      ],
+    } as never);
+    expect(number).toMatchObject({ isError: true });
+    expect(textOf(number)).toContain(
+      'str_replace requires a string field; /content/widgetConfig/variables/0/max is number',
+    );
+
+    const missing = await patch.execute('missing', {
+      target: '/scenes/scene_widget',
+      intent: 'Replace inside a missing field',
+      ops: [{ op: 'str_replace', path: '/content/html/typo', oldText: 'a', newText: 'b' }],
+    } as never);
+    expect(missing).toMatchObject({ isError: true });
+    expect(textOf(missing)).toContain(
+      'str_replace requires a string field; /content/html/typo is missing',
+    );
+    expect(current.putScene).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the whole batch when a str_replace op fails mid-way', async () => {
+    const current = state();
+    const before = JSON.stringify(current.get());
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/scene_widget',
+      intent: 'Atomic batch with a failing str_replace',
+      ops: [
+        { op: 'set', path: '/content/widgetConfig/description', value: 'Changed first' },
+        { op: 'str_replace', path: '/content/html', oldText: 'nope-nope', newText: 'x' },
+      ],
+    } as never);
+    expect(result).toMatchObject({ isError: true, details: { failedOp: 2 } });
+    expect(current.putScene).not.toHaveBeenCalled();
+    expect(JSON.stringify(current.get())).toBe(before);
+  });
+
+  it('str_replace with an empty newText deletes the anchor', async () => {
+    const current = state();
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/scene_widget',
+      intent: 'Drop the unused style block',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/html',
+          oldText: '<style>.hidden{}</style>',
+          newText: '',
+        },
+      ],
+    } as never);
+    expect(result).not.toHaveProperty('isError');
+    expect((current.get().scenes[2]!.content as InteractiveContent).html).toBe(
+      '<html><body>Visible widget words</body></html>',
+    );
+  });
+
+  it('rejects a full read-only placeholder ASSEMBLED ACROSS str_replace ops (final-state guard)', async () => {
+    const scene = slideScene();
+    (scene.content as SlideContent).canvas.elements.unshift({
+      id: 'image-1',
+      type: 'image',
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      rotate: 0,
+      fixedRatio: true,
+      src: 'https://cdn.example.com/real.png',
+    } as unknown as SlideContent['canvas']['elements'][number]);
+    const current = state(course([scene]));
+    const before = JSON.stringify(current.get());
+    const patch = tool(dslTools(current.store), 'patch_stage');
+    const result = await patch.execute('patch', {
+      target: '/scenes/1',
+      intent: 'Assemble a placeholder across two ops',
+      ops: [
+        {
+          op: 'str_replace',
+          path: '/content/canvas/elements/0/src',
+          oldText: 'https://cdn.example.com/real.png',
+          newText: '<image bytes omitted:',
+        },
+        {
+          op: 'str_replace',
+          path: '/content/canvas/elements/0/src',
+          oldText: 'omitted:',
+          newText:
+            'omitted: image/png, 9999 bytes; read-only placeholder; to replace it, write a new media src/URL at this path>',
+        },
+      ],
+    } as never);
+    expect(result).toMatchObject({ isError: true, details: { failedOp: 2 } });
+    expect(textOf(result)).toContain('read-only media placeholder');
+    // Nothing persisted: the real src survives byte-for-byte.
+    expect(current.putScene).not.toHaveBeenCalled();
+    expect(JSON.stringify(current.get())).toBe(before);
+    expect((current.get().scenes[0]!.content as SlideContent).canvas.elements[0]).toMatchObject({
+      src: 'https://cdn.example.com/real.png',
+    });
+  });
+
+  it('requires intent and at least one op at the schema layer', () => {
+    expect(Check(PATCH_COURSE_SCHEMA, { target: '/scenes/1', ops: [{ op: 'remove' }] })).toBe(
+      false,
+    );
+    expect(Check(PATCH_COURSE_SCHEMA, { target: '/scenes/1', intent: 'Change', ops: [] })).toBe(
+      false,
+    );
+    expect(Check(READ_COURSE_SCHEMA, { detail: 'source', offset: -1 })).toBe(false);
+    expect(
+      Check(PATCH_COURSE_SCHEMA, {
+        target: '/scenes/1',
+        intent: 'Change',
+        ops: [{ op: 'str_replace', path: '/content/html', oldText: '', newText: 'y' }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('grep_stage', () => {
+  it('matches case-insensitively and maps NFKC-expanded matches to original offsets', async () => {
+    const scene = slideScene();
+    scene.title = 'prefix ＡＩ suffix';
+    const current = state(course([scene]));
+    const grep = tool(dslTools(current.store), 'grep_stage');
+    const result = await grep.execute('grep', { query: 'ai', scope: 'text' } as never);
+    const details = result.details as {
+      hits: Array<{ start: number; end: number; snippet: string }>;
+    };
+    expect(details.hits.length).toBeGreaterThanOrEqual(2);
+    const fullWidth = details.hits.find((hit) => hit.snippet.includes('ＡＩ'))!;
+    const source = 'prefix ＡＩ suffix\nHello AI\nWelcome';
+    expect(source.slice(fullWidth.start, fullWidth.end)).toBe('ＡＩ');
+  });
+
+  it('folds per grapheme cluster: a decomposed e+combining-acute matches a precomposed é query', async () => {
+    const scene = slideScene();
+    ((scene.content as SlideContent).canvas.elements[0] as PPTTextElement).content =
+      '<p>cafe\u0301</p>';
+    const current = state(course([scene]));
+    const grep = tool(dslTools(current.store), 'grep_stage');
+    const result = await grep.execute('grep', { query: 'é', scope: 'text' } as never);
+    const details = result.details as {
+      hits: Array<{ start: number; end: number; snippet: string }>;
+    };
+    expect(details.hits.length).toBeGreaterThanOrEqual(1);
+    // The scene's combined visible text: title, the slide element, the action.
+    const source = 'ＡＩ 开场\ncafe\u0301\nWelcome';
+    const hit = details.hits.find((h) => h.snippet.includes('cafe'))!;
+    // The hit's span covers the whole original cluster (e + combining accent).
+    expect(source.slice(hit.start, hit.end)).toBe('e\u0301');
+  });
+
+  it('foldNfkcCaseWithOffsets composes combining sequences and keeps cluster-boundary spans', () => {
+    // Direct probe of the exported fold: decomposed and precomposed forms fold
+    // to the same value, and every folded code unit maps to the WHOLE original
+    // cluster (so a match always slices valid original text).
+    const decomposed = foldNfkcCaseWithOffsets('cafe\u0301');
+    expect(decomposed.value).toBe('café');
+    expect('cafe\u0301'.normalize('NFKC')).toBe('café');
+    expect(decomposed.value.indexOf('é')).toBe(3);
+    expect('cafe\u0301'.slice(decomposed.originalStarts[3]!, decomposed.originalEnds[3]!)).toBe(
+      'e\u0301',
+    );
+
+    // A cluster that EXPANDS under NFKC maps both folded units to the same
+    // original cluster span (ligature ﬁ → fi: 'o'+'ﬁ'+'ce' folds to 'ofice').
+    const ligature = foldNfkcCaseWithOffsets('oﬁce');
+    expect(ligature.value).toBe('ofice');
+    expect(ligature.originalStarts[1]).toBe(1);
+    expect(ligature.originalStarts[2]).toBe(1);
+    expect(ligature.originalEnds[1]).toBe(2);
+    expect(ligature.originalEnds[2]).toBe(2);
+  });
+
+  it('foldNfkcCaseWithOffsets folds Greek Σ/ς/σ to the same σ (R2-P2-2)', () => {
+    // Unicode case folding: an uppercase ΟΣ, a word-final ς and a medial σ
+    // must all search as σ, regardless of the word context a per-grapheme
+    // lowercase can never see.
+    expect(foldNfkcCaseWithOffsets('ΟΣ').value).toBe('οσ');
+    expect(foldNfkcCaseWithOffsets('ος').value).toBe('οσ');
+    expect(foldNfkcCaseWithOffsets('λόγος').value).toBe('λόγοσ');
+    expect(foldNfkcCaseWithOffsets('σ').value).toBe('σ');
+  });
+
+  it('matches an uppercase Greek ΟΣ against a lowercase ος query with correct offsets (R2-P2-2)', async () => {
+    const scene = slideScene();
+    scene.title = 'ΟΣ 开场';
+    const current = state(course([scene]));
+    const grep = tool(dslTools(current.store), 'grep_stage');
+    const result = await grep.execute('grep', { query: 'ος', scope: 'text' } as never);
+    const details = result.details as {
+      hits: Array<{ start: number; end: number; snippet: string }>;
+    };
+    expect(details.hits.length).toBeGreaterThanOrEqual(1);
+    const source = 'ΟΣ 开场\nHello AI\nWelcome';
+    const hit = details.hits.find((h) => h.snippet.includes('ΟΣ'))!;
+    expect(source.slice(hit.start, hit.end)).toBe('ΟΣ');
+  });
+
+  it('matches a word-final ς source against a medial σ query (R2-P2-2)', async () => {
+    const scene = slideScene();
+    scene.title = 'λόγος 开场';
+    const current = state(course([scene]));
+    const grep = tool(dslTools(current.store), 'grep_stage');
+    const result = await grep.execute('grep', { query: 'σ', scope: 'text' } as never);
+    const details = result.details as {
+      hits: Array<{ start: number; end: number; snippet: string }>;
+    };
+    expect(details.hits.length).toBeGreaterThanOrEqual(1);
+    const source = 'λόγος 开场\nHello AI\nWelcome';
+    const hit = details.hits.find((h) => h.snippet.includes('ς'))!;
+    expect(source.slice(hit.start, hit.end)).toBe('ς');
+  });
+
+  it('returns a cursor on truncation and continuation concatenates to the full scan', async () => {
+    const scenes = Array.from({ length: 35 }, (_, index) => {
+      const scene = slideScene(index + 1, `scene_${index + 1}`);
+      scene.title = `needle page ${index + 1}`;
+      ((scene.content as SlideContent).canvas.elements[0] as PPTTextElement).content =
+        '<p>plain</p>';
+      scene.actions = [];
+      return scene;
+    });
+    const current = state(course(scenes));
+    const grep = tool(dslTools(current.store), 'grep_stage');
+    const first = await grep.execute('first', { query: 'needle' } as never);
+    expect(first.details).toMatchObject({ truncated: true, cursor: expect.any(String) });
+    const firstDetails = first.details as { hits: unknown[]; cursor: string };
+    expect(firstDetails.hits).toHaveLength(30);
+    const second = await grep.execute('second', {
+      query: 'needle',
+      cursor: firstDetails.cursor,
+    } as never);
+    const secondDetails = second.details as { hits: unknown[]; truncated: boolean };
+    expect(secondDetails.hits).toHaveLength(5);
+    expect(secondDetails.truncated).toBe(false);
+    expect([...firstDetails.hits, ...secondDetails.hits]).toHaveLength(35);
+  });
+
+  it('declares query bounds and rejects a cursor used with another query', async () => {
+    expect(Check(GREP_COURSE_SCHEMA, { query: '' })).toBe(false);
+    expect(Check(GREP_COURSE_SCHEMA, { query: 'x'.repeat(201) })).toBe(false);
+    const current = state(
+      course(Array.from({ length: 35 }, (_, i) => slideScene(i + 1, `scene_${i}`))),
+    );
+    const grep = tool(dslTools(current.store), 'grep_stage');
+    const first = await grep.execute('first', { query: 'hello' } as never);
+    const cursor = (first.details as { cursor: string }).cursor;
+    const mismatch = await grep.execute('mismatch', { query: 'other', cursor } as never);
+    expect(mismatch).toMatchObject({ isError: true });
+  });
+});
+
+describe('DSL course-tool wiring', () => {
+  const deps = (store: CourseStore) => ({
+    store,
+    onCheckpoint: () => undefined,
+  });
+
+  it('always registers DSL tools, excludes every legacy editor, and serializes patch_stage', () => {
+    const current = state();
+    const tools = buildDslCourseToolset(deps(current.store));
+    const names = tools.map((item) => item.name);
+    for (const name of ['read_stage', 'patch_stage', 'grep_stage']) {
+      expect(names).toContain(name);
+      expect(buildCourseAllowlist()).toContain(name);
+    }
+    // The stage-level CRUD is a separate curriculum toolset the runner
+    // registers beside the DSL tools; both feed the one allowlist.
+    for (const name of ['create_stage', 'read_stage_outline']) {
+      expect(buildCourseAllowlist()).toContain(name);
+    }
+    for (const name of [
+      'read_scene',
+      'edit_slide',
+      'edit_quiz',
+      'edit_widget',
+      'edit_actions',
+      'edit_pbl',
+      'edit_deck',
+      'generate_scene',
+      'set_roster',
+    ]) {
+      expect(names).not.toContain(name);
+      expect(buildCourseAllowlist()).not.toContain(name);
+    }
+    expect(tool(tools, 'patch_stage')).toMatchObject({ executionMode: 'sequential' });
+    expect(tool(tools, 'read_stage')).not.toHaveProperty('executionMode');
+    expect(tool(tools, 'grep_stage')).not.toHaveProperty('executionMode');
+    expect(new Set(names)).toEqual(new Set(['read_stage', 'patch_stage', 'grep_stage']));
+  });
+
+  it('injects generic DSL compatibility guidance into every runner prompt', () => {
+    expect(buildRunnerCoursePrompt({}).includes(DSL_TOOLS_PROMPT)).toBe(true);
+    expect(DSL_TOOLS_PROMPT).toContain('stage-dsl');
+    expect(DSL_TOOLS_PROMPT).toContain('/scenes/<1-based order|sceneId>');
+    expect(DSL_TOOLS_PROMPT).toContain('Start with detail:"tree" to see structure');
+    expect(DSL_TOOLS_PROMPT).toContain('prefer grep_stage over paging with offset');
+  });
+});
+
+describe('grep_stage source scope searches the bounded projection (R6-P2-6)', () => {
+  it('large inline media bytes never enter the searched source', async () => {
+    const bigBytes = `UNIQUE-MEDIA-NEEDLE-${'A'.repeat(120_000)}`;
+    const scene = slideScene();
+    (
+      scene.content as unknown as {
+        canvas: { elements: { type: string; id: string; src?: string }[] };
+      }
+    ).canvas.elements.push({
+      type: 'image',
+      id: 'img-big',
+      src: `data:image/png;base64,${bigBytes}`,
+    });
+    const s = state(course([scene]));
+    const grep = tool(dslTools(s.store), 'grep_stage');
+
+    // A needle that only exists inside the omitted media bytes: unreachable,
+    // because the projection replaced those bytes before serialization.
+    const insideMedia = (await grep.execute('c1', {
+      stageId: 'stage-test',
+      query: 'UNIQUE-MEDIA-NEEDLE',
+      scope: 'source',
+    } as never)) as { details: { hits: unknown[] } };
+    expect(insideMedia.details.hits).toHaveLength(0);
+
+    // The placeholder marker IS findable — proof the projection (the same
+    // source read_stage serves) is what got searched.
+    const placeholder = (await grep.execute('c2', {
+      stageId: 'stage-test',
+      query: 'bytes omitted',
+      scope: 'source',
+    } as never)) as { details: { hits: unknown[] } };
+    expect(placeholder.details.hits.length).toBeGreaterThan(0);
+
+    // Non-media source content stays searchable.
+    const normal = (await grep.execute('c3', {
+      stageId: 'stage-test',
+      query: 'canvas-1',
+      scope: 'source',
+    } as never)) as { details: { hits: unknown[] } };
+    expect(normal.details.hits.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Cross-owner isolation through the run's OWNER-BOUND store.
+ *
+ * The runner binds ONE store per run: `documentStore.forOwner(ownerId)`, the
+ * same seam the storage package contracts. These tests drive the real
+ * `PgDocumentStore` owner scope over PGlite through the actual tool entry
+ * points, so "a stage owned by another owner is not readable or patchable"
+ * is asserted against the SQL scope predicate, not a hand-written fake.
+ */
+describe('cross-owner isolation (owner-scoped store)', () => {
+  let db: PGlite;
+
+  function ownerStore(ownerId: string): CourseStore {
+    const pg = new PgDocumentStore(db, {
+      withTransaction: (body) => db.transaction((tx) => body(tx)),
+    }).forOwner(ownerId);
+    return withPlainJsonDocumentWrites(pg as unknown as DocumentStore<AppScene, AppStage>);
+  }
+
+  function toolsFor(ownerId: string, sessionId: string) {
+    const store = ownerStore(ownerId);
+    const dsl = dslTools(store);
+    const curriculum = buildCurriculumTools({
+      store,
+      ownerId,
+      sessionId,
+    });
+    const run = (toolList: AgentTool<never, never>[], name: string) => {
+      const found = toolList.find((item) => item.name === name);
+      if (!found) throw new Error(`missing tool ${name}`);
+      return found;
+    };
+    return {
+      store,
+      readStage: run(dsl, 'read_stage'),
+      patchStage: run(dsl, 'patch_stage'),
+      createStage: run(curriculum, 'create_stage'),
+    };
+  }
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureDocumentSchema(db);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it('a stage owned by another owner is not readable or patchable through the run store', async () => {
+    const alice = toolsFor('anon:alice', 'session-alice');
+    const bob = toolsFor('anon:bob', 'session-bob');
+
+    const created = (await alice.createStage.execute('call-1', {
+      title: 'Alice stage',
+      brief: 'mine',
+    } as never)) as { details: { stageId: string }; isError?: boolean };
+    expect(created.isError).toBeUndefined();
+    const stageId = created.details.stageId;
+
+    // Bob's read_stage on Alice's stage: fail-closed "not found or not
+    // accessible" — never a confirmation that the id exists.
+    const foreignRead = (await bob.readStage.execute('read-1', {
+      stageId,
+      path: '/scenes/1',
+    } as never)) as { isError?: boolean; content: { text: string }[] };
+    expect(foreignRead.isError).toBe(true);
+    expect(foreignRead.content[0]!.text).toContain('not accessible');
+
+    // Bob's patch_stage on Alice's stage: refused, nothing persisted.
+    const foreignPatch = (await bob.patchStage.execute('patch-1', {
+      stageId,
+      target: '/scenes/1',
+      intent: 'Tamper with a foreign stage',
+      ops: [{ op: 'set', path: '/actions', value: [] }],
+    } as never)) as { isError?: boolean };
+    expect(foreignPatch.isError).toBe(true);
+
+    // Alice's own tools still read the stage, and the document is intact.
+    const ownRead = (await alice.readStage.execute('read-2', { stageId } as never)) as {
+      isError?: boolean;
+      content: { text: string }[];
+    };
+    expect(ownRead.isError).toBeUndefined();
+    expect(JSON.parse(ownRead.content[0]!.text)).toMatchObject({
+      stage: { id: stageId, name: 'Alice stage' },
+    });
+    // Bob's store can never list Alice's stage.
+    await expect(bob.store.loadDocument(stageId)).resolves.toBeNull();
+  });
+
+  it('an owner can read and patch only what its own store sees, after another owner wrote it', async () => {
+    const alice = toolsFor('anon:alice', 'session-alice');
+    const bob = toolsFor('anon:bob', 'session-bob');
+
+    const created = (await alice.createStage.execute('call-1', {
+      title: 'Shared? No.',
+    } as never)) as { details: { stageId: string } };
+    const stageId = created.details.stageId;
+
+    // Bob mints his OWN stage with the same tool; ids derive from
+    // (sessionId, callId), so a different session never collides.
+    const bobCreated = (await bob.createStage.execute('call-1', {
+      title: 'Bob stage',
+    } as never)) as { details: { stageId: string }; isError?: boolean };
+    expect(bobCreated.isError).toBeUndefined();
+    expect(bobCreated.details.stageId).not.toBe(stageId);
+
+    // Each owner reads exactly their own document.
+    const bobList = await bob.store.loadDocument(bobCreated.details.stageId);
+    expect(bobList?.stage.name).toBe('Bob stage');
+    expect(bobList?.stage.id).not.toBe(stageId);
+    const aliceList = await alice.store.loadDocument(stageId);
+    expect(aliceList?.stage.name).toBe('Shared? No.');
+    expect(await bob.store.listDocuments()).toHaveLength(1);
+    expect(await alice.store.listDocuments()).toHaveLength(1);
+  });
+});

--- a/tests/agent-runtime/runner-skills-registration.test.ts
+++ b/tests/agent-runtime/runner-skills-registration.test.ts
@@ -46,6 +46,7 @@ const fixture = vi.hoisted(() => {
 const mocks = vi.hoisted(() => ({
   randomUUID: vi.fn(() => 'runner-test-uuid'),
   getAgentSessionStore: vi.fn(),
+  getServerPersistenceProvider: vi.fn(),
   openEntryStorage: vi.fn(),
   resolveAgentDriverModel: vi.fn(),
   createCallLlmStreamFn: vi.fn(),
@@ -59,6 +60,10 @@ vi.mock('node:crypto', async (importActual) => {
 
 vi.mock('@/lib/server/agent-runtime/store', () => ({
   getAgentSessionStore: mocks.getAgentSessionStore,
+}));
+
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: mocks.getServerPersistenceProvider,
 }));
 
 vi.mock('@/lib/server/agent-runtime/entry-tree-storage', async (importActual) => {
@@ -193,6 +198,11 @@ beforeEach(() => {
     reservedOutputTokens: 8192,
   });
   mocks.createCallLlmStreamFn.mockReturnValue((() => {}) as never);
+  // The owner-bound document store is never touched in these runner pins
+  // (buildAgent is mocked), so a bare forOwner facade is enough.
+  mocks.getServerPersistenceProvider.mockResolvedValue({
+    documentStore: { forOwner: () => ({}) },
+  });
 });
 
 interface RunOutcome {
@@ -238,14 +248,24 @@ describe('skills runner registration', () => {
       'patch_skill',
       'read',
       'fetch_url',
+      'read_stage',
+      'patch_stage',
+      'grep_stage',
+      'create_stage',
+      'read_stage_outline',
     ]);
     expect([...(options.allowedToolNames ?? [])].sort()).toEqual([
       'ask_user',
       'create_skill',
+      'create_stage',
       'fetch_url',
+      'grep_stage',
       'patch_skill',
+      'patch_stage',
       'read',
       'read_skill',
+      'read_stage',
+      'read_stage_outline',
     ]);
     expect(options.systemPrompt).toContain('<available_skills>');
     expect(options.systemPrompt).toContain('<name>pro-editing</name>');

--- a/tests/agent-runtime/runner-tool-call-integrity.test.ts
+++ b/tests/agent-runtime/runner-tool-call-integrity.test.ts
@@ -22,6 +22,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   randomUUID: vi.fn(() => 'runner-test-uuid'),
   getAgentSessionStore: vi.fn(),
+  getServerPersistenceProvider: vi.fn(),
   openEntryStorage: vi.fn(),
   resolveAgentDriverModel: vi.fn(),
   createCallLlmStreamFn: vi.fn(),
@@ -35,6 +36,10 @@ vi.mock('node:crypto', async (importActual) => {
 
 vi.mock('@/lib/server/agent-runtime/store', () => ({
   getAgentSessionStore: mocks.getAgentSessionStore,
+}));
+
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: mocks.getServerPersistenceProvider,
 }));
 
 vi.mock('@/lib/server/agent-runtime/entry-tree-storage', async (importActual) => {
@@ -231,6 +236,11 @@ beforeEach(() => {
     reservedOutputTokens: 8192,
   });
   mocks.createCallLlmStreamFn.mockReturnValue((() => {}) as never);
+  // The owner-bound document store is never touched in these runner pins
+  // (buildAgent is mocked), so a bare forOwner facade is enough.
+  mocks.getServerPersistenceProvider.mockResolvedValue({
+    documentStore: { forOwner: () => ({}) },
+  });
 });
 
 describe('write-time settlement of interrupted tool calls', () => {

--- a/tests/agent-runtime/runner-web-search-registration.test.ts
+++ b/tests/agent-runtime/runner-web-search-registration.test.ts
@@ -20,6 +20,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   randomUUID: vi.fn(() => 'runner-test-uuid'),
   getAgentSessionStore: vi.fn(),
+  getServerPersistenceProvider: vi.fn(),
   openEntryStorage: vi.fn(),
   resolveAgentDriverModel: vi.fn(),
   createCallLlmStreamFn: vi.fn(),
@@ -36,6 +37,10 @@ vi.mock('node:crypto', async (importActual) => {
 
 vi.mock('@/lib/server/agent-runtime/store', () => ({
   getAgentSessionStore: mocks.getAgentSessionStore,
+}));
+
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: mocks.getServerPersistenceProvider,
 }));
 
 vi.mock('@/lib/web-search', () => ({
@@ -196,6 +201,11 @@ beforeEach(() => {
   });
   mocks.createCallLlmStreamFn.mockReturnValue((() => {}) as never);
   mocks.buildAgent.mockReturnValue(makeFakeAgent() as never);
+  // The owner-bound document store is never touched in these registration
+  // pins (buildAgent is mocked), so a bare forOwner facade is enough.
+  mocks.getServerPersistenceProvider.mockResolvedValue({
+    documentStore: { forOwner: () => ({}) },
+  });
 });
 
 async function runToBuildAgent(): Promise<BuildAgentOptions> {
@@ -239,13 +249,23 @@ describe('web_search runner registration', () => {
       'read_skill',
       'patch_skill',
       'fetch_url',
+      'read_stage',
+      'patch_stage',
+      'grep_stage',
+      'create_stage',
+      'read_stage_outline',
     ]);
     expect([...(options.allowedToolNames ?? [])].sort()).toEqual([
       'ask_user',
       'create_skill',
+      'create_stage',
       'fetch_url',
+      'grep_stage',
       'patch_skill',
+      'patch_stage',
       'read_skill',
+      'read_stage',
+      'read_stage_outline',
       'web_search',
     ]);
     expect(options.systemPrompt).toContain('## Web search');
@@ -270,13 +290,23 @@ describe('web_search runner registration', () => {
       'read_skill',
       'patch_skill',
       'fetch_url',
+      'read_stage',
+      'patch_stage',
+      'grep_stage',
+      'create_stage',
+      'read_stage_outline',
     ]);
     expect([...(options.allowedToolNames ?? [])].sort()).toEqual([
       'ask_user',
       'create_skill',
+      'create_stage',
       'fetch_url',
+      'grep_stage',
       'patch_skill',
+      'patch_stage',
       'read_skill',
+      'read_stage',
+      'read_stage_outline',
     ]);
     expect(options.systemPrompt).not.toContain('web_search');
     expect(options.systemPrompt).not.toContain('## Web search');

--- a/tests/agent-runtime/stage-writer-registry.test.ts
+++ b/tests/agent-runtime/stage-writer-registry.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { STAGE_WRITER_TOOL_NAMES, isStageWriterTool } from '@/lib/agent-runtime/stage-writer-tools';
+import { DOCUMENT_WRITING_TOOLS } from '@/lib/server/agent-runtime/course-tools';
+import { DSL_COURSE_WRITE_TOOLS } from '@/lib/server/agent-runtime/dsl-tools';
 
 /**
  * The stage-writer registry is the single source of truth for "which agent
  * tools WRITE a stage document". The cross-module consistency assertions
  * against the server scheduler (`DOCUMENT_WRITING_TOOLS`) and the per-toolset
- * writer lists live in this suite once those modules land in a later slice;
- * here the registry's own contents and the reader/writer split are pinned.
+ * writer lists live here: the scheduler set must be exactly the shared list
+ * minus `rename_stage`, and every per-toolset writer list must be contained in
+ * the shared registry.
  */
-describe('stage writer registry is the single source', () => {
+describe('stage writer registry is the single source (R6-P1-1)', () => {
   it('every registered name is recognized as a writer', () => {
     for (const name of STAGE_WRITER_TOOL_NAMES) {
       expect(isStageWriterTool(name)).toBe(true);
@@ -33,6 +36,20 @@ describe('stage writer registry is the single source', () => {
         'rename_stage',
       ].sort(),
     );
+  });
+
+  it('the server scheduler set is exactly the shared list minus rename_stage', () => {
+    const expected = new Set(
+      [...STAGE_WRITER_TOOL_NAMES].filter((name) => name !== 'rename_stage'),
+    );
+    expect(new Set(DOCUMENT_WRITING_TOOLS)).toEqual(expected);
+  });
+
+  it('every per-toolset writer list is contained in the shared registry', () => {
+    for (const name of [...DSL_COURSE_WRITE_TOOLS]) {
+      expect(isStageWriterTool(name)).toBe(true);
+    }
+    expect(isStageWriterTool('rename_stage')).toBe(true);
   });
 
   it('reader tools are NOT writers — ownership must never arm on them', () => {


### PR DESCRIPTION
Seventh slice of the tools wave, and the first half of the course toolset: the generic stage read/patch surface, sitting directly on the ownership scope from #1191.

## Tools

- **`read_stage`** — tree / source / text views over any addressable subtree (``, `/outline`, `/scenes/<order|id>`, `/scenes/<...>/actions`), paginating after 12k chars. The source projection omits large inline media bytes behind a read-only placeholder, so token cost stays bounded and stored bytes stay byte-identical.
- **`patch_stage`** — an atomic per-scene batch (JSON Pointer set/remove, str_replace, add_element/delete_element): every op must pass before the single `putScene` write, so a failing op mid-batch persists nothing. Element identity is server-owned — `add_element` rejects a caller-supplied id, and a pointer patch cannot add, remove, or rename element ids. Final-state validation includes a whole-batch guard against a read-only media placeholder assembled across several ops.
- **`grep_stage`** — NFKC-normalized literal search with bounded caps (10 hits/scene, 30 total, 1M chars, 100 ms) and an opaque continuation cursor bound to (stage, query, scope).
- **`create_stage`** / **`read_stage_outline`** — the stage CRUD the DSL tools need. `create_stage` derives its id from (session, callId), so a crash-replayed call lands on the stage it already minted and reports `reused`; a document at that id which this session did not mint is refused fail-closed.

## Ownership and scheduling

One owner-scoped store per run: `documentStore.forOwner(session.ownerId)`, shared by every stage tool. The owner id comes from the claimed durable session and appears in **no** model-visible parameter — the model cannot name a target owner. A foreign stage reads as absent and a write to it is refused inside the store transaction; the reference's separate stage-metadata probe was therefore not needed.

`patch_stage` is marked `executionMode: 'sequential'` through the shared writer registry added in #1184 (its first real consumer), so a batch containing a write runs sequentially and same-batch reads observe committed state.

The DSL path is server-authoritative whole-scene writes; the editor's incremental whiteboard path is a separate entry point and is untouched — the two coexist.

## Tests

Ported reference suite plus new coverage: batch atomicity (several failure modes, stored document byte-identical after a rollback), pointer/str_replace semantics, paging boundaries, grep caps and cursor continuation, and **cross-owner isolation driven through the real `PgDocumentStore.forOwner` scope on PGlite via the actual tool entry points** — verified by mutation: dropping the owner scope turns those cases red.

1,183 tests green across agent-runtime/server/document suites; storage package 294 green; tsc/prettier/eslint clean. No storage-package change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)