### PR TITLE
fix(agent): report the runtime as unusable without a database

### DIFF
--- a/app/api/agent/runtime/route.ts
+++ b/app/api/agent/runtime/route.ts
@@ -1,9 +1,25 @@
-/** Server-side agent runtime status probe. */
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+/**
+ * Server-side agent runtime status probe.
+ *
+ *   GET /api/agent/runtime -> { enabled: boolean, runtimeEnabled: boolean }
+ *
+ * `enabled` reports usability, not intent: the workbench client gates its
+ * entry on this field, so it is true only when the runtime can actually serve
+ * a request — the flag AND a `DATABASE_URL` (the runner and every
+ * persistence-touching route need the store). `runtimeEnabled` carries the
+ * raw intent flag so a client can tell "off by choice" (`runtimeEnabled:
+ * false`) from "on but unusable" (`runtimeEnabled: true`, missing
+ * DATABASE_URL).
+ */
+import { isAgentRuntimeConfigured, isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
 
 export const runtime = 'nodejs';
 
 export async function GET() {
-  // Intentionally no materials flag: isAgentMaterialsEnabled does not exist in this repo.
-  return Response.json({ enabled: isAgentRuntimeEnabled() });
+  // Intentionally no materials flag: isAgentMaterialsEnabled does not exist in
+  // this repo (the materials routes gate on the runtime, like the stages).
+  return Response.json({
+    enabled: isAgentRuntimeConfigured(),
+    runtimeEnabled: isAgentRuntimeEnabled(),
+  });
 }

--- a/app/api/materials/[id]/route.ts
+++ b/app/api/materials/[id]/route.ts
@@ -13,7 +13,7 @@
  */
 import type { NextRequest } from 'next/server';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
 import {
   getSessionMaterial,
@@ -28,7 +28,7 @@ export const runtime = 'nodejs';
 type Params = { params: Promise<{ id: string }> };
 
 export async function GET(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   const sessionId = new URL(req.url).searchParams.get('sessionId')?.trim();
   if (!sessionId) return apiError('MISSING_REQUIRED_FIELD', 400, 'sessionId is required');

--- a/app/api/materials/route.ts
+++ b/app/api/materials/route.ts
@@ -13,15 +13,17 @@
  * no second byte path is invented. Uploaded files are `source` materials:
  * they carry no readable text by design, matching the agent tools' contract.
  *
- * The runtime flag gates the family: the workbench is agent-runtime
+ * The configured runtime gates the family: the workbench is agent-runtime
  * territory, and there is deliberately no separate materials flag in this
- * repo (the runtime probe route documents that).
+ * repo (the runtime probe route documents that). A runtime that is off OR
+ * enabled without a DATABASE_URL answers the same plain 404 as the stages
+ * routes — never a 500 from a store that cannot connect.
  */
 import { basename } from 'node:path';
 
 import type { NextRequest } from 'next/server';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
 import {
   createSourceMaterial,
@@ -88,7 +90,7 @@ function parseLimit(raw: string | null): { limit?: number } | { invalid: true } 
 // GET /api/materials?sessionId=&limit=&before= — list one owned session's
 // materials, newest first, keyset-paged.
 export async function GET(req: NextRequest) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   const url = new URL(req.url);
   const sessionId = url.searchParams.get('sessionId')?.trim();
@@ -123,7 +125,7 @@ export async function GET(req: NextRequest) {
 // session. The raw bytes ride the body; `content-type` is the MIME type and
 // `x-material-filename` the display name.
 export async function POST(req: NextRequest) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   const sessionId = new URL(req.url).searchParams.get('sessionId')?.trim();
   if (!sessionId) return apiError('MISSING_REQUIRED_FIELD', 400, 'sessionId is required');

--- a/app/api/stages/[id]/freshness/route.ts
+++ b/app/api/stages/[id]/freshness/route.ts
@@ -24,7 +24,7 @@
  */
 import type { NextRequest } from 'next/server';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { resolveRequestOwnerId } from '@/lib/server/agent-runtime/owner';
 import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
 import { ownerNotFound } from '@/lib/server/agent-runtime/route-response';
@@ -44,7 +44,7 @@ export const STAGE_FRESHNESS_RETRY_MS = 3_000;
 type Params = { params: Promise<{ id: string }> };
 
 export async function GET(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   const responseHeaders = new Headers();
   const ownerId = resolveRequestOwnerId(req, responseHeaders);

--- a/app/api/stages/[id]/manifest/route.ts
+++ b/app/api/stages/[id]/manifest/route.ts
@@ -18,7 +18,7 @@
  */
 import type { NextRequest } from 'next/server';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
 import { ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
 import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
@@ -28,7 +28,7 @@ export const runtime = 'nodejs';
 type Params = { params: Promise<{ id: string }> };
 
 export async function GET(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
     const { id } = await params;

--- a/app/api/stages/[id]/route.ts
+++ b/app/api/stages/[id]/route.ts
@@ -14,13 +14,14 @@
  *          bumps `stage.updatedAt` so the freshness signal sees the change.
  * - DELETE removes the course and its cascading child rows.
  *
- * The runtime flag gates the family (see `app/api/stages/route.ts`).
+ * The configured runtime gates the family (see `app/api/stages/route.ts`):
+ * off, or on without a DATABASE_URL, answers the same plain 404.
  */
 import type { NextRequest } from 'next/server';
 
 import { DocumentNotFoundError, DocumentVersionError, type MaicDocument } from '@openmaic/storage';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
 import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
 import { ownerApiError, ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
@@ -62,7 +63,7 @@ function mapSaveError(error: unknown, headers: Headers) {
 
 // GET /api/stages/[id] — the full document.
 export async function GET(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
     const { id } = await params;
@@ -75,7 +76,7 @@ export async function GET(req: NextRequest, { params }: Params) {
 
 // PATCH /api/stages/[id] — rename the course (owner-only).
 export async function PATCH(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   let body: unknown;
   try {
@@ -115,7 +116,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
 // PUT /api/stages/[id] — save a whole document.
 export async function PUT(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   let body: unknown;
   try {
@@ -177,7 +178,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
 
 // DELETE /api/stages/[id] — remove the course and its scenes/outline.
 export async function DELETE(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
     const { id } = await params;

--- a/app/api/stages/[id]/scenes/route.ts
+++ b/app/api/stages/[id]/scenes/route.ts
@@ -21,7 +21,7 @@
  */
 import type { NextRequest } from 'next/server';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
 import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
 import { ownerJson, ownerNotFound } from '@/lib/server/agent-runtime/route-response';
@@ -46,7 +46,7 @@ function isQueryableSceneId(sceneId: string): boolean {
 type Params = { params: Promise<{ id: string }> };
 
 export async function GET(req: NextRequest, { params }: Params) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   const rawIds = new URL(req.url).searchParams.get('ids');
   const requested = (rawIds ?? '')

--- a/app/api/stages/route.ts
+++ b/app/api/stages/route.ts
@@ -8,14 +8,15 @@
  * binds for the stage tools. A stage created here is visible to this browser
  * and to nobody else.
  *
- * The runtime flag gates the whole family: these routes serve the workbench,
- * which is agent-runtime territory, so a disabled runtime answers the same
- * plain 404 as the agent control-plane routes.
+ * The configured runtime gates the whole family: these routes serve the
+ * workbench, which is agent-runtime territory, so a runtime that is off OR
+ * enabled without a DATABASE_URL answers the same plain 404 as the agent
+ * control-plane routes — never a 500 from a store that cannot connect.
  */
 import type { NextRequest } from 'next/server';
 import { randomBytes } from 'node:crypto';
 
-import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
+import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import type { AppDocumentOutline } from '@/lib/document-store/persistence-types';
 import { apiError } from '@/lib/server/api-response';
 import { getOwnerScopedDocumentStore } from '@/lib/server/agent-runtime/owner-scoped-documents';
@@ -32,7 +33,7 @@ function createStageId(): string {
 
 // GET /api/stages — list every stage document owned by the caller.
 export async function GET(req: NextRequest) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
     const store = await getOwnerScopedDocumentStore(ownerId);
@@ -47,7 +48,7 @@ export async function GET(req: NextRequest) {
 // a malformed body must not mint an anonymous cookie partition for a request
 // that will not proceed.
 export async function POST(req: NextRequest) {
-  if (!isAgentRuntimeEnabled()) return new Response('Not found', { status: 404 });
+  if (!isAgentRuntimeConfigured()) return new Response('Not found', { status: 404 });
 
   let body: unknown;
   try {

--- a/lib/server/config-validation.ts
+++ b/lib/server/config-validation.ts
@@ -13,13 +13,17 @@
  *  - a bare model id (no `provider:` prefix) — it still defaults to `openai`
  *    for backward compatibility, but that fallback is deprecated;
  *  - a `<PREFIX>_MODELS` env set for a provider whose key env is absent
- *    (pinned models on an unconfigured provider — probably a typo).
+ *    (pinned models on an unconfigured provider — probably a typo);
+ *  - the agent runtime flag set without a `DATABASE_URL` — the runtime is
+ *    enabled but unusable, so its probe reports disabled and its routes
+ *    answer 404 while the runner never starts.
  *
  * Everything here is a warning, never a throw: operators with partial config
  * still get a running app, and the warnings name exactly what is broken.
  */
 
 import { getProvider, warnBareModelIdDeprecation } from '@/lib/ai/providers';
+import { isAgentRuntimeEnabled } from '@/lib/config/feature-flags';
 import { LLM_STAGES } from '@/lib/server/model-routes';
 import {
   isServerConfiguredProvider,
@@ -149,6 +153,22 @@ function validateModelsEnvPins(): void {
 }
 
 /**
+ * The agent runtime needs the flag AND a database: the runner and every
+ * persistence-touching route depend on the store. A flag without
+ * `DATABASE_URL` is the classic "nothing happens" misconfiguration — the
+ * probe reports the runtime unusable, its routes answer 404, and no runner
+ * starts. One boot-time warning saves the whole debugging session.
+ */
+function validateAgentRuntime(): void {
+  if (!isAgentRuntimeEnabled()) return;
+  if (!process.env.DATABASE_URL?.trim()) {
+    warn(
+      'OPENMAIC_AGENT_RUNTIME_ENABLED is set but DATABASE_URL is not — the agent runtime is enabled but unusable: its probe reports disabled, its routes answer 404, and no runner starts. Set DATABASE_URL or disable the flag.',
+    );
+  }
+}
+
+/**
  * Validate server model-routing config at boot. Warn-only, cheap, and
  * non-throwing: a broken config never prevents the server from starting.
  */
@@ -157,6 +177,7 @@ export function validateServerConfig(): void {
     validateModelRoutes();
     validateDefaultModel();
     validateModelsEnvPins();
+    validateAgentRuntime();
   } catch (err) {
     // Boot-time validation must never take the server down.
     const detail = err instanceof Error ? err.message : String(err);

--- a/tests/agent-runtime/material-detail-route.test.ts
+++ b/tests/agent-runtime/material-detail-route.test.ts
@@ -4,14 +4,14 @@ import { NextRequest } from 'next/server';
 import type { AgentSessionMaterial } from '@openmaic/storage';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   resolveOwnedSession: vi.fn(),
   getSessionMaterial: vi.fn(),
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -53,7 +53,7 @@ function call(id = MATERIAL_ID) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.resolveOwnedSession.mockResolvedValue({ id: SESSION_ID, ownerId: 'owner-1' });
   mocks.getSessionMaterial.mockResolvedValue(material());
@@ -108,8 +108,8 @@ describe('GET /api/materials/[id]', () => {
     expect(response.headers.get('set-cookie')).toContain('anonymous_id=anon-2');
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     expect((await call()).status).toBe(404);
   });
 });

--- a/tests/agent-runtime/materials-route.test.ts
+++ b/tests/agent-runtime/materials-route.test.ts
@@ -4,7 +4,7 @@ import { NextRequest } from 'next/server';
 import type { AgentSessionMaterial } from '@openmaic/storage';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   resolveOwnedSession: vi.fn(),
   listSessionMaterials: vi.fn(),
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -49,7 +49,7 @@ function material(overrides: Partial<AgentSessionMaterial> = {}): AgentSessionMa
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.resolveOwnedSession.mockResolvedValue({ id: SESSION_ID, ownerId: 'owner-1' });
   mocks.listSessionMaterials.mockResolvedValue([material()]);
@@ -118,8 +118,8 @@ describe('GET /api/materials', () => {
     expect(mocks.listSessionMaterials).not.toHaveBeenCalled();
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     const response = await GET(
       new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`),
     );
@@ -232,8 +232,8 @@ describe('POST /api/materials', () => {
     await expect(response.json()).resolves.toMatchObject({ errorCode: 'INTERNAL_ERROR' });
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     const response = await POST(
       new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
         method: 'POST',

--- a/tests/agent-runtime/persistence-routes-gate.test.ts
+++ b/tests/agent-runtime/persistence-routes-gate.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import type { AgentSessionMaterial } from '@openmaic/storage';
+
+import { createFakeDocumentStore } from './_fake-document-store';
+import { makeDocument, makeSlideScene } from './_stage-fixtures';
+
+/**
+ * Every persistence-touching route must gate on `isAgentRuntimeConfigured()`
+ * — the flag AND a DATABASE_URL — so an enabled-but-unconfigured runtime
+ * answers the same clean 404 as a disabled one, never a 500 from a store that
+ * cannot connect. This suite drives the REAL feature-flag predicates from the
+ * environment (no feature-flags mock) across the three environment states:
+ *
+ *   - flag off, no DATABASE_URL  -> routes 404 (the no-DB default)
+ *   - flag on,  no DATABASE_URL  -> routes 404 (NOT 500)
+ *   - flag on,  DATABASE_URL set -> routes serve
+ *
+ * The store seams are mocked (same facades as the per-route suites), so the
+ * "serves" row is exercised hermetically. A future route added to the wrong
+ * gate fails the middle row — the row that used to 500.
+ */
+const ENV_KEYS = ['OPENMAIC_AGENT_RUNTIME_ENABLED', 'DATABASE_URL'] as const;
+
+const STAGE_ID = 'stage-1';
+const SESSION_ID = 'session-1';
+const MATERIAL_ID = 'mat_00000000000000000000000000';
+
+const mocks = vi.hoisted(() => ({
+  resolveRequestOwnerId: vi.fn(),
+  resolveOwnedSession: vi.fn(),
+  listSessionMaterials: vi.fn(),
+  createSourceMaterial: vi.fn(),
+  getSessionMaterial: vi.fn(),
+  fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
+}));
+
+vi.mock('@/lib/server/agent-runtime/owner', () => ({
+  resolveRequestOwnerId: mocks.resolveRequestOwnerId,
+}));
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: async () => ({ documentStore: mocks.fakeStore!.store }),
+}));
+vi.mock('@/lib/server/agent-runtime/session-materials', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/agent-runtime/session-materials')>();
+  return {
+    ...actual,
+    resolveOwnedSession: mocks.resolveOwnedSession,
+    listSessionMaterials: mocks.listSessionMaterials,
+    createSourceMaterial: mocks.createSourceMaterial,
+    getSessionMaterial: mocks.getSessionMaterial,
+  };
+});
+
+import { GET as getStages, POST as postStages } from '@/app/api/stages/route';
+import {
+  DELETE as deleteStage,
+  GET as getStage,
+  PATCH as patchStage,
+  PUT as putStage,
+} from '@/app/api/stages/[id]/route';
+import { GET as getScenes } from '@/app/api/stages/[id]/scenes/route';
+import { GET as getManifest } from '@/app/api/stages/[id]/manifest/route';
+import { GET as getFreshness } from '@/app/api/stages/[id]/freshness/route';
+import { GET as getMaterials, POST as postMaterials } from '@/app/api/materials/route';
+import { GET as getMaterial } from '@/app/api/materials/[id]/route';
+
+interface RouteCase {
+  name: string;
+  call: () => Promise<Response>;
+  /** The status the route must return when the runtime is configured. */
+  happyStatus: number;
+}
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const ROUTES: RouteCase[] = [
+  { name: 'GET /api/stages', call: () => getStages(new NextRequest('http://localhost/api/stages')), happyStatus: 200 },
+  {
+    name: 'POST /api/stages',
+    call: () =>
+      postStages(
+        new NextRequest('http://localhost/api/stages', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Day 1' }),
+        }),
+      ),
+    happyStatus: 201,
+  },
+  {
+    name: 'GET /api/stages/[id]',
+    call: () => getStage(new NextRequest(`http://localhost/api/stages/${STAGE_ID}`), params(STAGE_ID)),
+    happyStatus: 200,
+  },
+  {
+    name: 'PATCH /api/stages/[id]',
+    call: () =>
+      patchStage(
+        new NextRequest(`http://localhost/api/stages/${STAGE_ID}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Renamed' }),
+        }),
+        params(STAGE_ID),
+      ),
+    happyStatus: 200,
+  },
+  {
+    name: 'PUT /api/stages/[id]',
+    call: () =>
+      putStage(
+        new NextRequest(`http://localhost/api/stages/${STAGE_ID}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(makeDocument(STAGE_ID, 'Course')),
+        }),
+        params(STAGE_ID),
+      ),
+    happyStatus: 200,
+  },
+  {
+    name: 'DELETE /api/stages/[id]',
+    call: () =>
+      deleteStage(new NextRequest(`http://localhost/api/stages/${STAGE_ID}`, { method: 'DELETE' }), params(STAGE_ID)),
+    happyStatus: 200,
+  },
+  {
+    name: 'GET /api/stages/[id]/scenes',
+    call: () =>
+      getScenes(
+        new NextRequest(`http://localhost/api/stages/${STAGE_ID}/scenes?ids=scene-1`),
+        params(STAGE_ID),
+      ),
+    happyStatus: 200,
+  },
+  {
+    name: 'GET /api/stages/[id]/manifest',
+    call: () => getManifest(new NextRequest(`http://localhost/api/stages/${STAGE_ID}/manifest`), params(STAGE_ID)),
+    happyStatus: 200,
+  },
+  {
+    name: 'GET /api/stages/[id]/freshness',
+    call: () =>
+      getFreshness(new NextRequest(`http://localhost/api/stages/${STAGE_ID}/freshness`), params(STAGE_ID)),
+    happyStatus: 200,
+  },
+  {
+    name: 'GET /api/materials',
+    call: () => getMaterials(new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`)),
+    happyStatus: 200,
+  },
+  {
+    name: 'POST /api/materials',
+    call: () =>
+      postMaterials(
+        new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/pdf', 'x-material-filename': 'notes.pdf' },
+          body: Buffer.from('hello'),
+        }),
+      ),
+    happyStatus: 201,
+  },
+  {
+    name: 'GET /api/materials/[id]',
+    call: () =>
+      getMaterial(
+        new NextRequest(`http://localhost/api/materials/${MATERIAL_ID}?sessionId=${SESSION_ID}`),
+        params(MATERIAL_ID),
+      ),
+    happyStatus: 200,
+  },
+];
+
+interface EnvState {
+  label: string;
+  runtimeFlag: string | undefined;
+  databaseUrl: string | undefined;
+  /** Whether the routes must serve (true) or answer 404 (false). */
+  serves: boolean;
+}
+
+const STATES: EnvState[] = [
+  { label: 'flag off, no DATABASE_URL', runtimeFlag: undefined, databaseUrl: undefined, serves: false },
+  { label: 'flag on, no DATABASE_URL', runtimeFlag: 'true', databaseUrl: undefined, serves: false },
+  { label: 'flag on, DATABASE_URL present', runtimeFlag: 'true', databaseUrl: 'postgres://runtime', serves: true },
+];
+
+function material(): AgentSessionMaterial {
+  return {
+    id: MATERIAL_ID,
+    sessionId: SESSION_ID,
+    kind: 'web',
+    title: 'Example',
+    sourceUrl: 'https://example.com/doc',
+    textAssetId: 'asset-1',
+    rawAssetId: null,
+    textChars: 42,
+    createdAt: '2025-01-01T00:00:00.000Z',
+  };
+}
+
+for (const state of STATES) {
+  describe(`agent runtime gate — ${state.label}`, () => {
+    const originals = new Map<string, string | undefined>();
+
+    beforeEach(() => {
+      for (const key of ENV_KEYS) {
+        originals.set(key, process.env[key]);
+        delete process.env[key];
+      }
+      if (state.runtimeFlag !== undefined) process.env.OPENMAIC_AGENT_RUNTIME_ENABLED = state.runtimeFlag;
+      if (state.databaseUrl !== undefined) process.env.DATABASE_URL = state.databaseUrl;
+
+      vi.clearAllMocks();
+      mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
+      mocks.resolveOwnedSession.mockResolvedValue({ id: SESSION_ID, ownerId: 'owner-1' });
+      mocks.listSessionMaterials.mockResolvedValue([material()]);
+      mocks.createSourceMaterial.mockResolvedValue(material());
+      mocks.getSessionMaterial.mockResolvedValue(material());
+      mocks.fakeStore = createFakeDocumentStore();
+      mocks.fakeStore.docs.set(
+        STAGE_ID,
+        makeDocument(STAGE_ID, 'Course', [makeSlideScene('scene-1', STAGE_ID, 1)]),
+      );
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        const original = originals.get(key);
+        if (original === undefined) delete process.env[key];
+        else process.env[key] = original;
+      }
+      originals.clear();
+    });
+
+    it.each(ROUTES.map((route) => [route.name, route] as const))(
+      '%s',
+      async (_name, route) => {
+        const response = await route.call();
+        if (state.serves) {
+          expect(response.status).toBe(route.happyStatus);
+        } else {
+          // The 404 must come from the gate, before any owner/store work —
+          // and it must be a 404, never the 500 a store without a connection
+          // would have produced.
+          expect(response.status).toBe(404);
+        }
+        // Close any stream the freshness route opened so its timers cannot
+        // outlive the test.
+        await response.body?.cancel().catch(() => undefined);
+      },
+    );
+  });
+}

--- a/tests/agent-runtime/persistence-routes-gate.test.ts
+++ b/tests/agent-runtime/persistence-routes-gate.test.ts
@@ -77,7 +77,11 @@ interface RouteCase {
 const params = (id: string) => ({ params: Promise.resolve({ id }) });
 
 const ROUTES: RouteCase[] = [
-  { name: 'GET /api/stages', call: () => getStages(new NextRequest('http://localhost/api/stages')), happyStatus: 200 },
+  {
+    name: 'GET /api/stages',
+    call: () => getStages(new NextRequest('http://localhost/api/stages')),
+    happyStatus: 200,
+  },
   {
     name: 'POST /api/stages',
     call: () =>
@@ -92,7 +96,8 @@ const ROUTES: RouteCase[] = [
   },
   {
     name: 'GET /api/stages/[id]',
-    call: () => getStage(new NextRequest(`http://localhost/api/stages/${STAGE_ID}`), params(STAGE_ID)),
+    call: () =>
+      getStage(new NextRequest(`http://localhost/api/stages/${STAGE_ID}`), params(STAGE_ID)),
     happyStatus: 200,
   },
   {
@@ -124,7 +129,10 @@ const ROUTES: RouteCase[] = [
   {
     name: 'DELETE /api/stages/[id]',
     call: () =>
-      deleteStage(new NextRequest(`http://localhost/api/stages/${STAGE_ID}`, { method: 'DELETE' }), params(STAGE_ID)),
+      deleteStage(
+        new NextRequest(`http://localhost/api/stages/${STAGE_ID}`, { method: 'DELETE' }),
+        params(STAGE_ID),
+      ),
     happyStatus: 200,
   },
   {
@@ -138,18 +146,26 @@ const ROUTES: RouteCase[] = [
   },
   {
     name: 'GET /api/stages/[id]/manifest',
-    call: () => getManifest(new NextRequest(`http://localhost/api/stages/${STAGE_ID}/manifest`), params(STAGE_ID)),
+    call: () =>
+      getManifest(
+        new NextRequest(`http://localhost/api/stages/${STAGE_ID}/manifest`),
+        params(STAGE_ID),
+      ),
     happyStatus: 200,
   },
   {
     name: 'GET /api/stages/[id]/freshness',
     call: () =>
-      getFreshness(new NextRequest(`http://localhost/api/stages/${STAGE_ID}/freshness`), params(STAGE_ID)),
+      getFreshness(
+        new NextRequest(`http://localhost/api/stages/${STAGE_ID}/freshness`),
+        params(STAGE_ID),
+      ),
     happyStatus: 200,
   },
   {
     name: 'GET /api/materials',
-    call: () => getMaterials(new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`)),
+    call: () =>
+      getMaterials(new NextRequest(`http://localhost/api/materials?sessionId=${SESSION_ID}`)),
     happyStatus: 200,
   },
   {
@@ -184,9 +200,19 @@ interface EnvState {
 }
 
 const STATES: EnvState[] = [
-  { label: 'flag off, no DATABASE_URL', runtimeFlag: undefined, databaseUrl: undefined, serves: false },
+  {
+    label: 'flag off, no DATABASE_URL',
+    runtimeFlag: undefined,
+    databaseUrl: undefined,
+    serves: false,
+  },
   { label: 'flag on, no DATABASE_URL', runtimeFlag: 'true', databaseUrl: undefined, serves: false },
-  { label: 'flag on, DATABASE_URL present', runtimeFlag: 'true', databaseUrl: 'postgres://runtime', serves: true },
+  {
+    label: 'flag on, DATABASE_URL present',
+    runtimeFlag: 'true',
+    databaseUrl: 'postgres://runtime',
+    serves: true,
+  },
 ];
 
 function material(): AgentSessionMaterial {
@@ -212,7 +238,8 @@ for (const state of STATES) {
         originals.set(key, process.env[key]);
         delete process.env[key];
       }
-      if (state.runtimeFlag !== undefined) process.env.OPENMAIC_AGENT_RUNTIME_ENABLED = state.runtimeFlag;
+      if (state.runtimeFlag !== undefined)
+        process.env.OPENMAIC_AGENT_RUNTIME_ENABLED = state.runtimeFlag;
       if (state.databaseUrl !== undefined) process.env.DATABASE_URL = state.databaseUrl;
 
       vi.clearAllMocks();
@@ -237,22 +264,19 @@ for (const state of STATES) {
       originals.clear();
     });
 
-    it.each(ROUTES.map((route) => [route.name, route] as const))(
-      '%s',
-      async (_name, route) => {
-        const response = await route.call();
-        if (state.serves) {
-          expect(response.status).toBe(route.happyStatus);
-        } else {
-          // The 404 must come from the gate, before any owner/store work —
-          // and it must be a 404, never the 500 a store without a connection
-          // would have produced.
-          expect(response.status).toBe(404);
-        }
-        // Close any stream the freshness route opened so its timers cannot
-        // outlive the test.
-        await response.body?.cancel().catch(() => undefined);
-      },
-    );
+    it.each(ROUTES.map((route) => [route.name, route] as const))('%s', async (_name, route) => {
+      const response = await route.call();
+      if (state.serves) {
+        expect(response.status).toBe(route.happyStatus);
+      } else {
+        // The 404 must come from the gate, before any owner/store work —
+        // and it must be a 404, never the 500 a store without a connection
+        // would have produced.
+        expect(response.status).toBe(404);
+      }
+      // Close any stream the freshness route opened so its timers cannot
+      // outlive the test.
+      await response.body?.cancel().catch(() => undefined);
+    });
   });
 }

--- a/tests/agent-runtime/runtime-probe.test.ts
+++ b/tests/agent-runtime/runtime-probe.test.ts
@@ -1,24 +1,48 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const flags = vi.hoisted(() => ({ runtime: false }));
-
-vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => flags.runtime,
-}));
-
+// No feature-flags mock: the probe reads the REAL environment, so each row
+// below exercises the actual `isAgentRuntimeConfigured()` /
+// `isAgentRuntimeEnabled()` predicates. The suite runs without `.env.local`
+// (see tests/setup-env.ts), so "no DATABASE_URL in the environment at all"
+// is the default state here.
 import { GET } from '@/app/api/agent/runtime/route';
 
-beforeEach(() => {
-  flags.runtime = false;
-});
+const ENV_KEYS = ['OPENMAIC_AGENT_RUNTIME_ENABLED', 'DATABASE_URL'] as const;
 
 describe('agent runtime probe', () => {
-  it('reports the disabled runtime', async () => {
-    await expect((await GET()).json()).resolves.toEqual({ enabled: false });
+  const originals = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originals.set(key, process.env[key]);
+      delete process.env[key];
+    }
   });
 
-  it('reports the enabled runtime without unrelated capability flags', async () => {
-    flags.runtime = true;
-    await expect((await GET()).json()).resolves.toEqual({ enabled: true });
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const original = originals.get(key);
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+    originals.clear();
   });
+
+  it.each([
+    ['the runtime flag is off (the no-DB default)', undefined, undefined, false, false],
+    ['the runtime is on but DATABASE_URL is absent', 'true', undefined, false, true],
+    ['the runtime is on and DATABASE_URL is set', 'true', 'postgres://runtime', true, true],
+  ])(
+    'reports %s as { enabled: %s, runtimeEnabled: %s }',
+    async (_case, runtimeFlag, databaseUrl, enabled, runtimeEnabled) => {
+      if (runtimeFlag !== undefined) process.env.OPENMAIC_AGENT_RUNTIME_ENABLED = runtimeFlag;
+      if (databaseUrl !== undefined) process.env.DATABASE_URL = databaseUrl;
+
+      // `enabled` is usability: it must be true only when the runtime can
+      // actually serve a request. `runtimeEnabled` is the raw intent flag, so
+      // "off by choice" (false/false) is distinguishable from "on but
+      // unusable" (false/true).
+      await expect((await GET()).json()).resolves.toEqual({ enabled, runtimeEnabled });
+    },
+  );
 });

--- a/tests/agent-runtime/stage-detail-route.test.ts
+++ b/tests/agent-runtime/stage-detail-route.test.ts
@@ -7,13 +7,13 @@ import { createFakeDocumentStore } from './_fake-document-store';
 import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -46,7 +46,7 @@ function jsonInit(method: string, body: unknown): NextInit {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.fakeStore = createFakeDocumentStore();
   mocks.fakeStore.docs.set(
@@ -73,8 +73,8 @@ describe('GET /api/stages/[id]', () => {
     expect(await response.text()).toBe('Not found');
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     expect((await call(GET)).status).toBe(404);
   });
 });

--- a/tests/agent-runtime/stage-freshness-route.test.ts
+++ b/tests/agent-runtime/stage-freshness-route.test.ts
@@ -5,13 +5,13 @@ import { createFakeDocumentStore } from './_fake-document-store';
 import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -50,7 +50,7 @@ async function readUntilFreshness(
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.fakeStore = createFakeDocumentStore();
   mocks.fakeStore.docs.set(
@@ -133,8 +133,8 @@ describe('GET /api/stages/[id]/freshness', () => {
     expect(response.headers.get('set-cookie')).toContain('anonymous_id=anon-2');
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     expect((await call()).status).toBe(404);
   });
 });

--- a/tests/agent-runtime/stage-manifest-route.test.ts
+++ b/tests/agent-runtime/stage-manifest-route.test.ts
@@ -5,13 +5,13 @@ import { createFakeDocumentStore } from './_fake-document-store';
 import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -31,7 +31,7 @@ function call(id = STAGE_ID) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.fakeStore = createFakeDocumentStore();
 });
@@ -75,8 +75,8 @@ describe('GET /api/stages/[id]/manifest', () => {
     expect(response.status).toBe(404);
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     expect((await call()).status).toBe(404);
   });
 });

--- a/tests/agent-runtime/stage-scenes-route.test.ts
+++ b/tests/agent-runtime/stage-scenes-route.test.ts
@@ -5,13 +5,13 @@ import { createFakeDocumentStore } from './_fake-document-store';
 import { makeDocument, makeSlideScene } from './_stage-fixtures';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -31,7 +31,7 @@ function call(query = '') {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.fakeStore = createFakeDocumentStore();
   mocks.fakeStore.docs.set(
@@ -90,8 +90,8 @@ describe('GET /api/stages/[id]/scenes?ids=', () => {
     expect(response.status).toBe(404);
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     expect((await call('?ids=scene-1')).status).toBe(404);
   });
 });

--- a/tests/agent-runtime/stages-route.test.ts
+++ b/tests/agent-runtime/stages-route.test.ts
@@ -6,13 +6,13 @@ import type { AppScene } from '@/lib/types/stage';
 import { createFakeDocumentStore } from './_fake-document-store';
 
 const mocks = vi.hoisted(() => ({
-  runtimeEnabled: true,
+  runtimeConfigured: true,
   resolveRequestOwnerId: vi.fn(),
   fakeStore: null as ReturnType<typeof createFakeDocumentStore> | null,
 }));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeConfigured,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
   resolveRequestOwnerId: mocks.resolveRequestOwnerId,
@@ -48,7 +48,7 @@ function makeDocument(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.runtimeEnabled = true;
+  mocks.runtimeConfigured = true;
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.fakeStore = createFakeDocumentStore();
 });
@@ -81,8 +81,8 @@ describe('GET /api/stages', () => {
     expect(mocks.resolveRequestOwnerId).toHaveBeenCalledOnce();
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     const response = await GET(new NextRequest('http://localhost/api/stages'));
     expect(response.status).toBe(404);
     expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
@@ -205,8 +205,8 @@ describe('POST /api/stages', () => {
     expect(mocks.resolveRequestOwnerId).not.toHaveBeenCalled();
   });
 
-  it('answers 404 when the agent runtime is disabled', async () => {
-    mocks.runtimeEnabled = false;
+  it('answers 404 when the agent runtime is not configured', async () => {
+    mocks.runtimeConfigured = false;
     const response = await POST(
       new NextRequest('http://localhost/api/stages', {
         method: 'POST',

--- a/tests/config/feature-flags.test.ts
+++ b/tests/config/feature-flags.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  isAgentRuntimeConfigured,
+  isAgentRuntimeEnabled,
   isEditorRendererEnabled,
   isMaicEditorEnabled,
   isPlaybackRendererEnabled,
@@ -14,6 +16,44 @@ import {
 } from '@/lib/config/feature-flags';
 
 const FLAG = 'NEXT_PUBLIC_MAIC_EDITOR_ENABLED';
+
+describe('agent runtime configuration predicate', () => {
+  const ENV_KEYS = ['OPENMAIC_AGENT_RUNTIME_ENABLED', 'DATABASE_URL'] as const;
+  const originals = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originals.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const original = originals.get(key);
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+    originals.clear();
+  });
+
+  it.each([
+    ['the flag is off with no DATABASE_URL', undefined, undefined, false, false],
+    ['the flag is off with DATABASE_URL set', undefined, 'postgres://runtime', false, false],
+    ['the flag is on with no DATABASE_URL', 'true', undefined, true, false],
+    ['the flag is on with a blank DATABASE_URL', 'true', '   ', true, false],
+    ['the flag is on with DATABASE_URL set', 'true', 'postgres://runtime', true, true],
+  ])(
+    '%s: enabled = %s, configured = %s',
+    (_case, runtimeFlag, databaseUrl, enabled, configured) => {
+      if (runtimeFlag !== undefined) process.env.OPENMAIC_AGENT_RUNTIME_ENABLED = runtimeFlag;
+      if (databaseUrl !== undefined) process.env.DATABASE_URL = databaseUrl;
+
+      expect(isAgentRuntimeEnabled()).toBe(enabled);
+      expect(isAgentRuntimeConfigured()).toBe(configured);
+    },
+  );
+});
 
 describe('isMaicEditorEnabled', () => {
   let original: string | undefined;

--- a/tests/server/config-validation.test.ts
+++ b/tests/server/config-validation.test.ts
@@ -54,6 +54,8 @@ const LLM_ENV_PREFIXES = [
 function clearConfigEnv() {
   delete process.env.MODEL_ROUTES;
   delete process.env.DEFAULT_MODEL;
+  delete process.env.OPENMAIC_AGENT_RUNTIME_ENABLED;
+  delete process.env.DATABASE_URL;
   for (const prefix of LLM_ENV_PREFIXES) {
     delete process.env[`${prefix}_API_KEY`];
     delete process.env[`${prefix}_BASE_URL`];
@@ -228,6 +230,43 @@ describe('validateServerConfig — warning matrix', () => {
     const { validateServerConfig } = await import('@/lib/server/config-validation');
     validateServerConfig();
     expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+
+  describe('agent runtime configuration', () => {
+    it('warns when the runtime flag is set without DATABASE_URL', async () => {
+      vi.stubEnv('OPENMAIC_AGENT_RUNTIME_ENABLED', 'true');
+      const { validateServerConfig } = await import('@/lib/server/config-validation');
+      validateServerConfig();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0][0]);
+      expect(message).toContain('OPENMAIC_AGENT_RUNTIME_ENABLED');
+      expect(message).toContain('DATABASE_URL');
+    });
+
+    it('warns when the runtime flag is set and DATABASE_URL is blank', async () => {
+      vi.stubEnv('OPENMAIC_AGENT_RUNTIME_ENABLED', 'true');
+      vi.stubEnv('DATABASE_URL', '   ');
+      const { validateServerConfig } = await import('@/lib/server/config-validation');
+      validateServerConfig();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain('DATABASE_URL');
+    });
+
+    it('does not warn when the runtime flag is set with DATABASE_URL present', async () => {
+      vi.stubEnv('OPENMAIC_AGENT_RUNTIME_ENABLED', 'true');
+      vi.stubEnv('DATABASE_URL', 'postgres://runtime');
+      const { validateServerConfig } = await import('@/lib/server/config-validation');
+      validateServerConfig();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the runtime flag is off even without DATABASE_URL', async () => {
+      // This is the no-DB default deployment: flag unset, no database. It must
+      // boot silently — the warning is for the MISCONFIGURED state only.
+      const { validateServerConfig } = await import('@/lib/server/config-validation');
+      validateServerConfig();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
Upstream supports running with no database: server-backed persistence is opt-in and the agent runtime is separately gated, so a deployment that sets neither flag is untouched by this change and stays that way. The broken case is the **misconfigured** one — runtime flag on, `DATABASE_URL` absent — where three things conspired to waste an operator's afternoon:

1. `/api/agent/runtime` reported `enabled` (the operator's *intent*) rather than usability, so the client offered the workbench and every call behind it failed.
2. The persistence-touching routes (`/api/stages*`, `/api/materials*`) gated on the enabled flag and then reached a store that needs a connection — a 500 per request instead of the clean 404 the flag-off case gives.
3. The runner never started (its own gate is correct and requires the database), so even a session that got created would never be claimed. The visible symptom was "nothing happens", not "you did not set DATABASE_URL".

Now: the probe reports usability, the persistence routes answer 404 exactly as they do when the flag is off, and the startup config validator warns when the runtime is enabled without a database — one line that replaces a debugging session.

**The agent control-plane gates are deliberately left alone.** The reference tree gates `/api/agent/sessions` on the enabled flag only; that is quoted in full in the branch's notes. Fidelity to the reference wins over my preference for a stricter gate.

Tests are table-driven over the three environment states (flag off / flag on without a database / flag on with one), so a future route added behind the wrong gate fails a row rather than silently 500ing in production. 1,091 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)