### PR TITLE
feat(api): add stage, folder and material HTTP routes

### DIFF
--- a/app/api/materials/[id]/route.ts
+++ b/app/api/materials/[id]/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/materials/[id]?sessionId= — one owned session's material, in the
+ * same public projection the list and the agent's `list_materials` tool use.
+ *
+ * Materials are session-scoped; the client names the session and the session's
+ * owner row is the authorization. A foreign or missing session, and a material
+ * id that does not exist or belongs to another session, all answer the same
+ * plain 404 (no existence oracle).
+ *
+ * Deletion is deliberately not exposed: the session-material store from the
+ * materials slice has no delete operation, and this slice adds no persistence
+ * — a later slice grows deletion on the store, then the route.
+ */
+import type { NextRequest } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
+import {
+  getSessionMaterial,
+  publicMaterialView,
+  resolveOwnedSession,
+} from '@/lib/server/agent-runtime/session-materials';
+import { ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+
+export const runtime = 'nodejs';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  const sessionId = new URL(req.url).searchParams.get('sessionId')?.trim();
+  if (!sessionId) return apiError('MISSING_REQUIRED_FIELD', 400, 'sessionId is required');
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const session = await resolveOwnedSession(sessionId, ownerId);
+    if (!session) return ownerNotFound(responseHeaders);
+    const { id } = await params;
+    const material = await getSessionMaterial(sessionId, id);
+    if (!material) return ownerNotFound(responseHeaders);
+    return ownerJson({ material: publicMaterialView(material) }, 200, responseHeaders);
+  });
+}

--- a/app/api/materials/route.ts
+++ b/app/api/materials/route.ts
@@ -1,0 +1,161 @@
+/**
+ * /api/materials — the workbench's session-material list and upload face.
+ *
+ * Materials are session-scoped (the store from the materials slice), so the
+ * client names the session with `?sessionId=`; the session's own owner row is
+ * the authorization — a foreign or missing session answers the same plain 404
+ * as every other agent-runtime route. The owner itself resolves from the
+ * anonymous cookie and is never a request parameter.
+ *
+ * Uploads reuse the exact byte path the material store uses for fetched pages
+ * (`createSourceMaterial` → the hash-addressed asset registry under the
+ * session's own partition + a material row recording the returned asset id);
+ * no second byte path is invented. Uploaded files are `source` materials:
+ * they carry no readable text by design, matching the agent tools' contract.
+ *
+ * The runtime flag gates the family: the workbench is agent-runtime
+ * territory, and there is deliberately no separate materials flag in this
+ * repo (the runtime probe route documents that).
+ */
+import { basename } from 'node:path';
+
+import type { NextRequest } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
+import {
+  createSourceMaterial,
+  listSessionMaterials,
+  publicMaterialView,
+  resolveOwnedSession,
+} from '@/lib/server/agent-runtime/session-materials';
+import { ownerApiError, ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+
+export const runtime = 'nodejs';
+
+/** Upper bound for one uploaded file. */
+export const MAX_MATERIAL_UPLOAD_BYTES = 25 * 1024 * 1024;
+/** The store's keyset-paging ceiling (default 50, capped at 200). */
+export const MAX_MATERIAL_LIST_LIMIT = 200;
+
+/** The `x-material-filename` header, sanitized to a bare file name. */
+function materialFilename(req: NextRequest): string | null {
+  const raw = req.headers.get('x-material-filename');
+  if (!raw) return null;
+  let decoded = raw;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    // Preserve a plain header value; malformed percent escapes are not paths.
+  }
+  const name = basename(decoded.replace(/\\/g, '/')).trim().slice(0, 512);
+  return name || null;
+}
+
+/** Read the body up to a cap; `null` when empty or over the cap. */
+async function readBodyBytes(
+  req: NextRequest,
+  limit: number,
+): Promise<{ ok: true; bytes: Buffer } | { ok: false }> {
+  if (!req.body) return { ok: false };
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const reader = req.body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const buffer = Buffer.from(value);
+    total += buffer.byteLength;
+    if (total > limit) {
+      await reader.cancel().catch(() => undefined);
+      return { ok: false };
+    }
+    chunks.push(buffer);
+  }
+  if (total === 0) return { ok: false };
+  return { ok: true, bytes: Buffer.concat(chunks) };
+}
+
+function parseLimit(raw: string | null): { limit?: number } | { invalid: true } {
+  if (raw === null || raw === '') return {};
+  if (!/^\d+$/.test(raw)) return { invalid: true };
+  const parsed = Number(raw);
+  if (parsed < 1 || parsed > MAX_MATERIAL_LIST_LIMIT) return { invalid: true };
+  return { limit: parsed };
+}
+
+// GET /api/materials?sessionId=&limit=&before= — list one owned session's
+// materials, newest first, keyset-paged.
+export async function GET(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  const url = new URL(req.url);
+  const sessionId = url.searchParams.get('sessionId')?.trim();
+  if (!sessionId) return apiError('MISSING_REQUIRED_FIELD', 400, 'sessionId is required');
+
+  const parsedLimit = parseLimit(url.searchParams.get('limit'));
+  if ('invalid' in parsedLimit) {
+    return apiError(
+      'INVALID_REQUEST',
+      400,
+      `limit must be an integer between 1 and ${MAX_MATERIAL_LIST_LIMIT}`,
+    );
+  }
+  const before = url.searchParams.get('before')?.trim() || undefined;
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const session = await resolveOwnedSession(sessionId, ownerId);
+    if (!session) return ownerNotFound(responseHeaders);
+    const materials = await listSessionMaterials(sessionId, {
+      ...(parsedLimit.limit === undefined ? {} : { limit: parsedLimit.limit }),
+      ...(before ? { before } : {}),
+    });
+    return ownerJson(
+      { materials: materials.map((material) => publicMaterialView(material)) },
+      200,
+      responseHeaders,
+    );
+  });
+}
+
+// POST /api/materials?sessionId= — upload a source file into one owned
+// session. The raw bytes ride the body; `content-type` is the MIME type and
+// `x-material-filename` the display name.
+export async function POST(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  const sessionId = new URL(req.url).searchParams.get('sessionId')?.trim();
+  if (!sessionId) return apiError('MISSING_REQUIRED_FIELD', 400, 'sessionId is required');
+
+  const filename = materialFilename(req);
+  if (!filename) {
+    return apiError('MISSING_REQUIRED_FIELD', 400, 'x-material-filename header is required');
+  }
+  const mimeType =
+    (req.headers.get('content-type') ?? '').split(';', 1)[0].trim() || 'application/octet-stream';
+
+  const body = await readBodyBytes(req, MAX_MATERIAL_UPLOAD_BYTES);
+  if (!body.ok) {
+    return apiError('INVALID_REQUEST', 413, `upload exceeds ${MAX_MATERIAL_UPLOAD_BYTES} bytes`);
+  }
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const session = await resolveOwnedSession(sessionId, ownerId);
+    if (!session) return ownerNotFound(responseHeaders);
+    try {
+      const record = await createSourceMaterial(sessionId, {
+        filename,
+        mimeType,
+        bytes: body.bytes,
+      });
+      return ownerJson({ material: publicMaterialView(record) }, 201, responseHeaders);
+    } catch (error) {
+      console.error(
+        `[Materials] Failed to store upload [sessionId=${sessionId}, ownerId=${ownerId}]:`,
+        error,
+      );
+      return ownerApiError('INTERNAL_ERROR', 500, 'material upload failed', responseHeaders);
+    }
+  });
+}

--- a/app/api/stages/[id]/freshness/route.ts
+++ b/app/api/stages/[id]/freshness/route.ts
@@ -1,0 +1,152 @@
+/**
+ * GET /api/stages/[id]/freshness — volatile freshness SSE for one course (the
+ * reference's `stages/:id/freshness`, ported onto the owner-bound store).
+ *
+ * The workbench's push side: when the stage's revision moves, this stream
+ * sends the client one frame carrying the current `rev`; the client reacts by
+ * pulling the manifest and re-fetching only the scenes that changed.
+ *
+ * The reference woke this stream from a DB trigger; the upstream storage
+ * package exposes no LISTEN/NOTIFY, so this stream POLLS the owner-bound
+ * store for the stage's `updatedAt` (the same correctness mechanism as
+ * `app/api/agent/owner-events/route.ts`). A frame is emitted when the rev
+ * moves; the first frame is sent on connect. `rev` is doc-level (see the
+ * manifest route) — the signal is intentionally coarse but honest, and the
+ * client's fallback polling still converges independently.
+ *
+ * Degradation is by design: this stream is a pure optimization. A dead or
+ * missing stream only costs latency — the client's low-frequency fallback
+ * poll still converges. Conventions mirror the sibling SSE routes: a 25s
+ * heartbeat comment frame keeps intermediaries from ending the stream, an
+ * explicit `retry:` hint sets the browser's reconnect delay, the stream never
+ * closes on a terminal state, and a broken socket is the client's
+ * EventSource problem, not this route's.
+ */
+import type { NextRequest } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
+import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
+import { ownerNotFound } from '@/lib/server/agent-runtime/route-response';
+
+export const runtime = 'nodejs';
+// Self-hosted `next start` ignores maxDuration; Vercel's adapter can still use
+// it. The 25s heartbeat keeps this sparse stream active through idle periods.
+export const maxDuration = 300;
+
+/** How often the stream re-checks the stage's revision. */
+export const STAGE_FRESHNESS_POLL_INTERVAL_MS = 5_000;
+/** Same ceiling as the sibling SSE streams. */
+export const STAGE_FRESHNESS_HEARTBEAT_MS = 25_000;
+/** Browser reconnect delay, sent as the SSE `retry:` field. */
+export const STAGE_FRESHNESS_RETRY_MS = 3_000;
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  const responseHeaders = new Headers();
+  const ownerId = resolveRequestOwnerId(req, responseHeaders);
+  const { id: stageId } = await params;
+
+  // Existence-gated, exactly like the manifest route: the owner-bound store
+  // reads a foreign or missing stage as absent, and the 404 carries the
+  // owner cookie the same way every response of this family does.
+  const store = await getOwnerScopedDocumentStore(ownerId);
+  const initial = await store.loadDocument(stageId);
+  if (!initial) return ownerNotFound(responseHeaders);
+
+  const encoder = new TextEncoder();
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+
+  const clearTimers = () => {
+    if (pollTimer) clearTimeout(pollTimer);
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    pollTimer = null;
+    heartbeatTimer = null;
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const write = (chunk: string) => {
+        if (closed) return false;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+          return true;
+        } catch {
+          // A broken socket is not guaranteed to invoke cancel() in every
+          // runtime; stop the timers the moment enqueue proves it closed.
+          closed = true;
+          clearTimers();
+          return false;
+        }
+      };
+
+      let lastRev = 0;
+
+      // The frame carries the current rev so a client that wants to skip the
+      // manifest round-trip when nothing changed can, but the contract is
+      // "pull the manifest on every frame" — rev is informational, never
+      // authoritative. A read failure sends rev 0 (never a terminal state: a
+      // stage can always be written again), matching the reference.
+      const emitFreshness = async () => {
+        if (closed) return;
+        let rev = 0;
+        try {
+          const document = await store.loadDocument(stageId);
+          rev = document ? document.stage.updatedAt : 0;
+        } catch {
+          // Fall through to the rev-0 frame.
+        }
+        if (rev === lastRev) return;
+        lastRev = rev;
+        write(
+          `event: stage_freshness\ndata: ${JSON.stringify({
+            type: 'stage_freshness',
+            stageId,
+            rev,
+          })}\n\n`,
+        );
+      };
+
+      // Chained setTimeout: the next poll is scheduled only after the previous
+      // read settles, so polls can never overlap.
+      const schedulePoll = () => {
+        if (closed) return;
+        pollTimer = setTimeout(async () => {
+          try {
+            await emitFreshness();
+          } finally {
+            schedulePoll();
+          }
+        }, STAGE_FRESHNESS_POLL_INTERVAL_MS);
+      };
+
+      // Reconnect hint + the first frame of the stream.
+      write(`retry: ${STAGE_FRESHNESS_RETRY_MS}\n\n`);
+      await emitFreshness();
+
+      heartbeatTimer = setInterval(() => {
+        if (closed) return;
+        write(': ping\n\n');
+      }, STAGE_FRESHNESS_HEARTBEAT_MS);
+      schedulePoll();
+    },
+    cancel() {
+      closed = true;
+      clearTimers();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      ...Object.fromEntries(responseHeaders),
+    },
+  });
+}

--- a/app/api/stages/[id]/manifest/route.ts
+++ b/app/api/stages/[id]/manifest/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET /api/stages/[id]/manifest — freshness manifest for one course (the
+ * reference's `stages/:id/manifest`, ported onto the owner-bound store).
+ *
+ * Returns `{rev, scenes: [{id, order, rev}]}` — the revision index the
+ * workbench canvas diffs against before re-fetching scenes. The upstream
+ * store carries no per-scene revisions and adds none (this slice reuses the
+ * existing stores), so `rev` is the document's `stage.updatedAt` and every
+ * scene shares it: any document-level change invalidates the whole scene set,
+ * which is correct if coarser than the reference — the client's manifest diff
+ * logic works unchanged and re-fetches exactly the (possibly all) scenes
+ * whose rev moved. Writes through this slice's PUT/PATCH bump `updatedAt`, so
+ * the UI's own saves drive the signal.
+ *
+ * Permission boundary is the same as every stage route: the owner-bound store
+ * reads a foreign or missing stage as absent, and both answer the identical
+ * 404 (the id is not an existence oracle).
+ */
+import type { NextRequest } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
+import { ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+
+export const runtime = 'nodejs';
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    const document = await store.loadDocument(id);
+    if (!document) return ownerNotFound(responseHeaders);
+    const rev = document.stage.updatedAt;
+    return ownerJson(
+      {
+        rev,
+        scenes: document.scenes.map((scene) => ({ id: scene.id, order: scene.order, rev })),
+      },
+      200,
+      responseHeaders,
+    );
+  });
+}

--- a/app/api/stages/[id]/route.ts
+++ b/app/api/stages/[id]/route.ts
@@ -1,0 +1,188 @@
+/**
+ * /api/stages/[id] — read, rename, save, and delete one owned course document.
+ *
+ * Ownership is enforced by the store itself, not by a pre-check: every read
+ * and write goes through the owner-bound document store, so a foreign or
+ * missing id answers the identical 404 (the no-existence-oracle posture of
+ * the agent-runtime routes), and a write into a foreign document is refused
+ * inside the store's transaction (`persistStage` re-checks the owner scope).
+ *
+ * - GET    returns the whole document (stage + scenes + outline).
+ * - PATCH  renames the course ({ name }), the reference's update path.
+ * - PUT    saves a whole document ({ stage, scenes, outline? }) — the coarse
+ *          "update stage document" write the UI saves through; the server
+ *          bumps `stage.updatedAt` so the freshness signal sees the change.
+ * - DELETE removes the course and its cascading child rows.
+ *
+ * The runtime flag gates the family (see `app/api/stages/route.ts`).
+ */
+import type { NextRequest } from 'next/server';
+
+import { DocumentNotFoundError, DocumentVersionError, type MaicDocument } from '@openmaic/storage';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
+import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
+import { ownerApiError, ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+import { STAGE_NAME_MAX_LENGTH } from '@/lib/server/agent-runtime/stage-limits';
+
+export const runtime = 'nodejs';
+
+type Params = { params: Promise<{ id: string }> };
+
+/** A save refused because the payload is not a structurally valid document. */
+function isStoreValidationError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    error.message.startsWith('@openmaic/storage:') &&
+    !(error instanceof DocumentNotFoundError) &&
+    !(error instanceof DocumentVersionError)
+  );
+}
+
+/** Map a store save failure onto the route's error surface. */
+function mapSaveError(error: unknown, headers: Headers) {
+  if (error instanceof DocumentNotFoundError) return ownerNotFound(headers);
+  if (error instanceof DocumentVersionError) {
+    // A document written by a newer client cannot be saved by this one.
+    return ownerApiError(
+      'INVALID_REQUEST',
+      400,
+      'document was written by a newer client; reload before saving',
+      headers,
+      error.message,
+    );
+  }
+  if (isStoreValidationError(error)) {
+    return ownerApiError('INVALID_REQUEST', 400, 'invalid stage document', headers, error.message);
+  }
+  throw error;
+}
+
+// GET /api/stages/[id] — the full document.
+export async function GET(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    const document = await store.loadDocument(id);
+    if (!document) return ownerNotFound(responseHeaders);
+    return ownerJson(document, 200, responseHeaders);
+  });
+}
+
+// PATCH /api/stages/[id] — rename the course (owner-only).
+export async function PATCH(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+  }
+  const rawName = (body as { name?: unknown })?.name;
+  if (typeof rawName !== 'string' || rawName.trim().length === 0) {
+    return apiError('INVALID_REQUEST', 400, 'name must be a non-empty string');
+  }
+  const name = rawName.trim();
+  if (name.length > STAGE_NAME_MAX_LENGTH) {
+    return apiError(
+      'INVALID_REQUEST',
+      400,
+      `name exceeds the ${STAGE_NAME_MAX_LENGTH} character limit`,
+    );
+  }
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    const document = await store.loadDocument(id);
+    if (!document) return ownerNotFound(responseHeaders);
+    try {
+      await store.saveDocument({
+        ...document,
+        stage: { ...document.stage, name, updatedAt: Date.now() },
+      });
+    } catch (error) {
+      return mapSaveError(error, responseHeaders);
+    }
+    return ownerJson({ success: true, name }, 200, responseHeaders);
+  });
+}
+
+// PUT /api/stages/[id] — save a whole document.
+export async function PUT(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+  }
+  const candidate = body as {
+    stage?: { id?: unknown; updatedAt?: unknown };
+    scenes?: unknown;
+  };
+  if (
+    typeof candidate !== 'object' ||
+    candidate === null ||
+    typeof candidate.stage !== 'object' ||
+    candidate.stage === null ||
+    typeof candidate.stage.id !== 'string' ||
+    !Array.isArray(candidate.scenes)
+  ) {
+    return apiError(
+      'INVALID_REQUEST',
+      400,
+      'request body must be a stage document with `stage` and `scenes`',
+    );
+  }
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    if (candidate.stage!.id !== id) {
+      return ownerApiError(
+        'INVALID_REQUEST',
+        400,
+        'document stage id does not match the requested stage',
+        responseHeaders,
+      );
+    }
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    // Save is existence-gated (the reference's update path is too): PUT
+    // updates a course that exists; it must not resurrect a deleted one or
+    // mint a course under a client-chosen id. The owner scope is re-checked
+    // inside the write transaction, so a foreign id still refuses there.
+    const existing = await store.loadDocument(id);
+    if (!existing) return ownerNotFound(responseHeaders);
+    try {
+      // The server is authoritative for "last modified": bumping updatedAt
+      // keeps the manifest/freshness signal accurate for this route's writes.
+      // The full payload is validated inside the store before anything is
+      // persisted (invalid stage/scene shapes throw and map to 400 below).
+      await store.saveDocument({
+        ...(body as MaicDocument),
+        stage: { ...(body as MaicDocument).stage, updatedAt: Date.now() },
+      });
+    } catch (error) {
+      return mapSaveError(error, responseHeaders);
+    }
+    return ownerJson({ success: true }, 200, responseHeaders);
+  });
+}
+
+// DELETE /api/stages/[id] — remove the course and its scenes/outline.
+export async function DELETE(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    await store.deleteDocument(id);
+    return ownerJson({ ok: true }, 200, responseHeaders);
+  });
+}

--- a/app/api/stages/[id]/scenes/route.ts
+++ b/app/api/stages/[id]/scenes/route.ts
@@ -1,0 +1,81 @@
+/**
+ * GET /api/stages/[id]/scenes?ids=a,b,c — batch scene read (reference
+ * `stages/:id/scenes`, ported onto the owner-bound document store).
+ *
+ * Returns ONLY the requested scenes, in document (`scene_order`) order — the
+ * narrow re-fetch half of the workbench's manifest sync: the client diffs
+ * `GET /api/stages/:id/manifest` against what it rendered with, then asks
+ * this endpoint for exactly the scene ids whose rev changed. One page commit
+ * therefore moves one scene instead of the whole document.
+ *
+ * Ownership and existence share the store's no-existence-oracle posture: the
+ * owner-bound store reads a foreign or missing stage as absent, and both
+ * answer the identical 404. A requested id that does not exist (deleted
+ * between the manifest read and here) is simply absent from the array.
+ *
+ * Ids are bounded: a pathological diff could name every scene, so the request
+ * is capped at MAX_BATCH_SCENE_IDS; over the cap is a 400 rather than a
+ * silent truncation (truncating would drop scenes the client believes it
+ * fetched). The client treats 400 as a failed pass and retries on the next
+ * trigger.
+ */
+import type { NextRequest } from 'next/server';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
+import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
+import { ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+
+export const runtime = 'nodejs';
+
+/** Upper bound on `ids` — see the file header. */
+export const MAX_BATCH_SCENE_IDS = 200;
+
+/**
+ * Scene ids travel the same wire as stage ids, so they face the same driver
+ * hazard: a `\0` or a lone surrogate in the query parameter would make an id
+ * comparison throw at the driver. Such an id can never match a stored scene,
+ * so dropping it is exact (reference rationale).
+ */
+const LONE_SURROGATE = /[\uD800-\uDFFF]/u;
+function isQueryableSceneId(sceneId: string): boolean {
+  return !sceneId.includes('\u0000') && !LONE_SURROGATE.test(sceneId);
+}
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: Params) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  const rawIds = new URL(req.url).searchParams.get('ids');
+  const requested = (rawIds ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    // Dedupe: a repeated id is the same scene; counting it twice would also
+    // inflate the bound check.
+    .filter((value, index, all) => all.indexOf(value) === index)
+    .filter(isQueryableSceneId);
+  if (requested.length === 0) {
+    return apiError('INVALID_REQUEST', 400, 'empty_scene_ids');
+  }
+  if (requested.length > MAX_BATCH_SCENE_IDS) {
+    return apiError(
+      'INVALID_REQUEST',
+      400,
+      'too_many_scene_ids',
+      `limit ${MAX_BATCH_SCENE_IDS}, requested ${requested.length}`,
+    );
+  }
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    const document = await store.loadDocument(id);
+    if (!document) return ownerNotFound(responseHeaders);
+    const wanted = new Set(requested);
+    const scenes = document.scenes.filter((scene) => wanted.has(scene.id));
+    return ownerJson({ scenes }, 200, responseHeaders);
+  });
+}

--- a/app/api/stages/route.ts
+++ b/app/api/stages/route.ts
@@ -1,0 +1,115 @@
+/**
+ * /api/stages — the workbench's course-document index and create face.
+ *
+ * Every handler is owner-scoped exactly like the agent tools: the owner
+ * resolves from the anonymous cookie (`withRequestOwnerId`) and is never a
+ * request parameter, and all reads and writes go through the owner-bound
+ * document store (`getOwnerScopedDocumentStore`), the same seam the runner
+ * binds for the stage tools. A stage created here is visible to this browser
+ * and to nobody else.
+ *
+ * The runtime flag gates the whole family: these routes serve the workbench,
+ * which is agent-runtime territory, so a disabled runtime answers the same
+ * plain 404 as the agent control-plane routes.
+ */
+import type { NextRequest } from 'next/server';
+import { randomBytes } from 'node:crypto';
+
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import type { AppDocumentOutline } from '@/lib/document-store/persistence-types';
+import { apiError } from '@/lib/server/api-response';
+import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
+import { ownerJson } from '@/lib/server/agent-runtime/route-response';
+import { STAGE_NAME_MAX_LENGTH } from '@/lib/server/agent-runtime/stage-limits';
+import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+
+export const runtime = 'nodejs';
+
+/** Mint a fresh, collision-free course id in the same `stage-` family as the agent tools. */
+function createStageId(): string {
+  return `stage-${randomBytes(9).toString('base64url')}`;
+}
+
+// GET /api/stages — list every stage document owned by the caller.
+export async function GET(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    const stages = await store.listDocuments();
+    return ownerJson({ stages }, 200, responseHeaders);
+  });
+}
+
+// POST /api/stages — create a stage document shell { name, description? }.
+//
+// Validation happens before owner resolution, like the agent session routes:
+// a malformed body must not mint an anonymous cookie partition for a request
+// that will not proceed.
+export async function POST(req: NextRequest) {
+  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+  }
+  if (typeof body !== 'object' || body === null) {
+    return apiError('INVALID_REQUEST', 400, 'request body must be a JSON object');
+  }
+  const { name, description } = body as { name?: unknown; description?: unknown };
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    return apiError('MISSING_REQUIRED_FIELD', 400, 'name is required');
+  }
+  const trimmedName = name.trim();
+  if (trimmedName.length > STAGE_NAME_MAX_LENGTH) {
+    return apiError(
+      'INVALID_REQUEST',
+      400,
+      `name exceeds the ${STAGE_NAME_MAX_LENGTH} character limit`,
+    );
+  }
+  if (description !== undefined && typeof description !== 'string') {
+    return apiError('INVALID_REQUEST', 400, 'description must be a string when present');
+  }
+  const trimmedDescription = description?.trim();
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const id = createStageId();
+    const now = Date.now();
+    const outline: AppDocumentOutline = {
+      outlines: [],
+      requirement: trimmedName,
+      generationComplete: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const store = await getOwnerScopedDocumentStore(ownerId);
+    await store.saveDocument({
+      stage: {
+        id,
+        name: trimmedName,
+        ...(trimmedDescription ? { description: trimmedDescription } : {}),
+        createdAt: now,
+        updatedAt: now,
+      },
+      scenes: [],
+      outline,
+    });
+    return ownerJson(
+      {
+        stage: {
+          id,
+          name: trimmedName,
+          ...(trimmedDescription ? { description: trimmedDescription } : {}),
+          createdAt: now,
+          updatedAt: now,
+          sceneCount: 0,
+        },
+      },
+      201,
+      responseHeaders,
+    );
+  });
+}

--- a/lib/server/agent-runtime/owner-scoped-documents.ts
+++ b/lib/server/agent-runtime/owner-scoped-documents.ts
@@ -1,0 +1,27 @@
+import type { DocumentStore } from '@openmaic/storage';
+
+import { withPlainJsonDocumentWrites } from '@/lib/document-store/plain-json-store';
+import type { AppStage } from '@/lib/document-store/persistence-types';
+import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
+import type { AppScene } from '@/lib/types/stage';
+
+/**
+ * The owner-bound document store for one HTTP request.
+ *
+ * This is the exact seam the agent runner uses (`runner.ts`): the document
+ * provider is bound to the resolved owner via `forOwner`, so every read and
+ * write is partitioned to that identity — a stage created by the agent for an
+ * owner is visible to the same browser and to nobody else, and a foreign id
+ * reads as absent and cannot be written (the owner scope is re-checked inside
+ * the write transaction). `withPlainJsonDocumentWrites` keeps the write
+ * boundary identical to the agent tools' (undefined-valued members are never
+ * persisted as JSON nulls).
+ */
+export async function getOwnerScopedDocumentStore(
+  ownerId: string,
+): Promise<DocumentStore<AppScene, AppStage>> {
+  const { documentStore } = await getServerPersistenceProvider(process.env.DATABASE_URL ?? '');
+  return withPlainJsonDocumentWrites(
+    documentStore.forOwner(ownerId) as unknown as DocumentStore<AppScene, AppStage>,
+  );
+}

--- a/lib/server/agent-runtime/route-response.ts
+++ b/lib/server/agent-runtime/route-response.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+
+import { apiError, type ApiErrorCode } from '@/lib/server/api-response';
+
+/**
+ * Response builders for owner-scoped routes.
+ *
+ * Every response of an owner-scoped route must carry the response headers the
+ * owner resolution produced: a freshly minted anonymous cookie must ride
+ * success AND 4xx/5xx responses alike, so a client that retries after an error
+ * keeps the same owner partition (see `with-owner.ts`).
+ */
+
+/** Attach the owner-resolution headers (e.g. a minted Set-Cookie) to a response. */
+export function withOwnerResponseHeaders(response: NextResponse, headers: Headers): NextResponse {
+  for (const [key, value] of headers) response.headers.append(key, value);
+  return response;
+}
+
+/** A JSON body under the owner headers. */
+export function ownerJson(body: unknown, status: number, headers: Headers): NextResponse {
+  return NextResponse.json(body, { status, headers });
+}
+
+/** The repo's apiError envelope under the owner headers. */
+export function ownerApiError(
+  code: ApiErrorCode,
+  status: number,
+  message: string,
+  headers: Headers,
+  details?: string,
+): NextResponse {
+  return withOwnerResponseHeaders(apiError(code, status, message, details), headers);
+}
+
+/**
+ * The no-existence-oracle 404: foreign and missing resources answer the same
+ * plain body as every other agent-runtime route (an existence probe must not
+ * be able to distinguish "never existed" from "someone else's").
+ */
+export function ownerNotFound(headers: Headers): NextResponse {
+  return new NextResponse('Not found', { status: 404, headers });
+}

--- a/lib/server/agent-runtime/session-materials.ts
+++ b/lib/server/agent-runtime/session-materials.ts
@@ -19,12 +19,14 @@ import {
   createMaterialId,
   toAssetId,
   type AgentSessionMaterial,
+  type AgentSessionMeta,
   type AssetPrincipal,
   type ListAgentSessionMaterialsOptions,
 } from '@openmaic/storage';
 
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
 
+import { getAgentSessionStore } from './store';
 import type { ExtractedWebPage } from './fetch-url';
 
 interface AgentSessionMaterialStoreState {
@@ -126,6 +128,95 @@ export async function createWebMaterial(
     }
     throw error;
   }
+}
+
+/** A user-uploaded source file, persisted through the same seams as a fetch. */
+export interface CreateSourceMaterialInput {
+  /** Display name of the uploaded file (the `x-material-filename` header). */
+  filename: string;
+  /** Canonical MIME type of the uploaded bytes. */
+  mimeType: string;
+  /** The uploaded bytes. */
+  bytes: Buffer;
+}
+
+/**
+ * Persist a user-uploaded file as a session material: the raw bytes go into
+ * the asset registry under the session's own partition and the material row
+ * records the returned asset id (`rawAssetId`), mirroring
+ * {@link createWebMaterial}'s asset/metadata handoff. The kind is `source`,
+ * the same vocabulary the reference uses for uploads: source records carry no
+ * readable text by design (the agent reads extraction or image derivatives
+ * instead), so `textChars` stays 0 and only `rawAssetId` is recorded. A
+ * confirmed material-row failure removes the just-stored asset; ambiguous
+ * database outcomes are verified before cleanup, exactly like the web path.
+ */
+export async function createSourceMaterial(
+  sessionId: string,
+  input: CreateSourceMaterialInput,
+): Promise<AgentSessionMaterial> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error('Agent runtime requires DATABASE_URL');
+  const provider = await getServerPersistenceProvider(connectionString);
+  const id = createMaterialId();
+  const body = Buffer.from(input.bytes);
+  const principal = materialPrincipal(sessionId);
+  const store = await getAgentSessionMaterialStore();
+  const assetId = await provider.assetStore.put(
+    principal,
+    new Blob([body], { type: input.mimeType }),
+    { contentType: input.mimeType },
+  );
+  try {
+    return await store.createMaterial(sessionId, {
+      id,
+      kind: 'source',
+      title: input.filename,
+      rawAssetId: assetId,
+      textChars: 0,
+    });
+  } catch (error) {
+    // Same ambiguous-commit discipline as createWebMaterial: only remove the
+    // asset when the row is confirmed absent.
+    const committed = await store.getMaterial(sessionId, id).catch(() => undefined);
+    if (committed) return committed;
+    if (committed === null) {
+      await provider.assetStore.remove(principal, assetId).catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
+/**
+ * The HTTP-visible projection of one material row — the same shape the
+ * `list_materials` agent tool exposes. Asset ids stay off the wire: the
+ * registry handles are internal to the host seam, and nothing downstream of
+ * the store should depend on them.
+ */
+export function publicMaterialView(record: AgentSessionMaterial): Record<string, unknown> {
+  return {
+    materialId: record.id,
+    kind: record.kind,
+    ...(record.title ? { title: record.title } : {}),
+    ...(record.sourceUrl ? { sourceUrl: record.sourceUrl } : {}),
+    textChars: record.textChars,
+    createdAt: record.createdAt,
+  };
+}
+
+/**
+ * Resolve a session the owner may reach, or `null` — the materials routes'
+ * ownership gate. Materials are session-scoped, so an HTTP client must name
+ * the session it means; the session's own owner row is the authorization, and
+ * a foreign or missing session answers the same `null` (no existence oracle).
+ */
+export async function resolveOwnedSession(
+  sessionId: string,
+  ownerId: string,
+): Promise<AgentSessionMeta | null> {
+  const store = await getAgentSessionStore();
+  const session = await store.getSession(sessionId);
+  return session && session.ownerId === ownerId ? session : null;
 }
 
 /** Newest-first session material listing with keyset paging. */

--- a/lib/server/agent-runtime/stage-limits.ts
+++ b/lib/server/agent-runtime/stage-limits.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared limits for the stage HTTP routes.
+ */
+
+/**
+ * Course-name cap; the publish dialog enforces the same 120-char rule
+ * client-side (reference semantics).
+ */
+export const STAGE_NAME_MAX_LENGTH = 120;

--- a/tests/agent-runtime/_fake-document-store.ts
+++ b/tests/agent-runtime/_fake-document-store.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared in-memory DocumentStore facade for the stage route tests.
+ *
+ * The routes reach the store through `getOwnerScopedDocumentStore`, which
+ * binds the provider's document store to the request owner with `forOwner`.
+ * Route tests mock `@/lib/persistence/server-provider` to return THIS facade,
+ * already scoped to one owner: seeding it with a document is "a document this
+ * owner owns", and an id absent from it reads as missing — the same
+ * no-existence-oracle the real owner-bound store produces for a foreign id.
+ */
+import type { DocumentStore, MaicDocument } from '@openmaic/storage';
+
+import type { AppStage } from '@/lib/document-store/persistence-types';
+import type { AppScene } from '@/lib/types/stage';
+
+export interface FakeDocumentStore {
+  store: OwnerScopedFakeStore;
+  docs: Map<string, MaicDocument<AppScene, AppStage>>;
+  saveCalls: MaicDocument<AppScene, AppStage>[];
+  /** Make the next saveDocument call throw (e.g. a validation failure). */
+  failNextSaveWith(error: unknown): void;
+}
+
+/** The fake store is already one owner's partition, so scoping is identity. */
+export type OwnerScopedFakeStore = DocumentStore<AppScene, AppStage> & {
+  forOwner(ownerId: string): OwnerScopedFakeStore;
+};
+
+export function createFakeDocumentStore(): FakeDocumentStore {
+  const docs = new Map<string, MaicDocument<AppScene, AppStage>>();
+  const saveCalls: MaicDocument<AppScene, AppStage>[] = [];
+  let saveError: unknown = null;
+
+  const store = {
+    forOwner: () => store,
+    async saveDocument(doc: MaicDocument<AppScene, AppStage>) {
+      if (saveError) throw saveError;
+      saveCalls.push(structuredClone(doc));
+      docs.set(doc.stage.id, structuredClone(doc));
+    },
+    async loadDocument(stageId: string) {
+      const doc = docs.get(stageId);
+      return doc ? structuredClone(doc) : null;
+    },
+    async listDocuments() {
+      return [...docs.values()]
+        .map((doc) => ({
+          id: doc.stage.id,
+          name: doc.stage.name,
+          ...(doc.stage.description ? { description: doc.stage.description } : {}),
+          createdAt: doc.stage.createdAt,
+          updatedAt: doc.stage.updatedAt,
+          sceneCount: doc.scenes.length,
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id));
+    },
+    async deleteDocument(stageId: string) {
+      docs.delete(stageId);
+    },
+    async putStage(stageId: string, stage: AppStage) {
+      const doc = docs.get(stageId);
+      if (!doc) throw new Error('@openmaic/storage: document not found');
+      docs.set(stageId, { ...doc, stage });
+    },
+    async putScene(stageId: string, scene: AppScene) {
+      const doc = docs.get(stageId);
+      if (!doc) throw new Error('@openmaic/storage: document not found');
+      docs.set(stageId, {
+        ...doc,
+        scenes: [...doc.scenes.filter((s) => s.id !== scene.id), scene].sort(
+          (left, right) => left.order - right.order,
+        ),
+      });
+    },
+    async getScene(stageId: string, sceneId: string) {
+      return docs.get(stageId)?.scenes.find((scene) => scene.id === sceneId) ?? null;
+    },
+    async deleteScene(stageId: string, sceneId: string) {
+      const doc = docs.get(stageId);
+      if (doc) {
+        docs.set(stageId, { ...doc, scenes: doc.scenes.filter((scene) => scene.id !== sceneId) });
+      }
+    },
+  } as OwnerScopedFakeStore;
+
+  return {
+    store,
+    docs,
+    saveCalls,
+    failNextSaveWith(error) {
+      saveError = error;
+    },
+  };
+}

--- a/tests/agent-runtime/_stage-fixtures.ts
+++ b/tests/agent-runtime/_stage-fixtures.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared stage-document fixtures for the route tests: a valid document, a
+ * valid slide scene, and the outline envelope.
+ */
+import type { AppDocument, AppDocumentOutline } from '@/lib/document-store/persistence-types';
+import type { AppScene } from '@/lib/types/stage';
+
+/** A fixed clock so timestamps are assertable. */
+export const FIXED_NOW = 1_700_000_000_000;
+
+/** A minimal structurally valid slide scene. */
+export function makeSlideScene(
+  id: string,
+  stageId: string,
+  order: number,
+  title = `Scene ${order}`,
+): AppScene {
+  return {
+    id,
+    stageId,
+    order,
+    title,
+    type: 'slide',
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+    content: {
+      type: 'slide',
+      canvas: {
+        id: `canvas-${id}`,
+        viewportSize: 1000,
+        viewportRatio: 16 / 9,
+        theme: {
+          backgroundColor: '#ffffff',
+          themeColors: ['#2563eb'],
+          fontColor: '#111827',
+          fontName: 'Inter',
+        },
+        elements: [],
+      },
+    },
+  };
+}
+
+export function makeOutline(requirement: string): AppDocumentOutline {
+  return {
+    outlines: [],
+    requirement,
+    generationComplete: false,
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+  };
+}
+
+export function makeDocument(
+  id: string,
+  name: string,
+  scenes: AppScene[] = [],
+  outline: AppDocumentOutline = makeOutline(name),
+): AppDocument {
+  return {
+    stage: { id, name, createdAt: FIXED_NOW, updatedAt: FIXED_NOW },
+    scenes,
+    outline,
+  };
+}

--- a/tests/agent-runtime/material-detail-route.test.ts
+++ b/tests/agent-runtime/material-detail-route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { AgentSessionMaterial } from '@openmaic/storage';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  resolveOwnedSession: vi.fn(),
+  getSessionMaterial: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/server/agent-runtime/session-materials', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/agent-runtime/session-materials')>();
+  return {
+    ...actual,
+    resolveOwnedSession: mocks.resolveOwnedSession,
+    getSessionMaterial: mocks.getSessionMaterial,
+  };
+});
+
+import { GET } from '@/app/api/materials/[id]/route';
+
+const SESSION_ID = 'session-1';
+const MATERIAL_ID = 'mat_00000000000000000000000000';
+
+function material(overrides: Partial<AgentSessionMaterial> = {}): AgentSessionMaterial {
+  return {
+    id: MATERIAL_ID,
+    sessionId: SESSION_ID,
+    kind: 'web',
+    title: 'Example',
+    sourceUrl: 'https://example.com/doc',
+    textAssetId: 'asset-1',
+    rawAssetId: null,
+    textChars: 42,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function call(id = MATERIAL_ID) {
+  const req = new NextRequest(`http://localhost/api/materials/${id}?sessionId=${SESSION_ID}`);
+  return GET(req, { params: Promise.resolve({ id }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.resolveOwnedSession.mockResolvedValue({ id: SESSION_ID, ownerId: 'owner-1' });
+  mocks.getSessionMaterial.mockResolvedValue(material());
+});
+
+describe('GET /api/materials/[id]', () => {
+  it("returns one owned session's material as a public view", async () => {
+    const response = await call();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      material: {
+        materialId: MATERIAL_ID,
+        kind: 'web',
+        title: 'Example',
+        sourceUrl: 'https://example.com/doc',
+        textChars: 42,
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+    });
+    expect(mocks.getSessionMaterial).toHaveBeenCalledWith(SESSION_ID, MATERIAL_ID);
+  });
+
+  it('rejects a missing sessionId', async () => {
+    const req = new NextRequest(`http://localhost/api/materials/${MATERIAL_ID}`);
+    const response = await GET(req, { params: Promise.resolve({ id: MATERIAL_ID }) });
+    expect(response.status).toBe(400);
+    expect(mocks.getSessionMaterial).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 for a foreign or missing session (no existence oracle)', async () => {
+    mocks.resolveOwnedSession.mockResolvedValue(null);
+    const response = await call();
+    expect(response.status).toBe(404);
+    expect(mocks.getSessionMaterial).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 for a missing or foreign material', async () => {
+    mocks.getSessionMaterial.mockResolvedValue(null);
+    const response = await call();
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+  });
+
+  it('rides the owner cookie on the 404', async () => {
+    mocks.resolveRequestOwnerId.mockImplementationOnce((_req, responseHeaders: Headers) => {
+      responseHeaders.set('Set-Cookie', 'anonymous_id=anon-2; Path=/');
+      return 'anon:anon-2';
+    });
+    mocks.getSessionMaterial.mockResolvedValue(null);
+    const response = await call();
+    expect(response.status).toBe(404);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=anon-2');
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    expect((await call()).status).toBe(404);
+  });
+});

--- a/tests/agent-runtime/materials-route.test.ts
+++ b/tests/agent-runtime/materials-route.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { AgentSessionMaterial } from '@openmaic/storage';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  resolveOwnedSession: vi.fn(),
+  listSessionMaterials: vi.fn(),
+  createSourceMaterial: vi.fn(),
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/server/agent-runtime/session-materials', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/agent-runtime/session-materials')>();
+  return {
+    ...actual,
+    resolveOwnedSession: mocks.resolveOwnedSession,
+    listSessionMaterials: mocks.listSessionMaterials,
+    createSourceMaterial: mocks.createSourceMaterial,
+  };
+});
+
+import { GET, POST } from '@/app/api/materials/route';
+
+const SESSION_ID = 'session-1';
+
+function material(overrides: Partial<AgentSessionMaterial> = {}): AgentSessionMaterial {
+  return {
+    id: 'mat_00000000000000000000000000',
+    sessionId: SESSION_ID,
+    kind: 'web',
+    title: 'Example',
+    sourceUrl: 'https://example.com/doc',
+    textAssetId: 'asset-1',
+    rawAssetId: null,
+    textChars: 42,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.resolveOwnedSession.mockResolvedValue({ id: SESSION_ID, ownerId: 'owner-1' });
+  mocks.listSessionMaterials.mockResolvedValue([material()]);
+  mocks.createSourceMaterial.mockImplementation(
+    async (_sessionId: string, input: { filename: string; mimeType: string; bytes: Buffer }) =>
+      material({ kind: 'source', title: input.filename }),
+  );
+});
+
+describe('GET /api/materials', () => {
+  it("lists one owned session's materials as public views", async () => {
+    const response = await GET(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      materials: [
+        {
+          materialId: 'mat_00000000000000000000000000',
+          kind: 'web',
+          title: 'Example',
+          sourceUrl: 'https://example.com/doc',
+          textChars: 42,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(mocks.resolveOwnedSession).toHaveBeenCalledWith(SESSION_ID, 'owner-1');
+    expect(mocks.listSessionMaterials).toHaveBeenCalledWith(SESSION_ID, {});
+  });
+
+  it('passes limit and before through as keyset paging', async () => {
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/materials?sessionId=${SESSION_ID}&limit=10&before=mat_prev`,
+      ),
+    );
+    expect(response.status).toBe(200);
+    expect(mocks.listSessionMaterials).toHaveBeenCalledWith(SESSION_ID, {
+      limit: 10,
+      before: 'mat_prev',
+    });
+  });
+
+  it('rejects a missing sessionId', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/materials'));
+    expect(response.status).toBe(400);
+    expect(mocks.resolveOwnedSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed or out-of-range limit', async () => {
+    for (const limit of ['abc', '0', '201']) {
+      const response = await GET(
+        new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}&limit=${limit}`),
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it('answers 404 for a foreign or missing session (no existence oracle)', async () => {
+    mocks.resolveOwnedSession.mockResolvedValue(null);
+    const response = await GET(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`),
+    );
+    expect(response.status).toBe(404);
+    expect(mocks.listSessionMaterials).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    const response = await GET(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`),
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('POST /api/materials', () => {
+  it('uploads raw bytes as a source material', async () => {
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/pdf',
+          'x-material-filename': encodeURIComponent('讲义.pdf'),
+        },
+        body: Buffer.from('hello'),
+      }),
+    );
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      material: expect.objectContaining({ materialId: 'mat_00000000000000000000000000' }),
+    });
+    expect(mocks.createSourceMaterial).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({
+        filename: '讲义.pdf',
+        mimeType: 'application/pdf',
+      }),
+    );
+    const input = mocks.createSourceMaterial.mock.calls[0]![1] as { bytes: Buffer };
+    expect(Buffer.from(input.bytes).toString('utf8')).toBe('hello');
+  });
+
+  it('defaults the mime type to octet-stream when the header is absent', async () => {
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: { 'x-material-filename': 'notes.txt' },
+        body: Buffer.from('text'),
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect(mocks.createSourceMaterial).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ mimeType: 'application/octet-stream' }),
+    );
+  });
+
+  it('rejects a missing sessionId', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/materials', {
+        method: 'POST',
+        headers: { 'x-material-filename': 'a.pdf' },
+        body: Buffer.from('x'),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.createSourceMaterial).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing filename header', async () => {
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/pdf' },
+        body: Buffer.from('x'),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.createSourceMaterial).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body over the upload cap with 413', async () => {
+    const { MAX_MATERIAL_UPLOAD_BYTES } = await import('@/app/api/materials/route');
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: { 'x-material-filename': 'big.bin' },
+        body: Buffer.alloc(MAX_MATERIAL_UPLOAD_BYTES + 1),
+      }),
+    );
+    expect(response.status).toBe(413);
+    expect(mocks.createSourceMaterial).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 for a foreign or missing session', async () => {
+    mocks.resolveOwnedSession.mockResolvedValue(null);
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: { 'x-material-filename': 'a.pdf' },
+        body: Buffer.from('x'),
+      }),
+    );
+    expect(response.status).toBe(404);
+    expect(mocks.createSourceMaterial).not.toHaveBeenCalled();
+  });
+
+  it('answers 500 when persisting the material fails', async () => {
+    mocks.createSourceMaterial.mockRejectedValue(new Error('asset registry unavailable'));
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: { 'x-material-filename': 'a.pdf' },
+        body: Buffer.from('x'),
+      }),
+    );
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ errorCode: 'INTERNAL_ERROR' });
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    const response = await POST(
+      new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+        method: 'POST',
+        headers: { 'x-material-filename': 'a.pdf' },
+        body: Buffer.from('x'),
+      }),
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/agent-runtime/stage-detail-route.test.ts
+++ b/tests/agent-runtime/stage-detail-route.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { DocumentNotFoundError, DocumentVersionError } from '@openmaic/storage';
+
+import { createFakeDocumentStore } from './_fake-document-store';
+import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: async () => ({ documentStore: mocks.fakeStore!.store }),
+}));
+
+import { DELETE, GET, PATCH, PUT } from '@/app/api/stages/[id]/route';
+
+const STAGE_ID = 'stage-1';
+
+/** NextRequest's own init type, so `signal: null` (DOM RequestInit) is not required. */
+type NextInit = ConstructorParameters<typeof NextRequest>[1];
+
+function call(handler: unknown, init: NextInit = {}, id = STAGE_ID) {
+  const req = new NextRequest(`http://localhost/api/stages/${id}`, init);
+  return (
+    handler as (req: NextRequest, ctx: { params: Promise<{ id: string }> }) => Promise<Response>
+  )(req, { params: Promise.resolve({ id }) });
+}
+
+function jsonInit(method: string, body: unknown): NextInit {
+  return {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.fakeStore = createFakeDocumentStore();
+  mocks.fakeStore.docs.set(
+    STAGE_ID,
+    makeDocument(STAGE_ID, 'Original Name', [
+      makeSlideScene('scene-1', STAGE_ID, 1),
+      makeSlideScene('scene-2', STAGE_ID, 2),
+    ]),
+  );
+});
+
+describe('GET /api/stages/[id]', () => {
+  it('returns the whole document', async () => {
+    const response = await call(GET);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.stage).toMatchObject({ id: STAGE_ID, name: 'Original Name' });
+    expect(body.scenes.map((scene: { id: string }) => scene.id)).toEqual(['scene-1', 'scene-2']);
+  });
+
+  it('answers 404 for a missing stage', async () => {
+    const response = await call(GET, {}, 'stage-absent');
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    expect((await call(GET)).status).toBe(404);
+  });
+});
+
+describe('PATCH /api/stages/[id]', () => {
+  it('renames an owned course and returns the new name', async () => {
+    const response = await call(PATCH, jsonInit('PATCH', { name: '  New Name  ' }));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true, name: 'New Name' });
+
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(1);
+    const saved = mocks.fakeStore!.saveCalls[0]!;
+    expect(saved.stage.name).toBe('New Name');
+    expect(saved.stage.updatedAt).toBeGreaterThan(FIXED_NOW);
+    // Scenes and outline survive a rename untouched.
+    expect(saved.scenes.map((scene) => scene.id)).toEqual(['scene-1', 'scene-2']);
+  });
+
+  it.each([
+    [
+      'non-JSON body',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'nope',
+      } as NextInit,
+    ],
+    ['non-string name', jsonInit('PATCH', { name: 42 })],
+    ['empty name', jsonInit('PATCH', { name: '   ' })],
+    ['missing name', jsonInit('PATCH', {})],
+  ])('rejects %s with 400', async (_label, init) => {
+    const response = await call(PATCH, init);
+    expect(response.status).toBe(400);
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(0);
+  });
+
+  it('rejects a name over the 120-char cap', async () => {
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'x'.repeat(121) }));
+    expect(response.status).toBe(400);
+  });
+
+  it('accepts a name at exactly the 120-char cap', async () => {
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'x'.repeat(120) }));
+    expect(response.status).toBe(200);
+  });
+
+  it('answers 404 for a missing or foreign stage (no existence oracle)', async () => {
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'X' }), 'stage-absent');
+    expect(response.status).toBe(404);
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(0);
+  });
+
+  it('answers 404 when the write is refused by the owner scope', async () => {
+    mocks.fakeStore!.failNextSaveWith(
+      new DocumentNotFoundError(STAGE_ID, 'belongs to another scope'),
+    );
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'X' }));
+    expect(response.status).toBe(404);
+  });
+
+  it('answers 400 with the store message when the saved document is invalid', async () => {
+    mocks.fakeStore!.failNextSaveWith(new Error('@openmaic/storage: invalid stage: /name: x'));
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'X' }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.errorCode).toBe('INVALID_REQUEST');
+    expect(body.details).toContain('@openmaic/storage: invalid stage');
+  });
+
+  it('answers 400 for a future-version document', async () => {
+    mocks.fakeStore!.failNextSaveWith(
+      new DocumentVersionError(STAGE_ID, 'future', '99.0.0', 'written at DSL version 99.0.0'),
+    );
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'X' }));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ errorCode: 'INVALID_REQUEST' });
+  });
+
+  it('answers 500 when the store throws unexpectedly', async () => {
+    mocks.fakeStore!.failNextSaveWith(new Error('connection reset'));
+    const response = await call(PATCH, jsonInit('PATCH', { name: 'X' }));
+    expect(response.status).toBe(500);
+  });
+});
+
+describe('PUT /api/stages/[id]', () => {
+  it('saves a whole document and bumps updatedAt server-side', async () => {
+    const document = makeDocument(STAGE_ID, 'Edited', [
+      makeSlideScene('scene-1', STAGE_ID, 1),
+      makeSlideScene('scene-2', STAGE_ID, 2),
+    ]);
+    const response = await call(PUT, jsonInit('PUT', document));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(1);
+    const saved = mocks.fakeStore!.saveCalls[0]!;
+    expect(saved.stage.name).toBe('Edited');
+    expect(saved.stage.updatedAt).toBeGreaterThan(FIXED_NOW);
+    expect(saved.scenes.map((scene) => scene.id)).toEqual(['scene-1', 'scene-2']);
+  });
+
+  it('rejects a body whose stage id does not match the path', async () => {
+    const document = makeDocument('stage-other', 'Other');
+    const response = await call(PUT, jsonInit('PUT', document));
+    expect(response.status).toBe(400);
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ['non-object', 42],
+    ['missing stage', { scenes: [] }],
+    ['missing scenes', { stage: { id: STAGE_ID } }],
+    ['non-string stage id', { stage: { id: 7 }, scenes: [] }],
+  ])('rejects %s with 400', async (_label, body) => {
+    const response = await call(PUT, jsonInit('PUT', body));
+    expect(response.status).toBe(400);
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(0);
+  });
+
+  it('answers 404 for a missing or foreign stage', async () => {
+    const document = makeDocument('stage-absent', 'X');
+    const response = await call(PUT, jsonInit('PUT', document), 'stage-absent');
+    expect(response.status).toBe(404);
+  });
+
+  it('answers 404 when the owner scope refuses the write', async () => {
+    mocks.fakeStore!.failNextSaveWith(
+      new DocumentNotFoundError(STAGE_ID, 'belongs to another scope'),
+    );
+    const response = await call(PUT, jsonInit('PUT', makeDocument(STAGE_ID, 'X')));
+    expect(response.status).toBe(404);
+  });
+
+  it('answers 400 when the document fails store validation', async () => {
+    mocks.fakeStore!.failNextSaveWith(new Error('@openmaic/storage: invalid scene: /id'));
+    const response = await call(PUT, jsonInit('PUT', makeDocument(STAGE_ID, 'X')));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ errorCode: 'INVALID_REQUEST' });
+  });
+
+  it('rides the owner cookie on success', async () => {
+    mocks.resolveRequestOwnerId.mockImplementationOnce((_req, responseHeaders: Headers) => {
+      responseHeaders.set('Set-Cookie', 'anonymous_id=anon-2; Path=/');
+      return 'anon:anon-2';
+    });
+    const response = await call(PUT, jsonInit('PUT', makeDocument(STAGE_ID, 'X')));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=anon-2');
+  });
+});
+
+describe('DELETE /api/stages/[id]', () => {
+  it('removes the course and answers ok', async () => {
+    const response = await call(DELETE);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mocks.fakeStore!.docs.has(STAGE_ID)).toBe(false);
+  });
+
+  it('is idempotent for an already-absent stage', async () => {
+    const response = await call(DELETE, {}, 'stage-absent');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+});

--- a/tests/agent-runtime/stage-freshness-route.test.ts
+++ b/tests/agent-runtime/stage-freshness-route.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { createFakeDocumentStore } from './_fake-document-store';
+import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: async () => ({ documentStore: mocks.fakeStore!.store }),
+}));
+
+import { GET, STAGE_FRESHNESS_POLL_INTERVAL_MS } from '@/app/api/stages/[id]/freshness/route';
+
+const STAGE_ID = 'stage-1';
+
+function call(id = STAGE_ID) {
+  const req = new NextRequest(`http://localhost/api/stages/${id}/freshness`);
+  return GET(req, { params: Promise.resolve({ id }) });
+}
+
+async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string | null> {
+  const chunk = await reader.read();
+  return chunk.done ? null : new TextDecoder().decode(chunk.value);
+}
+
+/** Accumulate chunks until one carries a `stage_freshness` frame (or the stream closes). */
+async function readUntilFreshness(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string | null> {
+  let accumulated = '';
+  for (;;) {
+    const chunk = await readChunk(reader);
+    if (chunk === null) return accumulated === '' ? null : accumulated;
+    accumulated += chunk;
+    if (accumulated.includes('stage_freshness')) return accumulated;
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.fakeStore = createFakeDocumentStore();
+  mocks.fakeStore.docs.set(
+    STAGE_ID,
+    makeDocument(STAGE_ID, 'Course', [makeSlideScene('scene-1', STAGE_ID, 1)]),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET /api/stages/[id]/freshness', () => {
+  it('opens the stream with the retry hint and the current rev', async () => {
+    const response = await call();
+    const reader = response.body!.getReader();
+
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    const received = await readUntilFreshness(reader);
+    expect(received).toContain('retry: 3000');
+    expect(received).toContain(
+      `event: stage_freshness\ndata: ${JSON.stringify({
+        type: 'stage_freshness',
+        stageId: STAGE_ID,
+        rev: FIXED_NOW,
+      })}`,
+    );
+    await reader.cancel();
+  });
+
+  it('emits a frame when the stage rev moves', async () => {
+    const response = await call();
+    const reader = response.body!.getReader();
+    await readUntilFreshness(reader);
+
+    const document = mocks.fakeStore!.docs.get(STAGE_ID)!;
+    mocks.fakeStore!.docs.set(STAGE_ID, {
+      ...document,
+      stage: { ...document.stage, updatedAt: FIXED_NOW + 1 },
+    });
+
+    const pending = readUntilFreshness(reader);
+    await vi.advanceTimersByTimeAsync(STAGE_FRESHNESS_POLL_INTERVAL_MS);
+    const changed = await pending;
+    expect(changed).not.toBeNull();
+    expect(changed).toContain(
+      `data: ${JSON.stringify({
+        type: 'stage_freshness',
+        stageId: STAGE_ID,
+        rev: FIXED_NOW + 1,
+      })}`,
+    );
+    await reader.cancel();
+  });
+
+  it('stays silent while the rev is unchanged (heartbeats aside)', async () => {
+    const response = await call();
+    const reader = response.body!.getReader();
+    await readUntilFreshness(reader);
+
+    let delivered = false;
+    const pending = readUntilFreshness(reader).then((frame) => {
+      delivered = frame !== null && frame.includes('stage_freshness');
+      return frame;
+    });
+    await vi.advanceTimersByTimeAsync(STAGE_FRESHNESS_POLL_INTERVAL_MS * 3);
+    expect(delivered).toBe(false);
+    await reader.cancel();
+    await pending;
+  });
+
+  it('answers 404 for a missing or foreign stage and still rides the owner cookie', async () => {
+    mocks.resolveRequestOwnerId.mockImplementationOnce((_req, responseHeaders: Headers) => {
+      responseHeaders.set('Set-Cookie', 'anonymous_id=anon-2; Path=/');
+      return 'anon:anon-2';
+    });
+    const response = await call('stage-absent');
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=anon-2');
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    expect((await call()).status).toBe(404);
+  });
+});

--- a/tests/agent-runtime/stage-manifest-route.test.ts
+++ b/tests/agent-runtime/stage-manifest-route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { createFakeDocumentStore } from './_fake-document-store';
+import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: async () => ({ documentStore: mocks.fakeStore!.store }),
+}));
+
+import { GET } from '@/app/api/stages/[id]/manifest/route';
+
+const STAGE_ID = 'stage-1';
+
+function call(id = STAGE_ID) {
+  const req = new NextRequest(`http://localhost/api/stages/${id}/manifest`);
+  return GET(req, { params: Promise.resolve({ id }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.fakeStore = createFakeDocumentStore();
+});
+
+describe('GET /api/stages/[id]/manifest', () => {
+  it('returns the document rev and one entry per scene', async () => {
+    mocks.fakeStore!.docs.set(
+      STAGE_ID,
+      makeDocument(STAGE_ID, 'Course', [
+        makeSlideScene('scene-1', STAGE_ID, 1),
+        makeSlideScene('scene-2', STAGE_ID, 2),
+      ]),
+    );
+
+    const response = await call();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      rev: FIXED_NOW,
+      scenes: [
+        { id: 'scene-1', order: 1, rev: FIXED_NOW },
+        { id: 'scene-2', order: 2, rev: FIXED_NOW },
+      ],
+    });
+  });
+
+  it('reflects a new updatedAt as a new rev', async () => {
+    const document = makeDocument(STAGE_ID, 'Course', [makeSlideScene('scene-1', STAGE_ID, 1)]);
+    mocks.fakeStore!.docs.set(STAGE_ID, document);
+    mocks.fakeStore!.docs.set(STAGE_ID, {
+      ...document,
+      stage: { ...document.stage, updatedAt: FIXED_NOW + 1 },
+    });
+
+    const body = await (await call()).json();
+    expect(body.rev).toBe(FIXED_NOW + 1);
+    expect(body.scenes[0].rev).toBe(FIXED_NOW + 1);
+  });
+
+  it('answers 404 for a missing or foreign stage', async () => {
+    const response = await call('stage-absent');
+    expect(response.status).toBe(404);
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    expect((await call()).status).toBe(404);
+  });
+});

--- a/tests/agent-runtime/stage-scenes-route.test.ts
+++ b/tests/agent-runtime/stage-scenes-route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { createFakeDocumentStore } from './_fake-document-store';
+import { makeDocument, makeSlideScene } from './_stage-fixtures';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: async () => ({ documentStore: mocks.fakeStore!.store }),
+}));
+
+import { GET, MAX_BATCH_SCENE_IDS } from '@/app/api/stages/[id]/scenes/route';
+
+const STAGE_ID = 'stage-1';
+
+function call(query = '') {
+  const req = new NextRequest(`http://localhost/api/stages/${STAGE_ID}/scenes${query}`);
+  return GET(req, { params: Promise.resolve({ id: STAGE_ID }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.fakeStore = createFakeDocumentStore();
+  mocks.fakeStore.docs.set(
+    STAGE_ID,
+    makeDocument(STAGE_ID, 'Course', [
+      makeSlideScene('scene-1', STAGE_ID, 1, 'Intro'),
+      makeSlideScene('scene-2', STAGE_ID, 2, 'Body'),
+      makeSlideScene('scene-3', STAGE_ID, 3, 'Quiz'),
+    ]),
+  );
+});
+
+describe('GET /api/stages/[id]/scenes?ids=', () => {
+  it('returns exactly the requested scenes in document order', async () => {
+    const response = await call('?ids=scene-2,scene-1');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      scenes: [
+        expect.objectContaining({ id: 'scene-1', title: 'Intro' }),
+        expect.objectContaining({ id: 'scene-2', title: 'Body' }),
+      ],
+    });
+  });
+
+  it('omits requested ids that do not exist', async () => {
+    const response = await call('?ids=scene-1,scene-ghost');
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.scenes.map((scene: { id: string }) => scene.id)).toEqual(['scene-1']);
+  });
+
+  it('deduplicates repeated ids', async () => {
+    const response = await call('?ids=scene-1,scene-1,scene-2');
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.scenes.map((scene: { id: string }) => scene.id)).toEqual(['scene-1', 'scene-2']);
+  });
+
+  it('rejects an empty ids list', async () => {
+    for (const query of ['?ids=', '?ids=,,', '']) {
+      const response = await call(query);
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it('rejects more than the batch cap without truncating', async () => {
+    const ids = Array.from({ length: MAX_BATCH_SCENE_IDS + 1 }, (_, index) => `scene-${index}`);
+    const response = await call(`?ids=${ids.join(',')}`);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ errorCode: 'INVALID_REQUEST' });
+  });
+
+  it('answers 404 for a missing or foreign stage', async () => {
+    const req = new NextRequest('http://localhost/api/stages/stage-absent/scenes?ids=scene-1');
+    const response = await GET(req, { params: Promise.resolve({ id: 'stage-absent' }) });
+    expect(response.status).toBe(404);
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    expect((await call('?ids=scene-1')).status).toBe(404);
+  });
+});

--- a/tests/agent-runtime/stages-route.test.ts
+++ b/tests/agent-runtime/stages-route.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { AppDocumentOutline } from '@/lib/document-store/persistence-types';
+import type { AppScene } from '@/lib/types/stage';
+import { createFakeDocumentStore } from './_fake-document-store';
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  resolveRequestOwnerId: vi.fn(),
+  fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
+}));
+
+vi.mock('@/lib/config/feature-flags', () => ({
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+}));
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: async () => ({ documentStore: mocks.fakeStore!.store }),
+}));
+
+import { GET, POST } from '@/app/api/stages/route';
+
+const now = 1_700_000_000_000;
+
+function makeDocument(
+  id: string,
+  name: string,
+): {
+  stage: { id: string; name: string; createdAt: number; updatedAt: number };
+  scenes: AppScene[];
+  outline: AppDocumentOutline;
+} {
+  return {
+    stage: { id, name, createdAt: now, updatedAt: now },
+    scenes: [],
+    outline: {
+      outlines: [],
+      requirement: name,
+      generationComplete: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
+  mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+  mocks.fakeStore = createFakeDocumentStore();
+});
+
+describe('GET /api/stages', () => {
+  it('lists every stage document owned by the caller as summaries', async () => {
+    mocks.fakeStore!.docs.set('stage-aaa', makeDocument('stage-aaa', 'Day 1'));
+    mocks.fakeStore!.docs.set('stage-bbb', makeDocument('stage-bbb', 'Day 2'));
+
+    const response = await GET(new NextRequest('http://localhost/api/stages'));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      stages: [
+        {
+          id: 'stage-aaa',
+          name: 'Day 1',
+          createdAt: now,
+          updatedAt: now,
+          sceneCount: 0,
+        },
+        {
+          id: 'stage-bbb',
+          name: 'Day 2',
+          createdAt: now,
+          updatedAt: now,
+          sceneCount: 0,
+        },
+      ],
+    });
+    expect(mocks.resolveRequestOwnerId).toHaveBeenCalledOnce();
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    const response = await GET(new NextRequest('http://localhost/api/stages'));
+    expect(response.status).toBe(404);
+    expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
+  });
+
+  it('rides the owner cookie minted for the request', async () => {
+    mocks.resolveRequestOwnerId.mockImplementationOnce((_req, responseHeaders: Headers) => {
+      responseHeaders.set('Set-Cookie', 'anonymous_id=anon-2; Path=/');
+      return 'anon:anon-2';
+    });
+    const response = await GET(new NextRequest('http://localhost/api/stages'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=anon-2');
+  });
+});
+
+describe('POST /api/stages', () => {
+  it('creates an empty stage shell and returns its summary', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: '  Day 1 — Python  ' }),
+      }),
+    );
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.stage.id).toMatch(/^stage-[A-Za-z0-9_-]{10,}$/);
+    expect(body.stage).toMatchObject({
+      name: 'Day 1 — Python',
+      sceneCount: 0,
+      createdAt: expect.any(Number),
+      updatedAt: expect.any(Number),
+    });
+
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(1);
+    const saved = mocks.fakeStore!.saveCalls[0]!;
+    expect(saved.stage.id).toBe(body.stage.id);
+    expect(saved.stage.name).toBe('Day 1 — Python');
+    expect(saved.scenes).toEqual([]);
+    expect(saved.outline).toMatchObject({
+      outlines: [],
+      requirement: 'Day 1 — Python',
+      generationComplete: false,
+    });
+  });
+
+  it('stores an optional description trimmed of surrounding whitespace', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Day 1', description: '  first unit  ' }),
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect((await response.json()).stage.description).toBe('first unit');
+    expect(mocks.fakeStore!.saveCalls[0]!.stage.description).toBe('first unit');
+  });
+
+  it.each([
+    ['missing name', { description: 'x' }],
+    ['empty name', { name: '   ' }],
+    ['non-string name', { name: 42 }],
+  ])('rejects %s with 400', async (_label, body) => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(0);
+  });
+
+  it('rejects a name over the 120-char cap', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'x'.repeat(121) }),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.fakeStore!.saveCalls).toHaveLength(0);
+  });
+
+  it('accepts a name at exactly the 120-char cap', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'x'.repeat(120) }),
+      }),
+    );
+    expect(response.status).toBe(201);
+  });
+
+  it('rejects a non-string description', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Day 1', description: 7 }),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects a non-JSON body without touching the owner seam', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'not json',
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
+  });
+
+  it('answers 404 when the agent runtime is disabled', async () => {
+    mocks.runtimeEnabled = false;
+    const response = await POST(
+      new NextRequest('http://localhost/api/stages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Day 1' }),
+      }),
+    );
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
The client-facing HTTP surface the workbench UI reads and writes through. Upstream had the stores (the owner-scopable document store, the folder entity, the session-material store) but none of these routes, so this is the blocker for the UI port — it lands first and on its own.

## Endpoints

**Stages** — `GET/POST /api/stages`, `GET/PATCH/PUT/DELETE /api/stages/[id]`, `GET /api/stages/[id]/scenes?ids=` (batch read, 200-id cap), `GET /api/stages/[id]/manifest` (revision index the canvas diffs against), `GET /api/stages/[id]/freshness` (SSE).
**Folders** — `GET/POST /api/folders`, `PATCH/DELETE /api/folders/[id]` (`?mode=ungroup|remove`), `POST /api/folders/members`.
**Materials** — `GET /api/materials` (keyset-paged), `GET /api/materials/[id]`, `POST /api/materials` (raw-body upload, 25 MB cap).

Every route resolves the owner the same way the agent routes do and binds the store with `forOwner`, so a course the agent created is visible to the same browser and to nobody else. Foreign and missing ids answer identically (404, no existence oracle). Writes re-check ownership inside the transaction rather than trusting a prior read.

## Two deliberate degradations, both documented in code

- **Freshness is polled, and `rev` is document-level.** The reference woke its SSE from a database trigger with per-scene monotonic revisions; upstream's storage package exposes no LISTEN/NOTIFY and the document store carries no per-scene revision, so this polls the bound store — the same correctness mechanism the owner-events stream already uses — and reports `stage.updatedAt`. The client's manifest-diff logic works unchanged (a document-level change marks the whole scene set). Raising this to per-scene revisions needs new persistence and is a later slice.
- **`DELETE /api/materials/[id]` is intentionally absent.** The session-material store has no delete operation, and this slice adds no persistence. Exposing a route that cannot honour its verb would be worse than not having it; it lands when the store grows deletion.

## Tests

Per-family route tests covering owner scoping (foreign → 404, identical to missing), validation failures, the happy paths the UI depends on, store-failure mapping (scope refusal → 404, validation → 400, unexpected → 500), and the runtime-flag gate. One fixture uses a non-ASCII filename on purpose — it is what proves the `x-material-filename` encode/decode round-trip, which an ASCII name cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)