### PR TITLE
feat(media): add an optional local ffmpeg media extractor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,12 @@ ASR_AZURE_BASE_URL=https://{region}.api.cognitive.microsoft.com
 # ASR_OPENAI_ENABLED=false
 # ASR_BROWSER_NATIVE_ENABLED=false
 
+# Optional local audio/video material extraction uses the first enabled server
+# ASR provider above. It also requires the system `ffmpeg` and `ffprobe`
+# executables on PATH; no bundled binary or npm dependency is installed.
+# Without both executables, OpenMAIC skips the local extractor and uses a
+# configured AliDocMind cloud extractor when available. With neither path
+# enabled, media materials fail cleanly with setup guidance.
 
 # --- PDF Processing -----------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ ASR_FUNASR_BASE_URL=http://localhost:8000/v1
 
 Use `funasr-server --device cpu --model sensevoice` for a CPU-only setup. See the [FunASR deployment guide](https://github.com/modelscope/FunASR#deploy) for production options.
 
+### Optional: Local Audio and Video Extraction
+
+OpenMAIC can extract timestamped transcripts and prepared video keyframes locally. Install the system `ffmpeg` package so both `ffmpeg` and `ffprobe` are executable on `PATH`, then configure one server ASR provider (for example FunASR, Lemonade, or OpenAI) using the variables above. The application resolves the executables at extraction time; ffmpeg is not an npm dependency and is not required to start or use OpenMAIC.
+
+If the executables are unavailable, the local extractor is skipped. A configured AliDocMind provider remains available as the cloud extraction path. When neither local ffmpeg extraction nor AliDocMind is available, audio/video materials are marked failed with an actionable setup message instead of hanging or completing with an empty transcript.
+
 OpenAI quick example:
 
 ```env

--- a/app/api/extract-document/route.ts
+++ b/app/api/extract-document/route.ts
@@ -217,19 +217,26 @@ async function runExtraction(
   // flattened to the same text shape documents produce. Same route, same
   // downstream generation path.
   if (SUPPORTED_MEDIA_MIME_TYPES.includes(mimeType)) {
-    logState.resolvedProviderId = requestConfig.providerId || 'alidocmind';
+    logState.resolvedProviderId = requestConfig.providerId || '';
     // Reject a document-only provider (e.g. unpdf/mineru) for a media upload
     // with a clear 4xx instead of forwarding it into the media registry and
     // surfacing an opaque 500.
-    const mediaProvider = getMediaExtractorProvider(logState.resolvedProviderId);
-    if (!mediaProvider || !mediaProvider.supportedMimeTypes.includes(mimeType)) {
+    const mediaProvider = requestConfig.providerId
+      ? getMediaExtractorProvider(requestConfig.providerId)
+      : undefined;
+    if (
+      requestConfig.providerId &&
+      (!mediaProvider || !mediaProvider.supportedMimeTypes.includes(mimeType))
+    ) {
       return apiError(
         'INVALID_REQUEST',
         400,
-        `Provider "${logState.resolvedProviderId}" cannot extract ${mimeType}. Choose a media-capable provider (e.g. AliDocMind).`,
+        `Provider "${requestConfig.providerId}" cannot extract ${mimeType}. Choose a media-capable provider (AliDocMind or local ffmpeg).`,
       );
     }
-    const mediaManaged = isServerConfiguredProvider('pdf', logState.resolvedProviderId);
+    const mediaManaged =
+      requestConfig.providerId !== 'local-ffmpeg' &&
+      isServerConfiguredProvider('pdf', 'alidocmind');
     // When managed, resolve the server-owned AK/SK (env OR YAML) explicitly so
     // a YAML-only deployment works — the client-level env fallback reads env
     // vars only. Client-entered creds are used only when unmanaged.
@@ -249,7 +256,7 @@ async function runExtraction(
       fileSize,
       mimeType,
       config: {
-        providerId: logState.resolvedProviderId,
+        providerId: requestConfig.providerId || '',
         apiKey: mediaManaged ? undefined : requestConfig.apiKey || undefined,
         baseUrl: mediaManaged ? mediaManagedCreds?.baseUrl : mediaClientBaseUrl,
         accessKeyId: mediaManaged
@@ -263,6 +270,8 @@ async function runExtraction(
         allowEnvFallback: mediaManaged,
       },
     });
+    logState.resolvedProviderId =
+      mediaArtifact.metadata.providerId || requestConfig.providerId || '';
 
     const mediaText = mediaArtifactToText(mediaArtifact);
     // An artifact with no transcript, keyframes, or synopsis carries no usable

--- a/lib/document/extract-media.ts
+++ b/lib/document/extract-media.ts
@@ -2,9 +2,10 @@ import { selectMediaExtractorProvider } from './extractors/media-registry';
 import type { MediaArtifact, MediaExtractorInput } from './types';
 
 export async function extractMedia(input: MediaExtractorInput): Promise<MediaArtifact> {
-  const provider = selectMediaExtractorProvider({
+  const provider = await selectMediaExtractorProvider({
     mimeType: input.mimeType,
     preferredProviderId: input.config.providerId,
+    input,
   });
 
   return provider.extract(input);

--- a/lib/document/extractors/images.ts
+++ b/lib/document/extractors/images.ts
@@ -1,0 +1,49 @@
+import sharp from 'sharp';
+
+export const MAX_DERIVED_IMAGES = 100;
+export const MAX_DERIVED_IMAGE_BYTES = 2 * 1024 * 1024;
+const DERIVED_IMAGE_ATTEMPTS = [
+  { dimension: 2048, quality: 82 },
+  { dimension: 1600, quality: 70 },
+  { dimension: 1280, quality: 60 },
+  { dimension: 960, quality: 50 },
+] as const;
+
+export interface PreparedDerivedImage {
+  buffer: Buffer;
+  mime: 'image/webp';
+  width?: number;
+  height?: number;
+}
+
+export function limitDerivedImages<T>(assets: readonly T[]): { selected: T[]; skipped: number } {
+  return {
+    selected: assets.slice(0, MAX_DERIVED_IMAGES),
+    skipped: Math.max(0, assets.length - MAX_DERIVED_IMAGES),
+  };
+}
+
+/** Downsample and progressively compress one extracted image to the shared 2MB cap. */
+export async function prepareDerivedImage(buffer: Buffer): Promise<PreparedDerivedImage | null> {
+  for (const attempt of DERIVED_IMAGE_ATTEMPTS) {
+    const output = await sharp(buffer, { failOn: 'none' })
+      .rotate()
+      .resize({
+        width: attempt.dimension,
+        height: attempt.dimension,
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .webp({ quality: attempt.quality, effort: 4 })
+      .toBuffer({ resolveWithObject: true });
+    if (output.data.byteLength <= MAX_DERIVED_IMAGE_BYTES) {
+      return {
+        buffer: output.data,
+        mime: 'image/webp',
+        ...(output.info.width ? { width: output.info.width } : {}),
+        ...(output.info.height ? { height: output.info.height } : {}),
+      };
+    }
+  }
+  return null;
+}

--- a/lib/document/extractors/local-media.ts
+++ b/lib/document/extractors/local-media.ts
@@ -1,0 +1,835 @@
+import { execFile } from 'node:child_process';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { access, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, delimiter, extname, join, resolve as resolvePath } from 'node:path';
+
+import { transcribeAudio, type ASRTranscriptionResult } from '@/lib/audio/asr-providers';
+import type { ASRModelConfig, ASRProviderId } from '@/lib/audio/types';
+import {
+  resolveASRApiKey,
+  resolveASRBaseUrl,
+  resolveASRModel,
+  resolveServerASRProviderId,
+} from '@/lib/server/provider-config';
+
+import { LOCAL_FFMPEG_MEDIA_MIMES } from '../mime';
+import type {
+  DocumentAsset,
+  MediaArtifact,
+  MediaExtractorInput,
+  MediaExtractorProvider,
+  MediaTranscriptSegment,
+} from '../types';
+import {
+  isTransientExtractionError,
+  MaterialExtractionError,
+} from '../../server/material-extraction/errors';
+import { MAX_DERIVED_IMAGES, prepareDerivedImage } from './images';
+import { getMediaExtractorManifestEntry } from './manifest';
+
+export const MEDIA_ASR_CHUNK_SEC = 600;
+const MEDIA_COMMAND_TIMEOUT_MS = 20 * 60 * 1000;
+const FFPROBE_TIMEOUT_MS = 30_000;
+const MEDIA_JOB_TIMEOUT_MS = 45 * 60 * 1000;
+const MEDIA_ASR_TIMEOUT_MS = 8 * 60 * 1000;
+const MEDIA_MAX_DURATION_SEC = 90 * 60;
+const COMMAND_MAX_BUFFER = 8 * 1024 * 1024;
+const MAX_KEYFRAME_CANDIDATES = 50_000;
+const KEYFRAME_END_SAFETY_MS = 1500;
+const MEDIA_MIME_SET = new Set<string>(LOCAL_FFMPEG_MEDIA_MIMES);
+const asrFetchSignal = new AsyncLocalStorage<AbortSignal>();
+let abortableFetchInstalled = false;
+
+export type MediaExtractionStage = 'probing' | 'audio' | 'asr' | 'keyframes';
+
+export interface MediaExtractionProgress {
+  stage: MediaExtractionStage;
+  current?: number;
+  total?: number;
+}
+
+export interface MediaCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface MediaCommandRunner {
+  resolve(name: 'ffmpeg' | 'ffprobe'): Promise<string>;
+  run(file: string, args: string[], timeoutMs: number): Promise<MediaCommandResult>;
+}
+
+export interface LocalMediaExtractorDependencies {
+  commands?: MediaCommandRunner;
+  transcribe?: (config: ASRModelConfig, audio: Buffer) => Promise<ASRTranscriptionResult>;
+  resolveASRConfig?: () => ASRModelConfig;
+  jobTimeoutMs?: number;
+}
+
+interface KeyframeMaterial {
+  asset: DocumentAsset;
+  timeMs: number;
+}
+
+export { MaterialExtractionError as LocalMediaExtractionError };
+export const isTransientMediaExtractionError = isTransientExtractionError;
+
+export interface MediaProbe {
+  durationSec: number;
+  hasAudioStream: boolean;
+  videoDurationSec?: number;
+}
+
+class MediaJobDeadline {
+  private readonly expiresAt: number;
+
+  constructor(timeoutMs: number) {
+    this.expiresAt = Date.now() + timeoutMs;
+  }
+
+  remainingMs(): number {
+    return Math.max(0, this.expiresAt - Date.now());
+  }
+
+  check(): void {
+    if (this.remainingMs() <= 0) {
+      throw new MaterialExtractionError('media extraction job deadline exceeded', true);
+    }
+  }
+
+  commandTimeoutMs(maximum: number): number {
+    this.check();
+    return Math.max(1, Math.min(maximum, this.remainingMs()));
+  }
+
+  beforeAwait<T>(operation: () => Promise<T>): Promise<T> {
+    this.check();
+    return operation();
+  }
+}
+
+function installAbortableFetch(): void {
+  if (abortableFetchInstalled) return;
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const contextSignal = asrFetchSignal.getStore();
+    if (!contextSignal) return originalFetch(input, init);
+    const signal = init?.signal ? AbortSignal.any([init.signal, contextSignal]) : contextSignal;
+    return originalFetch(input, { ...init, signal });
+  }) as typeof globalThis.fetch;
+  abortableFetchInstalled = true;
+}
+
+async function runASRWithTimeout<T>(run: () => Promise<T>, deadline: MediaJobDeadline): Promise<T> {
+  deadline.check();
+  installAbortableFetch();
+  const jobRemainingMs = deadline.remainingMs();
+  const perChunkMs = MEDIA_ASR_TIMEOUT_MS;
+  const timeoutMs = Math.max(1, Math.min(jobRemainingMs, perChunkMs));
+  const jobDeadlineWins = jobRemainingMs <= perChunkMs;
+  const controller = new AbortController();
+  const timeoutError = new MaterialExtractionError(
+    jobDeadlineWins ? 'media extraction job deadline exceeded' : 'ASR chunk timed out',
+    true,
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([asrFetchSignal.run(controller.signal, run), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function runMediaCommand(
+  commands: MediaCommandRunner,
+  file: string,
+  args: string[],
+  maximumTimeoutMs: number,
+  deadline: MediaJobDeadline,
+): Promise<MediaCommandResult> {
+  const timeoutMs = deadline.commandTimeoutMs(maximumTimeoutMs);
+  const jobLimited = timeoutMs < maximumTimeoutMs;
+  try {
+    const result = await commands.run(file, args, timeoutMs);
+    deadline.check();
+    return result;
+  } catch (error) {
+    if (deadline.remainingMs() <= 0) deadline.check();
+    const commandError = error as NodeJS.ErrnoException & { killed?: boolean };
+    if (jobLimited && (commandError.code === 'ETIMEDOUT' || commandError.killed)) {
+      throw new MaterialExtractionError('media extraction job deadline exceeded', true, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+export function isSupportedMediaMime(mime: string): boolean {
+  return MEDIA_MIME_SET.has(mime.toLowerCase());
+}
+
+async function resolveExecutable(name: 'ffmpeg' | 'ffprobe'): Promise<string> {
+  const candidates = new Set<string>();
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    if (directory) candidates.add(resolvePath(directory, name));
+  }
+  for (const directory of ['/usr/local/bin', '/opt/homebrew/bin', '/usr/bin', '/bin']) {
+    candidates.add(join(directory, name));
+  }
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      // Keep looking; the final error is explicit and permanent.
+    }
+  }
+  throw new MaterialExtractionError(
+    `${name} is unavailable; install ffmpeg (including ffprobe) to extract media materials`,
+    false,
+  );
+}
+
+export const defaultMediaCommands: MediaCommandRunner = {
+  resolve: resolveExecutable,
+  run(file, args, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      execFile(
+        file,
+        args,
+        { timeout: timeoutMs, maxBuffer: COMMAND_MAX_BUFFER, encoding: 'utf8' },
+        (error, stdout, stderr) => {
+          if (error) {
+            const detail = String(stderr || stdout || error.message)
+              .trim()
+              .slice(-4000);
+            const wrapped = new Error(`${basename(file)} failed: ${detail || error.message}`, {
+              cause: error,
+            }) as Error & { code?: string };
+            wrapped.code = (error as NodeJS.ErrnoException).code;
+            reject(wrapped);
+            return;
+          }
+          resolve({ stdout: String(stdout), stderr: String(stderr) });
+        },
+      );
+    });
+  },
+};
+
+export function parseMediaProbe(stdout: string): MediaProbe {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new MaterialExtractionError('ffprobe returned malformed duration metadata', false, {
+      cause: error,
+    });
+  }
+  const probe = parsed as {
+    format?: { duration?: unknown };
+    streams?: Array<{ codec_type?: unknown; duration?: unknown }>;
+  };
+  const value = probe?.format?.duration;
+  const duration = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new MaterialExtractionError(
+      'ffprobe could not determine a positive media duration',
+      false,
+    );
+  }
+  const streams = Array.isArray(probe.streams) ? probe.streams : [];
+  const videoStream = streams.find((stream) => stream?.codec_type === 'video');
+  const rawVideoDuration = videoStream?.duration;
+  const parsedVideoDuration =
+    typeof rawVideoDuration === 'number' ? rawVideoDuration : Number(rawVideoDuration);
+  const videoDurationSec = videoStream
+    ? Number.isFinite(parsedVideoDuration) && parsedVideoDuration > 0
+      ? parsedVideoDuration
+      : Math.max(0, duration - KEYFRAME_END_SAFETY_MS / 1000)
+    : undefined;
+  return {
+    durationSec: duration,
+    hasAudioStream: streams.some((stream) => stream?.codec_type === 'audio'),
+    ...(videoDurationSec !== undefined ? { videoDurationSec } : {}),
+  };
+}
+
+export function parseMediaDuration(stdout: string): number {
+  return parseMediaProbe(stdout).durationSec;
+}
+
+export interface MediaChunkWindow {
+  index: number;
+  startMs: number;
+  endMs: number;
+}
+
+export function mediaChunkWindows(durationSec: number): MediaChunkWindow[] {
+  const count = Math.max(1, Math.ceil(durationSec / MEDIA_ASR_CHUNK_SEC));
+  return Array.from({ length: count }, (_, index) => ({
+    index,
+    startMs: index * MEDIA_ASR_CHUNK_SEC * 1000,
+    endMs: Math.min(durationSec * 1000, (index + 1) * MEDIA_ASR_CHUNK_SEC * 1000),
+  }));
+}
+
+export function maxMediaChunkCheckpoints(): number {
+  return Math.max(1, Math.ceil(MEDIA_MAX_DURATION_SEC / MEDIA_ASR_CHUNK_SEC));
+}
+
+export function uniformKeyframeTimes(
+  sceneTimesMs: readonly number[],
+  videoDurationSec: number,
+): number[] {
+  const durationMs = Math.max(0, Math.round(videoDurationSec * 1000));
+  const lastSafeTimeMs = durationMs - KEYFRAME_END_SAFETY_MS;
+  if (lastSafeTimeMs < 0) return [];
+  const scenes = new Set<number>();
+  for (const raw of sceneTimesMs.slice(0, MAX_KEYFRAME_CANDIDATES)) {
+    if (!Number.isFinite(raw)) continue;
+    const rounded = Math.round(raw);
+    if (rounded < 0 || rounded > lastSafeTimeMs) continue;
+    scenes.add(Math.min(rounded, lastSafeTimeMs));
+  }
+  const candidates = new Set<number>(scenes);
+  for (let timeMs = 0; timeMs <= lastSafeTimeMs; timeMs += 60_000) candidates.add(timeMs);
+  candidates.add(lastSafeTimeMs);
+  const ordered = [...candidates].sort((a, b) => a - b);
+  if (ordered.length <= MAX_DERIVED_IMAGES) return ordered;
+
+  // Once the cap is reached, the timeline—not candidate density—is the
+  // authority. A burst of scene changes in one chapter must not consume most
+  // of the 100-frame budget. Prefer the scene nearest each bucket's centre;
+  // an empty bucket receives its centre grid anchor.
+  const orderedScenes = [...scenes].sort((a, b) => a - b);
+  let sceneIndex = 0;
+  return Array.from({ length: MAX_DERIVED_IMAGES }, (_, bucket) => {
+    const samplingSpanMs = lastSafeTimeMs + 1;
+    const start = Math.floor((bucket * samplingSpanMs) / MAX_DERIVED_IMAGES);
+    const end = Math.max(
+      start + 1,
+      Math.floor(((bucket + 1) * samplingSpanMs) / MAX_DERIVED_IMAGES),
+    );
+    const anchor = Math.min(lastSafeTimeMs, Math.floor((start + end - 1) / 2));
+    while (sceneIndex < orderedScenes.length && orderedScenes[sceneIndex] < start) sceneIndex += 1;
+    let best = -1;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (
+      let index = sceneIndex;
+      index < orderedScenes.length && orderedScenes[index] < end;
+      index += 1
+    ) {
+      const distance = Math.abs(orderedScenes[index] - anchor);
+      if (distance < bestDistance) {
+        best = orderedScenes[index];
+        bestDistance = distance;
+      }
+    }
+    return best >= 0 ? best : anchor;
+  });
+}
+
+function formatMarkerTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(timeMs / 1000));
+  return `${String(Math.floor(totalSeconds / 60)).padStart(2, '0')}:${String(totalSeconds % 60).padStart(2, '0')}`;
+}
+
+/** Render a readable transcript while proving every inline image id belongs to this derivation. */
+export function renderTranscriptView(
+  segments: readonly MediaTranscriptSegment[],
+  keyframes: readonly { materialId: string; timeMs: number }[],
+  allowedMaterialIds: ReadonlySet<string>,
+): string {
+  for (const frame of keyframes) {
+    if (!allowedMaterialIds.has(frame.materialId)) {
+      throw new MaterialExtractionError(
+        `cross-reference ${frame.materialId} is outside this material's derived domain`,
+        false,
+      );
+    }
+  }
+  const orderedSegments = [...segments].sort((a, b) => a.startMs - b.startMs);
+  const orderedFrames = [...keyframes].sort((a, b) => a.timeMs - b.timeMs);
+  const lines: string[] = [];
+  let frameIndex = 0;
+  for (const segment of orderedSegments) {
+    while (
+      frameIndex < orderedFrames.length &&
+      orderedFrames[frameIndex].timeMs < segment.startMs
+    ) {
+      const frame = orderedFrames[frameIndex++];
+      lines.push(`[keyframe@${formatMarkerTime(frame.timeMs)}](${frame.materialId})`);
+    }
+    lines.push(
+      `[${formatMarkerTime(segment.startMs)}-${formatMarkerTime(segment.endMs)}] ${segment.text}`,
+    );
+    while (frameIndex < orderedFrames.length && orderedFrames[frameIndex].timeMs <= segment.endMs) {
+      const frame = orderedFrames[frameIndex++];
+      lines.push(`[keyframe@${formatMarkerTime(frame.timeMs)}](${frame.materialId})`);
+    }
+  }
+  while (frameIndex < orderedFrames.length) {
+    const frame = orderedFrames[frameIndex++];
+    lines.push(`[keyframe@${formatMarkerTime(frame.timeMs)}](${frame.materialId})`);
+  }
+  return lines.join('\n\n');
+}
+
+function sourceExtension(mime: string): string {
+  const extensions: Record<string, string> = {
+    'video/mp4': '.mp4',
+    'video/quicktime': '.mov',
+    'video/webm': '.webm',
+    'audio/mpeg': '.mp3',
+    'audio/wav': '.wav',
+    'audio/x-wav': '.wav',
+    'audio/mp4': '.m4a',
+    'audio/aac': '.aac',
+    'audio/webm': '.webm',
+  };
+  return extensions[mime] ?? '.media';
+}
+
+function derivedStem(originalName: string | null, fallback: string): string {
+  if (!originalName) return fallback;
+  const name = basename(originalName);
+  const extension = extname(name);
+  return extension ? name.slice(0, -extension.length) : name;
+}
+
+function configuredASR(): ASRModelConfig {
+  const providerId = resolveServerASRProviderId();
+  if (!providerId) {
+    throw new MaterialExtractionError(
+      'No server ASR provider is configured for local media extraction',
+      false,
+    );
+  }
+  return {
+    providerId: providerId as ASRProviderId,
+    modelId: resolveASRModel(providerId),
+    apiKey: resolveASRApiKey(providerId) || undefined,
+    baseUrl: resolveASRBaseUrl(providerId),
+    language: 'auto',
+  };
+}
+
+function frameTimes(stderr: string): number[] {
+  return [...stderr.matchAll(/showinfo[^\n]*pts_time:\s*([0-9]+(?:\.[0-9]+)?)/g)].map((match) =>
+    Math.round(Number(match[1]) * 1000),
+  );
+}
+
+async function readRequiredIntermediate(
+  path: string,
+  description: string,
+  deadline: MediaJobDeadline,
+): Promise<Buffer> {
+  try {
+    return await deadline.beforeAwait(() => readFile(path));
+  } catch (error) {
+    if (error instanceof MaterialExtractionError) throw error;
+    throw new MaterialExtractionError(
+      `${description} is missing or unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      false,
+      { cause: error },
+    );
+  }
+}
+
+function incrementDiagnostic(diagnostics: Map<string, number>, reason: string): void {
+  diagnostics.set(reason, (diagnostics.get(reason) ?? 0) + 1);
+}
+
+function aggregatedDiagnostics(diagnostics: ReadonlyMap<string, number>): string[] {
+  return [...diagnostics].map(([reason, count]) => (count > 1 ? `${reason} (${count})` : reason));
+}
+
+async function probeMedia(
+  commands: MediaCommandRunner,
+  ffprobe: string,
+  sourcePath: string,
+  deadline: MediaJobDeadline,
+): Promise<MediaProbe> {
+  try {
+    const result = await runMediaCommand(
+      commands,
+      ffprobe,
+      [
+        '-v',
+        'error',
+        '-show_entries',
+        'format=duration:stream=codec_type,duration',
+        '-of',
+        'json',
+        sourcePath,
+      ],
+      FFPROBE_TIMEOUT_MS,
+      deadline,
+    );
+    return parseMediaProbe(result.stdout);
+  } catch (error) {
+    if (error instanceof MaterialExtractionError) throw error;
+    throw new MaterialExtractionError(
+      `ffprobe could not inspect this media file: ${error instanceof Error ? error.message : String(error)}`,
+      false,
+      { cause: error },
+    );
+  }
+}
+
+async function transcribeChunks(
+  chunkPaths: string[],
+  windows: MediaChunkWindow[],
+  config: ASRModelConfig,
+  transcribe: (config: ASRModelConfig, audio: Buffer) => Promise<ASRTranscriptionResult>,
+  deadline: MediaJobDeadline,
+  onProgress?: (progress: MediaExtractionProgress) => void | Promise<void>,
+): Promise<MediaTranscriptSegment[]> {
+  const segments: MediaTranscriptSegment[] = [];
+  for (const [index, chunkPath] of chunkPaths.entries()) {
+    try {
+      deadline.check();
+      await deadline.beforeAwait(async () =>
+        onProgress?.({ stage: 'asr', current: index + 1, total: chunkPaths.length }),
+      );
+      const chunk = await readRequiredIntermediate(
+        chunkPath,
+        `ASR chunk ${index + 1}/${chunkPaths.length}`,
+        deadline,
+      );
+      const result = await runASRWithTimeout(() => transcribe(config, chunk), deadline);
+      const text = result.text.trim();
+      if (text) {
+        segments.push({
+          id: `segment-${String(index + 1).padStart(3, '0')}`,
+          startMs: windows[index].startMs,
+          endMs: windows[index].endMs,
+          text,
+          metadata: { chunk: index + 1 },
+        });
+      }
+    } catch (error) {
+      throw new MaterialExtractionError(
+        `ASR chunk ${index + 1}/${chunkPaths.length} failed: ${error instanceof Error ? error.message : String(error)}`,
+        isTransientExtractionError(error),
+        { cause: error },
+      );
+    } finally {
+      await rm(chunkPath, { force: true }).catch(() => undefined);
+    }
+  }
+  return segments;
+}
+
+/** Execute the ffmpeg + ASR light pipeline for one media source. */
+export async function extractMediaMaterial(
+  input: MediaExtractorInput,
+  dependencies: LocalMediaExtractorDependencies = {},
+): Promise<MediaArtifact> {
+  if (!isSupportedMediaMime(input.mimeType)) {
+    throw new MaterialExtractionError(`Unsupported media MIME type: ${input.mimeType}`, false);
+  }
+  const startedAt = Date.now();
+  const deadline = new MediaJobDeadline(dependencies.jobTimeoutMs ?? MEDIA_JOB_TIMEOUT_MS);
+  const commands = dependencies.commands ?? defaultMediaCommands;
+  const transcribe = dependencies.transcribe ?? transcribeAudio;
+  const sessionDir = await deadline.beforeAwait(() => mkdtemp(join(tmpdir(), 'openmaic-media-')));
+  const sourcePath = join(sessionDir, `source${sourceExtension(input.mimeType)}`);
+  try {
+    await deadline.beforeAwait(() => writeFile(sourcePath, input.buffer));
+    const [ffprobe, ffmpeg] = await deadline.beforeAwait(() =>
+      Promise.all([commands.resolve('ffprobe'), commands.resolve('ffmpeg')]),
+    );
+    const probe = await probeMedia(commands, ffprobe, sourcePath, deadline);
+    const { durationSec } = probe;
+    if (durationSec > MEDIA_MAX_DURATION_SEC) {
+      throw new MaterialExtractionError(
+        `Media duration ${Math.ceil(durationSec)} seconds exceeds the ${MEDIA_MAX_DURATION_SEC}-second limit; trim it before uploading`,
+        false,
+      );
+    }
+
+    const isVideo = input.mimeType.startsWith('video/');
+    const stem = derivedStem(input.fileName ?? null, 'media');
+    let segments: MediaTranscriptSegment[];
+    let asrChunks = 0;
+    let transcriptDurationSec = durationSec;
+
+    if (isVideo && !probe.hasAudioStream) {
+      segments = [
+        {
+          id: 'segment-001',
+          startMs: 0,
+          endMs: Math.round(durationSec * 1000),
+          text: 'No audio track',
+          metadata: { noAudioTrack: true },
+        },
+      ];
+    } else {
+      if (!probe.hasAudioStream) {
+        throw new MaterialExtractionError(
+          'ffprobe found no audio stream in this audio material',
+          false,
+        );
+      }
+      let audioInputPath: string;
+      if (isVideo) {
+        audioInputPath = join(sessionDir, 'audio-track.wav');
+        await runMediaCommand(
+          commands,
+          ffmpeg,
+          [
+            '-hide_banner',
+            '-loglevel',
+            'error',
+            '-y',
+            '-i',
+            sourcePath,
+            '-vn',
+            '-ac',
+            '1',
+            '-ar',
+            '16000',
+            '-c:a',
+            'pcm_s16le',
+            audioInputPath,
+          ],
+          MEDIA_COMMAND_TIMEOUT_MS,
+          deadline,
+        );
+        transcriptDurationSec = (await probeMedia(commands, ffprobe, audioInputPath, deadline))
+          .durationSec;
+      } else {
+        // Audio uploads already are the reference track; preserve their exact bytes and codec lineage.
+        audioInputPath = sourcePath;
+      }
+
+      const chunkPattern = join(sessionDir, 'chunk-%03d.wav');
+      try {
+        await runMediaCommand(
+          commands,
+          ffmpeg,
+          [
+            '-hide_banner',
+            '-loglevel',
+            'error',
+            '-y',
+            '-i',
+            audioInputPath,
+            '-vn',
+            '-ac',
+            '1',
+            '-ar',
+            '16000',
+            '-c:a',
+            'pcm_s16le',
+            '-f',
+            'segment',
+            '-segment_time',
+            String(MEDIA_ASR_CHUNK_SEC),
+            '-reset_timestamps',
+            '1',
+            chunkPattern,
+          ],
+          MEDIA_COMMAND_TIMEOUT_MS,
+          deadline,
+        );
+      } finally {
+        if (isVideo) await rm(audioInputPath, { force: true }).catch(() => undefined);
+      }
+      const chunkPaths = (await deadline.beforeAwait(() => readdir(sessionDir)))
+        .filter((name) => /^chunk-\d{3}\.wav$/.test(name))
+        .sort()
+        .map((name) => join(sessionDir, name));
+      if (chunkPaths.length === 0) {
+        throw new MaterialExtractionError('ffmpeg produced no ASR audio chunks', false);
+      }
+      const windows = mediaChunkWindows(transcriptDurationSec);
+      if (chunkPaths.length !== windows.length) {
+        throw new MaterialExtractionError(
+          `ffmpeg produced ${chunkPaths.length} ASR chunks; expected ${windows.length} for ${transcriptDurationSec} seconds`,
+          false,
+        );
+      }
+      asrChunks = chunkPaths.length;
+      const asr = dependencies.resolveASRConfig?.() ?? configuredASR();
+      segments = await deadline.beforeAwait(() =>
+        transcribeChunks(chunkPaths, windows, asr, transcribe, deadline),
+      );
+    }
+
+    const keyframes: KeyframeMaterial[] = [];
+    let imagesSkipped = 0;
+    const keyframeDiagnostics = new Map<string, number>();
+    if (isVideo) {
+      let detectedSceneTimes: number[] = [];
+      try {
+        const sceneResult = await runMediaCommand(
+          commands,
+          ffmpeg,
+          [
+            '-hide_banner',
+            '-i',
+            sourcePath,
+            '-vf',
+            'select=gt(scene\\,0.3),showinfo',
+            '-an',
+            '-f',
+            'null',
+            '-',
+          ],
+          MEDIA_COMMAND_TIMEOUT_MS,
+          deadline,
+        );
+        detectedSceneTimes = frameTimes(sceneResult.stderr);
+      } catch {
+        incrementDiagnostic(
+          keyframeDiagnostics,
+          'keyframe scene detection failed; used uniform sampling',
+        );
+      }
+      const selectedTimes = uniformKeyframeTimes(
+        detectedSceneTimes,
+        probe.videoDurationSec ?? Math.max(0, durationSec - KEYFRAME_END_SAFETY_MS / 1000),
+      );
+      for (const [index, timeMs] of selectedTimes.entries()) {
+        const framePath = join(sessionDir, `frame-${String(index + 1).padStart(3, '0')}.png`);
+        let stage: 'ffmpeg' | 'read' | 'prepare' | 'store' = 'ffmpeg';
+        try {
+          deadline.check();
+          await runMediaCommand(
+            commands,
+            ffmpeg,
+            [
+              '-hide_banner',
+              '-loglevel',
+              'error',
+              '-y',
+              '-ss',
+              (timeMs / 1000).toFixed(3),
+              '-i',
+              sourcePath,
+              '-frames:v',
+              '1',
+              '-vf',
+              'scale=1280:1280:force_original_aspect_ratio=decrease',
+              framePath,
+            ],
+            MEDIA_COMMAND_TIMEOUT_MS,
+            deadline,
+          );
+          stage = 'read';
+          const frameBytes = await deadline.beforeAwait(() => readFile(framePath));
+          stage = 'prepare';
+          const prepared = await deadline.beforeAwait(() => prepareDerivedImage(frameBytes));
+          if (!prepared) {
+            imagesSkipped += 1;
+            incrementDiagnostic(
+              keyframeDiagnostics,
+              'keyframe image preparation returned no image',
+            );
+            continue;
+          }
+          stage = 'store';
+          const assetId = `keyframe-${String(index + 1).padStart(3, '0')}`;
+          const asset: DocumentAsset = {
+            id: assetId,
+            type: 'image',
+            mimeType: prepared.mime,
+            data: prepared.buffer.toString('base64'),
+            width: prepared.width,
+            height: prepared.height,
+            description: `${stem} at ${(timeMs / 1000).toFixed(3)} seconds`,
+            metadata: { timeMs },
+          };
+          keyframes.push({ asset, timeMs });
+        } catch (error) {
+          imagesSkipped += 1;
+          const code = (error as NodeJS.ErrnoException | null)?.code;
+          incrementDiagnostic(
+            keyframeDiagnostics,
+            code === 'ENOENT'
+              ? `keyframe ${stage} failed: output missing (ENOENT)`
+              : `keyframe ${stage} failed`,
+          );
+        } finally {
+          await rm(framePath, { force: true }).catch(() => undefined);
+        }
+      }
+    }
+
+    const allowedImageIds = new Set(keyframes.map((frame) => frame.asset.id));
+    const transcriptText = renderTranscriptView(
+      segments,
+      keyframes.map((frame) => ({ materialId: frame.asset.id, timeMs: frame.timeMs })),
+      allowedImageIds,
+    );
+    return {
+      metadata: {
+        fileName: input.fileName,
+        fileSize: input.fileSize ?? input.buffer.byteLength,
+        mimeType: input.mimeType,
+        durationMs: Math.round(transcriptDurationSec * 1000),
+        providerId: 'local-ffmpeg',
+        processingTime: Date.now() - startedAt,
+      },
+      transcript: segments,
+      keyframes: keyframes.map((frame) => ({
+        id: frame.asset.id,
+        assetId: frame.asset.id,
+        timeMs: frame.timeMs,
+      })),
+      assets: keyframes.map((frame) => frame.asset),
+      diagnostics: [
+        ...aggregatedDiagnostics(keyframeDiagnostics),
+        ...(imagesSkipped > 0 ? [`${imagesSkipped} keyframe images were skipped`] : []),
+      ].map((message) => ({
+        severity: 'warning' as const,
+        message,
+        providerId: 'local-ffmpeg',
+      })),
+      providerRaw: { transcriptText, durationSec, asrChunks },
+    };
+  } finally {
+    await rm(sessionDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+export function createLocalMediaExtractorProvider(
+  dependencies: LocalMediaExtractorDependencies = {},
+): MediaExtractorProvider {
+  const entry = getMediaExtractorManifestEntry('local-ffmpeg');
+  if (!entry) throw new Error('No media extractor manifest entry for provider "local-ffmpeg"');
+  const commands = dependencies.commands ?? defaultMediaCommands;
+  return {
+    ...entry,
+    supportedMimeTypes: entry.supportedMimeTypes.filter(isSupportedMediaMime),
+    async availability() {
+      try {
+        await Promise.all([commands.resolve('ffmpeg'), commands.resolve('ffprobe')]);
+        return { available: true };
+      } catch (error) {
+        return {
+          available: false,
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    extract(input) {
+      return extractMediaMaterial(input, { ...dependencies, commands });
+    },
+  };
+}
+
+export const localMediaExtractorProvider = createLocalMediaExtractorProvider();

--- a/lib/document/extractors/manifest.ts
+++ b/lib/document/extractors/manifest.ts
@@ -29,6 +29,7 @@ import {
   MINERU_CLOUD_MIMES,
   MINERU_SELFHOST_MIMES,
   PLAIN_TEXT_MIMES,
+  LOCAL_FFMPEG_MEDIA_MIMES,
 } from '../mime';
 import type { DocumentExtractorCapabilities, MediaExtractorCapabilities } from '../types';
 
@@ -147,6 +148,19 @@ const MEDIA_EXTRACTOR_MANIFEST: Record<string, MediaExtractorManifestEntry> = {
       synopsis: true,
       ocr: true,
       async: true,
+    },
+  },
+  'local-ffmpeg': {
+    id: 'local-ffmpeg',
+    displayName: 'Local ffmpeg',
+    version: '1',
+    supportedMimeTypes: LOCAL_FFMPEG_MEDIA_MIMES,
+    capabilities: {
+      transcript: true,
+      keyframes: true,
+      synopsis: false,
+      ocr: false,
+      async: false,
     },
   },
 };

--- a/lib/document/extractors/media-registry.ts
+++ b/lib/document/extractors/media-registry.ts
@@ -1,8 +1,15 @@
 import { mediaBackedExtractorProviders } from './media';
-import type { MediaExtractorProvider, MediaExtractorProviderId } from '../types';
+import { localMediaExtractorProvider } from './local-media';
+import type {
+  MediaExtractorInput,
+  MediaExtractorProvider,
+  MediaExtractorProviderId,
+} from '../types';
 
 const MEDIA_EXTRACTOR_PROVIDERS: Record<MediaExtractorProviderId, MediaExtractorProvider> =
-  Object.fromEntries(mediaBackedExtractorProviders.map((p) => [p.id, p]));
+  Object.fromEntries(
+    [...mediaBackedExtractorProviders, localMediaExtractorProvider].map((p) => [p.id, p]),
+  );
 
 export function getMediaExtractorProviders(): MediaExtractorProvider[] {
   return Object.values(MEDIA_EXTRACTOR_PROVIDERS);
@@ -14,11 +21,13 @@ export function getMediaExtractorProvider(
   return MEDIA_EXTRACTOR_PROVIDERS[providerId];
 }
 
-export function selectMediaExtractorProvider(options: {
+export async function selectMediaExtractorProvider(options: {
   mimeType: string;
   preferredProviderId?: MediaExtractorProviderId;
   requiredCapabilities?: Partial<MediaExtractorProvider['capabilities']>;
-}): MediaExtractorProvider {
+  input: MediaExtractorInput;
+  providers?: MediaExtractorProvider[];
+}): Promise<MediaExtractorProvider> {
   const normalizedMimeType = options.mimeType.toLowerCase();
   const supportsRequest = (provider: MediaExtractorProvider) =>
     provider.supportedMimeTypes.includes(normalizedMimeType) &&
@@ -28,8 +37,17 @@ export function selectMediaExtractorProvider(options: {
         provider.capabilities[capability as keyof MediaExtractorProvider['capabilities']],
     );
 
+  const providers = options.providers ?? getMediaExtractorProviders();
+  const providerById = new Map(providers.map((provider) => [provider.id, provider]));
+  const availabilityReason = async (provider: MediaExtractorProvider) => {
+    const availability = await provider.availability?.(options.input);
+    return availability && !availability.available
+      ? (availability.reason ?? 'unavailable')
+      : undefined;
+  };
+
   if (options.preferredProviderId) {
-    const preferred = getMediaExtractorProvider(options.preferredProviderId);
+    const preferred = providerById.get(options.preferredProviderId);
     if (!preferred) {
       throw new Error(`Unknown media extractor provider: ${options.preferredProviderId}`);
     }
@@ -38,14 +56,18 @@ export function selectMediaExtractorProvider(options: {
         `Media extractor "${preferred.id}" does not support MIME type "${options.mimeType}" with the requested capabilities`,
       );
     }
+    const reason = await availabilityReason(preferred);
+    if (reason) {
+      throw new Error(`Media extractor "${preferred.id}" is unavailable: ${reason}`);
+    }
     return preferred;
   }
 
-  const provider = getMediaExtractorProviders().find(supportsRequest);
-  if (!provider) {
-    throw new Error(
-      `No media extractor supports MIME type "${options.mimeType}" with the requested capabilities`,
-    );
+  const supported = providers.filter(supportsRequest);
+  for (const provider of supported) {
+    if (!(await availabilityReason(provider))) return provider;
   }
-  return provider;
+  throw new Error(
+    `Media extraction is unavailable for "${options.mimeType}". Configure AliDocMind credentials for cloud extraction, or install ffmpeg (including ffprobe) and configure a server ASR provider for local extraction.`,
+  );
 }

--- a/lib/document/extractors/media.ts
+++ b/lib/document/extractors/media.ts
@@ -21,6 +21,21 @@ function createMediaBackedExtractor(id: MediaParseProviderId): MediaExtractorPro
     // MEDIA_PARSE_PROVIDERS entry ever lacks a manifest entry, and the
     // registry sync test pins the reverse direction (no orphan entries).
     ...mediaManifestEntry(id),
+    async availability(input) {
+      const config = input.config;
+      const hasExplicitCredentials = Boolean(config.accessKeyId && config.accessKeySecret);
+      const hasEnvironmentCredentials = Boolean(
+        config.allowEnvFallback &&
+        process.env.ALIDOCMIND_ACCESS_KEY_ID &&
+        process.env.ALIDOCMIND_ACCESS_KEY_SECRET,
+      );
+      return hasExplicitCredentials || hasEnvironmentCredentials
+        ? { available: true }
+        : {
+            available: false,
+            reason: 'AliDocMind credentials are not configured',
+          };
+    },
     async extract(input: MediaExtractorInput) {
       return parseMedia({
         buffer: input.buffer,

--- a/lib/document/mime.ts
+++ b/lib/document/mime.ts
@@ -203,8 +203,21 @@ export const ALIDOCMIND_MEDIA_MIMES: readonly string[] = [
   M.aac,
 ];
 
+/** Media formats accepted by the optional local ffmpeg pipeline. */
+export const LOCAL_FFMPEG_MEDIA_MIMES: readonly string[] = [
+  M.mp4,
+  M.mov,
+  'video/webm',
+  M.mp3,
+  M.wav,
+  M.m4a,
+  M.aac,
+  'audio/webm',
+];
+
 export const MEDIA_PROVIDER_SUPPORTED_MIME_TYPES: Record<string, readonly string[]> = {
   alidocmind: ALIDOCMIND_MEDIA_MIMES,
+  'local-ffmpeg': LOCAL_FFMPEG_MEDIA_MIMES,
 };
 
 /** All audio/video MIME types any media provider accepts. */

--- a/lib/document/types.ts
+++ b/lib/document/types.ts
@@ -86,6 +86,8 @@ export interface MediaExtractorProvider {
    * artifacts are derived and cached. Nothing consumes it yet.
    */
   version: string;
+  /** Resolve optional runtime requirements before this provider is selected. */
+  availability?(input: MediaExtractorInput): Promise<{ available: boolean; reason?: string }>;
   extract(input: MediaExtractorInput): Promise<MediaArtifact>;
 }
 

--- a/lib/server/material-extraction/errors.ts
+++ b/lib/server/material-extraction/errors.ts
@@ -26,6 +26,13 @@ function numericStatus(error: unknown): number | undefined {
 /** Retry only errors carrying a concrete transient transport/runtime signal. */
 export function isTransientExtractionError(error: unknown): boolean {
   if (error instanceof MaterialExtractionError) return error.retryable;
+  if (
+    error &&
+    typeof error === 'object' &&
+    typeof (error as { retryable?: unknown }).retryable === 'boolean'
+  ) {
+    return (error as { retryable: boolean }).retryable;
+  }
   const status = numericStatus(error);
   if (status !== undefined) {
     if (status >= 500 && status <= 599) return true;

--- a/lib/server/material-extraction/extract.ts
+++ b/lib/server/material-extraction/extract.ts
@@ -7,14 +7,19 @@ import {
 
 import {
   getDocumentExtractorProviders,
+  getMediaExtractorProviders,
+  selectMediaExtractorProvider,
   type DocumentArtifact,
   type DocumentExtractorProvider,
+  type MediaArtifact,
+  type MediaExtractorProvider,
 } from '@/lib/document';
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
 import {
   getServerPDFProviders,
   resolvePDFApiKey,
   resolvePDFBaseUrl,
+  resolveServerMediaExtractorConfig,
 } from '@/lib/server/provider-config';
 import {
   getAgentSessionMaterialStore,
@@ -29,8 +34,10 @@ export interface MaterialExtractionExecutionDependencies {
     assetId: string,
   ) => Promise<{ bytes: Buffer; mime: string } | null>;
   providers?: () => DocumentExtractorProvider[];
+  mediaProviders?: () => MediaExtractorProvider[];
   configuredProviderIds?: () => string[];
   putText?: (sessionId: string, text: Buffer) => Promise<string>;
+  putAsset?: (sessionId: string, bytes: Buffer, mime: string) => Promise<string>;
   complete?: (input: CompleteMaterialExtractionInput) => Promise<boolean>;
 }
 
@@ -39,6 +46,24 @@ function artifactText(artifact: DocumentArtifact): string {
     .filter((block) => block.type === 'text' || block.type === 'markdown')
     .map((block) => block.text?.trim())
     .filter((text): text is string => Boolean(text))
+    .join('\n\n');
+}
+
+function markerTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, timeMs) / 1000;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = (totalSeconds % 60).toFixed(3).padStart(6, '0');
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${seconds}`;
+}
+
+export function mediaArtifactText(artifact: MediaArtifact): string {
+  return (artifact.transcript ?? [])
+    .filter((segment) => segment.text.trim())
+    .map(
+      (segment) =>
+        `[${markerTime(segment.startMs)} - ${markerTime(segment.endMs)}] ${segment.text.trim()}`,
+    )
     .join('\n\n');
 }
 
@@ -75,6 +100,17 @@ async function defaultPutText(sessionId: string, text: Buffer): Promise<string> 
   );
 }
 
+async function defaultPutAsset(sessionId: string, bytes: Buffer, mime: string): Promise<string> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error('Agent runtime requires DATABASE_URL');
+  const provider = await getServerPersistenceProvider(connectionString);
+  return provider.assetStore.put(
+    materialPrincipal(sessionId),
+    new Blob([new Uint8Array(bytes)], { type: mime }),
+    { contentType: mime },
+  );
+}
+
 /** Extract one lease-fenced source through the upstream extractor registry. */
 export async function extractClaimedSessionMaterial(
   claim: ClaimedMaterialExtraction,
@@ -85,6 +121,94 @@ export async function extractClaimedSessionMaterial(
   const resolveSource = dependencies.resolveSource ?? defaultResolveSource;
   const raw = await resolveSource(source.sessionId, source.rawAssetId);
   if (!raw) throw new Error(`source bytes are unavailable for material ${source.id}`);
+
+  const mediaProviders = dependencies.mediaProviders?.() ?? getMediaExtractorProviders();
+  const isMedia = mediaProviders.some((provider) =>
+    provider.supportedMimeTypes.includes(raw.mime.toLowerCase()),
+  );
+  if (isMedia) {
+    const mediaInput = {
+      buffer: raw.bytes,
+      fileName: source.title ?? undefined,
+      fileSize: raw.bytes.byteLength,
+      mimeType: raw.mime,
+      config: resolveServerMediaExtractorConfig(),
+    };
+    let selected: MediaExtractorProvider;
+    let artifact: MediaArtifact;
+    try {
+      selected = await selectMediaExtractorProvider({
+        mimeType: raw.mime,
+        input: mediaInput,
+        providers: mediaProviders,
+      });
+      artifact = await selected.extract({
+        ...mediaInput,
+        config: { ...mediaInput.config, providerId: selected.id },
+      });
+    } catch (error) {
+      throw new MaterialExtractionError(
+        error instanceof Error ? error.message : String(error),
+        isTransientExtractionError(error),
+        { cause: error },
+      );
+    }
+    const text = mediaArtifactText(artifact);
+    if (!text) {
+      throw new MaterialExtractionError(
+        'media extraction produced no transcript; configure a working local ASR provider or a cloud media extractor',
+        false,
+      );
+    }
+    const textAssetId = await (dependencies.putText ?? defaultPutText)(
+      source.sessionId,
+      Buffer.from(text, 'utf8'),
+    );
+    const transcriptId = createMaterialId();
+    const putAsset = dependencies.putAsset ?? defaultPutAsset;
+    const images = [];
+    for (const asset of artifact.assets ?? []) {
+      if (asset.type !== 'image' || !asset.data) continue;
+      const bytes = Buffer.from(asset.data, 'base64');
+      const rawAssetId = await putAsset(source.sessionId, bytes, asset.mimeType ?? 'image/webp');
+      images.push({
+        id: createMaterialId(),
+        kind: 'image' as const,
+        title: asset.description ?? `${source.title ?? 'media'}.${asset.id}.webp`,
+        rawAssetId,
+      });
+    }
+    const store = dependencies.complete ? undefined : await getAgentSessionMaterialStore();
+    const complete = dependencies.complete ?? store!.completeExtraction.bind(store);
+    const extractorVersion = `${selected.id}@${selected.version}`;
+    const completed = await complete({
+      sourceId: source.id,
+      workerId: claim.workerId,
+      extractorVersion,
+      stats: {
+        chars: text.length,
+        pages: 0,
+        imageCount: images.length,
+        durationSec: artifact.metadata.durationMs ? artifact.metadata.durationMs / 1000 : undefined,
+        asrChunks: artifact.transcript?.length ?? 0,
+        ...(artifact.diagnostics?.length
+          ? { diagnostics: artifact.diagnostics.map((diagnostic) => diagnostic.message) }
+          : {}),
+      },
+      derived: [
+        {
+          id: transcriptId,
+          kind: 'transcript',
+          title: source.title ? `${source.title}.transcript.md` : 'transcript.md',
+          textAssetId,
+          textChars: text.length,
+        },
+        ...images,
+      ],
+    });
+    if (!completed) throw new Error(`material extraction lease lost for ${source.id}`);
+    return { materialId: transcriptId, text, extractorVersion };
+  }
 
   const providers = dependencies.providers?.() ?? getDocumentExtractorProviders();
   const configuredIds =

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -416,6 +416,24 @@ export function resolveManagedAliDocMindCredentials():
   return undefined;
 }
 
+/** Provider-neutral extraction input populated from server-managed media credentials. */
+export function resolveServerMediaExtractorConfig(): {
+  providerId: string;
+  accessKeyId?: string;
+  accessKeySecret?: string;
+  baseUrl?: string;
+  allowEnvFallback: boolean;
+} {
+  const credentials = resolveManagedAliDocMindCredentials();
+  return {
+    providerId: '',
+    accessKeyId: credentials?.accessKeyId,
+    accessKeySecret: credentials?.accessKeySecret,
+    baseUrl: credentials?.baseUrl,
+    allowEnvFallback: true,
+  };
+}
+
 function applyOpenAIImageFallback(
   imageConfig: Record<string, ServerProviderEntry>,
   yamlImageSection: Record<string, Partial<ServerProviderEntry>> | undefined,

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/material/pg.ts
+++ b/packages/@openmaic/storage/src/material/pg.ts
@@ -399,7 +399,7 @@ export class PgAgentSessionMaterialStore implements AgentSessionMaterialStore {
   }
 
   async completeExtraction(input: CompleteMaterialExtractionInput): Promise<boolean> {
-    const derived = input.derived;
+    const derived = Array.isArray(input.derived) ? input.derived : [input.derived];
     const result = await this.queryable.query(
       `WITH source AS (
          UPDATE ${this.table}
@@ -412,28 +412,34 @@ export class PgAgentSessionMaterialStore implements AgentSessionMaterialStore {
           RETURNING session_id
        ), removed AS (
          DELETE FROM ${this.table} WHERE derived_from = $1
+       ), derivative AS (
+         SELECT * FROM unnest(
+           $5::text[], $6::text[], $7::text[], $8::text[], $9::text[], $10::integer[]
+         ) AS value(id, kind, title, text_asset_id, raw_asset_id, text_chars)
        )
        INSERT INTO ${this.table}
          (id, session_id, kind, title, text_asset_id, raw_asset_id, text_chars,
           derived_from, extraction_status, extraction_stats, extractor_version, created_at)
-       SELECT $5, source.session_id, $6, $7, $8, $9, $10, $1, 'done', $3::jsonb, $4, $11
-         FROM source
+       SELECT derivative.id, source.session_id, derivative.kind, derivative.title,
+              derivative.text_asset_id, derivative.raw_asset_id, derivative.text_chars,
+              $1, 'done', $3::jsonb, $4, $11
+         FROM source CROSS JOIN derivative
        RETURNING id`,
       [
         input.sourceId,
         input.workerId,
         JSON.stringify(input.stats),
         input.extractorVersion,
-        derived.id,
-        derived.kind,
-        derived.title ?? null,
-        derived.textAssetId ?? null,
-        derived.rawAssetId ?? null,
-        derived.textChars ?? 0,
+        derived.map((item) => item.id),
+        derived.map((item) => item.kind),
+        derived.map((item) => item.title ?? null),
+        derived.map((item) => item.textAssetId ?? null),
+        derived.map((item) => item.rawAssetId ?? null),
+        derived.map((item) => item.textChars ?? 0),
         this.now(),
       ],
     );
-    return result.rows.length > 0;
+    return result.rows.length === derived.length;
   }
 
   async settleExtractionFailure(

--- a/packages/@openmaic/storage/src/material/types.ts
+++ b/packages/@openmaic/storage/src/material/types.ts
@@ -6,9 +6,8 @@
  * bytes are not kept on this row — they are stored through the package's
  * hash-addressed asset registry/byte store and the row records the returned
  * asset ids (`textAssetId` for the extracted markdown, `rawAssetId` for the
- * optional raw download), exactly like the reference product's `ossKey`
- * linkage. The material id (`mat_` + Crockford base32 suffix) is minted by
- * {@link createMaterialId}, mirroring the reference's id shape.
+ * optional raw download). The material id (`mat_` + Crockford base32 suffix)
+ * is minted by {@link createMaterialId}.
  *
  * Extraction is coordinated durably on source rows. Bytes continue to live in
  * the asset registry; the lifecycle only coordinates which worker may turn a
@@ -18,7 +17,7 @@ import { randomBytes } from 'node:crypto';
 
 const CROCKFORD_BASE32 = '0123456789abcdefghjkmnpqrstvwxyz';
 
-/** Allocate a private material id from 128 random bits (reference id shape). */
+/** Allocate a private material id from 128 random bits. */
 export function createMaterialId(): string {
   const bytes = randomBytes(16);
   let bits = 0;
@@ -39,10 +38,8 @@ export function createMaterialId(): string {
 }
 
 /**
- * The reference store's kind vocabulary. Only `web` is written by this slice,
- * but the CHECK keeps the full forward-compatible set so a later slice can
- * persist `source` uploads and derived extraction/transcript/media records
- * without a migration.
+ * The material kind vocabulary covers source uploads and their
+ * extraction/transcript/media derivatives without a schema migration.
  */
 export const AGENT_SESSION_MATERIAL_KINDS = [
   'source',
@@ -71,6 +68,8 @@ export interface MaterialExtractionStats {
   imageCount: number;
   truncated?: boolean;
   diagnostics?: string[];
+  durationSec?: number;
+  asrChunks?: number;
 }
 
 export interface MaterialExtractionState {
@@ -136,7 +135,17 @@ export interface CompleteMaterialExtractionInput {
   workerId: string;
   extractorVersion: string;
   stats: MaterialExtractionStats;
-  derived: CreateAgentSessionMaterialInput & { id: string; kind: 'extraction' | 'transcript' };
+  derived:
+    | (CreateAgentSessionMaterialInput & {
+        id: string;
+        kind: 'extraction' | 'transcript' | 'audio-track' | 'image';
+      })
+    | Array<
+        CreateAgentSessionMaterialInput & {
+          id: string;
+          kind: 'extraction' | 'transcript' | 'audio-track' | 'image';
+        }
+      >;
 }
 
 export interface MaterialExtractionFailureSettlement {

--- a/tests/agent-runtime/material-extraction.test.ts
+++ b/tests/agent-runtime/material-extraction.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from '@electric-sql/pglite';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentTool } from '@earendil-works/pi-agent-core';
 import {
   PgAgentSessionStore,
@@ -14,6 +14,29 @@ import {
 import { buildMaterialTools } from '@/lib/server/agent-runtime/material-tools';
 import { extractClaimedSessionMaterial } from '@/lib/server/material-extraction/extract';
 import { runNextMaterialExtraction } from '@/lib/server/material-extraction/runner';
+import { LocalMediaExtractionError } from '@/lib/document/extractors/local-media';
+import type { MediaExtractorProvider } from '@/lib/document';
+
+function mediaProvider(
+  extract: MediaExtractorProvider['extract'],
+  available = true,
+): MediaExtractorProvider {
+  return {
+    id: 'test-media',
+    displayName: 'Test media',
+    version: '1',
+    supportedMimeTypes: ['video/mp4'],
+    capabilities: {
+      transcript: true,
+      keyframes: true,
+      synopsis: false,
+      ocr: false,
+      async: false,
+    },
+    availability: vi.fn(async () => ({ available })),
+    extract,
+  };
+}
 
 describe('uploaded material extraction lifecycle', () => {
   let db: PGlite | undefined;
@@ -127,6 +150,157 @@ describe('uploaded material extraction lifecycle', () => {
       status: 'pending',
       attempts: 1,
       error: 'connection reset',
+    });
+  });
+
+  it('persists a media transcript and prepared images through the asset registry', async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureAgentSessionSchema(db);
+    await ensureAgentSessionMaterialSchema(db);
+    const sessions = new PgAgentSessionStore(db, {
+      withTransaction: (body) => db!.transaction((tx: Queryable) => body(tx)),
+    });
+    const materials = new PgAgentSessionMaterialStore(db);
+    await sessions.createSession({ id: 'session-1', ownerId: 'owner-1', prompt: 'p' });
+    await materials.createMaterial('session-1', {
+      id: 'mat_media',
+      kind: 'source',
+      title: 'lesson.mp4',
+      rawAssetId: 'ast_raw',
+    });
+    await materials.enqueueExtraction('session-1', 'mat_media');
+    const claim = await materials.claimNextExtraction('worker-1', { leaseTtlMs: 10_000 });
+    const stored = new Map<string, Buffer>();
+
+    const result = await extractClaimedSessionMaterial(claim!, {
+      resolveSource: async () => ({ bytes: Buffer.from('video'), mime: 'video/mp4' }),
+      mediaProviders: () => [
+        mediaProvider(async () => ({
+          metadata: { durationMs: 2_000, providerId: 'test-media' },
+          transcript: [{ id: 'segment-1', startMs: 0, endMs: 2_000, text: 'Hello media.' }],
+          assets: [
+            {
+              id: 'frame-1',
+              type: 'image',
+              mimeType: 'image/webp',
+              data: Buffer.from('prepared-webp').toString('base64'),
+            },
+          ],
+        })),
+      ],
+      putText: async (_sessionId, bytes) => {
+        stored.set('ast_transcript', bytes);
+        return 'ast_transcript';
+      },
+      putAsset: async (_sessionId, bytes) => {
+        stored.set('ast_frame', bytes);
+        return 'ast_frame';
+      },
+      complete: materials.completeExtraction.bind(materials),
+    });
+
+    expect(result.text).toContain('[00:00:00.000 - 00:00:02.000] Hello media.');
+    expect(stored.get('ast_frame')?.toString()).toBe('prepared-webp');
+    const derivatives = (await materials.listMaterials('session-1')).filter(
+      (material) => material.derivedFrom === 'mat_media',
+    );
+    expect(derivatives.map((material) => material.kind).sort()).toEqual(['image', 'transcript']);
+  });
+
+  it('retries a transient ASR failure and permanently fails a rejected ASR request', async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureAgentSessionSchema(db);
+    await ensureAgentSessionMaterialSchema(db);
+    const sessions = new PgAgentSessionStore(db, {
+      withTransaction: (body) => db!.transaction((tx: Queryable) => body(tx)),
+    });
+    const materials = new PgAgentSessionMaterialStore(db);
+    await sessions.createSession({ id: 'session-1', ownerId: 'owner-1', prompt: 'p' });
+    await materials.createMaterial('session-1', {
+      id: 'mat_transient',
+      kind: 'source',
+      rawAssetId: 'ast_transient',
+    });
+    await materials.enqueueExtraction('session-1', 'mat_transient');
+    await runNextMaterialExtraction(materials, 'worker-1', (claim) =>
+      extractClaimedSessionMaterial(claim, {
+        resolveSource: async () => ({ bytes: Buffer.from('video'), mime: 'video/mp4' }),
+        mediaProviders: () => [
+          mediaProvider(async () => {
+            throw new LocalMediaExtractionError('ASR HTTP status 503', true);
+          }),
+        ],
+      }),
+    );
+
+    expect((await materials.getMaterial('session-1', 'mat_transient'))?.extraction).toEqual({
+      status: 'pending',
+      attempts: 1,
+      error: 'ASR HTTP status 503',
+    });
+    const retryClaim = await materials.claimNextExtraction('cleanup-worker', {
+      leaseTtlMs: 10_000,
+    });
+    await materials.settleExtractionFailure(
+      retryClaim!.material.id,
+      'cleanup-worker',
+      'stop retrying in this test',
+      false,
+    );
+
+    await materials.createMaterial('session-1', {
+      id: 'mat_permanent',
+      kind: 'source',
+      rawAssetId: 'ast_permanent',
+    });
+    await materials.enqueueExtraction('session-1', 'mat_permanent');
+    await runNextMaterialExtraction(materials, 'worker-1', (claim) =>
+      extractClaimedSessionMaterial(claim, {
+        resolveSource: async () => ({ bytes: Buffer.from('video'), mime: 'video/mp4' }),
+        mediaProviders: () => [
+          mediaProvider(async () => {
+            throw new LocalMediaExtractionError('ASR HTTP status 400', false);
+          }),
+        ],
+      }),
+    );
+    expect((await materials.getMaterial('session-1', 'mat_permanent'))?.extraction).toEqual({
+      status: 'failed',
+      attempts: 0,
+      error: 'ASR HTTP status 400',
+    });
+  });
+
+  it('fails cleanly with both media enablement paths when no provider is available', async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureAgentSessionSchema(db);
+    await ensureAgentSessionMaterialSchema(db);
+    const sessions = new PgAgentSessionStore(db, {
+      withTransaction: (body) => db!.transaction((tx: Queryable) => body(tx)),
+    });
+    const materials = new PgAgentSessionMaterialStore(db);
+    await sessions.createSession({ id: 'session-1', ownerId: 'owner-1', prompt: 'p' });
+    await materials.createMaterial('session-1', {
+      id: 'mat_unavailable',
+      kind: 'source',
+      rawAssetId: 'ast_raw',
+    });
+    await materials.enqueueExtraction('session-1', 'mat_unavailable');
+
+    await runNextMaterialExtraction(materials, 'worker-1', (claim) =>
+      extractClaimedSessionMaterial(claim, {
+        resolveSource: async () => ({ bytes: Buffer.from('video'), mime: 'video/mp4' }),
+        mediaProviders: () => [mediaProvider(vi.fn(), false)],
+      }),
+    );
+
+    expect((await materials.getMaterial('session-1', 'mat_unavailable'))?.extraction).toEqual({
+      status: 'failed',
+      attempts: 0,
+      error: expect.stringMatching(/Configure AliDocMind credentials.*install ffmpeg.*server ASR/i),
     });
   });
 });

--- a/tests/document/local-media-extractor.test.ts
+++ b/tests/document/local-media-extractor.test.ts
@@ -1,0 +1,168 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MediaExtractorInput, MediaExtractorProvider } from '@/lib/document';
+import { selectMediaExtractorProvider } from '@/lib/document/extractors/media-registry';
+import {
+  createLocalMediaExtractorProvider,
+  defaultMediaCommands,
+} from '@/lib/document/extractors/local-media';
+
+const execFileAsync = promisify(execFile);
+const unavailableCommands = {
+  resolve: vi.fn(async (name: 'ffmpeg' | 'ffprobe') => {
+    throw new Error(`${name} missing`);
+  }),
+  run: vi.fn(),
+};
+const input: MediaExtractorInput = {
+  buffer: Buffer.from('fixture'),
+  fileName: 'lesson.mp4',
+  mimeType: 'video/mp4',
+  config: { providerId: '' },
+};
+
+function cloudProvider(available: boolean): MediaExtractorProvider {
+  return {
+    id: 'cloud',
+    displayName: 'Cloud',
+    version: '1',
+    supportedMimeTypes: ['video/mp4'],
+    capabilities: {
+      transcript: true,
+      keyframes: true,
+      synopsis: true,
+      ocr: true,
+      async: true,
+    },
+    availability: vi.fn(async () => ({ available })),
+    extract: vi.fn(),
+  };
+}
+
+describe('optional local media extractor availability', () => {
+  it('does not offer the local provider when either executable is absent', async () => {
+    const local = createLocalMediaExtractorProvider({ commands: unavailableCommands });
+
+    await expect(local.availability?.(input)).resolves.toMatchObject({ available: false });
+    expect(unavailableCommands.resolve).toHaveBeenCalledWith('ffmpeg');
+    expect(unavailableCommands.resolve).toHaveBeenCalledWith('ffprobe');
+  });
+
+  it('falls back to a configured cloud provider without calling local extraction', async () => {
+    const cloud = cloudProvider(true);
+    const local = createLocalMediaExtractorProvider({ commands: unavailableCommands });
+
+    await expect(
+      selectMediaExtractorProvider({
+        mimeType: input.mimeType,
+        input,
+        providers: [local, cloud],
+      }),
+    ).resolves.toBe(cloud);
+  });
+
+  it('names both enablement paths when no provider is available', async () => {
+    const local = createLocalMediaExtractorProvider({ commands: unavailableCommands });
+
+    await expect(
+      selectMediaExtractorProvider({
+        mimeType: input.mimeType,
+        input,
+        providers: [cloudProvider(false), local],
+      }),
+    ).rejects.toThrow(/Configure AliDocMind credentials.*install ffmpeg.*configure a server ASR/i);
+  });
+});
+
+let ffmpegAvailable = false;
+try {
+  await Promise.all([
+    defaultMediaCommands.resolve('ffmpeg'),
+    defaultMediaCommands.resolve('ffprobe'),
+  ]);
+  ffmpegAvailable = true;
+} catch {
+  // The real-pipeline suite is optional, like the PostgreSQL-backed suites.
+}
+
+describe.skipIf(!ffmpegAvailable)('local media extractor real pipeline', () => {
+  it('probes, chunks, transcribes, and timestamps a tiny fixture', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'openmaic-media-test-'));
+    const fixturePath = join(directory, 'fixture.mp4');
+    try {
+      await execFileAsync('ffmpeg', [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-y',
+        '-f',
+        'lavfi',
+        '-i',
+        'color=c=blue:s=160x90:d=2',
+        '-f',
+        'lavfi',
+        '-i',
+        'sine=frequency=440:duration=2',
+        '-shortest',
+        '-c:v',
+        'libx264',
+        '-c:a',
+        'aac',
+        fixturePath,
+      ]);
+      const provider = createLocalMediaExtractorProvider({
+        transcribe: vi.fn(async () => ({ text: 'A tiny local transcript.' })),
+        resolveASRConfig: () => ({
+          providerId: 'openai-whisper',
+          modelId: 'whisper-1',
+          language: 'auto',
+        }),
+      });
+
+      const artifact = await provider.extract({
+        buffer: await readFile(fixturePath),
+        fileName: 'fixture.mp4',
+        mimeType: 'video/mp4',
+        config: { providerId: 'local-ffmpeg' },
+      });
+
+      expect(artifact.metadata.durationMs).toBeGreaterThan(1_500);
+      expect(artifact.transcript).toEqual([
+        expect.objectContaining({
+          startMs: 0,
+          endMs: expect.any(Number),
+          text: 'A tiny local transcript.',
+        }),
+      ]);
+      expect(artifact.transcript?.[0].endMs).toBeGreaterThan(1_500);
+      expect(artifact.keyframes?.length).toBeGreaterThan(0);
+      expect(artifact.assets?.[0]).toMatchObject({ type: 'image', mimeType: 'image/webp' });
+
+      const deadlineProvider = createLocalMediaExtractorProvider({
+        transcribe: vi.fn(() => new Promise<{ text: string }>(() => undefined)),
+        resolveASRConfig: () => ({
+          providerId: 'openai-whisper',
+          modelId: 'whisper-1',
+          language: 'auto',
+        }),
+        jobTimeoutMs: 2_000,
+      });
+      await expect(
+        deadlineProvider.extract({
+          buffer: await readFile(fixturePath),
+          fileName: 'long-running.mp4',
+          mimeType: 'video/mp4',
+          config: { providerId: 'local-ffmpeg' },
+        }),
+      ).rejects.toThrow(/media extraction job deadline exceeded/);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Adds a local ffmpeg/ffprobe pipeline as a second media extraction provider behind the extractor registry, faithfully ported from the reference implementation (measured line similarity 74% against the reference pipeline; every divergent hunk is an import adjustment, a deployment-specific strip, an upstream API replacement, or the registry-optionality integration — the executable probing and MIME-support helpers survive verbatim).

- **Optional by construction**: availability probing feeds the registry's candidate selection — without ffmpeg/ffprobe the provider is simply not a candidate; with neither ffmpeg nor a cloud provider configured, extraction fails with an actionable message naming both enablement paths. No npm dependency bundles ffmpeg.
- Media materials route through the same extraction lifecycle + lease fence as documents (no parallel queue).
- Tests inject the executable resolver: the missing-ffmpeg path is the default-tested one (CI has no ffmpeg); the real pipeline test is skip-if-unavailable.
- `@openmaic/storage` 0.13.0 → 0.14.0.

Verification: tsc clean, 1084 tests passed (87 files) including the extraction lifecycle and registry suites; the real-pipeline test ran green on a machine with ffmpeg present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)