### PR TITLE
fix(workbench): PG-mode home listing via owner stages; keep the interrupted terminal course card

### DIFF
--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -40,7 +40,8 @@ import {
   withRuntimeStorageExclusiveLockUntilSettled,
   withRuntimeStorageSharedLock,
 } from './chat-storage-lock';
-import { DocumentVersionError } from '@openmaic/storage';
+import { DocumentVersionError, type DocumentSummary } from '@openmaic/storage';
+import { isBrowserPersistenceEnabled } from '@/lib/persistence/bootstrap';
 import { preparePBLScenesForDocumentPersistence } from '@/lib/pbl/v2/runtime/document-persistence';
 import {
   MISSING_ASSET_LEASE,
@@ -721,10 +722,57 @@ async function performStageDeletion(stageId: string): Promise<void> {
 }
 
 /**
+ * PG mode: the owner-scoped course listing.
+ *
+ * The generic `GET /api/persistence/documents` listing is deliberately refused
+ * server-side (`403 FORBIDDEN_DOCUMENTS`): the capability model serves reads by
+ * id and listings owner-only, so the home's course list must not ask for an
+ * unscoped listing at all. `GET /api/stages` IS the owner listing — it resolves
+ * the anonymous owner from the same cookie the workbench uses and returns that
+ * owner's stage documents. Folders stay device-local (Dexie), so the same
+ * membership overlay the local path applies keeps courses filed in this browser
+ * grouped.
+ */
+async function listOwnerStagesFromServer(): Promise<StageListItem[]> {
+  const res = await fetch('/api/stages', { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`Failed to list owner stages: HTTP ${res.status}`);
+  }
+  const body = (await res.json().catch(() => null)) as { stages?: unknown } | null;
+  if (!body || !Array.isArray(body.stages)) {
+    throw new Error('Malformed /api/stages response: expected { stages: [...] }');
+  }
+  const memberships = await db.stageFolders.toArray();
+  const folderByStage = new Map(memberships.map((m) => [m.stageId, m.folderId]));
+  return (body.stages as DocumentSummary[])
+    .map((item) => {
+      const base: StageListItem = {
+        id: item.id,
+        name: item.name,
+        sceneCount: item.sceneCount,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        ...(item.description !== undefined ? { description: item.description } : {}),
+        ...(item.interactiveMode !== undefined ? { interactiveMode: item.interactiveMode } : {}),
+        ...(item.taskEngineMode !== undefined ? { taskEngineMode: item.taskEngineMode } : {}),
+      };
+      const folderId = folderByStage.get(item.id) ?? item.folderId;
+      return folderId ? { ...base, folderId } : base;
+    })
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
  * List all stages
  */
 export async function listStages(): Promise<StageListItem[]> {
   try {
+    if (isBrowserPersistenceEnabled()) {
+      // Server persistence is on: the generic document listing answers 403 by
+      // design, so the home/workspace library lists through the owner-scoped
+      // workbench surface instead.
+      return await listOwnerStagesFromServer();
+    }
     const summaries = await getDocumentStore().listDocuments();
     const ids = new Set(summaries.map((summary) => summary.id));
     const legacy = await getLegacyDocumentStore().listStages();

--- a/lib/workbench/session-store.ts
+++ b/lib/workbench/session-store.ts
@@ -320,8 +320,12 @@ export interface WorkbenchFold {
    * It deliberately spans the gap BEFORE a run opens. A `user_message` is written
    * by the control plane outside any run, so a classroom the user `@`-named lands
    * here first and is flushed at the end of the answer to it. A run that dies
-   * without ever reaching `agent_end` therefore paints no card — nothing was
-   * produced to point at, and the user's own bubble already shows the `@` pill.
+   * without ever reaching `agent_end` — a plain failure — therefore paints no
+   * card: nothing was produced to point at, and the user's own bubble already
+   * shows the `@` pill. A run that is interrupted and repaired and then stopped
+   * (`session_end` cancelled) is different: the answer's sightings survive the
+   * repair, so the cancelled terminal flush paints the card set (see `agent_end`
+   * and `session_end`).
    *
    * See `lib/workbench/run-courses` for what counts as a sighting.
    */
@@ -1647,6 +1651,28 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
         // raced the loop's exit — would otherwise be left spinning under a
         // transcript that already says the run stopped. A stopped run has
         // nothing still running, so the cards say so.
+        //
+        // A run that was interrupted and then repaired can end cancelled
+        // without ever reaching `agent_end` — a server restart parked it
+        // (`session_interrupted`) and the next instance resumed it
+        // (`session_resumed`) only for the stop to land before pi closed the
+        // answer. The exchange's pending classroom sightings would otherwise
+        // strand in the buffer and the timeline would end on the caption alone,
+        // losing the course the answer produced. Flush them into the same card
+        // set `agent_end` paints, so the terminal card carries the known stage
+        // refs whenever the session has them.
+        const pendingCourses =
+          next.runCourseStageIds.length > 0
+            ? [
+                {
+                  key: `${key}-course`,
+                  kind: 'course' as const,
+                  text: '',
+                  stageIds: next.runCourseStageIds,
+                },
+              ]
+            : [];
+        if (pendingCourses.length > 0) next.runCourseStageIds = [];
         next.chat = [
           ...settleRunningToolCards(settled, {
             ts: event.ts,
@@ -1656,6 +1682,7 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
               next.generatingOrder = null;
             },
           }),
+          ...pendingCourses,
           {
             key,
             kind: 'boundary',

--- a/tests/workbench/pg-mode-home-listing.test.ts
+++ b/tests/workbench/pg-mode-home-listing.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+
+/**
+ * PG mode home listing — the owner-scoped course list.
+ *
+ * With server persistence on (`NEXT_PUBLIC_PERSISTENCE=1`) the generic
+ * `GET /api/persistence/documents` listing is refused server-side
+ * (`403 FORBIDDEN_DOCUMENTS`) by the capability model: reads are by-id and
+ * listings are owner-only. The home/workspace library must therefore list
+ * through the owner-scoped workbench surface (`GET /api/stages`, the same
+ * anonymous-owner cookie the workbench uses) instead of the generic listing —
+ * and must surface no persistence warning when that listing succeeds.
+ *
+ * The storage seams (IndexedDB document store, Dexie) are mocked so the local
+ * fallback path is inert; the real `listStages` PG-mode branch is what runs.
+ */
+import { act, createElement, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  listLegacyStages: vi.fn(),
+  readLegacyStage: vi.fn(),
+  folders: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError, success: vi.fn() } }));
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}));
+vi.mock('@/lib/store/media-generation', () => ({
+  useMediaGenerationStore: {
+    getState: () => ({ revokeObjectUrls: vi.fn() }),
+    setState: vi.fn(),
+  },
+}));
+vi.mock('@/components/discovery/folder-dialogs', () => ({ NewFolderDialog: () => null }));
+vi.mock('@/lib/import/use-import-classroom', () => ({
+  useImportClassroom: () => ({
+    importing: false,
+    fileInputRef: { current: null },
+    triggerFileSelect: vi.fn(),
+    handleFileChange: vi.fn(),
+  }),
+}));
+// The device-local storage seams: `stage-storage` must load, but the PG-mode
+// branch never consults the document store or the legacy listing.
+vi.mock('@/lib/document-store', () => ({
+  getDocumentStore: () => ({ listDocuments: mocks.listDocuments }),
+  getLegacyDocumentStore: () => ({
+    listStages: mocks.listLegacyStages,
+    read: mocks.readLegacyStage,
+  }),
+}));
+vi.mock('@/lib/utils/database', () => ({
+  db: {
+    stageFolders: { toArray: () => Promise.resolve([]) },
+    folders: { toArray: mocks.folders },
+  },
+}));
+vi.mock('@/lib/utils/chat-storage', () => ({
+  ChatStorageLockUnavailableError: class extends Error {},
+  saveChatSessions: vi.fn(),
+  loadChatSessions: vi.fn(),
+  deleteChatSessions: vi.fn(),
+}));
+vi.mock('@/lib/playback/cursor', () => ({ clearCursor: vi.fn() }));
+vi.mock('@/lib/quiz/persistence', () => ({ clearAllForScene: vi.fn() }));
+vi.mock('@/lib/runtime/store', () => ({ beginStageRuntimeDeletionSafely: vi.fn() }));
+vi.mock('@/lib/pbl/v2/runtime/drain', () => ({ clearStageDrainWatermarks: vi.fn() }));
+vi.mock('@/lib/utils/chat-storage-lock', () => ({
+  withRuntimeStorageExclusiveLockUntilSettled: vi.fn(),
+  withRuntimeStorageSharedLock: vi.fn(),
+}));
+
+import { useHomeDiscovery, type HomeDiscovery } from '@/lib/hooks/use-home-discovery';
+
+let root: Root | null = null;
+let discovery: HomeDiscovery | null = null;
+
+function Harness({ onDiscovery }: { onDiscovery: (value: HomeDiscovery) => void }) {
+  const value = useHomeDiscovery({ mode: 'discover-only' });
+  useEffect(() => onDiscovery(value), [onDiscovery, value]);
+  return null;
+}
+
+const OWNER_STAGES = [
+  { id: 'stage-1', name: '光的折射', sceneCount: 12, createdAt: 1, updatedAt: 2 },
+  { id: 'stage-2', name: '二次函数', sceneCount: 0, createdAt: 3, updatedAt: 4 },
+];
+
+function stagesResponse() {
+  return new Response(JSON.stringify({ stages: OWNER_STAGES }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('PG-mode home listing', () => {
+  beforeEach(() => {
+    discovery = null;
+    vi.stubEnv('NEXT_PUBLIC_PERSISTENCE', '1');
+    vi.stubGlobal('fetch', vi.fn());
+    mocks.toastError.mockClear();
+    mocks.folders.mockResolvedValue([]);
+    mocks.listDocuments.mockClear();
+    mocks.listLegacyStages.mockClear();
+  });
+
+  afterEach(async () => {
+    if (root) await act(async () => root?.unmount());
+    root = null;
+    document.body.innerHTML = '';
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('lists the owner’s stages through /api/stages and never asks for the generic listing', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(stagesResponse());
+
+    const { listStages } = await import('@/lib/utils/stage-storage');
+    const stages = await listStages();
+
+    // The list mirrors the local path's newest-first order.
+    expect(stages).toEqual([
+      expect.objectContaining({ id: 'stage-2', name: '二次函数', sceneCount: 0 }),
+      expect.objectContaining({ id: 'stage-1', name: '光的折射', sceneCount: 12 }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('/api/stages');
+    expect(init).toMatchObject({ credentials: 'include' });
+    expect(String(url)).not.toContain('/api/persistence/documents');
+    // The local document seams are not consulted in PG mode.
+    expect(mocks.listDocuments).not.toHaveBeenCalled();
+    expect(mocks.listLegacyStages).not.toHaveBeenCalled();
+  });
+
+  it('mounts the home library on the owner listing with no persistence warning', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(stagesResponse());
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () =>
+      root?.render(
+        createElement(Harness, {
+          onDiscovery: (value) => {
+            discovery = value;
+          },
+        }),
+      ),
+    );
+
+    expect(discovery?.state).toBe('ready');
+    expect(discovery?.classrooms).toEqual([
+      expect.objectContaining({ id: 'stage-2', name: '二次函数' }),
+      expect.objectContaining({ id: 'stage-1', name: '光的折射' }),
+    ]);
+    // The owner listing succeeded — no "Persistence is unavailable" toast.
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith('/api/stages', expect.objectContaining({}));
+  });
+
+  it('propagates a refused owner listing so the caller can surface the warning', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response('forbidden', { status: 403 }));
+
+    const { listStages } = await import('@/lib/utils/stage-storage');
+    await expect(listStages()).rejects.toThrow(/403/);
+    expect(mocks.listDocuments).not.toHaveBeenCalled();
+    expect(mocks.listLegacyStages).not.toHaveBeenCalled();
+  });
+
+  it('keeps the local IndexedDB listing when server persistence is off', async () => {
+    vi.stubEnv('NEXT_PUBLIC_PERSISTENCE', '');
+    mocks.listDocuments.mockResolvedValue([
+      { id: 'local-1', name: 'Local course', sceneCount: 1, createdAt: 1, updatedAt: 2 },
+    ]);
+    mocks.listLegacyStages.mockResolvedValue([]);
+
+    const { listStages } = await import('@/lib/utils/stage-storage');
+    const stages = await listStages();
+
+    expect(stages).toEqual([expect.objectContaining({ id: 'local-1', name: 'Local course' })]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/workbench/session-fold.test.ts
+++ b/tests/workbench/session-fold.test.ts
@@ -945,6 +945,41 @@ describe('an answer ends with the classrooms it touched', () => {
     expect(cardsOf(state)).toEqual([['stage-a', 'stage-b']]);
   });
 
+  it('flushes an interrupted answer’s classrooms when the repaired run ends cancelled', () => {
+    // A server restart parks the run (`session_interrupted`), the next instance
+    // resumes it (`session_resumed`), and the stop lands before pi closes the
+    // answer (`session_end` cancelled) — so no `agent_end` ever drains the
+    // buffer. The pending sightings are the classrooms this answer produced,
+    // and the terminal card must still carry them: the card the timeline ends
+    // with is the course the session knows, not the stopped caption alone.
+    const state = foldAll([
+      ev('session_start', { prompt: '写一门课' }),
+      ev('agent_start', {}),
+      ev('checkpoint', {
+        tool: 'patch_stage',
+        stageId: 'stage-a',
+        sceneId: 's1',
+        order: 1,
+        outline: [],
+        courseTitle: '光的折射',
+      }),
+      ev('session_interrupted', { reason: 'lease lost' }),
+      ev('session_resumed', { reason: 'crash', repairedToolCalls: [] }),
+      ev('session_end', { status: 'cancelled' }),
+    ]);
+    const courses = state.chat.filter((n) => n.kind === 'course');
+    expect(courses).toHaveLength(1);
+    // The card carries the known stage ref — the name/link the timeline ends on.
+    expect(courses[0]?.stageIds).toEqual(['stage-a']);
+    // It sits at the tail, directly above the stopped caption.
+    const kinds = contentOf(state).map((n) => n.kind);
+    expect(kinds.slice(-2)).toEqual(['course', 'boundary']);
+    // The buffer drained into the card, and the fold still knows the course
+    // name the card renders from.
+    expect(state.runCourseStageIds).toEqual([]);
+    expect(state.courseTitle).toBe('光的折射');
+  });
+
   it('keeps the legacy single unbound row for checkpoints without a stageId', () => {
     // A v1 transcript's page checkpoint carried no stage id at all — and may
     // predate the pi frames the per-exchange rule flushes on, so this row is


### PR DESCRIPTION
Two findings from the live end-to-end acceptance run.

**PG-mode course discovery (high)**: with server persistence on, the home/workspace library listed through the generic `GET /api/persistence/documents`, which the capability access model deliberately refuses (403) — the UI showed "Persistence is unavailable" while the owner-scoped `GET /api/stages` listed the courses fine. Fixed at the shared caller seam: `listStages()` now lists through the owner-scoped surface (same anonymous-owner cookie the workbench uses) when server persistence is on; the 403 on generic listings is untouched; folders stay device-local as before. 4 new tests (red before, green after), including "never calls the generic listing" and "no persistence warning".

**Interrupted terminal card (medium)**: a cancel that lands after a restart-resume, before the answer closes, ended with `session_end{cancelled}` and no `agent_end`, stranding the run's course sightings — the terminal card said "Untitled course / This build was stopped" though the course exists. The cancelled branch now flushes the pending course refs into the same course card the normal path paints. 1 new fold test (red before, green after); the "plain failure paints no card" behavior stays pinned.

Verification on the current tip: tsc clean, 1840 tests green across workbench/agent-runtime/document-store; 918 workbench tests green standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)