### PR TITLE
fix(workbench): restore the attach entry, add the rail settings entry, pin all three entry points

### DIFF
--- a/components/workbench/compose-extras.tsx
+++ b/components/workbench/compose-extras.tsx
@@ -277,6 +277,17 @@ export interface ComposerMaterials {
 let materialsEnabledCache: boolean | null = null;
 let materialsProbe: Promise<boolean> | null = null;
 
+/**
+ * The server's answer, remembered for the life of the tab: whether the
+ * material upload path can actually serve a request.
+ *
+ * The branch substitution: the reference's probe reads `materialsEnabled`
+ * (its runtime answers `enabled && isAgentMaterialsEnabled()`). This port has
+ * no separate materials flag — the materials routes gate on the runtime
+ * itself, like the stages — so the probe reads the runtime's `enabled` field,
+ * which IS the upload action's precondition (`POST /api/materials` 404s when
+ * it is false).
+ */
 async function probeMaterialsEnabled(): Promise<boolean> {
   if (materialsEnabledCache !== null) return materialsEnabledCache;
   if (!materialsProbe) {
@@ -284,9 +295,7 @@ async function probeMaterialsEnabled(): Promise<boolean> {
       .then(async (response) => (response.ok ? ((await response.json()) as unknown) : null))
       .then((body) => {
         const enabled =
-          !!body &&
-          typeof body === 'object' &&
-          (body as { materialsEnabled?: unknown }).materialsEnabled === true;
+          !!body && typeof body === 'object' && (body as { enabled?: unknown }).enabled === true;
         materialsEnabledCache = enabled;
         return enabled;
       })

--- a/components/workbench/workspace/WorkspaceRail.tsx
+++ b/components/workbench/workspace/WorkspaceRail.tsx
@@ -86,6 +86,7 @@ import {
   Plus,
   RefreshCw,
   Search,
+  Settings,
   Trash2,
   Upload,
   X,
@@ -97,6 +98,7 @@ import type { HomeDiscoveryState, useHomeDiscovery } from '@/lib/hooks/use-home-
 import { ProBadge } from '@/components/workbench/ProBadge';
 import { LanguageSwitcher } from '@/components/language-switcher';
 import { ThemeToggle } from '@/components/site-header/theme-toggle';
+import { SettingsDialog } from '@/components/settings';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -257,6 +259,8 @@ export function WorkspaceRail({
   const [renamingSessionId, setRenamingSessionId] = useState<string | null>(null);
   /** The folder whose delete has been asked for, and not yet answered. */
   const [folderToDelete, setFolderToDelete] = useState<{ id: string; name: string } | null>(null);
+  /** The model/provider settings dialog, opened from the rail's foot cluster. */
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   /**
    * Commit a folder rename. Returns null when it landed and a readable message
@@ -675,10 +679,22 @@ export function WorkspaceRail({
           className="ws-utils flex shrink-0 flex-col items-center gap-0.5 py-2.5"
         >
           {/* 60px of width does not hold five controls, so at this size the
-              overflow is where everything but the two most-used entries
-              lives — including the locale switcher. */}
+              overflow is where everything but the most-used entries lives —
+              including the locale switcher. Settings stays on the surface: the
+              collapsed rail must not lose the one entry that configures the
+              providers the surface depends on. */}
           <RailOverflow testId="pro-rail-more-mini" mini withLanguage />
           <ThemeToggle />
+          <button
+            type="button"
+            data-testid="pro-nav-settings-mini"
+            onClick={() => setSettingsOpen(true)}
+            aria-label={t('settings.title')}
+            title={t('settings.title')}
+            className="ws-mini-btn"
+          >
+            <Settings className="size-4" aria-hidden="true" />
+          </button>
         </div>
       </nav>
     );
@@ -1173,9 +1189,20 @@ export function WorkspaceRail({
         ) : null}
       </div>
 
-      <RailUtilities />
+      <RailUtilities onOpenSettings={() => setSettingsOpen(true)} />
 
       {resizeHandle}
+
+      {/* The model/provider settings dialog — the same component the classic
+          home opens from its header pill. The rail owns the mount so the
+          trigger in the foot cluster stays one component away from its dialog,
+          like the folder-delete question below. */}
+      <SettingsDialog
+        open={settingsOpen}
+        onOpenChange={(next) => {
+          setSettingsOpen(next);
+        }}
+      />
 
       {/* Deleting a folder does something to the courses inside it, so it is
           asked as a question with that consequence stated — not the two-press
@@ -2028,11 +2055,18 @@ function SessionDot({ status }: { readonly status: ProHomeSessionItem['status'] 
  * daily; feedback and the community links are a press further, behind one
  * quiet ⋯, because a rail is navigation first and a settings bar second.
  *
+ * The settings entry lives here too, in the slot the removed saved-courses
+ * drawer left in this cluster (a product decision on this branch: the drawer
+ * could only ever render empty, and the model/provider dialog is the one
+ * surface-wide setting the workspace still needs). It is the same dialog the
+ * classic home opens from its header pill; the rail trigger owns its own
+ * mount.
+ *
  * The product ships no reusable notification bell (the only Bell in the tree
  * belongs to the community dialog), so there is nothing to cluster here for
  * notifications.
  */
-function RailUtilities() {
+function RailUtilities({ onOpenSettings }: { readonly onOpenSettings: () => void }) {
   const { t } = useI18n();
   return (
     <div className="shrink-0" data-testid="pro-rail-utilities">
@@ -2043,6 +2077,16 @@ function RailUtilities() {
       >
         <LanguageSwitcher />
         <ThemeToggle />
+        <button
+          type="button"
+          data-testid="pro-nav-settings"
+          onClick={onOpenSettings}
+          aria-label={t('settings.title')}
+          title={t('settings.title')}
+          className="ws-util-btn"
+        >
+          <Settings className="size-4" aria-hidden="true" />
+        </button>
       </div>
     </div>
   );

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -1941,7 +1941,7 @@
     "error": "رمز الوصول غير صالح. يرجى المحاولة مرة أخرى."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "إرفاق مواد",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/de-DE.json
+++ b/lib/i18n/locales/de-DE.json
@@ -1941,7 +1941,7 @@
     "error": "Ungültiger Zugangscode. Bitte versuche es erneut."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "Attach material",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/es-MX.json
+++ b/lib/i18n/locales/es-MX.json
@@ -1941,7 +1941,7 @@
     "error": "Código de acceso no válido. Inténtalo de nuevo."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "Adjuntar material",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/fr-FR.json
+++ b/lib/i18n/locales/fr-FR.json
@@ -1941,7 +1941,7 @@
     "error": "Code d’accès invalide. Veuillez réessayer."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "Joindre un support",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -1941,7 +1941,7 @@
     "error": "アクセスコードが正しくありません。もう一度お試しください。"
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "教材を添付",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -1941,7 +1941,7 @@
     "error": "유효하지 않은 접근 코드입니다. 다시 시도해 주세요."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "자료 첨부",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -1941,7 +1941,7 @@
     "error": "Código inválido. Tente novamente."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "Anexar material",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -1941,7 +1941,7 @@
     "error": "Неверный код доступа. Попробуйте ещё раз."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "Прикрепить материал",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/lib/i18n/locales/vi-VN.json
+++ b/lib/i18n/locales/vi-VN.json
@@ -1941,7 +1941,7 @@
     "error": "Mã truy cập không đúng. Vui lòng thử lại."
   },
   "proMode": {
-    "attach": "添加材料",
+    "attach": "Đính kèm tài liệu",
     "mentionCourse": "引用课堂",
     "loadSkill": "加载 skill",
     "skillMenuTitle": "选择课程设计技能",

--- a/tests/workbench/entry-points-restore.test.ts
+++ b/tests/workbench/entry-points-restore.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+/**
+ * The three restored entry points, pinned:
+ *
+ *  1. the workspace rail's courses tab carries an upload control next to the
+ *     name filter (it imports a course package from disk into the list);
+ *  2. the Pro launch composer (and the chat composer) carries an attach
+ *     control in the glyph row, rendered exactly when the material upload
+ *     path can serve a request;
+ *  3. the rail's foot cluster — the bottom-left utilities — mounts the
+ *     settings trigger for the model/provider dialog, in the slot the removed
+ *     saved-courses drawer left.
+ *
+ * Items 1 and 3 are pinned from source (the rail and the shell are heavy
+ * client surfaces the suite renders nowhere else); item 2 is pinned by an
+ * actual render of `AttachButton` under both probe answers, plus source pins
+ * for where it is mounted and the copy it carries in every locale.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+  TooltipContent: () => null,
+}));
+
+const hosts: Array<{ root: Root; host: HTMLDivElement }> = [];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const { root, host } of hosts.splice(0)) {
+    root.unmount();
+    host.remove();
+  }
+});
+
+/** Load a fresh module copy so the probe cache starts empty — the cache is
+ *  module-level and remembered for the life of the tab, exactly as in the app,
+ *  so one test's probe answer must not leak into the next. */
+async function importFreshExtras(): Promise<
+  typeof import('@/components/workbench/compose-extras')
+> {
+  vi.resetModules();
+  return await import('@/components/workbench/compose-extras');
+}
+
+function mount(children: ReactNode): Root {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  hosts.push({ root, host });
+  return root;
+}
+
+/** Flush the probe's fetch → json → state chain, then the re-render. */
+async function flushProbe() {
+  await act(async () => {
+    await new Promise((settle) => setTimeout(settle, 0));
+  });
+}
+
+describe('entry point 1 — the courses-tab upload control', () => {
+  const rail = read('components/workbench/workspace/WorkspaceRail.tsx');
+  const shell = read('components/workbench/workspace/WorkspaceShell.tsx');
+  const discovery = read('lib/hooks/use-home-discovery.tsx');
+
+  it('renders the upload button beside the course name filter', () => {
+    // The find row lives under the tab strip and above the tabpanel.
+    const findRow = rail.slice(
+      rail.indexOf('pro-nav-search-input'),
+      rail.indexOf('role="tabpanel"'),
+    );
+    expect(findRow).toContain('data-testid="pro-nav-import-course"');
+    expect(findRow).toContain('<Upload className="size-4"');
+  });
+
+  it('opens the same course-package import the home surface uses, disabled while one runs', () => {
+    const button = rail.slice(
+      rail.indexOf('data-testid="pro-nav-import-course"'),
+      rail.indexOf('data-testid="pro-nav-new-folder"'),
+    );
+    // Clearing the filter first means the imported course is not hidden by a
+    // stale query, then the discovery hook's import trigger fires.
+    expect(button).toContain("coursesSection.setQuery('')");
+    expect(button).toContain('courses.triggerImport()');
+    expect(button).toContain('disabled={courses.importing}');
+    expect(button).toContain("aria-label={t('import.classroom')}");
+    expect(button).toContain("title={t('import.classroom')}");
+  });
+
+  it('is gated by the same condition as its action: the courses tab', () => {
+    const coursesTab = rail.indexOf("{tab === 'courses' ? (");
+    const upload = rail.indexOf('pro-nav-import-course');
+    const conditionalEnd = rail.indexOf(') : null}', upload);
+    expect(coursesTab).toBeGreaterThan(-1);
+    expect(upload).toBeGreaterThan(coursesTab);
+    // The button sits inside the conditional (before its close), so a session-
+    // tab view never shows an import affordance.
+    expect(upload).toBeLessThan(conditionalEnd);
+  });
+
+  it('mounts the hidden file input once, from the discovery hook the button calls', () => {
+    expect(shell).toContain('{courses.importInput}');
+    expect(discovery).toContain('triggerFileSelect');
+    expect(discovery).toContain('triggerImport');
+    expect(discovery).toContain('importing: isImporting');
+    expect(discovery).toContain('accept=".zip"');
+  });
+});
+
+describe('entry point 2 — the composer attach control', () => {
+  const extras = read('components/workbench/compose-extras.tsx');
+  const launch = read('components/workbench/ProLaunchPanel.tsx');
+  const chat = read('components/workbench/WorkbenchChat.tsx');
+
+  it('is mounted in the Pro launch composer’s glyph row, before the mention and skill', () => {
+    expect(launch).toContain('testId="pro-launch-attach"');
+    const row = launch.slice(launch.indexOf('pro-launch-attach'), launch.indexOf('<ProLaunchSend'));
+    expect(row).toContain('<AtSignButton');
+    expect(row).toContain('<SkillButton');
+  });
+
+  it('is mounted in the chat composer’s glyph row too', () => {
+    expect(chat).toContain('<AttachButton');
+    expect(chat).toContain('testId="workbench-attach"');
+  });
+
+  it('renders when the runtime says the upload path is live', async () => {
+    // The probe resolves to this branch's runtime `enabled` field — the same
+    // value that gates `POST /api/materials`, the upload action's precondition.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ enabled: true, runtimeEnabled: true })),
+    );
+    const { AttachButton } = await importFreshExtras();
+    const root = mount(null);
+    await act(async () => {
+      root.render(createElement(AttachButton, { onFiles: () => undefined, label: 'attach' }));
+    });
+    await flushProbe();
+    const host = hosts[hosts.length - 1].host;
+    expect(host.querySelector('[data-testid="workbench-attach"]')).not.toBeNull();
+    expect(host.querySelector('input[type="file"]')).not.toBeNull();
+  });
+
+  it('stays hidden while the upload path is off (no dead button)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ enabled: false })),
+    );
+    const { AttachButton } = await importFreshExtras();
+    const root = mount(null);
+    await act(async () => {
+      root.render(createElement(AttachButton, { onFiles: () => undefined, label: 'attach' }));
+    });
+    await flushProbe();
+    const host = hosts[hosts.length - 1].host;
+    expect(host.querySelector('[data-testid="workbench-attach"]')).toBeNull();
+  });
+
+  it('reads the runtime `enabled` field, this branch’s upload precondition', () => {
+    // The reference probes `materialsEnabled` (its runtime answers
+    // `enabled && isAgentMaterialsEnabled()`); this port has no separate
+    // materials flag, so the probe must read `enabled` — otherwise the button
+    // could never render.
+    expect(extras).toContain('(body as { enabled?: unknown }).enabled === true');
+    expect(extras).not.toContain('materialsEnabled === true');
+    expect(extras).not.toContain('materialsEnabled?: unknown');
+  });
+
+  it('carries the reference’s own copy in every locale', () => {
+    const expected: Record<string, string> = {
+      'ar-SA': 'إرفاق مواد',
+      'de-DE': 'Attach material',
+      'en-US': 'Attach material',
+      'es-MX': 'Adjuntar material',
+      'fr-FR': 'Joindre un support',
+      'ja-JP': '教材を添付',
+      'ko-KR': '자료 첨부',
+      'pt-BR': 'Anexar material',
+      'ru-RU': 'Прикрепить материал',
+      'vi-VN': 'Đính kèm tài liệu',
+      'zh-CN': '添加材料',
+      'zh-TW': '添加材料',
+    };
+    for (const [locale, copy] of Object.entries(expected)) {
+      const parsed = JSON.parse(read(`lib/i18n/locales/${locale}.json`)) as {
+        proMode?: { attach?: string };
+      };
+      expect(parsed.proMode?.attach, locale).toBe(copy);
+    }
+  });
+});
+
+describe('entry point 3 — the settings entry in the rail’s foot cluster', () => {
+  const rail = read('components/workbench/workspace/WorkspaceRail.tsx');
+
+  it('mounts the settings trigger in the expanded foot cluster', () => {
+    const utilities = rail.slice(rail.indexOf('function RailUtilities'));
+    expect(utilities).toContain('data-testid="pro-nav-settings"');
+    expect(utilities).toContain('<Settings className="size-4"');
+    expect(utilities).toContain("aria-label={t('settings.title')}");
+    expect(utilities).toContain("title={t('settings.title')}");
+  });
+
+  it('keeps the trigger on the collapsed strip too', () => {
+    const mini = rail.slice(
+      rail.indexOf('pro-rail-utilities-mini'),
+      rail.indexOf('renderCourseRow'),
+    );
+    expect(mini).toContain('data-testid="pro-nav-settings-mini"');
+    expect(mini).toContain('onClick={() => setSettingsOpen(true)}');
+  });
+
+  it('opens the model/provider dialog, mounted by the rail itself', () => {
+    expect(rail).toContain("import { SettingsDialog } from '@/components/settings'");
+    expect(rail).toContain('<SettingsDialog');
+    expect(rail).toContain('open={settingsOpen}');
+    const trigger = rail.slice(rail.indexOf('data-testid="pro-nav-settings"'));
+    expect(trigger.slice(0, trigger.indexOf('</button>'))).toContain('onClick={onOpenSettings}');
+  });
+
+  it('sits beside the language and display toggles in the cluster order', () => {
+    const utilities = rail.slice(rail.indexOf('function RailUtilities'));
+    const order = ['<LanguageSwitcher', '<ThemeToggle', 'pro-nav-settings'].map((token) =>
+      utilities.indexOf(token),
+    );
+    for (const index of order) expect(index).toBeGreaterThan(-1);
+    expect(order[0]).toBeLessThan(order[1]);
+    expect(order[1]).toBeLessThan(order[2]);
+  });
+});


### PR DESCRIPTION
## What

Product review against the reference implementation found missing entry points. Two fixes plus a pinning test suite:

1. **Composer attach button never rendered.** Its gate probed a `materialsEnabled` field that `GET /api/agent/runtime` does not have, so the probe always answered false and the attach entry was invisible in both the launch and chat composers — while the whole upload path (`useComposerMaterials` → `POST /api/materials`) sat fully wired behind it. The probe now reads the runtime's `enabled` field — the same value that gates `POST /api/materials` (404 when off), so the render condition equals the action precondition. The `proMode.attach` label's reference translations are restored verbatim across all 12 locales.
2. **Settings entry in the rail's foot cluster.** The workspace rail had no way to open the model/provider settings dialog. A settings trigger now sits in the bottom-left utilities cluster (expanded rail and collapsed strip), mounting the existing `SettingsDialog`; the classic home keeps its own header trigger.
3. **Courses-tab upload button**: verified already present and correctly wired (it survived the saved-courses drawer removal); now pinned by tests alongside the other two.

## Verification

- `tsc --noEmit` 0 errors, `prettier --check` clean, `check:i18n-keys` aligned, `pnpm build` green (client import graph changed)
- vitest workbench: 70 files / 929 tests green, including 14 new tests pinning presence + wiring of all three entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)