### PR TITLE
fix(editor): resolve dock-bar i18n keys, remove dock height drag, wire element referencing

### DIFF
--- a/components/edit/EditDock/EditDock.tsx
+++ b/components/edit/EditDock/EditDock.tsx
@@ -5,8 +5,11 @@
  *
  * Two parts, and only two: a global edit bar (`DockEditBar`) that never changes,
  * and the narration timeline below it. The dock owns the surface — the top
- * border, the blur, the drag-resize handle, the fold — while the timeline owns
- * its own header row and body and reads the fold from `useEditDock`.
+ * border, the blur, the fold — while the timeline owns its own header row and
+ * body and reads the fold from `useEditDock`. The dock's height is fixed (the
+ * timeline is folded or not, nothing else changes it): the height-drag handle
+ * the reference implementation carries above the bar was removed per product
+ * decision — this bar must not support height dragging.
  *
  * It briefly had a tab strip and a second tool (an element-reference panel).
  * That was wrong twice over: an exclusive panel hid the timeline to do something
@@ -18,7 +21,7 @@
  * type scale and flat icon buttons; the timeline keeps the height, padding and
  * geometry it had as a standalone bar.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useStageStore } from '@/lib/store/stage';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useWorkbenchStore } from '@/lib/workbench/session-store';
@@ -29,12 +32,11 @@ import { EditDockProvider } from './dock-context';
 import { DockEditBar, DOCK_EDIT_BAR_HEIGHT } from './DockEditBar';
 
 /**
- * The timeline's heights, in px — the body only; the edit bar is added on top of
- * every one of them, so folding and dragging never take the bar away.
+ * The timeline's height, in px — the body only; the edit bar is added on top of
+ * it, so folding never takes the bar away. The timeline height is fixed: the
+ * height-drag handle was removed (owner decision), so only the fold moves it.
  */
 const TIMELINE_DEFAULT_HEIGHT = 224;
-const TIMELINE_MIN_HEIGHT = 168;
-const TIMELINE_MAX_HEIGHT = 520;
 /** The axis of node icons, with room for the chips that hang off it. */
 const TIMELINE_COLLAPSED_HEIGHT = 86;
 
@@ -62,7 +64,6 @@ export function EditDock({
   const canPickElements = sceneType === 'slide' || sceneType === 'interactive';
 
   const [collapsed, setCollapsed] = useState(false);
-  const [height, setHeight] = useState(TIMELINE_DEFAULT_HEIGHT);
   const toggleCollapsed = useCallback(() => setCollapsed((current) => !current), []);
 
   /**
@@ -90,73 +91,16 @@ export function EditDock({
     }
   }, [currentStageId, sceneId, sessionId]);
 
-  const sectionRef = useRef<HTMLElement>(null);
-  const resizeRef = useRef<{
-    startY: number;
-    startH: number;
-    lastH: number;
-    pointerId: number;
-  } | null>(null);
-
-  const onResizeStart = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      const measured = sectionRef.current?.getBoundingClientRect().height;
-      const startH = measured === undefined ? height : measured - DOCK_EDIT_BAR_HEIGHT;
-      resizeRef.current = { startY: e.clientY, startH, lastH: startH, pointerId: e.pointerId };
-      try {
-        e.currentTarget.setPointerCapture(e.pointerId);
-      } catch {
-        /* best effort */
-      }
-      document.body.style.cursor = 'row-resize';
-    },
-    [height],
-  );
-  const onResizeMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const d = resizeRef.current;
-    if (!d || e.pointerId !== d.pointerId) return;
-    const next = Math.min(
-      TIMELINE_MAX_HEIGHT,
-      Math.max(TIMELINE_MIN_HEIGHT, d.startH + (d.startY - e.clientY)),
-    );
-    d.lastH = next;
-    if (sectionRef.current) sectionRef.current.style.height = `${next + DOCK_EDIT_BAR_HEIGHT}px`;
-  }, []);
-  const onResizeEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const d = resizeRef.current;
-    if (!d || e.pointerId !== d.pointerId) return;
-    try {
-      e.currentTarget.releasePointerCapture(e.pointerId);
-    } catch {
-      /* may already be released */
-    }
-    setHeight(d.lastH);
-    resizeRef.current = null;
-    document.body.style.cursor = '';
-  }, []);
-
   return (
     <section
-      ref={sectionRef}
       data-testid="edit-dock"
       data-collapsed={collapsed ? 'true' : 'false'}
       style={{
-        height: (collapsed ? TIMELINE_COLLAPSED_HEIGHT : height) + DOCK_EDIT_BAR_HEIGHT,
+        height:
+          (collapsed ? TIMELINE_COLLAPSED_HEIGHT : TIMELINE_DEFAULT_HEIGHT) + DOCK_EDIT_BAR_HEIGHT,
       }}
       className="relative flex flex-col border-t border-gray-100 bg-white/80 backdrop-blur-xl dark:border-gray-800 dark:bg-slate-900/80"
     >
-      {!collapsed && (
-        <div
-          onPointerDown={onResizeStart}
-          onPointerMove={onResizeMove}
-          onPointerUp={onResizeEnd}
-          onPointerCancel={onResizeEnd}
-          className="group absolute inset-x-0 top-0 z-10 h-1.5 cursor-row-resize touch-none transition-colors hover:bg-violet-400/30 active:bg-violet-500/50 dark:hover:bg-violet-500/30"
-        >
-          <div className="absolute left-1/2 top-[3px] h-0.5 w-9 -translate-x-1/2 rounded-full bg-gray-300 transition-colors group-hover:bg-violet-400 dark:bg-gray-600 dark:group-hover:bg-violet-500" />
-        </div>
-      )}
-
       <DockEditBar sceneId={sceneId} canPickElements={canPickElements} pager={pager} />
 
       <div data-testid="edit-dock-timeline" className="flex min-h-0 flex-1 flex-col">

--- a/components/edit/surfaces/slide/ElementPickLayer.tsx
+++ b/components/edit/surfaces/slide/ElementPickLayer.tsx
@@ -1,97 +1,147 @@
 'use client';
 
 /**
- * ElementPickLayer — canvas-side target picker for the timeline.
+ * ElementPickLayer — canvas-side element picker, for both of its callers.
  *
- * When the ActionsBar arms "pick" mode (useCanvasStore.pickTarget, keyed by
- * actionId), this layer covers the slide canvas and lets the user bind a cue's
- * target either by clicking the element on the slide (hit-tested live) or by
- * clicking a row in the floating element panel (draggable + collapsible). Every
- * selectable element is outlined; the hovered one gets a solid ring + live
- * spotlight/laser preview. Click empty canvas or press Esc to cancel.
+ * Armed through `useCanvasStore.pickTarget` (see `PickTarget`), it covers the
+ * slide canvas, outlines every selectable element and hit-tests the pointer
+ * live. What a click MEANS is the target's `purpose`:
+ *
+ * - `cue` (timeline): bind this element to the armed scene action, then leave.
+ *   Hovering previews the real playback effect (spotlight / laser) so the
+ *   author sees what they are choosing.
+ * - `element-ref` (dock lasso): toggle this element in the message's reference
+ *   list and STAY armed — multi-pick is the point. Already-referenced elements
+ *   wear their pin number, and clicking one un-picks it. No cue preview: the
+ *   elements are being named, not animated.
+ *
+ * Empty-canvas click cancels in `cue` mode (there is one thing to choose and
+ * clicking past it means "never mind"); in `element-ref` mode it does nothing,
+ * because losing a five-element selection to a stray click is not a cancel the
+ * user asked for. Esc always leaves.
+ *
+ * The canvas itself stays as the author wrote it. Pick mode used to outline EVERY
+ * selectable element with a faint ring and wash, on the theory that an author
+ * cannot tell what is clickable — the cost was a slide covered in violet boxes,
+ * which is a worse answer to "what am I about to pick" than the pointer's own
+ * hover ring. So: one ring on the element under the pointer, the numbered pins on
+ * the ones already staged (`ElementRefPinLayer`), and nothing else.
+ *
+ * A floating element panel (draggable + collapsible) lists the page's elements
+ * for the same two actions, for elements too small to hit or hidden behind
+ * another. Hovering a row rings the element on the canvas — the same single ring,
+ * driven by the same `hover` state, which is why the panel still works with the
+ * all-elements outlining gone.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronDown, GripHorizontal, MousePointerClick } from 'lucide-react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Check, ChevronDown, GripHorizontal, MousePointerClick } from 'lucide-react';
 import { useCanvasStore } from '@/lib/store/canvas';
+import { useElementRefsForSession, useElementRefsStore } from '@/lib/store/element-refs';
 import { useStageStore } from '@/lib/store/stage';
+import { useWorkbenchStore } from '@/lib/workbench/session-store';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { setElementIdById } from '@/components/edit/ActionsBar/actions-edit';
-import { cueLabel, elementLabel } from '@/components/edit/ActionsBar/cue-meta';
+import { cueLabel } from '@/components/edit/ActionsBar/cue-meta';
 import { clearCuePreview, previewCueEffect } from '@/components/edit/ActionsBar/cue-preview';
-import { editableElementDomId } from './renderer-element-dom';
+import {
+  MAX_ELEMENT_REFS,
+  elementRefLabel,
+  elementRefOrdinal,
+  makeElementRef,
+  type SlideElementLike,
+} from '@/lib/workbench/element-refs';
+import { elementIdAtPoint, measureElementBox, type CanvasBox } from './element-hit-test';
+import {
+  CANVAS_OVERLAY_FRAME_SELECTOR,
+  CANVAS_OVERLAY_Z,
+  CanvasOverlayPortal,
+} from './CanvasOverlayPortal';
 
 const PANEL_W = 232;
+/** Margin kept between the panel and its container on every side. */
+const PANEL_MARGIN = 8;
+/** Height assumed for the panel while its DOM node is not yet measurable (the header strip). */
+const PANEL_FALLBACK_HEIGHT = 40;
 
-interface Box {
-  left: number;
-  top: number;
+export interface PanelPosition {
+  x: number;
+  y: number;
+}
+
+export interface PanelSize {
   width: number;
   height: number;
 }
-interface ElementLite {
-  id: string;
-  type: string;
-  content?: string;
+
+/**
+ * Clamp a floating panel's top-left corner inside its container so the WHOLE
+ * panel stays visible, not just its drag handle: on each axis the position is
+ * pinned to `[PANEL_MARGIN, container − panel − PANEL_MARGIN]`. When the panel
+ * is larger than the container (a long list in a short frame) the upper bound
+ * collapses and the panel pins to the top-left margin instead of hanging past
+ * the bottom/right edge. The drag path and the re-clamp path both call this, so
+ * the boundary rule lives in exactly one place.
+ */
+export function clampPanelPosition(
+  pos: PanelPosition,
+  containerSize: PanelSize,
+  panelSize: PanelSize,
+): PanelPosition {
+  const maxX = Math.max(PANEL_MARGIN, containerSize.width - panelSize.width - PANEL_MARGIN);
+  const maxY = Math.max(PANEL_MARGIN, containerSize.height - panelSize.height - PANEL_MARGIN);
+  return {
+    x: Math.min(Math.max(PANEL_MARGIN, pos.x), maxX),
+    y: Math.min(Math.max(PANEL_MARGIN, pos.y), maxY),
+  };
 }
 
-const INTERACTION_ELEMENT_ID_ATTRIBUTES = [
-  'data-element-id',
-  'data-select-element-id',
-  'data-context-element-id',
-] as const;
-
-function interactionElementIdAt(x: number, y: number): string | null {
-  for (const node of document.elementsFromPoint(x, y)) {
-    const target = (node as HTMLElement).closest?.(
-      INTERACTION_ELEMENT_ID_ATTRIBUTES.map((attribute) => `[${attribute}]`).join(','),
-    ) as HTMLElement | null;
-    if (!target) continue;
-    for (const attribute of INTERACTION_ELEMENT_ID_ATTRIBUTES) {
-      const id = target.getAttribute(attribute);
-      if (id) return id;
-    }
-  }
-  return null;
-}
-
-function rendererPaintNode(elementId: string): HTMLElement | null {
-  const host = document.getElementById(editableElementDomId(elementId));
-  if (!host) return null;
-  return host.querySelector<HTMLElement>(
-    '.slide-element-hit-target > [class^="base-element-"], .slide-element-hit-target > [class*=" base-element-"]',
-  );
-}
+/**
+ * A canvas element as this layer needs it: everything `elementRefLabel` reads
+ * (per-type text lives on different fields), plus a definite `id` — an element
+ * with no id cannot be picked, measured or referenced.
+ */
+type PickableElement = SlideElementLike & { id: string };
 
 export function ElementPickLayer() {
   const { t } = useI18n();
   const pickTarget = useCanvasStore.use.pickTarget();
+  const sessionId = useWorkbenchStore((s) => s.sessionId);
+  const currentStageId = useStageStore((s) => s.stage?.id ?? null);
+  const currentSceneId = useStageStore.use.currentSceneId();
   // Reactive scene lookup so the panel/binding state tracks store updates.
   const scene = useStageStore((s) =>
-    pickTarget ? (s.scenes.find((x) => x.id === pickTarget.sceneId) ?? null) : null,
+    pickTarget && s.stage?.id === pickTarget.stageId && s.currentSceneId === pickTarget.sceneId
+      ? (s.scenes.find((x) => x.id === pickTarget.sceneId) ?? null)
+      : null,
   );
+  const refs = useElementRefsForSession(sessionId);
 
   const rootRef = useRef<HTMLDivElement>(null);
-  const [hover, setHover] = useState<{ id: string; box: Box } | null>(null);
-  const [outlines, setOutlines] = useState<Array<{ id: string; box: Box }>>([]);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<{ id: string; box: CanvasBox } | null>(null);
   const [panel, setPanel] = useState<{ x: number; y: number }>({ x: 0, y: 16 });
   const [collapsed, setCollapsed] = useState(false);
   const dragRef = useRef<{ px: number; py: number; ox: number; oy: number } | null>(null);
   const moveRafRef = useRef<number | null>(null);
 
-  const cueTarget = pickTarget?.purpose === 'element-ref' ? null : pickTarget;
-  const cueType = cueTarget?.cueType;
-  const elements = useMemo<ElementLite[]>(
+  const purpose = pickTarget?.purpose;
+  const cueType = pickTarget?.purpose === 'cue' ? pickTarget.cueType : undefined;
+  const elements = useMemo<PickableElement[]>(
     () =>
-      (scene?.content as { canvas?: { elements?: ElementLite[] } } | undefined)?.canvas?.elements ??
-      [],
+      (
+        (scene?.content as { canvas?: { elements?: SlideElementLike[] } } | undefined)?.canvas
+          ?.elements ?? []
+      ).filter((element): element is PickableElement => typeof element.id === 'string'),
     [scene],
   );
   const currentBound =
-    (
-      scene?.actions?.find((a) => a.id === cueTarget?.actionId) as
-        | { elementId?: string }
-        | undefined
-    )?.elementId ?? '';
+    pickTarget?.purpose === 'cue'
+      ? ((
+          scene?.actions?.find((a) => a.id === pickTarget.actionId) as
+            | { elementId?: string }
+            | undefined
+        )?.elementId ?? '')
+      : '';
 
   const preview = useCallback(
     (elementId: string) => {
@@ -106,48 +156,125 @@ export function ElementPickLayer() {
     setHover(null);
   }, []);
 
-  const bind = useCallback(
+  /**
+   * A pick. In `cue` mode it binds by `actionId` (index-stale-safe against a
+   * concurrent reorder/delete) and ends the mode; in `element-ref` mode it
+   * toggles the element in the staged list and keeps the layer armed.
+   */
+  const pick = useCallback(
     (elementId: string) => {
       const pt = useCanvasStore.getState().pickTarget;
-      if (!pt || pt.purpose === 'element-ref') return;
-      const sc = useStageStore.getState().scenes.find((s) => s.id === pt.sceneId);
+      if (!pt) return;
+      if (pt.purpose === 'element-ref') {
+        const currentSessionId = useWorkbenchStore.getState().sessionId;
+        const refsState = useElementRefsStore.getState();
+        // The pick may target a course other than the session's bound one: refs
+        // carry their own stageId and the runner resolves against that (the
+        // open-domain tool surface has no mutable "active stage"), so the only
+        // fences are the chat that owns the draft and the course on screen.
+        if (
+          !currentSessionId ||
+          pt.ownerSessionId !== currentSessionId ||
+          refsState.ownerSessionId !== currentSessionId
+        ) {
+          finish();
+          return;
+        }
+        const stageState = useStageStore.getState();
+        if (stageState.stage?.id !== pt.stageId) {
+          finish();
+          return;
+        }
+        const sc = stageState.scenes.find((s) => s.id === pt.sceneId);
+        const element = (
+          sc?.content as { canvas?: { elements?: SlideElementLike[] } } | undefined
+        )?.canvas?.elements?.find((el) => el.id === elementId);
+        if (!element) return;
+        const ref = makeElementRef(pt.stageId, pt.sceneId, element, t);
+        if (ref) refsState.toggle(ref);
+        return;
+      }
+      const stageState = useStageStore.getState();
+      if (stageState.stage?.id !== pt.stageId) {
+        finish();
+        return;
+      }
+      const sc = stageState.scenes.find((s) => s.id === pt.sceneId);
       if (sc) {
-        // Bind by actionId — index-stale-safe against concurrent reorder/delete.
         useStageStore.getState().updateScene(pt.sceneId, {
           actions: setElementIdById(sc.actions ?? [], pt.actionId, elementId),
         });
       }
       finish();
     },
-    [finish],
+    [finish, t],
   );
 
-  // Local (canvas-relative) box for a viewport rect.
-  const toLocal = useCallback((r: DOMRect): Box | null => {
-    const cr = rootRef.current?.getBoundingClientRect();
-    if (!cr) return null;
-    return { left: r.left - cr.left, top: r.top - cr.top, width: r.width, height: r.height };
+  // The target is UI state owned by one exact course page. Clear every visual
+  // side effect as soon as navigation makes either half of that identity stale;
+  // merely rendering null would leave shortcuts disabled and pins suppressed.
+  // For `element-ref`, identity is (chat, DISPLAYED course, page) — never the
+  // session's bound stage: the open-domain tool surface has no mutable "active
+  // stage" pointer, element refs carry their own stageId, and the runner
+  // resolves them against the course they name. So a pick may point at a course
+  // other than the one the chat session is bound to.
+  useLayoutEffect(() => {
+    if (
+      !pickTarget ||
+      (pickTarget.stageId === currentStageId &&
+        pickTarget.sceneId === currentSceneId &&
+        (pickTarget.purpose !== 'element-ref' || pickTarget.ownerSessionId === sessionId))
+    ) {
+      return;
+    }
+    if (moveRafRef.current != null) {
+      cancelAnimationFrame(moveRafRef.current);
+      moveRafRef.current = null;
+    }
+    clearCuePreview();
+    useCanvasStore.getState().setPickTarget(null);
+    setHover(null);
+  }, [currentSceneId, currentStageId, pickTarget, sessionId]);
+
+  /**
+   * Re-measure the hovered element's ring. The ring is a box in canvas
+   * coordinates, so anything that moves the canvas under a still pointer (a
+   * window resize, a scroll in an ancestor) leaves it pointing at where the
+   * element WAS. Nothing else is measured up front any more: with the
+   * all-elements outlining gone there is exactly one box on screen.
+   */
+  const remeasureHover = useCallback(() => {
+    setHover((current) => {
+      if (!current) return current;
+      const box = measureElementBox(current.id, rootRef.current);
+      return box ? { id: current.id, box } : null;
+    });
   }, []);
 
-  const measureOutlines = useCallback(() => {
-    const boxes: Array<{ id: string; box: Box }> = [];
-    for (const el of elements) {
-      const paint = rendererPaintNode(el.id);
-      if (!paint) continue;
-      const b = toLocal(paint.getBoundingClientRect());
-      if (b) boxes.push({ id: el.id, box: b });
-    }
-    setOutlines(boxes);
-  }, [elements, toLocal]);
+  /**
+   * Pull the panel back inside the container. The drag clamps against the
+   * panel's CURRENT size, so a panel whose height changes under it (expanding a
+   * collapsed panel that was dragged to the bottom, a longer element list, a
+   * resized container) can end up overhanging the frame; this re-applies the
+   * same pure clamp the drag uses, so the two paths cannot drift apart.
+   */
+  const reclampPanel = useCallback(() => {
+    const cr = rootRef.current?.getBoundingClientRect();
+    if (!cr) return;
+    const panelH = panelRef.current?.offsetHeight ?? PANEL_FALLBACK_HEIGHT;
+    setPanel((prev) => clampPanelPosition(prev, cr, { width: PANEL_W, height: panelH }));
+  }, []);
 
-  // On entering pick mode: outline every selectable element, dock panel top-right.
+  // On entering pick mode: dock the element panel top-right.
   useEffect(() => {
     if (!pickTarget) return;
-    measureOutlines();
     const cr = rootRef.current?.getBoundingClientRect();
     if (cr) setPanel({ x: Math.max(8, cr.width - PANEL_W - 16), y: 16 });
     setCollapsed(false);
-    const onResize = () => measureOutlines();
+    const onResize = () => {
+      remeasureHover();
+      reclampPanel();
+    };
     window.addEventListener('resize', onResize);
     window.addEventListener('scroll', onResize, true);
     return () => {
@@ -155,7 +282,46 @@ export function ElementPickLayer() {
       window.removeEventListener('scroll', onResize, true);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cueTarget?.sceneId, cueTarget?.actionId, elements.length]);
+  }, [pickTarget?.sceneId, purpose, elements.length, reclampPanel]);
+
+  /**
+   * The portaled container (`rootRef`) only exists once `CanvasOverlayPortal`
+   * has measured the frame rect — a render AFTER this layer first arms — so a
+   * ref callback is the mount signal: `containerReady` flips true exactly when
+   * the node the panel clamps to is in the DOM.
+   */
+  const [containerReady, setContainerReady] = useState(false);
+  const attachContainerRef = useCallback((node: HTMLDivElement | null) => {
+    rootRef.current = node;
+    if (node) setContainerReady(true);
+  }, []);
+
+  // Re-clamp on in-frame container resizes: dragging the edit dock's handle up
+  // shrinks the studio frame from below, and the workspace divider drags
+  // re-shape it — neither fires a window resize, but the portaled box tracks
+  // them via `CanvasOverlayPortal`'s rAF rect loop, so `rootRef` (which fills
+  // the box) resizes in place. The observer fires for exactly those changes
+  // and pulls the panel back inside (the real-browser repro: a taller timeline
+  // pushed the panel over the dock). `reclampPanel` is idempotent, so the
+  // window-resize path keeping it too is harmless.
+  useEffect(() => {
+    if (!pickTarget || !containerReady) return;
+    const observed = rootRef.current;
+    if (!observed || typeof ResizeObserver === 'undefined') return;
+    const frameObserver = new ResizeObserver(() => reclampPanel());
+    frameObserver.observe(observed);
+    return () => frameObserver.disconnect();
+  }, [pickTarget, containerReady, reclampPanel]);
+
+  // Re-clamp when the panel's own size changes under a position that was
+  // clamped against the old one: a collapsed panel dragged to the bottom grows
+  // on expand, and a longer element list does the same. Container resizes are
+  // covered by the entry effect above (window resize listener + the
+  // ResizeObserver on the container).
+  useEffect(() => {
+    if (!pickTarget) return;
+    reclampPanel();
+  }, [collapsed, elements.length, pickTarget, reclampPanel]);
 
   useEffect(() => {
     if (!pickTarget) return;
@@ -183,9 +349,24 @@ export function ElementPickLayer() {
     [],
   );
 
-  if (!cueTarget) return null;
+  if (!pickTarget) return null;
+  // The owner fence is the only render condition: cross-course picks (displayed
+  // course ≠ session-bound course) are valid, refs self-describe their stage.
+  if (pickTarget.purpose === 'element-ref' && pickTarget.ownerSessionId !== sessionId) return null;
+  if (!scene) return null;
 
-  const typeLabel = cueLabel(cueTarget.cueType, t);
+  const isRefMode = pickTarget.purpose === 'element-ref';
+  const sceneId = pickTarget.sceneId;
+  const atCap = isRefMode && refs.length >= MAX_ELEMENT_REFS;
+  const banner = isRefMode
+    ? {
+        lead: t('edit.pick.refLead', { count: refs.length, max: MAX_ELEMENT_REFS }),
+        hint: atCap ? t('edit.pick.refCapHint') : t('edit.pick.refHint'),
+      }
+    : {
+        lead: t('edit.pick.pickFor', { label: cueLabel(pickTarget.cueType, t) }),
+        hint: t('edit.pick.pickHint'),
+      };
 
   // Hit-test on mousemove, coalesced to one rAF per frame.
   const onCanvasMove = (e: React.MouseEvent) => {
@@ -193,7 +374,7 @@ export function ElementPickLayer() {
     if (moveRafRef.current != null) return;
     moveRafRef.current = requestAnimationFrame(() => {
       moveRafRef.current = null;
-      const id = interactionElementIdAt(clientX, clientY);
+      const id = elementIdAtPoint(clientX, clientY);
       if (!id) {
         if (hover) {
           setHover(null);
@@ -202,8 +383,7 @@ export function ElementPickLayer() {
         return;
       }
       if (id !== hover?.id) {
-        const paint = rendererPaintNode(id);
-        const box = paint ? toLocal(paint.getBoundingClientRect()) : null;
+        const box = measureElementBox(id, rootRef.current);
         setHover(box ? { id, box } : null);
         preview(id);
       }
@@ -211,13 +391,14 @@ export function ElementPickLayer() {
   };
 
   const onCanvasClick = () => {
-    if (hover) bind(hover.id);
-    else finish();
+    if (hover) pick(hover.id);
+    // Clicking past every element: a cue pick is a single choice, so this reads
+    // as "never mind". A multi-pick selection must not evaporate the same way.
+    else if (!isRefMode) finish();
   };
 
   const highlightById = (id: string) => {
-    const paint = rendererPaintNode(id);
-    const box = paint ? toLocal(paint.getBoundingClientRect()) : null;
+    const box = measureElementBox(id, rootRef.current);
     setHover(box ? { id, box } : { id, box: { left: 0, top: 0, width: 0, height: 0 } });
     preview(id);
   };
@@ -233,127 +414,150 @@ export function ElementPickLayer() {
   const onPanelMove = (e: React.PointerEvent) => {
     const d = dragRef.current;
     if (!d) return;
+    const next = { x: d.ox + (e.clientX - d.px), y: d.oy + (e.clientY - d.py) };
     const cr = rootRef.current?.getBoundingClientRect();
-    const maxX = cr ? cr.width - PANEL_W - 8 : 9999;
-    const maxY = cr ? cr.height - 40 : 9999;
-    setPanel({
-      x: Math.min(Math.max(8, d.ox + (e.clientX - d.px)), Math.max(8, maxX)),
-      y: Math.min(Math.max(8, d.oy + (e.clientY - d.py)), Math.max(8, maxY)),
-    });
+    if (!cr) {
+      setPanel(next);
+      return;
+    }
+    // Clamp against the panel's ACTUAL height — the old `height - 40` only kept
+    // the handle's top inside the frame, letting a tall list hang below it.
+    const panelH = panelRef.current?.offsetHeight ?? PANEL_FALLBACK_HEIGHT;
+    setPanel(clampPanelPosition(next, cr, { width: PANEL_W, height: panelH }));
   };
   const onPanelUp = () => {
     dragRef.current = null;
   };
 
   return (
-    <div ref={rootRef} className="absolute inset-0 z-[120]">
-      {/* click-catcher (sibling of the panel, so panel clicks never reach it) */}
-      <div
-        className="absolute inset-0 cursor-crosshair"
-        onMouseMove={onCanvasMove}
-        onClick={onCanvasClick}
-      />
-
-      {/* every selectable element gets a faint outline → "this is clickable" */}
-      {outlines.map((o) => (
+    // Portaled onto the STUDIO FRAME (the padded canvas container), so the panel
+    // is never clipped by the card's `overflow-hidden` and can roam the grey
+    // padding around the card without escaping to the dock. The box IS the
+    // frame's, and everything in here measures relative to `rootRef` (which fills
+    // it), so element rings and hit-tests land at the same screen point as before.
+    // `capturePointer`: pick mode deliberately covers the whole canvas — a click
+    // anywhere means "this element", or "never mind" on the empty padding.
+    <CanvasOverlayPortal
+      zIndex={CANVAS_OVERLAY_Z.picker}
+      testId="element-pick-layer"
+      measureSelector={CANVAS_OVERLAY_FRAME_SELECTOR}
+      capturePointer
+    >
+      <div ref={attachContainerRef} className="absolute inset-0">
+        {/* click-catcher (sibling of the panel, so panel clicks never reach it) */}
         <div
-          key={o.id}
-          className="pointer-events-none absolute rounded-[3px] ring-1 ring-violet-400/40 bg-violet-400/[0.04]"
-          style={{ left: o.box.left, top: o.box.top, width: o.box.width, height: o.box.height }}
+          className="absolute inset-0 cursor-crosshair"
+          onMouseMove={onCanvasMove}
+          onClick={onCanvasClick}
         />
-      ))}
 
-      {/* hovered element — solid ring */}
-      {hover && hover.box.width > 0 && (
-        <div
-          className="pointer-events-none absolute rounded-md ring-2 ring-violet-500 bg-violet-500/[0.06]"
-          style={{
-            left: hover.box.left - 2,
-            top: hover.box.top - 2,
-            width: hover.box.width + 4,
-            height: hover.box.height + 4,
-          }}
-        />
-      )}
+        {/* hovered element — the one ring on the canvas */}
+        {hover && hover.box.width > 0 && (
+          <div
+            className="pointer-events-none absolute rounded-md bg-violet-500/[0.06] ring-2 ring-violet-500"
+            style={{
+              left: hover.box.left - 2,
+              top: hover.box.top - 2,
+              width: hover.box.width + 4,
+              height: hover.box.height + 4,
+            }}
+          />
+        )}
 
-      {/* instruction banner */}
-      <div className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 rounded-full border border-violet-300/60 bg-popover/95 px-3.5 py-1.5 text-[12px] font-medium text-foreground shadow-lg shadow-black/10 backdrop-blur">
-        <span className="text-violet-600 dark:text-violet-400">
-          {t('edit.pick.pickFor', { label: typeLabel })}
-        </span>{' '}
-        · {t('edit.pick.pickHint')}
-      </div>
-
-      {/* draggable + collapsible element panel, inside the canvas */}
-      <div
-        onClick={(e) => e.stopPropagation()}
-        style={{ left: panel.x, top: panel.y, width: PANEL_W }}
-        className="absolute flex max-h-[70%] flex-col overflow-hidden rounded-2xl border border-border bg-popover/95 shadow-xl shadow-black/15 backdrop-blur"
-      >
-        <div
-          onPointerDown={onPanelDown}
-          onPointerMove={onPanelMove}
-          onPointerUp={onPanelUp}
-          onPointerCancel={onPanelUp}
-          className="flex cursor-grab touch-none items-center gap-1.5 border-b border-border px-2.5 py-2 active:cursor-grabbing"
-        >
-          <GripHorizontal className="size-3.5 text-muted-foreground/40" />
-          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
-            {t('edit.pick.pageElements', { count: elements.length })}
-          </span>
-          <button
-            type="button"
-            onClick={() => setCollapsed((v) => !v)}
-            className="ml-auto grid size-5 place-items-center rounded text-muted-foreground/60 hover:bg-muted hover:text-foreground"
-            aria-label={collapsed ? t('edit.pick.expand') : t('edit.pick.collapse')}
-          >
-            <ChevronDown
-              className={`size-3.5 transition-transform ${collapsed ? '-rotate-90' : ''}`}
-            />
-          </button>
+        {/* instruction banner */}
+        <div className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 rounded-full border border-violet-300/60 bg-popover/95 px-3.5 py-1.5 text-[12px] font-medium text-foreground shadow-lg shadow-black/10 backdrop-blur">
+          <span className="text-violet-600 dark:text-violet-400">{banner.lead}</span> ·{' '}
+          {banner.hint}
         </div>
 
-        {!collapsed && (
-          <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
-            {elements.length === 0 ? (
-              <p className="px-2 py-3 text-[11px] text-muted-foreground/70">
-                {t('edit.pick.noElements')}
-              </p>
-            ) : (
-              elements.map((el) => (
-                <button
-                  key={el.id}
-                  type="button"
-                  onMouseEnter={() => highlightById(el.id)}
-                  onMouseLeave={() => {
-                    setHover(null);
-                    preview('');
-                  }}
-                  onClick={() => bind(el.id)}
-                  className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[12px] transition-colors hover:bg-muted ${
-                    el.id === currentBound
-                      ? 'bg-violet-50 ring-1 ring-violet-200 dark:bg-violet-500/10 dark:ring-violet-500/30'
-                      : ''
-                  }`}
-                >
-                  <span className="min-w-0 flex-1 truncate text-foreground/90">
-                    {elementLabel(el, t)}
-                  </span>
-                  <span className="shrink-0 font-mono text-[9px] text-muted-foreground/45">
-                    {el.id.slice(0, 6)}
-                  </span>
-                </button>
-              ))
-            )}
+        {/* draggable + collapsible element panel, inside the canvas */}
+        <div
+          ref={panelRef}
+          onClick={(e) => e.stopPropagation()}
+          style={{ left: panel.x, top: panel.y, width: PANEL_W }}
+          className="absolute flex max-h-[70%] flex-col overflow-hidden rounded-2xl border border-border bg-popover/95 shadow-xl shadow-black/15 backdrop-blur"
+        >
+          <div
+            onPointerDown={onPanelDown}
+            onPointerMove={onPanelMove}
+            onPointerUp={onPanelUp}
+            onPointerCancel={onPanelUp}
+            className="flex cursor-grab touch-none items-center gap-1.5 border-b border-border px-2.5 py-2 active:cursor-grabbing"
+          >
+            <GripHorizontal className="size-3.5 text-muted-foreground/40" />
+            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+              {t('edit.pick.pageElements', { count: elements.length })}
+            </span>
+            <button
+              type="button"
+              onClick={() => setCollapsed((v) => !v)}
+              className="ml-auto grid size-5 place-items-center rounded text-muted-foreground/60 hover:bg-muted hover:text-foreground"
+              aria-label={collapsed ? t('edit.pick.expand') : t('edit.pick.collapse')}
+            >
+              <ChevronDown
+                className={`size-3.5 transition-transform ${collapsed ? '-rotate-90' : ''}`}
+              />
+            </button>
           </div>
-        )}
 
-        {collapsed && (
-          <div className="flex items-center gap-1 px-2.5 py-1.5 text-[10px] text-muted-foreground/50">
-            <MousePointerClick className="size-3" /> {t('edit.pick.bindHint')}
-          </div>
-        )}
+          {!collapsed && (
+            <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+              {elements.length === 0 ? (
+                <p className="px-2 py-3 text-[11px] text-muted-foreground/70">
+                  {t('edit.pick.noElements')}
+                </p>
+              ) : (
+                elements.map((el) => {
+                  const ordinal = isRefMode
+                    ? elementRefOrdinal(refs, pickTarget.stageId, sceneId, el.id)
+                    : 0;
+                  const marked = isRefMode ? ordinal > 0 : el.id === currentBound;
+                  return (
+                    <button
+                      key={el.id}
+                      type="button"
+                      onMouseEnter={() => highlightById(el.id)}
+                      onMouseLeave={() => {
+                        setHover(null);
+                        preview('');
+                      }}
+                      onClick={() => pick(el.id)}
+                      disabled={isRefMode && atCap && ordinal === 0}
+                      className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[12px] transition-colors hover:bg-muted disabled:opacity-40 disabled:hover:bg-transparent ${
+                        marked
+                          ? 'bg-violet-50 ring-1 ring-violet-200 dark:bg-violet-500/10 dark:ring-violet-500/30'
+                          : ''
+                      }`}
+                    >
+                      <span className="min-w-0 flex-1 truncate text-foreground/90">
+                        {elementRefLabel(el, t)}
+                      </span>
+                      {ordinal > 0 ? (
+                        <span className="grid size-4 shrink-0 place-items-center rounded-full bg-violet-500 text-[9px] font-semibold tabular-nums text-white">
+                          {ordinal}
+                        </span>
+                      ) : marked ? (
+                        <Check className="size-3 shrink-0 text-violet-500" />
+                      ) : (
+                        <span className="shrink-0 font-mono text-[9px] text-muted-foreground/45">
+                          {el.id.slice(0, 6)}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          )}
+
+          {collapsed && (
+            <div className="flex items-center gap-1 px-2.5 py-1.5 text-[10px] text-muted-foreground/50">
+              <MousePointerClick className="size-3" />{' '}
+              {isRefMode ? t('edit.pick.refHint') : t('edit.pick.bindHint')}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </CanvasOverlayPortal>
   );
 }

--- a/components/edit/surfaces/slide/SlideCanvas.tsx
+++ b/components/edit/surfaces/slide/SlideCanvas.tsx
@@ -50,8 +50,8 @@ export function SlideCanvas() {
       </SceneProvider>
       {!useRendererEditor && <AnchoredTextBar editingElementId={editingElementId} />}
       {!useRendererEditor && <AnchoredElementBar element={nonTextElement} />}
-      <ElementPickLayer />
       <ElementRefPinLayer />
+      <ElementPickLayer />
     </div>
   );
 }

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -6,7 +6,8 @@
     "loading": "جارٍ التحميل...",
     "errorPrefix": "خطأ: ",
     "loadingClassroom": "جارٍ تحميل الفصل...",
-    "retry": "إعادة المحاولة"
+    "retry": "إعادة المحاولة",
+    "close": "إغلاق"
   },
   "home": {
     "slogan": "التعلّم التوليدي في فصل تفاعلي متعدد الوكلاء",
@@ -353,7 +354,10 @@
       "deckLabel": "المشاهد",
       "moreActions": "إجراءات إضافية",
       "rename": "إعادة تسمية",
-      "sceneIncomplete": "محتوى هذه الصفحة غير مكتمل"
+      "sceneIncomplete": "محتوى هذه الصفحة غير مكتمل",
+      "addPage": "إضافة صفحة",
+      "nextPage": "الصفحة التالية",
+      "prevPage": "الصفحة السابقة"
     },
     "zorder": {
       "toFront": "إحضار إلى الأمام",
@@ -550,7 +554,10 @@
       "expand": "توسيع",
       "collapse": "طي",
       "noElements": "لا توجد عناصر يمكن تحديدها في هذه الشريحة.",
-      "bindHint": "انقر على عنصر مميز على اللوحة للربط"
+      "bindHint": "انقر على عنصر مميز على اللوحة للربط",
+      "refCapHint": "تم الوصول إلى الحد — أزل عنصرًا للاستبدال · Esc للإنهاء",
+      "refHint": "انقر للإضافة أو الإزالة · Esc للإنهاء",
+      "refLead": "الإشارة إلى العناصر · {{count}}/{{max}}"
     },
     "regen": {
       "title": "إعادة توليد السرد",
@@ -605,10 +612,18 @@
       "moveDown": "نقل لأسفل",
       "removeFromClass": "إزالة من الفصل",
       "aiClassmates": "زملاء AI · {{count}}",
-      "addRole": "إضافة دور"
+      "addRole": "إضافة دور",
+      "shortTitle": "التشكيلة"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "تمت الإشارة إلى {{count}}/{{max}}",
+      "exitPicking": "إنهاء التحديد",
+      "startPicking": "الإشارة إلى العناصر"
+    },
+    "dock": {
+      "elementRefHint": "مراجع العناصر — اختر عناصر لإرسالها مع رسالتك التالية",
+      "globalTools": "أدوات عامة"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/de-DE.json
+++ b/lib/i18n/locales/de-DE.json
@@ -6,7 +6,8 @@
     "loading": "Wird geladen...",
     "errorPrefix": "Fehler: ",
     "loadingClassroom": "Klassenzimmer wird geladen ...",
-    "retry": "Erneut versuchen"
+    "retry": "Erneut versuchen",
+    "close": "Schließen"
   },
   "home": {
     "slogan": "Generatives Lernen im interaktiven Lernraum mit mehreren KI-Agenten",
@@ -353,7 +354,10 @@
       "deckLabel": "Szenen",
       "moreActions": "Weitere Aktionen",
       "rename": "Umbenennen",
-      "sceneIncomplete": "Diese Seite enthält unvollständige Inhalte"
+      "sceneIncomplete": "Diese Seite enthält unvollständige Inhalte",
+      "addPage": "Seite hinzufügen",
+      "nextPage": "Next page",
+      "prevPage": "Previous page"
     },
     "zorder": {
       "toFront": "In den Vordergrund",
@@ -550,7 +554,10 @@
       "expand": "Ausklappen",
       "collapse": "Einklappen",
       "noElements": "Auf dieser Folie sind keine auswählbaren Elemente vorhanden.",
-      "bindHint": "Klicke zum Verknüpfen auf ein markiertes Element auf der Arbeitsfläche"
+      "bindHint": "Klicke zum Verknüpfen auf ein markiertes Element auf der Arbeitsfläche",
+      "refCapHint": "Grenze erreicht – eines entfernen zum Tauschen · Esc zum Beenden",
+      "refHint": "Klicken zum Hinzufügen oder Entfernen · Esc zum Beenden",
+      "refLead": "Elemente referenzieren · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Sprechertext neu erstellen",
@@ -605,10 +612,18 @@
       "moveDown": "Nach unten",
       "removeFromClass": "Aus dem Kurs entfernen",
       "aiClassmates": "KI-Mitlernende · {{count}}",
-      "addRole": "Rolle hinzufügen"
+      "addRole": "Rolle hinzufügen",
+      "shortTitle": "Roster"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "{{count}}/{{max}} referenziert",
+      "exitPicking": "Auswahl beenden",
+      "startPicking": "Elemente referenzieren"
+    },
+    "dock": {
+      "elementRefHint": "Elementverweise – Elemente für die nächste Nachricht auswählen",
+      "globalTools": "Globale Werkzeuge"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -6,7 +6,8 @@
     "loading": "Loading...",
     "errorPrefix": "Error: ",
     "loadingClassroom": "Loading classroom...",
-    "retry": "Retry"
+    "retry": "Retry",
+    "close": "Close"
   },
   "home": {
     "slogan": "Generative Learning in Multi-Agent Interactive Classroom",
@@ -353,7 +354,10 @@
       "deckLabel": "Scenes",
       "moreActions": "More actions",
       "rename": "Rename",
-      "sceneIncomplete": "This page has incomplete content"
+      "sceneIncomplete": "This page has incomplete content",
+      "addPage": "Add page",
+      "nextPage": "Next page",
+      "prevPage": "Previous page"
     },
     "zorder": {
       "toFront": "Bring to front",
@@ -550,7 +554,10 @@
       "expand": "Expand",
       "collapse": "Collapse",
       "noElements": "No locatable elements on this slide.",
-      "bindHint": "Click a highlighted element on the canvas to bind"
+      "bindHint": "Click a highlighted element on the canvas to bind",
+      "refCapHint": "Limit reached — remove one to swap · Esc when done",
+      "refHint": "Click to add or remove · Esc when done",
+      "refLead": "Referencing elements · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Regenerate narration",
@@ -605,10 +612,18 @@
       "moveDown": "Move down",
       "removeFromClass": "Remove from class",
       "aiClassmates": "AI classmates · {{count}}",
-      "addRole": "Add role"
+      "addRole": "Add role",
+      "shortTitle": "Roster"
     },
     "elementRef": {
-      "remove": "Remove reference {{label}}"
+      "remove": "Remove reference {{label}}",
+      "counts": "{{count}}/{{max}} referenced",
+      "exitPicking": "Done picking",
+      "startPicking": "Reference elements"
+    },
+    "dock": {
+      "elementRefHint": "Element references — pick elements to send with your next message",
+      "globalTools": "Global tools"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/es-MX.json
+++ b/lib/i18n/locales/es-MX.json
@@ -6,7 +6,8 @@
     "loading": "Cargando...",
     "errorPrefix": "Error: ",
     "loadingClassroom": "Cargando el aula...",
-    "retry": "Reintentar"
+    "retry": "Reintentar",
+    "close": "Cerrar"
   },
   "home": {
     "slogan": "Aprendizaje generativo en un aula interactiva multiagente",
@@ -353,7 +354,10 @@
       "deckLabel": "Escenas",
       "moreActions": "Más acciones",
       "rename": "Renombrar",
-      "sceneIncomplete": "Esta página tiene contenido incompleto"
+      "sceneIncomplete": "Esta página tiene contenido incompleto",
+      "addPage": "Agregar página",
+      "nextPage": "Página siguiente",
+      "prevPage": "Página anterior"
     },
     "zorder": {
       "toFront": "Traer al frente",
@@ -550,7 +554,10 @@
       "expand": "Expandir",
       "collapse": "Contraer",
       "noElements": "No hay elementos localizables en esta diapositiva.",
-      "bindHint": "Haz clic en un elemento resaltado del lienzo para vincularlo"
+      "bindHint": "Haz clic en un elemento resaltado del lienzo para vincularlo",
+      "refCapHint": "Límite alcanzado: quita uno para cambiarlo · Esc para terminar",
+      "refHint": "Haz clic para agregar o quitar · Esc para terminar",
+      "refLead": "Referenciando elementos · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Regenerar narración",
@@ -605,10 +612,18 @@
       "moveDown": "Mover abajo",
       "removeFromClass": "Quitar del aula",
       "aiClassmates": "Compañeros de IA · {{count}}",
-      "addRole": "Agregar rol"
+      "addRole": "Agregar rol",
+      "shortTitle": "Elenco"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "{{count}}/{{max}} referenciados",
+      "exitPicking": "Terminar selección",
+      "startPicking": "Referenciar elementos"
+    },
+    "dock": {
+      "elementRefHint": "Referencias de elementos: elige elementos para enviar con tu próximo mensaje",
+      "globalTools": "Herramientas globales"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/fr-FR.json
+++ b/lib/i18n/locales/fr-FR.json
@@ -6,7 +6,8 @@
     "loading": "Chargement…",
     "errorPrefix": "Erreur : ",
     "loadingClassroom": "Chargement de la classe…",
-    "retry": "Réessayer"
+    "retry": "Réessayer",
+    "close": "Fermer"
   },
   "home": {
     "slogan": "L’apprentissage génératif en classe interactive multi-agents",
@@ -353,7 +354,10 @@
       "deckLabel": "Scènes",
       "moreActions": "Autres actions",
       "rename": "Renommer",
-      "sceneIncomplete": "Le contenu de cette page est incomplet"
+      "sceneIncomplete": "Le contenu de cette page est incomplet",
+      "addPage": "Ajouter une page",
+      "nextPage": "Page suivante",
+      "prevPage": "Page précédente"
     },
     "zorder": {
       "toFront": "Mettre au premier plan",
@@ -550,7 +554,10 @@
       "expand": "Déplier",
       "collapse": "Replier",
       "noElements": "Aucun élément localisable sur cette diapositive.",
-      "bindHint": "Cliquez sur un élément mis en évidence du canevas pour l’associer"
+      "bindHint": "Cliquez sur un élément mis en évidence du canevas pour l’associer",
+      "refCapHint": "Limite atteinte — retirez-en un pour échanger · Échap pour terminer",
+      "refHint": "Cliquez pour ajouter ou retirer · Échap pour terminer",
+      "refLead": "Référencement d’éléments · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Régénérer la narration",
@@ -605,10 +612,18 @@
       "moveDown": "Descendre",
       "removeFromClass": "Retirer de la classe",
       "aiClassmates": "Camarades IA · {{count}}",
-      "addRole": "Ajouter un rôle"
+      "addRole": "Ajouter un rôle",
+      "shortTitle": "Distribution"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "{{count}}/{{max}} référencés",
+      "exitPicking": "Terminer la sélection",
+      "startPicking": "Référencer des éléments"
+    },
+    "dock": {
+      "elementRefHint": "Références d’éléments — choisissez les éléments à joindre au prochain message",
+      "globalTools": "Outils globaux"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -6,7 +6,8 @@
     "loading": "読み込み中...",
     "errorPrefix": "エラー：",
     "loadingClassroom": "教室を読み込み中...",
-    "retry": "再試行"
+    "retry": "再試行",
+    "close": "閉じる"
   },
   "home": {
     "slogan": "マルチエージェント対話型教室で生成的に学ぶ",
@@ -353,7 +354,10 @@
       "deckLabel": "シーン",
       "moreActions": "その他の操作",
       "rename": "名前を変更",
-      "sceneIncomplete": "このページの内容が未完成です"
+      "sceneIncomplete": "このページの内容が未完成です",
+      "addPage": "ページを追加",
+      "nextPage": "次のページ",
+      "prevPage": "前のページ"
     },
     "zorder": {
       "toFront": "最前面へ移動",
@@ -550,7 +554,10 @@
       "expand": "展開",
       "collapse": "折りたたむ",
       "noElements": "このスライドには指定できる要素がありません。",
-      "bindHint": "キャンバス上のハイライト要素をクリックして紐付け"
+      "bindHint": "キャンバス上のハイライト要素をクリックして紐付け",
+      "refCapHint": "上限に達しました。1 つ解除して入れ替え · Esc で終了",
+      "refHint": "クリックで追加／解除 · Esc で終了",
+      "refLead": "要素を参照中 · {{count}}/{{max}}"
     },
     "regen": {
       "title": "ナレーションを再生成",
@@ -605,10 +612,18 @@
       "moveDown": "下へ移動",
       "removeFromClass": "クラスから削除",
       "aiClassmates": "AIクラスメイト · {{count}}",
-      "addRole": "役割を追加"
+      "addRole": "役割を追加",
+      "shortTitle": "編成"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "参照 {{count}}/{{max}}",
+      "exitPicking": "選択を終了",
+      "startPicking": "要素を参照"
+    },
+    "dock": {
+      "elementRefHint": "要素参照 — 次のメッセージと一緒に送る要素を選ぶ",
+      "globalTools": "全体ツール"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -6,7 +6,8 @@
     "loading": "로딩 중...",
     "errorPrefix": "오류: ",
     "loadingClassroom": "강의실 불러오는 중...",
-    "retry": "다시 시도"
+    "retry": "다시 시도",
+    "close": "닫기"
   },
   "home": {
     "slogan": "멀티 에이전트 인터랙티브 교실에서 펼치는 생성형 학습",
@@ -353,7 +354,10 @@
       "deckLabel": "장면",
       "moreActions": "더 보기",
       "rename": "이름 바꾸기",
-      "sceneIncomplete": "이 페이지의 내용이 미완성입니다"
+      "sceneIncomplete": "이 페이지의 내용이 미완성입니다",
+      "addPage": "페이지 추가",
+      "nextPage": "다음 페이지",
+      "prevPage": "이전 페이지"
     },
     "cue": {
       "speech": "내레이션",
@@ -477,7 +481,10 @@
       "expand": "펼치기",
       "collapse": "접기",
       "noElements": "이 슬라이드에는 지정할 수 있는 요소가 없습니다.",
-      "bindHint": "캔버스에서 강조된 요소를 클릭하여 연결"
+      "bindHint": "캔버스에서 강조된 요소를 클릭하여 연결",
+      "refCapHint": "한도에 도달했습니다. 하나를 해제해 교체하세요 · Esc로 종료",
+      "refHint": "클릭해 추가하거나 해제 · Esc로 종료",
+      "refLead": "요소 참조 중 · {{count}}/{{max}}"
     },
     "regen": {
       "title": "내레이션 다시 생성",
@@ -605,10 +612,18 @@
       "moveDown": "아래로 이동",
       "removeFromClass": "수업에서 제거",
       "aiClassmates": "AI 반 친구 · {{count}}",
-      "addRole": "역할 추가"
+      "addRole": "역할 추가",
+      "shortTitle": "구성원"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "참조 {{count}}/{{max}}",
+      "exitPicking": "선택 완료",
+      "startPicking": "요소 참조"
+    },
+    "dock": {
+      "elementRefHint": "요소 참조 — 다음 메시지와 함께 보낼 요소 선택",
+      "globalTools": "전역 도구"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -6,7 +6,8 @@
     "loading": "Carregando...",
     "errorPrefix": "Erro: ",
     "loadingClassroom": "Carregando sala de aula...",
-    "retry": "Tentar novamente"
+    "retry": "Tentar novamente",
+    "close": "Fechar"
   },
   "home": {
     "slogan": "Aprendizagem Generativa em Sala de Aula Interativa Multi-Agente",
@@ -338,7 +339,10 @@
       "deckLabel": "Cenas",
       "moreActions": "Mais ações",
       "rename": "Renomear",
-      "sceneIncomplete": "Esta página tem conteúdo incompleto"
+      "sceneIncomplete": "Esta página tem conteúdo incompleto",
+      "addPage": "Adicionar página",
+      "nextPage": "Próxima página",
+      "prevPage": "Página anterior"
     },
     "zorder": {
       "toFront": "Trazer para a frente",
@@ -535,7 +539,10 @@
       "expand": "Expandir",
       "collapse": "Recolher",
       "noElements": "Nenhum elemento localizável neste slide.",
-      "bindHint": "Clique em um elemento destacado no canvas para vincular"
+      "bindHint": "Clique em um elemento destacado no canvas para vincular",
+      "refCapHint": "Limite atingido — remova um para trocar · Esc para concluir",
+      "refHint": "Clique para adicionar ou remover · Esc para concluir",
+      "refLead": "Referenciando elementos · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Regenerar narração",
@@ -590,10 +597,18 @@
       "moveDown": "Mover para baixo",
       "removeFromClass": "Remover da sala",
       "aiClassmates": "Colegas de IA · {{count}}",
-      "addRole": "Adicionar papel"
+      "addRole": "Adicionar papel",
+      "shortTitle": "Elenco"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "{{count}}/{{max}} referenciados",
+      "exitPicking": "Concluir seleção",
+      "startPicking": "Referenciar elementos"
+    },
+    "dock": {
+      "elementRefHint": "Referências de elementos — escolha elementos para enviar na próxima mensagem",
+      "globalTools": "Ferramentas globais"
     }
   },
   "stage": {

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -6,7 +6,8 @@
     "loading": "Загрузка...",
     "errorPrefix": "Ошибка: ",
     "loadingClassroom": "Загрузка класса...",
-    "retry": "Повторить"
+    "retry": "Повторить",
+    "close": "Закрыть"
   },
   "home": {
     "slogan": "Generative Learning in Multi-Agent Interactive Classroom",
@@ -353,7 +354,10 @@
       "deckLabel": "Сцены",
       "moreActions": "Ещё действия",
       "rename": "Переименовать",
-      "sceneIncomplete": "Содержимое этой страницы не заполнено"
+      "sceneIncomplete": "Содержимое этой страницы не заполнено",
+      "addPage": "Добавить страницу",
+      "nextPage": "Следующая страница",
+      "prevPage": "Предыдущая страница"
     },
     "zorder": {
       "toFront": "На передний план",
@@ -550,7 +554,10 @@
       "expand": "Развернуть",
       "collapse": "Свернуть",
       "noElements": "На этом слайде нет элементов для выбора.",
-      "bindHint": "Нажмите на подсвеченный элемент на холсте для привязки"
+      "bindHint": "Нажмите на подсвеченный элемент на холсте для привязки",
+      "refCapHint": "Достигнут предел — уберите один, чтобы заменить · Esc — готово",
+      "refHint": "Нажмите, чтобы добавить или убрать · Esc — готово",
+      "refLead": "Ссылки на элементы · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Сгенерировать закадровый текст заново",
@@ -605,10 +612,18 @@
       "moveDown": "Переместить вниз",
       "removeFromClass": "Удалить из класса",
       "aiClassmates": "AI-одноклассники · {{count}}",
-      "addRole": "Добавить роль"
+      "addRole": "Добавить роль",
+      "shortTitle": "Состав"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "Выбрано {{count}}/{{max}}",
+      "exitPicking": "Завершить выбор",
+      "startPicking": "Ссылка на элементы"
+    },
+    "dock": {
+      "elementRefHint": "Ссылки на элементы — выберите элементы для следующего сообщения",
+      "globalTools": "Общие инструменты"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/vi-VN.json
+++ b/lib/i18n/locales/vi-VN.json
@@ -6,7 +6,8 @@
     "loading": "Đang tải…",
     "errorPrefix": "Lỗi: ",
     "loadingClassroom": "Đang tải lớp học...",
-    "retry": "Thử lại"
+    "retry": "Thử lại",
+    "close": "Đóng"
   },
   "home": {
     "slogan": "Học tập sinh tạo trong lớp học tương tác đa tác nhân",
@@ -353,7 +354,10 @@
       "deckLabel": "Các cảnh",
       "moreActions": "Thêm hành động",
       "rename": "Đổi tên",
-      "sceneIncomplete": "Trang này còn thiếu nội dung"
+      "sceneIncomplete": "Trang này còn thiếu nội dung",
+      "addPage": "Thêm trang",
+      "nextPage": "Trang sau",
+      "prevPage": "Trang trước"
     },
     "zorder": {
       "toFront": "Đưa lên trên cùng",
@@ -550,7 +554,10 @@
       "expand": "Mở rộng",
       "collapse": "Thu gọn",
       "noElements": "Slide này không có đối tượng nào để chọn.",
-      "bindHint": "Bấm vào một đối tượng đang nổi bật trên khung vẽ để gắn"
+      "bindHint": "Bấm vào một đối tượng đang nổi bật trên khung vẽ để gắn",
+      "refCapHint": "Đã đạt giới hạn — bỏ một phần tử để thay · Esc để kết thúc",
+      "refHint": "Nhấp để thêm hoặc bỏ · Esc để kết thúc",
+      "refLead": "Đang tham chiếu phần tử · {{count}}/{{max}}"
     },
     "regen": {
       "title": "Viết lại lời giảng",
@@ -605,10 +612,18 @@
       "moveDown": "Chuyển xuống",
       "removeFromClass": "Bỏ khỏi lớp",
       "aiClassmates": "Bạn học AI · {{count}}",
-      "addRole": "Thêm vai"
+      "addRole": "Thêm vai",
+      "shortTitle": "Danh sách nhân vật"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "Đã tham chiếu {{count}}/{{max}}",
+      "exitPicking": "Xong",
+      "startPicking": "Tham chiếu phần tử"
+    },
+    "dock": {
+      "elementRefHint": "Tham chiếu phần tử — chọn phần tử để gửi kèm tin nhắn tiếp theo",
+      "globalTools": "Công cụ chung"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -6,7 +6,8 @@
     "loading": "加载中...",
     "errorPrefix": "错误：",
     "loadingClassroom": "正在加载课堂...",
-    "retry": "重试"
+    "retry": "重试",
+    "close": "关闭"
   },
   "home": {
     "slogan": "Generative Learning in Multi-Agent Interactive Classroom",
@@ -353,7 +354,10 @@
       "deckLabel": "场景",
       "moreActions": "更多操作",
       "rename": "重命名",
-      "sceneIncomplete": "本页内容不完整"
+      "sceneIncomplete": "本页内容不完整",
+      "addPage": "新增页面",
+      "nextPage": "下一页",
+      "prevPage": "上一页"
     },
     "zorder": {
       "toFront": "置于顶层",
@@ -550,7 +554,10 @@
       "expand": "展开",
       "collapse": "折叠",
       "noElements": "这一页没有可定位的元素。",
-      "bindHint": "点画布上高亮的元素绑定"
+      "bindHint": "点画布上高亮的元素绑定",
+      "refCapHint": "已达上限，取消一个再换 · Esc 结束",
+      "refHint": "点击加入或取消 · Esc 结束",
+      "refLead": "引用元素 · {{count}}/{{max}}"
     },
     "regen": {
       "title": "重新生成讲解",
@@ -605,10 +612,18 @@
       "moveDown": "下移",
       "removeFromClass": "移出课堂",
       "aiClassmates": "AI 同学 · {{count}}",
-      "addRole": "添加角色"
+      "addRole": "添加角色",
+      "shortTitle": "阵容"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "已引用 {{count}}/{{max}}",
+      "exitPicking": "完成选取",
+      "startPicking": "引用元素"
+    },
+    "dock": {
+      "elementRefHint": "元素引用 —— 选中元素随下一条消息发给 Agent",
+      "globalTools": "全局工具"
     }
   },
   "classroomComplete": {

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -6,7 +6,8 @@
     "loading": "載入中...",
     "errorPrefix": "错误：",
     "loadingClassroom": "正在加载课堂...",
-    "retry": "重试"
+    "retry": "重试",
+    "close": "關閉"
   },
   "home": {
     "slogan": "多智能體互動課室中的生成式學習",
@@ -302,7 +303,10 @@
       "deckLabel": "場景",
       "moreActions": "更多操作",
       "rename": "重新命名",
-      "sceneIncomplete": "此頁面內容不完整"
+      "sceneIncomplete": "此頁面內容不完整",
+      "addPage": "新增頁面",
+      "nextPage": "下一頁",
+      "prevPage": "上一頁"
     },
     "zorder": {
       "toFront": "移至最上層",
@@ -478,7 +482,10 @@
       "expand": "展開",
       "collapse": "收合",
       "noElements": "此頁面上沒有可定位的元素。",
-      "bindHint": "點選畫布上凸顯的元素以繫結"
+      "bindHint": "點選畫布上凸顯的元素以繫結",
+      "refCapHint": "已達上限，取消一個再換 · Esc 結束",
+      "refHint": "點擊加入或取消 · Esc 結束",
+      "refLead": "引用元素 · {{count}}/{{max}}"
     },
     "regen": {
       "title": "重新生成講稿",
@@ -533,7 +540,8 @@
       "moveDown": "下移",
       "removeFromClass": "移出課堂",
       "aiClassmates": "AI 同學 · {{count}}",
-      "addRole": "新增角色"
+      "addRole": "新增角色",
+      "shortTitle": "陣容"
     },
     "line": {
       "toolbar": "線條工具列",
@@ -608,7 +616,14 @@
       "confirm": "確定"
     },
     "elementRef": {
-      "remove": "移除引用 {{label}}"
+      "remove": "移除引用 {{label}}",
+      "counts": "已引用 {{count}}/{{max}}",
+      "exitPicking": "完成選取",
+      "startPicking": "引用元素"
+    },
+    "dock": {
+      "elementRefHint": "元素引用 —— 選取元素隨下一則訊息發給 Agent",
+      "globalTools": "全域工具"
     }
   },
   "whiteboard": {

--- a/lib/store/canvas.ts
+++ b/lib/store/canvas.ts
@@ -41,9 +41,7 @@ export type PickTarget =
       stageId: string;
       sceneId: string;
       ownerSessionId: string;
-    }
-  /** Compatibility for a timeline pick armed before the global dock shipped. */
-  | { purpose?: undefined; sceneId: string; actionId: string; cueType: string };
+    };
 
 /**
  * Canvas Store - Manages all UI state of the Canvas editor

--- a/tests/edit/edit-dock-lifecycle.test.ts
+++ b/tests/edit/edit-dock-lifecycle.test.ts
@@ -1,0 +1,322 @@
+// @vitest-environment jsdom
+
+/**
+ * The edit dock's structure: a global edit bar that never changes, and the
+ * narration timeline below it.
+ *
+ * What is pinned here is what the tab strip used to make fragile — the lasso's
+ * ownership gate, the pick-mode cleanup matrix, and the fact that reaching for a
+ * global control never disturbs the timeline underneath (an in-flight TTS batch
+ * included).
+ */
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const lifecycle = vi.hoisted(() => ({ timelineMounts: 0 }));
+const canvas = vi.hoisted(() => ({
+  pickTarget: null as Record<string, unknown> | null,
+  spotlight: '',
+  laser: '',
+  setPickTarget: vi.fn((target: Record<string, unknown> | null) => {
+    canvas.pickTarget = target;
+  }),
+  setSpotlight: vi.fn((elementId: string) => {
+    canvas.spotlight = elementId;
+  }),
+  clearLaser: vi.fn(() => {
+    canvas.laser = '';
+  }),
+}));
+
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/lib/store/canvas', () => ({
+  useCanvasStore: Object.assign(() => canvas.pickTarget, {
+    getState: () => canvas,
+    use: { pickTarget: () => canvas.pickTarget },
+  }),
+}));
+// The timeline stands in for `ActionsBar`: it owns its header row and a piece of
+// state (a running TTS batch) that must survive anything the bar does.
+vi.mock('@/components/edit/ActionsBar/ActionsBar', async () => {
+  const { createElement: h, useEffect, useState } = await import('react');
+  const { useEditDock } = await import('@/components/edit/EditDock/dock-context');
+  const ActionsBar = () => {
+    const dock = useEditDock();
+    const [running, setRunning] = useState(false);
+    useEffect(() => {
+      lifecycle.timelineMounts += 1;
+    }, []);
+    return h(
+      'div',
+      { 'data-testid': 'timeline-body', 'data-collapsed': String(dock.collapsed) },
+      h(
+        'button',
+        { 'data-testid': 'timeline-fold', onClick: dock.toggleCollapsed },
+        'edit.timeline.collapseAxis',
+      ),
+      h(
+        'button',
+        { 'data-testid': 'tts-batch', onClick: () => setRunning(true), disabled: running },
+        running ? 'running' : 'idle',
+      ),
+    );
+  };
+  return { ActionsBar };
+});
+// The roster editor reads the whole stage document; the dock only owes it a mount
+// point, so it is stubbed down to a marker.
+vi.mock('@/components/edit/AgentsView/RosterDialog', async () => {
+  const { createElement: h } = await import('react');
+  return {
+    RosterDialog: ({ open }: { open: boolean }) =>
+      open ? h('div', { 'data-testid': 'roster-dialog' }) : null,
+  };
+});
+
+import { EditDock } from '@/components/edit/EditDock/EditDock';
+import { useStageStore } from '@/lib/store/stage';
+import { useElementRefsStore } from '@/lib/store/element-refs';
+import { useWorkbenchStore } from '@/lib/workbench/session-store';
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+  lifecycle.timelineMounts = 0;
+  canvas.pickTarget = null;
+  canvas.spotlight = '';
+  canvas.laser = '';
+  useStageStore.setState({ stage: null, scenes: [], currentSceneId: null });
+  useWorkbenchStore.setState({ sessionId: null, stageId: null });
+  useElementRefsStore.getState().detachOwner();
+  vi.clearAllMocks();
+});
+
+async function unmountDock() {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+}
+
+async function renderDock({
+  sessionId = 'session-a',
+  sessionStageId = 'stage-1',
+  currentStageId = 'stage-1',
+  sceneType = 'slide',
+  // Set so the terminal-status case can prove the lasso ignores it.
+  status = 'running',
+}: {
+  sessionId?: string | null;
+  sessionStageId?: string | null;
+  currentStageId?: string;
+  sceneType?: string;
+  status?: string;
+} = {}) {
+  useStageStore.setState({ stage: { id: currentStageId } as never });
+  useWorkbenchStore.setState({ sessionId, stageId: sessionStageId, status: status as never });
+  // The composer that would receive the pills. In the workspace the chat pane is
+  // mounted whenever the store holds a session (`chatMounted`), and mounting it is
+  // what claims the reference draft — the lasso is only painted for that owner.
+  if (sessionId) useElementRefsStore.getState().attachOwner(sessionId);
+  else useElementRefsStore.getState().detachOwner();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(EditDock, { sceneId: 'scene-1', sceneType: sceneType as never }));
+  });
+  return container;
+}
+
+async function click(target: Element | null) {
+  if (!(target instanceof HTMLElement)) throw new Error('missing click target');
+  await act(async () => target.click());
+}
+
+describe('EditDock structure', () => {
+  it('mounts the timeline as the dock body, under a global edit bar', async () => {
+    const host = await renderDock();
+
+    expect(host.querySelector('[data-testid="edit-dock-bar"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="timeline-body"]')).not.toBeNull();
+    // No tab strip: the timeline is the only body, and nothing hides it.
+    expect(host.querySelector('[role="tablist"]')).toBeNull();
+    expect(lifecycle.timelineMounts).toBe(1);
+  });
+
+  it('offers the roster on every scene type, from the bar', async () => {
+    const host = await renderDock({ sceneType: 'quiz' });
+
+    expect(host.querySelector('[data-testid="edit-dock-roster"]')).not.toBeNull();
+    await click(host.querySelector('[data-testid="edit-dock-roster"]'));
+    expect(host.querySelector('[data-testid="roster-dialog"]')).not.toBeNull();
+  });
+});
+
+describe('EditDock lasso availability', () => {
+  it('shows the lasso on a slide, whatever the agent is doing with the course', async () => {
+    // Picking elements is a human authoring gesture: it stages pills in the
+    // composer and writes nothing. So a slide plus a conversation is the whole
+    // condition — no ownership, no run status.
+    const own = await renderDock();
+    expect(own.querySelector('[data-testid="element-ref-arm"]')).not.toBeNull();
+  });
+
+  it('shows the same lasso on an interactive scene', async () => {
+    const host = await renderDock({ sceneType: 'interactive' });
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).not.toBeNull();
+  });
+
+  it('shows the lasso on a course the run never linked or touched', async () => {
+    // Reached through read-only tools (search / read_classroom), so the course is
+    // in neither `stageLinkStageIds` nor `touchedStageIds` — the old gate hid the
+    // lasso here, which is one half of why it never appeared.
+    const host = await renderDock({
+      sessionStageId: 'stage-placeholder',
+      currentStageId: 'stage-unrelated',
+    });
+
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).not.toBeNull();
+  });
+
+  it('keeps the lasso after the run finishes — the case the feature exists for', async () => {
+    // `agentOwnsPaneCourse` releases ownership on a terminal status, so the old
+    // gate made the lasso vanish exactly when the user sat down to edit the deck
+    // the agent had just built.
+    for (const status of ['succeeded', 'failed', 'cancelled'] as const) {
+      const host = await renderDock({ status });
+      expect(
+        host.querySelector('[data-testid="element-ref-arm"]'),
+        `terminal status ${status} must not hide the lasso`,
+      ).not.toBeNull();
+      await unmountDock();
+    }
+  });
+
+  it('hides the lasso with no conversation to hand references to', async () => {
+    // Not an ownership claim: with no chat there is no next message and no
+    // composer to render the pills in, so the gesture would go nowhere.
+    const host = await renderDock({ sessionId: null, sessionStageId: null });
+
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).toBeNull();
+  });
+
+  it('hides the lasso on a scene type with no canvas elements', async () => {
+    const host = await renderDock({ sceneType: 'quiz' });
+
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).toBeNull();
+  });
+});
+
+describe('EditDock pick-mode cleanup', () => {
+  // The criterion is the (chat, course, page) identity a pick was armed for.
+  // Switching any of the three disarms what the previous one left behind — the
+  // invariants cr pinned, now that "the agent stopped owning this" is gone.
+  it('disarms a lasso left armed by another session (chat switch)', async () => {
+    canvas.pickTarget = {
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-old',
+    };
+
+    await renderDock({ sessionId: 'session-a' });
+
+    expect(canvas.setPickTarget).toHaveBeenCalledWith(null);
+    expect(canvas.pickTarget).toBeNull();
+  });
+
+  it('disarms a lasso armed for another page of the same course (page switch)', async () => {
+    canvas.pickTarget = {
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-9',
+      ownerSessionId: 'session-a',
+    };
+
+    await renderDock({ sessionId: 'session-a' });
+
+    expect(canvas.pickTarget).toBeNull();
+  });
+
+  it('disarms a lasso armed for a different course (course switch)', async () => {
+    // The pick was staged on another deck; the dock now shows `stage-2`, so the
+    // stale target must not survive into it.
+    canvas.pickTarget = {
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-a',
+    };
+
+    await renderDock({ sessionId: 'session-a', currentStageId: 'stage-2' });
+
+    expect(canvas.pickTarget).toBeNull();
+  });
+
+  it('leaves a matching lasso alone, whatever the session status', async () => {
+    canvas.pickTarget = {
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-a',
+    };
+    // A finished run no longer disarms the human's pick mode.
+    await renderDock({ sessionId: 'session-a', status: 'succeeded' });
+    expect(canvas.pickTarget).not.toBeNull();
+  });
+
+  it('leaves a timeline cue pick alone', async () => {
+    // A cue pick belongs to the timeline; the dock has no business clearing it.
+    canvas.setPickTarget.mockClear();
+    canvas.pickTarget = { purpose: 'cue', actionId: 'spotlight-1' };
+    await renderDock({ sessionId: 'session-b' });
+    expect(canvas.setPickTarget).not.toHaveBeenCalled();
+    expect(canvas.pickTarget).toMatchObject({ purpose: 'cue' });
+  });
+});
+
+describe('EditDock fold', () => {
+  it('keeps the global edit bar while the timeline is folded, at the fixed height', async () => {
+    const host = await renderDock();
+    const section = host.querySelector('[data-testid="edit-dock"]') as HTMLElement;
+    // 224 timeline + 36 bar. The height is FIXED: the height-drag handle above
+    // the bar was removed (owner decision), so only the fold moves it.
+    expect(section.style.height).toBe('260px');
+    expect(section.querySelector('.cursor-row-resize')).toBeNull();
+
+    await click(host.querySelector('[data-testid="timeline-fold"]'));
+    // 86 collapsed timeline + 36 bar: folding never folds the bar away.
+    expect(section.style.height).toBe('122px');
+    expect(host.querySelector('[data-testid="edit-dock-bar"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="edit-dock-roster"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).not.toBeNull();
+    expect(
+      host.querySelector('[data-testid="timeline-body"]')?.getAttribute('data-collapsed'),
+    ).toBe('true');
+
+    await click(host.querySelector('[data-testid="timeline-fold"]'));
+    expect(section.style.height).toBe('260px');
+  });
+
+  it('never remounts the timeline for a global control, batch in flight included', async () => {
+    const host = await renderDock();
+    await click(host.querySelector('[data-testid="tts-batch"]'));
+
+    await click(host.querySelector('[data-testid="element-ref-arm"]'));
+    await click(host.querySelector('[data-testid="edit-dock-roster"]'));
+    await click(host.querySelector('[data-testid="timeline-fold"]'));
+    await click(host.querySelector('[data-testid="timeline-fold"]'));
+
+    expect(host.querySelector('[data-testid="tts-batch"]')?.textContent).toBe('running');
+    expect(lifecycle.timelineMounts).toBe(1);
+  });
+});

--- a/tests/edit/element-ref-lasso.test.ts
+++ b/tests/edit/element-ref-lasso.test.ts
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+
+/**
+ * The lasso button, on real stores.
+ *
+ * Two things are pinned: the Cursor-style toggle (press to arm, press again or Esc
+ * to leave, references land in the composer's list rather than in a panel here),
+ * and the OWNER FENCE — during a direct navigation from chat A to chat B, nothing
+ * of A's draft may be shown or acted on, not even for the one render before B's
+ * attach effect runs.
+ */
+import { act, createElement, Fragment } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { flushSync } from 'react-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ElementRefLassoButton } from '@/components/edit/EditDock/ElementRefLassoButton';
+import { useCanvasStore } from '@/lib/store/canvas';
+import { useElementRefsOwnerLifecycle, useElementRefsStore } from '@/lib/store/element-refs';
+import { useStageStore } from '@/lib/store/stage';
+import { useWorkbenchStore } from '@/lib/workbench/session-store';
+import type { ElementRef } from '@/lib/workbench/element-refs';
+
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const oldRef: ElementRef = {
+  kind: 'slide-element',
+  stageId: 'stage-1',
+  sceneId: 'scene-1',
+  elementId: 'title-1',
+  elementType: 'text',
+  label: '会话 A 的标题',
+};
+
+let root: Root | null = null;
+
+function ChatOwner() {
+  const sessionId = useWorkbenchStore((state) => state.sessionId);
+  useElementRefsOwnerLifecycle(sessionId);
+  return null;
+}
+
+function seedSlideCourse() {
+  useStageStore.setState({
+    stage: { id: 'stage-1' } as never,
+    scenes: [
+      {
+        id: 'scene-1',
+        stageId: 'stage-1',
+        type: 'slide',
+        content: { type: 'slide', canvas: { elements: [] } },
+      } as never,
+    ],
+    currentSceneId: 'scene-1',
+  });
+}
+
+function mount(children: ReturnType<typeof createElement>) {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  flushSync(() => root?.render(children));
+  return host;
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  useCanvasStore.getState().resetCanvasState();
+  useStageStore.setState({ stage: null, scenes: [], currentSceneId: null });
+  useWorkbenchStore.setState({ sessionId: null, stageId: null });
+  useElementRefsStore.setState({
+    ownerSessionId: null,
+    refs: [],
+    hovered: null,
+    nextGeneration: 1,
+  });
+  document.body.innerHTML = '';
+});
+
+describe('element reference lasso', () => {
+  it('arms the canvas for this page, leaves on a second press, and leaves on Esc', async () => {
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+    await act(async () => undefined);
+    const button = host.querySelector('[data-testid="element-ref-arm"]') as HTMLElement;
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+
+    await act(async () => button.click());
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-a',
+    });
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+
+    await act(async () => button.click());
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+
+    await act(async () => button.click());
+    expect(useCanvasStore.getState().pickTarget).not.toBeNull();
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('arms the lasso across courses: the session-bound stage may differ from the displayed one', async () => {
+    // The chat session is bound to course `stage-2`, but the classroom pane
+    // shows course `stage-1`. The lasso arms against the DISPLAYED course — it
+    // must not be gated on the session's bound stage, or the button could never
+    // light up for a course other than the one the chat is attached to.
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-2' });
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+    await act(async () => undefined);
+    const button = host.querySelector('[data-testid="element-ref-arm"]') as HTMLElement;
+    await act(async () => button.click());
+
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-a',
+    });
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('takes the canvas from a timeline cue pick and clears its live preview', async () => {
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'cue',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      actionId: 'spotlight-1',
+      cueType: 'spotlight',
+    });
+    useCanvasStore.getState().setSpotlight('title-1');
+
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+    await act(async () => undefined);
+    await act(async () =>
+      (host.querySelector('[data-testid="element-ref-arm"]') as HTMLElement).click(),
+    );
+
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({ purpose: 'element-ref' });
+    expect(useCanvasStore.getState().spotlightElementId).toBe('');
+  });
+
+  it('is not painted at all while no chat owns the reference draft', async () => {
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    // No `ChatOwner`: the element-refs store has no owner, so a reference staged
+    // now would belong to nobody — and a button that cannot act must not be drawn.
+    const host = mount(createElement(ElementRefLassoButton, { sceneId: 'scene-1' }));
+    await act(async () => undefined);
+
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).toBeNull();
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+  });
+
+  it('disappears — rather than going dead — when the chat unmounts under a live session id', async () => {
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+    await act(async () => undefined);
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).not.toBeNull();
+
+    // Leaving `/workspace` for a standalone `/classroom/<id>` (the discover feed
+    // does exactly this): the chat unmounts and releases the draft, while the
+    // workbench store keeps the session id across the client-side navigation.
+    await act(async () => {
+      root?.render(createElement(ElementRefLassoButton, { sceneId: 'scene-1' }));
+    });
+    expect(useWorkbenchStore.getState().sessionId).toBe('session-a');
+    expect(useElementRefsStore.getState().ownerSessionId).toBeNull();
+    expect(host.querySelector('[data-testid="element-ref-arm"]')).toBeNull();
+  });
+
+  it('keeps the way out of picking when ownership drops mid-pick', async () => {
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+    await act(async () => undefined);
+    await act(async () =>
+      (host.querySelector('[data-testid="element-ref-arm"]') as HTMLElement).click(),
+    );
+    expect(useCanvasStore.getState().pickTarget).not.toBeNull();
+
+    await act(async () => useElementRefsStore.getState().detachOwner());
+    const button = host.querySelector('[data-testid="element-ref-arm"]') as HTMLElement;
+    expect(button).not.toBeNull();
+    await act(async () => button.click());
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+  });
+
+  it('counts only the owning chat’s references', async () => {
+    seedSlideCourse();
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+    await act(async () => undefined);
+    expect(host.querySelector('[data-testid="element-ref-count"]')).toBeNull();
+
+    await act(async () => useElementRefsStore.getState().add(oldRef));
+    expect(host.querySelector('[data-testid="element-ref-count"]')?.textContent).toBe('1');
+  });
+
+  it('never shows or acts on session A during a direct navigation to B', async () => {
+    seedSlideCourse();
+    const refs = useElementRefsStore.getState();
+    refs.attachOwner('session-a');
+    refs.add(oldRef);
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-a',
+    });
+    useWorkbenchStore.setState({ sessionId: 'session-b', stageId: 'stage-1' });
+
+    const host = mount(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        createElement(ElementRefLassoButton, { sceneId: 'scene-1' }),
+      ),
+    );
+
+    // The render-phase owner fence hides A's tally, and A's armed mode never
+    // reads as this button's own, once B's attach effect has claimed the draft.
+    expect(host.querySelector('[data-testid="element-ref-count"]')).toBeNull();
+    expect(
+      host.querySelector('[data-testid="element-ref-arm"]')?.getAttribute('aria-pressed'),
+    ).toBe('false');
+
+    await act(async () => undefined);
+    expect(useElementRefsStore.getState()).toMatchObject({ ownerSessionId: 'session-b', refs: [] });
+  });
+});

--- a/tests/edit/surfaces/slide/element-pick-layer-purposes.test.ts
+++ b/tests/edit/surfaces/slide/element-pick-layer-purposes.test.ts
@@ -1,0 +1,1019 @@
+// @vitest-environment jsdom
+import { act, createElement, Fragment } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ElementPickLayer } from '@/components/edit/surfaces/slide/ElementPickLayer';
+import { CANVAS_OVERLAY_Z } from '@/components/edit/surfaces/slide/CanvasOverlayPortal';
+import { ElementRefPinLayer } from '@/components/edit/surfaces/slide/ElementRefPinLayer';
+import {
+  MAIC_ELEMENT_ID_ATTRIBUTE,
+  editableElementDomId,
+} from '@/components/edit/surfaces/slide/renderer-element-dom';
+import { useCanvasStore } from '@/lib/store/canvas';
+import { useElementRefsOwnerLifecycle, useElementRefsStore } from '@/lib/store/element-refs';
+import { useStageStore } from '@/lib/store/stage';
+import { useWorkbenchStore } from '@/lib/workbench/session-store';
+import type { Scene } from '@/lib/types/stage';
+
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const scene = {
+  id: 'scene-1',
+  stageId: 'stage-1',
+  order: 1,
+  title: 'Slide',
+  type: 'slide',
+  content: {
+    type: 'slide',
+    canvas: {
+      id: 'slide-1',
+      viewportSize: 1000,
+      viewportRatio: 0.5625,
+      elements: [
+        {
+          id: 'title-1',
+          type: 'text',
+          left: 0,
+          top: 0,
+          width: 100,
+          height: 40,
+          rotate: 0,
+          content: '<p>折射定律</p>',
+          defaultFontName: 'Inter',
+          defaultColor: '#111111',
+        },
+        {
+          id: 'note-1',
+          type: 'shape',
+          left: 0,
+          top: 60,
+          width: 100,
+          height: 40,
+          rotate: 0,
+          text: { content: '<p>入射角</p>' },
+        },
+      ],
+    },
+  },
+  actions: [{ id: 'spotlight-1', type: 'spotlight', elementId: '' }],
+} as unknown as Scene;
+
+/**
+ * A LEGACY editor host: a `#editable-element-{id}` wrapper carrying only
+ * `data-maic-element-id`, with the painted box on `.element-content`. This is
+ * the DEFAULT canvas, and before the shared DOM contract it emitted neither the
+ * attribute the hit-test looks for nor a paint node the layer knew about — so
+ * picking silently found nothing on it.
+ */
+function mountLegacyHost(elementId: string, top: number) {
+  const host = document.createElement('div');
+  host.id = editableElementDomId(elementId);
+  host.setAttribute(MAIC_ELEMENT_ID_ATTRIBUTE, elementId);
+  host.getBoundingClientRect = () => ({ left: 0, top: 0, width: 0, height: 0 }) as DOMRect;
+  const paint = document.createElement('div');
+  paint.className = 'element-content';
+  paint.getBoundingClientRect = () =>
+    ({ left: 10, top, width: 120, height: 40, right: 130, bottom: top + 40 }) as DOMRect;
+  host.appendChild(paint);
+  document.body.appendChild(host);
+  return { host, paint };
+}
+
+function stubPointAt(node: HTMLElement | null) {
+  Object.defineProperty(document, 'elementsFromPoint', {
+    configurable: true,
+    value: () => (node ? [node] : []),
+  });
+}
+
+afterEach(() => {
+  useCanvasStore.getState().resetCanvasState();
+  useElementRefsStore.getState().clear();
+  useStageStore.setState({ stage: null, scenes: [], currentSceneId: null });
+  useWorkbenchStore.setState({ sessionId: null, stageId: null });
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+});
+
+/**
+ * The studio frame the overlay clamps to. Mocked at the origin with a large
+ * size so it is the whole canvas container without shifting element-relative ring
+ * coordinates (a child measured against a box at 0,0 keeps its element coords).
+ */
+const FRAME_RECT = { left: 0, top: 0, width: 1000, height: 600 } as const;
+
+async function render(includePins = false) {
+  useWorkbenchStore.setState({
+    sessionId: 'session-a',
+    stageId: useStageStore.getState().stage?.id ?? null,
+  });
+  const container = document.createElement('div');
+  // The picker renders inside the slide card, which sits inside the studio frame
+  // it must clamp to; reproduce that ancestry so `closest()` resolves the frame.
+  const frame = document.createElement('div');
+  frame.setAttribute('data-maic-studio-frame', 'true');
+  frame.getBoundingClientRect = () =>
+    ({
+      ...FRAME_RECT,
+      right: FRAME_RECT.width,
+      bottom: FRAME_RECT.height,
+      x: FRAME_RECT.left,
+      y: FRAME_RECT.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  frame.appendChild(container);
+  document.body.appendChild(frame);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      includePins
+        ? createElement(
+            Fragment,
+            null,
+            createElement(ElementRefPinLayer),
+            createElement(ElementPickLayer),
+          )
+        : createElement(ElementPickLayer),
+    );
+  });
+  return { container, root };
+}
+
+function ChatOwner() {
+  const sessionId = useWorkbenchStore((state) => state.sessionId);
+  useElementRefsOwnerLifecycle(sessionId);
+  return null;
+}
+
+async function renderWithChatOwner(includePins = false) {
+  useWorkbenchStore.setState({
+    sessionId: 'session-a',
+    stageId: useStageStore.getState().stage?.id ?? null,
+  });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      createElement(
+        Fragment,
+        null,
+        createElement(ChatOwner),
+        includePins ? createElement(ElementRefPinLayer) : null,
+        createElement(ElementPickLayer),
+      ),
+    );
+  });
+  return { container, root };
+}
+
+describe('ElementPickLayer purposes', () => {
+  it('finds a legacy-canvas element through the shared data attribute', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    const { paint } = mountLegacyHost('title-1', 30);
+    mountLegacyHost('note-1', 90);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await render();
+    // The canvas starts CLEAN — no all-elements outlining. The ring appears on
+    // the element under the pointer, measured from its `.element-content` box
+    // rather than the zero-size wrapper the ids hang on.
+    expect(document.querySelector('.ring-violet-500')).toBeNull();
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    await act(async () => {
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    });
+
+    const ring = document.querySelector('.ring-violet-500') as HTMLElement;
+    // The ring sits 2px outside the measured box on every side.
+    expect(ring.style.left).toBe('8px');
+    expect(ring.style.width).toBe('124px');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders on the body, so the element panel is never clipped by the card', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    mountLegacyHost('title-1', 30);
+    stubPointAt(null);
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { container, root } = await render();
+
+    // The card's `overflow-hidden` used to cut the bottom off the element list.
+    // The mount point now keeps only the invisible measuring anchor.
+    expect(container.querySelector('[data-testid="element-pick-layer"]')).toBeNull();
+    expect(container.querySelector('[data-canvas-overlay-anchor]')).not.toBeNull();
+    const layer = document.querySelector('[data-testid="element-pick-layer"]') as HTMLElement;
+    expect(layer.parentElement).toBe(document.body);
+    expect(layer.style.position).toBe('fixed');
+    // Clamped to the studio frame (the whole canvas container), so the panel can
+    // roam the padding around the card but never escape onto the dock.
+    expect(layer.style.width).toBe(`${FRAME_RECT.width}px`);
+    expect(layer.style.height).toBe(`${FRAME_RECT.height}px`);
+    // Above the insert palette AT REST: while picking, a click on the slide means
+    // "this element", not "insert one". The strip itself is allowed over the
+    // picker while picking — raised but inert, so the click still reaches here —
+    // and that is the only thing above this layer.
+    expect(layer.style.zIndex).toBe(String(CANVAS_OVERLAY_Z.picker));
+    expect(CANVAS_OVERLAY_Z.picker).toBeGreaterThan(CANVAS_OVERLAY_Z.palette);
+    expect(CANVAS_OVERLAY_Z.paletteOverPicker).toBeGreaterThan(CANVAS_OVERLAY_Z.picker);
+    // The picker still swallows canvas clicks: its box is NOT click-through.
+    expect(layer.style.pointerEvents).toBe('');
+
+    await act(async () => root.unmount());
+  });
+
+  it('keeps the staged pins under the picker’s own hover ring', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    const { paint } = mountLegacyHost('title-1', 30);
+    mountLegacyHost('note-1', 90);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useElementRefsStore.getState().attachOwner('session-a');
+    useElementRefsStore.getState().add({
+      kind: 'slide-element',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      elementId: 'title-1',
+      elementType: 'text',
+      label: '标题',
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await render(true);
+
+    // The pins keep their own in-canvas layer at z-[110], below the portaled pick
+    // layer — so the hover ring, which the picker owns, paints over them. Raising
+    // the insert strip over the picker must not disturb this pair.
+    const pin = document.querySelector('[data-testid="element-ref-pin"]') as HTMLElement;
+    expect((pin.parentElement as HTMLElement).className).toContain('z-[110]');
+    expect(CANVAS_OVERLAY_Z.picker).toBeGreaterThan(110);
+
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    await act(async () => {
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    });
+    const layer = document.querySelector('[data-testid="element-pick-layer"]') as HTMLElement;
+    const ring = document.querySelector('.ring-violet-500') as HTMLElement;
+    expect(layer.contains(ring)).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+
+  it('rings an element from the panel list, with the canvas otherwise untouched', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    mountLegacyHost('title-1', 30);
+    mountLegacyHost('note-1', 90);
+    // Nothing under the pointer: the panel is the only way in, which is exactly
+    // the case it exists for (elements too small to hit, or hidden behind one
+    // another) and part of what the removed all-elements outlining used to carry.
+    stubPointAt(null);
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await render();
+    expect(document.querySelector('.ring-violet-500')).toBeNull();
+
+    const noteRow = Array.from(document.querySelectorAll('button')).find((row) =>
+      row.textContent?.includes('入射角'),
+    );
+    expect(noteRow).toBeDefined();
+    await act(async () => {
+      noteRow?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    // `note-1` is the second legacy host, painted at top 90 — ringed 2px outside.
+    const ring = document.querySelector('.ring-violet-500') as HTMLElement;
+    expect(ring.style.top).toBe('88px');
+    expect(ring.style.width).toBe('124px');
+
+    await act(async () => root.unmount());
+  });
+
+  it('element-ref mode toggles refs and stays armed', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    const { paint } = mountLegacyHost('title-1', 30);
+    mountLegacyHost('note-1', 90);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await renderWithChatOwner(true);
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    const move = () =>
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    const click = () => catcher.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await act(async () => move());
+    await act(async () => click());
+    expect(useElementRefsStore.getState().refs).toEqual([
+      {
+        kind: 'slide-element',
+        stageId: 'stage-1',
+        sceneId: 'scene-1',
+        elementId: 'title-1',
+        elementType: 'text',
+        label: 'edit.element.text · 折射定律',
+        snapshotText: '折射定律',
+      },
+    ]);
+    const stagedPins = document.querySelectorAll('[data-testid="element-ref-pin"]');
+    expect(stagedPins).toHaveLength(1);
+    expect(stagedPins[0]?.textContent).toBe('1');
+    // Only the staged ordinal persists. The unselected note — and every other
+    // non-hovered element — keeps the clean-canvas contract with no frame.
+    expect(
+      Array.from(document.querySelectorAll('[data-testid="element-ref-pin"]')).some((pin) =>
+        pin.classList.contains('ring-violet-400/55'),
+      ),
+    ).toBe(false);
+    // Multi-pick is the point: the mode must survive a pick.
+    expect(useCanvasStore.getState().pickTarget).toEqual({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: 'scene-1',
+      ownerSessionId: 'session-a',
+    });
+
+    // A second click on the same element un-picks it.
+    await act(async () => click());
+    expect(useElementRefsStore.getState().refs).toEqual([]);
+    expect(useCanvasStore.getState().pickTarget).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('element-ref mode survives a click on empty canvas; a cue pick cancels on it', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    mountLegacyHost('title-1', 30);
+    stubPointAt(null); // pointer over nothing
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+    const first = await render();
+    await act(async () => {
+      (document.querySelector('.cursor-crosshair') as HTMLElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    // Losing a multi-element selection to a stray click is not a cancel anyone
+    // asked for.
+    expect(useCanvasStore.getState().pickTarget).not.toBeNull();
+    await act(async () => first.root.unmount());
+
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'cue',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      actionId: 'spotlight-1',
+      cueType: 'spotlight',
+    });
+    const second = await render();
+    await act(async () => {
+      (document.querySelector('.cursor-crosshair') as HTMLElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+    await act(async () => second.root.unmount());
+  });
+
+  it('cue mode still binds one element and leaves, staging no refs', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    const { paint } = mountLegacyHost('title-1', 30);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'cue',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      actionId: 'spotlight-1',
+      cueType: 'spotlight',
+    });
+
+    const { root } = await render();
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    await act(async () => {
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    });
+    await act(async () => catcher.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    const action = useStageStore.getState().scenes[0].actions?.[0] as { elementId?: string };
+    expect(action.elementId).toBe('title-1');
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+    // The two purposes must not leak into each other.
+    expect(useElementRefsStore.getState().refs).toEqual([]);
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not carry an armed picker into a cloned course with the same scene and element ids', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-2' } as never,
+      scenes: [{ ...scene, stageId: 'stage-2' }],
+      currentSceneId: scene.id,
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+    useElementRefsStore.getState().attachOwner('session-a');
+    useElementRefsStore.getState().add({
+      kind: 'slide-element',
+      stageId: 'stage-2',
+      sceneId: scene.id,
+      elementId: 'title-1',
+      elementType: 'text',
+      label: '克隆课程标题',
+    });
+    mountLegacyHost('title-1', 30);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    const { root } = await render(true);
+    expect(document.querySelector('.cursor-crosshair')).toBeNull();
+    // Clearing the foreign lasso restores both renderer shortcuts (the global
+    // target is null) and the current course's pin layer.
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+    expect(document.querySelector('[data-testid="element-ref-pin"]')).not.toBeNull();
+    expect(useElementRefsStore.getState().refs).toHaveLength(1);
+    await act(async () => root.unmount());
+  });
+
+  it('disarms session A on navigation and lets session B re-arm a clean draft', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    const { paint } = mountLegacyHost('title-1', 30);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await renderWithChatOwner();
+    expect(document.querySelector('.cursor-crosshair')).not.toBeNull();
+
+    await act(async () => useWorkbenchStore.setState({ sessionId: 'session-b' }));
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+    expect(document.querySelector('.cursor-crosshair')).toBeNull();
+    expect(useElementRefsStore.getState()).toMatchObject({
+      ownerSessionId: 'session-b',
+      refs: [],
+    });
+
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-b',
+    });
+    await act(async () => undefined);
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    await act(async () => {
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    });
+    await act(async () => catcher.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    expect(useElementRefsStore.getState()).toMatchObject({
+      ownerSessionId: 'session-b',
+      refs: [expect.objectContaining({ elementId: 'title-1' })],
+    });
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({
+      purpose: 'element-ref',
+      ownerSessionId: 'session-b',
+    });
+    await act(async () => root.unmount());
+  });
+
+  it('keeps an element-ref armed across courses: session binds one course, canvas shows another', async () => {
+    // The chat session is bound to course `stage-1`, but the classroom pane is
+    // showing course `stage-2` — exactly the cross-course case that used to be
+    // disarmed the same frame it armed, because the pick's stage was required to
+    // equal the session's bound stage.
+    useStageStore.setState({
+      stage: { id: 'stage-2' } as never,
+      scenes: [{ ...scene, stageId: 'stage-2' }],
+      currentSceneId: scene.id,
+    });
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    const { paint } = mountLegacyHost('title-1', 30);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-2',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(Fragment, null, createElement(ChatOwner), createElement(ElementPickLayer)),
+      );
+    });
+
+    // The same-frame identity guard must NOT clear the cross-course arm, and the
+    // layer must render (it used to be hidden because bound stage ≠ displayed).
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({
+      purpose: 'element-ref',
+      stageId: 'stage-2',
+    });
+    expect(document.querySelector('.cursor-crosshair')).not.toBeNull();
+
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    await act(async () => {
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    });
+    await act(async () => catcher.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    // The pick lands against the DISPLAYED course — the ref carries its own
+    // stageId — and the mode stays armed for multi-pick.
+    expect(useElementRefsStore.getState().refs).toEqual([
+      expect.objectContaining({ stageId: 'stage-2', sceneId: scene.id, elementId: 'title-1' }),
+    ]);
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({
+      purpose: 'element-ref',
+      stageId: 'stage-2',
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it('still disarms an element-ref owned by another chat, even on the same course', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    useWorkbenchStore.setState({ sessionId: 'session-a', stageId: 'stage-1' });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-b', // some other chat's pick
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(ElementPickLayer));
+    });
+
+    // The owner fence is still identity: another session's pick must not leak
+    // into this chat's canvas, even when the course matches.
+    expect(useCanvasStore.getState().pickTarget).toBeNull();
+    expect(document.querySelector('.cursor-crosshair')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('lets the armed pick land when the session switches bound stage while the canvas stays put', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    const { paint } = mountLegacyHost('title-1', 30);
+    stubPointAt(paint);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useElementRefsStore.getState().attachOwner('session-a');
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await renderWithChatOwner();
+    const catcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    expect(catcher).not.toBeNull();
+    await act(async () => {
+      catcher.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, clientX: 40, clientY: 40 }),
+      );
+    });
+
+    // `switch_stage` updates the session-bound stage, but the canvas is still
+    // showing the old course — that is now a CROSS-COURSE pick, and refs support
+    // it by carrying their own stageId. Neither the session's bound stage nor a
+    // click landing before navigation may veto the pick.
+    await act(async () => {
+      useWorkbenchStore.setState({ stageId: 'stage-2' });
+      catcher.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(useElementRefsStore.getState().refs).toEqual([
+      expect.objectContaining({ stageId: 'stage-1', sceneId: scene.id, elementId: 'title-1' }),
+    ]);
+    expect(useCanvasStore.getState().pickTarget).toMatchObject({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+    });
+    expect(document.querySelector('.cursor-crosshair')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('repositions a staged pin after a keyboard geometry commit', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    let top = 30;
+    const { paint } = mountLegacyHost('title-1', top);
+    paint.getBoundingClientRect = () =>
+      ({ left: 10, top, width: 120, height: 40, right: 130, bottom: top + 40 }) as DOMRect;
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    useElementRefsStore.getState().attachOwner('session-a');
+    useElementRefsStore.getState().add({
+      kind: 'slide-element',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      elementId: 'title-1',
+      elementType: 'text',
+      label: '标题',
+    });
+
+    const { root } = await render(true);
+    await act(async () => frames.splice(0).forEach((frame) => frame(0)));
+    expect(
+      (document.querySelector('[data-testid="element-ref-pin"]') as HTMLElement).style.top,
+    ).toBe('30px');
+
+    top = 46;
+    const movedScene = structuredClone(scene);
+    const movedElement = (movedScene.content as { canvas: { elements: Array<{ top: number }> } })
+      .canvas.elements[0];
+    movedElement.top = 16;
+    await act(async () => useStageStore.setState({ scenes: [movedScene] }));
+    await act(async () => frames.splice(0).forEach((frame) => frame(0)));
+
+    expect(
+      (document.querySelector('[data-testid="element-ref-pin"]') as HTMLElement).style.top,
+    ).toBe('46px');
+    await act(async () => root.unmount());
+  });
+
+  it('resizes a staged pin when text auto-height changes without pointerup', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    let height = 40;
+    const { paint } = mountLegacyHost('title-1', 30);
+    paint.getBoundingClientRect = () =>
+      ({ left: 10, top: 30, width: 120, height, right: 130, bottom: 30 + height }) as DOMRect;
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    let notifyResize: ResizeObserverCallback | null = null;
+    class TestResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        notifyResize = callback;
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+    useElementRefsStore.getState().attachOwner('session-a');
+    useElementRefsStore.getState().add({
+      kind: 'slide-element',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      elementId: 'title-1',
+      elementType: 'text',
+      label: '标题',
+    });
+
+    const { root } = await render(true);
+    await act(async () => frames.splice(0).forEach((frame) => frame(0)));
+    expect(
+      (document.querySelector('[data-testid="element-ref-pin"]') as HTMLElement).style.height,
+    ).toBe('40px');
+
+    height = 76;
+    await act(async () => {
+      notifyResize?.([], {} as ResizeObserver);
+      frames.splice(0).forEach((frame) => frame(0));
+    });
+
+    expect(
+      (document.querySelector('[data-testid="element-ref-pin"]') as HTMLElement).style.height,
+    ).toBe('76px');
+    await act(async () => root.unmount());
+  });
+
+  it('clamps the panel inside the container by its real height, re-clamping on expand', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    const { root } = await render();
+
+    // The panel clamps against `rootRef` (the layer's only child), which jsdom
+    // lays out as a zero box; give it the studio-frame geometry the panel is
+    // supposed to stay inside.
+    const layer = document.querySelector('[data-testid="element-pick-layer"]') as HTMLElement;
+    const rootBox = layer.firstElementChild as HTMLElement;
+    Object.defineProperty(rootBox, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          left: FRAME_RECT.left,
+          top: FRAME_RECT.top,
+          width: FRAME_RECT.width,
+          height: FRAME_RECT.height,
+          right: FRAME_RECT.width,
+          bottom: FRAME_RECT.height,
+        }) as DOMRect,
+    });
+
+    const panel = Array.from(layer.querySelectorAll('div')).find(
+      (el) => (el as HTMLElement).style.width === '232px',
+    ) as HTMLElement;
+    expect(panel).toBeDefined();
+    const toggle = panel.querySelector('button[aria-label]') as HTMLButtonElement;
+    const header = panel.querySelector('.cursor-grab') as HTMLElement;
+    // No layout engine in jsdom: simulate the panel's real height — 40px
+    // collapsed (the header row), 400px expanded (header + the element rows).
+    Object.defineProperty(panel, 'offsetHeight', {
+      configurable: true,
+      get: () => (toggle.getAttribute('aria-label') === 'edit.pick.expand' ? 40 : 400),
+    });
+
+    // Collapse, drag the now-short panel as low as its collapsed height allows…
+    await act(async () => toggle.click());
+    const dragToBottom = () => {
+      header.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 40, clientY: 0 }),
+      );
+      header.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 40, clientY: 600 }),
+      );
+      header.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    };
+    await act(async () => dragToBottom());
+    expect(panel.style.top).toBe('552px'); // 600 − 40 (collapsed) − 8
+
+    // …then expanding the panel grows it past the container's bottom edge, and
+    // the re-clamp must pull the whole panel back inside.
+    await act(async () => toggle.click());
+    expect(panel.style.top).toBe('192px'); // 600 − 400 (expanded) − 8
+
+    await act(async () => root.unmount());
+  });
+
+  it('re-clamps the panel when the container shrinks in place (dock/divider drag)', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'element-ref',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      ownerSessionId: 'session-a',
+    });
+
+    // jsdom has no ResizeObserver; capture the ones the layer tree constructs
+    // so the test can fire the pick layer's container observer like a real
+    // in-frame resize — a dock/divider drag re-shapes the studio frame without
+    // a window resize, so the window-resize listener never runs.
+    const instances: Array<{
+      callback: ResizeObserverCallback;
+      observed: Element[];
+      disconnect: ReturnType<typeof vi.fn>;
+    }> = [];
+    class TestResizeObserver {
+      callback: ResizeObserverCallback;
+      observed: Element[] = [];
+      observe = vi.fn((el: Element) => {
+        this.observed.push(el);
+      });
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        instances.push(this);
+      }
+    }
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+
+    const { root } = await render();
+
+    const layer = document.querySelector('[data-testid="element-pick-layer"]') as HTMLElement;
+    const rootBox = layer.firstElementChild as HTMLElement;
+    // The panel clamps against `rootRef`, which jsdom lays out as a zero box;
+    // give it the studio-frame geometry and let the test shrink it afterwards.
+    let frameHeight: number = FRAME_RECT.height;
+    Object.defineProperty(rootBox, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          left: FRAME_RECT.left,
+          top: FRAME_RECT.top,
+          width: FRAME_RECT.width,
+          height: frameHeight,
+          right: FRAME_RECT.width,
+          bottom: frameHeight,
+        }) as DOMRect,
+    });
+
+    const panel = Array.from(layer.querySelectorAll('div')).find(
+      (el) => (el as HTMLElement).style.width === '232px',
+    ) as HTMLElement;
+    expect(panel).toBeDefined();
+    Object.defineProperty(panel, 'offsetHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+
+    // The pick layer's own observer is the one watching the container it clamps
+    // to (`CanvasOverlayPortal` observes the studio frame instead).
+    const containerObserver = instances.find((o) => o.observed.includes(rootBox));
+    expect(containerObserver).toBeDefined();
+
+    // Drag the (tall) panel to the container's bottom edge…
+    const header = panel.querySelector('.cursor-grab') as HTMLElement;
+    await act(async () => {
+      header.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 40, clientY: 0 }),
+      );
+      header.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 40, clientY: 600 }),
+      );
+      header.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    });
+    expect(panel.style.top).toBe('192px'); // 600 − 400 − 8
+
+    // …then the frame shrinks in place (e.g. the user drags the edit dock
+    // taller). No window resize fires; the observer must see the container
+    // change and pull the panel back — all the way to the top margin here,
+    // since 300 − 400 − 8 is below it.
+    frameHeight = 300;
+    await act(async () => containerObserver?.callback([], {} as ResizeObserver));
+    expect(panel.style.top).toBe('8px');
+
+    // Leaving pick mode disconnects the observer.
+    await act(async () => root.unmount());
+    expect(containerObserver?.disconnect).toHaveBeenCalled();
+  });
+
+  it('disarms and clears cue preview when the current page changes in the same course', async () => {
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene, { ...scene, id: 'scene-2', order: 2 }],
+      currentSceneId: scene.id,
+    });
+    useCanvasStore.getState().setPickTarget({
+      purpose: 'cue',
+      stageId: 'stage-1',
+      sceneId: scene.id,
+      actionId: 'spotlight-1',
+      cueType: 'spotlight',
+    });
+    useCanvasStore.getState().setSpotlight('title-1');
+    useCanvasStore.getState().setLaser('title-1');
+    const { root } = await render();
+
+    await act(async () => useStageStore.setState({ currentSceneId: 'scene-2' }));
+
+    expect(useCanvasStore.getState()).toMatchObject({
+      pickTarget: null,
+      spotlightElementId: '',
+      laserElementId: '',
+    });
+    await act(async () => root.unmount());
+  });
+});

--- a/tests/edit/surfaces/slide/element-pick-layer-renderer-dom.test.ts
+++ b/tests/edit/surfaces/slide/element-pick-layer-renderer-dom.test.ts
@@ -45,15 +45,21 @@ const scene = {
 
 afterEach(() => {
   useCanvasStore.getState().resetCanvasState();
-  useStageStore.setState({ scenes: [], currentSceneId: null });
+  useStageStore.setState({ stage: null, scenes: [], currentSceneId: null });
   document.body.innerHTML = '';
   vi.unstubAllGlobals();
 });
 
 describe('ElementPickLayer renderer DOM integration', () => {
   it('measures a renderer element host and binds the picked id to the timeline action', async () => {
-    useStageStore.setState({ scenes: [scene], currentSceneId: scene.id });
+    useStageStore.setState({
+      stage: { id: 'stage-1' } as never,
+      scenes: [scene],
+      currentSceneId: scene.id,
+    });
     useCanvasStore.getState().setPickTarget({
+      purpose: 'cue',
+      stageId: 'stage-1',
       sceneId: scene.id,
       actionId: 'spotlight-1',
       cueType: 'spotlight',
@@ -91,18 +97,22 @@ describe('ElementPickLayer renderer DOM integration', () => {
       root.render(createElement(ElementPickLayer));
     });
 
-    const outline = container.querySelector('.ring-violet-400\\/40') as HTMLElement;
-    expect(outline.style.left).toBe('40px');
-    expect(outline.style.top).toBe('30px');
-    expect(outline.style.width).toBe('120px');
-    expect(outline.style.height).toBe('50px');
-
-    const clickCatcher = container.querySelector('.cursor-crosshair') as HTMLElement;
+    const clickCatcher = document.querySelector('.cursor-crosshair') as HTMLElement;
+    // Pick mode leaves the slide alone until the pointer names an element.
+    expect(document.querySelector('.ring-violet-500')).toBeNull();
     await act(async () => {
       clickCatcher.dispatchEvent(
         new MouseEvent('mousemove', { bubbles: true, clientX: 60, clientY: 50 }),
       );
     });
+
+    // The ring is measured off the renderer's paint node, 2px outside it.
+    const ring = document.querySelector('.ring-violet-500') as HTMLElement;
+    expect(ring.style.left).toBe('38px');
+    expect(ring.style.top).toBe('28px');
+    expect(ring.style.width).toBe('124px');
+    expect(ring.style.height).toBe('54px');
+
     await act(async () => {
       clickCatcher.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/tests/i18n/edit-chrome-keys.test.ts
+++ b/tests/i18n/edit-chrome-keys.test.ts
@@ -1,0 +1,201 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { workbenchResourceFor } from '@/lib/i18n/workbench';
+import arSA from '@/lib/i18n/locales/ar-SA.json';
+import deDE from '@/lib/i18n/locales/de-DE.json';
+import enUS from '@/lib/i18n/locales/en-US.json';
+import esMX from '@/lib/i18n/locales/es-MX.json';
+import frFR from '@/lib/i18n/locales/fr-FR.json';
+import jaJP from '@/lib/i18n/locales/ja-JP.json';
+import koKR from '@/lib/i18n/locales/ko-KR.json';
+import ptBR from '@/lib/i18n/locales/pt-BR.json';
+import ruRU from '@/lib/i18n/locales/ru-RU.json';
+import viVN from '@/lib/i18n/locales/vi-VN.json';
+import zhCN from '@/lib/i18n/locales/zh-CN.json';
+import zhTW from '@/lib/i18n/locales/zh-TW.json';
+
+/**
+ * Guard for the editor-chrome locale contract.
+ *
+ * The ported editor chrome (`components/edit/**`, `components/workbench/**`,
+ * `lib/workbench/**`) renders its copy through `t('...')`. When a key is
+ * missing from a locale, i18next falls back to the raw key string and the user
+ * sees `edit.roster.shortTitle` instead of text. That regression shipped once;
+ * this test makes it impossible to ship again.
+ *
+ * It statically extracts the `t(...)` string literals from those directories,
+ * resolves each against the SAME merged resource the runtime uses — the locale
+ * JSON deep-merged with the hook-free `workbench.*` map from
+ * `lib/i18n/workbench.ts` (mirroring `lib/i18n/config.ts`) — and asserts the
+ * key resolves to a non-empty string in every one of the 12 locales.
+ *
+ * Dynamic keys are NOT guessed. The two bounded dynamic prefixes are expanded
+ * from explicit static tables below (the `SceneType` union and the FONTS
+ * registry's `labelKey`), each with the file that owns the mapping; everything
+ * truly data-driven (server-provided copy keys such as `node.copyKey` or
+ * `snapshot.error`) is out of scope and resolves against server-side locales.
+ */
+const SCAN_DIRS = ['components/edit', 'components/workbench', 'lib/workbench'] as const;
+
+/**
+ * `t('edit.sceneType.' + scene.type)` in
+ * `components/edit/SlideNavRail/ThumbItem.tsx` — one key per `SceneType` value
+ * (`packages/@openmaic/dsl/src/stage.ts`).
+ */
+const SCENE_TYPE_VALUES = ['slide', 'quiz', 'interactive', 'pbl'] as const;
+
+/**
+ * `t(f.labelKey)` in `components/edit/surfaces/slide/text-format-bar.tsx`
+ * reads `labelKey` from the FONTS registry (`configs/font.ts`), which lives
+ * outside the scanned directories.
+ */
+const FONT_LABEL_KEYS = ['edit.text.fontDefault'] as const;
+
+const LOCALE_RESOURCES: Record<string, unknown> = {
+  'ar-SA': arSA,
+  'de-DE': deDE,
+  'en-US': enUS,
+  'es-MX': esMX,
+  'fr-FR': frFR,
+  'ja-JP': jaJP,
+  'ko-KR': koKR,
+  'pt-BR': ptBR,
+  'ru-RU': ruRU,
+  'vi-VN': viVN,
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+};
+
+const LOCALES = Object.keys(LOCALE_RESOURCES);
+
+function walk(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      files.push(...walk(path));
+    } else if (path.endsWith('.ts') || path.endsWith('.tsx')) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+/**
+ * Collect every i18n key the scanned code can ask for: direct `t('...')`
+ * literals, ternary literals inside `t(...)`, the `labelKey:` values the
+ * registries resolve through `t(some.labelKey)`, and the statically known
+ * values of the bounded dynamic prefixes.
+ */
+function extractKeys(): string[] {
+  const keys = new Set<string>();
+  const labelKeyPattern = /labelKey:\s*'([^']+)'/g;
+  const directPattern = /(?:^|[^a-zA-Z0-9_])t\(\s*'([^']*)'/g;
+  const doubleQuotePattern = /(?:^|[^a-zA-Z0-9_])t\(\s*"([^"]*)"/g;
+  // `t(condition ? 'a' : 'b')` — both arms are keys.
+  const ternaryPattern = /\bt\([^)]*\?\s*'([^']*)'\s*:\s*'([^']*)'/g;
+  const concatPrefixPattern = /(?:^|[^a-zA-Z0-9_])t\(\s*'([^']+)'\s*\+/g;
+
+  for (const dir of SCAN_DIRS) {
+    for (const file of walk(dir)) {
+      const source = readFileSync(file, 'utf8');
+      for (const pattern of [directPattern, doubleQuotePattern]) {
+        pattern.lastIndex = 0;
+        for (const match of source.matchAll(pattern)) {
+          const key = match[1];
+          // A trailing dot marks a dynamic prefix (`'edit.sceneType.' + ...`),
+          // expanded below; it is not a key on its own.
+          if (key && !key.endsWith('.')) keys.add(key);
+        }
+      }
+      ternaryPattern.lastIndex = 0;
+      for (const match of source.matchAll(ternaryPattern)) {
+        keys.add(match[1]);
+        keys.add(match[2]);
+      }
+      labelKeyPattern.lastIndex = 0;
+      for (const match of source.matchAll(labelKeyPattern)) {
+        keys.add(match[1]);
+      }
+      concatPrefixPattern.lastIndex = 0;
+      for (const match of source.matchAll(concatPrefixPattern)) {
+        const prefix = match[1];
+        if (prefix === 'edit.sceneType.') {
+          for (const value of SCENE_TYPE_VALUES) keys.add(`${prefix}${value}`);
+        } else {
+          // A new dynamic prefix would be flagged here instead of guessed.
+          throw new Error(`unexpected dynamic i18n prefix '${prefix}' in ${file}`);
+        }
+      }
+    }
+  }
+
+  for (const key of FONT_LABEL_KEYS) keys.add(key);
+  return [...keys].sort();
+}
+
+function readPath(value: unknown, path: readonly string[]): unknown {
+  let current: unknown = value;
+  for (const part of path) {
+    if (current === null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * The merged view the React `t` actually resolves against: the locale JSON
+ * deep-merged with `{ workbench: workbenchResourceFor(language) }` — the same
+ * merge `lib/i18n/config.ts` performs for i18next.
+ */
+function mergedResource(localeCode: string): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    ...(LOCALE_RESOURCES[localeCode] as Record<string, unknown>),
+  };
+  const overlay = { workbench: workbenchResourceFor(localeCode) };
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overlay)) {
+    result[key] =
+      isRecord(value) && isRecord(result[key]) ? mergedResourceMerge(result[key], value) : value;
+  }
+  return result;
+}
+
+function mergedResourceMerge(
+  base: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overlay)) {
+    result[key] =
+      isRecord(value) && isRecord(result[key]) ? mergedResourceMerge(result[key], value) : value;
+  }
+  return result;
+}
+
+describe('editor chrome i18n keys', () => {
+  const keys = extractKeys();
+
+  it('finds a non-trivial set of keys to guard', () => {
+    // Sanity: the scan must actually see the chrome's copy calls, including the
+    // keys the acceptance test found leaking.
+    expect(keys).toContain('edit.roster.shortTitle');
+    expect(keys).toContain('edit.elementRef.startPicking');
+    expect(keys).toContain('edit.elementRef.exitPicking');
+    expect(keys.length).toBeGreaterThan(100);
+  });
+
+  it.each(LOCALES)('resolves every extracted key in %s', (locale) => {
+    const resource = mergedResource(locale);
+    const unresolved = keys.filter((key) => {
+      const value = readPath(resource, key.split('.'));
+      return typeof value !== 'string' || value.length === 0;
+    });
+    expect(unresolved, `unresolved keys in ${locale}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Three acceptance regressions in the ported editor chrome: (1) raw i18n keys rendered in the dock bar — 13 keys were referenced by the ported components but missing from every locale; ported from the reference for all 12 locales, plus a static guard test that extracts every referenced key and asserts it resolves everywhere; (2) removed the dock's height-drag affordance (explicit product decision; fixed collapsed/expanded heights retained); (3) element referencing did nothing — ElementPickLayer was a stale pre-port version that rendered null for element-ref picks; replaced with the reference implementation (portaled overlay, hit-testing, multi-pick), fixed layer mount order, dropped the dead legacy PickTarget variant. 41 new/updated seam tests.