### PR TITLE
test(storage): keep the PG contract suite order-independent

### DIFF
--- a/packages/@openmaic/storage/test/pg-agent-session-contract-helpers.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-contract-helpers.ts
@@ -1,0 +1,74 @@
+import type { Pool } from 'pg';
+
+import type { Queryable } from '../src/runtime/pg.js';
+
+/**
+ * Shared infrastructure for the PostgreSQL agent-session contract suites.
+ *
+ * The suites live in one file per backend (store, material) and share ONE
+ * PostgreSQL database, exactly as the PG16 CI job provisions it. That shared
+ * database is why everything here exists; see the two sections below.
+ */
+
+/**
+ * Postgres advisory-lock key that makes the agent-session PG suites mutually
+ * exclusive. Any value works; this one is just a fixed, documented constant.
+ */
+export const AGENT_SESSION_PG_CONTRACT_LOCK_KEY = 91_110_533;
+
+/**
+ * Serialize the agent-session PG suites on the shared database.
+ *
+ * Both suites TRUNCATE the same tables between tests (`agent_sessions` and the
+ * tables that reference it), because both create sessions with identical fixed
+ * ids. That is only safe when the suites never run at the same time: if two
+ * suites were running concurrently, either suite's `beforeEach` would wipe the
+ * rows the other suite's test just created and the tests would fail with
+ * missing sessions. A JS-level lock cannot express this (vitest runs each file
+ * in its own process), but a Postgres advisory lock can: it is scoped to a
+ * database connection, so it serializes across processes.
+ *
+ * Call this in `beforeAll`, keep the returned release function for `afterAll`,
+ * and give the hook a generous timeout (the waiting suite blocks for the whole
+ * duration of the other suite). Every suite that TRUNCATEs agent-session tables
+ * must take this lock, or a full-suite run becomes scheduling-dependent.
+ */
+export async function acquireAgentSessionPgContractLock(pool: Pool): Promise<() => Promise<void>> {
+  const client = await pool.connect();
+  try {
+    await client.query('SELECT pg_advisory_lock($1)', [AGENT_SESSION_PG_CONTRACT_LOCK_KEY]);
+  } catch (error) {
+    client.release();
+    throw error;
+  }
+  return async () => {
+    try {
+      await client.query('SELECT pg_advisory_unlock($1)', [AGENT_SESSION_PG_CONTRACT_LOCK_KEY]);
+    } finally {
+      client.release();
+    }
+  };
+}
+
+/**
+ * Empty every agent-session-owned table between PostgreSQL contract tests.
+ *
+ * The statement lists only the tables the agent-session backend owns and lets
+ * `CASCADE` reach everything else that references `agent_sessions`. That
+ * indirection is the point: an exhaustive list would have to grow every time a
+ * store adds a foreign key to `agent_sessions` — the material store did exactly
+ * that, and once its suite had ensured its schema, the agent-session suite's
+ * plain TRUNCATE was rejected with `cannot truncate a table referenced in a
+ * foreign key constraint`, failing the whole PG job whenever the material suite
+ * ran first. `CASCADE` follows the foreign-key graph instead, so a future
+ * FK-referencing store is cleaned up automatically, in any file order, with no
+ * edit here (see the `beforeEach cleanup` probe test in the agent-session
+ * suite).
+ */
+export async function truncateAgentSessionTables(queryable: Queryable): Promise<void> {
+  await queryable.query(
+    `TRUNCATE agent_session_entries, agent_session_events,
+            agent_owner_session_events, agent_owner_session_event_counters,
+            agent_session_urls, agent_sessions CASCADE`,
+  );
+}

--- a/packages/@openmaic/storage/test/pg-agent-session-material.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-material.pg.test.ts
@@ -11,6 +11,10 @@ import {
   PgAgentSessionMaterialStore,
   ensureAgentSessionMaterialSchema,
 } from '../src/material/pg.js';
+import {
+  acquireAgentSessionPgContractLock,
+  truncateAgentSessionTables,
+} from './pg-agent-session-contract-helpers.js';
 import { runAgentSessionMaterialContract } from './agent-session-material-contract.js';
 
 const contractUrl = process.env.PG_CONTRACT_URL;
@@ -45,22 +49,25 @@ function transactionFor(pool: Pool): WithTransaction {
 
 describe.skipIf(!contractUrl)('PgAgentSessionMaterialStore with PostgreSQL 16', () => {
   let pool: Pool;
+  let releaseContractLock: (() => Promise<void>) | undefined;
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: contractUrl, max: 16 });
+    // Same shared-database lock as the agent-session store suite: these suites
+    // TRUNCATE the same tables, so they must run one at a time.
+    releaseContractLock = await acquireAgentSessionPgContractLock(pool);
     await ensureAgentSessionSchema(pool as Queryable);
     await ensureAgentSessionMaterialSchema(pool as Queryable);
-  });
+  }, 60_000);
 
   beforeEach(async () => {
-    await pool.query(
-      `TRUNCATE agent_session_materials, agent_session_urls, agent_session_entries,
-                agent_session_events, agent_owner_session_events,
-                agent_owner_session_event_counters, agent_sessions`,
-    );
+    // Same order-independent cleanup the agent-session suite uses; CASCADE
+    // empties this suite's own material table through its FK to agent_sessions.
+    await truncateAgentSessionTables(pool as Queryable);
   });
 
   afterAll(async () => {
+    await releaseContractLock?.();
     await pool.end();
   });
 

--- a/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
@@ -7,6 +7,10 @@ import {
   type Queryable,
   type WithTransaction,
 } from '../src/agent-session/pg.js';
+import {
+  acquireAgentSessionPgContractLock,
+  truncateAgentSessionTables,
+} from './pg-agent-session-contract-helpers.js';
 import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
 import { runAgentSessionStoreContract } from './agent-session-contract.js';
 import { runAgentSessionUrlContract } from './agent-session-url-contract.js';
@@ -44,22 +48,26 @@ function transactionFor(pool: Pool): WithTransaction {
 describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
   let pool: Pool;
   let store: PgAgentSessionStore;
+  let releaseContractLock: (() => Promise<void>) | undefined;
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: contractUrl, max: 16 });
+    // The agent-session PG suites share one database and TRUNCATE the same
+    // tables, so they must never run at the same time; the advisory lock
+    // blocks this suite until the other suite's afterAll releases it.
+    releaseContractLock = await acquireAgentSessionPgContractLock(pool);
     await ensureAgentSessionSchema(pool as Queryable);
-  });
+  }, 60_000);
 
   beforeEach(async () => {
-    await pool.query(
-      `TRUNCATE agent_session_entries, agent_session_events,
-                agent_owner_session_events, agent_owner_session_event_counters,
-                agent_session_urls, agent_sessions`,
-    );
+    // CASCADE keeps this order-independent against any table that references
+    // agent_sessions without this suite listing it — see the probe test below.
+    await truncateAgentSessionTables(pool as Queryable);
     store = new PgAgentSessionStore(pool as Queryable, { withTransaction: transactionFor(pool) });
   });
 
   afterAll(async () => {
+    await releaseContractLock?.();
     await pool.end();
   });
 
@@ -68,6 +76,44 @@ describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
     genuineConcurrency: true,
   });
   runAgentSessionUrlContract('PostgreSQL 16 (node-postgres)', () => store);
+
+  test('beforeEach cleanup reaches FK-referencing tables the suite does not list', async () => {
+    // Simulate the next store that references agent_sessions (the way the
+    // material store did) without editing this suite: its table must be
+    // emptied by the cleanup through CASCADE, or a full-suite run breaks
+    // again with "cannot truncate a table referenced in a foreign key
+    // constraint". The probe runs in one transaction so it is atomic and
+    // self-cleaning: any failure rolls everything back, and the shared
+    // database is left exactly as it was.
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO agent_sessions (id, owner_id, prompt, stage_id)
+         VALUES ('cleanup-probe-session', 'cleanup-probe-owner', 'probe', 'stage-cleanup-probe')`,
+      );
+      await client.query(
+        `CREATE TABLE agent_session_cleanup_probe (
+           id         TEXT PRIMARY KEY,
+           session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE
+         )`,
+      );
+      await client.query(
+        `INSERT INTO agent_session_cleanup_probe (id, session_id)
+         VALUES ('cleanup-probe-1', 'cleanup-probe-session')`,
+      );
+      // The exact statement the suite's beforeEach relies on.
+      await truncateAgentSessionTables(client as Queryable);
+      const { rows } = await client.query<{ n: number }>(
+        `SELECT count(*)::int AS n FROM agent_session_cleanup_probe`,
+      );
+      expect(rows[0]!.n).toBe(0);
+    } finally {
+      await client.query('ROLLBACK').catch(() => {});
+      await client.query('DROP TABLE IF EXISTS agent_session_cleanup_probe').catch(() => {});
+      client.release();
+    }
+  });
 
   test('runs against PostgreSQL 16 or newer', async () => {
     const result = await pool.query<{ version_num: string }>(


### PR DESCRIPTION
The PG16 contract job fails 24 cases in `pg-agent-session-store.pg.test.ts` with `cannot truncate a table referenced in a foreign key constraint` — but only in a full-suite run, which is why single-file runs and per-PR checks missed it.

Root cause: the session-material store's table references `agent_sessions(id)`, and the PG16 job shares one database across test files. Once the material suite has ensured its schema, the agent-session suite's plain `TRUNCATE` is rejected. Whichever suite runs first decides whether the job passes.

## Fixed structurally, not by extending a list

Two changes, both in test support:

- **`TRUNCATE … CASCADE`** over the tables the agent-session backend *owns*, letting the foreign-key graph reach the rest. An exhaustive list would need editing every time a store gains an FK to `agent_sessions` — the material store was the third to do so, so a list is a defect generator. A probe test pins the property.
- **A Postgres advisory lock** shared by both suites. Both truncate the same tables and create sessions with identical fixed ids, so they must not overlap; vitest runs each file in its own process, so a JS-level lock cannot express this, but a connection-scoped advisory lock serializes across processes.

## Verification

97/97 across the five PG-gated suites against a real PostgreSQL 16. Order-independence exercised explicitly: material-then-store, store-then-material, and both forced concurrent with the default worker count — all pass, serialized by the lock. Also re-ran each suite alone against a database left dirty by a full run (the exact pre-fix failure condition). Non-PG runs skip cleanly. tsc/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)