### PR TITLE
fix(agent): fence durable tool writes and consume cancel requests atomically

### DIFF
--- a/lib/persistence/owner-bound-document-store.ts
+++ b/lib/persistence/owner-bound-document-store.ts
@@ -31,11 +31,13 @@ export interface OwnerBoundDocumentStoreOptions {
   ownerId: string;
   validateScene: SceneValidator;
   validateStage: StageValidator;
+  /** Runner-only lease fence, evaluated inside every mutation transaction. */
+  mutationFence?: (queryable: Queryable) => Promise<void>;
 }
 
-type OwnershipMode = 'create' | 'mutate' | 'read' | 'delete';
+type OwnershipMode = 'create' | 'mutate' | 'read' | 'delete' | 'library';
 interface PendingOperation {
-  stageId: string;
+  stageId?: string;
   mode: OwnershipMode;
 }
 
@@ -137,7 +139,7 @@ class OwnerBoundDocumentStore<TScene extends SceneLike, TStage extends Stage>
   }
 
   createFolder(folderId: string, name: string, limit?: number) {
-    return this.inner.createFolder(folderId, name, limit);
+    return this.tagged({ mode: 'library' }, () => this.inner.createFolder(folderId, name, limit));
   }
 
   listFolders(): Promise<DocumentFolder[]> {
@@ -145,22 +147,26 @@ class OwnerBoundDocumentStore<TScene extends SceneLike, TStage extends Stage>
   }
 
   moveDocumentToFolder(stageId: string, folderId: string): Promise<boolean> {
-    return this.inner.moveDocumentToFolder(stageId, folderId);
+    return this.tagged({ stageId, mode: 'mutate' }, () =>
+      this.inner.moveDocumentToFolder(stageId, folderId),
+    );
   }
 
   renameFolder(id: string, name: string): Promise<DocumentFolder | null> {
-    return this.inner.renameFolder(id, name);
+    return this.tagged({ mode: 'library' }, () => this.inner.renameFolder(id, name));
   }
 
   deleteFolder(
     id: string,
     mode: 'ungroup' | 'remove',
   ): Promise<{ removedStageIds: string[] } | null> {
-    return this.inner.deleteFolder(id, mode);
+    return this.tagged({ mode: 'library' }, () => this.inner.deleteFolder(id, mode));
   }
 
   setStageFolder(stageId: string, folderId: string | null): Promise<boolean> {
-    return this.inner.setStageFolder(stageId, folderId);
+    return this.tagged({ stageId, mode: 'mutate' }, () =>
+      this.inner.setStageFolder(stageId, folderId),
+    );
   }
 }
 
@@ -177,7 +183,8 @@ export function createOwnerBoundDocumentStore<
       try {
         const queryable = queryableFor(client);
         const operation = pending.operation;
-        if (operation) {
+        if (operation && operation.mode !== 'read') await options.mutationFence?.(queryable);
+        if (operation?.stageId) {
           const lock = operation.mode === 'read' ? 'FOR SHARE' : 'FOR UPDATE';
           const result = await queryable.query<RawOwnershipRow>(
             `SELECT owner_id, deleted_at FROM stage_meta WHERE stage_id = $1 ${lock}`,
@@ -206,8 +213,9 @@ export function createOwnerBoundDocumentStore<
 
         const result = await body(queryable);
         if (operation?.mode === 'create') {
-          await claimStageMeta(queryable, operation.stageId, options.ownerId);
+          await claimStageMeta(queryable, operation.stageId!, options.ownerId);
         }
+        if (operation && operation.mode !== 'read') await options.mutationFence?.(queryable);
         await client.query('COMMIT');
         return result;
       } catch (error) {

--- a/lib/server/agent-runtime/course-edit/tools.ts
+++ b/lib/server/agent-runtime/course-edit/tools.ts
@@ -9,6 +9,7 @@ import { createBlankScene } from './apply';
 import type { CourseToolDeps } from '../course-tools';
 import { COURSE_STAGE_ID_DESCRIPTION } from '../course-stage';
 import { synthesizeSceneNarration } from '../scene-tts';
+import { runStageMutation } from '../mutation-fence';
 
 const Target = {
   stageId: Type.String({ description: COURSE_STAGE_ID_DESCRIPTION }),
@@ -120,7 +121,7 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
         );
       }
       if (summary.changed) {
-        await deps.store.putScene(params.stageId, scene);
+        await runStageMutation(signal, () => deps.store.putScene(params.stageId, scene));
         deps.onCheckpoint({
           tool: 'generate_tts',
           stageId: params.stageId,
@@ -146,7 +147,7 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
     label: 'Edit course pages',
     description: 'Retitle, insert, delete, or reorder pages without regenerating their content.',
     parameters: DeckParams,
-    async execute(_callId, params) {
+    async execute(_callId, params, signal) {
       const doc = await deps.store.loadDocument(params.stageId);
       if (!doc) return result('No course document yet. Call create_stage first.', {}, true);
       const scenes = [...doc.scenes].sort((a, b) => a.order - b.order);
@@ -161,11 +162,13 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
             ? { ...entry, title: next.title }
             : entry,
         );
-        await deps.store.saveDocument({
-          ...doc,
-          scenes: scenes.map((item) => (item.id === scene.id ? next : item)),
-          outline: nextOutline ? { ...outline, outlines: nextOutline } : doc.outline,
-        });
+        await runStageMutation(signal, () =>
+          deps.store.saveDocument({
+            ...doc,
+            scenes: scenes.map((item) => (item.id === scene.id ? next : item)),
+            outline: nextOutline ? { ...outline, outlines: nextOutline } : doc.outline,
+          }),
+        );
         deps.onCheckpoint({
           tool: 'edit_deck',
           stageId: params.stageId,
@@ -184,11 +187,13 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
           title: params.title?.trim() || `Page ${at}`,
           type: params.type ?? 'slide',
         });
-        await deps.store.saveDocument({
-          ...doc,
-          scenes: [...shifted.scenes, created].sort((a, b) => a.order - b.order),
-          outline: shifted.outline,
-        });
+        await runStageMutation(signal, () =>
+          deps.store.saveDocument({
+            ...doc,
+            scenes: [...shifted.scenes, created].sort((a, b) => a.order - b.order),
+            outline: shifted.outline,
+          }),
+        );
         deps.onCheckpoint({
           tool: 'edit_deck',
           stageId: params.stageId,
@@ -208,7 +213,9 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
           scenes.filter((item) => item.id !== scene.id),
           outline,
         );
-        await deps.store.saveDocument({ ...doc, scenes: next.scenes, outline: next.outline });
+        await runStageMutation(signal, () =>
+          deps.store.saveDocument({ ...doc, scenes: next.scenes, outline: next.outline }),
+        );
         deps.onCheckpoint({
           tool: 'edit_deck',
           stageId: params.stageId,
@@ -226,7 +233,9 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
       });
       ordered.push(...scenes.filter((scene) => byId.has(scene.id)));
       const next = renumberCourseOrders(ordered, outline);
-      await deps.store.saveDocument({ ...doc, scenes: next.scenes, outline: next.outline });
+      await runStageMutation(signal, () =>
+        deps.store.saveDocument({ ...doc, scenes: next.scenes, outline: next.outline }),
+      );
       deps.onCheckpoint({ tool: 'edit_deck', stageId: params.stageId, detail: 'reordered pages' });
       return result('Reordered pages.', {
         pages: next.scenes.map(({ id, order, title }) => ({ id, order, title })),

--- a/lib/server/agent-runtime/curriculum-tools.ts
+++ b/lib/server/agent-runtime/curriculum-tools.ts
@@ -20,6 +20,7 @@ import { getServerPersistenceProvider } from '@/lib/persistence/server-provider'
 import type { CourseDocument, CourseStore } from './course-tools';
 import { folderIdForCall, stageIdForCall } from './course-stage';
 import { mergeStageOutline } from './course-outline-union';
+import { runStageMutation } from './mutation-fence';
 import { FOLDER_COUNT_LIMIT, validateFolderName } from '@/lib/utils/folder-name-validation';
 
 export { stageIdForCall } from './course-stage';
@@ -239,7 +240,9 @@ export function buildCurriculumTools(deps: CurriculumToolDeps): AgentTool<never,
           );
         }
         if (folderId) {
-          const moved = await deps.store.moveDocumentToFolder(stageId, folderId);
+          const moved = await runStageMutation(signal, () =>
+            deps.store.moveDocumentToFolder(stageId, folderId),
+          );
           if (signal?.aborted) throw new Error('aborted');
           if (!moved) {
             return toolResult(
@@ -297,10 +300,12 @@ export function buildCurriculumTools(deps: CurriculumToolDeps): AgentTool<never,
       // the owner scope in one transaction. A concurrent mint of the same id
       // is refused by the store's owner scope; the replay is sequential, so
       // the loadDocument pre-check above is the ordering guarantee.
-      await deps.store.saveDocument(document);
+      await runStageMutation(signal, () => deps.store.saveDocument(document));
       if (signal?.aborted) throw new Error('aborted');
       if (folderId) {
-        const moved = await deps.store.moveDocumentToFolder(stageId, folderId);
+        const moved = await runStageMutation(signal, () =>
+          deps.store.moveDocumentToFolder(stageId, folderId),
+        );
         if (signal?.aborted) throw new Error('aborted');
         if (!moved) {
           return toolResult(
@@ -346,10 +351,12 @@ export function buildCurriculumTools(deps: CurriculumToolDeps): AgentTool<never,
         );
       }
       try {
-        const created = await deps.store.createFolder(
-          folderIdForCall(deps.sessionId, callId),
-          name,
-          FOLDER_COUNT_LIMIT,
+        const created = await runStageMutation(signal, () =>
+          deps.store.createFolder(
+            folderIdForCall(deps.sessionId, callId),
+            name,
+            FOLDER_COUNT_LIMIT,
+          ),
         );
         if (signal?.aborted) throw new Error('aborted');
         if (!created.reused) {
@@ -384,7 +391,9 @@ export function buildCurriculumTools(deps: CurriculumToolDeps): AgentTool<never,
       const access = await deps.stageAccess(params.stageId);
       if (signal?.aborted) throw new Error('aborted');
       if (access.kind !== 'owned') return notYoursResult(`Stage "${params.stageId}"`);
-      const moved = await deps.store.moveDocumentToFolder(params.stageId, params.folderId);
+      const moved = await runStageMutation(signal, () =>
+        deps.store.moveDocumentToFolder(params.stageId, params.folderId),
+      );
       if (signal?.aborted) throw new Error('aborted');
       if (!moved) {
         return toolResult(
@@ -443,7 +452,7 @@ export function buildCurriculumTools(deps: CurriculumToolDeps): AgentTool<never,
         updatedAt: Date.now(),
         ...(description ? { description } : {}),
       };
-      await deps.store.saveDocument({ ...doc, stage: renamed });
+      await runStageMutation(signal, () => deps.store.saveDocument({ ...doc, stage: renamed }));
       if (signal?.aborted) throw new Error('aborted');
       deps.onCheckpoint?.({
         tool: 'rename_stage',

--- a/lib/server/agent-runtime/dsl-tools.ts
+++ b/lib/server/agent-runtime/dsl-tools.ts
@@ -4,6 +4,7 @@ import type { Action } from '@/lib/types/action';
 import type { Scene, SlideContent } from '@/lib/types/stage';
 import { validateAppScene } from '@/lib/document-store/validators';
 import type { CourseDocument, CourseToolDeps } from './course-tools';
+import { runStageMutation } from './mutation-fence';
 import {
   applyJsonPointerEdit,
   applySlideEdit,
@@ -772,7 +773,7 @@ export function buildDslCourseTools(deps: CourseToolDeps): AgentTool<never, neve
     description:
       'Atomically patch ONE scene at /scenes/<order|sceneId>. Read source first. set/remove use JSON Pointers rooted at that exact scene source (/content/... or /actions/...); str_replace swaps one exact occurrence of oldText inside a string field at a pointer (all occurrences with replaceAll); add_element/delete_element preserve server-owned slide element identity. Any failed op or resulting validation error rejects the whole batch. Stage/page-list operations remain on edit_deck.',
     parameters: PATCH_COURSE_SCHEMA,
-    async execute(_id, params: PatchParams) {
+    async execute(_id, params: PatchParams, signal) {
       if (!params.intent.trim()) return toolResult('intent must not be blank', {}, true);
       const loaded = await loadCourse(deps, params.stageId);
       if ('error' in loaded) return toolResult(loaded.error, {}, true);
@@ -831,7 +832,7 @@ export function buildDslCourseTools(deps: CourseToolDeps): AgentTool<never, neve
         );
       }
       try {
-        await deps.store.putScene(loaded.stageId, next);
+        await runStageMutation(signal, () => deps.store.putScene(loaded.stageId, next));
       } catch (error) {
         return toolResult(
           `patch_stage could not persist the scene: ${error instanceof Error ? error.message : String(error)}`,

--- a/lib/server/agent-runtime/generation-tools.ts
+++ b/lib/server/agent-runtime/generation-tools.ts
@@ -18,6 +18,7 @@ import type { Action } from '@/lib/types/action';
 import type { Scene } from '@/lib/types/stage';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
 import type { CourseToolDeps } from './course-tools';
+import { runStageMutation } from './mutation-fence';
 import { shiftCourseOrders } from './course-edit/tools';
 import { createGenerationAiCallFactory, sceneContentStage } from './generation-ai-call';
 import { synthesizeSceneNarration } from './scene-tts';
@@ -206,7 +207,7 @@ export function buildGenerationTools(deps: GenerationToolDeps): AgentTool<never,
       });
       if (!built) return result('Page assembly failed; nothing was written.', {}, true);
       const scene = built as Scene;
-      await deps.store.putScene(params.stageId, scene);
+      await runStageMutation(signal, () => deps.store.putScene(params.stageId, scene));
       deps.onCheckpoint({
         tool: 'generate_scene',
         stageId: params.stageId,
@@ -268,7 +269,7 @@ export function buildGenerationTools(deps: GenerationToolDeps): AgentTool<never,
       if (!actions.length)
         return result('No known actions were generated; the page was unchanged.', {}, true);
       const next = { ...scene, actions } as Scene;
-      await deps.store.putScene(params.stageId, next);
+      await runStageMutation(signal, () => deps.store.putScene(params.stageId, next));
       deps.onCheckpoint({
         tool: 'generate_actions',
         stageId: params.stageId,
@@ -285,7 +286,7 @@ export function buildGenerationTools(deps: GenerationToolDeps): AgentTool<never,
           signal,
         });
         if (audio.changed) {
-          await deps.store.putScene(params.stageId, next);
+          await runStageMutation(signal, () => deps.store.putScene(params.stageId, next));
           deps.onCheckpoint({
             tool: 'generate_actions',
             stageId: params.stageId,
@@ -309,7 +310,7 @@ export function buildGenerationTools(deps: GenerationToolDeps): AgentTool<never,
     description:
       'Copy an existing page to a new position without actions. Replaying the same tool call is idempotent.',
     parameters: DuplicateParams,
-    async execute(callId, params) {
+    async execute(callId, params, signal) {
       const doc = await deps.store.loadDocument(params.stageId);
       if (!doc) return result('No course document yet. Call create_stage first.', {}, true);
       const scenes = [...doc.scenes].sort((a, b) => a.order - b.order);
@@ -344,11 +345,13 @@ export function buildGenerationTools(deps: GenerationToolDeps): AgentTool<never,
         createdAt: now,
         updatedAt: now,
       } as Scene;
-      await deps.store.saveDocument({
-        ...doc,
-        scenes: [...shifted.scenes, created].sort((a, b) => a.order - b.order),
-        outline: shifted.outline,
-      });
+      await runStageMutation(signal, () =>
+        deps.store.saveDocument({
+          ...doc,
+          scenes: [...shifted.scenes, created].sort((a, b) => a.order - b.order),
+          outline: shifted.outline,
+        }),
+      );
       deps.onCheckpoint({
         tool: 'duplicate_scene',
         stageId: params.stageId,

--- a/lib/server/agent-runtime/import-pptx.ts
+++ b/lib/server/agent-runtime/import-pptx.ts
@@ -30,6 +30,7 @@ import type { Scene, SlideContent, Stage } from '@/lib/types/stage';
 import { stripTags } from './course-edit/apply';
 import { shiftCourseOrders } from './course-edit/tools';
 import type { CourseDocument, CourseToolDeps } from './course-tools';
+import { runStageMutation } from './mutation-fence';
 import { isPptxMaterial } from './pptx-mime';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
 import { getSessionMaterial, resolveSessionMaterialRawAsset } from './session-materials';
@@ -532,7 +533,7 @@ export function buildImportPptxTool(
           },
         } satisfies AppDocumentOutline,
       };
-      await deps.store.saveDocument(nextDoc);
+      await runStageMutation(signal, () => deps.store.saveDocument(nextDoc));
 
       const notesPages = scenes.filter((scene) =>
         (scene.actions ?? []).some((action) => action.type === 'speech'),

--- a/lib/server/agent-runtime/mutation-fence.ts
+++ b/lib/server/agent-runtime/mutation-fence.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const mutationSignal = new AsyncLocalStorage<AbortSignal | undefined>();
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw signal.reason ?? new Error('aborted');
+}
+
+/** Carry one tool call's derived abort signal into its persistence transaction. */
+export async function runStageMutation<T>(
+  signal: AbortSignal | undefined,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  throwIfAborted(signal);
+  return mutationSignal.run(signal, async () => {
+    const result = await mutation();
+    throwIfAborted(signal);
+    return result;
+  });
+}
+
+/** Reject a persistence transaction whose owning tool call has been aborted. */
+export function assertCurrentStageMutationActive(): void {
+  throwIfAborted(mutationSignal.getStore());
+}

--- a/lib/server/agent-runtime/owner-scoped-documents.ts
+++ b/lib/server/agent-runtime/owner-scoped-documents.ts
@@ -10,6 +10,7 @@ import { validateAppScene, validateAppStage } from '@/lib/document-store/validat
 import { createOwnerBoundDocumentStore } from '@/lib/persistence/owner-bound-document-store';
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
 import type { AppScene } from '@/lib/types/stage';
+import type { Queryable } from '@openmaic/storage/document/pg';
 
 /**
  * The owner-bound document store for one HTTP request, plus the
@@ -33,6 +34,7 @@ export type OwnerScopedDocumentStore = DocumentStore<AppScene, AppStage> &
  */
 export async function getOwnerScopedDocumentStore(
   ownerId: string,
+  mutationFence?: (queryable: Queryable) => Promise<void>,
 ): Promise<OwnerScopedDocumentStore> {
   const { pool } = await getServerPersistenceProvider(process.env.DATABASE_URL ?? '');
   return withPlainJsonDocumentWrites(
@@ -41,6 +43,7 @@ export async function getOwnerScopedDocumentStore(
       ownerId,
       validateScene: validateAppScene,
       validateStage: validateAppStage,
+      mutationFence,
     }) as unknown as OwnerScopedDocumentStore,
   );
 }

--- a/lib/server/agent-runtime/roster-tools.ts
+++ b/lib/server/agent-runtime/roster-tools.ts
@@ -45,6 +45,7 @@ import { enabledServerTTSProviderIds, resolveTTSApiKey } from '@/lib/server/prov
 import type { CheckpointInfo } from './course-tools';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
 import { markDocumentWritersSequential } from './course-tools';
+import { runStageMutation } from './mutation-fence';
 
 export type CourseDocument = MaicDocument<Scene, Stage>;
 export type CourseStore = DocumentStore<Scene, Stage>;
@@ -125,6 +126,7 @@ async function persistRoster(
   store: CourseStore,
   doc: CourseDocument,
   roster: GeneratedAgentConfig[],
+  signal?: AbortSignal,
 ): Promise<void> {
   const now = Date.now();
   const stage: Stage = {
@@ -133,11 +135,13 @@ async function persistRoster(
     agentIds: roster.map((agent) => agent.id),
     updatedAt: now,
   };
-  await store.saveDocument({
-    stage,
-    scenes: doc.scenes,
-    outline: doc.outline,
-  });
+  await runStageMutation(signal, () =>
+    store.saveDocument({
+      stage,
+      scenes: doc.scenes,
+      outline: doc.outline,
+    }),
+  );
 }
 
 // ── Tool parameter schemas ──────────────────────────────────────────────────
@@ -336,7 +340,7 @@ export function buildRosterTools(deps: RosterToolDeps): AgentTool<never, never>[
       });
 
       if (signal?.aborted) throw new Error('aborted');
-      await persistRoster(deps.store, doc, roster);
+      await persistRoster(deps.store, doc, roster, signal);
       deps.onCheckpoint({
         tool: 'set_roster',
         stageId,

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -77,6 +77,7 @@ import {
 import { getAgentSessionStore } from './store';
 import { subscribeAgentEventWakeup } from './event-notify-bus';
 import { getOwnerScopedDocumentStore } from './owner-scoped-documents';
+import { assertCurrentStageMutationActive } from './mutation-fence';
 
 const log = createLogger('AgentRunner');
 const WORKER_ID = `${randomUUID().slice(0, 8)}:${process.pid}`;
@@ -448,6 +449,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
   }
   let leaseLost = false;
   let cancelled = false;
+  let cancelRequestedAt: number | null = null;
   let chain: Promise<void> = Promise.resolve();
   let criticalWriteError: unknown;
   let entryWritesHealthy = true;
@@ -616,8 +618,12 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         'send a new message to retry';
       emit(LIFECYCLE.sessionEnd, { status: 'failed', error });
       await flushAll();
-      await store.finishSession(id, WORKER_ID, { status: 'failed', error });
-      await requeueIfUndelivered('over-cap verdict', true);
+      const settled = await store.finishSession(id, WORKER_ID, {
+        status: 'failed',
+        error,
+        expectedAttempt: attempt,
+      });
+      if (settled) await requeueIfUndelivered('over-cap verdict', true);
       return;
     } finally {
       await flushAll(false);
@@ -658,9 +664,10 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
   let drainOnWake: (() => void) | null = null;
   const checkCancel = (): void => {
     store
-      .isCancelRequested(id)
-      .then((requested) => {
-        if (requested) {
+      .getCancelRequestedAt(id)
+      .then((requestedAt) => {
+        if (requestedAt !== null) {
+          cancelRequestedAt = requestedAt;
           cancelled = true;
           abort.abort();
         }
@@ -748,11 +755,12 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         note: 'entry history already terminal',
       });
       await flushAll();
-      await store.finishSession(id, WORKER_ID, {
+      const settled = await store.finishSession(id, WORKER_ID, {
         status: 'succeeded',
         resetAttempt: true,
+        expectedAttempt: attempt,
       });
-      await requeueIfUndelivered('early settle');
+      if (settled) await requeueIfUndelivered('early settle');
       return;
     }
 
@@ -814,7 +822,14 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
     // that carries them never persists a JSON-null key (reference semantics).
     // `getAgentSessionStore` above already guards on DATABASE_URL, so the
     // provider can only be reached with a configured connection string.
-    const ownerScopedStore = (await getOwnerScopedDocumentStore(meta.ownerId)) as CourseStore;
+    const ownerScopedStore = (await getOwnerScopedDocumentStore(
+      meta.ownerId,
+      async (transaction) => {
+        assertCurrentStageMutationActive();
+        await store.assertActiveLease(id, WORKER_ID, attempt, transaction);
+        assertCurrentStageMutationActive();
+      },
+    )) as CourseStore;
     // The owner probe is the tool layer's legality boundary: every course call
     // declares its stageId, and stageAccess resolves that stage against the
     // session owner (owned / foreign / missing / tombstoned) before the tool
@@ -1190,22 +1205,27 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         return;
       }
 
-      const settledCancelled = cancelled || (await store.isCancelRequested(id));
+      cancelRequestedAt ??= await store.getCancelRequestedAt(id);
+      const settledCancelled = cancelled || cancelRequestedAt !== null;
       if (settledCancelled) abort.abort();
       const error = !settledCancelled && loopError ? loopError : undefined;
       const status = settledCancelled ? 'cancelled' : error ? 'failed' : 'succeeded';
       emit(LIFECYCLE.sessionEnd, { status, toolCalls, ...(error ? { error } : {}) });
       await flushAll();
-      await store.finishSession(id, WORKER_ID, {
+      const settled = await store.finishSession(id, WORKER_ID, {
         status,
         ...(error ? { error } : {}),
         resetAttempt: status !== 'failed',
+        expectedAttempt: attempt,
+        ...(settledCancelled && cancelRequestedAt !== null
+          ? { consumeCancelRequestedAt: cancelRequestedAt }
+          : {}),
       });
-      // Clear only the cancel request included in the terminal verdict. A poll
-      // that observes a later request must not erase it with a stale verdict.
-      if (settledCancelled) {
-        await store.clearCancel(id);
-      } else {
+      if (!settled) {
+        markLeaseLost();
+        return;
+      }
+      if (!settledCancelled) {
         await requeueIfUndelivered('settle');
       }
       log.info(`session ${id} -> ${status} (attempt ${attempt}, ${toolCalls} tool calls)`);
@@ -1229,8 +1249,12 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
           emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
         }
         await flushAll(false);
-        await store.finishSession(id, WORKER_ID, { status: 'failed', error: message });
-        await requeueIfUndelivered('run failure');
+        const settled = await store.finishSession(id, WORKER_ID, {
+          status: 'failed',
+          error: message,
+          expectedAttempt: attempt,
+        });
+        if (settled) await requeueIfUndelivered('run failure');
         log.error(`session ${id} failed`, error);
       }
     } finally {
@@ -1255,10 +1279,14 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         emit(LIFECYCLE.sessionEnd, { status: 'failed', error: message });
       }
       await flushAll(false).catch(() => {});
-      await store
-        .finishSession(id, WORKER_ID, { status: 'failed', error: message })
-        .catch(() => {});
-      await requeueIfUndelivered('setup failure');
+      const settled = await store
+        .finishSession(id, WORKER_ID, {
+          status: 'failed',
+          error: message,
+          expectedAttempt: attempt,
+        })
+        .catch(() => false);
+      if (settled) await requeueIfUndelivered('setup failure');
     }
     log.error(`session ${id} failed during setup`, error);
   } finally {

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -598,6 +598,22 @@ export class PgAgentSessionStore
     return result.rows.length > 0;
   }
 
+  async assertActiveLease(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    transaction: AgentSessionTransaction,
+  ): Promise<void> {
+    const result = await transaction.query<{ attempt: number }>(
+      `SELECT attempt FROM ${this.table('sessions')}
+       WHERE id = $1 AND lease_worker_id = $2 AND attempt = $3
+         AND cancel_requested_at IS NULL AND deleted_at IS NULL
+       FOR SHARE`,
+      [sessionId, workerId, attempt],
+    );
+    if (!result.rows[0]) throw new AgentSessionLeaseLostError(sessionId, workerId, attempt);
+  }
+
   async finishSession(
     sessionId: string,
     workerId: string,
@@ -612,8 +628,15 @@ export class PgAgentSessionStore
              lease_worker_pid = CASE WHEN $6::boolean THEN NULL ELSE lease_worker_pid END,
              lease_heartbeat_at = CASE WHEN $6::boolean THEN NULL ELSE lease_heartbeat_at END,
              attempt = CASE WHEN $7::boolean THEN 0 ELSE attempt END,
+             cancel_requested_at = CASE
+               WHEN $8::bigint IS NOT NULL AND cancel_requested_at = $8 THEN NULL
+               ELSE cancel_requested_at
+             END,
              updated_at = now()
-         WHERE id = $1 AND lease_worker_id = $2 AND deleted_at IS NULL RETURNING attempt`,
+         WHERE id = $1 AND lease_worker_id = $2 AND deleted_at IS NULL
+           AND ($8::bigint IS NULL OR cancel_requested_at = $8)
+           AND ($9::integer IS NULL OR attempt = $9)
+         RETURNING attempt`,
         [
           sessionId,
           workerId,
@@ -622,6 +645,8 @@ export class PgAgentSessionStore
           patch.error ?? null,
           release,
           patch.resetAttempt === true,
+          patch.consumeCancelRequestedAt ?? null,
+          patch.expectedAttempt ?? null,
         ],
       );
       const row = result.rows[0];
@@ -995,21 +1020,33 @@ export class PgAgentSessionStore
   }
 
   async isCancelRequested(sessionId: string): Promise<boolean> {
-    const result = await this.queryable.query<{ requested: boolean }>(
-      `SELECT cancel_requested_at IS NOT NULL AS requested FROM ${this.table('sessions')}
-       WHERE id = $1 AND deleted_at IS NULL`,
-      [sessionId],
-    );
-    return result.rows[0]?.requested === true;
+    return (await this.getCancelRequestedAt(sessionId)) !== null;
   }
 
-  async clearCancel(sessionId: string): Promise<void> {
-    await this.queryable.query(
-      `UPDATE ${this.table('sessions')}
-       SET cancel_requested_at = NULL, updated_at = now()
+  async getCancelRequestedAt(sessionId: string): Promise<number | null> {
+    const result = await this.queryable.query<{ requested_at: number | string | null }>(
+      `SELECT cancel_requested_at AS requested_at FROM ${this.table('sessions')}
        WHERE id = $1 AND deleted_at IS NULL`,
       [sessionId],
     );
+    const value = result.rows[0]?.requested_at;
+    return value === null || value === undefined ? null : Number(value);
+  }
+
+  async clearCancel(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    expectedRequestedAt: number,
+  ): Promise<boolean> {
+    const result = await this.queryable.query<{ id: string }>(
+      `UPDATE ${this.table('sessions')}
+       SET cancel_requested_at = NULL, updated_at = now()
+       WHERE id = $1 AND lease_worker_id = $2 AND attempt = $3
+         AND cancel_requested_at = $4 AND deleted_at IS NULL RETURNING id`,
+      [sessionId, workerId, attempt, expectedRequestedAt],
+    );
+    return result.rows.length > 0;
   }
 
   async registerSessionUrls(

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -128,6 +128,10 @@ export interface FinishAgentSessionPatch {
   releaseLease?: boolean;
   /** Clean endings reset the consecutive-failure chain when requested. */
   resetAttempt?: boolean;
+  /** Reject settlement if this claim generation is no longer current. */
+  expectedAttempt?: number;
+  /** Atomically consume exactly the cancellation request used for the verdict. */
+  consumeCancelRequestedAt?: number;
 }
 
 export interface PostAgentUserMessageResult {
@@ -286,6 +290,12 @@ export interface AgentSessionStore {
     options: ClaimAgentSessionOptions,
   ): Promise<ClaimedAgentSession | null>;
   heartbeat(sessionId: string, workerId: string): Promise<boolean>;
+  assertActiveLease(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    transaction: AgentSessionTransaction,
+  ): Promise<void>;
   finishSession(
     sessionId: string,
     workerId: string,
@@ -293,8 +303,14 @@ export interface AgentSessionStore {
   ): Promise<boolean>;
   releaseLease(sessionId: string, workerId: string): Promise<void>;
   requestCancel(sessionId: string): Promise<void>;
+  getCancelRequestedAt(sessionId: string): Promise<number | null>;
   isCancelRequested(sessionId: string): Promise<boolean>;
-  clearCancel(sessionId: string): Promise<void>;
+  clearCancel(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    expectedRequestedAt: number,
+  ): Promise<boolean>;
   /** An attended retry clears the consecutive-failure generation. */
   requeueSession(sessionId: string): Promise<boolean>;
   /** An unattended retry preserves the consecutive-failure generation. */

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -254,13 +254,15 @@ export function runAgentSessionStoreContract(
     test('supports cancellation and distinct attended and unattended requeues', async () => {
       const store = makeStore();
       await store.createSession(makeAgentSessionInput());
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
       await store.requestCancel('session-1');
       await store.requestCancel('session-1');
       expect(await store.isCancelRequested('session-1')).toBe(true);
-      await store.clearCancel('session-1');
+      const requestedAt = await store.getCancelRequestedAt('session-1');
+      expect(requestedAt).not.toBeNull();
+      await expect(store.clearCancel('session-1', 'worker-a', 1, requestedAt!)).resolves.toBe(true);
       expect(await store.isCancelRequested('session-1')).toBe(false);
 
-      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
       await store.finishSession('session-1', 'worker-a', { status: 'failed', error: 'failure' });
       expect(await store.requeueForRetry('session-1')).toBe(true);
       expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 1 });
@@ -268,6 +270,32 @@ export function runAgentSessionStoreContract(
       await store.finishSession('session-1', 'worker-a', { status: 'failed' });
       expect(await store.requeueSession('session-1')).toBe(true);
       expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 0 });
+    });
+
+    test('a stale cancellation cleanup cannot erase a newer attempt request', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      await store.requestCancel('session-1');
+      const firstRequest = await store.getCancelRequestedAt('session-1');
+      expect(firstRequest).not.toBeNull();
+
+      await expect(
+        store.finishSession('session-1', 'worker-a', {
+          status: 'cancelled',
+          resetAttempt: true,
+          expectedAttempt: 1,
+          consumeCancelRequestedAt: firstRequest!,
+        }),
+      ).resolves.toBe(true);
+      await store.postUserMessage('session-1', { text: 'Run again' });
+      await store.claimNextSession('worker-b', 202, { leaseTtlMs: 10_000, maxAttempts: 3 });
+      await store.requestCancel('session-1');
+
+      await expect(store.clearCancel('session-1', 'worker-a', 1, firstRequest!)).resolves.toBe(
+        false,
+      );
+      expect(await store.isCancelRequested('session-1')).toBe(true);
     });
 
     test('settles a cancel-requested queued session as cancelled on claim, never leasing it', async () => {

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -8,7 +8,11 @@ import {
   type PgAgentSessionStoreOptions,
   type Queryable,
 } from '../src/agent-session/pg.js';
-import { AgentSessionEntryTreeError, AGENT_SESSION_LIFECYCLE } from '../src/agent-session/types.js';
+import {
+  AgentSessionEntryTreeError,
+  AgentSessionLeaseLostError,
+  AGENT_SESSION_LIFECYCLE,
+} from '../src/agent-session/types.js';
 import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
 import { makeAgentSessionInput, runAgentSessionStoreContract } from './agent-session-contract.js';
 import { runAgentSessionUrlContract } from './agent-session-url-contract.js';
@@ -54,6 +58,24 @@ describe('PgAgentSessionStore with PGlite', () => {
     expect(() => new PgAgentSessionStore(db, {} as PgAgentSessionStoreOptions)).toThrow(
       /withTransaction.*fresh.*connection.*transaction/i,
     );
+  });
+
+  test('rejects a durable mutation after its lease attempt is superseded', async () => {
+    await db.query('CREATE TABLE mutation_probe (value TEXT NOT NULL)');
+    await store.createSession(makeAgentSessionInput());
+    await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
+    await store.finishSession('session-1', 'worker-a', { status: 'failed' });
+    await store.requeueForRetry('session-1');
+    await store.claimNextSession('worker-b', 202, { leaseTtlMs: 10_000, maxAttempts: 3 });
+
+    await expect(
+      db.transaction(async (tx: Queryable) => {
+        await store.assertActiveLease('session-1', 'worker-a', 1, tx);
+        await tx.query("INSERT INTO mutation_probe (value) VALUES ('stale')");
+      }),
+    ).rejects.toBeInstanceOf(AgentSessionLeaseLostError);
+    const rows = await db.query<{ value: string }>('SELECT value FROM mutation_probe');
+    expect(rows.rows).toEqual([]);
   });
 
   test('runs owner resolution before insertion and creation hook before commit', async () => {

--- a/tests/agent-runtime/runner-event-order.test.ts
+++ b/tests/agent-runtime/runner-event-order.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/server/agent-runtime/store', () => ({
     getSession: vi.fn(async () => null),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(async () => []),
     releaseLease: mocks.releaseLease,

--- a/tests/agent-runtime/runner-skills-registration.test.ts
+++ b/tests/agent-runtime/runner-skills-registration.test.ts
@@ -146,6 +146,7 @@ function makeStore(meta: ClaimedAgentSession) {
     getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(async () => []),
     registerSessionUrls: vi.fn(async () => []),

--- a/tests/agent-runtime/runner-tool-call-integrity.test.ts
+++ b/tests/agent-runtime/runner-tool-call-integrity.test.ts
@@ -143,6 +143,7 @@ function makeStore(meta: ClaimedAgentSession, options: { hasSessionRunHistory?: 
     getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
     hasSessionRunHistory: vi.fn(async () => options.hasSessionRunHistory ?? false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(async () => []),
     releaseLease: vi.fn(async () => undefined),

--- a/tests/agent-runtime/runner-tool-timeout-cancel.test.ts
+++ b/tests/agent-runtime/runner-tool-timeout-cancel.test.ts
@@ -176,6 +176,7 @@ function makeStore(meta: ClaimedAgentSession, options: { cancelRequested?: () =>
     getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => (options.cancelRequested?.() ? 123 : null)),
     isCancelRequested: vi.fn(async () => options.cancelRequested?.() ?? false),
     listUserMessages: vi.fn(async () => []),
     releaseLease: vi.fn(async () => undefined),
@@ -324,9 +325,14 @@ describe('runner: cancel of a hung tool', () => {
     expect(store.finishSession).toHaveBeenCalledWith(
       SESSION_ID,
       WORKER_ID,
-      expect.objectContaining({ status: 'cancelled', resetAttempt: true }),
+      expect.objectContaining({
+        status: 'cancelled',
+        resetAttempt: true,
+        expectedAttempt: 1,
+        consumeCancelRequestedAt: 123,
+      }),
     );
-    expect(store.clearCancel).toHaveBeenCalledWith(SESSION_ID);
+    expect(store.clearCancel).not.toHaveBeenCalled();
     // The abort was delivered to the tool's in-flight work.
     expect(captured).toHaveLength(1);
     expect(captured[0]?.aborted).toBe(true);

--- a/tests/agent-runtime/runner-voice-registration.test.ts
+++ b/tests/agent-runtime/runner-voice-registration.test.ts
@@ -175,6 +175,7 @@ function makeStore(meta: ClaimedAgentSession) {
     getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(async () => []),
     registerSessionUrls: vi.fn(async () => []),

--- a/tests/agent-runtime/runner-wakeup.test.ts
+++ b/tests/agent-runtime/runner-wakeup.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => {
     ),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(
       async (): Promise<
@@ -318,7 +319,7 @@ describe('runSession NOTIFY wakeup wiring', () => {
     // The wake runs BOTH cheap point reads: the drain above and the cancel
     // check — one shared subscription, two checks (reference semantics).
     expect(mocks.store.listUserMessages).toHaveBeenCalledWith('session-wake');
-    expect(mocks.store.isCancelRequested).toHaveBeenCalled();
+    expect(mocks.store.getCancelRequestedAt).toHaveBeenCalled();
 
     // Release the pending prompt and let the run settle; the subscription must
     // go away with it.

--- a/tests/agent-runtime/runner-web-search-registration.test.ts
+++ b/tests/agent-runtime/runner-web-search-registration.test.ts
@@ -149,6 +149,7 @@ function makeStore(meta: ClaimedAgentSession) {
     getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(async () => []),
     registerSessionUrls: vi.fn(async () => []),

--- a/tests/lib/agent/runtime/tool-timeout.test.ts
+++ b/tests/lib/agent/runtime/tool-timeout.test.ts
@@ -21,6 +21,7 @@ import {
   resolveAgentToolTimeoutMs,
   withAgentToolTimeout,
 } from '@/lib/agent/runtime/tool-timeout';
+import { runStageMutation } from '@/lib/server/agent-runtime/mutation-fence';
 
 const Params = Type.Object({});
 
@@ -160,7 +161,7 @@ describe('withAgentToolTimeout', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('forwards in-flight updates but drops updates and results from a zombie tool', async () => {
+  it('forwards in-flight updates but drops updates and results from a timed-out tool', async () => {
     vi.useFakeTimers();
     const emit = vi.fn<AgentToolUpdateCallback>();
     const tool = withAgentToolTimeout(
@@ -180,13 +181,36 @@ describe('withAgentToolTimeout', () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await settled;
     // Only the update emitted while the call was still in flight reached the
-    // agent loop; the zombie tool's post-settlement update is dropped.
+    // agent loop; the timed-out tool's post-settlement update is dropped.
     expect(emit).toHaveBeenCalledTimes(1);
     expect(emit).toHaveBeenCalledWith(result('progress'));
 
-    // The zombie's timer and result are both ignored after the race settled.
+    // The late timer and result are both ignored after the race settled.
     await vi.advanceTimersByTimeAsync(1_000);
     expect(emit).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('rejects a delayed durable mutation after the tool times out', async () => {
+    vi.useFakeTimers();
+    const durable: string[] = [];
+    const tool = withAgentToolTimeout(
+      makeTool(async (_id, _args, signal) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 6_000));
+        await runStageMutation(signal, async () => {
+          durable.push('committed');
+        });
+        return result('late-result');
+      }),
+    );
+
+    const promise = tool.execute('call-1', {}, undefined);
+    const settled = expect(promise).rejects.toBeInstanceOf(AgentToolTimeoutError);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settled;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(durable).toEqual([]);
     expect(vi.getTimerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes two P1 findings from the 1.0.0 release review: (1) timed-out or cancelled mutating tools could commit zombie writes — durable stage mutations are now fenced by the active session lease (session_id, worker_id, attempt) inside the same transaction and re-check the tool abort signal before commit; (2) the runner's stale cancel cleanup could erase a newer cancel request — cancellation is now consumed atomically with terminal settlement, and clearCancel requires the exact expected token. Adds deterministic interleaving coverage. Storage bumped 0.21.0 -> 0.22.0.