### PR TITLE
fix(workbench): send the opening session message exactly once with refs intact

### DIFF
--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -19,6 +19,7 @@ import { buildAgent } from '@/lib/agent/runtime/build-agent';
 import { createCallLlmStreamFn } from '@/lib/agent/runtime/stream-fn';
 import { HOST_AGENT_LIFECYCLE as LIFECYCLE } from '@/lib/agent-runtime/lifecycle';
 import { createLogger } from '@/lib/logger';
+import { parseCourseRefs, type CourseRef } from '@/lib/workbench/course-refs';
 
 import { resolveAgentDriverModel } from './agent-driver-model';
 import { buildAskUserTool } from './ask-user';
@@ -340,6 +341,13 @@ export interface FollowUpMessage {
     mime?: string;
     bytes?: number;
   }>;
+  /**
+   * Classrooms the message named with `@`. The runner resolves each ref
+   * against the owner's own library before composing (see
+   * `resolveCourseRefsForContext`), so the model is told the course's CURRENT
+   * name rather than the snapshot the composer captured at pick time.
+   */
+  courseRefs?: readonly CourseRef[];
 }
 
 /** Derive delivery from the immutable entry sequence, not in-memory state. */
@@ -357,8 +365,44 @@ export function loggedMessageCursor(input: {
   };
 }
 
+/**
+ * The classrooms a message named, resolved against the owner's own library.
+ *
+ * The composer stores a SNAPSHOT title on the ref, which is right for the
+ * receipt the bubble shows but stale for the model: a renamed course would be
+ * described by its old name. Each ref is probed for ownership and the current
+ * name; a classroom that no longer resolves (missing, foreign, or tombstoned)
+ * degrades to the snapshot title — the user named it, so the model still
+ * learns which one — while the durable stageId stays the handle the course
+ * tools address.
+ */
+export async function resolveCourseRefsForContext(
+  ownerId: string,
+  refs: readonly CourseRef[],
+): Promise<CourseRef[]> {
+  const resolved: CourseRef[] = [];
+  for (const ref of refs) {
+    const probe = await probeStageAccess(ownerId, ref.stageId);
+    resolved.push({
+      kind: 'course',
+      stageId: ref.stageId,
+      title: probe.kind === 'owned' ? probe.stage.name : ref.title,
+    });
+  }
+  return resolved;
+}
+
+/** Append the named classrooms to a message the runner is about to deliver. */
+export function composeCourseRefsText(text: string, refs: readonly CourseRef[]): string {
+  if (refs.length === 0) return text;
+  const label = refs.length === 1 ? 'classroom' : 'classrooms';
+  const list = refs.map((ref) => `"${ref.title}" (${ref.stageId})`).join(', ');
+  return `${text}\n\n[The user named this ${label}: ${list}. Work on the named ${label} for this message.]`;
+}
+
 export function composeFollowUpText(message: FollowUpMessage): string {
-  if (!message.materials?.length) return message.text;
+  const text = composeCourseRefsText(message.text, message.courseRefs ?? []);
+  if (!message.materials?.length) return text;
   const list = message.materials
     .map((material) => {
       const id = material.materialId ?? 'attached material';
@@ -366,7 +410,7 @@ export function composeFollowUpText(message: FollowUpMessage): string {
       return `"${material.originalName ?? id}" (${mime}, ${material.bytes ?? 0} bytes)`;
     })
     .join(', ');
-  return `${message.text}\n\n[The user attached session material: ${list}. It is registered with this session; use use_material_media when it contains embeddable image, video, or audio bytes.]`;
+  return `${text}\n\n[The user attached session material: ${list}. It is registered with this session; use use_material_media when it contains embeddable image, video, or audio bytes.]`;
 }
 
 export function planRunStart(input: {
@@ -379,7 +423,18 @@ export function planRunStart(input: {
   if (input.plan.kind === 'start' && input.pending.length > 0 && input.idleAttach) {
     return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
   }
-  if (input.plan.kind === 'start') return { kind: 'prompt', text: input.prompt };
+  if (input.plan.kind === 'start') {
+    // A session created with opening context requeues its opening message as a
+    // durable `user_message` before the runner claims; `pending[0]` is that
+    // message. Its classrooms must reach the model, or the run would not know
+    // which classroom the user named. Nothing else changes: the raw prompt is
+    // still the base, and materials are already listed in the system block.
+    const opening = input.pending[0];
+    if (opening?.courseRefs?.length) {
+      return { kind: 'prompt', text: composeCourseRefsText(input.prompt, opening.courseRefs) };
+    }
+    return { kind: 'prompt', text: input.prompt };
+  }
   if (input.claimReason === 'queued' && input.pending.length > 0) {
     return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
   }
@@ -414,11 +469,15 @@ export interface RunContext {
 }
 
 function toFollowUp(message: AgentSessionUserMessage): FollowUpMessage {
+  // The durable event carries the refs the control plane persisted; the
+  // runner resolves them against the owner library before composing.
+  const courseRefs = parseCourseRefs(message.courseRefs);
   return {
     text: message.text,
     ...(message.materials.length
       ? { materials: message.materials as FollowUpMessage['materials'] }
       : {}),
+    ...(courseRefs.length ? { courseRefs } : {}),
   };
 }
 
@@ -746,7 +805,21 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       idleAttach: meta.existingCourse,
     });
     const followUpsDelivered = cursor.delivered;
-    const pending = loggedMessages.slice(followUpsDelivered).map(toFollowUp);
+    // Resolve the classrooms each pending message named against the owner's
+    // library BEFORE the prompt is built: the run must be told the course's
+    // current name (reference semantics), and the same resolved refs feed the
+    // `session_start` receipt when the opening message is a durable message.
+    const pending = await Promise.all(
+      loggedMessages.slice(followUpsDelivered).map(async (message) => {
+        const followUp = toFollowUp(message);
+        return followUp.courseRefs?.length
+          ? {
+              ...followUp,
+              courseRefs: await resolveCourseRefsForContext(meta.ownerId, followUp.courseRefs),
+            }
+          : followUp;
+      }),
+    );
     const idleAttach = cursor.idle;
 
     if (plan.kind === 'already-complete' && pending.length === 0) {
@@ -769,6 +842,10 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         workerId: WORKER_ID,
         pid: process.pid,
         prompt: meta.prompt,
+        // The opening message is durable with its classrooms (the create route
+        // requeues it before the runner can claim), so the start frame carries
+        // the same receipt any `user_message` does.
+        ...(pending[0]?.courseRefs?.length ? { courseRefs: pending[0].courseRefs } : {}),
       });
     } else {
       emit(LIFECYCLE.sessionResumed, {
@@ -1038,9 +1115,19 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       let delivered = 0;
       for (const [index, message] of all.entries()) {
         if (index < handled) continue;
+        const followUp = toFollowUp(message);
+        // Same resolution as the start path: a steered message names its
+        // classrooms on the durable event, and the model must be told the
+        // course's current name, not the pick-time snapshot.
+        const resolved = followUp.courseRefs?.length
+          ? {
+              ...followUp,
+              courseRefs: await resolveCourseRefsForContext(meta.ownerId, followUp.courseRefs),
+            }
+          : followUp;
         agent.steer({
           role: 'user',
-          content: composeFollowUpText(toFollowUp(message)),
+          content: composeFollowUpText(resolved),
         } as unknown as AgentMessage);
         delivered += 1;
       }

--- a/lib/workbench/session-store.ts
+++ b/lib/workbench/session-store.ts
@@ -954,16 +954,33 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
       // receipt any later one does. Same untrusted-log rule as `user_message`
       // (drop mode), and same single source — a session-level list is never
       // consulted for this.
-      const startCourseRefs = parseCourseRefs(data.courseRefs);
-      next.chat = [
-        ...answerOpenQuestions(state.chat),
-        {
-          key: `${key}-u`,
-          kind: 'user',
-          text: String(data.prompt ?? ''),
-          ...(startCourseRefs.length ? { courseRefs: startCourseRefs } : {}),
-        },
-      ];
+      //
+      // A session created WITH opening context (materials or `@`-named
+      // classrooms) already has its message on the timeline: the create route
+      // persists it as a durable `user_message` — the very write that requeues
+      // the session — so the runner's `session_start` prompt would paint the
+      // same bubble twice. That durable message is the one true opening bubble
+      // (it carries the materials and courseRefs receipts); paint from
+      // `session_start` only when no such message precedes it. Sessions
+      // created without opening context have no durable message and still need
+      // this bubble. `session_start` fires only on the very first run, so a
+      // matching user node can only be that durable opening message.
+      const startPrompt = String(data.prompt ?? '');
+      const lastUser = [...state.chat].reverse().find((node) => node.kind === 'user');
+      const openingAlreadyPainted =
+        lastUser !== undefined && lastUser.kind === 'user' && lastUser.text === startPrompt;
+      if (!openingAlreadyPainted) {
+        const startCourseRefs = parseCourseRefs(data.courseRefs);
+        next.chat = [
+          ...answerOpenQuestions(state.chat),
+          {
+            key: `${key}-u`,
+            kind: 'user',
+            text: startPrompt,
+            ...(startCourseRefs.length ? { courseRefs: startCourseRefs } : {}),
+          },
+        ];
+      }
       // The first LLM call is now in flight — the gap indicator opens.
       openWaiting(next, `${key}-w`, event.ts);
       break;

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -851,6 +851,7 @@ export class PgAgentSessionStore
         text: String(data.text ?? ''),
         delivery: String(data.delivery ?? ''),
         materials: Array.isArray(data.materials) ? data.materials : [],
+        ...(Array.isArray(data.courseRefs) ? { courseRefs: data.courseRefs } : {}),
       };
     });
   }

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -350,6 +350,8 @@ export interface AgentSessionUserMessage {
   text: string;
   delivery: string;
   materials: unknown[];
+  /** Classrooms the message named with `@`; the runner composes them into the run. */
+  courseRefs?: unknown[];
 }
 
 /** The durable stream has separate lease-bound and control-plane writers. */

--- a/tests/agent-runtime/run-start.test.ts
+++ b/tests/agent-runtime/run-start.test.ts
@@ -1,12 +1,25 @@
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { planResume } from '@/lib/server/agent-runtime/resume';
 import {
+  composeCourseRefsText,
   composeFollowUpText,
   loggedMessageCursor,
   planRunStart,
+  resolveCourseRefsForContext,
 } from '@/lib/server/agent-runtime/runner';
+import type { CourseRef } from '@/lib/workbench/course-refs';
+
+const mocks = vi.hoisted(() => ({
+  probeStageAccess: vi.fn(),
+}));
+
+vi.mock('@/lib/server/agent-runtime/curriculum-tools', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/agent-runtime/curriculum-tools')>();
+  return { ...actual, probeStageAccess: mocks.probeStageAccess };
+});
 
 const user = (text: string) => ({ role: 'user', content: text }) as unknown as AgentMessage;
 const assistant = (text: string) =>
@@ -98,5 +111,64 @@ describe('composeFollowUpText', () => {
     expect(text).toContain('lecture.mp4');
     expect(text).toContain('video/mp4');
     expect(text).toContain('use use_material_media');
+  });
+});
+
+describe('courseRefs reach the run prompt', () => {
+  const ref = (stageId: string, title: string): CourseRef => ({ kind: 'course', stageId, title });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('composes the named classrooms into a follow-up message', () => {
+    const text = composeFollowUpText({
+      text: 'Add an example',
+      courseRefs: [ref('stage-1', '光的折射')],
+    });
+    expect(text).toContain('Add an example');
+    expect(text).toContain('光的折射');
+    expect(text).toContain('stage-1');
+  });
+
+  it('prompts a first run with the opening message plus its classrooms', () => {
+    const named = [ref('stage-1', '光的折射')];
+    expect(
+      planRunStart({
+        plan: planResume(null),
+        claimReason: 'queued',
+        pending: [{ text: 'Build a course', courseRefs: named }],
+        prompt: 'Build a course',
+      }),
+    ).toEqual({ kind: 'prompt', text: composeCourseRefsText('Build a course', named) });
+  });
+
+  it('keeps the raw prompt when the opening message named no classroom', () => {
+    expect(
+      planRunStart({
+        plan: planResume(null),
+        claimReason: 'queued',
+        pending: [{ text: 'Build a course' }],
+        prompt: 'Build a course',
+      }),
+    ).toEqual({ kind: 'prompt', text: 'Build a course' });
+  });
+
+  it('resolves refs to the current name and degrades an unresolved one', async () => {
+    mocks.probeStageAccess.mockImplementation(async (ownerId: string, stageId: string) =>
+      stageId === 'stage-1'
+        ? { kind: 'owned', stage: { stageId, name: 'Renamed classroom' } }
+        : { kind: 'missing' },
+    );
+
+    const resolved = await resolveCourseRefsForContext('owner-1', [
+      ref('stage-1', 'Old snapshot name'),
+      ref('stage-2', 'Gone classroom'),
+    ]);
+
+    expect(resolved).toEqual([
+      { kind: 'course', stageId: 'stage-1', title: 'Renamed classroom' },
+      { kind: 'course', stageId: 'stage-2', title: 'Gone classroom' },
+    ]);
   });
 });

--- a/tests/agent-runtime/sessions-route.test.ts
+++ b/tests/agent-runtime/sessions-route.test.ts
@@ -154,6 +154,41 @@ describe('agent session collection route', () => {
     );
   });
 
+  it('persists the opening message exactly once, with materials and course refs intact', async () => {
+    const courseRefs = [{ kind: 'course', stageId: 'stage-2', title: 'Referenced course' }];
+    mocks.bindOwnerMaterialsToSession.mockResolvedValue([
+      { materialId: 'material-1', originalName: 'notes.pdf', bytes: 42 },
+    ]);
+    const response = await post({
+      prompt: 'Read this and compare',
+      materialIds: ['material-1'],
+      courseRefs,
+    });
+
+    expect(response.status).toBe(202);
+    // The create-with-opening-context flow must write the opening message as a
+    // durable `user_message` EXACTLY ONCE, carrying both the bound materials
+    // and the named classrooms — no second copy without the refs may exist.
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'succeeded' }),
+    );
+    expect(mocks.postUserMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.postUserMessage).toHaveBeenCalledWith(
+      'session-1',
+      {
+        text: 'Read this and compare',
+        materials: [{ materialId: 'material-1', originalName: 'notes.pdf', bytes: 42 }],
+        courseRefs,
+      },
+      { expectedOwnerId: 'anon:test' },
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      id: 'session-1',
+      status: 'queued',
+      courseRefs,
+    });
+  });
+
   it('rejects an explicit skill that matches neither id nor name', async () => {
     const response = await post({ prompt: 'Build a course', skill: 'my-unknown' });
 

--- a/tests/workbench/session-fold.test.ts
+++ b/tests/workbench/session-fold.test.ts
@@ -75,6 +75,29 @@ describe('lifecycle events', () => {
     expect(state.chat[0]).toMatchObject({ kind: 'user', text: '给我讲讲光的折射' });
   });
 
+  it('does not paint the opening message twice when it is already a durable user_message', () => {
+    // A session created WITH opening context gets its message persisted as a
+    // durable `user_message` by the create route before the runner claims, so
+    // the runner's `session_start` must not paint a second bubble — the one
+    // true bubble is the durable message, receipt included.
+    const named = [{ kind: 'course', stageId: 'stage-a', title: '光的折射' }];
+    const state = foldAll([
+      ev('user_message', { text: '帮我在这门课程中增加内容', courseRefs: named }),
+      ev('session_start', { prompt: '帮我在这门课程中增加内容', workerId: 'w1' }),
+    ]);
+    expect(state.status).toBe('running');
+    const users = contentOf(state).filter((node) => node.kind === 'user');
+    expect(users).toHaveLength(1);
+    expect(users[0]).toMatchObject({ text: '帮我在这门课程中增加内容', courseRefs: named });
+  });
+
+  it('session_start still paints the opening bubble when no durable message preceded it', () => {
+    const state = foldAll([ev('session_start', { prompt: '做一门新课', workerId: 'w1' })]);
+    const users = contentOf(state).filter((node) => node.kind === 'user');
+    expect(users).toHaveLength(1);
+    expect(users[0]).toMatchObject({ text: '做一门新课' });
+  });
+
   it('session_resumed is one quiet system line', () => {
     const state = foldAll([
       ev('session_start', { prompt: 'p' }),


### PR DESCRIPTION
Acceptance regression on new workbench sessions with an @classroom mention: the opening message painted twice (once from the durable user_message with the mention chip, once from session_start without it) and the run itself never received the classroom reference. Root causes: the runner composed only materials into run prompts and follow-ups, dropping courseRefs everywhere (planRunStart, toFollowUp, steer drain), and session_start omitted them; the client fold painted a second bubble from session_start. The runner now resolves refs against the owner's library and composes them into every delivered message, session_start carries them, and the fold skips the duplicate bubble when the durable message already painted it. The #1229 claim-before-bind invariant is untouched. Storage 0.22.0 -> 0.23.0 (user messages now return courseRefs).