### PR TITLE
chore(config): the Pro workbench flag implies the MAIC Editor gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -296,7 +296,14 @@ WEB_SEARCH_CLAUDE_MODELS=
 # Boolean feature flags accept "true" or "1". NEXT_PUBLIC_* values are compiled
 # into the browser bundle at build time, so changing them requires a rebuild.
 
-# Master gate for the MAIC Editor Pro-mode entry point.
+# Enable the Pro workbench entry (the workbench also requires the agent
+# runtime to be configured server-side; see the Agent Runtime section).
+# Implies the MAIC Editor gate below — Pro mode always ships with the editor.
+# NEXT_PUBLIC_PRO_WORKBENCH_ENABLED=true
+
+# Master gate for the MAIC Editor Pro-mode entry point. Implied by
+# NEXT_PUBLIC_PRO_WORKBENCH_ENABLED; set it alone to enable the classroom
+# editor on a deployment without the workbench.
 # NEXT_PUBLIC_MAIC_EDITOR_ENABLED=true
 
 # Select @openmaic/editor inside Pro mode. This does not enable Pro mode by itself.

--- a/lib/config/feature-flags.ts
+++ b/lib/config/feature-flags.ts
@@ -38,9 +38,14 @@ export function isProWorkbenchEnabled(): boolean {
  * affordance in `Header`. The `StageMode` type union is unaffected so
  * existing code paths typecheck identically with the flag in either
  * state.
+ *
+ * Implied by the Pro workbench flag: the workbench IS Pro mode, and a
+ * workbench build without the editor toggle has no way to edit a course.
+ * The standalone flag remains for deployments that want the classroom
+ * editor without the workbench.
  */
 export function isMaicEditorEnabled(): boolean {
-  return readBoolean(process.env.NEXT_PUBLIC_MAIC_EDITOR_ENABLED);
+  return isProWorkbenchEnabled() || readBoolean(process.env.NEXT_PUBLIC_MAIC_EDITOR_ENABLED);
 }
 
 /**

--- a/tests/config/feature-flags.test.ts
+++ b/tests/config/feature-flags.test.ts
@@ -56,10 +56,14 @@ describe('agent runtime configuration predicate', () => {
 });
 
 describe('isMaicEditorEnabled', () => {
+  const PRO_FLAG = 'NEXT_PUBLIC_PRO_WORKBENCH_ENABLED';
   let original: string | undefined;
+  let originalPro: string | undefined;
 
   beforeEach(() => {
     original = process.env[FLAG];
+    originalPro = process.env[PRO_FLAG];
+    delete process.env[PRO_FLAG];
   });
 
   afterEach(() => {
@@ -67,6 +71,11 @@ describe('isMaicEditorEnabled', () => {
       delete process.env[FLAG];
     } else {
       process.env[FLAG] = original;
+    }
+    if (originalPro === undefined) {
+      delete process.env[PRO_FLAG];
+    } else {
+      process.env[PRO_FLAG] = originalPro;
     }
   });
 
@@ -93,6 +102,18 @@ describe('isMaicEditorEnabled', () => {
   it('returns false for an unrecognized string', () => {
     process.env[FLAG] = 'yes';
     expect(isMaicEditorEnabled()).toBe(false);
+  });
+
+  it('is implied by the Pro workbench flag when its own flag is unset', () => {
+    delete process.env[FLAG];
+    process.env[PRO_FLAG] = 'true';
+    expect(isMaicEditorEnabled()).toBe(true);
+  });
+
+  it('stays on under the Pro workbench flag even with its own flag set false', () => {
+    process.env[FLAG] = 'false';
+    process.env[PRO_FLAG] = 'true';
+    expect(isMaicEditorEnabled()).toBe(true);
   });
 });
 


### PR DESCRIPTION
Enabling `NEXT_PUBLIC_PRO_WORKBENCH_ENABLED` while forgetting `NEXT_PUBLIC_MAIC_EDITOR_ENABLED` produced a Pro build with no editor toggle and no way to edit a course — the two flags gate one product surface. The workbench flag now implies the editor gate; the standalone editor flag remains for deployments that want the classroom editor without the workbench. `.env.example` documents both flags (the workbench flag was previously undocumented).

Tests pin the implication (workbench flag alone → editor on, even with the editor flag explicitly false) alongside the existing standalone-flag cases. `tsc` 0 errors, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)