### PR TITLE
fix(materials): serialize per-owner quota reservations and make crashed uploads reclaimable

### DIFF
--- a/app/api/materials/route.ts
+++ b/app/api/materials/route.ts
@@ -17,11 +17,14 @@
  *   `maxUploadBytes`, documents/images at `min(maxDocumentBytes,
  *   maxUploadBytes)` — both 413 when exceeded, checked on the declared
  *   `content-length` AND on the streamed body.
- * - Lifecycle: the upload reserves a quota-checked `uploading` row (429 when
- *   the owner's count or byte quota is exceeded), streams the bytes through a
- *   sha256 meter into the asset registry, and finalizes the row to `ready`
- *   with the digest. Failures abandon the reservation; crash leftovers are
- *   swept by the next upload's 24-hour lazy sweep.
+ * - Lifecycle: the upload reclaims crashed `uploading` leftovers older than
+ *   24 hours (their asset entries first, then the reservations), reserves a
+ *   quota-checked `uploading` row (429 when the owner's count or byte quota is
+ *   exceeded), streams the bytes through a sha256 meter into the asset
+ *   registry, records the returned asset id onto the reservation in its own
+ *   durable step, and finalizes the row to `ready` with the digest. Failures
+ *   abandon the reservation; crash leftovers are reclaimed by the next
+ *   upload's 24-hour sweep.
  * - Every response echoes the `x-request-id` header so the uploader can pair
  *   a failure with its log line.
  *
@@ -52,6 +55,8 @@ import {
   finalizeOwnerMaterial,
   MaterialQuotaExceededError,
   publicMaterial,
+  reclaimStaleOwnerMaterialUploads,
+  recordOwnerMaterialAsset,
   registerOwnerMaterial,
 } from '@/lib/persistence/owner-materials';
 import { getServerPersistenceProvider } from '@/lib/persistence/server-provider';
@@ -228,6 +233,35 @@ export async function POST(req: NextRequest) {
       const reservedBytes =
         Number.isFinite(declaredBytes) && declaredBytes > 0 ? declaredBytes : uploadLimit;
 
+      // Reclaim uploads that crashed before finalize and are older than the
+      // 24-hour horizon. Each reservation's asset entry (recorded in its own
+      // durable step before finalize) is removed first; the reservation is
+      // deleted only after that, so a failure here keeps the reservation for
+      // the next pass instead of losing the pointer to its bytes.
+      phase = 'reclaim_stale_uploads';
+      await reclaimStaleOwnerMaterialUploads(
+        provider.pool as unknown as ConnectableQueryable,
+        ownerId,
+        async (assetId) => {
+          try {
+            await provider.assetStore.remove(principal, assetId);
+          } catch (error) {
+            console.warn(
+              'material stale asset removal failed; keeping its reservation for the next pass',
+              context({ assetId }),
+              error,
+            );
+            throw error;
+          }
+        },
+      ).catch((error) => {
+        console.warn(
+          'material stale-upload reclaim failed; retrying on the next upload',
+          context(),
+          error,
+        );
+      });
+
       phase = 'reserve_material';
       try {
         await registerOwnerMaterial(
@@ -249,9 +283,6 @@ export async function POST(req: NextRequest) {
         );
       } catch (error) {
         if (error instanceof MaterialQuotaExceededError) {
-          for (const stale of error.stale) {
-            await provider.assetStore.remove(principal, stale.assetId).catch(() => undefined);
-          }
           return reject(
             apiError('INVALID_REQUEST', 429, error.message),
             'quota_exceeded',
@@ -311,9 +342,10 @@ export async function POST(req: NextRequest) {
       }
 
       // Put the bytes into the asset registry, then bind the returned asset id
-      // onto the reserved row. The row stays `uploading` (hidden and
-      // quota-counted) until finalize; a crash leaves it for the 24-hour lazy
-      // sweep.
+      // onto the reserved row in its own durable step BEFORE finalize. A crash
+      // after the put commits but before finalize therefore leaves the id
+      // recorded, so the 24-hour reclaim can remove the bytes when it reclaims
+      // the stale reservation.
       const hash = createHash('sha256').update(bytes).digest('hex');
       let assetId: string | null = null;
       try {
@@ -321,6 +353,11 @@ export async function POST(req: NextRequest) {
           principal,
           new Blob([new Uint8Array(bytes)], { type: mime }),
           { contentType: mime },
+        );
+        await recordOwnerMaterialAsset(
+          provider.pool as unknown as ConnectableQueryable,
+          createdMaterialId,
+          assetId,
         );
         const row = await finalizeOwnerMaterial(
           provider.pool as unknown as ConnectableQueryable,

--- a/lib/persistence/owner-materials.ts
+++ b/lib/persistence/owner-materials.ts
@@ -18,8 +18,9 @@
  * the owner's active source materials), streams its bytes into the asset
  * registry through a sha256 meter, then finalizes the row to `'ready'` with the
  * digest. A failed upload abandons the row; a process death leaves `uploading`
- * rows behind, which the next upload's 24-hour lazy sweep deletes (and its
- * caller best-effort removes the orphaned bytes).
+ * rows behind, which the next upload's 24-hour reclaim removes -- its asset
+ * entry first, then the reservation, so a crash mid-reclaim never loses the
+ * pointer to the bytes.
  */
 import type { Queryable } from '@openmaic/storage/document/pg';
 import {
@@ -72,7 +73,6 @@ export class MaterialQuotaExceededError extends Error {
   constructor(
     readonly quota: 'count' | 'bytes',
     readonly maximum: number,
-    readonly stale: Array<{ id: string; assetId: string }> = [],
   ) {
     super(
       quota === 'count'
@@ -208,30 +208,90 @@ export function publicMaterial(record: OwnerMaterialRecord): OwnerMaterialView {
 const STALE_UPLOAD_AGE_MS = 24 * 60 * 60 * 1_000;
 
 /**
+ * Per-owner advisory-lock key that serializes quota reservations.
+ *
+ * The key namespaces the owner's id so two concurrent uploads for the same
+ * owner queue behind the same transaction-scoped lock (see
+ * {@link registerOwnerMaterial}). It deliberately differs from the asset
+ * registry's own per-principal lock key: reserving a material and storing its
+ * bytes are separate transactions, so sharing a key would only couple them
+ * without adding safety.
+ */
+export function ownerMaterialQuotaLockKey(ownerId: string): string {
+  return `owner-materials:${ownerId}:quota`;
+}
+
+/**
+ * Reclaim uploads that crashed before finalize and are older than the sweep
+ * horizon.
+ *
+ * Order is load-bearing: each stale reservation's asset entry is removed
+ * first, and only then is the reservation deleted. Deleting the reservation
+ * first would lose the pointer to its bytes on a crash between the two, so the
+ * asset entry would keep consuming the owner's asset quota forever. A
+ * reservation whose asset removal throws is left in place (still quota-counted)
+ * and the next pass retries it.
+ *
+ * @param removeAsset Reclaims one recorded asset id; must resolve when the
+ *   entry is removed or confirmed already absent, and throw to keep the
+ *   reservation for the next pass.
+ */
+export async function reclaimStaleOwnerMaterialUploads(
+  queryable: Queryable,
+  ownerId: string,
+  removeAsset: (assetId: string) => Promise<void>,
+): Promise<void> {
+  const staleBefore = Date.now() - STALE_UPLOAD_AGE_MS;
+  const stale = await queryable.query<{ id: string; asset_id: string }>(
+    `SELECT id, asset_id
+       FROM owner_material
+      WHERE owner_id = $1
+        AND status = 'uploading'
+        AND created_at < $2`,
+    [ownerId, staleBefore],
+  );
+  for (const row of stale.rows) {
+    if (row.asset_id !== '') {
+      try {
+        await removeAsset(row.asset_id);
+      } catch {
+        // The asset entry is not confirmed gone; keep the reservation so the
+        // next pass retries with the pointer intact.
+        continue;
+      }
+    }
+    await queryable.query(
+      `DELETE FROM owner_material
+        WHERE id = $1 AND status = 'uploading'`,
+      [row.id],
+    );
+  }
+}
+
+/**
  * Reserve one uploading row under the owner's quota.
  *
- * Runs in a transaction: the 24-hour lazy sweep of stale `uploading` rows, the
- * quota check, and the INSERT are one unit, so concurrent uploads cannot
- * double-spend the owner's quota. Returns the swept stale rows so the caller
- * can best-effort delete their orphaned asset-registry bytes.
+ * Runs in a transaction that takes a transaction-scoped advisory lock keyed on
+ * the owner before the quota read. Under READ COMMITTED the aggregate quota
+ * query alone locks no row, so without the lock two concurrent uploads could
+ * both observe the same remaining slot or bytes and both insert, overshooting
+ * the configured boundary; the lock makes the read-check-insert one critical
+ * section per owner. Stale `uploading` rows from crashed uploads are reclaimed
+ * by the caller via {@link reclaimStaleOwnerMaterialUploads} before this call.
  */
 export async function registerOwnerMaterial(
   queryable: ConnectableQueryable,
   input: RegisterOwnerMaterialInput,
   limits: OwnerMaterialRegistrationLimits,
-): Promise<{ record: OwnerMaterialRecord; stale: Array<{ id: string; assetId: string }> }> {
-  const staleBefore = Date.now() - STALE_UPLOAD_AGE_MS;
+): Promise<OwnerMaterialRecord> {
   const withTransaction = nodePostgresTransaction(queryable);
   return withTransaction(async (tx) => {
-    const staleResult = await tx.query<RawOwnerMaterialRow>(
-      `DELETE FROM owner_material
-        WHERE owner_id = $1
-          AND status = 'uploading'
-          AND created_at < $2
-       RETURNING ${OWNER_MATERIAL_COLUMNS}`,
-      [input.ownerId, staleBefore],
-    );
-    const stale = staleResult.rows.map((row) => ({ id: row.id, assetId: row.asset_id }));
+    // hashtextextended is 64-bit (hashtext is 32-bit and could block unrelated
+    // owners on a collision); the lock is transaction-scoped and releases on
+    // commit or rollback.
+    await tx.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+      ownerMaterialQuotaLockKey(input.ownerId),
+    ]);
 
     const usage = await tx.query<{ count: number | string; total_bytes: number | string }>(
       `SELECT COUNT(*)::text AS count,
@@ -243,10 +303,10 @@ export async function registerOwnerMaterial(
     const count = Number(usage.rows[0]?.count ?? 0);
     const totalBytes = Number(usage.rows[0]?.total_bytes ?? 0);
     if (count >= limits.maxCount) {
-      throw new MaterialQuotaExceededError('count', limits.maxCount, stale);
+      throw new MaterialQuotaExceededError('count', limits.maxCount);
     }
     if (totalBytes + input.bytes > limits.maxTotalBytes) {
-      throw new MaterialQuotaExceededError('bytes', limits.maxTotalBytes, stale);
+      throw new MaterialQuotaExceededError('bytes', limits.maxTotalBytes);
     }
 
     const inserted = await tx.query<RawOwnerMaterialRow>(
@@ -268,8 +328,35 @@ export async function registerOwnerMaterial(
         Date.now(),
       ],
     );
-    return { record: rowToRecord(inserted.rows[0]), stale };
+    return rowToRecord(inserted.rows[0]);
   });
+}
+
+/**
+ * Bind the asset-registry id onto a still-`uploading` reservation.
+ *
+ * The upload's bytes are stored in a separate transaction from the
+ * reservation, so this is a distinct durable step between the asset `put` and
+ * {@link finalizeOwnerMaterial}. Recording the id here -- not only inside
+ * finalize -- closes the crash window in which a committed asset entry had its
+ * id recorded nowhere: the stale-upload reclaim can now see the id and remove
+ * the bytes when it reclaims the reservation.
+ */
+export async function recordOwnerMaterialAsset(
+  queryable: Queryable,
+  materialId: string,
+  assetId: string,
+): Promise<void> {
+  const result = await queryable.query<{ id: string }>(
+    `UPDATE owner_material
+        SET asset_id = $2
+      WHERE id = $1
+        AND status = 'uploading'
+        AND deleted_at IS NULL
+      RETURNING id`,
+    [materialId, assetId],
+  );
+  if (!result.rows[0]) throw new Error(`material ${materialId} cannot record its asset id`);
 }
 
 /** Finalize a successfully stored object. Reserved bytes may only shrink. */

--- a/tests/agent-runtime/materials-route.test.ts
+++ b/tests/agent-runtime/materials-route.test.ts
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   listSessionMaterials: vi.fn(),
   createSourceMaterial: vi.fn(),
   registerOwnerMaterial: vi.fn(),
+  recordOwnerMaterialAsset: vi.fn(),
+  reclaimStaleOwnerMaterialUploads: vi.fn(),
   finalizeOwnerMaterial: vi.fn(),
   abandonOwnerMaterial: vi.fn(),
   assetStore: {
@@ -50,6 +52,8 @@ vi.mock('@/lib/persistence/owner-materials', async (importOriginal) => {
   return {
     ...actual,
     registerOwnerMaterial: mocks.registerOwnerMaterial,
+    recordOwnerMaterialAsset: mocks.recordOwnerMaterialAsset,
+    reclaimStaleOwnerMaterialUploads: mocks.reclaimStaleOwnerMaterialUploads,
     finalizeOwnerMaterial: mocks.finalizeOwnerMaterial,
     abandonOwnerMaterial: mocks.abandonOwnerMaterial,
   };
@@ -102,10 +106,9 @@ beforeEach(() => {
   mocks.resolveRequestOwnerId.mockReturnValue('owner-1');
   mocks.resolveOwnedSession.mockResolvedValue({ id: SESSION_ID, ownerId: 'owner-1' });
   mocks.listSessionMaterials.mockResolvedValue([material()]);
-  mocks.registerOwnerMaterial.mockResolvedValue({
-    record: ownerMaterial(),
-    stale: [],
-  });
+  mocks.registerOwnerMaterial.mockResolvedValue(ownerMaterial());
+  mocks.recordOwnerMaterialAsset.mockResolvedValue(undefined);
+  mocks.reclaimStaleOwnerMaterialUploads.mockResolvedValue(undefined);
   mocks.finalizeOwnerMaterial.mockImplementation(async (_pool: unknown, id: string) =>
     ownerMaterial({ id }),
   );
@@ -232,6 +235,22 @@ describe('POST /api/materials', () => {
       '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
       'asset-1',
     );
+    // The upload reclaims crashed leftovers before reserving, and records the
+    // returned asset id onto the reservation in its own durable step BEFORE
+    // finalize, closing the crash window between put and finalize.
+    expect(mocks.reclaimStaleOwnerMaterialUploads).toHaveBeenCalledWith(
+      expect.anything(),
+      'owner-1',
+      expect.any(Function),
+    );
+    expect(mocks.recordOwnerMaterialAsset).toHaveBeenCalledWith(
+      expect.anything(),
+      body.materialId,
+      'asset-1',
+    );
+    const recordCall = mocks.recordOwnerMaterialAsset.mock.invocationCallOrder[0]!;
+    const finalizeCall = mocks.finalizeOwnerMaterial.mock.invocationCallOrder[0]!;
+    expect(recordCall).toBeLessThan(finalizeCall);
   });
 
   it('rejects an unsupported mime type with 415', async () => {
@@ -259,14 +278,14 @@ describe('POST /api/materials', () => {
     expect(mocks.finalizeOwnerMaterial).not.toHaveBeenCalled();
   });
 
-  it('answers 429 when the owner quota is exceeded and cleans stale bytes', async () => {
+  it('answers 429 when the owner quota is exceeded', async () => {
     const { MaterialQuotaExceededError } = await import('@/lib/persistence/owner-materials');
-    mocks.registerOwnerMaterial.mockRejectedValue(
-      new MaterialQuotaExceededError('bytes', 1024, [{ id: 'mat_stale', assetId: 'asset-stale' }]),
-    );
+    mocks.registerOwnerMaterial.mockRejectedValue(new MaterialQuotaExceededError('bytes', 1024));
     const response = await post(Buffer.from('hello'));
     expect(response.status).toBe(429);
-    expect(mocks.assetStore.remove).toHaveBeenCalledWith(expect.anything(), 'asset-stale');
+    // The reclaim of stale uploads is a separate pre-step; the quota rejection
+    // itself never touches the asset registry.
+    expect(mocks.assetStore.remove).not.toHaveBeenCalled();
   });
 
   it('abandons the reservation and answers 500 when the asset store fails', async () => {
@@ -274,6 +293,20 @@ describe('POST /api/materials', () => {
     const response = await post(Buffer.from('hello'));
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({ errorCode: 'INTERNAL_ERROR' });
+    expect(mocks.abandonOwnerMaterial).toHaveBeenCalled();
+  });
+
+  it('removes the stored asset and abandons the reservation when finalize fails after the asset id was recorded', async () => {
+    // The put committed and the asset id was durably recorded on the
+    // reservation; only finalize failed. The route must still clean up both
+    // the asset entry and the reservation (a hard crash between the two is the
+    // sweeper's job, covered by the persistence suite).
+    mocks.finalizeOwnerMaterial.mockRejectedValue(new Error('finalize failed'));
+    const response = await post(Buffer.from('hello'));
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ errorCode: 'INTERNAL_ERROR' });
+    expect(mocks.recordOwnerMaterialAsset).toHaveBeenCalled();
+    expect(mocks.assetStore.remove).toHaveBeenCalledWith(expect.anything(), 'asset-1');
     expect(mocks.abandonOwnerMaterial).toHaveBeenCalled();
   });
 

--- a/tests/persistence/owner-materials.pg.test.ts
+++ b/tests/persistence/owner-materials.pg.test.ts
@@ -1,0 +1,134 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ConnectableQueryable } from '@openmaic/storage/server/reference';
+
+import {
+  ensureOwnerMaterialSchema,
+  MaterialQuotaExceededError,
+  ownerMaterialQuotaLockKey,
+  registerOwnerMaterial,
+  type RegisterOwnerMaterialInput,
+} from '@/lib/persistence/owner-materials';
+
+const contractUrl = process.env.PG_CONTRACT_URL;
+
+/** Wait until some backend in this database is blocked on a lock. */
+async function waitForLockWaiter(pool: Pool): Promise<void> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    const waiting = await pool.query(
+      `SELECT 1 FROM pg_stat_activity
+        WHERE wait_event_type = 'Lock' AND datname = current_database()`,
+    );
+    if (waiting.rows.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error('no backend blocked on a lock: the reservation never contended');
+}
+
+describe.skipIf(!contractUrl)('owner material quota reservations on PostgreSQL', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: contractUrl });
+    await ensureOwnerMaterialSchema(pool as unknown as ConnectableQueryable);
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE owner_material');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  const input = (id: string): RegisterOwnerMaterialInput => ({
+    id,
+    ownerId: 'owner-1',
+    kind: 'source',
+    mime: 'application/pdf',
+    bytes: 10,
+    originalName: `${id}.pdf`,
+    assetId: '',
+    extraction: { status: 'idle' },
+  });
+
+  it('rejects the second of two concurrent reservations for one remaining slot', async () => {
+    // Two separate connections (each register call checks out its own), both
+    // racing for the owner's last slot. The per-owner advisory lock serializes
+    // the read-check-insert, so exactly one may pass.
+    const limits = { maxCount: 1, maxTotalBytes: 10_000 };
+    const results = await Promise.allSettled([
+      registerOwnerMaterial(pool as unknown as ConnectableQueryable, input('mat-a'), limits),
+      registerOwnerMaterial(pool as unknown as ConnectableQueryable, input('mat-b'), limits),
+    ]);
+
+    const accepted = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+    expect(accepted).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      MaterialQuotaExceededError,
+    );
+
+    const rows = await pool.query<{ id: string }>('SELECT id FROM owner_material');
+    expect(rows.rows).toHaveLength(1);
+  });
+
+  it('parks a concurrent reservation at the per-owner advisory lock before its usage read', async () => {
+    // Manual mirror of registerOwnerMaterial's transaction with a barrier after
+    // the first usage read: the second connection must wait at the advisory
+    // lock, so its usage read runs only after the first reservation commits and
+    // sees the consumed slot -- the interleaving that used to double-spend now
+    // serializes into one acceptance and one rejection.
+    const lockKey = ownerMaterialQuotaLockKey('owner-1');
+    const usageSql = `SELECT COUNT(*)::text AS count
+        FROM owner_material
+       WHERE owner_id = $1 AND kind = 'source' AND deleted_at IS NULL`;
+    const insertSql = `INSERT INTO owner_material
+        (id, owner_id, kind, mime, bytes, original_name, asset_id, sha256,
+         status, extraction, created_at)
+      VALUES ($1, 'owner-1', 'source', 'application/pdf', 10, $2, 'asset-a',
+              NULL, 'uploading', NULL, $3)`;
+
+    const first = await pool.connect();
+    const second = await pool.connect();
+    try {
+      await first.query('BEGIN');
+      await first.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [lockKey]);
+      const before = await first.query<{ count: string }>(usageSql, ['owner-1']);
+      expect(Number(before.rows[0]!.count)).toBe(0);
+
+      // Start the second reservation. It parks at the advisory lock, so its
+      // usage read cannot run until the first reservation commits.
+      const secondReservation = (async () => {
+        await second.query('BEGIN');
+        await second.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [lockKey]);
+        const usage = await second.query<{ count: string }>(usageSql, ['owner-1']);
+        if (Number(usage.rows[0]!.count) >= 1) {
+          throw new MaterialQuotaExceededError('count', 1);
+        }
+        await second.query(insertSql, ['mat-b', 'b.pdf', Date.now()]);
+        await second.query('COMMIT');
+      })();
+
+      // Barrier after the first usage read: the second connection is genuinely
+      // blocked on the advisory lock, before it has read any usage.
+      await waitForLockWaiter(pool);
+
+      await first.query(insertSql, ['mat-a', 'a.pdf', Date.now()]);
+      await first.query('COMMIT');
+
+      await expect(secondReservation).rejects.toBeInstanceOf(MaterialQuotaExceededError);
+      const rows = await pool.query<{ id: string }>('SELECT id FROM owner_material');
+      expect(rows.rows.map((row) => row.id)).toEqual(['mat-a']);
+    } finally {
+      // Release the second connection's transaction (and its advisory lock)
+      // whatever happened; the first is already committed or rolled back.
+      await second.query('ROLLBACK').catch(() => undefined);
+      await first.query('ROLLBACK').catch(() => undefined);
+      first.release();
+      second.release();
+    }
+  });
+});

--- a/tests/persistence/owner-materials.test.ts
+++ b/tests/persistence/owner-materials.test.ts
@@ -1,0 +1,283 @@
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConnectableQueryable } from '@openmaic/storage/server/reference';
+
+import {
+  ensureOwnerMaterialSchema,
+  finalizeOwnerMaterial,
+  ownerMaterialQuotaLockKey,
+  reclaimStaleOwnerMaterialUploads,
+  recordOwnerMaterialAsset,
+  registerOwnerMaterial,
+  type RegisterOwnerMaterialInput,
+} from '@/lib/persistence/owner-materials';
+
+/** The node-postgres pool surface, backed by the single-connection PGlite. */
+class PGlitePool {
+  readonly statements: string[] = [];
+
+  constructor(readonly db: PGlite) {}
+
+  query<TRow>(text: string, params?: unknown[]) {
+    this.statements.push(text);
+    return this.db.query<TRow>(text, params);
+  }
+
+  async connect() {
+    return {
+      query: <TRow>(text: string, params?: unknown[]) => {
+        this.statements.push(text);
+        return this.db.query<TRow>(text, params);
+      },
+      release() {},
+    };
+  }
+
+  async end() {
+    await this.db.close();
+  }
+}
+
+const input = (
+  overrides: Partial<RegisterOwnerMaterialInput> = {},
+): RegisterOwnerMaterialInput => ({
+  id: 'mat_1',
+  ownerId: 'owner-1',
+  kind: 'source',
+  mime: 'application/pdf',
+  bytes: 100,
+  originalName: 'a.pdf',
+  assetId: '',
+  extraction: { status: 'idle' },
+  ...overrides,
+});
+
+/** Insert an `uploading` row directly, e.g. one old enough to reclaim. */
+async function insertRawUpload(
+  db: PGlite,
+  row: {
+    id: string;
+    ownerId?: string;
+    assetId?: string;
+    bytes?: number;
+    status?: string;
+    createdAt?: number;
+  },
+): Promise<void> {
+  await db.query(
+    `INSERT INTO owner_material
+       (id, owner_id, kind, mime, bytes, original_name, asset_id, sha256,
+        status, extraction, created_at)
+     VALUES ($1, $2, 'source', 'application/pdf', $3, 'stale.pdf', $4, NULL,
+             $5, NULL, $6)`,
+    [
+      row.id,
+      row.ownerId ?? 'owner-1',
+      row.bytes ?? 10,
+      row.assetId ?? '',
+      row.status ?? 'uploading',
+      row.createdAt ?? Date.now(),
+    ],
+  );
+}
+
+async function rowById(db: PGlite, id: string): Promise<Record<string, unknown> | null> {
+  const result = await db.query<Record<string, unknown>>(
+    'SELECT id, asset_id, status FROM owner_material WHERE id = $1',
+    [id],
+  );
+  return result.rows[0] ?? null;
+}
+
+describe('owner material reservations', () => {
+  let pool: PGlitePool;
+
+  beforeEach(async () => {
+    const db = new PGlite();
+    await db.waitReady;
+    await ensureOwnerMaterialSchema(db);
+    pool = new PGlitePool(db);
+  });
+
+  afterEach(async () => {
+    await pool.end();
+  });
+
+  it('takes the per-owner advisory lock before the quota read and inserts one uploading row', async () => {
+    const record = await registerOwnerMaterial(pool as unknown as ConnectableQueryable, input(), {
+      maxCount: 10,
+      maxTotalBytes: 1_000,
+    });
+    expect(record.id).toBe('mat_1');
+    expect(record.status).toBe('uploading');
+    expect(record.assetId).toBe('');
+
+    const lockStatement = pool.statements.findIndex((statement) =>
+      statement.includes('pg_advisory_xact_lock(hashtextextended($1, 0))'),
+    );
+    const usageStatement = pool.statements.findIndex((statement) => statement.includes('COUNT(*)'));
+    const insertStatement = pool.statements.findIndex((statement) =>
+      statement.includes('INSERT INTO'),
+    );
+    expect(lockStatement).toBeGreaterThanOrEqual(0);
+    expect(usageStatement).toBeGreaterThan(lockStatement);
+    expect(insertStatement).toBeGreaterThan(usageStatement);
+  });
+
+  it('rejects a reservation when the owner count quota is already spent', async () => {
+    const limits = { maxCount: 1, maxTotalBytes: 1_000 };
+    await registerOwnerMaterial(pool as unknown as ConnectableQueryable, input(), limits);
+    await expect(
+      registerOwnerMaterial(
+        pool as unknown as ConnectableQueryable,
+        input({ id: 'mat_2' }),
+        limits,
+      ),
+    ).rejects.toMatchObject({ name: 'MaterialQuotaExceededError', quota: 'count', maximum: 1 });
+    const rows = await pool.query<{ id: string }>('SELECT id FROM owner_material');
+    expect(rows.rows).toHaveLength(1);
+  });
+
+  it('rejects a reservation when the owner byte quota would be exceeded', async () => {
+    const limits = { maxCount: 10, maxTotalBytes: 100 };
+    await registerOwnerMaterial(
+      pool as unknown as ConnectableQueryable,
+      input({ bytes: 80 }),
+      limits,
+    );
+    await expect(
+      registerOwnerMaterial(
+        pool as unknown as ConnectableQueryable,
+        input({ id: 'mat_2', bytes: 30 }),
+        limits,
+      ),
+    ).rejects.toMatchObject({ name: 'MaterialQuotaExceededError', quota: 'bytes', maximum: 100 });
+  });
+
+  it('records the asset id on the uploading reservation before finalize', async () => {
+    const limits = { maxCount: 10, maxTotalBytes: 1_000 };
+    await registerOwnerMaterial(pool as unknown as ConnectableQueryable, input(), limits);
+    await recordOwnerMaterialAsset(pool as unknown as ConnectableQueryable, 'mat_1', 'asset-abc');
+    const before = await rowById(pool.db, 'mat_1');
+    expect(before).toMatchObject({ asset_id: 'asset-abc', status: 'uploading' });
+
+    const finalized = await finalizeOwnerMaterial(
+      pool as unknown as ConnectableQueryable,
+      'mat_1',
+      100,
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+      'asset-abc',
+    );
+    expect(finalized.status).toBe('ready');
+    expect(finalized.assetId).toBe('asset-abc');
+  });
+
+  it('reclaims a crashed reservation and its recorded asset entry (crash between put and finalize)', async () => {
+    // Simulate the crash point: the put committed and the asset id was durably
+    // recorded on the still-uploading reservation, but finalize never ran.
+    await registerOwnerMaterial(pool as unknown as ConnectableQueryable, input(), {
+      maxCount: 10,
+      maxTotalBytes: 1_000,
+    });
+    await recordOwnerMaterialAsset(pool as unknown as ConnectableQueryable, 'mat_1', 'asset-crash');
+    await pool.query('UPDATE owner_material SET created_at = $2 WHERE id = $1', [
+      'mat_1',
+      Date.now() - 25 * 60 * 60 * 1_000,
+    ]);
+
+    const removeAsset = vi.fn(async (assetId: string) => {
+      // The reservation must still exist when its asset entry is removed: the
+      // pointer is deleted only after the bytes are confirmed reclaimed.
+      const stillPresent = await pool.db.query<{ id: string }>(
+        'SELECT id FROM owner_material WHERE id = $1',
+        ['mat_1'],
+      );
+      expect(stillPresent.rows).toHaveLength(1);
+      expect(assetId).toBe('asset-crash');
+    });
+
+    await reclaimStaleOwnerMaterialUploads(
+      pool as unknown as ConnectableQueryable,
+      'owner-1',
+      removeAsset,
+    );
+
+    expect(removeAsset).toHaveBeenCalledTimes(1);
+    expect(removeAsset).toHaveBeenCalledWith('asset-crash');
+    expect(await rowById(pool.db, 'mat_1')).toBeNull();
+  });
+
+  it('keeps a stale reservation when its asset removal fails and retries on the next pass', async () => {
+    await insertRawUpload(pool.db, {
+      id: 'mat_stale',
+      assetId: 'asset-stubborn',
+      createdAt: Date.now() - 25 * 60 * 60 * 1_000,
+    });
+
+    const removeAsset = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('registry unavailable'))
+      .mockResolvedValue(undefined);
+
+    await reclaimStaleOwnerMaterialUploads(
+      pool as unknown as ConnectableQueryable,
+      'owner-1',
+      removeAsset,
+    );
+    // First pass: removal failed, so the reservation stays for the next pass.
+    expect(await rowById(pool.db, 'mat_stale')).not.toBeNull();
+
+    await reclaimStaleOwnerMaterialUploads(
+      pool as unknown as ConnectableQueryable,
+      'owner-1',
+      removeAsset,
+    );
+    expect(removeAsset).toHaveBeenCalledTimes(2);
+    expect(await rowById(pool.db, 'mat_stale')).toBeNull();
+  });
+
+  it('deletes stale asset-less reservations without touching the registry', async () => {
+    await insertRawUpload(pool.db, {
+      id: 'mat_empty',
+      assetId: '',
+      createdAt: Date.now() - 25 * 60 * 60 * 1_000,
+    });
+
+    const removeAsset = vi.fn().mockResolvedValue(undefined);
+    await reclaimStaleOwnerMaterialUploads(
+      pool as unknown as ConnectableQueryable,
+      'owner-1',
+      removeAsset,
+    );
+
+    expect(removeAsset).not.toHaveBeenCalled();
+    expect(await rowById(pool.db, 'mat_empty')).toBeNull();
+  });
+
+  it('leaves fresh uploads and ready rows alone', async () => {
+    await insertRawUpload(pool.db, { id: 'mat_fresh', assetId: 'asset-fresh' });
+    await insertRawUpload(pool.db, {
+      id: 'mat_old_ready',
+      assetId: 'asset-ready',
+      status: 'ready',
+      createdAt: Date.now() - 25 * 60 * 60 * 1_000,
+    });
+
+    const removeAsset = vi.fn().mockResolvedValue(undefined);
+    await reclaimStaleOwnerMaterialUploads(
+      pool as unknown as ConnectableQueryable,
+      'owner-1',
+      removeAsset,
+    );
+
+    expect(removeAsset).not.toHaveBeenCalled();
+    expect(await rowById(pool.db, 'mat_fresh')).toMatchObject({ status: 'uploading' });
+    expect(await rowById(pool.db, 'mat_old_ready')).toMatchObject({ status: 'ready' });
+  });
+
+  it('derives a per-owner lock key that does not collide with the asset registry key', () => {
+    expect(ownerMaterialQuotaLockKey('owner-1')).toBe('owner-materials:owner-1:quota');
+    expect(ownerMaterialQuotaLockKey('owner-1')).not.toBe('owner-materials:owner-1');
+  });
+});


### PR DESCRIPTION
Fixes a P1 and a P2 from the 1.0.0 release review: (1) concurrent uploads could double-spend per-owner material quotas under READ COMMITTED — reservations now serialize on a transaction-scoped per-owner advisory lock (same idiom as the asset registry), proven by an env-gated two-connection PostgreSQL test; (2) a crash between asset insertion and material finalization leaked the asset entry forever — the asset id is now durably recorded on the reservation before finalization, and the stale-upload sweep removes the asset entry before deleting the reservation (order is load-bearing; failures retry on the next pass).