### PR TITLE
fix(agent): bound every tool call with a timeout; never resurrect a cancelled session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -356,6 +356,13 @@ WEB_SEARCH_CLAUDE_MODELS=
 # OPENMAIC_AGENT_RUNTIME_MAX_CONCURRENT=2
 # OPENMAIC_AGENT_RUNTIME_MAX_ATTEMPTS=5
 
+# Global per-tool-call execution bound for every agent run (ms). A tool call
+# that neither resolves nor rejects within the budget is aborted and settles as
+# an error tool-result the agent can retry or proceed from; the session does
+# not die. Default 600000 (10 minutes). Tools with known longer budgets (media
+# synthesis, material extraction) carry their own explicit bounds in code.
+# OPENMAIC_AGENT_TOOL_TIMEOUT_MS=600000
+
 # Conversation compaction is reserved and OFF by default. The reusable
 # compaction runtime is not implemented yet — it lands in a later slice of
 # work — and until then the runner runs without context transformation, so

--- a/lib/agent/runtime/build-agent.ts
+++ b/lib/agent/runtime/build-agent.ts
@@ -20,6 +20,7 @@ import type { Api, Model } from '@earendil-works/pi-ai';
 import { makeAllowlistGate } from './allowlist';
 import { makeQuotaHook } from './quota';
 import { hasLengthToolCallProvenance } from './stream-fn';
+import { withAgentToolTimeout } from './tool-timeout';
 
 // pi needs *a* model object on state; the injected StreamFn ignores it and uses
 // OpenMAIC's resolved model, so this is a metadata stub (high contextWindow so
@@ -71,7 +72,9 @@ export function buildAgent(opts: BuildAgentOptions): Agent {
     initialState: {
       systemPrompt: opts.systemPrompt,
       model: opts.model ?? STUB_MODEL,
-      tools: opts.tools,
+      // Every tool call is raced against a global execution timeout (and the
+      // caller's abort signal); see tool-timeout.ts.
+      tools: opts.tools.map((tool) => withAgentToolTimeout(tool)),
       // Seed prior turns so `agent.prompt(newMessage)` runs with the full
       // conversation in context — without this the agent is stateless per turn.
       ...(opts.history && opts.history.length > 0 ? { messages: opts.history } : {}),

--- a/lib/agent/runtime/tool-timeout.ts
+++ b/lib/agent/runtime/tool-timeout.ts
@@ -1,0 +1,202 @@
+/**
+ * Global per-tool-call execution bound for every agent built through
+ * `buildAgent`.
+ *
+ * pi's agent loop awaits `tool.execute(...)` with no deadline: a tool await
+ * that neither resolves nor rejects (a hung provider request, a database
+ * write that never returns, a library call stuck on an uncancellable await)
+ * wedges the session forever — the lease keeps heartbeating and no repair
+ * ever runs while the process lives. This module races every tool call
+ * against:
+ *
+ * - a hard time budget (`OPENMAIC_AGENT_TOOL_TIMEOUT_MS`, default 10 min),
+ *   which also fires the AbortSignal delivered to the tool's in-flight work;
+ * - the caller's own AbortSignal (session cancel / lease loss / shutdown),
+ *   so even a signal-ignoring await cannot keep the session running after a
+ *   cancel request lands.
+ *
+ * On timeout the tool call rejects with {@link AgentToolTimeoutError}; pi
+ * converts the rejection into a structured error tool-result in the
+ * transcript, so the agent sees the failure and can retry or proceed — the
+ * session does not die.
+ */
+import type { AgentTool, AgentToolUpdateCallback } from '@earendil-works/pi-agent-core';
+
+/**
+ * Default budget for a single tool call. Generous on purpose: media-bearing
+ * tools synthesize narration and model content per page, and known long
+ * runners are given larger explicit budgets in
+ * {@link AGENT_TOOL_TIMEOUT_OVERRIDES}.
+ */
+export const DEFAULT_AGENT_TOOL_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Per-tool budgets for tools with known longer (or shorter) execution
+ * profiles. The map wins over the env-tunable default: it encodes the
+ * deployment's own knowledge of how long a tool may legitimately run.
+ */
+export const AGENT_TOOL_TIMEOUT_OVERRIDES: Readonly<Record<string, number>> = {
+  // Scene generation can synthesize narration audio for every speech action
+  // (each provider request is itself bounded) on top of several model calls.
+  generate_scene: 15 * 60_000,
+  generate_actions: 15 * 60_000,
+  // Material extraction may wait on a slow upstream document pipeline.
+  extract_material: 15 * 60_000,
+};
+
+/** Environment variable that tunes the default tool-call budget. */
+export const AGENT_TOOL_TIMEOUT_ENV = 'OPENMAIC_AGENT_TOOL_TIMEOUT_MS';
+
+/** Resolve the execution budget for one tool call, in milliseconds. */
+export function resolveAgentToolTimeoutMs(
+  toolName: string,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const override = AGENT_TOOL_TIMEOUT_OVERRIDES[toolName];
+  if (override !== undefined) return override;
+  const raw = env[AGENT_TOOL_TIMEOUT_ENV]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_AGENT_TOOL_TIMEOUT_MS;
+}
+
+/** The tool call exceeded its execution budget and was aborted. */
+export class AgentToolTimeoutError extends Error {
+  readonly toolName: string;
+  readonly timeoutMs: number;
+
+  constructor(toolName: string, timeoutMs: number) {
+    super(
+      `Tool "${toolName}" exceeded its ${timeoutMs}ms execution budget and was aborted; ` +
+        'the call did not complete. Retry the call or proceed without its result.',
+    );
+    this.name = 'AgentToolTimeoutError';
+    this.toolName = toolName;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/** The tool call was aborted by the caller's signal (cancel / lease loss). */
+export class AgentToolAbortedError extends Error {
+  readonly toolName: string;
+
+  constructor(toolName: string) {
+    super(`Tool "${toolName}" was aborted before it completed.`);
+    this.name = 'AgentToolAbortedError';
+    this.toolName = toolName;
+  }
+}
+
+/**
+ * Wrap a tool so every execution is bounded by the tool timeout and by the
+ * caller's AbortSignal.
+ *
+ * The tool receives a derived signal that fires on timeout or when the outer
+ * signal fires, so abort is actually delivered to the tool's in-flight work
+ * even though the agent loop itself keeps running after a timeout. Progress
+ * updates emitted by a zombie tool after the race settles are dropped.
+ */
+export function withAgentToolTimeout(tool: AgentTool): AgentTool {
+  const timeoutMs = resolveAgentToolTimeoutMs(tool.name);
+  const execute = tool.execute.bind(tool);
+  return {
+    ...tool,
+    execute: (toolCallId, args, signal, onUpdate) =>
+      executeWithToolBound(execute, tool.name, timeoutMs, toolCallId, args, signal, onUpdate),
+  };
+}
+
+type ToolExecute = AgentTool['execute'];
+type ToolResult = Awaited<ReturnType<ToolExecute>>;
+
+async function executeWithToolBound(
+  execute: ToolExecute,
+  toolName: string,
+  timeoutMs: number,
+  toolCallId: string,
+  args: Parameters<ToolExecute>[1],
+  signal: AbortSignal | undefined,
+  onUpdate: Parameters<ToolExecute>[3],
+): Promise<ToolResult> {
+  // The derived signal is what the tool actually sees: the outer signal is
+  // forwarded into it, and the timeout fires it as well.
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort(signal?.reason);
+  if (signal?.aborted) controller.abort(signal.reason);
+  else signal?.addEventListener('abort', forwardAbort, { once: true });
+
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  // Abort delivery to the tool must never break the race settlement: a
+  // throwing abort listener is a tool bug, not a reason to wedge the session.
+  const abortWork = (reason: unknown): void => {
+    try {
+      controller.abort(reason);
+    } catch {
+      // Ignore: the race below still settles.
+    }
+  };
+
+  const cleanup = (): void => {
+    if (timer !== undefined) clearTimeout(timer);
+    if (signal) {
+      signal.removeEventListener('abort', forwardAbort);
+      signal.removeEventListener('abort', onCancelled);
+    }
+  };
+
+  // One settlement wins: timeout, caller abort, or the tool itself. The guard
+  // also makes the timeout error the race winner even when the tool rejects
+  // synchronously from the abort it was just delivered.
+  const finish = (apply: () => void): void => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    apply();
+  };
+
+  const onCancelled = (): void => {
+    const error = new AgentToolAbortedError(toolName);
+    finish(() => {
+      abortWork(error);
+      rejectRace(error);
+    });
+  };
+
+  const onTimeout = (): void => {
+    const error = new AgentToolTimeoutError(toolName, timeoutMs);
+    finish(() => {
+      abortWork(error);
+      rejectRace(error);
+    });
+  };
+
+  let resolveRace: (result: ToolResult) => void = () => {};
+  let rejectRace: (error: unknown) => void = () => {};
+  const race = new Promise<ToolResult>((resolve, reject) => {
+    resolveRace = resolve;
+    rejectRace = reject;
+  });
+
+  if (signal) {
+    if (signal.aborted) {
+      onCancelled();
+      return race;
+    }
+    signal.addEventListener('abort', onCancelled, { once: true });
+  }
+  if (timeoutMs > 0) timer = setTimeout(onTimeout, timeoutMs);
+
+  const guardedUpdate: AgentToolUpdateCallback | undefined = onUpdate
+    ? (partial) => {
+        if (!settled) onUpdate(partial);
+      }
+    : undefined;
+
+  execute(toolCallId, args, controller.signal, guardedUpdate).then(
+    (result) => finish(() => resolveRace(result)),
+    (error) => finish(() => rejectRace(error)),
+  );
+
+  return race;
+}

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -477,8 +477,12 @@ export class PgAgentSessionStore
     );
     for (const candidate of candidates.rows) {
       const claimed = await this.transaction(async (tx) => {
-        const locked = await tx.query<{ status: string }>(
-          `SELECT status FROM ${this.table('sessions')}
+        const locked = await tx.query<{
+          status: string;
+          attempt: number;
+          cancel_requested_at: number | string | Date | null;
+        }>(
+          `SELECT status, attempt, cancel_requested_at FROM ${this.table('sessions')}
            WHERE id = $1 AND deleted_at IS NULL
              AND (status = 'queued' OR
                   (status = 'running'
@@ -491,6 +495,14 @@ export class PgAgentSessionStore
         const previous = locked.rows[0];
         if (!previous) return null;
         const now = this.clock();
+        // A cancel request is terminal: the session must never be re-leased
+        // for another attempt (a restart would otherwise resurrect a session
+        // the user already cancelled). Settle it as cancelled under the same
+        // lock the claim would have used, then keep scanning.
+        if (previous.cancel_requested_at !== null && previous.cancel_requested_at !== undefined) {
+          await this.settleCancelledAtClaim(tx, candidate.id, now, previous.attempt);
+          return null;
+        }
         // PostgreSQL evaluates every SET expression from the locked pre-update
         // row, so lease_worker_id still identifies the prior holder here.
         const updated = await tx.query<SessionRow>(
@@ -531,6 +543,43 @@ export class PgAgentSessionStore
       if (claimed) return claimed;
     }
     return null;
+  }
+
+  /**
+   * Terminal bookkeeping for a cancel-requested session the claim scan just
+   * encountered, mirroring what the runner's own cancel path does: the row
+   * settles as `cancelled` with the attempt reset and the cancel request
+   * cleared, the owner projection records the terminal status, and the event
+   * log receives a `session_end` frame so the stream shows the terminal
+   * transition even though no lease holder ever ran this attempt.
+   */
+  private async settleCancelledAtClaim(
+    tx: Queryable,
+    sessionId: string,
+    now: number,
+    attempt: number,
+  ): Promise<void> {
+    const result = await tx.query<SessionRow>(
+      `UPDATE ${this.table('sessions')}
+       SET status = 'cancelled', attempt = 0, error = NULL,
+           lease_worker_id = NULL, lease_worker_pid = NULL, lease_heartbeat_at = NULL,
+           cancel_requested_at = NULL, updated_at = now()
+       WHERE id = $1 AND deleted_at IS NULL AND cancel_requested_at IS NOT NULL
+       RETURNING ${SESSION_COLUMNS}`,
+      [sessionId],
+    );
+    const row = result.rows[0];
+    if (!row) return;
+    await this.appendProjection(
+      { type: 'session_status', sessionId, ts: now, status: 'cancelled', attempt: 0 },
+      tx,
+    );
+    await this.insertEvent(tx, sessionId, {
+      ts: now,
+      attempt,
+      type: AGENT_SESSION_LIFECYCLE.sessionEnd,
+      data: { status: 'cancelled' },
+    });
   }
 
   async heartbeat(sessionId: string, workerId: string): Promise<boolean> {

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -262,6 +262,11 @@ export interface AgentSessionStore {
    * Scan optimistically, then lock and recheck one candidate. The second
    * check is the authority: candidate snapshots are stale as soon as read.
    *
+   * A candidate with a pending cancel request is never leased: the scan
+   * settles it as `cancelled` (attempt reset, cancel cleared, terminal
+   * `session_end` event) and returns null for it, so a restart can never
+   * resurrect a session the user already cancelled.
+   *
    * Attempt charging is per takeover: queued claims and takeovers of an
    * abandoned (non-null stale) lease each consume one attempt, while takeovers
    * of a cleanly-released (null) lease consume none. Clean parks therefore

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -241,6 +241,37 @@ export function runAgentSessionStoreContract(
       expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 0 });
     });
 
+    test('settles a cancel-requested queued session as cancelled on claim, never leasing it', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.requestCancel('session-1');
+      expect(await store.isCancelRequested('session-1')).toBe(true);
+
+      const claim = await store.claimNextSession('worker-a', 101, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      // The scan must not lease the session for another attempt: it settles
+      // the pending cancel under the claim lock and moves on.
+      expect(claim).toBeNull();
+
+      const meta = await store.getSession('session-1');
+      expect(meta).toMatchObject({ status: 'cancelled', attempt: 0 });
+      expect(meta?.lease).toBeUndefined();
+      expect(await store.isCancelRequested('session-1')).toBe(false);
+      // The event log carries the terminal frame and the owner projection
+      // records the terminal status, exactly like the runner's cancel path.
+      const events = await store.readEventsAfter('session-1', 0);
+      expect(events.at(-1)).toMatchObject({ type: AGENT_SESSION_LIFECYCLE.sessionEnd });
+      expect((events.at(-1)?.data as { status?: unknown } | undefined)?.status).toBe('cancelled');
+      const projection = await store.readAfter('owner-a', BigInt(0));
+      expect(projection.at(-1)).toMatchObject({
+        type: 'session_status',
+        status: 'cancelled',
+        attempt: 0,
+      });
+    });
+
     test('appends and reopens an entry tree with labels, paths, and leaf markers', async () => {
       const store = makeStore();
       await store.createSession(makeAgentSessionInput());

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -8,7 +8,7 @@ import {
   type PgAgentSessionStoreOptions,
   type Queryable,
 } from '../src/agent-session/pg.js';
-import { AgentSessionEntryTreeError } from '../src/agent-session/types.js';
+import { AgentSessionEntryTreeError, AGENT_SESSION_LIFECYCLE } from '../src/agent-session/types.js';
 import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
 import { makeAgentSessionInput, runAgentSessionStoreContract } from './agent-session-contract.js';
 import { runAgentSessionUrlContract } from './agent-session-url-contract.js';
@@ -225,5 +225,66 @@ describe('PgAgentSessionStore with PGlite', () => {
     expect(indexNames).toContain('spec_sessions_owner_live_idx');
     expect(indexNames).toContain('spec_entries_type_idx');
     expect(indexNames).not.toContain('spec_session_entries_type_idx');
+  });
+
+  test('settles a cancel-requested stale-running session as cancelled on claim, never attempt N+1', async () => {
+    // The incident shape: a worker dies mid-run with the cancel request set;
+    // after the restart the claim scan must NOT re-lease the session for
+    // attempt 2 — it settles the pending cancel as `cancelled` instead.
+    let now = 1_000_000;
+    const clocked = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      now: () => now,
+    });
+    await clocked.createSession(makeAgentSessionInput());
+    const first = await clocked.claimNextSession('worker-a', 101, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 3,
+    });
+    expect(first).toMatchObject({ id: 'session-1', status: 'running', attempt: 1 });
+
+    await clocked.requestCancel('session-1');
+    now += 20_000; // The 10s lease is stale; the worker is gone.
+
+    const retry = await clocked.claimNextSession('worker-b', 102, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 3,
+    });
+    expect(retry).toBeNull();
+
+    const meta = await clocked.getSession('session-1');
+    expect(meta).toMatchObject({ status: 'cancelled', attempt: 0 });
+    expect(meta?.lease).toBeUndefined();
+    expect(await clocked.isCancelRequested('session-1')).toBe(false);
+    const events = await clocked.readEventsAfter('session-1', 0);
+    expect(events.at(-1)).toMatchObject({ type: AGENT_SESSION_LIFECYCLE.sessionEnd });
+    expect((events.at(-1)?.data as { status?: unknown } | undefined)?.status).toBe('cancelled');
+  });
+
+  test('claim scan settles a cancel-requested session and still claims the next queued one', async () => {
+    const clocked = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      now: () => 1_000_000,
+    });
+    await clocked.createSession(makeAgentSessionInput({ id: 'session-cancel' }));
+    await clocked.requestCancel('session-cancel');
+    await clocked.createSession(makeAgentSessionInput({ id: 'session-next', stageId: 'stage-2' }));
+    // Pin the scan order: the cancel-requested candidate must sort first.
+    await db.query(`UPDATE agent_sessions SET created_at = $2 WHERE id = $1`, [
+      'session-cancel',
+      new Date('2020-01-01T00:00:00Z'),
+    ]);
+    await db.query(`UPDATE agent_sessions SET created_at = $2 WHERE id = $1`, [
+      'session-next',
+      new Date('2021-01-01T00:00:00Z'),
+    ]);
+
+    const claim = await clocked.claimNextSession('worker-a', 101, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 3,
+    });
+    // The scan keeps going after settling the cancel-requested candidate.
+    expect(claim?.id).toBe('session-next');
+    expect(await clocked.getSession('session-cancel')).toMatchObject({ status: 'cancelled' });
   });
 });

--- a/tests/agent-runtime/runner-tool-timeout-cancel.test.ts
+++ b/tests/agent-runtime/runner-tool-timeout-cancel.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Runner-level pins for the global tool-call execution bound and prompt
+ * cancellation of a hung tool.
+ *
+ * These tests drive the REAL `runSession` loop with the REAL `buildAgent` and
+ * the REAL pi agent loop (only the LLM transport, the session store, and the
+ * tool assembly seam are mocked). They pin the two incident behaviors:
+ *
+ * - a tool call that never settles ends with a structured timeout error result
+ *   in the transcript at the configured bound, and the session keeps running
+ *   and settles normally (the session does NOT die);
+ * - a cancel request that lands while a tool is hung settles the session as
+ *   `cancelled` promptly — without waiting for the tool to finish — and the
+ *   abort signal is delivered to the tool's in-flight work.
+ */
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { InMemorySessionRepo, Session } from '@earendil-works/pi-agent-core';
+import type { ClaimedAgentSession } from '@openmaic/storage';
+import { Type } from 'typebox';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  randomUUID: vi.fn(() => 'runner-test-uuid'),
+  getAgentSessionStore: vi.fn(),
+  getServerPersistenceProvider: vi.fn(),
+  openEntryStorage: vi.fn(),
+  resolveAgentDriverModel: vi.fn(),
+  streamLLM: vi.fn(),
+  assembleRunnerTools: vi.fn(),
+  buildRunnerCoursePrompt: vi.fn(() => 'system prompt'),
+  getOwnerScopedDocumentStore: vi.fn(async () => ({})),
+}));
+
+vi.mock('node:crypto', async (importActual) => {
+  const actual = await importActual<typeof import('node:crypto')>();
+  return { ...actual, randomUUID: mocks.randomUUID };
+});
+
+vi.mock('@/lib/server/agent-runtime/store', () => ({
+  getAgentSessionStore: mocks.getAgentSessionStore,
+}));
+
+vi.mock('@/lib/persistence/server-provider', () => ({
+  getServerPersistenceProvider: mocks.getServerPersistenceProvider,
+}));
+
+vi.mock('@/lib/server/agent-runtime/session-materials', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@/lib/server/agent-runtime/session-materials')>();
+  return { ...actual, listSessionMaterials: vi.fn(async () => []) };
+});
+
+vi.mock('@/lib/server/agent-runtime/entry-tree-storage', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@/lib/server/agent-runtime/entry-tree-storage')>();
+  return {
+    ...actual,
+    AgentSessionEntryStorage: {
+      open: mocks.openEntryStorage,
+    },
+  };
+});
+
+vi.mock('@/lib/server/agent-runtime/agent-driver-model', () => ({
+  resolveAgentDriverModel: mocks.resolveAgentDriverModel,
+}));
+
+vi.mock('@/lib/ai/llm', () => ({
+  streamLLM: mocks.streamLLM,
+  callLLM: vi.fn(),
+}));
+
+// The tool assembly seam is mocked so the runner's agent executes exactly one
+// instrumented hung tool instead of the full production toolset.
+vi.mock('@/lib/server/agent-runtime/runner-contract', () => ({
+  assembleRunnerTools: mocks.assembleRunnerTools,
+  buildRunnerCoursePrompt: mocks.buildRunnerCoursePrompt,
+}));
+
+vi.mock('@/lib/server/agent-runtime/owner-scoped-documents', () => ({
+  getOwnerScopedDocumentStore: mocks.getOwnerScopedDocumentStore,
+}));
+
+// Skills are orthogonal to the behaviour under test; pin the runner to a
+// deployment with NO installed skills so no user-skill store is touched.
+vi.mock('@/lib/server/agent-runtime/skills', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/server/agent-runtime/skills')>();
+  return {
+    ...actual,
+    listSkills: vi.fn(async () => []),
+    findSkill: vi.fn(async () => null),
+  };
+});
+vi.mock('@/lib/server/agent-runtime/user-skills', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/server/agent-runtime/user-skills')>();
+  return { ...actual, listUserSkills: vi.fn(async () => []) };
+});
+
+import { runSession } from '@/lib/server/agent-runtime/runner';
+import { AGENT_TOOL_TIMEOUT_ENV } from '@/lib/agent/runtime/tool-timeout';
+
+const SESSION_ID = 'session-1';
+const TOOL_NAME = 'read_stage';
+/** Mirrors the runner's `WORKER_ID` derivation with the fixed mock uuid. */
+const WORKER_ID = `runner-t:${process.pid}`;
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+
+const finish = (finishReason: string) => ({
+  type: 'finish',
+  finishReason,
+  totalUsage: ZERO_USAGE,
+});
+
+const toolCallPart = (args: unknown = {}) => ({
+  type: 'tool-call',
+  toolCallId: 'call-1',
+  toolName: TOOL_NAME,
+  input: args,
+});
+
+const resultFrom = (parts: Array<Record<string, unknown>>) => ({
+  fullStream: (async function* () {
+    for (const part of parts) yield part;
+  })(),
+  usage: new Promise(() => {}),
+});
+
+function useResponses(responses: Array<Array<Record<string, unknown>>>) {
+  mocks.streamLLM.mockImplementation(() => {
+    const parts = responses.shift();
+    return resultFrom(
+      parts ?? [{ type: 'text-delta', text: 'unexpected transport' }, finish('stop')],
+    );
+  });
+}
+
+function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSession {
+  return {
+    id: SESSION_ID,
+    ownerId: 'owner-1',
+    prompt: 'Build a lesson',
+    stageId: 'stage-1',
+    existingCourse: false,
+    status: 'running',
+    attempt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    claimReason: 'queued',
+    claimSeq: 0,
+    ...overrides,
+  };
+}
+
+function makeStore(meta: ClaimedAgentSession, options: { cancelRequested?: () => boolean } = {}) {
+  let seq = 0;
+  return {
+    appendRunEvent: vi.fn(
+      async (
+        _id: string,
+        _workerId: string,
+        _event: { type: string; data?: Record<string, unknown> },
+      ) => {
+        seq += 1;
+        return seq;
+      },
+    ),
+    clearCancel: vi.fn(async () => undefined),
+    finishSession: vi.fn(
+      async (_id: string, _workerId: string, _patch: { status: string }) => true,
+    ),
+    getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
+    hasSessionRunHistory: vi.fn(async () => false),
+    heartbeat: vi.fn(async () => true),
+    isCancelRequested: vi.fn(async () => options.cancelRequested?.() ?? false),
+    listUserMessages: vi.fn(async () => []),
+    releaseLease: vi.fn(async () => undefined),
+    requeueForRetry: vi.fn(async () => false),
+    requeueSession: vi.fn(async () => false),
+  };
+}
+
+type FakeStore = ReturnType<typeof makeStore>;
+
+async function makeEntryTree(): Promise<Session> {
+  const repo = new InMemorySessionRepo();
+  return repo.create({ id: SESSION_ID });
+}
+
+const HungToolParams = Type.Object({});
+
+/** A tool whose execution never settles on its own, recording the signal. */
+function makeHungTool(
+  captured: AbortSignal[],
+  started?: () => void,
+): AgentTool<typeof HungToolParams> {
+  return {
+    name: TOOL_NAME,
+    label: 'Read stage',
+    description: 'Test tool',
+    parameters: HungToolParams,
+    async execute(_callId, _params, signal) {
+      if (signal) captured.push(signal);
+      started?.();
+      return new Promise(() => {});
+    },
+  };
+}
+
+const setToolTimeout = (value: string | undefined): void => {
+  if (value === undefined) delete process.env[AGENT_TOOL_TIMEOUT_ENV];
+  else process.env[AGENT_TOOL_TIMEOUT_ENV] = value;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveAgentDriverModel.mockResolvedValue({
+    // A truthy model stub: the real stream-fn adapter reads `.provider` off
+    // the language model while mapping the first turn.
+    connection: { model: {} as never, thinkingConfig: undefined },
+    piModel: { api: 'openai-completions', provider: 'openai', id: 'driver-model' },
+    wireMaxOutputTokens: undefined,
+    reservedOutputTokens: 8192,
+  });
+  mocks.getServerPersistenceProvider.mockResolvedValue({
+    documentStore: { forOwner: () => ({}) },
+  });
+});
+
+afterEach(() => {
+  setToolTimeout(undefined);
+  vi.useRealTimers();
+});
+
+describe('runner: global tool-call execution bound', () => {
+  it('ends a never-settling tool call with a timeout error result and keeps the session alive', async () => {
+    vi.useFakeTimers();
+    setToolTimeout('5000');
+    const meta = makeMeta();
+    const session = await makeEntryTree();
+    const store = makeStore(meta);
+    const captured: AbortSignal[] = [];
+    let started!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+    mocks.assembleRunnerTools.mockReturnValue([makeHungTool(captured, started)]);
+    useResponses([
+      [toolCallPart(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'complete' }, finish('stop')],
+    ]);
+
+    const run = runSession({ running: new Map(), shuttingDown: false }, meta);
+    await gate;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await run;
+
+    // The tool call settled as a structured error tool-result in the
+    // transcript at the configured bound...
+    const messages = (await session.buildContext()).messages;
+    const toolResult = messages.find((message) => message.role === 'toolResult');
+    expect(toolResult).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'call-1',
+      toolName: TOOL_NAME,
+      isError: true,
+    });
+    expect(JSON.stringify(toolResult)).toContain('execution budget');
+    expect(JSON.stringify(toolResult)).toContain('5000ms');
+    // ...the session did NOT die: it settled normally as succeeded...
+    expect(store.finishSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      WORKER_ID,
+      expect.objectContaining({ status: 'succeeded' }),
+    );
+    expect(store.clearCancel).not.toHaveBeenCalled();
+    // ...the agent made its next model turn after the timeout error...
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    // ...and the abort signal reached the tool's in-flight work.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.aborted).toBe(true);
+    expect(captured[0]?.reason).toMatchObject({ name: 'AgentToolTimeoutError' });
+  });
+});
+
+describe('runner: cancel of a hung tool', () => {
+  it('settles the session as cancelled promptly without waiting for the tool', async () => {
+    vi.useFakeTimers();
+    // The tool budget is far beyond the test window: only the cancel can end
+    // the call within it.
+    setToolTimeout('60000');
+    const meta = makeMeta();
+    const session = await makeEntryTree();
+    let cancelRequested = false;
+    const store = makeStore(meta, { cancelRequested: () => cancelRequested });
+    const captured: AbortSignal[] = [];
+    let started!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+    mocks.assembleRunnerTools.mockReturnValue([makeHungTool(captured, started)]);
+    useResponses([[toolCallPart(), finish('tool-calls')]]);
+
+    const run = runSession({ running: new Map(), shuttingDown: false }, meta);
+    await gate;
+    expect(captured[0]?.aborted).toBe(false);
+
+    // The user cancels while the tool is still hung. The runner observes the
+    // cancel at its next checkpoint and the tool-call race settles on the
+    // abort signal — the session must reach `cancelled` within one poll
+    // interval, nowhere near the 60s tool budget.
+    cancelRequested = true;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await run;
+
+    expect(store.finishSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      WORKER_ID,
+      expect.objectContaining({ status: 'cancelled', resetAttempt: true }),
+    );
+    expect(store.clearCancel).toHaveBeenCalledWith(SESSION_ID);
+    // The abort was delivered to the tool's in-flight work.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.aborted).toBe(true);
+    // The hung tool's own promise never settled: the run ended on the cancel,
+    // not on the tool.
+    expect(store.finishSession.mock.calls[0]?.[2]).toMatchObject({ status: 'cancelled' });
+  });
+});

--- a/tests/lib/agent/runtime/agent-tool-timeout.test.ts
+++ b/tests/lib/agent/runtime/agent-tool-timeout.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Agent-loop pins for the global tool-call execution bound.
+ *
+ * These tests drive the REAL pi Agent through the REAL `buildAgent` and the
+ * REAL stream-fn adapter (only the underlying `streamLLM` transport is
+ * mocked), so the timeout wiring is exercised end to end: a tool that never
+ * settles must end its call with a structured error tool-result in the
+ * transcript at the configured bound, and the agent must keep running (the
+ * session does not die), while the abort signal is delivered to the tool's
+ * in-flight work.
+ */
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { Type } from 'typebox';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ streamLLM: vi.fn() }));
+
+vi.mock('@/lib/ai/llm', () => ({ streamLLM: mocks.streamLLM }));
+
+import { buildAgent } from '@/lib/agent/runtime/build-agent';
+import { createCallLlmStreamFn } from '@/lib/agent/runtime/stream-fn';
+import { AGENT_TOOL_TIMEOUT_ENV } from '@/lib/agent/runtime/tool-timeout';
+
+const ZERO_USAGE = {
+  inputTokens: 0,
+  outputTokens: 0,
+  inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 0 },
+};
+
+const finish = (finishReason: string) => ({
+  type: 'finish',
+  finishReason,
+  totalUsage: ZERO_USAGE,
+});
+
+const toolCall = (args: unknown = {}) => ({
+  type: 'tool-call',
+  toolCallId: 'call-1',
+  toolName: 'demo',
+  input: args,
+});
+
+const resultFrom = (parts: Array<Record<string, unknown>>) => ({
+  fullStream: (async function* () {
+    for (const part of parts) yield part;
+  })(),
+  usage: new Promise(() => {}),
+});
+
+function useResponses(responses: Array<Array<Record<string, unknown>>>) {
+  mocks.streamLLM.mockImplementation(() => {
+    const parts = responses.shift();
+    return resultFrom(
+      parts ?? [{ type: 'text-delta', text: 'unexpected transport' }, finish('stop')],
+    );
+  });
+}
+
+const DemoParams = Type.Object({});
+
+/** A tool whose execution never settles, recording the signal it received. */
+function makeHungTool(captured: AbortSignal[], started?: () => void): AgentTool<typeof DemoParams> {
+  return {
+    name: 'demo',
+    label: 'Demo',
+    description: 'Test tool',
+    parameters: DemoParams,
+    async execute(_callId, _params, signal) {
+      if (signal) captured.push(signal);
+      started?.();
+      return new Promise(() => {});
+    },
+  };
+}
+
+const setToolTimeout = (value: string | undefined): void => {
+  if (value === undefined) delete process.env[AGENT_TOOL_TIMEOUT_ENV];
+  else process.env[AGENT_TOOL_TIMEOUT_ENV] = value;
+};
+
+describe('agent loop tool-execution bound', () => {
+  beforeEach(() => {
+    mocks.streamLLM.mockReset();
+  });
+
+  afterEach(() => {
+    setToolTimeout(undefined);
+    vi.useRealTimers();
+  });
+
+  it('ends a never-settling tool call with a timeout error result at the configured bound', async () => {
+    vi.useFakeTimers();
+    setToolTimeout('5000');
+    const captured: AbortSignal[] = [];
+    let started!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'complete' }, finish('stop')],
+    ]);
+    const agent = buildAgent({
+      streamFn: createCallLlmStreamFn({ languageModel: {} as never }),
+      systemPrompt: 'system',
+      tools: [makeHungTool(captured, started)],
+      allowedToolNames: new Set(['demo']),
+    });
+
+    const prompt = agent.prompt('start');
+    await gate;
+    // The tool call is in flight with a live signal; the timeout fires at the
+    // configured bound and the call settles as an error result.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await prompt;
+
+    const toolResult = agent.state.messages.find((message) => message.role === 'toolResult');
+    expect(toolResult).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'call-1',
+      toolName: 'demo',
+      isError: true,
+    });
+    expect(JSON.stringify(toolResult)).toContain('execution budget');
+    expect(JSON.stringify(toolResult)).toContain('5000ms');
+    // The agent survived the timeout and continued with the next model turn.
+    expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
+    // The abort was delivered to the tool's in-flight work.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.aborted).toBe(true);
+  });
+});

--- a/tests/lib/agent/runtime/tool-timeout.test.ts
+++ b/tests/lib/agent/runtime/tool-timeout.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit pins for the global tool-call execution bound.
+ *
+ * The wrapper races every tool call against a hard time budget and against the
+ * caller's AbortSignal. These tests exercise the wrapper directly: a tool that
+ * never settles must reject with the timeout error at the configured budget
+ * while still delivering the abort to the tool's in-flight work, a caller
+ * abort must settle the race promptly even when the tool ignores the signal,
+ * and normal completion must pass through untouched with no timer left behind.
+ */
+import type { AgentTool, AgentToolUpdateCallback } from '@earendil-works/pi-agent-core';
+import { Type } from 'typebox';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AGENT_TOOL_TIMEOUT_ENV,
+  AGENT_TOOL_TIMEOUT_OVERRIDES,
+  AgentToolAbortedError,
+  AgentToolTimeoutError,
+  DEFAULT_AGENT_TOOL_TIMEOUT_MS,
+  resolveAgentToolTimeoutMs,
+  withAgentToolTimeout,
+} from '@/lib/agent/runtime/tool-timeout';
+
+const Params = Type.Object({});
+
+type DemoTool = AgentTool<typeof Params>;
+
+function makeTool(execute: DemoTool['execute']): DemoTool {
+  return {
+    name: 'demo_tool',
+    label: 'Demo',
+    description: 'Test tool',
+    parameters: Params,
+    execute,
+  };
+}
+
+/** A tool whose execution never settles on its own, recording the signal it got. */
+function hungTool(captured: AbortSignal[], started?: () => void): DemoTool {
+  return makeTool((_id, _args, signal) => {
+    if (signal) captured.push(signal);
+    started?.();
+    return new Promise(() => {});
+  });
+}
+
+const result = (text: string) => ({
+  content: [{ type: 'text' as const, text }],
+  details: { source: 'tool' },
+});
+
+const setEnv = (value: string | undefined): void => {
+  if (value === undefined) delete process.env[AGENT_TOOL_TIMEOUT_ENV];
+  else process.env[AGENT_TOOL_TIMEOUT_ENV] = value;
+};
+
+describe('resolveAgentToolTimeoutMs', () => {
+  afterEach(() => {
+    setEnv(undefined);
+  });
+
+  it('uses the generous default when the env var is absent or invalid', () => {
+    expect(resolveAgentToolTimeoutMs('any_tool')).toBe(DEFAULT_AGENT_TOOL_TIMEOUT_MS);
+    setEnv('not-a-number');
+    expect(resolveAgentToolTimeoutMs('any_tool')).toBe(DEFAULT_AGENT_TOOL_TIMEOUT_MS);
+    setEnv('0');
+    expect(resolveAgentToolTimeoutMs('any_tool')).toBe(DEFAULT_AGENT_TOOL_TIMEOUT_MS);
+  });
+
+  it('reads the env-tunable default', () => {
+    setEnv('7000');
+    expect(resolveAgentToolTimeoutMs('any_tool')).toBe(7000);
+  });
+
+  it('prefers the per-tool override map over the env default', () => {
+    setEnv('7000');
+    expect(AGENT_TOOL_TIMEOUT_OVERRIDES['generate_scene']).toBeGreaterThan(7000);
+    expect(resolveAgentToolTimeoutMs('generate_scene')).toBe(
+      AGENT_TOOL_TIMEOUT_OVERRIDES['generate_scene'],
+    );
+  });
+});
+
+describe('withAgentToolTimeout', () => {
+  beforeEach(() => {
+    setEnv('5000');
+  });
+
+  afterEach(() => {
+    setEnv(undefined);
+    vi.useRealTimers();
+  });
+
+  it('rejects a never-settling tool at the configured budget and aborts its signal', async () => {
+    vi.useFakeTimers();
+    const captured: AbortSignal[] = [];
+    const tool = withAgentToolTimeout(hungTool(captured));
+
+    // Attach the rejection handlers before the timer fires so the rejection is
+    // never observed as unhandled.
+    const promise = tool.execute('call-1', {}, undefined);
+    const isTimeout = expect(promise).rejects.toBeInstanceOf(AgentToolTimeoutError);
+    const namesTool = expect(promise).rejects.toThrow(/demo_tool/);
+    const namesBudget = expect(promise).rejects.toThrow(/5000ms/);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await Promise.all([isTimeout, namesTool, namesBudget]);
+
+    // The abort was actually delivered to the tool's in-flight work, with the
+    // timeout error as the signal reason.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.aborted).toBe(true);
+    expect(captured[0]?.reason).toBeInstanceOf(AgentToolTimeoutError);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('settles promptly when the caller signal aborts a never-settling tool', async () => {
+    vi.useFakeTimers();
+    const captured: AbortSignal[] = [];
+    let started!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const tool = withAgentToolTimeout(hungTool(captured, started));
+    const controller = new AbortController();
+
+    const promise = tool.execute('call-1', {}, controller.signal);
+    await gate;
+    expect(captured[0]?.aborted).toBe(false);
+    const settled = expect(promise).rejects.toBeInstanceOf(AgentToolAbortedError);
+    controller.abort();
+    // The cancel settles the race immediately, long before the 5s budget.
+    await vi.advanceTimersByTimeAsync(0);
+    await settled;
+
+    expect(captured[0]?.aborted).toBe(true);
+    // No timer is left behind once the race settled via cancellation.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('never starts a tool whose caller signal already fired', async () => {
+    const captured: AbortSignal[] = [];
+    const tool = withAgentToolTimeout(hungTool(captured));
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(tool.execute('call-1', {}, controller.signal)).rejects.toBeInstanceOf(
+      AgentToolAbortedError,
+    );
+    expect(captured).toHaveLength(0);
+  });
+
+  it('passes normal completion through unchanged and clears the timer', async () => {
+    vi.useFakeTimers();
+    const execute = vi.fn(async () => result('ok'));
+    const tool = withAgentToolTimeout(makeTool(execute));
+
+    await expect(tool.execute('call-1', {}, undefined)).resolves.toEqual(result('ok'));
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('forwards in-flight updates but drops updates and results from a zombie tool', async () => {
+    vi.useFakeTimers();
+    const emit = vi.fn<AgentToolUpdateCallback>();
+    const tool = withAgentToolTimeout(
+      makeTool((_id, _args, _signal, onUpdate) => {
+        onUpdate?.(result('progress'));
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            onUpdate?.(result('late-progress'));
+            resolve(result('late-result'));
+          }, 6_000);
+        });
+      }),
+    );
+
+    const promise = tool.execute('call-1', {}, undefined, emit);
+    const settled = expect(promise).rejects.toBeInstanceOf(AgentToolTimeoutError);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settled;
+    // Only the update emitted while the call was still in flight reached the
+    // agent loop; the zombie tool's post-settlement update is dropped.
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(result('progress'));
+
+    // The zombie's timer and result are both ignored after the race settled.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Symptoms (live incident)

A session sat `running` for 40+ minutes inside a TTS tool call: the cancel request was set on the row but new provider requests kept going out, and after a server restart the claim scan re-leased the same session for attempt 2 and resumed generating.

## Fixes

1. **Global per-tool-call timeout.** Every tool built through `buildAgent` is raced against a hard budget (`OPENMAIC_AGENT_TOOL_TIMEOUT_MS`, default 10 min; per-tool overrides give media synthesis/extraction 15 min, calibrated above the existing provider-level bounds). On timeout the call settles as a structured error tool-result — the agent sees the failure and continues; the session does not die. The derived AbortController delivers the abort to the tool's in-flight work, and zombie updates after settlement are dropped.
2. **Cancel honored during tool execution.** The same race also settles on the caller's AbortSignal, so a cancel ends the tool call promptly even when the hang is in a non-fetch await the signal never reached.
3. **Claim scan respects a pending cancel.** `claimNextSession` settles a `cancel_requested_at` candidate as `cancelled` under the claim's own row lock (terminal bookkeeping: attempt reset, lease + cancel cleared, `session_end` event, owner projection) and keeps scanning — a restart can no longer resurrect a cancelled session. `postUserMessage`'s cancel-clearing for queued sessions is deliberate attended-retry semantics and is unchanged.

## Verification

Red→green at each seam: a never-settling tool ends with a timeout error result at the configured bound and the session survives; a cancel during a hung tool settles `cancelled` well under the tool budget; a cancel-requested session settles `cancelled` on claim (never attempt N+1) while the scan still claims the next queued candidate. `tsc` 0 errors, prettier clean; agent-runtime 845 tests green, buildAgent consumers 1113 green, storage suite 978 green. `@openmaic/storage` version bumped (will re-sequence against the tip at merge time if another in-flight bump lands first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)