### PR TITLE
feat(storage): per-scene monotonic revisions via database triggers

### DIFF
--- a/app/api/stages/[id]/freshness/route.ts
+++ b/app/api/stages/[id]/freshness/route.ts
@@ -6,13 +6,13 @@
  * sends the client one frame carrying the current `rev`; the client reacts by
  * pulling the manifest and re-fetching only the scenes that changed.
  *
- * The reference woke this stream from a DB trigger; the upstream storage
- * package exposes no LISTEN/NOTIFY, so this stream POLLS the owner-bound
- * store for the stage's `updatedAt` (the same correctness mechanism as
- * `app/api/agent/owner-events/route.ts`). A frame is emitted when the rev
- * moves; the first frame is sent on connect. `rev` is doc-level (see the
- * manifest route) — the signal is intentionally coarse but honest, and the
- * client's fallback polling still converges independently.
+ * The reference woke this stream from a DB trigger's NOTIFY; the upstream
+ * storage package exposes no LISTEN/NOTIFY, so this stream POLLS the
+ * owner-bound store for the stage's trigger-maintained revision (the same
+ * correctness mechanism as `app/api/agent/owner-events/route.ts`). A frame is
+ * emitted when the rev moves; the first frame is sent on connect. `rev` is the
+ * per-stage monotonic revision the manifest exposes, so a frame that arrives
+ * always reflects the same signal the manifest serves.
  *
  * Degradation is by design: this stream is a pure optimization. A dead or
  * missing stream only costs latency — the client's low-frequency fallback
@@ -54,7 +54,7 @@ export async function GET(req: NextRequest, { params }: Params) {
   // reads a foreign or missing stage as absent, and the 404 carries the
   // owner cookie the same way every response of this family does.
   const store = await getOwnerScopedDocumentStore(ownerId);
-  const initial = await store.loadDocument(stageId);
+  const initial = await store.readFreshnessManifest(stageId);
   if (!initial) return ownerNotFound(responseHeaders);
 
   const encoder = new TextEncoder();
@@ -96,8 +96,8 @@ export async function GET(req: NextRequest, { params }: Params) {
         if (closed) return;
         let rev = 0;
         try {
-          const document = await store.loadDocument(stageId);
-          rev = document ? document.stage.updatedAt : 0;
+          const manifest = await store.readFreshnessManifest(stageId);
+          rev = manifest ? manifest.rev : 0;
         } catch {
           // Fall through to the rev-0 frame.
         }

--- a/app/api/stages/[id]/manifest/route.ts
+++ b/app/api/stages/[id]/manifest/route.ts
@@ -2,15 +2,13 @@
  * GET /api/stages/[id]/manifest — freshness manifest for one course (the
  * reference's `stages/:id/manifest`, ported onto the owner-bound store).
  *
- * Returns `{rev, scenes: [{id, order, rev}]}` — the revision index the
- * workbench canvas diffs against before re-fetching scenes. The upstream
- * store carries no per-scene revisions and adds none (this slice reuses the
- * existing stores), so `rev` is the document's `stage.updatedAt` and every
- * scene shares it: any document-level change invalidates the whole scene set,
- * which is correct if coarser than the reference — the client's manifest diff
- * logic works unchanged and re-fetches exactly the (possibly all) scenes
- * whose rev moved. Writes through this slice's PUT/PATCH bump `updatedAt`, so
- * the UI's own saves drive the signal.
+ * Returns `{rev, scenes: [{id, order, rev}]}` — the per-stage monotonic
+ * revision and each scene's own revision, produced by DB triggers on
+ * `document_stages` / `document_scenes` (provisioned by the storage package's
+ * schema), so every write seam — HTTP routes, agent tools, jobs, manual SQL —
+ * moves them without application cooperation. The workbench canvas diffs this
+ * manifest against what it rendered with and re-fetches only the scenes whose
+ * rev changed.
  *
  * Permission boundary is the same as every stage route: the owner-bound store
  * reads a foreign or missing stage as absent, and both answer the identical
@@ -33,16 +31,8 @@ export async function GET(req: NextRequest, { params }: Params) {
   return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
     const { id } = await params;
     const store = await getOwnerScopedDocumentStore(ownerId);
-    const document = await store.loadDocument(id);
-    if (!document) return ownerNotFound(responseHeaders);
-    const rev = document.stage.updatedAt;
-    return ownerJson(
-      {
-        rev,
-        scenes: document.scenes.map((scene) => ({ id: scene.id, order: scene.order, rev })),
-      },
-      200,
-      responseHeaders,
-    );
+    const manifest = await store.readFreshnessManifest(id);
+    if (!manifest) return ownerNotFound(responseHeaders);
+    return ownerJson(manifest, 200, responseHeaders);
   });
 }

--- a/lib/document-store/plain-json-store.ts
+++ b/lib/document-store/plain-json-store.ts
@@ -11,11 +11,18 @@ export function resetPlainJsonDocumentWritesForTests(): void {
   wrappers = new WeakMap();
 }
 
-export function withPlainJsonDocumentWrites(
-  store: DocumentStore<AppScene, AppStage>,
-): DocumentStore<AppScene, AppStage> {
+/**
+ * Wrap a document store so every write strips undefined-valued members before
+ * persisting (the agent tools' boundary). The wrapper is a Proxy over the
+ * underlying store, so capabilities the `DocumentStore` interface does not
+ * declare (such as the PG store's `readFreshnessManifest`) fall through to the
+ * store itself; the generic return type keeps them visible to callers.
+ */
+export function withPlainJsonDocumentWrites<TStore extends DocumentStore<AppScene, AppStage>>(
+  store: TStore,
+): TStore {
   const existing = wrappers.get(store);
-  if (existing) return existing;
+  if (existing) return existing as TStore;
 
   const methods: DocumentStore<AppScene, AppStage> = {
     saveDocument(document) {
@@ -43,7 +50,7 @@ export function withPlainJsonDocumentWrites(
       return store.deleteScene(stageId, sceneId);
     },
   };
-  const facade = Object.create(Object.getPrototypeOf(store)) as DocumentStore<AppScene, AppStage>;
+  const facade = Object.create(Object.getPrototypeOf(store)) as TStore;
   Object.defineProperties(facade, Object.getOwnPropertyDescriptors(methods));
   const wrapper = new Proxy(facade, {
     get(target, property, receiver) {
@@ -55,5 +62,5 @@ export function withPlainJsonDocumentWrites(
   });
   wrappers.set(store, wrapper);
   wrappers.set(wrapper, wrapper);
-  return wrapper;
+  return wrapper as TStore;
 }

--- a/lib/persistence/owner-bound-document-store.ts
+++ b/lib/persistence/owner-bound-document-store.ts
@@ -111,8 +111,8 @@ class OwnerBoundDocumentStore<TScene extends SceneLike, TStage extends Stage>
   }
 
   /** The trigger-maintained freshness manifest is a read: capability-by-id. */
-  async readStageFreshnessManifest(stageId: string) {
-    return this.readGated(stageId, () => this.inner.readStageFreshnessManifest(stageId));
+  async readFreshnessManifest(stageId: string) {
+    return this.readGated(stageId, () => this.inner.readFreshnessManifest(stageId));
   }
 
   private async readGated<T>(stageId: string, body: () => Promise<T>): Promise<T | null> {

--- a/lib/server/agent-runtime/owner-scoped-documents.ts
+++ b/lib/server/agent-runtime/owner-scoped-documents.ts
@@ -1,9 +1,16 @@
-import type { DocumentStore } from '@openmaic/storage';
+import type { DocumentStore, StageFreshnessManifestStore } from '@openmaic/storage';
 
 import { withPlainJsonDocumentWrites } from '@/lib/document-store/plain-json-store';
 import type { AppStage } from '@/lib/document-store/persistence-types';
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
 import type { AppScene } from '@/lib/types/stage';
+
+/**
+ * The owner-bound document store for one HTTP request, plus the
+ * trigger-maintained freshness manifest read the PG backend provides.
+ */
+export type OwnerScopedDocumentStore = DocumentStore<AppScene, AppStage> &
+  StageFreshnessManifestStore;
 
 /**
  * The owner-bound document store for one HTTP request.
@@ -19,9 +26,9 @@ import type { AppScene } from '@/lib/types/stage';
  */
 export async function getOwnerScopedDocumentStore(
   ownerId: string,
-): Promise<DocumentStore<AppScene, AppStage>> {
+): Promise<OwnerScopedDocumentStore> {
   const { documentStore } = await getServerPersistenceProvider(process.env.DATABASE_URL ?? '');
   return withPlainJsonDocumentWrites(
-    documentStore.forOwner(ownerId) as unknown as DocumentStore<AppScene, AppStage>,
+    documentStore.forOwner(ownerId) as unknown as OwnerScopedDocumentStore,
   );
 }

--- a/lib/server/agent-runtime/owner-scoped-documents.ts
+++ b/lib/server/agent-runtime/owner-scoped-documents.ts
@@ -1,4 +1,8 @@
-import type { DocumentStore, StageFreshnessManifestStore } from '@openmaic/storage';
+import type {
+  DocumentFolderStore,
+  DocumentStore,
+  StageFreshnessManifestStore,
+} from '@openmaic/storage';
 
 import { withPlainJsonDocumentWrites } from '@/lib/document-store/plain-json-store';
 import type { AppStage } from '@/lib/document-store/persistence-types';
@@ -12,6 +16,7 @@ import type { AppScene } from '@/lib/types/stage';
  * trigger-maintained freshness manifest read the PG backend provides.
  */
 export type OwnerScopedDocumentStore = DocumentStore<AppScene, AppStage> &
+  DocumentFolderStore &
   StageFreshnessManifestStore;
 
 /**

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/document/pg.ts
+++ b/packages/@openmaic/storage/src/document/pg.ts
@@ -30,6 +30,8 @@ import type {
   MaicDocument,
   SceneLike,
   SceneValidator,
+  StageFreshnessManifest,
+  StageFreshnessManifestStore,
   StageValidator,
 } from './types.js';
 import { DocumentFolderLimitError, DocumentNotFoundError, DocumentVersionError } from './types.js';
@@ -109,7 +111,187 @@ CREATE TABLE IF NOT EXISTS document_outlines (
   stage_id TEXT PRIMARY KEY REFERENCES document_stages(id) ON DELETE CASCADE,
   data JSONB NOT NULL
 );
+
+-- Per-scene monotonic revision signal, at the DB layer (ported from the
+-- reference implementation's migration 0071).
+--
+-- WHY THE DB LAYER: course content has several write seams that share no
+-- application-level signal (HTTP routes, agent tools, jobs, migration
+-- scripts, manual psql). Only a trigger can make "wrote but never signaled"
+-- unexpressible. These companion tables and triggers keep a monotonic
+-- per-stage revision and a per-scene revision on every insert/update/delete
+-- of document_stages / document_scenes. Companion tables instead of columns
+-- keep the document tables' authoritative DDL untouched.
+--
+-- LOCK ORDER INVARIANT: the scene trigger bumps document_stage_revision (SR)
+-- BEFORE document_scene_revision (SCR) — the same order saveDocument uses
+-- (stage upsert first, then per-scene upserts). Any future code that writes
+-- these two companion tables must take SR before SCR, or the deadlock (40P01)
+-- between concurrent stage-first and scene-first writers comes back.
+--
+-- NOTIFY: each bump emits a JSON route {kind:'stage',stageId} on the
+-- agent-event wakeup channel (the same channel the reference's agent event
+-- notify bus LISTENs on), so a stage notification wakes exactly the
+-- subscribers listening for that stage. The payload is built with
+-- json_build_object — never hand-concatenated, because a stageId containing
+-- quotes or backslashes would yield invalid JSON.
+--
+-- NOTIFY SUPPRESSION SWITCH: both triggers check
+-- current_setting('openmaic.suppress_stage_notify', true) before pg_notify.
+-- Batch/backfill writers MUST run SET LOCAL openmaic.suppress_stage_notify =
+-- 'on' inside each batch transaction: the revision still bumps, only the
+-- notification is skipped. NOTE: SET LOCAL outside a transaction block only
+-- emits a warning and has NO effect.
+--
+-- TRUNCATE DOES NOT FIRE ROW TRIGGERS: a TRUNCATE reset of document_scenes /
+-- document_stages leaves the companion revision rows behind, so any TRUNCATE
+-- reset must also truncate document_scene_revision and
+-- document_stage_revision.
+--
+-- IDEMPOTENT BY CONSTRUCTION: CREATE TABLE IF NOT EXISTS, CREATE OR REPLACE
+-- FUNCTION, DROP TRIGGER IF EXISTS — replayable in any environment.
+
+CREATE TABLE IF NOT EXISTS document_stage_revision (
+  stage_id TEXT PRIMARY KEY NOT NULL,
+  rev BIGINT DEFAULT 0 NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS document_scene_revision (
+  stage_id TEXT NOT NULL,
+  scene_id TEXT NOT NULL,
+  rev BIGINT DEFAULT 0 NOT NULL,
+  CONSTRAINT document_scene_revision_pkey PRIMARY KEY (stage_id, scene_id)
+);
+
+CREATE OR REPLACE FUNCTION openmaic_bump_scene_revision() RETURNS trigger AS $$
+DECLARE
+  v_stage_id text;
+  v_scene_id text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_stage_id := OLD.stage_id;
+    v_scene_id := OLD.id;
+  ELSE
+    v_stage_id := NEW.stage_id;
+    v_scene_id := NEW.id;
+  END IF;
+  -- LOCK ORDER INVARIANT: SR row BEFORE the SCR row (see the header comment).
+  INSERT INTO document_stage_revision (stage_id, rev)
+  VALUES (v_stage_id, 1)
+  ON CONFLICT (stage_id) DO UPDATE SET rev = document_stage_revision.rev + 1;
+  INSERT INTO document_scene_revision (stage_id, scene_id, rev)
+  VALUES (v_stage_id, v_scene_id, 1)
+  ON CONFLICT (stage_id, scene_id) DO UPDATE SET rev = document_scene_revision.rev + 1;
+  IF coalesce(current_setting('openmaic.suppress_stage_notify', true), '') <> 'on' THEN
+    PERFORM pg_notify('openmaic_agent_event_wakeup', json_build_object('kind', 'stage', 'stageId', v_stage_id)::text);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION openmaic_bump_stage_revision() RETURNS trigger AS $$
+DECLARE
+  v_stage_id text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_stage_id := OLD.id;
+  ELSE
+    v_stage_id := NEW.id;
+  END IF;
+  INSERT INTO document_stage_revision (stage_id, rev)
+  VALUES (v_stage_id, 1)
+  ON CONFLICT (stage_id) DO UPDATE SET rev = document_stage_revision.rev + 1;
+  IF coalesce(current_setting('openmaic.suppress_stage_notify', true), '') <> 'on' THEN
+    PERFORM pg_notify('openmaic_agent_event_wakeup', json_build_object('kind', 'stage', 'stageId', v_stage_id)::text);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS openmaic_scene_revision_trigger ON document_scenes;
+
+CREATE TRIGGER openmaic_scene_revision_trigger
+AFTER INSERT OR UPDATE OR DELETE ON document_scenes
+FOR EACH ROW EXECUTE FUNCTION openmaic_bump_scene_revision();
+
+DROP TRIGGER IF EXISTS openmaic_stage_revision_trigger ON document_stages;
+
+CREATE TRIGGER openmaic_stage_revision_trigger
+AFTER INSERT OR UPDATE OR DELETE ON document_stages
+FOR EACH ROW EXECUTE FUNCTION openmaic_bump_stage_revision();
 `;
+
+/**
+ * Split a DDL string into individual statements. A plain `split(';')` would
+ * carve the `BEGIN ... END;` blocks inside the dollar-quoted plpgsql trigger
+ * bodies into bogus statements, so the splitter skips over single-quoted
+ * strings, double-quoted identifiers, `$$...$$` / `$tag$...$tag$` bodies, and
+ * `--` line comments and slash-star block comments.
+ */
+export function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let i = 0;
+  const end = sql.length;
+  while (i < end) {
+    const rest = sql.slice(i);
+    const ch = sql[i];
+    if (ch === ';') {
+      statements.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+    if (ch === '-' && rest.startsWith('--')) {
+      const newline = rest.indexOf('\n');
+      const lineEnd = newline === -1 ? end : i + newline + 1;
+      current += sql.slice(i, lineEnd);
+      i = lineEnd;
+      continue;
+    }
+    if (ch === '/' && rest.startsWith('/*')) {
+      const close = rest.indexOf('*/', 2);
+      const blockEnd = close === -1 ? end : i + close + 2;
+      current += sql.slice(i, blockEnd);
+      i = blockEnd;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      // Single-quoted string literal or double-quoted identifier; the quote
+      // is escaped by doubling, and an unterminated run consumes the rest.
+      current += ch;
+      i += 1;
+      while (i < end) {
+        current += sql[i];
+        if (sql[i] === ch) {
+          if (sql[i + 1] === ch) {
+            current += sql[i + 1];
+            i += 2;
+            continue;
+          }
+          i += 1;
+          break;
+        }
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === '$') {
+      const tag = /^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/.exec(rest)?.[0];
+      if (tag) {
+        const close = rest.indexOf(tag, tag.length);
+        if (close !== -1) {
+          current += rest.slice(0, close + tag.length);
+          i += close + tag.length;
+          continue;
+        }
+      }
+    }
+    current += ch;
+    i += 1;
+  }
+  return statements.map((statement) => statement.trim()).filter((statement) => statement !== '');
+}
 
 /**
  * Create the tables owned by this backend when absent. Safe to call repeatedly;
@@ -117,10 +299,59 @@ CREATE TABLE IF NOT EXISTS document_outlines (
  */
 export async function ensureDocumentSchema(queryable: Queryable): Promise<void> {
   // Keep Queryable minimal and PGlite-compatible: issue one statement at a time.
-  for (const sql of DOCUMENT_PG_SCHEMA.split(';')) {
-    const statement = sql.trim();
-    if (statement !== '') await queryable.query(statement);
+  for (const statement of splitSqlStatements(DOCUMENT_PG_SCHEMA)) {
+    await queryable.query(statement);
   }
+}
+
+const STAGE_REV_SQL = `
+  SELECT rev
+    FROM document_stage_revision
+   WHERE stage_id = $1
+`;
+
+const SCENES_SQL = `
+  SELECT s.id,
+         s.scene_order,
+         COALESCE(sr.rev, 0) AS rev
+    FROM document_scenes s
+    LEFT JOIN document_scene_revision sr
+      ON sr.stage_id = s.stage_id
+     AND sr.scene_id = s.id
+   WHERE s.stage_id = $1
+   ORDER BY s.scene_order ASC, s.id ASC
+`;
+
+/**
+ * Read the freshness manifest for one stage: the stage's monotonic revision
+ * plus every live scene's id/order/rev, produced by the triggers provisioned
+ * in `DOCUMENT_PG_SCHEMA`. A stage with no revision row yet reads as `rev: 0`
+ * (written before the triggers existed, or never written since); a scene the
+ * trigger never bumped also reads 0. Callers gate existence/visibility first
+ * (the owner-bound store method does), so this function assumes the stage
+ * exists and does not re-check it. Kept free of driver imports so the whole
+ * read is unit-testable against any queryable.
+ */
+export async function readStageFreshnessManifest(
+  stageId: string,
+  queryable: Queryable,
+): Promise<StageFreshnessManifest> {
+  const [stageRows, sceneRows] = await Promise.all([
+    queryable.query<{ rev: number | string }>(STAGE_REV_SQL, [stageId]),
+    queryable.query<{ id: string; scene_order: number | string; rev: number | string }>(
+      SCENES_SQL,
+      [stageId],
+    ),
+  ]);
+
+  return {
+    rev: stageRows.rows[0] === undefined ? 0 : Number(stageRows.rows[0].rev),
+    scenes: sceneRows.rows.map((row) => ({
+      id: row.id,
+      order: Number(row.scene_order),
+      rev: Number(row.rev),
+    })),
+  };
 }
 
 interface StoredJsonRow extends Record<string, unknown> {
@@ -225,7 +456,7 @@ function isPgQueryableKey(value: string): boolean {
 }
 
 export class PgDocumentStore<TScene extends SceneLike = Scene, TStage extends Stage = Stage>
-  implements DocumentStore<TScene, TStage>, DocumentFolderStore
+  implements DocumentStore<TScene, TStage>, DocumentFolderStore, StageFreshnessManifestStore
 {
   private readonly queryable: Queryable;
   private readonly transactionHook: WithTransaction;
@@ -494,6 +725,23 @@ export class PgDocumentStore<TScene extends SceneLike = Scene, TStage extends St
     const rows = await this.transaction((queryable) => this.loadRows(queryable, stageId));
     if (!rows) return null;
     return migrateDocument(reassembleDocument(rows.stageRow, rows.sceneRows, rows.outlineRow));
+  }
+
+  async readFreshnessManifest(stageId: string): Promise<StageFreshnessManifest | null> {
+    if (!isPgQueryableKey(stageId)) return null;
+    return this.transaction(async (queryable) => {
+      // Existence and ownership gate, exactly like loadDocument: a foreign or
+      // missing stage answers the same null. The revision read itself is
+      // un-scoped (readStageFreshnessManifest assumes the stage exists).
+      const scoped = await queryable.query<{ id: string }>(
+        `SELECT id
+           FROM document_stages
+          WHERE id = $1 AND ${this.scopePredicate('', 2)}`,
+        this.scopeParams(stageId),
+      );
+      if (scoped.rows.length === 0) return null;
+      return readStageFreshnessManifest(stageId, queryable);
+    });
   }
 
   async createFolder(

--- a/packages/@openmaic/storage/src/document/types.ts
+++ b/packages/@openmaic/storage/src/document/types.ts
@@ -215,3 +215,40 @@ export interface DocumentStore<TScene extends SceneLike = Scene, TStage extends 
    */
   deleteScene(stageId: string, sceneId: string): Promise<void>;
 }
+
+/** One scene's entry in a stage freshness manifest. */
+export interface StageSceneManifest {
+  id: string;
+  /** `document_scenes.scene_order`, the presentation order. */
+  order: number;
+  /** Monotonic per-(stage, scene) revision; 0 when the trigger never bumped it. */
+  rev: number;
+}
+
+/**
+ * The freshness manifest for one stage: a stage-level monotonic revision plus
+ * each live scene's own revision. Both are maintained by the DB triggers on
+ * `document_stages` / `document_scenes` (provisioned by `DOCUMENT_PG_SCHEMA`),
+ * so every write seam — HTTP routes, agent tools, jobs, manual SQL — moves
+ * them without application cooperation.
+ */
+export interface StageFreshnessManifest {
+  /** Monotonic per-stage revision; 0 when the trigger never bumped it. */
+  rev: number;
+  scenes: StageSceneManifest[];
+}
+
+/**
+ * The trigger-maintained freshness manifest read. Available only on DB-backed
+ * stores whose schema provisions the revision companion tables (the PG
+ * backend) — never on the browser or HTTP backends — mirroring
+ * `DocumentFolderStore`'s "bound server store only" rule.
+ */
+export interface StageFreshnessManifestStore {
+  /**
+   * Read the owner-scoped freshness manifest for one stage. `null` when the
+   * stage is absent from this store's scope (the same no-existence-oracle
+   * posture as `loadDocument`).
+   */
+  readFreshnessManifest(stageId: string): Promise<StageFreshnessManifest | null>;
+}

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -88,6 +88,9 @@ export type {
   SceneLike,
   SceneValidator,
   StageValidator,
+  StageSceneManifest,
+  StageFreshnessManifest,
+  StageFreshnessManifestStore,
 } from './document/types.js';
 export {
   DocumentFolderLimitError,
@@ -106,6 +109,8 @@ export {
   PgDocumentStore,
   DOCUMENT_PG_SCHEMA,
   ensureDocumentSchema,
+  readStageFreshnessManifest,
+  splitSqlStatements,
   type PgDocumentStoreOptions,
 } from './document/pg.js';
 

--- a/packages/@openmaic/storage/test/pg-document-contract-helpers.ts
+++ b/packages/@openmaic/storage/test/pg-document-contract-helpers.ts
@@ -1,0 +1,65 @@
+import type { Pool } from 'pg';
+
+import type { Queryable } from '../src/runtime/pg.js';
+
+/**
+ * Shared infrastructure for the PostgreSQL document contract suites.
+ *
+ * The suites live in one file per concern (document store, scene revisions)
+ * and share ONE PostgreSQL database, exactly as the PG16 CI job provisions it.
+ */
+
+/**
+ * Postgres advisory-lock key that makes the document PG suites mutually
+ * exclusive. Any fixed value works; this one is just a documented constant,
+ * distinct from the agent-session suites' key.
+ */
+export const DOCUMENT_PG_CONTRACT_LOCK_KEY = 91_110_601;
+
+/**
+ * Serialize the document PG suites on the shared database.
+ *
+ * Both suites provision the SAME document schema in `beforeAll`
+ * (`document_stages`, `document_scenes`, the revision companion tables, and
+ * the `CREATE OR REPLACE FUNCTION` / `CREATE TRIGGER` statements that
+ * reference them). Concurrent provisioning from two vitest processes races on
+ * the shared catalog rows ("tuple concurrently updated"), so the suites must
+ * never run at the same time. A JS-level lock cannot express this (vitest runs
+ * each file in its own process), but a Postgres advisory lock can: it is scoped
+ * to a database connection, so it serializes across processes.
+ *
+ * Call this in `beforeAll`, keep the returned release function for `afterAll`,
+ * and give the hook a generous timeout (the waiting suite blocks for the whole
+ * duration of the other suite). Every suite that provisions the document
+ * schema must take this lock, or a full-suite run becomes scheduling-dependent.
+ */
+export async function acquireDocumentPgContractLock(pool: Pool): Promise<() => Promise<void>> {
+  const client = await pool.connect();
+  try {
+    await client.query('SELECT pg_advisory_lock($1)', [DOCUMENT_PG_CONTRACT_LOCK_KEY]);
+  } catch (error) {
+    client.release();
+    throw error;
+  }
+  return async () => {
+    try {
+      await client.query('SELECT pg_advisory_unlock($1)', [DOCUMENT_PG_CONTRACT_LOCK_KEY]);
+    } finally {
+      client.release();
+    }
+  };
+}
+
+/**
+ * Empty every document-owned table between PostgreSQL contract tests.
+ *
+ * TRUNCATE does not fire row triggers, so the revision companion tables must
+ * be truncated alongside the rows that would bump them — otherwise a stale
+ * revision row makes the next test read a revision the trigger never produced.
+ */
+export async function truncateDocumentTables(queryable: Queryable): Promise<void> {
+  await queryable.query(
+    `TRUNCATE document_outlines, document_scenes, document_stages,
+            document_scene_revision, document_stage_revision`,
+  );
+}

--- a/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-document-store.pg.test.ts
@@ -6,6 +6,10 @@ import {
   type Queryable,
   type WithTransaction,
 } from '../src/document/pg.js';
+import {
+  acquireDocumentPgContractLock,
+  truncateDocumentTables,
+} from './pg-document-contract-helpers.js';
 import { runDocumentStoreContract } from './document-contract.js';
 
 const contractUrl = process.env.PG_CONTRACT_URL;
@@ -41,18 +45,24 @@ function transactionFor(pool: Pool): WithTransaction {
 describe.skipIf(!contractUrl)('PgDocumentStore with PostgreSQL 16', () => {
   let pool: Pool;
   let store: PgDocumentStore;
+  let releaseContractLock: (() => Promise<void>) | undefined;
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: contractUrl, max: 16 });
+    // Same shared-database lock as the scene-revision suite: both suites
+    // provision the same document schema (functions and triggers included),
+    // so they must never run at the same time.
+    releaseContractLock = await acquireDocumentPgContractLock(pool);
     await ensureDocumentSchema(pool as Queryable);
-  });
+  }, 60_000);
 
   beforeEach(async () => {
-    await pool.query('TRUNCATE document_outlines, document_scenes, document_stages');
+    await truncateDocumentTables(pool as Queryable);
     store = new PgDocumentStore(pool as Queryable, { withTransaction: transactionFor(pool) });
   });
 
   afterAll(async () => {
+    await releaseContractLock?.();
     await pool.end();
   });
 

--- a/packages/@openmaic/storage/test/pg-scene-revision.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-scene-revision.pg.test.ts
@@ -1,0 +1,276 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Pool } from 'pg';
+import {
+  PgDocumentStore,
+  ensureDocumentSchema,
+  type Queryable,
+  type WithTransaction,
+} from '../src/document/pg.js';
+import type { MaicDocument, StageFreshnessManifest } from '../src/document/types.js';
+import {
+  acquireDocumentPgContractLock,
+  truncateDocumentTables,
+} from './pg-document-contract-helpers.js';
+import { slideScene } from './document-contract.js';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+if (process.env.STORAGE_PG_CONTRACT_REQUIRED === '1' && !contractUrl) {
+  throw new Error(
+    '@openmaic/storage: STORAGE_PG_CONTRACT_REQUIRED=1 requires PG_CONTRACT_URL; ' +
+      'refusing to skip the PostgreSQL contract suite',
+  );
+}
+
+function transactionFor(pool: Pool): WithTransaction {
+  return async (body) => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await body(client as Queryable);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the transaction body's original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+}
+
+const OWNER = 'owner-1';
+
+/** A document whose scenes are exactly the given ids, in the given orders. */
+function makeDoc(stageId: string, scenes: { id: string; order: number }[]): MaicDocument {
+  return {
+    stage: { id: stageId, name: 'Course', createdAt: 1000, updatedAt: 2000 },
+    scenes: scenes.map((scene) => slideScene(stageId, scene.id, scene.order)),
+    outline: { entries: [{ id: 'o1', title: 'Intro' }], generationComplete: true },
+  };
+}
+
+/** The manifest row for one scene, straight from the companion table. */
+async function sceneRev(pool: Pool, stageId: string, sceneId: string): Promise<number> {
+  const result = await pool.query<{ rev: number | string }>(
+    'SELECT rev FROM document_scene_revision WHERE stage_id = $1 AND scene_id = $2',
+    [stageId, sceneId],
+  );
+  return result.rows[0] === undefined ? 0 : Number(result.rows[0].rev);
+}
+
+async function stageRev(pool: Pool, stageId: string): Promise<number> {
+  const result = await pool.query<{ rev: number | string }>(
+    'SELECT rev FROM document_stage_revision WHERE stage_id = $1',
+    [stageId],
+  );
+  return result.rows[0] === undefined ? 0 : Number(result.rows[0].rev);
+}
+
+describe.skipIf(!contractUrl)('per-scene monotonic revisions (freshness)', () => {
+  let pool: Pool;
+  let ownerStore: PgDocumentStore;
+  let releaseContractLock: (() => Promise<void>) | undefined;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl, max: 16 });
+    // Same shared-database lock as the document-store suite: both suites
+    // provision the same document schema (functions and triggers included),
+    // so they must never run at the same time.
+    releaseContractLock = await acquireDocumentPgContractLock(pool);
+    await ensureDocumentSchema(pool as Queryable);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await truncateDocumentTables(pool as Queryable);
+    ownerStore = new PgDocumentStore(pool as Queryable, {
+      withTransaction: transactionFor(pool),
+    }).forOwner(OWNER);
+  });
+
+  afterAll(async () => {
+    await releaseContractLock?.();
+    await pool.end();
+  });
+
+  const readManifest = (stageId: string): Promise<StageFreshnessManifest | null> =>
+    ownerStore.readFreshnessManifest(stageId);
+
+  it('HTTP route write (saveDocument) bumps the scene revisions of the stage and nothing else', async () => {
+    const stageId = 'http-route-stage';
+    const otherStage = 'http-route-other';
+    await ownerStore.saveDocument(
+      makeDoc(stageId, [
+        { id: 's1', order: 1 },
+        { id: 's2', order: 2 },
+      ]),
+    );
+    await ownerStore.saveDocument(makeDoc(otherStage, [{ id: 'x1', order: 1 }]));
+
+    expect(await readManifest(stageId)).toEqual({
+      rev: 3,
+      scenes: [
+        { id: 's1', order: 1, rev: 1 },
+        { id: 's2', order: 2, rev: 1 },
+      ],
+    });
+
+    // A second coarse save rewrites every scene row of this stage, so every
+    // scene's revision strictly increases...
+    await ownerStore.saveDocument(
+      makeDoc(stageId, [
+        { id: 's1', order: 3 },
+        { id: 's2', order: 2 },
+      ]),
+    );
+    const second = (await readManifest(stageId))!;
+    expect(second.rev).toBe(6);
+    expect(second.scenes.find((scene) => scene.id === 's1')!.rev).toBe(2);
+    expect(second.scenes.find((scene) => scene.id === 's2')!.rev).toBe(2);
+
+    // ...while an unrelated stage's revisions are untouched.
+    expect(await readManifest(otherStage)).toEqual({
+      rev: 2,
+      scenes: [{ id: 'x1', order: 1, rev: 1 }],
+    });
+  });
+
+  it('HTTP route rename (putStage) bumps the stage revision but no scene revision', async () => {
+    const stageId = 'http-route-rename';
+    await ownerStore.saveDocument(makeDoc(stageId, [{ id: 's1', order: 1 }]));
+    const before = (await readManifest(stageId))!;
+    expect(before).toEqual({ rev: 2, scenes: [{ id: 's1', order: 1, rev: 1 }] });
+
+    await ownerStore.putStage(stageId, {
+      id: stageId,
+      name: 'Renamed',
+      createdAt: 1000,
+      updatedAt: 3000,
+    });
+    const after = (await readManifest(stageId))!;
+    expect(after.rev).toBe(3);
+    expect(after.scenes).toEqual([{ id: 's1', order: 1, rev: 1 }]);
+  });
+
+  it('owner-scoped store write as agent tools use (putScene) bumps only the touched scene', async () => {
+    const stageId = 'agent-put-scene';
+    await ownerStore.saveDocument(
+      makeDoc(stageId, [
+        { id: 's1', order: 1 },
+        { id: 's2', order: 2 },
+      ]),
+    );
+    expect(await sceneRev(pool, stageId, 's1')).toBe(1);
+    expect(await sceneRev(pool, stageId, 's2')).toBe(1);
+    expect(await stageRev(pool, stageId)).toBe(3);
+
+    // The generation tools edit one page at a time via putScene.
+    await ownerStore.putScene(stageId, slideScene(stageId, 's1', 4));
+
+    expect(await sceneRev(pool, stageId, 's1')).toBe(2);
+    expect(await sceneRev(pool, stageId, 's2')).toBe(1);
+    expect(await stageRev(pool, stageId)).toBe(4);
+
+    // A brand-new scene starts at revision 1; siblings stay put.
+    await ownerStore.putScene(stageId, slideScene(stageId, 's3', 3));
+    expect(await sceneRev(pool, stageId, 's3')).toBe(1);
+    expect(await sceneRev(pool, stageId, 's1')).toBe(2);
+    expect(await stageRev(pool, stageId)).toBe(5);
+  });
+
+  it('direct SQL UPDATE bumps the touched scene via the trigger, without the store', async () => {
+    const stageId = 'direct-sql';
+    await ownerStore.saveDocument(
+      makeDoc(stageId, [
+        { id: 's1', order: 1 },
+        { id: 's2', order: 2 },
+      ]),
+    );
+    expect(await sceneRev(pool, stageId, 's1')).toBe(1);
+
+    // A manual or batch writer that bypasses the store entirely.
+    await pool.query(
+      'UPDATE document_scenes SET scene_order = $3 WHERE stage_id = $1 AND id = $2',
+      [stageId, 's1', 9],
+    );
+    expect(await sceneRev(pool, stageId, 's1')).toBe(2);
+    expect(await sceneRev(pool, stageId, 's2')).toBe(1);
+    expect(await stageRev(pool, stageId)).toBe(4);
+
+    // A direct stage write bumps the stage revision and leaves scenes alone.
+    await pool.query('UPDATE document_stages SET name = $2 WHERE id = $1', [stageId, 'Manual']);
+    expect(await stageRev(pool, stageId)).toBe(5);
+    expect(await sceneRev(pool, stageId, 's1')).toBe(2);
+    expect(await sceneRev(pool, stageId, 's2')).toBe(1);
+  });
+
+  it('deleteScene bumps the stage revision and removes the scene entry', async () => {
+    const stageId = 'agent-delete-scene';
+    await ownerStore.saveDocument(
+      makeDoc(stageId, [
+        { id: 's1', order: 1 },
+        { id: 's2', order: 2 },
+      ]),
+    );
+    await ownerStore.deleteScene(stageId, 's2');
+
+    const manifest = (await readManifest(stageId))!;
+    expect(manifest.rev).toBe(4);
+    expect(manifest.scenes).toEqual([{ id: 's1', order: 1, rev: 1 }]);
+    expect(await sceneRev(pool, stageId, 's1')).toBe(1);
+  });
+
+  it('reads rev 0 for rows the trigger never bumped (companion rows truncated)', async () => {
+    const stageId = 'gap-stage';
+    await ownerStore.saveDocument(makeDoc(stageId, [{ id: 's1', order: 1 }]));
+    // Simulate rows written before the trigger existed: wipe the companion
+    // tables while leaving the document rows behind.
+    await pool.query('TRUNCATE document_scene_revision, document_stage_revision');
+
+    expect(await readManifest(stageId)).toEqual({
+      rev: 0,
+      scenes: [{ id: 's1', order: 1, rev: 0 }],
+    });
+  });
+
+  it('answers null for a missing or foreign stage', async () => {
+    await ownerStore.saveDocument(makeDoc('owned-stage', [{ id: 's1', order: 1 }]));
+    expect(await readManifest('absent-stage')).toBeNull();
+    // A different owner cannot read this owner's manifest.
+    const otherOwner = new PgDocumentStore(pool as Queryable, {
+      withTransaction: transactionFor(pool),
+    }).forOwner('owner-2');
+    expect(await otherOwner.readFreshnessManifest('owned-stage')).toBeNull();
+  });
+
+  it('fault injection: without the triggers the revisions do not move (the signal is DB-borne)', async () => {
+    // This is the suite's mutation guard: every other test in this file
+    // asserts that writes DO move the revisions; this one proves that motion
+    // comes from the triggers and nowhere else. With the triggers dropped, the
+    // same write leaves the companion tables untouched — so a future change
+    // that silently removes the trigger provisioning makes every other test
+    // here fail, and this one still passes, pinning the mechanism in place.
+    const stageId = 'fault-injection';
+    await ownerStore.saveDocument(makeDoc(stageId, [{ id: 's1', order: 1 }]));
+    expect(await sceneRev(pool, stageId, 's1')).toBe(1);
+
+    await pool.query('DROP TRIGGER IF EXISTS openmaic_scene_revision_trigger ON document_scenes');
+    await pool.query('DROP TRIGGER IF EXISTS openmaic_stage_revision_trigger ON document_stages');
+    try {
+      await pool.query(
+        'UPDATE document_scenes SET scene_order = $3 WHERE stage_id = $1 AND id = $2',
+        [stageId, 's1', 5],
+      );
+      expect(await sceneRev(pool, stageId, 's1')).toBe(1);
+      expect(await stageRev(pool, stageId)).toBe(2);
+    } finally {
+      // Restore the triggers so the next test starts from the provisioned
+      // schema; ensureDocumentSchema is idempotent.
+      await ensureDocumentSchema(pool as Queryable);
+    }
+  });
+});

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { AGENT_SESSION_PG_SCHEMA, ensureAgentSessionSchema } from '../src/agent-session/pg.js';
-import { DOCUMENT_PG_SCHEMA, ensureDocumentSchema } from '../src/document/pg.js';
+import {
+  DOCUMENT_PG_SCHEMA,
+  ensureDocumentSchema,
+  splitSqlStatements,
+} from '../src/document/pg.js';
 import { RUNTIME_PG_SCHEMA, ensureSchema } from '../src/runtime/pg.js';
 import { USER_SKILL_PG_SCHEMA, ensureUserSkillSchema } from '../src/skill/pg.js';
 import {
@@ -89,6 +93,114 @@ CREATE TABLE IF NOT EXISTS document_outlines (
   stage_id TEXT PRIMARY KEY REFERENCES document_stages(id) ON DELETE CASCADE,
   data JSONB NOT NULL
 );
+
+-- Per-scene monotonic revision signal, at the DB layer (ported from the
+-- reference implementation's migration 0071).
+--
+-- WHY THE DB LAYER: course content has several write seams that share no
+-- application-level signal (HTTP routes, agent tools, jobs, migration
+-- scripts, manual psql). Only a trigger can make "wrote but never signaled"
+-- unexpressible. These companion tables and triggers keep a monotonic
+-- per-stage revision and a per-scene revision on every insert/update/delete
+-- of document_stages / document_scenes. Companion tables instead of columns
+-- keep the document tables' authoritative DDL untouched.
+--
+-- LOCK ORDER INVARIANT: the scene trigger bumps document_stage_revision (SR)
+-- BEFORE document_scene_revision (SCR) — the same order saveDocument uses
+-- (stage upsert first, then per-scene upserts). Any future code that writes
+-- these two companion tables must take SR before SCR, or the deadlock (40P01)
+-- between concurrent stage-first and scene-first writers comes back.
+--
+-- NOTIFY: each bump emits a JSON route {kind:'stage',stageId} on the
+-- agent-event wakeup channel (the same channel the reference's agent event
+-- notify bus LISTENs on), so a stage notification wakes exactly the
+-- subscribers listening for that stage. The payload is built with
+-- json_build_object — never hand-concatenated, because a stageId containing
+-- quotes or backslashes would yield invalid JSON.
+--
+-- NOTIFY SUPPRESSION SWITCH: both triggers check
+-- current_setting('openmaic.suppress_stage_notify', true) before pg_notify.
+-- Batch/backfill writers MUST run SET LOCAL openmaic.suppress_stage_notify =
+-- 'on' inside each batch transaction: the revision still bumps, only the
+-- notification is skipped. NOTE: SET LOCAL outside a transaction block only
+-- emits a warning and has NO effect.
+--
+-- TRUNCATE DOES NOT FIRE ROW TRIGGERS: a TRUNCATE reset of document_scenes /
+-- document_stages leaves the companion revision rows behind, so any TRUNCATE
+-- reset must also truncate document_scene_revision and
+-- document_stage_revision.
+--
+-- IDEMPOTENT BY CONSTRUCTION: CREATE TABLE IF NOT EXISTS, CREATE OR REPLACE
+-- FUNCTION, DROP TRIGGER IF EXISTS — replayable in any environment.
+
+CREATE TABLE IF NOT EXISTS document_stage_revision (
+  stage_id TEXT PRIMARY KEY NOT NULL,
+  rev BIGINT DEFAULT 0 NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS document_scene_revision (
+  stage_id TEXT NOT NULL,
+  scene_id TEXT NOT NULL,
+  rev BIGINT DEFAULT 0 NOT NULL,
+  CONSTRAINT document_scene_revision_pkey PRIMARY KEY (stage_id, scene_id)
+);
+
+CREATE OR REPLACE FUNCTION openmaic_bump_scene_revision() RETURNS trigger AS $$
+DECLARE
+  v_stage_id text;
+  v_scene_id text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_stage_id := OLD.stage_id;
+    v_scene_id := OLD.id;
+  ELSE
+    v_stage_id := NEW.stage_id;
+    v_scene_id := NEW.id;
+  END IF;
+  -- LOCK ORDER INVARIANT: SR row BEFORE the SCR row (see the header comment).
+  INSERT INTO document_stage_revision (stage_id, rev)
+  VALUES (v_stage_id, 1)
+  ON CONFLICT (stage_id) DO UPDATE SET rev = document_stage_revision.rev + 1;
+  INSERT INTO document_scene_revision (stage_id, scene_id, rev)
+  VALUES (v_stage_id, v_scene_id, 1)
+  ON CONFLICT (stage_id, scene_id) DO UPDATE SET rev = document_scene_revision.rev + 1;
+  IF coalesce(current_setting('openmaic.suppress_stage_notify', true), '') <> 'on' THEN
+    PERFORM pg_notify('openmaic_agent_event_wakeup', json_build_object('kind', 'stage', 'stageId', v_stage_id)::text);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION openmaic_bump_stage_revision() RETURNS trigger AS $$
+DECLARE
+  v_stage_id text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_stage_id := OLD.id;
+  ELSE
+    v_stage_id := NEW.id;
+  END IF;
+  INSERT INTO document_stage_revision (stage_id, rev)
+  VALUES (v_stage_id, 1)
+  ON CONFLICT (stage_id) DO UPDATE SET rev = document_stage_revision.rev + 1;
+  IF coalesce(current_setting('openmaic.suppress_stage_notify', true), '') <> 'on' THEN
+    PERFORM pg_notify('openmaic_agent_event_wakeup', json_build_object('kind', 'stage', 'stageId', v_stage_id)::text);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS openmaic_scene_revision_trigger ON document_scenes;
+
+CREATE TRIGGER openmaic_scene_revision_trigger
+AFTER INSERT OR UPDATE OR DELETE ON document_scenes
+FOR EACH ROW EXECUTE FUNCTION openmaic_bump_scene_revision();
+
+DROP TRIGGER IF EXISTS openmaic_stage_revision_trigger ON document_stages;
+
+CREATE TRIGGER openmaic_stage_revision_trigger
+AFTER INSERT OR UPDATE OR DELETE ON document_stages
+FOR EACH ROW EXECUTE FUNCTION openmaic_bump_stage_revision();
 `;
 
 const EXPECTED_RUNTIME_PG_SCHEMA = `
@@ -300,10 +412,9 @@ function recordingQueryable(): { statements: string[]; queryable: Queryable } {
 }
 
 function statementsOf(schema: string): string[] {
-  return schema
-    .split(';')
-    .map((statement) => statement.trim())
-    .filter((statement) => statement !== '');
+  // Same splitter the ensure functions run: plain `split(';')` would carve the
+  // dollar-quoted plpgsql trigger bodies into bogus statements.
+  return splitSqlStatements(schema);
 }
 
 const schemas = [
@@ -367,16 +478,21 @@ describe.each(schemas)('$name is a pinned contract', ({ name, actual, expected, 
   });
 
   it('keeps every statement guarded so the ensure functions stay idempotent', () => {
-    const statements = actual
-      .split(';')
-      .map((statement) => statement.trim())
-      .filter((statement) => statement !== '');
+    const statements = splitSqlStatements(actual);
 
     expect(statements.length).toBeGreaterThan(0);
     for (const statement of statements) {
+      // The splitter keeps leading `--` comment lines attached to the
+      // statement that follows them; strip them before judging the DDL.
+      const sql = statement.replace(/^(--[^\n]*\n?)+/, '').trim();
       expect(
-        /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(statement) ||
-          /^ALTER TABLE [a-z_]+\s+ADD COLUMN IF NOT EXISTS /.test(statement),
+        /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(sql) ||
+          /^ALTER TABLE [a-z_]+\s+ADD COLUMN IF NOT EXISTS /.test(sql) ||
+          /^CREATE OR REPLACE FUNCTION /.test(sql) ||
+          /^DROP TRIGGER IF EXISTS /.test(sql) ||
+          // CREATE TRIGGER is made idempotent by the paired DROP TRIGGER IF
+          // EXISTS that precedes it in the same schema constant.
+          /^CREATE TRIGGER /.test(sql),
         `${name} statement is not an idempotent create or additive migration: ${statement}`,
       ).toBe(true);
     }

--- a/scripts/assert-pg-contract-suites.mjs
+++ b/scripts/assert-pg-contract-suites.mjs
@@ -61,6 +61,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 const REQUIRED_SUITES = [
   'packages/@openmaic/storage/test/pg-document-store.pg.test.ts',
   'packages/@openmaic/storage/test/pg-runtime-store.pg.test.ts',
+  'packages/@openmaic/storage/test/pg-scene-revision.pg.test.ts',
 ];
 
 /**
@@ -73,6 +74,8 @@ const REQUIRED_TABLES = [
   'document_stages',
   'document_scenes',
   'document_outlines',
+  'document_stage_revision',
+  'document_scene_revision',
   'runtime_sessions',
   'runtime_records',
 ];
@@ -309,8 +312,8 @@ if (databaseFailures.length > 0) {
 }
 
 console.log(
-  `Verified: both contract suite files ran and passed, and all ${REQUIRED_TABLES.length} tables ` +
-    'the two PostgreSQL backends own gained inserts in a real database during this run. ' +
+  `Verified: the required contract suite files ran and passed, and all ${REQUIRED_TABLES.length} ` +
+    'tables the PostgreSQL backends own gained inserts in a real database during this run. ' +
     'This does not attribute those inserts to the built PgDocumentStore / PgRuntimeStore ' +
     'specifically — see the threat model at the top of this script.',
 );

--- a/tests/agent-runtime/_fake-document-store.ts
+++ b/tests/agent-runtime/_fake-document-store.ts
@@ -7,8 +7,14 @@
  * already scoped to one owner: seeding it with a document is "a document this
  * owner owns", and an id absent from it reads as missing — the same
  * no-existence-oracle the real owner-bound store produces for a foreign id.
+ *
+ * The facade also mirrors the PG backend's trigger-maintained freshness
+ * revisions: every write method bumps the stage revision, and a scene write
+ * bumps that scene's revision, exactly like the DB triggers the real store
+ * relies on. Route tests seed `stageRevs` / `sceneRevs` to fix the numbers a
+ * manifest response must carry.
  */
-import type { DocumentStore, MaicDocument } from '@openmaic/storage';
+import type { DocumentStore, MaicDocument, StageFreshnessManifestStore } from '@openmaic/storage';
 
 import type { AppStage } from '@/lib/document-store/persistence-types';
 import type { AppScene } from '@/lib/types/stage';
@@ -16,20 +22,38 @@ import type { AppScene } from '@/lib/types/stage';
 export interface FakeDocumentStore {
   store: OwnerScopedFakeStore;
   docs: Map<string, MaicDocument<AppScene, AppStage>>;
+  /** Per-stage revisions, mirroring the `document_stage_revision` trigger rows. */
+  stageRevs: Map<string, number>;
+  /** Per-(stage, scene) revisions, mirroring the `document_scene_revision` rows. */
+  sceneRevs: Map<string, Map<string, number>>;
   saveCalls: MaicDocument<AppScene, AppStage>[];
   /** Make the next saveDocument call throw (e.g. a validation failure). */
   failNextSaveWith(error: unknown): void;
 }
 
 /** The fake store is already one owner's partition, so scoping is identity. */
-export type OwnerScopedFakeStore = DocumentStore<AppScene, AppStage> & {
-  forOwner(ownerId: string): OwnerScopedFakeStore;
-};
+export type OwnerScopedFakeStore = DocumentStore<AppScene, AppStage> &
+  StageFreshnessManifestStore & {
+    forOwner(ownerId: string): OwnerScopedFakeStore;
+  };
 
 export function createFakeDocumentStore(): FakeDocumentStore {
   const docs = new Map<string, MaicDocument<AppScene, AppStage>>();
+  const stageRevs = new Map<string, number>();
+  const sceneRevs = new Map<string, Map<string, number>>();
   const saveCalls: MaicDocument<AppScene, AppStage>[] = [];
   let saveError: unknown = null;
+
+  const bumpStage = (stageId: string) => {
+    stageRevs.set(stageId, (stageRevs.get(stageId) ?? 0) + 1);
+  };
+  const bumpScene = (stageId: string, sceneId: string) => {
+    bumpStage(stageId);
+    const perScene = sceneRevs.get(stageId) ?? new Map<string, number>();
+    perScene.set(sceneId, (perScene.get(sceneId) ?? 0) + 1);
+    sceneRevs.set(stageId, perScene);
+  };
+  const revOf = (stageId: string, sceneId: string) => sceneRevs.get(stageId)?.get(sceneId) ?? 0;
 
   const store = {
     forOwner: () => store,
@@ -37,10 +61,36 @@ export function createFakeDocumentStore(): FakeDocumentStore {
       if (saveError) throw saveError;
       saveCalls.push(structuredClone(doc));
       docs.set(doc.stage.id, structuredClone(doc));
+      const stageId = doc.stage.id;
+      bumpStage(stageId);
+      const incoming = new Set(doc.scenes.map((scene) => scene.id));
+      for (const scene of doc.scenes) bumpScene(stageId, scene.id);
+      // Scenes the coarse save no longer contains are gone; drop their rows
+      // the way the DELETE cascade would.
+      const perScene = sceneRevs.get(stageId);
+      if (perScene) {
+        for (const sceneId of [...perScene.keys()]) {
+          if (!incoming.has(sceneId)) perScene.delete(sceneId);
+        }
+      }
     },
     async loadDocument(stageId: string) {
       const doc = docs.get(stageId);
       return doc ? structuredClone(doc) : null;
+    },
+    async readFreshnessManifest(stageId: string) {
+      const doc = docs.get(stageId);
+      if (!doc) return null;
+      return {
+        rev: stageRevs.get(stageId) ?? 0,
+        scenes: [...doc.scenes]
+          .sort((left, right) => left.order - right.order)
+          .map((scene) => ({
+            id: scene.id,
+            order: scene.order,
+            rev: revOf(stageId, scene.id),
+          })),
+      };
     },
     async listDocuments() {
       return [...docs.values()]
@@ -56,11 +106,14 @@ export function createFakeDocumentStore(): FakeDocumentStore {
     },
     async deleteDocument(stageId: string) {
       docs.delete(stageId);
+      stageRevs.delete(stageId);
+      sceneRevs.delete(stageId);
     },
     async putStage(stageId: string, stage: AppStage) {
       const doc = docs.get(stageId);
       if (!doc) throw new Error('@openmaic/storage: document not found');
       docs.set(stageId, { ...doc, stage });
+      bumpStage(stageId);
     },
     async putScene(stageId: string, scene: AppScene) {
       const doc = docs.get(stageId);
@@ -71,6 +124,7 @@ export function createFakeDocumentStore(): FakeDocumentStore {
           (left, right) => left.order - right.order,
         ),
       });
+      bumpScene(stageId, scene.id);
     },
     async getScene(stageId: string, sceneId: string) {
       return docs.get(stageId)?.scenes.find((scene) => scene.id === sceneId) ?? null;
@@ -80,12 +134,16 @@ export function createFakeDocumentStore(): FakeDocumentStore {
       if (doc) {
         docs.set(stageId, { ...doc, scenes: doc.scenes.filter((scene) => scene.id !== sceneId) });
       }
+      bumpStage(stageId);
+      sceneRevs.get(stageId)?.delete(sceneId);
     },
   } as OwnerScopedFakeStore;
 
   return {
     store,
     docs,
+    stageRevs,
+    sceneRevs,
     saveCalls,
     failNextSaveWith(error) {
       saveError = error;

--- a/tests/agent-runtime/stage-freshness-route.test.ts
+++ b/tests/agent-runtime/stage-freshness-route.test.ts
@@ -57,6 +57,7 @@ beforeEach(() => {
     STAGE_ID,
     makeDocument(STAGE_ID, 'Course', [makeSlideScene('scene-1', STAGE_ID, 1)]),
   );
+  mocks.fakeStore.stageRevs.set(STAGE_ID, FIXED_NOW);
 });
 
 afterEach(() => {
@@ -86,11 +87,9 @@ describe('GET /api/stages/[id]/freshness', () => {
     const reader = response.body!.getReader();
     await readUntilFreshness(reader);
 
-    const document = mocks.fakeStore!.docs.get(STAGE_ID)!;
-    mocks.fakeStore!.docs.set(STAGE_ID, {
-      ...document,
-      stage: { ...document.stage, updatedAt: FIXED_NOW + 1 },
-    });
+    // An external writer (the DB trigger on a manual SQL UPDATE, say) moves
+    // the stage revision; the stream notices on its next poll.
+    mocks.fakeStore!.stageRevs.set(STAGE_ID, FIXED_NOW + 1);
 
     const pending = readUntilFreshness(reader);
     await vi.advanceTimersByTimeAsync(STAGE_FRESHNESS_POLL_INTERVAL_MS);

--- a/tests/agent-runtime/stage-manifest-route.test.ts
+++ b/tests/agent-runtime/stage-manifest-route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 import { createFakeDocumentStore } from './_fake-document-store';
-import { FIXED_NOW, makeDocument, makeSlideScene } from './_stage-fixtures';
+import { makeDocument, makeSlideScene } from './_stage-fixtures';
 
 const mocks = vi.hoisted(() => ({
   runtimeConfigured: true,
@@ -37,7 +37,7 @@ beforeEach(() => {
 });
 
 describe('GET /api/stages/[id]/manifest', () => {
-  it('returns the document rev and one entry per scene', async () => {
+  it('returns the per-stage and per-scene revisions', async () => {
     mocks.fakeStore!.docs.set(
       STAGE_ID,
       makeDocument(STAGE_ID, 'Course', [
@@ -45,29 +45,47 @@ describe('GET /api/stages/[id]/manifest', () => {
         makeSlideScene('scene-2', STAGE_ID, 2),
       ]),
     );
+    mocks.fakeStore!.stageRevs.set(STAGE_ID, 7);
+    mocks.fakeStore!.sceneRevs.set(
+      STAGE_ID,
+      new Map([
+        ['scene-1', 3],
+        ['scene-2', 5],
+      ]),
+    );
 
     const response = await call();
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      rev: FIXED_NOW,
+      rev: 7,
       scenes: [
-        { id: 'scene-1', order: 1, rev: FIXED_NOW },
-        { id: 'scene-2', order: 2, rev: FIXED_NOW },
+        { id: 'scene-1', order: 1, rev: 3 },
+        { id: 'scene-2', order: 2, rev: 5 },
       ],
     });
   });
 
-  it('reflects a new updatedAt as a new rev', async () => {
-    const document = makeDocument(STAGE_ID, 'Course', [makeSlideScene('scene-1', STAGE_ID, 1)]);
+  it('serves per-scene revisions independently of the stage revision', async () => {
+    const document = makeDocument(STAGE_ID, 'Course', [
+      makeSlideScene('scene-1', STAGE_ID, 1),
+      makeSlideScene('scene-2', STAGE_ID, 2),
+    ]);
     mocks.fakeStore!.docs.set(STAGE_ID, document);
-    mocks.fakeStore!.docs.set(STAGE_ID, {
-      ...document,
-      stage: { ...document.stage, updatedAt: FIXED_NOW + 1 },
-    });
+    mocks.fakeStore!.stageRevs.set(STAGE_ID, 10);
+    mocks.fakeStore!.sceneRevs.set(
+      STAGE_ID,
+      new Map([
+        ['scene-1', 2],
+        ['scene-2', 9],
+      ]),
+    );
 
     const body = await (await call()).json();
-    expect(body.rev).toBe(FIXED_NOW + 1);
-    expect(body.scenes[0].rev).toBe(FIXED_NOW + 1);
+    expect(body.rev).toBe(10);
+    expect(body.scenes).toEqual([
+      { id: 'scene-1', order: 1, rev: 2 },
+      { id: 'scene-2', order: 2, rev: 9 },
+    ]);
   });
 
   it('answers 404 for a missing or foreign stage', async () => {


### PR DESCRIPTION
Restores the reference implementation's freshness granularity: a per-scene monotonic revision maintained by database triggers, so every writer — HTTP routes, agent tools, jobs, manual SQL — bumps it without application cooperation. The earlier port had degraded this to a document-level signal, which made any edit invalidate the whole scene set.

- Trigger SQL ported verbatim into the storage package's idempotent schema bootstrap (companion `document_stage_revision` / `document_scene_revision` tables, lock-order invariant, `pg_notify` wakeup, suppression switch for batch writers). No timestamps, no application-layer callbacks.
- The freshness and manifest routes now serve per-scene revisions with the reference response shape.
- `ensureDocumentSchema` gained a dollar-quote-aware statement splitter so plpgsql bodies survive.
- Mutation-verified: with the triggers dropped, the revision tests go red.
- Verified against a real PostgreSQL 16: storage suite 1071 tests green, including revision-row inserts observed during the contract run.
- `@openmaic/storage` 0.13.0 → 0.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)