### PR TITLE
fix(agent): enforce provider force-off in agent tools and scrub vendor identity from tool results

### DIFF
--- a/lib/server/agent-runtime/generate-image.ts
+++ b/lib/server/agent-runtime/generate-image.ts
@@ -10,11 +10,14 @@ import type {
   ImageProviderId,
 } from '@/lib/media/types';
 import {
+  enabledProviderIds,
   getServerImageProviders,
+  isServerProviderDisabled,
   resolveImageApiKey,
   resolveImageBaseUrl,
   resolveImageModel,
 } from '@/lib/server/provider-config';
+import { createLogger } from '@/lib/logger';
 import { resolveImageSize } from '@/lib/server/image-sizing';
 import { recordGenerationUsage } from '@/lib/server/usage-storage';
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
@@ -27,6 +30,9 @@ import {
 } from '@/lib/server/bounded-download';
 import type { CourseToolDeps } from './course-tools';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
+import { errorResult, MEDIA_TOOL_ERROR_REASONS } from './media-tool-result';
+
+const log = createLogger('AgentGenerateImage');
 
 export const GENERATE_IMAGE_TOOL_NAME = 'generate_image';
 export const GENERATE_IMAGE_TIMEOUT_MS = 300_000;
@@ -162,16 +168,17 @@ export async function defaultPersistGeneratedImage(
   return src;
 }
 
-function errorResult(text: string, details: Record<string, unknown> = {}) {
-  return {
-    content: [{ type: 'text' as const, text }],
-    details,
-    isError: true,
-  };
-}
-
-function selectProvider(configured: Record<string, { models?: string[] }>): ImageProviderId | null {
-  const ids = Object.keys(configured);
+/**
+ * Pick the image provider for this call: the operator's `DEFAULT_IMAGE_PROVIDER`
+ * when it names an enabled provider, otherwise the first enabled provider.
+ * Resolution goes through {@link enabledProviderIds}, so a force-disabled
+ * provider is never selected and `DEFAULT_IMAGE_PROVIDER` cannot bypass the
+ * force-off switch (#665).
+ */
+function selectProvider(
+  configured: Record<string, { models?: string[]; disabled?: boolean }>,
+): ImageProviderId | null {
+  const ids = enabledProviderIds(configured);
   const requested = process.env.DEFAULT_IMAGE_PROVIDER?.trim();
   if (requested) return ids.includes(requested) ? (requested as ImageProviderId) : null;
   return (ids[0] as ImageProviderId | undefined) ?? null;
@@ -198,7 +205,7 @@ export function buildGenerateImageTool(
     description:
       'Create a new image from a prompt, persist it with the explicitly targeted course media, and return a renderable src plus dimensions. Use the returned src in a later patch_stage set of an existing media element, or add an image element with patch_stage. This tool never edits a page itself.',
     parameters: GenerateImageParams,
-    async execute(_toolCallId, params: Static<typeof GenerateImageParams>, signal) {
+    async execute(toolCallId, params: Static<typeof GenerateImageParams>, signal) {
       const callerSignal = signal ?? deps.abortSignal;
       throwIfAborted(callerSignal);
 
@@ -212,26 +219,61 @@ export function buildGenerateImageTool(
       const providerId = selectProvider(providers);
       const requestedDefault = process.env.DEFAULT_IMAGE_PROVIDER?.trim();
       if (!providerId) {
+        if (requestedDefault) {
+          log.warn(
+            `[${toolCallId}] Image generation unavailable: requested default provider ${requestedDefault} is not enabled`,
+          );
+        } else {
+          log.warn(
+            `[${toolCallId}] Image generation unavailable: no enabled server image provider`,
+          );
+        }
         return errorResult(
           requestedDefault
-            ? `Image generation is unavailable: DEFAULT_IMAGE_PROVIDER=${requestedDefault} is not configured on this server.`
-            : 'Image generation is unavailable: no server image provider is configured.',
-          { stageId, sessionId: deps.sessionId, provider: requestedDefault ?? null },
+            ? 'Image generation is unavailable: the server default image provider is not available.'
+            : 'Image generation is unavailable: no server image provider is available.',
+          {
+            stageId,
+            sessionId: deps.sessionId,
+            reason: MEDIA_TOOL_ERROR_REASONS.noProvider,
+          },
         );
+      }
+
+      // Defense in depth: the operator force-off is authoritative at the call
+      // boundary — even if a caller explicitly selects a disabled provider id,
+      // the call fails before any provider I/O (#665).
+      if (isServerProviderDisabled('image', providerId)) {
+        log.warn(
+          `[${toolCallId}] Image generation rejected: provider ${providerId} is force-disabled`,
+        );
+        return errorResult('Image generation is unavailable.', {
+          stageId,
+          reason: MEDIA_TOOL_ERROR_REASONS.providerDisabled,
+        });
       }
 
       const provider = IMAGE_PROVIDERS[providerId];
       if (!provider) {
-        return errorResult(`Image generation is unavailable: unsupported provider ${providerId}.`, {
-          stageId,
-          provider: providerId,
-        });
+        log.error(
+          `[${toolCallId}] Image generation unavailable: unsupported provider ${providerId}`,
+        );
+        return errorResult(
+          'Image generation is unavailable: the selected provider is not supported by this server.',
+          {
+            stageId,
+            reason: MEDIA_TOOL_ERROR_REASONS.unsupportedProvider,
+          },
+        );
       }
       const providerConfig = resolveProviderConfig(providerId);
       if (provider.requiresApiKey && !providerConfig.apiKey) {
+        log.warn(
+          `[${toolCallId}] Image generation unavailable: no API key configured for provider ${providerId}`,
+        );
         return errorResult(
-          `Image generation is unavailable: no API key is configured for provider ${providerId}.`,
-          { stageId, provider: providerId },
+          'Image generation is unavailable: no API key is configured for the selected image provider.',
+          { stageId, reason: MEDIA_TOOL_ERROR_REASONS.missingApiKey },
         );
       }
 
@@ -242,9 +284,15 @@ export function buildGenerateImageTool(
       // default. Model-less providers (empty catalog, e.g. workflow-driven
       // runners) resolve their own target at call time.
       if ((provider.models?.length ?? 0) > 0 && !model) {
+        log.warn(
+          `[${toolCallId}] Image generation unavailable: no model configured for provider ${providerId}`,
+        );
         return errorResult(
-          `Image generation is unavailable: no model is configured for provider ${providerId} on this server.`,
-          { stageId, provider: providerId, reason: 'missing-model' },
+          'Image generation is unavailable: no model is configured for the selected image provider on this server.',
+          {
+            stageId,
+            reason: MEDIA_TOOL_ERROR_REASONS.missingModel,
+          },
         );
       }
 
@@ -273,6 +321,9 @@ export function buildGenerateImageTool(
           modelId: model,
           quantity: 1,
         });
+        log.info(
+          `[${toolCallId}] Image generated: provider=${providerId}, model=${model ?? 'default'}, ${result.width}x${result.height}`,
+        );
 
         return {
           content: [
@@ -285,22 +336,27 @@ export function buildGenerateImageTool(
             src,
             width: result.width,
             height: result.height,
-            provider: providerId,
           },
         };
       } catch (error) {
         if (callerSignal?.aborted) throw new Error('aborted');
         if (isTimeout(ioSignal)) {
-          return errorResult(
-            `Image generation timed out after ${deps.timeoutMs ?? GENERATE_IMAGE_TIMEOUT_MS}ms (provider ${providerId}).`,
-            { stageId, provider: providerId, reason: 'timeout' },
+          log.warn(
+            `[${toolCallId}] Image generation timed out: provider=${providerId}, model=${model ?? 'default'}, timeoutMs=${deps.timeoutMs ?? GENERATE_IMAGE_TIMEOUT_MS}`,
           );
+          return errorResult('Image generation timed out after the configured server timeout.', {
+            stageId,
+            reason: MEDIA_TOOL_ERROR_REASONS.timeout,
+          });
         }
         const message = error instanceof Error ? error.message : String(error);
-        return errorResult(`Image generation failed with provider ${providerId}: ${message}`, {
+        log.error(
+          `[${toolCallId}] Image generation failed: provider=${providerId}, model=${model ?? 'default'}, error=${message}`,
+          error,
+        );
+        return errorResult('Image generation failed.', {
           stageId,
-          provider: providerId,
-          reason: 'provider-or-storage-error',
+          reason: MEDIA_TOOL_ERROR_REASONS.generationFailed,
         });
       }
     },

--- a/lib/server/agent-runtime/generate-video.ts
+++ b/lib/server/agent-runtime/generate-video.ts
@@ -10,17 +10,23 @@ import type {
   VideoProviderId,
 } from '@/lib/media/types';
 import {
+  enabledProviderIds,
   getServerVideoProviders,
+  isServerProviderDisabled,
   resolveVideoApiKey,
   resolveVideoBaseUrl,
   resolveVideoModel,
 } from '@/lib/server/provider-config';
+import { createLogger } from '@/lib/logger';
 import { recordGenerationUsage } from '@/lib/server/usage-storage';
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
 import { validateUrlForSSRF } from '@/lib/server/ssrf-guard';
 import { readResponseBodyWithLimit } from '@/lib/server/bounded-download';
 import type { CourseToolDeps } from './course-tools';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
+import { errorResult, MEDIA_TOOL_ERROR_REASONS } from './media-tool-result';
+
+const log = createLogger('AgentGenerateVideo');
 
 export const GENERATE_VIDEO_TOOL_NAME = 'generate_video';
 // The longest provider poll budget is 15 minutes.
@@ -78,7 +84,7 @@ interface PersistedVideo {
 type PersistGeneratedVideo = (input: PersistVideoInput) => Promise<PersistedVideo>;
 
 export interface GenerateVideoToolDeps extends Pick<CourseToolDeps, 'sessionId' | 'abortSignal'> {
-  getConfiguredVideoProviders?: () => Record<string, unknown>;
+  getConfiguredVideoProviders?: () => Record<string, { models?: string[]; disabled?: boolean }>;
   resolveVideoProviderConfig?: (providerId: VideoProviderId) => VideoGenerationConfig;
   generateConfiguredVideo?: GenerateConfiguredVideo;
   persistGeneratedVideo?: PersistGeneratedVideo;
@@ -173,16 +179,18 @@ export async function defaultPersistGeneratedVideo(
   return { src, mime };
 }
 
-function errorResult(text: string, details: Record<string, unknown> = {}) {
-  return {
-    content: [{ type: 'text' as const, text }],
-    details,
-    isError: true,
-  };
-}
-
-function configuredProviderIds(configured: Record<string, unknown>): VideoProviderId[] {
-  return Object.keys(configured).filter((id): id is VideoProviderId => id in VIDEO_PROVIDERS);
+/**
+ * Enabled video provider ids from the listing: configured and not
+ * force-disabled (#665). The gate and the selector both resolve enabledness
+ * through {@link enabledProviderIds}, so an operator force-off is never
+ * registered or selected.
+ */
+function configuredProviderIds(
+  configured: Record<string, { models?: string[]; disabled?: boolean }>,
+): VideoProviderId[] {
+  return enabledProviderIds(configured).filter(
+    (id): id is VideoProviderId => id in VIDEO_PROVIDERS,
+  );
 }
 
 /** Server-side config resolution; the server `_MODELS` pin is authoritative. */
@@ -220,7 +228,7 @@ export function buildGenerateVideoTool(
     description:
       'Create a new video from a prompt, persist its provider-hosted result for the explicitly targeted course, and return a renderable src, mime and duration. Use the returned src in a later patch_stage set of an existing video element, or add a video element with patch_stage. Video elements also support autoplay and poster. This tool never edits a page itself.',
     parameters: GenerateVideoParams,
-    async execute(_toolCallId, params: Static<typeof GenerateVideoParams>, signal) {
+    async execute(toolCallId, params: Static<typeof GenerateVideoParams>, signal) {
       const callerSignal = signal ?? deps.abortSignal;
       throwIfAborted(callerSignal);
 
@@ -234,14 +242,28 @@ export function buildGenerateVideoTool(
         return !provider.requiresApiKey || !!resolveConfig(id).apiKey;
       });
       if (!providerId) {
+        log.warn(`[${toolCallId}] Video generation unavailable: no enabled server video provider`);
         return errorResult(
-          'Video generation is unavailable: no server video provider is configured.',
+          'Video generation is unavailable: no server video provider is available.',
           {
             stageId,
             sessionId: deps.sessionId,
-            provider: null,
+            reason: MEDIA_TOOL_ERROR_REASONS.noProvider,
           },
         );
+      }
+
+      // Defense in depth: the operator force-off is authoritative at the call
+      // boundary — even if a caller explicitly selects a disabled provider id,
+      // the call fails before any provider I/O (#665).
+      if (isServerProviderDisabled('video', providerId)) {
+        log.warn(
+          `[${toolCallId}] Video generation rejected: provider ${providerId} is force-disabled`,
+        );
+        return errorResult('Video generation is unavailable.', {
+          stageId,
+          reason: MEDIA_TOOL_ERROR_REASONS.providerDisabled,
+        });
       }
 
       const providerConfig = resolveConfig(providerId);
@@ -250,9 +272,15 @@ export function buildGenerateVideoTool(
       // resolution is authoritative, and a provider that expects an explicit
       // model errors here instead of silently defaulting.
       if ((VIDEO_PROVIDERS[providerId]?.models?.length ?? 0) > 0 && !model) {
+        log.warn(
+          `[${toolCallId}] Video generation unavailable: no model configured for provider ${providerId}`,
+        );
         return errorResult(
-          `Video generation is unavailable: no model is configured for provider ${providerId} on this server.`,
-          { stageId, provider: providerId, reason: 'missing-model' },
+          'Video generation is unavailable: no model is configured for the selected video provider on this server.',
+          {
+            stageId,
+            reason: MEDIA_TOOL_ERROR_REASONS.missingModel,
+          },
         );
       }
       const normalized = normalizeVideoOptions(providerId, {
@@ -285,6 +313,9 @@ export function buildGenerateVideoTool(
           modelId: model,
           quantity: result.duration,
         });
+        log.info(
+          `[${toolCallId}] Video generated: provider=${providerId}, model=${model ?? 'default'}, ${result.width}x${result.height}, ${result.duration}s`,
+        );
 
         return {
           content: [
@@ -297,26 +328,27 @@ export function buildGenerateVideoTool(
             src: stored.src,
             mime: stored.mime,
             ...(result.duration ? { durationSec: result.duration } : {}),
-            provider: providerId,
           },
         };
       } catch (error) {
         if (callerSignal?.aborted) throw new Error('aborted');
         if (isTimeout(ioSignal)) {
-          return errorResult(
-            `Video generation timed out after ${timeoutMs}ms (provider ${providerId}).`,
-            {
-              stageId,
-              provider: providerId,
-              reason: 'timeout',
-            },
+          log.warn(
+            `[${toolCallId}] Video generation timed out: provider=${providerId}, model=${model ?? 'default'}, timeoutMs=${timeoutMs}`,
           );
+          return errorResult('Video generation timed out after the configured server timeout.', {
+            stageId,
+            reason: MEDIA_TOOL_ERROR_REASONS.timeout,
+          });
         }
         const message = error instanceof Error ? error.message : String(error);
-        return errorResult(`Video generation failed with provider ${providerId}: ${message}`, {
+        log.error(
+          `[${toolCallId}] Video generation failed: provider=${providerId}, model=${model ?? 'default'}, error=${message}`,
+          error,
+        );
+        return errorResult('Video generation failed.', {
           stageId,
-          provider: providerId,
-          reason: 'provider-or-storage-error',
+          reason: MEDIA_TOOL_ERROR_REASONS.generationFailed,
         });
       }
     },

--- a/lib/server/agent-runtime/media-tool-result.ts
+++ b/lib/server/agent-runtime/media-tool-result.ts
@@ -1,0 +1,32 @@
+/**
+ * Provider-neutral result shapes for the agent media-generation tools
+ * (`generate_image`, `generate_video`).
+ *
+ * Tool results persist into the agent event stream consumed by the browser, so
+ * both success details and failure text/details must use stable,
+ * provider-neutral public error codes and generic text. Provider IDs, model
+ * names, endpoints and raw exception messages stay exclusively in server-side
+ * logs, correlated by the tool-call id.
+ */
+
+/** Stable public error codes shared by the image and video agent tools. */
+export const MEDIA_TOOL_ERROR_REASONS = {
+  noProvider: 'no-provider',
+  providerDisabled: 'provider-disabled',
+  unsupportedProvider: 'unsupported-provider',
+  missingApiKey: 'missing-api-key',
+  missingModel: 'missing-model',
+  timeout: 'timeout',
+  generationFailed: 'provider-or-storage-error',
+} as const;
+
+export type MediaToolErrorReason =
+  (typeof MEDIA_TOOL_ERROR_REASONS)[keyof typeof MEDIA_TOOL_ERROR_REASONS];
+
+export function errorResult(text: string, details: Record<string, unknown> = {}) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    details,
+    isError: true,
+  };
+}

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -586,6 +586,20 @@ export function isServerProviderDisabled(section: CapabilitySection, providerId:
   return getConfig().disabled[section].has(providerId);
 }
 
+/**
+ * Enabled-provider resolver: the provider IDs of a capability listing that
+ * this deployment actually serves — present in the listing and not
+ * force-disabled (`{ disabled: true }`, #665). The provider-config API
+ * deliberately includes force-disabled providers so admin surfaces can show
+ * them; every capability consumer (agent tool selectors and gates, server
+ * default resolution) must resolve enabledness through this — disable wins.
+ */
+export function enabledProviderIds<T extends { disabled?: boolean }>(
+  listing: Record<string, T>,
+): string[] {
+  return Object.keys(listing).filter((id) => !listing[id]?.disabled);
+}
+
 function resolveSectionApiKey(
   section: ProviderSection,
   providerId: string,

--- a/tests/agent-runtime/generate-image.test.ts
+++ b/tests/agent-runtime/generate-image.test.ts
@@ -6,6 +6,7 @@ import { MAX_REMOTE_IMAGE_BYTES } from '@/lib/server/bounded-download';
 const mocks = vi.hoisted(() => ({
   recordGenerationUsage: vi.fn().mockResolvedValue(undefined),
   getServerPersistenceProvider: vi.fn(),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 vi.mock('@/lib/server/usage-storage', () => ({
@@ -15,6 +16,7 @@ vi.mock('@/lib/persistence/server-provider', () => ({
   getServerPersistenceProvider: mocks.getServerPersistenceProvider,
 }));
 vi.mock('@/lib/server/ssrf-guard', () => ({ validateUrlForSSRF: async () => null }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => mocks.log }));
 
 import {
   buildGenerateImageTool,
@@ -81,11 +83,11 @@ describe('generate_image tool', () => {
     };
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('no server image provider is configured');
+    expect(result.content[0].text).toContain('no server image provider is available');
     expect(result.details).toMatchObject({
       stageId: 'stage-owner',
       sessionId: 'session-owner',
-      provider: null,
+      reason: 'no-provider',
     });
   });
 
@@ -165,7 +167,7 @@ describe('generate_image tool', () => {
     )) as {
       isError?: boolean;
       content: { text: string }[];
-      details: { src: string; width: number; height: number; provider: string };
+      details: { src: string; width: number; height: number };
     };
 
     expect(result.isError).toBeUndefined();
@@ -186,15 +188,20 @@ describe('generate_image tool', () => {
       expect.objectContaining({ size: Buffer.from('real-image-bytes').length, type: 'image/png' }),
       { contentType: 'image/png' },
     );
+    // Success details are provider-neutral: no provider id leaks into the
+    // transcript. The vendor choice stays in the server-side log, correlated
+    // by the tool-call id.
     expect(result.details).toEqual({
       src: 'ast_generated-image',
       width: 1024,
       height: 576,
-      provider: 'openai-image',
     });
     expect(result.content[0].text).toContain(result.details.src);
     expect(mocks.recordGenerationUsage).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'image', quantity: 1 }),
+    );
+    expect(mocks.log.info).toHaveBeenCalledWith(
+      expect.stringMatching(/call-1[\s\S]*provider=openai-image/),
     );
   });
 
@@ -242,6 +249,102 @@ describe('generate_image tool', () => {
       { key: 'shared' },
       expect.objectContaining({ size: Buffer.from('real-image-bytes').length, type: 'image/jpeg' }),
       { contentType: 'image/jpeg' },
+    );
+  });
+
+  it('skips a force-disabled provider in the selector even when it has a key', async () => {
+    const generateConfiguredImage = vi.fn().mockResolvedValue({
+      base64: Buffer.from('real-image-bytes').toString('base64'),
+      width: 1024,
+      height: 576,
+    });
+    const put = vi.fn().mockResolvedValue('ast_generated-image');
+    mocks.getServerPersistenceProvider.mockResolvedValue({ assetStore: { put } });
+    const tool = buildGenerateImageTool({
+      sessionId: 'session-owner',
+      // openai-image is force-disabled (`{ disabled: true }`); seedream is the
+      // only enabled entry, so the selector must pick seedream (#665).
+      getConfiguredProviders: () => ({
+        'openai-image': { disabled: true, models: ['gpt-image-1'] },
+        seedream: { models: ['doubao-seedream-3-0-t2i-250415'] },
+      }),
+      resolveProviderConfig: () => ({
+        providerId: 'seedream',
+        apiKey: 'test-key',
+        baseUrl: 'https://ark.cn-beijing.volces.com',
+        model: 'doubao-seedream-3-0-t2i-250415',
+      }),
+      generateConfiguredImage,
+    });
+
+    const result = (await tool.execute(
+      'call-1',
+      { stageId: 'stage-owner', prompt: 'A microscope' },
+      undefined,
+    )) as { isError?: boolean };
+
+    expect(result.isError).toBeUndefined();
+    expect(generateConfiguredImage).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'seedream' }),
+      expect.anything(),
+    );
+  });
+
+  it('does not select a force-disabled provider via DEFAULT_IMAGE_PROVIDER', async () => {
+    vi.stubEnv('DEFAULT_IMAGE_PROVIDER', 'openai-image');
+    const generateConfiguredImage = vi.fn();
+    const tool = buildGenerateImageTool({
+      sessionId: 'session-owner',
+      // openai-image is configured but force-disabled; the env default names it,
+      // so the call must fail instead of using the disabled provider (#665).
+      getConfiguredProviders: () => ({ 'openai-image': { disabled: true } }),
+      generateConfiguredImage,
+    });
+
+    const result = (await tool.execute(
+      'call-1',
+      { stageId: 'stage-owner', prompt: 'A microscope' },
+      undefined,
+    )) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('server default image provider is not available');
+    expect(result.details.reason).toBe('no-provider');
+    expect(generateConfiguredImage).not.toHaveBeenCalled();
+  });
+
+  it('keeps provider identity and raw errors out of tool results (server log only)', async () => {
+    const generateConfiguredImage = vi
+      .fn()
+      .mockRejectedValue(new Error('s3://internal-bucket-xyz quota exceeded'));
+    const tool = buildGenerateImageTool({
+      sessionId: 'session-owner',
+      getConfiguredProviders: () => ({ 'openai-image': { models: ['gpt-image-1'] } }),
+      resolveProviderConfig: () => ({
+        providerId: 'openai-image',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-image-1',
+      }),
+      generateConfiguredImage,
+    });
+
+    const result = (await tool.execute(
+      'call-1',
+      { stageId: 'stage-owner', prompt: 'A microscope' },
+      undefined,
+    )) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Image generation failed.');
+    expect(result.content[0].text).not.toContain('openai-image');
+    expect(result.content[0].text).not.toContain('internal-bucket');
+    expect(result.details).toEqual({ stageId: 'stage-owner', reason: 'provider-or-storage-error' });
+    // The provider id and the raw exception stay in the server-side log,
+    // correlated by the tool-call id.
+    expect(mocks.log.error).toHaveBeenCalledWith(
+      expect.stringMatching(/call-1[\s\S]*provider=openai-image[\s\S]*internal-bucket/),
+      expect.any(Error),
     );
   });
 });

--- a/tests/agent-runtime/generate-media-force-off.test.ts
+++ b/tests/agent-runtime/generate-media-force-off.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Agent media-tool force-off defense in depth (#665): mirror the capability
+// route guards — a provider the operator force-disabled is rejected before any
+// provider I/O even when a caller's listing omits the `{ disabled: true }`
+// flag, and a disabled provider is never picked as the server default. The
+// real server config is authoritative at the call boundary.
+
+const mocks = vi.hoisted(() => ({
+  recordGenerationUsage: vi.fn().mockResolvedValue(undefined),
+  generateConfiguredImage: vi.fn(),
+  generateConfiguredVideo: vi.fn(),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/server/usage-storage', () => ({
+  recordGenerationUsage: mocks.recordGenerationUsage,
+}));
+vi.mock('@/lib/server/ssrf-guard', () => ({ validateUrlForSSRF: async () => null }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => mocks.log }));
+
+const CAP_ENV_PREFIXES = [
+  'IMAGE_OPENAI',
+  'IMAGE_SEEDREAM',
+  'IMAGE_QWEN_IMAGE',
+  'IMAGE_NANO_BANANA',
+  'IMAGE_MINIMAX',
+  'IMAGE_GROK',
+  'IMAGE_LEMONADE',
+  'IMAGE_COMFYUI',
+  'VIDEO_SEEDANCE',
+  'VIDEO_KLING',
+  'VIDEO_VEO',
+  'VIDEO_SORA',
+  'VIDEO_MINIMAX',
+  'VIDEO_GROK',
+  'VIDEO_HAPPYHORSE',
+];
+
+function clearCapabilityEnv() {
+  for (const prefix of CAP_ENV_PREFIXES) {
+    delete process.env[`${prefix}_API_KEY`];
+    delete process.env[`${prefix}_BASE_URL`];
+    delete process.env[`${prefix}_MODELS`];
+    delete process.env[`${prefix}_ENABLED`];
+  }
+}
+
+describe('agent media tool force-off defense in depth (#665)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    clearCapabilityEnv();
+    vi.clearAllMocks();
+  });
+
+  it('image: rejects a force-disabled provider at the call boundary even when the listing omits the flag', async () => {
+    vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+    vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+    const { buildGenerateImageTool } = await import('@/lib/server/agent-runtime/generate-image');
+
+    const tool = buildGenerateImageTool({
+      sessionId: 'session-owner',
+      // The injected listing does NOT mark the provider disabled — the real
+      // server force-off set must still stop the call.
+      getConfiguredProviders: () => ({ 'openai-image': { models: ['gpt-image-1'] } }),
+      resolveProviderConfig: () => ({
+        providerId: 'openai-image',
+        apiKey: 'sk-img',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-image-1',
+      }),
+      generateConfiguredImage: mocks.generateConfiguredImage,
+    });
+
+    const result = (await tool.execute(
+      'call-1',
+      { stageId: 'stage-owner', prompt: 'A microscope' },
+      undefined,
+    )) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Image generation is unavailable.');
+    expect(result.details).toMatchObject({ stageId: 'stage-owner', reason: 'provider-disabled' });
+    expect(mocks.generateConfiguredImage).not.toHaveBeenCalled();
+  });
+
+  it('image: the default selector never picks a force-disabled provider', async () => {
+    vi.stubEnv('IMAGE_OPENAI_API_KEY', 'sk-img');
+    vi.stubEnv('IMAGE_OPENAI_ENABLED', 'false');
+    const { buildGenerateImageTool } = await import('@/lib/server/agent-runtime/generate-image');
+
+    const tool = buildGenerateImageTool({
+      generateConfiguredImage: mocks.generateConfiguredImage,
+    });
+
+    const result = (await tool.execute(
+      'call-1',
+      { stageId: 'stage-owner', prompt: 'A microscope' },
+      undefined,
+    )) as { isError?: boolean; details: Record<string, unknown> };
+
+    expect(result.isError).toBe(true);
+    expect(result.details.reason).toBe('no-provider');
+    expect(mocks.generateConfiguredImage).not.toHaveBeenCalled();
+  });
+
+  it('video: rejects a force-disabled provider at the call boundary even when the listing omits the flag', async () => {
+    vi.stubEnv('VIDEO_GROK_API_KEY', 'xai-video');
+    vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+    const { buildGenerateVideoTool } = await import('@/lib/server/agent-runtime/generate-video');
+
+    const tool = buildGenerateVideoTool({
+      sessionId: 'session-owner',
+      // The injected listing does NOT mark the provider disabled — the real
+      // server force-off set must still stop the call.
+      getConfiguredVideoProviders: () => ({ 'grok-video': { models: ['grok-imagine-video'] } }),
+      resolveVideoProviderConfig: () => ({
+        providerId: 'grok-video',
+        apiKey: 'xai-video',
+        baseUrl: 'https://api.x.ai/v1',
+        model: 'grok-imagine-video',
+      }),
+      generateConfiguredVideo: mocks.generateConfiguredVideo,
+    });
+
+    const result = (await tool.execute(
+      'call-1',
+      { stageId: 'stage-owner', prompt: 'motion' },
+      undefined,
+    )) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Video generation is unavailable.');
+    expect(result.details).toMatchObject({ stageId: 'stage-owner', reason: 'provider-disabled' });
+    expect(mocks.generateConfiguredVideo).not.toHaveBeenCalled();
+  });
+
+  it('video: the capability gate excludes a force-disabled provider from registration', async () => {
+    vi.stubEnv('VIDEO_GROK_API_KEY', 'xai-video');
+    vi.stubEnv('VIDEO_GROK_ENABLED', 'false');
+    const { hasConfiguredVideoGeneration } =
+      await import('@/lib/server/agent-runtime/generate-video');
+
+    // Default wiring (real server config): the only configured provider is
+    // force-disabled, so the gate must not register the tool.
+    expect(hasConfiguredVideoGeneration()).toBe(false);
+  });
+});

--- a/tests/agent-runtime/generate-video.test.ts
+++ b/tests/agent-runtime/generate-video.test.ts
@@ -9,12 +9,14 @@ import { MAX_GENERATED_VIDEO_BYTES } from '@/lib/server/agent-runtime/generate-v
 
 const mocks = vi.hoisted(() => ({
   recordGenerationUsage: vi.fn().mockResolvedValue(undefined),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 vi.mock('@/lib/server/usage-storage', () => ({
   recordGenerationUsage: mocks.recordGenerationUsage,
 }));
 vi.mock('@/lib/server/ssrf-guard', () => ({ validateUrlForSSRF: async () => null }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => mocks.log }));
 
 import {
   buildGenerateVideoTool,
@@ -136,7 +138,7 @@ describe('generate_video tool', () => {
     })) as {
       isError?: boolean;
       content: { text: string }[];
-      details: { src: string; mime: string; durationSec: number; provider: string };
+      details: { src: string; mime: string; durationSec: number };
     };
 
     expect(result.isError).toBeUndefined();
@@ -156,15 +158,20 @@ describe('generate_video tool', () => {
       stageId: 'stage-owner',
       signal: expect.any(AbortSignal),
     });
+    // Success details are provider-neutral: no provider id leaks into the
+    // transcript. The vendor choice stays in the server-side log, correlated
+    // by the tool-call id.
     expect(result.details).toEqual({
       src: 'ast_generated-video',
       mime: 'video/webm',
       durationSec: 5,
-      provider: 'seedance',
     });
     expect(result.content[0].text).toContain('autoplay and poster');
     expect(mocks.recordGenerationUsage).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'video', unit: 'second', quantity: 5 }),
+    );
+    expect(mocks.log.info).toHaveBeenCalledWith(
+      expect.stringMatching(/call-1[\s\S]*provider=seedance/),
     );
   });
 
@@ -250,9 +257,16 @@ describe('generate_video tool', () => {
       prompt: 'motion',
     })) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('content rejected');
-    expect(result.details.reason).toBe('provider-or-storage-error');
+    // The raw provider message never reaches the transcript; it stays in the
+    // server-side log correlated by the tool-call id.
+    expect(result.content[0].text).toBe('Video generation failed.');
+    expect(result.content[0].text).not.toContain('content rejected');
+    expect(result.details).toEqual({ stageId: 'stage-owner', reason: 'provider-or-storage-error' });
     expect(generateConfiguredVideo).toHaveBeenCalledTimes(1);
+    expect(mocks.log.error).toHaveBeenCalledWith(
+      expect.stringMatching(/call-1[\s\S]*provider=seedance[\s\S]*content rejected/),
+      expect.any(Error),
+    );
   });
 
   it('fails loudly on timeout', async () => {
@@ -267,7 +281,7 @@ describe('generate_video tool', () => {
       prompt: 'motion',
     })) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('timed out after 5ms');
+    expect(result.content[0].text).toContain('timed out');
     expect(result.details.reason).toBe('timeout');
   });
 
@@ -285,5 +299,86 @@ describe('generate_video tool', () => {
     );
     controller.abort();
     await expect(pending).rejects.toThrow('aborted');
+  });
+
+  it('does not register when the only configured provider is force-disabled', () => {
+    const deps = courseDeps({
+      getConfiguredVideoProviders: () => ({ seedance: { disabled: true } }),
+      resolveVideoProviderConfig: () => providerConfig,
+    });
+    // The capability gate resolves enabledness through the resolver: a
+    // force-disabled provider never registers the tool (#665).
+    expect(buildDslCourseToolset(deps).map((tool) => tool.name)).not.toContain('generate_video');
+    expect(buildCourseAllowlist(deps)).not.toContain('generate_video');
+  });
+
+  it('skips a force-disabled provider in the selector even when it has a key', async () => {
+    const generateConfiguredVideo = vi.fn().mockResolvedValue({
+      url: 'https://cdn.example.com/generated/lesson.webm',
+      duration: 5,
+      width: 1280,
+      height: 720,
+    });
+    const persistGeneratedVideo = vi.fn().mockResolvedValue({
+      src: 'ast_generated-video',
+      mime: 'video/webm',
+    });
+    const tool = buildGenerateVideoTool({
+      sessionId: 'session-owner',
+      // seedance is force-disabled; kling is the only enabled entry, so the
+      // selector must pick kling (#665).
+      getConfiguredVideoProviders: () => ({
+        seedance: { disabled: true, models: ['doubao-seedance-1-5-pro-251215'] },
+        kling: { models: ['kling-v1-6'] },
+      }),
+      resolveVideoProviderConfig: () => ({
+        providerId: 'kling',
+        apiKey: 'test-key',
+        baseUrl: 'https://api-beijing.klingai.com',
+        model: 'kling-v1-6',
+      }),
+      generateConfiguredVideo,
+      persistGeneratedVideo,
+    });
+
+    const result = (await tool.execute('call-1', {
+      stageId: 'stage-owner',
+      prompt: 'motion',
+    })) as { isError?: boolean };
+
+    expect(result.isError).toBeUndefined();
+    expect(generateConfiguredVideo).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'kling' }),
+      expect.anything(),
+    );
+  });
+
+  it('keeps provider identity and raw errors out of tool results (server log only)', async () => {
+    const generateConfiguredVideo = vi
+      .fn()
+      .mockRejectedValue(new Error('ark.cn-beijing.volces.com account suspended'));
+    const tool = buildGenerateVideoTool({
+      sessionId: 'session-owner',
+      getConfiguredVideoProviders: configured,
+      resolveVideoProviderConfig: () => providerConfig,
+      generateConfiguredVideo,
+    });
+
+    const result = (await tool.execute('call-1', {
+      stageId: 'stage-owner',
+      prompt: 'motion',
+    })) as { isError?: boolean; content: { text: string }[]; details: Record<string, unknown> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Video generation failed.');
+    expect(result.content[0].text).not.toContain('seedance');
+    expect(result.content[0].text).not.toContain('volces');
+    expect(result.details).toEqual({ stageId: 'stage-owner', reason: 'provider-or-storage-error' });
+    // The provider id and the raw exception stay in the server-side log,
+    // correlated by the tool-call id.
+    expect(mocks.log.error).toHaveBeenCalledWith(
+      expect.stringMatching(/call-1[\s\S]*provider=seedance[\s\S]*account suspended/),
+      expect.any(Error),
+    );
   });
 });

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -927,6 +927,33 @@ video:
     });
   });
 
+  describe('enabledProviderIds resolver (#665)', () => {
+    it('returns only non-disabled entries of a capability listing', async () => {
+      const { enabledProviderIds } = await import('@/lib/server/provider-config');
+      expect(
+        enabledProviderIds({
+          'openai-image': { models: ['gpt-image-1'] },
+          seedream: { disabled: true },
+          'grok-image': {},
+        }),
+      ).toEqual(['openai-image', 'grok-image']);
+    });
+
+    it('keeps object-key order and drops nothing when nothing is disabled', async () => {
+      const { enabledProviderIds } = await import('@/lib/server/provider-config');
+      expect(enabledProviderIds({ a: {}, b: { models: [] }, c: { disabled: false } })).toEqual([
+        'a',
+        'b',
+        'c',
+      ]);
+    });
+
+    it('returns an empty list when every entry is force-disabled', async () => {
+      const { enabledProviderIds } = await import('@/lib/server/provider-config');
+      expect(enabledProviderIds({ a: { disabled: true }, b: { disabled: true } })).toEqual([]);
+    });
+  });
+
   describe('Qwen TTS resolution', () => {
     it('uses the provider default base URL when none is configured or supplied', async () => {
       const { resolveTTSBaseUrl } = await import('@/lib/server/provider-config');


### PR DESCRIPTION
Fixes a P1 and a P2 from the 1.0.0 release review: (1) agent image/video tools bypassed the operator force-off switch — all capability consumers now resolve through a single enabled-provider resolver, with a defense-in-depth re-check at the call boundary; DEFAULT_IMAGE_PROVIDER can no longer select a disabled entry; (2) provider IDs and raw backend errors leaked into the browser-facing tool results — results now carry stable neutral error codes, vendor identity stays in server logs correlated by tool-call id. Adds force-off mirror tests for both tools.