### PR TITLE
fix(media): restore the reference classic media chain

### DIFF
--- a/lib/export/proxied-fetch.ts
+++ b/lib/export/proxied-fetch.ts
@@ -1,17 +1,36 @@
 /**
  * A fetch implementation that routes asset requests through the same-origin
- * /api/proxy-media endpoint, bypassing cross-origin CORS restrictions that block
- * direct browser fetches to CDNs like cdn.tailwindcss.com or CORS-locked image hosts.
- * The proxy validates the URL server-side (SSRF guard) and returns the bytes.
+ * /api/proxy-media endpoint. Callers that also handle browser-owned URLs can opt
+ * into cross-origin-only mode so local, blob, and data URLs stay direct, and can
+ * try a CORS-enabled CDN directly before falling back to the bounded proxy. The
+ * proxy validates the URL server-side (SSRF guard) and returns the bytes.
  */
-export function createProxiedFetch(): typeof fetch {
-  return (async (input: RequestInfo | URL) => {
-    const url =
-      typeof input === 'string' ? input : input instanceof URL ? input.href : String(input);
-    return fetch('/api/proxy-media', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url }),
-    });
+import { fetchProxiedMediaUrl } from '@/lib/media/proxy-media-cache';
+
+export function createProxiedFetch(
+  options: { crossOriginOnly?: boolean; directFirst?: boolean } = {},
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const pageHref = typeof location !== 'undefined' ? location.href : undefined;
+    let shouldProxy = false;
+    try {
+      const resolved = pageHref ? new URL(url, pageHref) : new URL(url);
+      shouldProxy =
+        (resolved.protocol === 'http:' || resolved.protocol === 'https:') &&
+        (!pageHref || resolved.origin !== new URL(pageHref).origin);
+    } catch {
+      // Relative and browser-owned URLs are fetched directly.
+    }
+    const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+    if (options.crossOriginOnly && !shouldProxy) return fetch(input, init);
+    if (options.directFirst) {
+      try {
+        return await fetch(input, init);
+      } catch (error) {
+        if (signal?.aborted) throw error;
+      }
+    }
+    return fetchProxiedMediaUrl(url, { signal });
   }) as unknown as typeof fetch;
 }

--- a/lib/hooks/use-scene-generator.ts
+++ b/lib/hooks/use-scene-generator.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useRef } from 'react';
-import { markStagePersistenceDirty, useStageStore } from '@/lib/store/stage';
+import { useStageStore } from '@/lib/store/stage';
 import { isSceneEditLocked } from '@/lib/edit/regen-lock';
 import { getCurrentModelConfig } from '@/lib/utils/model-config';
 import { useSettingsStore } from '@/lib/store/settings';
@@ -27,10 +27,7 @@ import {
 } from '@/lib/audio/voice-resolver';
 import { resolveTTSModelForVoice } from '@/lib/audio/constants';
 import { useAgentRegistry } from '@/lib/orchestration/registry/store';
-import {
-  generateMediaForOutlines,
-  reconcileCompletedMediaForScene,
-} from '@/lib/media/media-orchestrator';
+import { generateMediaForOutlines } from '@/lib/media/media-orchestrator';
 import { putAsset, removeAsset, replaceAsset } from '@/lib/media/asset-pool';
 import { lazyBoundedMap } from '@/lib/utils/concurrency';
 import { createLogger } from '@/lib/logger';
@@ -49,20 +46,6 @@ import {
 } from '@openmaic/generation';
 
 const log = createLogger('SceneGenerator');
-
-function addGeneratedScene(scene: Scene): void {
-  const state = useStageStore.getState();
-  if (!state.stage || scene.stageId !== state.stage.id) {
-    state.addScene(scene);
-    return;
-  }
-  const reconciled = reconcileCompletedMediaForScene(scene, state.stage);
-  if (reconciled.stage !== state.stage) {
-    useStageStore.setState({ stage: reconciled.stage });
-    markStagePersistenceDirty([{ kind: 'stage' }]);
-  }
-  useStageStore.getState().addScene(reconciled.scene);
-}
 
 interface SceneContentResult {
   success: boolean;
@@ -900,7 +883,7 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
             }
 
             removeGeneratingOutline(outline.id);
-            addGeneratedScene(scene);
+            useStageStore.getState().addScene(scene);
             options.onSceneGenerated?.(scene, outline.order);
             previousSpeeches = actionsResult.previousSpeeches || [];
           } else {
@@ -1074,7 +1057,7 @@ export function useSceneGenerator(options: UseSceneGeneratorOptions = {}) {
         }
 
         removeGeneratingOutline();
-        addGeneratedScene(actionsResult.scene);
+        useStageStore.getState().addScene(actionsResult.scene);
 
         // Resume remaining generation if there are pending outlines
         if (store.getState().generatingOutlines.length > 0 && lastParamsRef.current) {

--- a/lib/media/fetch-media-url.ts
+++ b/lib/media/fetch-media-url.ts
@@ -1,3 +1,32 @@
+import { fetchProxiedMediaUrl } from './proxy-media-cache';
+
+async function waitForRenderedMedia(url: string, maxWaitMs: number): Promise<void> {
+  if (typeof document === 'undefined' || typeof location === 'undefined') return;
+  const target = new URL(url, location.href).href;
+  const element = [
+    ...document.querySelectorAll<HTMLImageElement | HTMLMediaElement>(
+      'img[src],video[src],audio[src]',
+    ),
+  ].find((candidate) => {
+    const source = candidate.currentSrc || candidate.getAttribute('src');
+    return source ? new URL(source, location.href).href === target : false;
+  });
+  if (!element) return;
+  if (element.tagName === 'IMG' && (element as HTMLImageElement).complete) return;
+  if (element.tagName !== 'IMG' && (element as HTMLMediaElement).readyState >= 2) return;
+
+  await new Promise<void>((resolve) => {
+    const events = element.tagName === 'IMG' ? ['load', 'error'] : ['loadeddata', 'error'];
+    const finish = () => {
+      window.clearTimeout(timer);
+      for (const event of events) element.removeEventListener(event, finish);
+      resolve();
+    };
+    const timer = window.setTimeout(finish, maxWaitMs);
+    for (const event of events) element.addEventListener(event, finish, { once: true });
+  });
+}
+
 /**
  * Fetch a media URL through the same-origin media proxy when it is remote.
  * A plain browser fetch is CORS-blocked for cross-origin media exactly where
@@ -7,19 +36,31 @@
  * opts in, and a self-hosted deployment's own media routes are exactly that.
  * Local schemes (data:, relative) go direct. Always bounded; the caller maps
  * the response.
+ *
+ * Cross-origin requests route through the shared proxy-media negative cache:
+ * a 4xx verdict for a URL is remembered for the session and later calls
+ * short-circuit without a network request, so callers that re-probe the same
+ * URL on every load/play tick (legacy asset conversion, exports) cannot spam
+ * the proxy with a URL the upstream has permanently refused.
  */
-export function fetchMediaUrl(url: string, timeoutMs: number): Promise<Response> {
+export function fetchMediaUrl(
+  url: string,
+  timeoutMs: number,
+  options: { cache?: RequestCache; waitForRenderedMedia?: boolean } = {},
+): Promise<Response> {
   const init = { signal: AbortSignal.timeout(timeoutMs) };
+  const directInit: RequestInit = { ...init, ...(options.cache ? { cache: options.cache } : {}) };
   if (url.startsWith('http://') || url.startsWith('https://')) {
     const sameOrigin =
       typeof location !== 'undefined' && new URL(url, location.href).origin === location.origin;
-    if (sameOrigin) return fetch(url, init);
-    return fetch('/api/proxy-media', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url }),
-      ...init,
-    });
+    if (sameOrigin) {
+      return (
+        options.waitForRenderedMedia ? waitForRenderedMedia(url, 2_000) : Promise.resolve()
+      ).then(() => fetch(url, directInit));
+    }
+    return fetchProxiedMediaUrl(url, init);
   }
-  return fetch(url, init);
+  return (options.waitForRenderedMedia ? waitForRenderedMedia(url, 2_000) : Promise.resolve()).then(
+    () => fetch(url, directInit),
+  );
 }

--- a/lib/media/media-orchestrator.ts
+++ b/lib/media/media-orchestrator.ts
@@ -8,26 +8,11 @@
 
 import { useMediaGenerationStore } from '@/lib/store/media-generation';
 import { useSettingsStore } from '@/lib/store/settings';
-import { markStagePersistenceDirty, useStageStore } from '@/lib/store/stage';
 import { db, mediaFileKey } from '@/lib/utils/database';
-import { accessDocument, mutateDocument, type AppDocument } from '@/lib/document-store';
 import type { SceneOutline } from '@/lib/types/generation';
-import { makeScene, type Scene, type Stage, type Whiteboard } from '@/lib/types/stage';
 import type { MediaGenerationRequest } from '@/lib/media/types';
-import type { AssetMeta, PPTElement, Slide } from '@openmaic/dsl';
-import { putAsset, removeAsset, replaceAsset } from '@/lib/media/asset-pool';
-import { assetRefExists } from '@/lib/media/use-asset-url';
+import { fetchProxiedMediaUrl } from '@/lib/media/proxy-media-cache';
 import { createLogger } from '@/lib/logger';
-import { isStageWriteStale, stageDeletionEpoch } from '@/lib/utils/deleted-stages';
-import type { MediaTask } from '@/lib/store/media-generation';
-import {
-  collectStageAssetRefs,
-  isAllocatedAssetRefReferencedBySurvivingDocument,
-  proveExclusiveAssetOwnership,
-  type StageAssetRefs,
-} from './collect-stage-asset-refs';
-import { isGeneratedMediaPlaceholder } from './media-ref';
-import { slideMediaReferenceSlots } from './slide-media-slots';
 
 const log = createLogger('MediaOrchestrator');
 
@@ -38,6 +23,15 @@ class MediaApiError extends Error {
     super(message);
     this.errorCode = errorCode;
   }
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException !== 'undefined') return new DOMException('Aborted', 'AbortError');
+  return Object.assign(new Error('Aborted'), { name: 'AbortError' });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw createAbortError();
 }
 
 /**
@@ -51,16 +45,6 @@ export async function generateMediaForOutlines(
 ): Promise<void> {
   const settings = useSettingsStore.getState();
   const store = useMediaGenerationStore.getState();
-  let currentDocument: AppDocument | null = null;
-  try {
-    currentDocument = (await accessDocument(stageId)).document;
-  } catch (error) {
-    // Resume filtering is an optimization. If document truth is temporarily
-    // unreadable, fall back to the original task-only skip logic and generate
-    // the batch instead of silently dropping it.
-    log.warn(`Could not read document ${stageId} while resuming media generation:`, error);
-  }
-  const currentRefs = collectStageAssetRefs(currentDocument, { mediaRows: [], audioRows: [] });
 
   // Collect all media requests
   const allRequests: MediaGenerationRequest[] = [];
@@ -70,21 +54,9 @@ export async function generateMediaForOutlines(
       // Filter by enabled flags
       if (mg.type === 'image' && !settings.imageGenerationEnabled) continue;
       if (mg.type === 'video' && !settings.videoGenerationEnabled) continue;
-      // A restored success task is keyed by its allocated id, so match its
-      // persisted placeholder as well as the direct task key.
-      const existing =
-        store.getTask(mg.elementId) ??
-        Object.values(store.tasks).find(
-          (task) => task.stageId === stageId && task.placeholderRef === mg.elementId,
-        );
+      // Skip already completed or permanently failed (restored from DB)
+      const existing = store.getTask(mg.elementId);
       if (existing?.status === 'done' || existing?.status === 'failed') continue;
-      const owningSceneExists =
-        currentDocument?.scenes.some(
-          (scene) => scene.outlineId === outline.id || scene.order === outline.order,
-        ) ?? false;
-      // A generated scene that no longer references the placeholder has already
-      // been reconciled. A not-yet-generated scene still needs its media work.
-      if (owningSceneExists && !currentRefs.referenced.has(mg.elementId)) continue;
       allRequests.push(mg);
     }
   }
@@ -106,17 +78,11 @@ export async function generateMediaForOutlines(
  */
 export async function retryMediaTask(
   elementId: string,
-  target:
-    | {
-        readonly elementId: string;
-        readonly sceneId?: string;
-        readonly slideId?: string;
-      }
-    | undefined = undefined,
+  _target?: { readonly elementId: string; readonly sceneId?: string; readonly slideId?: string },
 ): Promise<void> {
   const store = useMediaGenerationStore.getState();
   const task = store.getTask(elementId);
-  if (!task || (task.status !== 'failed' && task.status !== 'done')) return;
+  if (!task || task.status !== 'failed') return;
 
   // Check if the corresponding generation type is still enabled in global settings
   const settings = useSettingsStore.getState();
@@ -129,99 +95,24 @@ export async function retryMediaTask(
     return;
   }
 
-  const stageState = useStageStore.getState();
-  const scopedTarget = target
-    ? {
-        ...target,
-        sceneId: target.sceneId ?? stageState.currentSceneId ?? undefined,
-      }
-    : undefined;
+  // Remove persisted failure record from DB so a fresh result can be written
+  const dbKey = mediaFileKey(task.stageId, elementId);
+  await db.mediaFiles.delete(dbKey).catch(() => {});
 
-  const allocated = await assetRefExists(elementId);
-  const ownership = allocated
-    ? await proveExclusiveAssetOwnership(elementId, task.stageId)
-    : undefined;
-  const activePersistedRefs = ownership?.activePersistedRefs;
-  const exclusive = ownership?.exclusive ?? false;
-  const replaceAssetId = allocated && exclusive ? elementId : undefined;
-  const targetedFork = allocated ? !replaceAssetId : !!target;
-  if (targetedFork && (!scopedTarget?.sceneId || !scopedTarget.slideId)) {
-    log.warn(`Cannot fork media ${elementId} without a scene-and-slide target`);
-    return;
-  }
-  const posterAssetIds =
-    replaceAssetId && task.type === 'video'
-      ? await replaceablePosterRefs(
-          task.stageId,
-          currentPosterRefs(task.stageId, replaceAssetId),
-          activePersistedRefs!,
-        )
-      : [];
-
-  // Only legacy/failure placeholders are disposable. Keep them durable while
-  // the retry is in flight, then remove them after a successful allocation.
-  const failureRefs = !replaceAssetId
-    ? new Set([elementId, target?.elementId].filter(Boolean) as string[])
-    : undefined;
-
-  const progressKey = targetedFork ? scopedTarget!.elementId : elementId;
-  if (targetedFork) {
-    useMediaGenerationStore.setState((state) => {
-      const previousFork = state.tasks[progressKey];
-      return {
-        tasks: {
-          ...state.tasks,
-          [progressKey]: {
-            ...task,
-            elementId: progressKey,
-            placeholderRef: undefined,
-            status: 'pending',
-            objectUrl: undefined,
-            poster: undefined,
-            posterAssetId: undefined,
-            error: undefined,
-            errorCode: undefined,
-            retryCount: (previousFork?.retryCount ?? task.retryCount) + 1,
-          },
-        },
-      };
-    });
-  } else {
-    store.markPendingForRetry(elementId);
-  }
-  const generatedAssetId = await generateSingleMedia(
+  store.markPendingForRetry(elementId);
+  await generateSingleMedia(
     {
       type: task.type,
       prompt: task.prompt,
-      elementId: progressKey,
+      elementId: task.elementId,
       aspectRatio: task.params.aspectRatio as MediaGenerationRequest['aspectRatio'],
       style: task.params.style,
     },
     task.stageId,
-    undefined,
-    {
-      replaceAssetId,
-      replacePosterAssetIds: posterAssetIds,
-      target: targetedFork ? scopedTarget : undefined,
-      sourceRef: targetedFork ? elementId : undefined,
-      forkIfShared:
-        replaceAssetId && scopedTarget
-          ? { sourceRef: elementId, target: scopedTarget, sourceTask: task }
-          : undefined,
-    },
   );
-  if (generatedAssetId && failureRefs) {
-    for (const ref of failureRefs) {
-      const key = mediaFileKey(task.stageId, ref);
-      const row = await db.mediaFiles.get(key).catch(() => undefined);
-      if (row && (row.error || row.blob.size === 0)) {
-        await db.mediaFiles.delete(key).catch(() => {});
-      }
-    }
-  }
 }
 
-/** Build a retry target without assuming the active scene owns a slide canvas. */
+/** Build the renderer retry scope while classic retries remain placeholder-keyed. */
 export function mediaRetryTarget(
   elementId: string,
   sceneId: string | undefined,
@@ -236,667 +127,149 @@ export function mediaRetryTarget(
 
 // ==================== Internal ====================
 
-function rewriteSlideMediaRefs<T extends Slide | Whiteboard>(
-  slide: T,
-  oldRef: string,
-  assetId: string,
-  posterAssetId?: string,
-  target?: { readonly elementId: string },
-): { slide: T; changed: boolean } {
-  const rewritten = structuredClone(slide);
-  let changed = false;
-  const matchedVideos = new Set<PPTElement>();
-  const slots = [...slideMediaReferenceSlots(rewritten)];
-  for (const slot of slots) {
-    if (target && slot.element?.id !== target.elementId) continue;
-    if (slot.kind === 'video-poster' || slot.read() !== oldRef) continue;
-    if (slot.kind === 'background-image' || slot.kind === 'image-src') {
-      changed = true;
-      slot.write(assetId);
-      continue;
-    }
-    if (slot.element?.type === 'video') {
-      changed = true;
-      slot.write(assetId);
-      matchedVideos.add(slot.element);
-    }
-  }
-  if (posterAssetId && matchedVideos.size > 0) {
-    for (const slot of slots) {
-      if (slot.kind === 'video-poster' && slot.element && matchedVideos.has(slot.element)) {
-        slot.write(posterAssetId);
-      }
-    }
-  }
-  return changed ? { slide: rewritten, changed } : { slide, changed };
-}
-
-function posterRefsInSlide(slide: Slide | Whiteboard, mediaRef: string): string[] {
-  const refs: string[] = [];
-  const seen = new Set<PPTElement>();
-  for (const slot of slideMediaReferenceSlots(slide)) {
-    const element = slot.element;
-    if (!element || element.type !== 'video' || seen.has(element)) continue;
-    seen.add(element);
-    if ((element.src === mediaRef || element.mediaRef === mediaRef) && element.poster) {
-      refs.push(element.poster);
-    }
-  }
-  return refs;
-}
-
-function currentPosterRefs(stageId: string, mediaRef: string): string[] {
-  const state = useStageStore.getState();
-  if (state.stage?.id !== stageId) return [];
-  const refs = new Set<string>();
-  for (const scene of state.scenes) {
-    if (scene.content.type === 'slide') {
-      for (const ref of posterRefsInSlide(scene.content.canvas, mediaRef)) refs.add(ref);
-    }
-    for (const whiteboard of scene.whiteboards ?? []) {
-      for (const ref of posterRefsInSlide(whiteboard, mediaRef)) refs.add(ref);
-    }
-  }
-  for (const slide of state.stage.whiteboard ?? []) {
-    for (const ref of posterRefsInSlide(slide, mediaRef)) refs.add(ref);
-  }
-  return [...refs];
-}
-
-function rewriteStageAndScenes(
-  stage: Stage,
-  scenes: Scene[],
-  oldRef: string,
-  assetId: string,
-  posterAssetId?: string,
-  options: {
-    readonly target?: {
-      readonly elementId: string;
-      readonly sceneId?: string;
-      readonly slideId?: string;
-    };
-    readonly preserveManifestSource?: boolean;
-  } = {},
-): { stage: Stage; scenes: Scene[]; changed: boolean } {
-  let changed = false;
-  let targetSceneChanged = false;
-  const rewrittenScenes = scenes.map((scene): Scene => {
-    if (options.target?.sceneId && scene.id !== options.target.sceneId) return scene;
-    let nextScene = scene;
-    let matchedTarget = false;
-    const contentIsTargetSlide =
-      scene.content.type === 'slide' &&
-      (!options.target?.slideId || scene.content.canvas.id === options.target.slideId);
-    if (scene.content.type === 'slide' && contentIsTargetSlide) {
-      const rewritten = rewriteSlideMediaRefs(
-        scene.content.canvas,
-        oldRef,
-        assetId,
-        posterAssetId,
-        options.target ? { elementId: options.target.elementId } : undefined,
-      );
-      if (rewritten.changed) {
-        changed = true;
-        matchedTarget = true;
-        const { type: _type, content: _content, ...core } = nextScene;
-        void _type;
-        void _content;
-        nextScene = makeScene(core, { ...scene.content, canvas: rewritten.slide });
-      }
-    }
-    if (scene.whiteboards) {
-      let sceneWhiteboardsChanged = false;
-      const hasExactWhiteboard =
-        !!options.target?.slideId &&
-        scene.whiteboards.some((slide) => slide.id === options.target!.slideId);
-      const whiteboards = scene.whiteboards.map((slide) => {
-        if (options.target && matchedTarget) return slide;
-        if (hasExactWhiteboard && slide.id !== options.target!.slideId) return slide;
-        const rewritten = rewriteSlideMediaRefs(
-          slide,
-          oldRef,
-          assetId,
-          posterAssetId,
-          options.target ? { elementId: options.target.elementId } : undefined,
-        );
-        sceneWhiteboardsChanged ||= rewritten.changed;
-        matchedTarget ||= rewritten.changed;
-        return rewritten.slide;
-      });
-      if (sceneWhiteboardsChanged) {
-        changed = true;
-        nextScene = { ...nextScene, whiteboards } as Scene;
-      }
-    }
-    targetSceneChanged ||= matchedTarget;
-    return nextScene;
-  });
-
-  let stageWhiteboardChanged = false;
-  let matchedStageWhiteboard = false;
-  const hasExactStageWhiteboard =
-    !!options.target?.slideId &&
-    !!stage.whiteboard?.some((slide) => slide.id === options.target!.slideId);
-  // A missed scene target is not permission to match a stage-whiteboard
-  // element by id alone. Targeted retries may fall through only when they name
-  // the exact stage-whiteboard slide; untargeted reconciliation still scans all.
-  const maySearchStageWhiteboard =
-    !options.target || (!targetSceneChanged && hasExactStageWhiteboard);
-  const whiteboard = stage.whiteboard?.map((slide) => {
-    if (!maySearchStageWhiteboard || (options.target && matchedStageWhiteboard)) return slide;
-    if (hasExactStageWhiteboard && slide.id !== options.target!.slideId) return slide;
-    const rewritten = rewriteSlideMediaRefs(
-      slide,
-      oldRef,
-      assetId,
-      posterAssetId,
-      options.target ? { elementId: options.target.elementId } : undefined,
-    );
-    stageWhiteboardChanged ||= rewritten.changed;
-    matchedStageWhiteboard ||= rewritten.changed;
-    changed ||= rewritten.changed;
-    return rewritten.slide;
-  });
-
-  let videoManifest = stage.videoManifest;
-  const manifestEntry = videoManifest?.[oldRef];
-  if (manifestEntry && videoManifest && (!options.target || changed)) {
-    if (options.preserveManifestSource) {
-      videoManifest = { ...videoManifest, [assetId]: manifestEntry };
-    } else {
-      const { [oldRef]: _oldEntry, ...remaining } = videoManifest;
-      void _oldEntry;
-      videoManifest = { ...remaining, [assetId]: manifestEntry };
-    }
-    changed = true;
-  }
-
-  const stageChanged = stageWhiteboardChanged || videoManifest !== stage.videoManifest;
-  return {
-    stage: stageChanged
-      ? { ...stage, ...(whiteboard ? { whiteboard } : {}), videoManifest }
-      : stage,
-    scenes: rewrittenScenes,
-    changed,
-  };
-}
-
-function rewriteDocumentMediaRef(
-  document: AppDocument,
-  oldRef: string,
-  assetId: string,
-  posterAssetId?: string,
-  options: {
-    readonly target?: {
-      readonly elementId: string;
-      readonly sceneId?: string;
-      readonly slideId?: string;
-    };
-    readonly preserveManifestSource?: boolean;
-  } = {},
-): AppDocument {
-  const rewritten = rewriteStageAndScenes(
-    document.stage,
-    document.scenes,
-    oldRef,
-    assetId,
-    posterAssetId,
-    options,
-  );
-  return rewritten.changed
-    ? { ...document, stage: rewritten.stage, scenes: rewritten.scenes }
-    : document;
-}
-
-/**
- * Reconcile media that completed before its generated scene was inserted.
- * Re-keyed tasks retain the placeholder they replaced, so insertion can make
- * the scene and video manifest point at the already-durable allocated ids.
- */
-export function reconcileCompletedMediaForScene(
-  scene: Scene,
-  stage: Stage,
-  tasks: Record<string, MediaTask> = useMediaGenerationStore.getState().tasks,
-): { scene: Scene; stage: Stage } {
-  let nextScene = scene;
-  let nextStage = stage;
-  for (const task of Object.values(tasks)) {
-    if (
-      task.stageId !== stage.id ||
-      task.status !== 'done' ||
-      !isGeneratedMediaPlaceholder(task.placeholderRef)
-    ) {
-      continue;
-    }
-    const rewritten = rewriteStageAndScenes(
-      nextStage,
-      [nextScene],
-      task.placeholderRef,
-      task.elementId,
-      task.posterAssetId,
-    );
-    nextStage = rewritten.stage;
-    nextScene = rewritten.scenes[0];
-  }
-  return { scene: nextScene, stage: nextStage };
-}
-
-async function persistDocumentMediaRef(
-  stageId: string,
-  oldRef: string,
-  assetId: string,
-  posterAssetId?: string,
-  options: {
-    readonly target?: {
-      readonly elementId: string;
-      readonly sceneId?: string;
-      readonly slideId?: string;
-    };
-    readonly preserveManifestSource?: boolean;
-  } = {},
-): Promise<ReadonlySet<string>> {
-  const capturedEpoch = stageDeletionEpoch(stageId);
-  const committed = new Set<string>();
-  await mutateDocument(stageId, async (document, store) => {
-    if (!document) throw new Error(`Cannot rewrite media in missing document ${stageId}`);
-    const rewritten = rewriteDocumentMediaRef(document, oldRef, assetId, posterAssetId, options);
-    if (isStageWriteStale(stageId, capturedEpoch)) return;
-    if (rewritten !== document) await store.saveDocument(rewritten);
-    const refs = collectStageAssetRefs(rewritten, { mediaRows: [], audioRows: [] }).document;
-    if (refs.has(assetId)) committed.add(assetId);
-    if (posterAssetId && refs.has(posterAssetId)) committed.add(posterAssetId);
-  });
-
-  if (isStageWriteStale(stageId, capturedEpoch)) return committed;
-
-  // The document store is authoritative, but the active editor has a separate
-  // in-memory aggregate. Mirror the committed rewrite and queue it as dirty so
-  // an older debounced snapshot cannot later restore the placeholder.
-  const state = useStageStore.getState();
-  if (state.stage?.id !== stageId) return committed;
-  const rewritten = rewriteStageAndScenes(
-    state.stage,
-    state.scenes,
-    oldRef,
-    assetId,
-    posterAssetId,
-    options,
-  );
-  if (!rewritten.changed) return committed;
-  useStageStore.setState({ stage: rewritten.stage, scenes: rewritten.scenes });
-  markStagePersistenceDirty([
-    { kind: 'stage' },
-    ...rewritten.scenes
-      .filter((scene, index) => scene !== state.scenes[index])
-      .map((scene) => ({ kind: 'scene' as const, sceneId: scene.id })),
-  ]);
-  return committed;
-}
-
-interface GeneratedMediaDetails {
-  width?: number;
-  height?: number;
-  duration?: number;
-}
-
-async function replaceablePosterRefs(
-  stageId: string,
-  refs: string[],
-  activePersistedRefs: StageAssetRefs,
-): Promise<string[]> {
-  if (refs.length === 0) return [];
-  if (refs.some((ref) => (activePersistedRefs.referenceCounts.get(ref) ?? 0) !== 1)) return [];
-  const shared = await Promise.all(
-    refs.map((ref) => isAllocatedAssetRefReferencedBySurvivingDocument(ref, stageId)),
-  );
-  if (shared.some(Boolean)) return [];
-  const found = await Promise.all(refs.map((ref) => assetRefExists(ref)));
-  return found.every(Boolean) ? refs : [];
-}
-
-function generationMeta(
-  req: MediaGenerationRequest,
-  contentType: string,
-  details: GeneratedMediaDetails,
-): AssetMeta {
-  const settings = useSettingsStore.getState();
-  const providerId = req.type === 'image' ? settings.imageProviderId : settings.videoProviderId;
-  const modelId = req.type === 'image' ? settings.imageModelId : settings.videoModelId;
-  return {
-    contentType,
-    mediaType: req.type,
-    prompt: req.prompt,
-    params: {
-      aspectRatio: req.aspectRatio,
-      style: req.style,
-    },
-    ...(details.width !== undefined && details.height !== undefined
-      ? { dimensions: { width: details.width, height: details.height } }
-      : {}),
-    ...(details.duration !== undefined ? { duration: details.duration } : {}),
-    provider: { id: providerId, model: modelId },
-  };
-}
-
 async function generateSingleMedia(
   req: MediaGenerationRequest,
   stageId: string,
   abortSignal?: AbortSignal,
-  replacement: {
-    readonly replaceAssetId?: string;
-    readonly replacePosterAssetIds?: readonly string[];
-    readonly target?: {
-      readonly elementId: string;
-      readonly sceneId?: string;
-      readonly slideId?: string;
-    };
-    readonly sourceRef?: string;
-    readonly forkIfShared?: {
-      readonly sourceRef: string;
-      readonly target: {
-        readonly elementId: string;
-        readonly sceneId?: string;
-        readonly slideId?: string;
-      };
-      readonly sourceTask: MediaTask;
-    };
-  } = {},
-): Promise<string | undefined> {
-  const { forkIfShared } = replacement;
-  let activeReplaceAssetId = replacement.replaceAssetId;
-  let activeReplacePosterAssetIds = replacement.replacePosterAssetIds ?? [];
-  let activeTarget = replacement.target;
-  let activeSourceRef = replacement.sourceRef;
-  let progressElementId = req.elementId;
+): Promise<void> {
   const store = useMediaGenerationStore.getState();
   store.markGenerating(req.elementId);
-  const placeholderRef =
-    activeSourceRef === undefined
-      ? (store.getTask(req.elementId)?.placeholderRef ??
-        (isGeneratedMediaPlaceholder(req.elementId) ? req.elementId : undefined))
-      : undefined;
-  const documentRef = activeSourceRef ?? req.elementId;
-  let poolReplacementCommitted = false;
-  const freshAllocations = new Set<string>();
 
   try {
-    let resultUrl: string;
-    let posterUrl: string | undefined;
-    let mimeType: string;
-    let details: GeneratedMediaDetails;
-
-    if (req.type === 'image') {
-      const result = await callImageApi(req, abortSignal);
-      resultUrl = result.url;
-      mimeType = 'image/png';
-      details = { width: result.width, height: result.height };
-    } else {
-      const result = await callVideoApi(req, abortSignal);
-      resultUrl = result.url;
-      posterUrl = result.poster;
-      mimeType = 'video/mp4';
-      details = { width: result.width, height: result.height, duration: result.duration };
-    }
-
-    if (abortSignal?.aborted) return;
-
-    // Fetch blob from URL
-    const blob = await fetchAsBlob(resultUrl);
-    const posterBlob = posterUrl ? await fetchAsBlob(posterUrl).catch(() => undefined) : undefined;
-
-    const contentType = blob.type || mimeType;
-    const meta = generationMeta(req, contentType, details);
-
-    // The generation request is asynchronous, so the start-time ownership
-    // proof may be stale. Re-run the repository-wide proof immediately before
-    // the first pool write and fail closed into the target-scoped fork path.
-    if (activeReplaceAssetId) {
-      const ownership = await proveExclusiveAssetOwnership(activeReplaceAssetId, stageId);
-      if (!ownership.exclusive) {
-        if (!forkIfShared?.target.sceneId || !forkIfShared.target.slideId) {
-          throw new MediaApiError(
-            'Media ownership changed and the retry target is no longer safely scoped',
-            'TARGET_MISSING',
-          );
-        }
-        const generatingTask = useMediaGenerationStore.getState().tasks[req.elementId];
-        activeSourceRef = forkIfShared.sourceRef;
-        activeTarget = forkIfShared.target;
-        progressElementId = forkIfShared.target.elementId;
-        activeReplaceAssetId = undefined;
-        activeReplacePosterAssetIds = [];
-        useMediaGenerationStore.setState((state) => ({
-          tasks: {
-            ...state.tasks,
-            [forkIfShared.sourceRef]: forkIfShared.sourceTask,
-            ...(generatingTask
-              ? {
-                  [progressElementId]: {
-                    ...generatingTask,
-                    elementId: progressElementId,
-                    placeholderRef: undefined,
-                    objectUrl: undefined,
-                    poster: undefined,
-                    posterAssetId: undefined,
-                  },
-                }
-              : {}),
-          },
-        }));
-      } else if (req.type === 'video' && ownership.activePersistedRefs) {
-        activeReplacePosterAssetIds = await replaceablePosterRefs(
-          stageId,
-          currentPosterRefs(stageId, activeReplaceAssetId),
-          ownership.activePersistedRefs,
-        );
-      }
-    }
-
-    // Crash-safety invariant: pool bytes first, the Part 2 compatibility
-    // double-write second, and the document rewrite last. A failed step leaves
-    // the document on its old reference, never pointing at missing bytes.
-    const assetId = activeReplaceAssetId ?? (await putAsset(blob, meta));
-    if (!activeReplaceAssetId) freshAllocations.add(assetId);
-    if (activeReplaceAssetId) {
-      await replaceAsset(activeReplaceAssetId, blob, meta);
-      poolReplacementCommitted = true;
-    }
-    const posterMeta: AssetMeta | undefined = posterBlob
-      ? {
-          ...meta,
-          contentType: posterBlob.type || 'image/jpeg',
-          mediaType: 'video-poster',
-          parentRef: assetId,
-        }
-      : undefined;
-    let posterAssetId: string | undefined;
-    if (posterBlob && posterMeta) {
-      if (activeReplaceAssetId && activeReplacePosterAssetIds.length > 0) {
-        await Promise.all(
-          activeReplacePosterAssetIds.map((ref) => replaceAsset(ref, posterBlob, posterMeta)),
-        );
-      } else {
-        posterAssetId = await putAsset(posterBlob, posterMeta);
-        freshAllocations.add(posterAssetId);
-      }
-    }
-
-    // Dexie remains a deliberate double-write until Part 3 converges the three
-    // export paths, thumbnail restoration, and import/export onto the pool.
-    const createdAt = Date.now();
-    const params = JSON.stringify({
+    const paramsJson = JSON.stringify({
       aspectRatio: req.aspectRatio,
       style: req.style,
     });
-    try {
+
+    if (req.type === 'image') {
+      const result = await callImageApi(req, stageId, abortSignal);
+
+      // CDN path: server already uploaded to OSS
+      if (result.ossUrl) {
+        throwIfAborted(abortSignal);
+        await db.mediaFiles.put({
+          id: mediaFileKey(stageId, req.elementId),
+          stageId,
+          type: 'image',
+          blob: new Blob([]),
+          mimeType: 'image/png',
+          size: 0,
+          ossKey: result.ossUrl,
+          prompt: req.prompt,
+          params: paramsJson,
+          createdAt: Date.now(),
+        });
+        useMediaGenerationStore.getState().markDone(req.elementId, result.ossUrl);
+        return;
+      }
+
+      // Fallback: fetch blob via proxy-media
+      throwIfAborted(abortSignal);
+      const blob = await fetchAsBlob(result.url);
       await db.mediaFiles.put({
-        id: mediaFileKey(stageId, assetId),
+        id: mediaFileKey(stageId, req.elementId),
         stageId,
-        type: req.type,
+        type: 'image',
         blob,
-        mimeType: contentType,
+        mimeType: 'image/png',
+        size: blob.size,
+        prompt: req.prompt,
+        params: paramsJson,
+        createdAt: Date.now(),
+      });
+      const objectUrl = URL.createObjectURL(blob);
+      useMediaGenerationStore.getState().markDone(req.elementId, objectUrl);
+    } else {
+      const result = await callVideoApi(req, abortSignal);
+
+      // CDN path: server already uploaded to OSS
+      if (result.ossUrl) {
+        throwIfAborted(abortSignal);
+        await db.mediaFiles.put({
+          id: mediaFileKey(stageId, req.elementId),
+          stageId,
+          type: 'video',
+          blob: new Blob([]),
+          mimeType: 'video/mp4',
+          size: 0,
+          ossKey: result.ossUrl,
+          posterOssKey: result.posterOssUrl,
+          prompt: req.prompt,
+          params: paramsJson,
+          createdAt: Date.now(),
+        });
+        useMediaGenerationStore
+          .getState()
+          .markDone(req.elementId, result.ossUrl, result.posterOssUrl);
+        return;
+      }
+
+      // Fallback: fetch blob via proxy-media
+      throwIfAborted(abortSignal);
+      const blob = await fetchAsBlob(result.url);
+      const posterBlob = result.poster
+        ? await fetchAsBlob(result.poster).catch(() => undefined)
+        : undefined;
+      await db.mediaFiles.put({
+        id: mediaFileKey(stageId, req.elementId),
+        stageId,
+        type: 'video',
+        blob,
+        mimeType: 'video/mp4',
         size: blob.size,
         poster: posterBlob,
         prompt: req.prompt,
-        params,
-        placeholderRef,
-        createdAt,
+        params: paramsJson,
+        createdAt: Date.now(),
       });
-
-      // Posters are independently allocated assets. Keep a compatibility row
-      // under each poster's own id as well as the legacy copy on the video row.
-      if (posterBlob) {
-        const posterIds = posterAssetId ? [posterAssetId] : activeReplacePosterAssetIds;
-        await Promise.all(
-          posterIds.map((posterId) =>
-            db.mediaFiles.put({
-              id: mediaFileKey(stageId, posterId),
-              stageId,
-              type: 'image',
-              blob: posterBlob,
-              mimeType: posterBlob.type || 'image/jpeg',
-              size: posterBlob.size,
-              prompt: req.prompt,
-              params,
-              createdAt,
-            }),
-          ),
-        );
-      }
-    } catch (error) {
-      if (activeReplaceAssetId && poolReplacementCommitted) {
-        throw new MediaApiError(
-          `Asset pool replacement succeeded but the compatibility media store lagged: ${error instanceof Error ? error.message : String(error)}`,
-          'MEDIA_COMPATIBILITY_STORE_LAGGED',
-        );
-      }
-      throw error;
+      const objectUrl = URL.createObjectURL(blob);
+      const posterObjectUrl = posterBlob ? URL.createObjectURL(posterBlob) : undefined;
+      useMediaGenerationStore.getState().markDone(req.elementId, objectUrl, posterObjectUrl);
     }
-
-    if (!activeReplaceAssetId || posterAssetId) {
-      const committed = await persistDocumentMediaRef(
-        stageId,
-        documentRef,
-        assetId,
-        posterAssetId,
-        {
-          target: activeTarget,
-          preserveManifestSource: activeSourceRef !== undefined,
-        },
-      );
-      for (const ref of committed) freshAllocations.delete(ref);
-      if (activeSourceRef !== undefined && !committed.has(assetId)) {
-        throw new MediaApiError(
-          'The selected media retry target no longer exists',
-          'TARGET_MISSING',
-        );
-      }
-    }
-
-    if (!activeReplaceAssetId && activeSourceRef === undefined) {
-      // Close the late-scene window: a scene inserted after the first rewrite
-      // is reconciled under the same document lock. Do not re-key the task
-      // until this final rewrite succeeds: rollback must retain the placeholder
-      // task and leave no completed task capable of resurrecting removed bytes.
-      const committed = await persistDocumentMediaRef(
-        stageId,
-        documentRef,
-        assetId,
-        posterAssetId,
-        {
-          target: activeTarget,
-          preserveManifestSource: false,
-        },
-      );
-      for (const ref of committed) freshAllocations.delete(ref);
-    }
-
-    // Publish completion only after every document reconciliation succeeds.
-    const objectUrl = URL.createObjectURL(blob);
-    const posterObjectUrl = posterBlob ? URL.createObjectURL(posterBlob) : undefined;
-    if (activeReplaceAssetId) {
-      useMediaGenerationStore.getState().markDone(assetId, objectUrl, posterObjectUrl);
-    } else if (activeSourceRef !== undefined) {
-      useMediaGenerationStore.setState((state) => {
-        const progress = state.tasks[progressElementId];
-        if (!progress) return state;
-        const tasks = { ...state.tasks };
-        delete tasks[progressElementId];
-        tasks[assetId] = {
-          ...progress,
-          elementId: assetId,
-          placeholderRef: undefined,
-          status: 'done',
-          objectUrl,
-          poster: posterObjectUrl,
-          posterAssetId,
-          error: undefined,
-          errorCode: undefined,
-        };
-        return {
-          tasks,
-        };
-      });
-    } else {
-      useMediaGenerationStore
-        .getState()
-        .rekeyDone(req.elementId, assetId, objectUrl, posterObjectUrl, posterAssetId);
-    }
-    return assetId;
   } catch (err) {
-    // A document commit can succeed before a later reconciliation fails. Treat
-    // those refs as committed even if the failure interrupted the return path.
-    const latest = await accessDocument(stageId).catch(() => undefined);
-    const protectedRefs = latest?.document
-      ? collectStageAssetRefs(latest.document, { mediaRows: [], audioRows: [] }).document
-      : new Set<string>();
-    for (const ref of freshAllocations) {
-      if (protectedRefs.has(ref)) continue;
-      await removeAsset(ref).catch(() => undefined);
-      await db.mediaFiles.delete(mediaFileKey(stageId, ref)).catch(() => undefined);
+    if (abortSignal?.aborted) {
+      // A submitted video MaaS task keeps running to a billable terminal state
+      // server-side even after this client stops polling. Mark either media
+      // task retryable instead of leaving it stuck in `generating`; note that
+      // retrying a video submits a second job rather than resuming the first.
+      const abortedMessage =
+        req.type === 'video'
+          ? 'Video generation polling was aborted; retry to submit a new job'
+          : 'Image generation was aborted; retry to submit a new request';
+      useMediaGenerationStore.getState().markFailed(req.elementId, abortedMessage);
+      return;
     }
-    if (abortSignal?.aborted) return;
     const message = err instanceof Error ? err.message : String(err);
     const errorCode = err instanceof MediaApiError ? err.errorCode : undefined;
     log.error(`Failed ${req.elementId}:`, message);
-    const failedRef = activeReplaceAssetId ?? progressElementId;
-    useMediaGenerationStore.getState().markFailed(failedRef, message, errorCode);
+    useMediaGenerationStore.getState().markFailed(req.elementId, message, errorCode);
 
-    // Never overwrite a usable same-id compatibility row with an empty failure
-    // marker. The live task still carries the retryable error while last-good
-    // bytes remain available through Dexie/the pool.
-    if (errorCode || activeReplaceAssetId) {
-      const key = mediaFileKey(stageId, failedRef);
-      const existing = await db.mediaFiles.get(key).catch(() => undefined);
-      if (!existing || existing.error || existing.blob.size === 0) {
-        await db.mediaFiles
-          .put({
-            id: key,
-            stageId,
-            type: req.type,
-            blob: new Blob(), // empty placeholder
-            mimeType: req.type === 'image' ? 'image/png' : 'video/mp4',
-            size: 0,
-            prompt: req.prompt,
-            params: JSON.stringify({
-              aspectRatio: req.aspectRatio,
-              style: req.style,
-            }),
-            error: message,
-            errorCode,
-            placeholderRef,
-            createdAt: Date.now(),
-          })
-          .catch(() => {}); // best-effort
-      }
+    // Persist non-retryable failures to IndexedDB so they survive page refresh
+    if (errorCode) {
+      await db.mediaFiles
+        .put({
+          id: mediaFileKey(stageId, req.elementId),
+          stageId,
+          type: req.type,
+          blob: new Blob(), // empty placeholder
+          mimeType: req.type === 'image' ? 'image/png' : 'video/mp4',
+          size: 0,
+          prompt: req.prompt,
+          params: JSON.stringify({ aspectRatio: req.aspectRatio, style: req.style }),
+          error: message,
+          errorCode,
+          createdAt: Date.now(),
+        })
+        .catch(() => {}); // best-effort
     }
   }
 }
 
 async function callImageApi(
   req: MediaGenerationRequest,
+  stageId: string,
   abortSignal?: AbortSignal,
-): Promise<{ url: string; width?: number; height?: number }> {
+): Promise<{ url: string; ossUrl?: string }> {
   const settings = useSettingsStore.getState();
   const providerConfig = settings.imageProvidersConfig?.[settings.imageProviderId];
 
@@ -913,6 +286,7 @@ async function callImageApi(
       prompt: req.prompt,
       aspectRatio: req.aspectRatio,
       style: req.style,
+      stageId,
     }),
     signal: abortSignal,
   });
@@ -926,11 +300,12 @@ async function callImageApi(
   if (!data.success)
     throw new MediaApiError(data.error || 'Image generation failed', data.errorCode);
 
-  // Result may have url or base64
+  // Result may have ossUrl (CDN direct), url, or base64
+  const ossUrl = data.result?.ossUrl as string | undefined;
   const url =
     data.result?.url || (data.result?.base64 ? `data:image/png;base64,${data.result.base64}` : '');
-  if (!url) throw new Error('No image URL in response');
-  return { url, width: data.result?.width, height: data.result?.height };
+  if (!ossUrl && !url) throw new Error('No image URL in response');
+  return { url, ossUrl };
 }
 
 async function callVideoApi(
@@ -939,6 +314,8 @@ async function callVideoApi(
 ): Promise<{
   url: string;
   poster?: string;
+  ossUrl?: string;
+  posterOssUrl?: string;
   width?: number;
   height?: number;
   duration?: number;
@@ -976,6 +353,8 @@ async function callVideoApi(
   return {
     url,
     poster: data.result?.poster,
+    ossUrl: data.result?.ossUrl,
+    posterOssUrl: data.result?.posterOssUrl,
     width: data.result?.width,
     height: data.result?.height,
     duration: data.result?.duration,
@@ -988,13 +367,11 @@ async function fetchAsBlob(url: string): Promise<Blob> {
     const res = await fetch(url);
     return res.blob();
   }
-  // For remote URLs, proxy through our server to bypass CORS restrictions
+  // For remote URLs, proxy through our server to bypass CORS restrictions.
+  // Routed through the shared proxy-media negative cache so a permanently
+  // failed URL (4xx) is not re-fetched by retries or later generation passes.
   if (url.startsWith('http://') || url.startsWith('https://')) {
-    const res = await fetch('/api/proxy-media', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url }),
-    });
+    const res = await fetchProxiedMediaUrl(url);
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
       throw new Error(data.error || `Proxy fetch failed: ${res.status}`);

--- a/lib/media/proxy-media-cache.ts
+++ b/lib/media/proxy-media-cache.ts
@@ -1,0 +1,390 @@
+/**
+ * Session-scoped negative cache for /api/proxy-media responses.
+ *
+ * The proxy contract (`app/api/proxy-media/route.ts`) forwards upstream 4xx
+ * as-is and treats most of them as PERMANENT: the upstream asserted the bytes
+ * are gone or not reachable, so re-requesting the same URL later in this
+ * session cannot succeed. Client callers that re-run on every load/play tick
+ * (legacy asset conversion, the media-generation blob fallback, the exporters)
+ * had no memory of that verdict, so a course whose TTS URLs live on an
+ * unreachable origin hammered the proxy with the same dead URLs forever.
+ * This module is the missing memory, shared by every caller that POSTs to
+ * /api/proxy-media:
+ *
+ * - 4xx: the URL is permanently failed for the session; later calls
+ *   short-circuit to a synthetic response carrying the recorded status and
+ *   never touch the network. EXCEPT the retryable 4xx set (408 request
+ *   timeout, 425 too early, 429 rate limited): those are transient failures —
+ *   a rate limit or a temporarily unready origin can recover, so they take
+ *   the same backoff path as 5xx instead of poisoning the URL for the rest
+ *   of the session.
+ * - 5xx / network errors: stay retryable (the caller still receives the
+ *   failure and may retry), but repeated attempts are throttled with a
+ *   simple exponential backoff and a session cap of
+ *   {@link MAX_TRANSIENT_ATTEMPTS} real requests per URL. Calls that arrive
+ *   inside a backoff window short-circuit without a request, and after the
+ *   cap the URL is blocked for the rest of the session. This is a transient
+ *   cap, not a permanent verdict: a page refresh starts a fresh session and
+ *   a URL that recovered is probed again.
+ * - A shared request that was torn down before settling (every caller left,
+ *   nobody received a result — e.g. every caller timed out) records ONE
+ *   transient failure (status 0), so a dead/slow URL enters the backoff and
+ *   the attempt cap instead of being re-fired back-to-back by the next
+ *   caller. A caller that aborts while OTHERS still wait records nothing.
+ *
+ * Concurrent in-flight requests for the SAME URL share ONE real request (the
+ * promise is deduped per URL), so a burst of callers cannot blow through the
+ * attempt cap or the anti-abuse intent before any failure state is recorded.
+ * The shared request is owned by the module, not by any single caller: it runs
+ * on an INTERNAL AbortController, each caller races only its OWN signal, and
+ * the internal fetch is aborted only when the last caller leaves. A caller's
+ * cancellation therefore rejects just that caller and — while others still
+ * wait — is never recorded as a failure (no backoff/cap poison for the URL).
+ *
+ * Success responses are BUFFERED exactly once (the proxy caps a single
+ * resource at 25 MiB, so one in-memory copy per shared request is the bounded
+ * price): the shared request resolves to the bytes and the module builds ONE
+ * shared Blob over that single copy. Every consumer synthesizes its own fresh
+ * Response over the SAME Blob — undici reads a Blob body lazily by reference,
+ * so constructing N consumer Responses adds no byte copies: N concurrent
+ * consumers cost one body copy, not N, with no clone()/tee chain and no
+ * per-consumer stream accumulation. The payload lives ONLY inside its
+ * in-flight entry: it is handed to the joined consumers and, once the last
+ * consumer leaves, the entry is dropped and the module references no body
+ * bytes. A caller arriving AFTER the shared request settled starts a FRESH
+ * fetch — deduplication covers the concurrency window only and never acts as
+ * a response cache. Failure responses are never buffered: every consumer
+ * receives a synthesized error response carrying the recorded status and the
+ * same JSON body the short-circuit path uses, so the caller-visible contract
+ * (status + error classification) is identical whether the verdict was just
+ * recorded or already cached.
+ *
+ * Deliberately in-memory only: nothing is written to IndexedDB, localStorage,
+ * or any server, so a refresh resets the whole cache (and with it the right
+ * to retry a URL that may have recovered).
+ */
+
+interface TransientState {
+  attempts: number;
+  blockedUntil: number;
+}
+
+/** The shared outcome of one real proxied request, buffered for every consumer. */
+interface SharedMediaResult {
+  status: number;
+  /**
+   * The 2xx body as ONE shared Blob — buffered exactly once, then referenced
+   * lazily by every consumer's Response (undici does not copy a Blob body at
+   * `new Response(blob, …)` construction). Absent for non-2xx (synthesized).
+   */
+  blob?: Blob;
+  /** content-type / content-length subset preserved from the real response. */
+  headers: Record<string, string>;
+}
+
+/** A shared real request for one URL plus the callers currently joined to it. */
+interface InFlightEntry {
+  promise: Promise<SharedMediaResult>;
+  /** Internal controller: no caller's signal is ever forwarded to the fetch. */
+  controller: AbortController;
+  /** Number of callers still waiting on (or tearing down) this entry. */
+  consumers: number;
+  /** Whether the shared request has settled (resolve or reject). */
+  settled: boolean;
+  /**
+   * The settled result, once the shared request resolved. A 2xx payload (the
+   * shared Blob) is referenced ONLY here while the entry is joined: it is
+   * handed to the waiting consumers and, when the last consumer leaves and
+   * the entry is dropped, the module holds no body bytes — there is no
+   * module-level response cache beyond the entry.
+   */
+  result?: SharedMediaResult;
+}
+
+const permanentFailures = new Map<string, number>();
+const transientFailures = new Map<string, TransientState>();
+/** Real requests currently in flight, keyed by URL: concurrent callers join one. */
+const inFlightRequests = new Map<string, InFlightEntry>();
+
+/** Real network attempts allowed per URL for transient (5xx/network) failures. */
+export const MAX_TRANSIENT_ATTEMPTS = 3;
+
+/**
+ * 4xx statuses that can recover before the page is reloaded: the upstream is
+ * not saying the bytes are gone, only that it cannot serve them right now
+ * (request timeout, too early, rate limited). They take the TRANSIENT path;
+ * every other 4xx remains a permanent verdict.
+ */
+const TRANSIENT_4XX_STATUSES: ReadonlySet<number> = new Set([408, 425, 429]);
+
+const BACKOFF_BASE_MS = 400;
+const BACKOFF_MAX_MS = 4_000;
+
+/** Test hook: forget every recorded verdict, as a page refresh would. */
+export function resetProxyMediaFailureCache(): void {
+  permanentFailures.clear();
+  transientFailures.clear();
+}
+
+/** The recorded permanent (4xx) status for a URL, or undefined when none. */
+export function proxyMediaPermanentStatus(url: string): number | undefined {
+  return permanentFailures.get(url);
+}
+
+/**
+ * Whether a transient (5xx/network) failure currently blocks a real request
+ * for this URL: the exponential backoff window is still open, or the
+ * per-session attempt cap was reached.
+ */
+export function isProxyMediaTransientBlocked(url: string, now = Date.now()): boolean {
+  const state = transientFailures.get(url);
+  if (!state) return false;
+  return state.attempts >= MAX_TRANSIENT_ATTEMPTS || state.blockedUntil > now;
+}
+
+/**
+ * Record a proxy failure for a URL.
+ *
+ * - 4xx is permanent per the proxy contract, EXCEPT the retryable set
+ *   (408/425/429) which the upstream may recover from before a reload.
+ * - Anything else (5xx, retryable 4xx, or `status === 0` for a network-level
+ *   failure) is transient: it counts toward the per-URL cap and re-arms the
+ *   backoff window for the next attempt.
+ */
+export function recordProxyMediaFailure(url: string, status: number, now = Date.now()): void {
+  if (status >= 400 && status < 500 && !TRANSIENT_4XX_STATUSES.has(status)) {
+    permanentFailures.set(url, status);
+    return;
+  }
+  const state = transientFailures.get(url) ?? { attempts: 0, blockedUntil: 0 };
+  state.attempts += 1;
+  if (state.attempts >= MAX_TRANSIENT_ATTEMPTS) {
+    state.blockedUntil = Number.POSITIVE_INFINITY;
+  } else {
+    const backoffMs = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * 2 ** (state.attempts - 1));
+    state.blockedUntil = now + backoffMs;
+  }
+  transientFailures.set(url, state);
+}
+
+/**
+ * Test hook: how many 2xx body payloads the module currently holds. A shared
+ * request's payload (its Blob) lives ONLY inside its in-flight entry — handed
+ * to the joined consumers, dropped when the last consumer leaves — so this
+ * count is the module's ENTIRE body retention: after every consumer of a URL
+ * has finished, its entry is gone and this is 0. A count, never the bytes:
+ * tests assert that nothing is retained, they do not read buffered bodies.
+ */
+export function proxyMediaRetainedBodyCount(): number {
+  let count = 0;
+  for (const entry of inFlightRequests.values()) {
+    if (entry.result?.blob) count += 1;
+  }
+  return count;
+}
+
+/** Mimic the proxy's JSON error body so cached verdicts behave like real ones. */
+function syntheticProxyError(status: number): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      errorCode: 'UPSTREAM_ERROR',
+      error: `Upstream returned ${status}`,
+    }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+/**
+ * POST one media URL through the same-origin /api/proxy-media, honoring the
+ * session negative cache. Every proxy-media caller routes through this
+ * function so a permanent 4xx verdict is recorded once and shared by all of
+ * them (conversion, generation fallback, exports), and a transient failure
+ * cannot be re-fired back-to-back by whichever caller loop is running.
+ *
+ * Concurrent calls for the SAME URL are deduped onto one in-flight request
+ * (they share the same promise): a burst of callers can never fire N real
+ * requests before any failure state is recorded, so the attempt cap and the
+ * anti-abuse intent hold under true concurrency, not just serial loops.
+ *
+ * The shared request runs on an INTERNAL AbortController — no caller's signal
+ * is forwarded to it. A caller's own `init.signal` is raced per call: aborting
+ * it rejects ONLY that caller with an AbortError, other consumers are
+ * untouched, and the internal fetch is aborted only when the last consumer
+ * leaves (refcount zero). While other callers still wait, a cancellation is
+ * never recorded as a failure. When the LAST caller leaves while the real
+ * request is still pending — no caller ever received a result — the teardown
+ * abort is the URL's only failure signal and records ONE transient failure
+ * (status 0), so a dead/slow URL (e.g. `fetchMediaUrl`'s fixed
+ * `AbortSignal.timeout`) enters the backoff and the session attempt cap
+ * instead of being re-fired by the next caller.
+ *
+ * Success responses are buffered exactly once into ONE shared Blob and every
+ * consumer synthesizes its own fresh Response over that same Blob — undici
+ * reads a Blob body lazily by reference, so N concurrent consumers cost ONE
+ * body copy with no clone()/tee chain and no per-consumer byte copy. The
+ * payload lives only inside the in-flight entry: after the last consumer
+ * leaves, the entry is dropped and the module retains no body bytes (a caller
+ * arriving later starts a fresh fetch; dedup never acts as a response cache).
+ * Non-2xx responses are delivered as synthesized error responses with the
+ * same JSON body the short-circuit path uses, so callers that classify 4xx vs
+ * 5xx (e.g. the legacy converter) make exactly the same decision they would
+ * have made for the original response.
+ */
+export async function fetchProxiedMediaUrl(url: string, init?: RequestInit): Promise<Response> {
+  const permanent = proxyMediaPermanentStatus(url);
+  if (permanent !== undefined) return syntheticProxyError(permanent);
+  if (isProxyMediaTransientBlocked(url)) return syntheticProxyError(502);
+  const callerSignal = init?.signal;
+  if (callerSignal?.aborted) throw createAbortError();
+  let entry = inFlightRequests.get(url);
+  if (!entry) {
+    const controller = new AbortController();
+    const promise = performProxiedFetch(url, controller);
+    const fresh: InFlightEntry = { promise, controller, consumers: 0, settled: false };
+    // Flip `settled` as soon as the shared request settles and remember its
+    // result, so the teardown never aborts a request that already produced
+    // its response. The payload (a 2xx Blob) is referenced only here, inside
+    // the in-flight entry: it is delivered to the joined consumers and dies
+    // with the entry when the last consumer leaves — no module-level response
+    // cache keeps it after that.
+    promise.then(
+      (result) => {
+        fresh.settled = true;
+        fresh.result = result;
+      },
+      () => void (fresh.settled = true),
+    );
+    entry = fresh;
+    inFlightRequests.set(url, entry);
+  }
+  entry.consumers += 1;
+  try {
+    // The shared request buffered the body ONCE into a single shared Blob;
+    // every consumer builds its OWN fresh Response over that same Blob.
+    // Undici reads a Blob body lazily by reference, so this construction does
+    // NOT copy the bytes per consumer — memory stays at one body copy for the
+    // whole burst.
+    const shared = await waitForCaller(entry.promise, callerSignal);
+    if (shared.blob) {
+      return new Response(shared.blob, { status: shared.status, headers: shared.headers });
+    }
+    // Non-2xx: a synthesized error response — the same caller-visible
+    // contract as the short-circuit path, and no stream to share at all.
+    return syntheticProxyError(shared.status);
+  } finally {
+    entry.consumers -= 1;
+    // Only the last caller to leave tears the shared request down — and only
+    // while it is still the entry (a late replacement is never torn down).
+    // Aborting the internal controller cancels the real request only when
+    // every caller is gone (all finished or all cancelled) and it is still
+    // pending. When NO caller received a result from a request that never
+    // settled, the teardown abort records ONE transient failure so the URL
+    // cannot be re-fired back-to-back; callers that cancelled still saw their
+    // own AbortError.
+    if (entry.consumers <= 0 && inFlightRequests.get(url) === entry) {
+      inFlightRequests.delete(url);
+      if (!entry.settled) {
+        entry.controller.abort();
+        recordProxyMediaFailure(url, 0);
+      }
+    }
+  }
+}
+
+/** Mimic the DOM fetch abort contract (`error.name === 'AbortError'`). */
+function createAbortError(): Error {
+  if (typeof DOMException !== 'undefined') return new DOMException('Aborted', 'AbortError');
+  return Object.assign(new Error('Aborted'), { name: 'AbortError' });
+}
+
+/**
+ * Await the shared request while racing the CALLER's own signal: aborting
+ * that signal rejects ONLY this caller with an AbortError — the shared
+ * request keeps running on its internal controller for whoever is left. With
+ * no signal, await the shared request directly.
+ */
+function waitForCaller<T>(promise: Promise<T>, signal?: AbortSignal | null): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(createAbortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function performProxiedFetch(
+  url: string,
+  controller: AbortController,
+): Promise<SharedMediaResult> {
+  let response: Response;
+  try {
+    response = await fetch('/api/proxy-media', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    // An AbortError here means the INTERNAL controller was aborted: either a
+    // caller-driven cancellation while the fetch still serves someone, or the
+    // last-caller teardown — which records its own transient failure. Neither
+    // is recorded here (no double count), and the rejection is preserved so
+    // callers handle it exactly as they do today. Any other rejection
+    // (connection reset, timeout, CORS) is transient: count it once toward
+    // the per-URL cap but keep the rejection contract.
+    if ((error as Error)?.name === 'AbortError') throw error;
+    recordProxyMediaFailure(url, 0);
+    throw error;
+  }
+  if (!response.ok) {
+    recordProxyMediaFailure(url, response.status);
+    // Failure responses are delivered as synthesized responses (same shape
+    // as the short-circuit path); the real error body is never shared.
+    return { status: response.status, headers: {} };
+  }
+  // Buffer the 2xx body exactly once. The proxy caps a single resource at
+  // 25 MiB, so one in-memory copy per shared request is the bounded price
+  // that removes the clone/tee chain N concurrent consumers used to form.
+  let body: ArrayBuffer;
+  try {
+    body = await response.arrayBuffer();
+  } catch (error) {
+    // Same rules as the fetch rejection above: a teardown-triggered AbortError
+    // is already recorded by the teardown (no double count); any other
+    // mid-body read failure is a network-level transient failure.
+    if ((error as Error)?.name === 'AbortError') throw error;
+    recordProxyMediaFailure(url, 0);
+    throw error;
+  }
+  // Construct ONE shared Blob over the buffered bytes — the module's single
+  // "buffer once" copy (Node copies the buffer into the Blob store at
+  // construction). Every consumer wraps THIS Blob, never the bytes: undici
+  // references a Blob body lazily, so N `new Response(blob, …)` constructions
+  // add no byte copies per consumer.
+  return {
+    status: response.status,
+    headers: pickMediaHeaders(response.headers),
+    blob: new Blob([body]),
+  };
+}
+
+/** The header subset consumers may rely on, preserved from the real response. */
+function pickMediaHeaders(headers: Headers): Record<string, string> {
+  const picked: Record<string, string> = {};
+  for (const name of ['content-type', 'content-length']) {
+    const value = headers.get(name);
+    if (value) picked[name] = value;
+  }
+  return picked;
+}

--- a/lib/store/media-generation.ts
+++ b/lib/store/media-generation.ts
@@ -213,10 +213,18 @@ export const useMediaGenerationStore = create<MediaGenerationState>()((set, get)
             stageId,
           };
         } else {
-          // Re-wrap blob with stored mimeType — IndexedDB may drop Blob.type
-          const blob = rec.blob.type ? rec.blob : new Blob([rec.blob], { type: rec.mimeType });
-          const objectUrl = URL.createObjectURL(blob);
-          const poster = rec.poster ? URL.createObjectURL(rec.poster) : undefined;
+          // Prefer a durable hosted URL when present; otherwise materialize
+          // the classic IndexedDB bytes as browser object URLs.
+          const objectUrl = rec.ossKey
+            ? rec.ossKey
+            : URL.createObjectURL(
+                rec.blob.type ? rec.blob : new Blob([rec.blob], { type: rec.mimeType }),
+              );
+          const poster = rec.posterOssKey
+            ? rec.posterOssKey
+            : rec.poster
+              ? URL.createObjectURL(rec.poster)
+              : undefined;
           restored[elementId] = {
             elementId,
             placeholderRef: rec.placeholderRef,

--- a/tests/export/proxied-fetch.test.ts
+++ b/tests/export/proxied-fetch.test.ts
@@ -1,24 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { createProxiedFetch } from '@/lib/export/proxied-fetch';
 
 describe('createProxiedFetch', () => {
   beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
 
   it('POSTs the original url to /api/proxy-media and returns the proxy response', async () => {
     const spy = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
         new Response('BYTES', { status: 200, headers: { 'content-type': 'text/javascript' } }),
     );
     vi.stubGlobal('fetch', spy);
     const pfetch = createProxiedFetch();
-    const res = await pfetch('https://cdn.tailwindcss.com');
+    const controller = new AbortController();
+    const res = await pfetch('https://cdn.tailwindcss.com', { signal: controller.signal });
+    // The shared proxy request runs on the module's INTERNAL controller (R2-P2-5):
+    // the caller's signal is raced per-call and must NOT be forwarded to fetch.
+    const fetchInit = spy.mock.calls[0]?.[1] as RequestInit | undefined;
     expect(spy).toHaveBeenCalledWith(
       '/api/proxy-media',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ url: 'https://cdn.tailwindcss.com' }),
+        signal: expect.any(AbortSignal),
       }),
     );
+    expect(fetchInit?.signal).not.toBe(controller.signal);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('BYTES');
   });
@@ -33,5 +40,56 @@ describe('createProxiedFetch', () => {
         body: JSON.stringify({ url: 'https://x/y.css' }),
       }),
     );
+  });
+
+  it.each([
+    ['/assets/local.png', undefined],
+    ['blob:https://app.example/asset-id', undefined],
+    ['data:text/plain;base64,QQ==', undefined],
+    ['https://app.example/assets/local.png', 'https://app.example/classrooms/1'],
+  ])('fetches local or browser-owned URL %s directly', async (url, pageHref) => {
+    if (pageHref) vi.stubGlobal('location', new URL(pageHref));
+    const spy = vi.fn(async () => new Response('BYTES'));
+    vi.stubGlobal('fetch', spy);
+    const controller = new AbortController();
+
+    await createProxiedFetch({ crossOriginOnly: true })(url, { signal: controller.signal });
+
+    expect(spy).toHaveBeenCalledWith(url, { signal: controller.signal });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the proxy when a direct cross-origin request is blocked', async () => {
+    const proxyResponse = new Response('BYTES');
+    const spy = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(proxyResponse);
+    vi.stubGlobal('fetch', spy);
+    const controller = new AbortController();
+
+    const response = await createProxiedFetch({ crossOriginOnly: true, directFirst: true })(
+      'https://cdn.example/audio.mp3',
+      { signal: controller.signal },
+    );
+
+    // The fallback reads the proxy bytes through the caller-visible response
+    // (a clone of the shared one), and the shared fetch runs on the internal
+    // controller, never the caller's signal.
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('BYTES');
+    expect(spy).toHaveBeenNthCalledWith(1, 'https://cdn.example/audio.mp3', {
+      signal: controller.signal,
+    });
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      '/api/proxy-media',
+      expect.objectContaining({
+        body: JSON.stringify({ url: 'https://cdn.example/audio.mp3' }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    const proxyInit = spy.mock.calls[1]?.[1] as RequestInit | undefined;
+    expect(proxyInit?.signal).not.toBe(controller.signal);
   });
 });

--- a/tests/media/media-orchestrator.test.ts
+++ b/tests/media/media-orchestrator.test.ts
@@ -1,36 +1,11 @@
-import { IDBFactory } from 'fake-indexeddb';
-import { BrowserAssetStore } from '@openmaic/storage';
-import type { Slide } from '@openmaic/dsl';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MediaTask } from '@/lib/store/media-generation';
-import type { Scene, Stage } from '@/lib/types/stage';
-import type { MediaFileRecord } from '@/lib/utils/database';
 
 const mocks = vi.hoisted(() => ({
-  probePresence: vi.fn(),
   settings: vi.fn(),
   mediaPut: vi.fn(),
-  mediaGet: vi.fn(),
   mediaDelete: vi.fn(),
-  getPool: vi.fn(),
-  document: null as ReturnType<typeof documentWithMedia> | null,
-  stageState: { stage: null, scenes: [] } as {
-    stage: ReturnType<typeof documentWithMedia>['stage'] | null;
-    scenes: ReturnType<typeof documentWithMedia>['scenes'];
-  },
-  stageSetState: vi.fn(),
-  markStagePersistenceDirty: vi.fn(),
-  beforeDocumentWork: vi.fn(),
-  accessDocument: vi.fn(),
-  listDocuments: vi.fn(),
-  loadDocument: vi.fn(),
-  otherDocuments: new Map<string, ReturnType<typeof documentWithMedia>>(),
-  mediaRows: new Map<string, { id: string; blob: Blob; error?: string }>(),
-  serverBacked: false,
-}));
-
-vi.mock('@/lib/media/asset-pool-config', () => ({
-  isAssetPoolServerBacked: () => mocks.serverBacked,
 }));
 
 vi.mock('@/lib/store/settings', () => ({
@@ -42,142 +17,35 @@ vi.mock('@/lib/utils/database', () => ({
   db: {
     mediaFiles: {
       put: mocks.mediaPut,
-      get: mocks.mediaGet,
       delete: mocks.mediaDelete,
     },
   },
 }));
 
-vi.mock('@/lib/media/asset-pool', () => ({
-  getAssetPool: mocks.getPool,
-  putAsset: (...args: unknown[]) => mocks.getPool().put(...args),
-  replaceAsset: (...args: unknown[]) => mocks.getPool().replace(...args),
-  removeAsset: (...args: unknown[]) => mocks.getPool().remove(...args),
-}));
-
-// Production runs one realm unless a peer answers; individual tests override
-// this to model an unavailable probe or a live peer.
-vi.mock('@/lib/media/stage-realm-presence', () => ({
-  probeStageRealmPresence: mocks.probePresence,
-}));
-
-vi.mock('@/lib/document-store', () => ({
-  accessDocument: mocks.accessDocument,
-  getDocumentStore: () => ({
-    listDocuments: mocks.listDocuments,
-    loadDocument: mocks.loadDocument,
-  }),
-  mutateDocument: async (
-    _stageId: string,
-    work: (document: unknown, store: { saveDocument: (next: unknown) => Promise<void> }) => unknown,
-  ) => (
-    mocks.beforeDocumentWork(),
-    work(mocks.document, {
-      saveDocument: async (next) => {
-        mocks.document = structuredClone(next) as ReturnType<typeof documentWithMedia>;
-      },
-    })
-  ),
-}));
-
-vi.mock('@/lib/store/stage', () => ({
-  useStageStore: {
-    getState: () => mocks.stageState,
-    setState: mocks.stageSetState,
-  },
-  markStagePersistenceDirty: mocks.markStagePersistenceDirty,
-}));
-
 import {
   generateMediaForOutlines,
   mediaRetryTarget,
-  reconcileCompletedMediaForScene,
   retryMediaTask,
 } from '@/lib/media/media-orchestrator';
-import { buildRestoredMediaTasks } from '@/lib/classroom/load-classroom';
-import { useMediaGenerationStore } from '@/lib/store/media-generation';
-import { markStageDeleted, unmarkStageDeleted } from '@/lib/utils/deleted-stages';
-import { resolveSlideMediaState } from '@/components/slide-renderer/use-resolved-slide';
-import { expectDocumentAssetOwnership } from './assert-stage-asset-ownership';
+import { resetProxyMediaFailureCache } from '@/lib/media/proxy-media-cache';
+import { useMediaGenerationStore, type MediaTask } from '@/lib/store/media-generation';
+import type { SceneOutline } from '@/lib/types/generation';
 
-const stageId = 'stage-write-path';
-const placeholder = 'gen_vid_1';
+const stageId = 'classic-stage';
+const imageRef = 'gen_img_classic';
+const videoRef = 'gen_vid_classic';
 
-function documentWithMedia(ref = placeholder, type: 'image' | 'video' = 'video') {
-  const element: {
-    id: string;
-    type: 'image' | 'video';
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-    rotate: number;
-    src: string;
-    mediaRef?: string;
-    poster?: string;
-    autoplay?: boolean;
-    fixedRatio?: boolean;
-  } =
-    type === 'video'
-      ? {
-          id: 'video-1',
-          type: 'video',
-          left: 0,
-          top: 0,
-          width: 100,
-          height: 56,
-          rotate: 0,
-          src: ref,
-          mediaRef: ref,
-          autoplay: false,
-        }
-      : {
-          id: 'image-1',
-          type: 'image',
-          left: 0,
-          top: 0,
-          width: 100,
-          height: 100,
-          rotate: 0,
-          fixedRatio: true,
-          src: ref,
-        };
+function outlineWith(
+  ...mediaGenerations: NonNullable<SceneOutline['mediaGenerations']>
+): SceneOutline {
   return {
-    dslVersion: 1,
-    stage: {
-      id: stageId,
-      name: 'Write paths',
-      createdAt: 1,
-      updatedAt: 1,
-      ...(type === 'video'
-        ? { videoManifest: { [ref]: { type: 'video', prompt: 'A short clip' } } }
-        : {}),
-    },
-    scenes: [
-      {
-        id: 'scene-1',
-        stageId,
-        title: 'Scene',
-        order: 1,
-        type: 'slide',
-        content: {
-          type: 'slide',
-          canvas: {
-            id: 'slide-1',
-            viewportSize: 1000,
-            viewportRatio: 0.5625,
-            background: { type: 'solid', color: '#fff' },
-            theme: {
-              fontName: 'Arial',
-              fontColor: '#111',
-              backgroundColor: '#fff',
-              themeColors: ['#111'],
-            },
-            elements: [element],
-          },
-        },
-      },
-    ],
+    id: 'outline-1',
+    type: 'slide',
+    title: 'Classic scene',
+    description: 'Classic scene',
+    keyPoints: ['media'],
+    order: 1,
+    mediaGenerations,
   };
 }
 
@@ -186,65 +54,22 @@ function failedTask(ref: string, type: 'image' | 'video' = 'image'): MediaTask {
     elementId: ref,
     type,
     status: 'failed',
-    prompt: type === 'image' ? 'A new image' : 'A short clip',
+    prompt: 'Retry media',
     params: { aspectRatio: '16:9' },
+    error: 'retry me',
     retryCount: 0,
     stageId,
-    error: 'retry me',
   };
 }
 
-function doneTask(ref: string, type: 'image' | 'video' = 'image'): MediaTask {
-  return {
-    ...failedTask(ref, type),
-    status: 'done',
-    objectUrl: 'blob:source',
-    error: undefined,
-  };
-}
-
-describe('media orchestrator asset write paths', () => {
-  let pool: BrowserAssetStore;
-  let objectUrls: Map<string, Blob>;
+describe('classic media orchestrator', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
+  let objectUrls: Map<string, Blob>;
 
   beforeEach(() => {
-    pool = new BrowserAssetStore({
-      indexedDB: new IDBFactory(),
-      dbName: `orchestrator-${crypto.randomUUID()}`,
-    });
-    mocks.getPool.mockReset();
-    mocks.getPool.mockReturnValue(pool);
-    mocks.probePresence.mockReset().mockResolvedValue('absent');
-    mocks.serverBacked = false;
-    mocks.mediaRows.clear();
-    mocks.mediaPut.mockReset().mockImplementation(async (row) => {
-      mocks.mediaRows.set(row.id, row);
-    });
-    mocks.mediaGet.mockReset().mockImplementation(async (id) => mocks.mediaRows.get(id));
-    mocks.mediaDelete.mockReset().mockImplementation(async (id) => {
-      mocks.mediaRows.delete(id);
-    });
-    mocks.stageSetState.mockReset();
-    mocks.markStagePersistenceDirty.mockReset();
-    mocks.beforeDocumentWork.mockReset();
-    mocks.otherDocuments.clear();
-    mocks.listDocuments
-      .mockReset()
-      .mockImplementation(async () => [
-        ...(mocks.document ? [{ id: mocks.document.stage.id }] : []),
-        ...[...mocks.otherDocuments.keys()].map((id) => ({ id })),
-      ]);
-    mocks.loadDocument
-      .mockReset()
-      .mockImplementation(async (id) =>
-        id === mocks.document?.stage.id ? mocks.document : (mocks.otherDocuments.get(id) ?? null),
-      );
-    mocks.accessDocument.mockReset().mockImplementation(async () => ({
-      document: mocks.document,
-      readOnlyLegacy: false,
-    }));
-    mocks.stageState = { stage: null, scenes: [] };
+    resetProxyMediaFailureCache();
+    mocks.mediaPut.mockReset().mockResolvedValue(undefined);
+    mocks.mediaDelete.mockReset().mockResolvedValue(undefined);
     mocks.settings.mockReset().mockReturnValue({
       imageGenerationEnabled: true,
       videoGenerationEnabled: true,
@@ -260,7 +85,7 @@ describe('media orchestrator asset write paths', () => {
     objectUrls = new Map();
     vi.stubGlobal('URL', {
       createObjectURL: vi.fn((blob: Blob) => {
-        const url = `blob:test-${objectUrls.size + 1}`;
+        const url = `blob:classic-${objectUrls.size + 1}`;
         objectUrls.set(url, blob);
         return url;
       }),
@@ -270,14 +95,29 @@ describe('media orchestrator asset write paths', () => {
     vi.stubGlobal('fetch', fetchMock);
   });
 
-  afterEach(async () => {
-    await pool.close();
+  afterEach(() => {
+    resetProxyMediaFailureCache();
     vi.unstubAllGlobals();
   });
 
-  function serveVideo(bytes = 'video-new') {
-    fetchMock.mockImplementation(async (input: string, init?: RequestInit) => {
-      if (input === '/api/generate/video') {
+  function serveImage(bytes = 'classic-image'): void {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/generate/image') {
+        return new Response(
+          JSON.stringify({ success: true, result: { url: 'https://media.test/image' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (String(input) === '/api/proxy-media') {
+        return new Response(new Blob([bytes], { type: 'image/png' }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    });
+  }
+
+  function serveVideo(): void {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/generate/video') {
         return new Response(
           JSON.stringify({
             success: true,
@@ -289,1408 +129,235 @@ describe('media orchestrator asset write paths', () => {
               duration: 5,
             },
           }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
+          { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (input === '/api/proxy-media') {
-        const requested = JSON.parse(String(init?.body)).url as string;
-        return requested.endsWith('/poster')
-          ? new Response(new Blob(['poster-new'], { type: 'image/jpeg' }), { status: 200 })
-          : new Response(new Blob([bytes], { type: 'video/mp4' }), { status: 200 });
+      if (String(input) === '/api/proxy-media') {
+        const requested = JSON.parse(String(init?.body)) as { url: string };
+        return requested.url.endsWith('/poster')
+          ? new Response(new Blob(['classic-poster'], { type: 'image/jpeg' }), { status: 200 })
+          : new Response(new Blob(['classic-video'], { type: 'video/mp4' }), { status: 200 });
       }
-      throw new Error(`Unexpected fetch: ${input}`);
+      throw new Error(`Unexpected fetch: ${String(input)}`);
     });
   }
 
-  function serveImage(bytes = 'image-new') {
-    fetchMock.mockImplementation(async (input: string) => {
-      if (input === '/api/generate/image') {
-        return new Response(
-          JSON.stringify({
-            success: true,
-            result: { url: 'https://media.test/image', width: 1024, height: 576 },
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      if (input === '/api/proxy-media') {
-        return new Response(new Blob([bytes], { type: 'image/png' }), { status: 200 });
-      }
-      throw new Error(`Unexpected fetch: ${input}`);
+  it('stores generated image bytes under the original placeholder without allocating an asset id', async () => {
+    serveImage();
+
+    await generateMediaForOutlines(
+      [outlineWith({ type: 'image', prompt: 'A diagram', elementId: imageRef })],
+      stageId,
+    );
+
+    expect(mocks.mediaPut).toHaveBeenCalledTimes(1);
+    const row = mocks.mediaPut.mock.calls[0]![0] as {
+      id: string;
+      stageId: string;
+      blob: Blob;
+      placeholderRef?: string;
+    };
+    expect(row.id).toBe(`${stageId}:${imageRef}`);
+    expect(row.stageId).toBe(stageId);
+    expect(row.placeholderRef).toBeUndefined();
+    await expect(row.blob.text()).resolves.toBe('classic-image');
+
+    const tasks = useMediaGenerationStore.getState().tasks;
+    expect(Object.keys(tasks)).toEqual([imageRef]);
+    expect(tasks[imageRef]).toMatchObject({
+      elementId: imageRef,
+      status: 'done',
+      objectUrl: 'blob:classic-1',
     });
-  }
+  });
 
-  async function resolvedText(ref: string): Promise<string | null> {
-    const url = await pool.resolve(ref);
-    return url ? ((await objectUrls.get(url)?.text()) ?? null) : null;
-  }
-
-  async function assertOwnership(): Promise<void> {
-    if (!mocks.document) throw new Error('Expected a document');
-    await expectDocumentAssetOwnership({
-      document: mocks.document as unknown as Parameters<
-        typeof expectDocumentAssetOwnership
-      >[0]['document'],
-      mediaRowIds: new Set(mocks.mediaRows.keys()),
-      audioRowIds: new Set(),
-      poolHas: async (ref) => {
-        const url = await pool.resolve(ref);
-        if (!url) return false;
-        await pool.release(ref);
-        return true;
-      },
-    });
-  }
-
-  it('converges when the scene is inserted before media completes', async () => {
-    mocks.document = documentWithMedia();
-    const put = vi.spyOn(pool, 'put');
+  it('stores video and poster bytes in one placeholder-keyed classic row', async () => {
     serveVideo();
 
     await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['video'],
-          order: 1,
-          mediaGenerations: [
-            { type: 'video', prompt: 'A short clip', elementId: placeholder, aspectRatio: '16:9' },
-          ],
-        },
-      ],
+      [outlineWith({ type: 'video', prompt: 'A clip', elementId: videoRef })],
       stageId,
     );
 
-    const element = mocks.document.scenes[0].content.canvas.elements[0];
-    const assetId = element.mediaRef as string;
-    const posterAssetId = element.poster;
-    expect(assetId).toMatch(/^ast_/);
-    expect(element.src).toBe(assetId);
-    expect(posterAssetId).toMatch(/^ast_/);
-    expect(mocks.document.stage.videoManifest).toEqual({
-      [assetId]: { type: 'video', prompt: 'A short clip' },
+    expect(mocks.mediaPut).toHaveBeenCalledTimes(1);
+    const row = mocks.mediaPut.mock.calls[0]![0] as { id: string; blob: Blob; poster?: Blob };
+    expect(row.id).toBe(`${stageId}:${videoRef}`);
+    await expect(row.blob.text()).resolves.toBe('classic-video');
+    await expect(row.poster?.text()).resolves.toBe('classic-poster');
+    expect(useMediaGenerationStore.getState().tasks[videoRef]).toMatchObject({
+      elementId: videoRef,
+      status: 'done',
+      objectUrl: 'blob:classic-1',
+      poster: 'blob:classic-2',
     });
-    expect(await resolvedText(assetId)).toBe('video-new');
-    expect(await resolvedText(posterAssetId as string)).toBe('poster-new');
-    expect(put).toHaveBeenCalledWith(
-      expect.any(Blob),
+  });
+
+  it('keeps a hosted result as classic row metadata without downloading or allocating it', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: { url: '', ossUrl: 'https://cdn.test/generated.png' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    await generateMediaForOutlines(
+      [outlineWith({ type: 'image', prompt: 'Hosted', elementId: imageRef })],
+      stageId,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mocks.mediaPut).toHaveBeenCalledWith(
       expect.objectContaining({
-        contentType: 'video/mp4',
-        prompt: 'A short clip',
-        dimensions: { width: 1280, height: 720 },
-        duration: 5,
+        id: `${stageId}:${imageRef}`,
+        ossKey: 'https://cdn.test/generated.png',
+        size: 0,
       }),
     );
-    expect(mocks.mediaPut).toHaveBeenCalledWith(
-      expect.objectContaining({ id: `${stageId}:${assetId}`, stageId, type: 'video' }),
+    expect(useMediaGenerationStore.getState().tasks[imageRef]?.objectUrl).toBe(
+      'https://cdn.test/generated.png',
     );
-    expect(mocks.mediaPut).toHaveBeenCalledWith(
-      expect.objectContaining({ id: `${stageId}:${posterAssetId}`, stageId, type: 'image' }),
-    );
-    expect(useMediaGenerationStore.getState().tasks[placeholder]).toBeUndefined();
-    expect(useMediaGenerationStore.getState().tasks[assetId]).toMatchObject({
-      elementId: assetId,
-      status: 'done',
-    });
-    await assertOwnership();
   });
 
-  it('converges when media completes before the generated scene is inserted', async () => {
-    const pendingDocument = documentWithMedia(placeholder, 'video');
-    const lateScene = structuredClone(pendingDocument.scenes[0]);
-    pendingDocument.scenes = [];
-    mocks.document = pendingDocument;
-    serveVideo('early-media');
+  it('processes API-limited media requests serially', async () => {
+    const events: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/generate/image') {
+        const body = JSON.parse(String(init?.body)) as { prompt: string };
+        events.push(`generate:${body.prompt}`);
+        return new Response(
+          JSON.stringify({
+            success: true,
+            result: { url: `https://media.test/${body.prompt}` },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (String(input) === '/api/proxy-media') {
+        const body = JSON.parse(String(init?.body)) as { url: string };
+        events.push(`proxy:${body.url.split('/').at(-1)}`);
+        return new Response(new Blob([body.url], { type: 'image/png' }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    });
 
     await generateMediaForOutlines(
       [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['video'],
-          order: 1,
-          mediaGenerations: [
-            { type: 'video', prompt: 'A short clip', elementId: placeholder, aspectRatio: '16:9' },
-          ],
-        },
+        outlineWith(
+          { type: 'image', prompt: 'first', elementId: 'gen_img_first' },
+          { type: 'image', prompt: 'second', elementId: 'gen_img_second' },
+        ),
       ],
       stageId,
     );
 
-    const completed = Object.values(useMediaGenerationStore.getState().tasks)[0];
-    expect(completed).toMatchObject({
-      status: 'done',
-      placeholderRef: placeholder,
-      elementId: expect.stringMatching(/^ast_/),
-    });
-    const reconciled = reconcileCompletedMediaForScene(
-      lateScene as unknown as Scene,
-      pendingDocument.stage as unknown as Stage,
-      useMediaGenerationStore.getState().tasks,
-    );
-    mocks.document = {
-      ...pendingDocument,
-      stage: reconciled.stage,
-      scenes: [reconciled.scene],
-    } as unknown as ReturnType<typeof documentWithMedia>;
-
-    const insertedDocument = mocks.document;
-    if (!insertedDocument) throw new Error('Expected the reconciled document');
-    const insertedRef = insertedDocument.scenes[0].content.canvas.elements[0].src;
-    expect(insertedRef).toBe(completed.elementId);
-    expect(insertedDocument.scenes[0].content.canvas.elements[0].poster).toBe(
-      completed.posterAssetId,
-    );
-    expect(insertedDocument.stage.videoManifest).toEqual({
-      [completed.elementId]: { type: 'video', prompt: 'A short clip' },
-    });
-    expect(await resolvedText(completed.elementId)).toBe('early-media');
-    expect(mocks.mediaPut).toHaveBeenCalledWith(
-      expect.objectContaining({ id: `${stageId}:${completed.elementId}` }),
-    );
+    expect(events).toEqual(['generate:first', 'proxy:first', 'generate:second', 'proxy:second']);
   });
 
-  it('makes zero API calls and zero allocations when a restored document no longer owns the placeholder', async () => {
-    const assetId = await pool.put(new Blob(['persisted-image'], { type: 'image/png' }));
-    const put = vi.spyOn(pool, 'put');
-    put.mockClear();
-    mocks.document = documentWithMedia(assetId, 'image');
+  it('skips already completed, permanently failed, and disabled requests', async () => {
     useMediaGenerationStore.setState({
-      tasks: buildRestoredMediaTasks(stageId, [
-        {
-          id: `${stageId}:${assetId}`,
-          stageId,
-          placeholderRef: placeholder,
-          type: 'image',
-          blob: new Blob(['persisted-image'], { type: 'image/png' }),
-          mimeType: 'image/png',
-          size: 15,
-          prompt: 'A new image',
-          params: '{}',
-          createdAt: 1,
-        },
-      ]),
+      tasks: {
+        done: { ...failedTask('done'), status: 'done', objectUrl: 'blob:done', error: undefined },
+        failed: failedTask('failed'),
+      },
+    });
+    mocks.settings.mockReturnValue({
+      ...mocks.settings(),
+      videoGenerationEnabled: false,
     });
 
     await generateMediaForOutlines(
       [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
+        outlineWith(
+          { type: 'image', prompt: 'done', elementId: 'done' },
+          { type: 'image', prompt: 'failed', elementId: 'failed' },
+          { type: 'video', prompt: 'disabled', elementId: 'disabled' },
+        ),
       ],
       stageId,
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(put).not.toHaveBeenCalled();
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(assetId);
-  });
-
-  it('runs a final document reconciliation before task re-keying when a scene lands late', async () => {
-    const pendingDocument = documentWithMedia(placeholder, 'video');
-    const lateScene = structuredClone(pendingDocument.scenes[0]);
-    pendingDocument.scenes = [];
-    mocks.document = pendingDocument;
-    serveVideo('late-window-media');
-    let documentScans = 0;
-    mocks.beforeDocumentWork.mockImplementation(() => {
-      documentScans += 1;
-      if (documentScans !== 2 || !mocks.document) return;
-      const pending = Object.values(useMediaGenerationStore.getState().tasks)[0];
-      expect(pending).toMatchObject({
-        status: 'generating',
-        elementId: placeholder,
-      });
-      mocks.document.scenes = [lateScene];
-    });
-
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['video'],
-          order: 1,
-          mediaGenerations: [
-            { type: 'video', prompt: 'A short clip', elementId: placeholder, aspectRatio: '16:9' },
-          ],
-        },
-      ],
-      stageId,
-    );
-
-    const completed = Object.values(useMediaGenerationStore.getState().tasks)[0];
-    expect(mocks.document.scenes[0].content.canvas.elements[0]).toMatchObject({
-      src: completed.elementId,
-      mediaRef: completed.elementId,
-      poster: completed.posterAssetId,
-    });
-  });
-
-  it('rollback layer 1: leaves the document and Dexie untouched when pool allocation fails', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    const before = structuredClone(mocks.document);
-    serveImage();
-    mocks.getPool.mockReturnValueOnce({
-      put: vi.fn().mockRejectedValue(new Error('pool write failed')),
-    });
-
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
-      ],
-      stageId,
-    );
-
-    expect(mocks.document).toEqual(before);
     expect(mocks.mediaPut).not.toHaveBeenCalled();
-    expect(useMediaGenerationStore.getState().tasks[placeholder]?.status).toBe('failed');
   });
 
-  it('rollback layer 2: removes every fresh allocation when compatibility persistence fails', async () => {
-    mocks.document = documentWithMedia(placeholder, 'video');
-    serveVideo('uncommitted-video');
-    const put = vi.spyOn(pool, 'put');
-    mocks.mediaPut.mockRejectedValueOnce(new Error('compatibility write failed'));
+  it('retries a failed placeholder by deleting and replacing its classic row', async () => {
+    useMediaGenerationStore.setState({ tasks: { [imageRef]: failedTask(imageRef) } });
+    serveImage('retried-image');
 
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['video'],
-          order: 1,
-          mediaGenerations: [
-            { type: 'video', prompt: 'A short clip', elementId: placeholder, aspectRatio: '16:9' },
-          ],
-        },
-      ],
-      stageId,
-    );
-
-    const allocated = await Promise.all(put.mock.results.map((result) => result.value));
-    expect(allocated).toHaveLength(2);
-    for (const ref of allocated) expect(await pool.resolve(ref)).toBeNull();
-    expect(mocks.mediaRows.size).toBe(0);
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(placeholder);
-  });
-
-  it('rollback layer 3: removes pool and compatibility writes when document commit fails', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    const before = structuredClone(mocks.document);
-    serveImage('uncommitted-image');
-    const put = vi.spyOn(pool, 'put');
-    mocks.beforeDocumentWork.mockImplementationOnce(() => {
-      throw new Error('document write failed');
-    });
-
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
-      ],
-      stageId,
-    );
-
-    const [allocated] = await Promise.all(put.mock.results.map((result) => result.value));
-    expect(await pool.resolve(allocated)).toBeNull();
-    expect(mocks.mediaRows.has(`${stageId}:${allocated}`)).toBe(false);
-    expect(mocks.document).toEqual(before);
-  });
-
-  it('replaces exclusively owned media bytes for a production-shaped targeted retry', async () => {
-    const assetId = await pool.put(new Blob(['image-old'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    const before = structuredClone(mocks.document);
-    const put = vi.spyOn(pool, 'put');
-    const replace = vi.spyOn(pool, 'replace');
-    // The existence probe is metadata-only now: exists(), not a lease's
-    // acquire/release pair.
-    const exists = vi.spyOn(pool, 'exists');
-    serveImage('image-replaced');
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-
-    await retryMediaTask(assetId, {
-      elementId: 'image-1',
+    await retryMediaTask(imageRef, {
+      elementId: 'image-element',
       sceneId: 'scene-1',
       slideId: 'slide-1',
     });
 
-    expect(replace).toHaveBeenCalledWith(
-      assetId,
-      expect.any(Blob),
+    expect(mocks.mediaDelete).toHaveBeenCalledWith(`${stageId}:${imageRef}`);
+    expect(mocks.mediaPut).toHaveBeenCalledWith(
+      expect.objectContaining({ id: `${stageId}:${imageRef}` }),
+    );
+    expect(useMediaGenerationStore.getState().tasks[imageRef]).toMatchObject({
+      status: 'done',
+      retryCount: 1,
+    });
+  });
+
+  it('persists structured terminal errors under the placeholder for reload', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Sensitive content', errorCode: 'CONTENT_SENSITIVE' }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    await generateMediaForOutlines(
+      [outlineWith({ type: 'image', prompt: 'Blocked', elementId: imageRef })],
+      stageId,
+    );
+
+    expect(useMediaGenerationStore.getState().tasks[imageRef]).toMatchObject({
+      status: 'failed',
+      errorCode: 'CONTENT_SENSITIVE',
+    });
+    expect(mocks.mediaPut).toHaveBeenCalledWith(
       expect.objectContaining({
-        prompt: 'A new image',
-        dimensions: { width: 1024, height: 576 },
+        id: `${stageId}:${imageRef}`,
+        errorCode: 'CONTENT_SENSITIVE',
+        size: 0,
       }),
     );
-    expect(put).not.toHaveBeenCalled();
-    expect(exists).toHaveBeenCalledWith(assetId);
-    expect(await resolvedText(assetId)).toBe('image-replaced');
-    expect(mocks.document).toEqual(before);
-    expect(mocks.mediaDelete).not.toHaveBeenCalled();
-    expect(mocks.mediaPut).toHaveBeenCalledWith(
-      expect.objectContaining({ id: `${stageId}:${assetId}` }),
-    );
-    expect(await mocks.mediaRows.get(`${stageId}:${assetId}`)?.blob.text()).toBe('image-replaced');
-    expect(useMediaGenerationStore.getState().tasks[assetId]?.status).toBe('done');
-    expect(mocks.listDocuments).toHaveBeenCalledTimes(2);
-    expect(mocks.loadDocument).toHaveBeenCalledWith(stageId);
-    await assertOwnership();
   });
 
-  it('forks a targeted retry when peer presence cannot be probed', async () => {
-    // No BroadcastChannel, binding not finished, or a constructor that threw all
-    // report 'unknown'. Proving nothing about other realms must not authorize a
-    // global mutation, so the write boundary itself has to fork.
-    mocks.probePresence.mockResolvedValue('unknown');
-    const assetId = await pool.put(new Blob(['image-old'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    const replace = vi.spyOn(pool, 'replace');
-    serveImage('image-forked');
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-
-    await retryMediaTask(assetId, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    const rewritten = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(replace).not.toHaveBeenCalled();
-    expect(rewritten).toMatch(/^ast_/);
-    expect(rewritten).not.toBe(assetId);
-    expect(await resolvedText(rewritten)).toBe('image-forked');
-    // A peer's unflushed owner, had there been one, still resolves the old bytes.
-    expect(await resolvedText(assetId)).toBe('image-old');
-  });
-
-  it('forks a targeted retry in server mode even when local ownership is exclusive', async () => {
-    mocks.serverBacked = true;
-    const assetId = await pool.put(new Blob(['image-old'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    const replace = vi.spyOn(pool, 'replace');
-    serveImage('image-server-fork');
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-
-    await retryMediaTask(assetId, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    const rewritten = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(replace).not.toHaveBeenCalled();
-    expect(rewritten).toMatch(/^ast_/);
-    expect(rewritten).not.toBe(assetId);
-    expect(await resolvedText(rewritten)).toBe('image-server-fork');
-    expect(await resolvedText(assetId)).toBe('image-old');
-  });
-
-  it('forks when an exclusive ref becomes shared while generation is pending', async () => {
-    const assetId = await pool.put(new Blob(['image-original'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${assetId}`, {
-      id: `${stageId}:${assetId}`,
-      blob: new Blob(['image-original'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-    const replace = vi.spyOn(pool, 'replace');
-    let finishGeneration!: (response: Response) => void;
-    const generation = new Promise<Response>((resolve) => {
-      finishGeneration = resolve;
-    });
-    fetchMock.mockImplementation(async (input: string) => {
-      if (input === '/api/generate/image') return generation;
-      if (input === '/api/proxy-media') {
-        return new Response(new Blob(['image-retried'], { type: 'image/png' }), { status: 200 });
-      }
-      throw new Error(`Unexpected fetch: ${input}`);
-    });
-
-    const retrying = retryMediaTask(assetId, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-    await vi.waitFor(() => {
-      expect(useMediaGenerationStore.getState().tasks[assetId]?.status).toBe('generating');
-    });
-
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState.scenes.push(structuredClone(copy));
-
-    finishGeneration(
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: { url: 'https://media.test/image', width: 1024, height: 576 },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ),
-    );
-    await retrying;
-
-    const targetRef = mocks.document.scenes[0].content.canvas.elements[0].src;
-    const copiedRef = mocks.document.scenes[1].content.canvas.elements[0].src;
-    expect(targetRef).toMatch(/^ast_/);
-    expect(targetRef).not.toBe(assetId);
-    expect(copiedRef).toBe(assetId);
-    expect(await resolvedText(targetRef)).toBe('image-retried');
-    expect(await resolvedText(copiedRef)).toBe('image-original');
-    expect(await mocks.mediaRows.get(`${stageId}:${assetId}`)?.blob.text()).toBe('image-original');
-    expect(replace).not.toHaveBeenCalled();
-    expect(mocks.listDocuments).toHaveBeenCalledTimes(2);
-  });
-
-  it('forks when the duplicate exists only in the unflushed editor state', async () => {
-    const assetId = await pool.put(new Blob(['image-original'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${assetId}`, {
-      id: `${stageId}:${assetId}`,
-      blob: new Blob(['image-original'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-    const replace = vi.spyOn(pool, 'replace');
-    let finishGeneration!: (response: Response) => void;
-    const generation = new Promise<Response>((resolve) => {
-      finishGeneration = resolve;
-    });
-    fetchMock.mockImplementation(async (input: string) => {
-      if (input === '/api/generate/image') return generation;
-      if (input === '/api/proxy-media') {
-        return new Response(new Blob(['image-retried'], { type: 'image/png' }), { status: 200 });
-      }
-      throw new Error(`Unexpected fetch: ${input}`);
-    });
-
-    const retrying = retryMediaTask(assetId, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-    await vi.waitFor(() => {
-      expect(useMediaGenerationStore.getState().tasks[assetId]?.status).toBe('generating');
-    });
-
-    // Duplication lands in the Zustand aggregate immediately; persistence is
-    // still behind its debounce, so the stored document keeps a single owner.
-    const copy = structuredClone(mocks.stageState.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.stageState.scenes.push(copy);
-    expect(mocks.document.scenes).toHaveLength(1);
-
-    finishGeneration(
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: { url: 'https://media.test/image', width: 1024, height: 576 },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ),
-    );
-    await retrying;
-
-    const targetRef = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(targetRef).toMatch(/^ast_/);
-    expect(targetRef).not.toBe(assetId);
-    expect(await resolvedText(targetRef)).toBe('image-retried');
-    // The unflushed copy still points at the original id, whose bytes are intact.
-    expect(mocks.stageState.scenes[1].content.canvas.elements[0].src).toBe(assetId);
-    expect(await resolvedText(assetId)).toBe('image-original');
-    expect(await mocks.mediaRows.get(`${stageId}:${assetId}`)?.blob.text()).toBe('image-original');
-    expect(replace).not.toHaveBeenCalled();
-  });
-
-  it('forks a targeted retry when another persisted document aliases the allocated ref', async () => {
-    const assetId = await pool.put(new Blob(['shared-original'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    const other = documentWithMedia(assetId, 'image');
-    other.stage.id = 'stage-other';
-    other.scenes[0].stageId = 'stage-other';
-    mocks.otherDocuments.set('stage-other', other);
-    mocks.mediaRows.set(`${stageId}:${assetId}`, {
-      id: `${stageId}:${assetId}`,
-      blob: new Blob(['shared-original'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-    const replace = vi.spyOn(pool, 'replace');
-    serveImage('retried-target');
-
-    await retryMediaTask(assetId, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    const retriedRef = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(retriedRef).toMatch(/^ast_/);
-    expect(retriedRef).not.toBe(assetId);
-    expect(other.scenes[0].content.canvas.elements[0].src).toBe(assetId);
-    expect(await resolvedText(assetId)).toBe('shared-original');
-    expect(await resolvedText(retriedRef)).toBe('retried-target');
-    expect(await mocks.mediaRows.get(`${stageId}:${assetId}`)?.blob.text()).toBe('shared-original');
-    expect(mocks.mediaDelete).not.toHaveBeenCalledWith(`${stageId}:${assetId}`);
-    expect(replace).not.toHaveBeenCalled();
-  });
-
-  it('forks instead of replacing when persisted ownership enumeration fails', async () => {
-    const assetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.listDocuments.mockRejectedValueOnce(new Error('document store unavailable'));
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-    const replace = vi.spyOn(pool, 'replace');
-    serveImage('forked-bytes');
-
-    await retryMediaTask(assetId, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    const retriedRef = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(retriedRef).toMatch(/^ast_/);
-    expect(retriedRef).not.toBe(assetId);
-    expect(await resolvedText(assetId)).toBe('original-bytes');
-    expect(await resolvedText(retriedRef)).toBe('forked-bytes');
-    expect(replace).not.toHaveBeenCalled();
-  });
-
-  it('replaces an allocated video and its referenced poster without rewriting the document', async () => {
-    const assetId = await pool.put(new Blob(['video-old'], { type: 'video/mp4' }));
-    const posterAssetId = await pool.put(new Blob(['poster-old'], { type: 'image/jpeg' }));
-    mocks.document = documentWithMedia(assetId, 'video');
-    mocks.document.scenes[0].content.canvas.elements[0].poster = posterAssetId;
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    const before = structuredClone(mocks.document);
-    serveVideo('video-replaced');
-    useMediaGenerationStore.setState({
-      tasks: { [assetId]: failedTask(assetId, 'video') },
-    });
-
-    await retryMediaTask(assetId, {
-      elementId: 'video-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    expect(await resolvedText(assetId)).toBe('video-replaced');
-    expect(await resolvedText(posterAssetId)).toBe('poster-new');
-    expect(mocks.document).toEqual(before);
-    expect(mocks.mediaPut).toHaveBeenCalledWith(
-      expect.objectContaining({ id: `${stageId}:${assetId}`, poster: expect.any(Blob) }),
-    );
-    await assertOwnership();
-  });
-
-  it('upgrades a legacy retry through the allocating path', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    const put = vi.spyOn(pool, 'put');
-    const replace = vi.spyOn(pool, 'replace');
-    serveImage('legacy-upgraded');
-    useMediaGenerationStore.setState({ tasks: { [placeholder]: failedTask(placeholder) } });
-    mocks.mediaRows.set(`${stageId}:${placeholder}`, {
-      id: `${stageId}:${placeholder}`,
-      blob: new Blob(),
-      error: 'legacy failure',
-    });
-
-    await retryMediaTask(placeholder, {
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    const assetId = mocks.document.scenes[0].content.canvas.elements[0].src as string;
-    expect(assetId).toMatch(/^ast_/);
-    expect(put).toHaveBeenCalled();
-    expect(replace).not.toHaveBeenCalled();
-    expect(mocks.mediaDelete).toHaveBeenCalledWith(`${stageId}:${placeholder}`);
-    expect(await resolvedText(assetId)).toBe('legacy-upgraded');
-    await assertOwnership();
-  });
-
-  it('forks a duplicated media ref on targeted regeneration', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    useMediaGenerationStore.setState({
-      tasks: { [sharedAssetId]: failedTask(sharedAssetId) },
-    });
-    const sourceStatuses: Array<MediaTask['status'] | undefined> = [];
-    const unsubscribe = useMediaGenerationStore.subscribe((state) => {
-      sourceStatuses.push(state.tasks[sharedAssetId]?.status);
-    });
-    serveImage('copy-bytes');
-
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    await retryMediaTask(sharedAssetId, {
-      elementId: 'image-copy',
-      sceneId: 'scene-copy',
-      slideId: 'slide-copy',
-    });
-    unsubscribe();
-
-    const [originalScene, copiedScene] = mocks.document.scenes;
-    const originalRef = originalScene.content.canvas.elements[0].src;
-    const copiedRef = copiedScene.content.canvas.elements[0].src;
-    expect(originalRef).toBe(sharedAssetId);
-    expect(copiedRef).toMatch(/^ast_/);
-    expect(copiedRef).not.toBe(sharedAssetId);
-    expect(await resolvedText(originalRef)).toBe('original-bytes');
-    expect(await resolvedText(copiedRef)).toBe('copy-bytes');
-    expect(mocks.mediaRows.has(`${stageId}:${sharedAssetId}`)).toBe(true);
-    expect(useMediaGenerationStore.getState().tasks[copiedRef]?.placeholderRef).toBeUndefined();
-    expect(useMediaGenerationStore.getState().tasks[sharedAssetId]).toMatchObject({
-      status: 'failed',
-      error: 'retry me',
-      retryCount: 0,
-    });
-    expect(sourceStatuses.length).toBeGreaterThan(0);
-    expect(sourceStatuses.every((status) => status === 'failed')).toBe(true);
-    expect(mocks.beforeDocumentWork).toHaveBeenCalledTimes(1);
-    await assertOwnership();
-  });
-
-  it('removes a failed fork from both key spaces after its retry succeeds', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: doneTask(sharedAssetId) } });
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          success: false,
-          error: 'fork generation failed',
-          errorCode: 'UPSTREAM_TIMEOUT',
-        }),
-        { headers: { 'Content-Type': 'application/json' } },
-      ),
-    );
-
-    const target = {
-      elementId: 'image-copy',
-      sceneId: 'scene-copy',
-      slideId: 'slide-copy',
-    };
-    await retryMediaTask(sharedAssetId, target);
-
-    expect(mocks.mediaRows.get(`${stageId}:image-copy`)).toMatchObject({
-      error: 'fork generation failed',
-    });
-    expect(useMediaGenerationStore.getState().tasks['image-copy']?.status).toBe('failed');
-
-    serveImage('recovered-fork');
-    await retryMediaTask(sharedAssetId, target);
-
-    const recoveredRef = mocks.document.scenes[1].content.canvas.elements[0].src;
-    expect(recoveredRef).toMatch(/^ast_/);
-    expect(mocks.mediaRows.has(`${stageId}:image-copy`)).toBe(false);
-    expect(useMediaGenerationStore.getState().tasks['image-copy']).toBeUndefined();
-    expect(useMediaGenerationStore.getState().tasks[recoveredRef]).toMatchObject({
-      elementId: recoveredRef,
-      status: 'done',
-    });
-
-    const restored = buildRestoredMediaTasks(stageId, [
-      ...mocks.mediaRows.values(),
-    ] as unknown as MediaFileRecord[]);
-    expect(restored['image-copy']).toBeUndefined();
-    expect(restored[recoveredRef]?.status).toBe('done');
-    const reloaded = resolveSlideMediaState(
-      mocks.document.scenes[1].content.canvas as unknown as Slide,
-      stageId,
-      restored,
-    );
-    expect(reloaded.byElementId['image-copy']).toMatchObject({
-      task: { elementId: recoveredRef, status: 'done' },
-      resolution: { kind: 'url' },
-    });
-  });
-
-  it('restores a fork failure after its retry fails without an error code', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: doneTask(sharedAssetId) } });
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          success: false,
-          error: 'fork generation failed',
-          errorCode: 'UPSTREAM_TIMEOUT',
-        }),
-        { headers: { 'Content-Type': 'application/json' } },
-      ),
-    );
-
-    const target = {
-      elementId: 'image-copy',
-      sceneId: 'scene-copy',
-      slideId: 'slide-copy',
-    };
-    await retryMediaTask(sharedAssetId, target);
-    expect(mocks.mediaRows.get(`${stageId}:image-copy`)).toMatchObject({
-      error: 'fork generation failed',
-      errorCode: 'UPSTREAM_TIMEOUT',
-    });
-
-    fetchMock.mockRejectedValueOnce(new Error('unstructured retry failure'));
-    await retryMediaTask(sharedAssetId, target);
-
-    const restored = buildRestoredMediaTasks(stageId, [
-      ...mocks.mediaRows.values(),
-    ] as unknown as MediaFileRecord[]);
-    expect(restored['image-copy']).toMatchObject({
-      status: 'failed',
-      error: 'fork generation failed',
-      errorCode: 'UPSTREAM_TIMEOUT',
-    });
-    const reloaded = resolveSlideMediaState(
-      mocks.document.scenes[1].content.canvas as unknown as Slide,
-      stageId,
-      restored,
-      { assetUrls: { [sharedAssetId]: 'blob:source-pool' } },
-    );
-    expect(reloaded.byElementId['image-copy']).toMatchObject({
-      task: { elementId: 'image-copy', status: 'failed', error: 'fork generation failed' },
-      resolution: { kind: 'url', url: 'blob:source-pool', retryable: true },
-    });
-  });
-
-  it('scopes a shared retry to the scene and slide when element ids recur', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    mocks.document.scenes[0].content.canvas.elements[0].id = 'repeated-image';
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: doneTask(sharedAssetId) } });
-    serveImage('scoped-copy');
-
-    await retryMediaTask(sharedAssetId, {
-      elementId: 'repeated-image',
-      sceneId: 'scene-copy',
-      slideId: 'slide-copy',
-    });
-
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(sharedAssetId);
-    expect(mocks.document.scenes[1].content.canvas.elements[0].src).not.toBe(sharedAssetId);
-    expect(useMediaGenerationStore.getState().tasks[sharedAssetId]).toMatchObject({
-      status: 'done',
-      objectUrl: 'blob:source',
-      retryCount: 0,
-    });
-    await assertOwnership();
-  });
-
-  it('keeps sharers on source bytes while a targeted fork is generating', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: doneTask(sharedAssetId) } });
-    let finishGeneration!: (response: Response) => void;
-    const generation = new Promise<Response>((resolve) => {
-      finishGeneration = resolve;
-    });
-    fetchMock.mockImplementation(async (input: string) => {
-      if (input === '/api/generate/image') return generation;
-      if (input === '/api/proxy-media') {
-        return new Response(new Blob(['fork-bytes'], { type: 'image/png' }), { status: 200 });
-      }
-      throw new Error(`Unexpected fetch: ${input}`);
-    });
-
-    const retrying = retryMediaTask(sharedAssetId, {
-      elementId: 'image-copy',
-      sceneId: 'scene-copy',
-      slideId: 'slide-copy',
-    });
-    await vi.waitFor(() => {
-      expect(useMediaGenerationStore.getState().tasks['image-copy']?.status).toBe('generating');
-    });
-
-    const tasks = useMediaGenerationStore.getState().tasks;
-    const source = resolveSlideMediaState(
-      mocks.document.scenes[0].content.canvas as unknown as Slide,
-      stageId,
-      tasks,
-      { assetUrls: { [sharedAssetId]: 'blob:source-pool' } },
-    );
-    const target = resolveSlideMediaState(
-      mocks.document.scenes[1].content.canvas as unknown as Slide,
-      stageId,
-      tasks,
-      { assetUrls: { [sharedAssetId]: 'blob:source-pool' } },
-    );
-    expect(tasks[sharedAssetId]).toMatchObject({ status: 'done', objectUrl: 'blob:source' });
-    expect(source.byElementId['image-1'].resolution).toEqual({
-      kind: 'url',
-      url: 'blob:source-pool',
-    });
-    expect(source.slide.elements[0]).toMatchObject({ src: 'blob:source-pool' });
-    expect(target.byElementId['image-copy'].resolution).toEqual({ kind: 'pending' });
-    expect(target.slide.elements[0]).toMatchObject({ src: '' });
-
-    finishGeneration(
-      new Response(
-        JSON.stringify({
-          success: true,
-          result: { url: 'https://media.test/image', width: 1024, height: 576 },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ),
-    );
-    await retrying;
-    expect(useMediaGenerationStore.getState().tasks[sharedAssetId]).toMatchObject({
-      status: 'done',
-      objectUrl: 'blob:source',
-      retryCount: 0,
-    });
-  });
-
-  it('forks a shared ref owned by a scene whiteboard despite the scene slide id', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const scene = mocks.document.scenes[0] as (typeof mocks.document.scenes)[number] & {
-      whiteboards: Array<(typeof mocks.document.scenes)[number]['content']['canvas']>;
-    };
-    scene.whiteboards = [
-      {
-        ...structuredClone(mocks.document.scenes[0].content.canvas),
-        id: 'scene-whiteboard',
-        elements: [
-          {
-            ...structuredClone(mocks.document.scenes[0].content.canvas.elements[0]),
-            id: 'whiteboard-image',
-            type: 'image',
-            src: sharedAssetId,
-          },
-        ],
-      },
-    ];
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: failedTask(sharedAssetId) } });
-    serveImage('whiteboard-copy');
-
-    await retryMediaTask(sharedAssetId, {
-      elementId: 'whiteboard-image',
-      sceneId: 'scene-1',
-      slideId: 'slide-1',
-    });
-
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(sharedAssetId);
-    const savedScene = mocks.document.scenes[0] as typeof scene;
-    expect(savedScene.whiteboards[0].elements[0].src).not.toBe(sharedAssetId);
-    expect(useMediaGenerationStore.getState().tasks[sharedAssetId]?.status).toBe('failed');
-  });
-
-  it('forks a shared ref owned by the stage whiteboard from a scene context', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const stage = mocks.document.stage as typeof mocks.document.stage & {
-      whiteboard: Array<(typeof mocks.document.scenes)[number]['content']['canvas']>;
-    };
-    stage.whiteboard = [
-      {
-        ...structuredClone(mocks.document.scenes[0].content.canvas),
-        id: 'stage-whiteboard',
-        elements: [
-          {
-            ...structuredClone(mocks.document.scenes[0].content.canvas.elements[0]),
-            id: 'stage-whiteboard-image',
-            type: 'image',
-            src: sharedAssetId,
-          },
-        ],
-      },
-    ];
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: failedTask(sharedAssetId) } });
-    serveImage('stage-whiteboard-copy');
-
-    await retryMediaTask(sharedAssetId, {
-      elementId: 'stage-whiteboard-image',
-      sceneId: 'scene-1',
-      slideId: 'stage-whiteboard',
-    });
-
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(sharedAssetId);
-    const savedStage = mocks.document.stage as typeof stage;
-    expect(savedStage.whiteboard[0].elements[0].src).not.toBe(sharedAssetId);
-    expect(useMediaGenerationStore.getState().tasks[sharedAssetId]?.status).toBe('failed');
-  });
-
-  it('does not fall back to a stage-whiteboard element id when the target slide misses', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const stage = mocks.document.stage as typeof mocks.document.stage & {
-      whiteboard: Array<(typeof mocks.document.scenes)[number]['content']['canvas']>;
-    };
-    stage.whiteboard = [
-      {
-        ...structuredClone(mocks.document.scenes[0].content.canvas),
-        id: 'stage-whiteboard',
-        elements: [
-          {
-            ...structuredClone(mocks.document.scenes[0].content.canvas.elements[0]),
-            id: 'stage-whiteboard-image',
-            type: 'image',
-            src: sharedAssetId,
-          },
-        ],
-      },
-    ];
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: failedTask(sharedAssetId) } });
-    serveImage('must-not-be-attached');
-
-    await retryMediaTask(sharedAssetId, {
-      elementId: 'stage-whiteboard-image',
-      sceneId: 'missing-scene',
-      slideId: 'missing-slide',
-    });
-
-    expect(stage.whiteboard[0].elements[0].src).toBe(sharedAssetId);
-    expect(useMediaGenerationStore.getState().tasks[sharedAssetId]?.status).toBe('failed');
-    expect(useMediaGenerationStore.getState().tasks['stage-whiteboard-image']).toMatchObject({
-      status: 'failed',
-      errorCode: 'TARGET_MISSING',
-    });
-  });
-
-  it('builds a safe retry target for a non-slide scene', () => {
-    expect(mediaRetryTarget('image-1', 'scene-1', { type: 'text', markdown: 'Notes' })).toEqual({
-      elementId: 'image-1',
-      sceneId: 'scene-1',
-    });
-  });
-
-  it('refuses to fork a shared ref without the owning slide instance', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.mediaRows.set(`${stageId}:${sharedAssetId}`, {
-      id: `${stageId}:${sharedAssetId}`,
-      blob: new Blob(['original-bytes'], { type: 'image/png' }),
-    });
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: failedTask(sharedAssetId) } });
-
-    await retryMediaTask(sharedAssetId, {
-      elementId: mocks.document.scenes[0].content.canvas.elements[0].id,
-      sceneId: mocks.document.scenes[0].id,
-    });
-
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(sharedAssetId);
-    expect(mocks.document.scenes[1].content.canvas.elements[0].src).toBe(sharedAssetId);
-    await assertOwnership();
-  });
-
-  it('rollback layer 4: protects first-commit bytes when later reconciliation fails', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    serveImage('committed-before-reconciliation-failure');
-    let documentWrites = 0;
-    mocks.beforeDocumentWork.mockImplementation(() => {
-      documentWrites += 1;
-      if (documentWrites === 2) throw new Error('second reconciliation failed');
-    });
+  it('keeps transient failures in memory without writing an empty durable row', async () => {
+    fetchMock.mockRejectedValue(new Error('network unavailable'));
 
     await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
-      ],
+      [outlineWith({ type: 'image', prompt: 'Retry later', elementId: imageRef })],
       stageId,
     );
 
-    const committedRef = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(committedRef).toMatch(/^ast_/);
-    expect(await resolvedText(committedRef)).toBe('committed-before-reconciliation-failure');
-    await assertOwnership();
+    expect(useMediaGenerationStore.getState().tasks[imageRef]).toMatchObject({
+      status: 'failed',
+      error: 'network unavailable',
+    });
+    expect(mocks.mediaPut).not.toHaveBeenCalled();
   });
 
-  it('protects document-committed refs when active-stage reconciliation throws', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    mocks.stageSetState.mockImplementationOnce(() => {
-      throw new Error('active-stage reconciliation failed');
-    });
-    serveImage('committed-before-active-stage-failure');
-
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
-      ],
-      stageId,
-    );
-
-    const committedRef = mocks.document.scenes[0].content.canvas.elements[0].src;
-    expect(mocks.stageSetState).toHaveBeenCalledOnce();
-    expect(committedRef).toMatch(/^ast_/);
-    expect(await resolvedText(committedRef)).toBe('committed-before-active-stage-failure');
-    expect(mocks.mediaRows.has(`${stageId}:${committedRef}`)).toBe(true);
+  it('does not import the asset pool or document mutation seams', () => {
+    const source = readFileSync(join(process.cwd(), 'lib/media/media-orchestrator.ts'), 'utf8');
+    expect(source).not.toMatch(/from ['"]@\/lib\/media\/asset-pool['"]/);
+    expect(source).not.toContain('putAsset(');
+    expect(source).not.toContain('replaceAsset(');
+    expect(source).not.toContain('mutateDocument(');
+    expect(source).not.toContain('.rekeyDone(');
   });
 
-  it('rollback layer 5: final rewrite failure leaves no task that can resurrect removed bytes', async () => {
-    const pendingDocument = documentWithMedia(placeholder, 'image');
-    const lateScene = structuredClone(pendingDocument.scenes[0]);
-    pendingDocument.scenes = [];
-    mocks.document = pendingDocument;
-    serveImage('removed-after-final-rewrite-failure');
-    const put = vi.spyOn(pool, 'put');
-    let documentWrites = 0;
-    mocks.beforeDocumentWork.mockImplementation(() => {
-      documentWrites += 1;
-      if (documentWrites === 2) throw new Error('second reconciliation failed');
-    });
-
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
-      ],
-      stageId,
-    );
-
-    const [removedRef] = await Promise.all(put.mock.results.map((result) => result.value));
-    expect(await pool.resolve(removedRef)).toBeNull();
-    expect(mocks.mediaRows.has(`${stageId}:${removedRef}`)).toBe(false);
-    expect(useMediaGenerationStore.getState().tasks).toEqual({
-      [placeholder]: expect.objectContaining({
-        elementId: placeholder,
-        status: 'failed',
-        error: 'second reconciliation failed',
-      }),
-    });
-
-    const reconciled = reconcileCompletedMediaForScene(
-      lateScene as unknown as Scene,
-      pendingDocument.stage as unknown as Stage,
-      useMediaGenerationStore.getState().tasks,
-    );
-    expect(reconciled.scene.content.type).toBe('slide');
-    if (reconciled.scene.content.type !== 'slide') throw new Error('Expected a slide scene');
-    const restoredElement = reconciled.scene.content.canvas.elements[0];
-    expect(restoredElement.type).toBe('image');
-    if (restoredElement.type !== 'image') throw new Error('Expected an image element');
-    expect(restoredElement.src).toBe(placeholder);
-  });
-
-  it('marks the targeted fork failed without mutating its shared source task', async () => {
-    const sharedAssetId = await pool.put(new Blob(['original-bytes'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(sharedAssetId, 'image');
-    const copy = structuredClone(mocks.document.scenes[0]);
-    copy.id = 'scene-copy';
-    copy.order = 2;
-    copy.content.canvas.id = 'slide-copy';
-    copy.content.canvas.elements[0].id = 'image-copy';
-    mocks.document.scenes.push(copy);
-    mocks.stageState = {
-      stage: structuredClone(mocks.document.stage),
-      scenes: structuredClone(mocks.document.scenes),
-    };
-    useMediaGenerationStore.setState({ tasks: { [sharedAssetId]: doneTask(sharedAssetId) } });
-    const sourceStatuses: Array<MediaTask['status'] | undefined> = [];
-    const unsubscribe = useMediaGenerationStore.subscribe((state) => {
-      sourceStatuses.push(state.tasks[sharedAssetId]?.status);
-    });
-    fetchMock.mockRejectedValue(new Error('fork generation failed'));
-
-    await retryMediaTask(sharedAssetId, {
-      elementId: 'image-copy',
-      sceneId: 'scene-copy',
-      slideId: 'slide-copy',
-    });
-    unsubscribe();
-
-    expect(useMediaGenerationStore.getState().tasks).toEqual({
-      [sharedAssetId]: expect.objectContaining({
-        elementId: sharedAssetId,
-        status: 'done',
-        objectUrl: 'blob:source',
-        retryCount: 0,
-      }),
-      'image-copy': expect.objectContaining({
-        elementId: 'image-copy',
-        status: 'failed',
-        error: 'fork generation failed',
-        retryCount: 1,
-      }),
-    });
-    expect(sourceStatuses.length).toBeGreaterThan(0);
-    expect(sourceStatuses.every((status) => status === 'done')).toBe(true);
-    const failedTarget = resolveSlideMediaState(
-      mocks.document.scenes[1].content.canvas as unknown as Slide,
-      stageId,
-      useMediaGenerationStore.getState().tasks,
-      { assetUrls: { [sharedAssetId]: 'blob:source-pool' } },
-    );
-    expect(failedTarget.byElementId['image-copy']).toMatchObject({
-      task: { elementId: 'image-copy', status: 'failed', error: 'fork generation failed' },
-      resolution: { kind: 'url', url: 'blob:source-pool', retryable: true },
-    });
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toBe(sharedAssetId);
-    expect(mocks.document.scenes[1].content.canvas.elements[0].src).toBe(sharedAssetId);
-  });
-
-  it('falls back to task-based resume filtering when legacy document access is locked', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    mocks.accessDocument.mockRejectedValueOnce(new Error('legacy lock unavailable'));
-    serveImage('generated-after-read-failure');
-
-    await generateMediaForOutlines(
-      [
-        {
-          id: 'outline-1',
-          type: 'slide',
-          title: 'Scene',
-          description: 'Scene',
-          keyPoints: ['image'],
-          order: 1,
-          mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-        },
-      ],
-      stageId,
-    );
-
-    expect(fetchMock).toHaveBeenCalledWith('/api/generate/image', expect.any(Object));
-    expect(mocks.document.scenes[0].content.canvas.elements[0].src).toMatch(/^ast_/);
-    await assertOwnership();
-  });
-
-  it('persists a retryable failure when pool replacement succeeds before Dexie fails', async () => {
-    const assetId = await pool.put(new Blob(['image-old'], { type: 'image/png' }));
-    mocks.document = documentWithMedia(assetId, 'image');
-    useMediaGenerationStore.setState({ tasks: { [assetId]: failedTask(assetId) } });
-    serveImage('pool-new-dexie-missed');
-    mocks.mediaPut.mockRejectedValueOnce(new Error('Dexie write failed'));
-    mocks.mediaGet.mockResolvedValue({
-      id: `${stageId}:${assetId}`,
-      stageId,
-      type: 'image',
-      blob: new Blob(['image-old'], { type: 'image/png' }),
-      mimeType: 'image/png',
-      size: 9,
-      prompt: 'A new image',
-      params: '{}',
-      createdAt: 1,
-    });
-
-    const target = {
-      elementId: 'image-1',
+  it('retains renderer retry targeting as a read-side compatibility seam', () => {
+    expect(mediaRetryTarget('image-element', 'scene-1', { canvas: { id: 'slide-1' } })).toEqual({
+      elementId: 'image-element',
       sceneId: 'scene-1',
       slideId: 'slide-1',
-    };
-    await retryMediaTask(assetId, target);
-
-    expect(await resolvedText(assetId)).toBe('pool-new-dexie-missed');
-    expect(useMediaGenerationStore.getState().tasks[assetId]).toMatchObject({
-      status: 'failed',
-      errorCode: 'MEDIA_COMPATIBILITY_STORE_LAGGED',
-      error: expect.stringContaining('compatibility media store lagged'),
     });
-    expect(mocks.mediaPut).not.toHaveBeenCalledWith(
-      expect.objectContaining({ errorCode: 'MEDIA_COMPATIBILITY_STORE_LAGGED' }),
-    );
-
-    serveImage('stores-converged');
-    await retryMediaTask(assetId, target);
-    expect(await resolvedText(assetId)).toBe('stores-converged');
-    expect(useMediaGenerationStore.getState().tasks[assetId]?.status).toBe('done');
-    expect(mocks.mediaPut).toHaveBeenLastCalledWith(
-      expect.objectContaining({ id: `${stageId}:${assetId}`, blob: expect.any(Blob) }),
-    );
-  });
-
-  it('drops a document rewrite fenced by a stage deletion epoch change', async () => {
-    mocks.document = documentWithMedia(placeholder, 'image');
-    const before = structuredClone(mocks.document);
-    serveImage();
-    mocks.beforeDocumentWork.mockImplementationOnce(() => markStageDeleted(stageId));
-
-    try {
-      await generateMediaForOutlines(
-        [
-          {
-            id: 'outline-1',
-            type: 'slide',
-            title: 'Scene',
-            description: 'Scene',
-            keyPoints: ['image'],
-            order: 1,
-            mediaGenerations: [{ type: 'image', prompt: 'A new image', elementId: placeholder }],
-          },
-        ],
-        stageId,
-      );
-      expect(mocks.document).toEqual(before);
-    } finally {
-      unmarkStageDeleted(stageId);
-    }
   });
 });

--- a/tests/media/proxy-media-cache.test.ts
+++ b/tests/media/proxy-media-cache.test.ts
@@ -1,0 +1,690 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MAX_TRANSIENT_ATTEMPTS,
+  fetchProxiedMediaUrl,
+  isProxyMediaTransientBlocked,
+  proxyMediaPermanentStatus,
+  proxyMediaRetainedBodyCount,
+  recordProxyMediaFailure,
+  resetProxyMediaFailureCache,
+} from '@/lib/media/proxy-media-cache';
+import { createProxiedFetch } from '@/lib/export/proxied-fetch';
+
+const URL = 'https://cdn.example.com/api/classroom-media/c1/audio/tts.mp3';
+
+/**
+ * A signal that aborts after `ms` via the (fake-)timers — the deterministic
+ * stand-in for `AbortSignal.timeout`, which `fetchMediaUrl` passes to every
+ * remote media fetch.
+ */
+function timeoutSignal(ms: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}
+
+describe('proxy-media session negative cache', () => {
+  beforeEach(() => {
+    resetProxyMediaFailureCache();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    resetProxyMediaFailureCache();
+  });
+
+  it('Case 1: 4xx marks the URL permanently failed: later calls short-circuit with no network request', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ success: false }), { status: 401 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await fetchProxiedMediaUrl(URL);
+    expect(first.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(proxyMediaPermanentStatus(URL)).toBe(401);
+
+    // Same URL again (and again) must never reach the network.
+    const second = await fetchProxiedMediaUrl(URL);
+    expect(second.status).toBe(401);
+    const third = await fetchProxiedMediaUrl(URL);
+    expect(third.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Case 1: fetchMediaUrl: after a 4xx, a second call to the same URL does not fetch', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ success: false }), { status: 401 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchMediaUrl } = await import('@/lib/media/fetch-media-url');
+
+    const first = await fetchMediaUrl(URL, 5_000);
+    expect(first.status).toBe(401);
+    await fetchMediaUrl(URL, 5_000);
+    await fetchMediaUrl(URL, 5_000);
+    // Only the first call hit the network.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Case 1: the recorded status is preserved in the short-circuited response (caller contract)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 403 })),
+    );
+    await fetchProxiedMediaUrl(URL);
+    const cached = await fetchProxiedMediaUrl(URL);
+    expect(cached.status).toBe(403);
+    const body = (await cached.json()) as { errorCode?: string; error?: string };
+    expect(body.errorCode).toBe('UPSTREAM_ERROR');
+    expect(typeof body.error).toBe('string');
+  });
+
+  it('Case 2: 5xx stays retryable: real attempts resume after the backoff window and cap at MAX_TRANSIENT_ATTEMPTS', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = vi.fn(async () => new Response(null, { status: 502 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Attempt 1: a real request, and the failure is NOT permanent.
+    const first = await fetchProxiedMediaUrl(URL);
+    expect(first.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(proxyMediaPermanentStatus(URL)).toBeUndefined();
+
+    // Inside the first backoff window: short-circuits without a request.
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Backoff(1)=400ms elapsed: a second REAL attempt happens.
+    vi.setSystemTime(400);
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Inside the second backoff window: short-circuits again.
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Backoff(2)=800ms elapsed: the third (final) real attempt.
+    vi.setSystemTime(400 + 800);
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // The per-URL cap is reached: every later call short-circuits.
+    await fetchProxiedMediaUrl(URL);
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(isProxyMediaTransientBlocked(URL)).toBe(true);
+  });
+
+  it('Case 2: network errors are transient: counted toward the cap, and the rejection contract is preserved', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchProxiedMediaUrl(URL)).rejects.toThrow('Failed to fetch');
+    expect(proxyMediaPermanentStatus(URL)).toBeUndefined();
+    expect(isProxyMediaTransientBlocked(URL, 0)).toBe(true); // backoff window open
+    expect(isProxyMediaTransientBlocked(URL, 500)).toBe(false); // window elapsed, cap not reached
+
+    vi.setSystemTime(500);
+    await expect(fetchProxiedMediaUrl(URL)).rejects.toThrow('Failed to fetch');
+    vi.setSystemTime(500 + 800);
+    await expect(fetchProxiedMediaUrl(URL)).rejects.toThrow('Failed to fetch');
+    // Cap reached: the next call short-circuits instead of throwing/reaching the network.
+    const shortCircuited = await fetchProxiedMediaUrl(URL);
+    expect(shortCircuited.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('Case 2: retryable 4xx (408/425/429) is transient: a recovered 429 returns 200 after the backoff window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response('bytes', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // A rate-limited first response is NOT a permanent verdict.
+    const first = await fetchProxiedMediaUrl(URL);
+    expect(first.status).toBe(429);
+    expect(proxyMediaPermanentStatus(URL)).toBeUndefined();
+
+    // Inside the backoff window: short-circuits, no real request.
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Backoff(1)=400ms elapsed: the retry is a REAL request and the upstream
+    // has recovered — the 200 is read and returned, not synthesized.
+    vi.setSystemTime(400);
+    const recovered = await fetchProxiedMediaUrl(URL);
+    expect(recovered.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('Case 2: 408/425/429 are the only 4xx that take the transient path; other 4xx stay permanent', async () => {
+    for (const status of [408, 425, 429]) {
+      recordProxyMediaFailure(URL, status);
+      expect(proxyMediaPermanentStatus(URL), String(status)).toBeUndefined();
+      expect(isProxyMediaTransientBlocked(URL, 0), String(status)).toBe(true);
+      resetProxyMediaFailureCache();
+    }
+    for (const status of [400, 401, 403, 404, 418, 422]) {
+      recordProxyMediaFailure(URL, status);
+      expect(proxyMediaPermanentStatus(URL), String(status)).toBe(status);
+      resetProxyMediaFailureCache();
+    }
+  });
+
+  it('Case 3: the negative cache is session-scoped memory: a reset (page refresh) allows re-probing', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    // Record one permanent (4xx) and one transient (5xx) verdict.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 502 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchProxiedMediaUrl(URL);
+    await fetchProxiedMediaUrl(URL + '#other'); // distinct URL for the 5xx record
+    expect(proxyMediaPermanentStatus(URL)).toBe(401);
+
+    // A page refresh forgets everything…
+    resetProxyMediaFailureCache();
+    expect(proxyMediaPermanentStatus(URL)).toBeUndefined();
+    expect(isProxyMediaTransientBlocked(URL)).toBe(false);
+
+    // …and the same URL is fetched again (a recovered URL gets one more chance).
+    fetchMock.mockResolvedValue(new Response('bytes', { status: 200 }));
+    const retried = await fetchProxiedMediaUrl(URL);
+    expect(retried.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('Case 3: nothing is persisted outside the module: only in-memory Maps are touched', async () => {
+    // The cache module has no storage imports; prove the verdicts live only in
+    // the session by re-importing the module (as a reload would) and observing
+    // an empty cache that fetches again.
+    const fetchMock = vi.fn(async () => new Response(null, { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    recordProxyMediaFailure(URL, 401);
+    expect(proxyMediaPermanentStatus(URL)).toBe(401);
+
+    vi.resetModules();
+    const fresh = await import('@/lib/media/proxy-media-cache');
+    expect(fresh.proxyMediaPermanentStatus(URL)).toBeUndefined();
+    await fresh.fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('covers the export proxied-fetch: a 4xx recorded through it short-circuits later calls', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ success: false }), { status: 401 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const pfetch = createProxiedFetch();
+
+    const first = await pfetch(URL);
+    expect(first.status).toBe(401);
+    const second = await pfetch(URL);
+    expect(second.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('same-origin absolute URLs go direct without overriding HTTP revalidation by default', async () => {
+    vi.stubGlobal('location', { origin: 'http://localhost:3000', href: 'http://localhost:3000/' });
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ success: false }), { status: 401 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchMediaUrl } = await import('@/lib/media/fetch-media-url');
+    const sameOriginUrl = 'http://localhost:3000/api/classroom-media/c1/audio/a.mp3';
+
+    await fetchMediaUrl(sameOriginUrl, 5_000);
+    await fetchMediaUrl(sameOriginUrl, 5_000);
+    // Both calls bypass the app's proxy cache and preserve the endpoint's
+    // default must-revalidate semantics for exports and other consumers.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      sameOriginUrl,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    const directInit = (fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>)[0]?.[1];
+    expect(directInit).not.toHaveProperty('cache');
+    expect(proxyMediaPermanentStatus(sameOriginUrl)).toBeUndefined();
+  });
+
+  it('lets the progressive converter explicitly reuse a just-rendered same-origin response', async () => {
+    vi.stubGlobal('location', { origin: 'http://localhost:3000', href: 'http://localhost:3000/' });
+    const fetchMock = vi.fn(async () => new Response(new Blob(['media']), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchMediaUrl } = await import('@/lib/media/fetch-media-url');
+    const sameOriginUrl = 'http://localhost:3000/api/classroom-media/c1/audio/a.mp3';
+
+    await fetchMediaUrl(sameOriginUrl, 5_000, { cache: 'force-cache' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      sameOriginUrl,
+      expect.objectContaining({ signal: expect.any(AbortSignal), cache: 'force-cache' }),
+    );
+  });
+
+  it('waits for an in-flight rendered image before issuing the conversion fetch', async () => {
+    const sameOriginUrl = 'http://localhost:3000/api/classroom-media/c1/images/a.png';
+    vi.stubGlobal('location', { origin: 'http://localhost:3000', href: 'http://localhost:3000/' });
+    const renderedImage = Object.assign(new EventTarget(), {
+      tagName: 'IMG',
+      currentSrc: sameOriginUrl,
+      complete: false,
+      getAttribute: () => sameOriginUrl,
+    });
+    vi.stubGlobal('document', {
+      querySelectorAll: () => [renderedImage],
+    });
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    });
+    const fetchMock = vi.fn(async () => new Response(new Blob(['media']), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchMediaUrl } = await import('@/lib/media/fetch-media-url');
+
+    const conversionFetch = fetchMediaUrl(sameOriginUrl, 5_000, {
+      cache: 'force-cache',
+      waitForRenderedMedia: true,
+    });
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    renderedImage.dispatchEvent(new Event('load'));
+    await conversionFetch;
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it(`rapid-fire back-to-back calls (the spam loop) let only one real request through`, async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // The observed symptom: a caller loop re-invoking the same URL every
+    // ~400ms. While the backoff window is open, every further call
+    // short-circuits — no network request is fired.
+    for (let i = 0; i < 20; i += 1) {
+      await fetchProxiedMediaUrl(URL);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Even after the backoff window elapses, the session cap bounds the total.
+    vi.setSystemTime(400);
+    await fetchProxiedMediaUrl(URL);
+    vi.setSystemTime(400 + 800);
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_TRANSIENT_ATTEMPTS);
+    await fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_TRANSIENT_ATTEMPTS);
+  });
+
+  it('concurrent in-flight calls for the same URL share ONE real request (P2-3)', async () => {
+    // P2-3: a serial loop was never the failure — 10 callers hitting the same
+    // URL at once all passed the blocked check before any failure was
+    // recorded, so 10 real requests fired. In-flight dedupe must collapse the
+    // burst onto a single fetch.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return new Response(null, { status: 503 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pending = Array.from({ length: 10 }, () => fetchProxiedMediaUrl(URL));
+    // All 10 are in flight (the fetch is gated) — and only one real request
+    // has been fired.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    release();
+    const responses = await Promise.all(pending);
+    expect(responses).toHaveLength(10);
+    expect(responses.every((r) => r.status === 503)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // After settlement the 503 was recorded once: the URL is now transient-
+    // blocked, so the next call short-circuits without a network request.
+    const next = await fetchProxiedMediaUrl(URL);
+    expect(next.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('each concurrent consumer reads the FULL body of the shared response (R2-P2-4)', async () => {
+    // R2-P2-4: dedupe handed every consumer the SAME Response object, so the
+    // first caller to consume the body made it unreadable for the rest — a
+    // shared success was only readable by one consumer. Every consumer must
+    // receive its own clone with the complete bytes.
+    const bytes = 'media-bytes-0123456789-abcdef';
+    const fetchMock = vi.fn(async () => new Response(bytes, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const [a, b] = await Promise.all([fetchProxiedMediaUrl(URL), fetchProxiedMediaUrl(URL)]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(a).not.toBe(b); // distinct Response objects, not one shared instance
+
+    await expect(a.text()).resolves.toBe(bytes);
+    await expect(b.text()).resolves.toBe(bytes);
+  });
+
+  it('aborting ONE caller rejects only that caller; others keep the 200 and the URL stays clean (R2-P2-5)', async () => {
+    // R2-P2-5: the shared fetch must not inherit any single caller's signal.
+    // Caller A cancels; caller B (no signal) must still receive the real 200
+    // and the URL must not be poisoned with a transient failure/backoff.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return new Response('bytes', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const owner = new AbortController();
+    const a = fetchProxiedMediaUrl(URL, { signal: owner.signal });
+    const b = fetchProxiedMediaUrl(URL);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Only caller A is cancelled — with the DOM abort contract (AbortError).
+    owner.abort();
+    await expect(a).rejects.toMatchObject({ name: 'AbortError' });
+
+    // B is untouched: the shared request is still pending on the internal
+    // controller, and B reads the full 200 response.
+    release();
+    const bResponse = await b;
+    expect(bResponse.status).toBe(200);
+    expect(await bResponse.text()).toBe('bytes');
+
+    // The caller cancellation was never recorded as a failure: no backoff and
+    // no cap — the next call fires a REAL request again.
+    expect(isProxyMediaTransientBlocked(URL)).toBe(false);
+    const after = await fetchProxiedMediaUrl(URL);
+    expect(after.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborting EVERY caller aborts the real fetch — the teardown records ONE transient failure (R3-P2-1)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let internalSignal: AbortSignal | null | undefined;
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      internalSignal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const a = new AbortController();
+    const b = new AbortController();
+    const pa = fetchProxiedMediaUrl(URL, { signal: a.signal });
+    const pb = fetchProxiedMediaUrl(URL, { signal: b.signal });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // A leaves: refcount is not zero yet (B is still in), so the real fetch
+    // keeps running — caller-driven cancellation while OTHERS wait records
+    // nothing.
+    a.abort();
+    await expect(pa).rejects.toMatchObject({ name: 'AbortError' });
+    expect(internalSignal?.aborted).toBe(false);
+
+    // B leaves too: refcount hits zero → the internal controller aborts the
+    // real fetch. NO caller received a result and the fetch never settled, so
+    // the teardown records ONE transient failure (status 0) — a dead/slow URL
+    // must not be re-fired back-to-back by the next caller. Callers still saw
+    // only their own AbortError.
+    b.abort();
+    await expect(pb).rejects.toMatchObject({ name: 'AbortError' });
+    expect(internalSignal?.aborted).toBe(true);
+    expect(isProxyMediaTransientBlocked(URL)).toBe(true);
+
+    // The recorded failure opens the backoff window: the next call
+    // short-circuits without a network request…
+    const shortCircuited = await fetchProxiedMediaUrl(URL);
+    expect(shortCircuited.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // …and after the window elapses a fresh REAL request is made (the URL is
+    // retryable, not permanently poisoned).
+    vi.setSystemTime(400);
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200 }));
+    const retried = await fetchProxiedMediaUrl(URL);
+    expect(retried.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('a dead URL whose callers time out enters backoff and short-circuits the next call (R3-P2-1)', async () => {
+    // fetchMediaUrl always passes AbortSignal.timeout(15_000). When the
+    // upstream/proxy hangs, every caller times out and the teardown abort is
+    // the URL's only signal — before this fix it was treated as plain caller
+    // cancellation and the next load/export fired the same dead request
+    // forever, never entering the backoff or the attempt cap.
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Caller 1 times out: nobody received a result → the teardown records the
+    // URL's FIRST transient failure and the backoff window opens.
+    const signal1 = timeoutSignal(5_000);
+    const p1 = fetchProxiedMediaUrl(URL, { signal: signal1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(5_000);
+    await expect(p1).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(isProxyMediaTransientBlocked(URL)).toBe(true); // backoff(1)=400ms open
+
+    // Backoff(1) elapses: caller 2 times out the same way → attempt 2.
+    vi.advanceTimersByTime(400);
+    const signal2 = timeoutSignal(5_000);
+    const p2 = fetchProxiedMediaUrl(URL, { signal: signal2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(5_000);
+    await expect(p2).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Caller 3 arrives inside the backoff window: the call short-circuits —
+    // no real request, no third timeout.
+    const third = await fetchProxiedMediaUrl(URL);
+    expect(third.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('a teardown abort while the 2xx body is still buffering records exactly once (R3-P2-1)', async () => {
+    // The shared fetch RESOLVED (status 200) but the body was still streaming
+    // into the buffer when the last caller left. The teardown aborts the
+    // internal controller, the body read rejects with AbortError, and that
+    // rejection must NOT be recorded a second time (the teardown already
+    // recorded the URL's one transient failure).
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              signal?.addEventListener('abort', () => {
+                controller.error(new DOMException('Aborted', 'AbortError'));
+              });
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const owner = new AbortController();
+    const pending = fetchProxiedMediaUrl(URL, { signal: owner.signal });
+    owner.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Exactly ONE transient failure is on the books: the backoff(1)=400ms
+    // window is open. A double count would have armed the longer window.
+    expect(isProxyMediaTransientBlocked(URL)).toBe(true);
+    vi.setSystemTime(400);
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200 }));
+    const retried = await fetchProxiedMediaUrl(URL);
+    expect(retried.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('buffers the shared 2xx body ONCE — 5 consumers × 512 KiB read the full bytes, 1 fetch (R3-P2-5)', async () => {
+    // The clone-per-consumer design formed a tee chain: N concurrent readers
+    // kept N stream branches of the unread original in memory. The shared
+    // path now buffers the body exactly once into a single Blob and every
+    // consumer synthesizes a fresh Response over that same Blob — memory is
+    // ONE body copy, never N ReadableStream branches and never N per-consumer
+    // Response byte copies.
+    const bytes = 'x'.repeat(512 * 1024); // 512 KiB, the acceptance body size
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(bytes, {
+          status: 200,
+          headers: { 'content-type': 'audio/mpeg', 'content-length': String(bytes.length) },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const responses = await Promise.all(Array.from({ length: 5 }, () => fetchProxiedMediaUrl(URL)));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Every consumer gets its OWN fresh Response (never a shared instance)…
+    expect(responses.every((r) => r.status === 200)).toBe(true);
+    expect(new Set(responses).size).toBe(5);
+    // …and reads the COMPLETE body, byte-identical.
+    const bodies = await Promise.all(responses.map((r) => r.text()));
+    expect(bodies.every((b) => b === bytes)).toBe(true);
+    // The synthesized responses preserved the content-type.
+    expect(responses[0]?.headers.get('content-type')).toBe('audio/mpeg');
+  });
+
+  it('memory contract: 5 consumer Responses over ONE shared Blob cost < 2× body, not 5× (R4-P2-1)', async () => {
+    // R4-P2-1: `new Response(shared.body)` with an ArrayBuffer body copied the
+    // bytes PER CONSUMER at construction (Node 22.22.0 probe: 5 ×
+    // new Response(20 MiB ArrayBuffer) → arrayBuffers +120 MiB ≈ 6× body).
+    // The shared path now buffers once into ONE Blob; undici reads a Blob
+    // body lazily by reference, so constructing N consumer Responses adds no
+    // byte copies (probe: 5 × new Response(20 MiB Blob) → +0.1 MiB).
+    const size = 512 * 1024;
+    // The single upstream byte copy the shared request reads once — held by
+    // the test so the measured window covers exactly the module's buffering
+    // plus the N Response constructions (the finding), not the upstream read.
+    const buffered = new ArrayBuffer(size);
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'audio/mpeg', 'content-length': String(size) }),
+      arrayBuffer: async () => buffered,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const before = process.memoryUsage().arrayBuffers;
+    const responses = await Promise.all(Array.from({ length: 5 }, () => fetchProxiedMediaUrl(URL)));
+    const delta = process.memoryUsage().arrayBuffers - before;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The shared path's total byte cost: ONE Blob copy (the module's single
+    // "buffer once" construction, 1× body) + 5 lazy Response(Blob)
+    // constructions (~0). If consumer Responses copied the bytes (the
+    // regression), the delta would be ≥ 5× body. Threshold 2× body: the
+    // buffered-once Blob is exactly 1×, leaving a full body-size of headroom
+    // for the Response objects and allocator noise.
+    expect(delta).toBeLessThan(2 * size);
+    // The bytes ARE the same single copy: every consumer reads the complete,
+    // byte-identical body.
+    const read = await Promise.all(responses.map((r) => r.arrayBuffer()));
+    expect(read.every((b) => b.byteLength === size)).toBe(true);
+    const first = new Uint8Array(read[0]);
+    for (const b of read.slice(1)) {
+      expect(new Uint8Array(b).every((v, i) => v === first[i])).toBe(true);
+    }
+  });
+
+  it('no module-level retention: 8 sequential URLs leave ZERO buffered bodies behind (R4-P2-2)', async () => {
+    // R4-P2-2: the removed `bufferedMedia` map kept every successful URL's
+    // full body for the session (probe: 8 × 4 MiB URLs → 32 MiB retained
+    // until an explicit reset). The payload now lives ONLY inside the
+    // in-flight entry: it is handed to the joined consumers and, once the
+    // last consumer leaves, the entry is dropped — the module references no
+    // body bytes.
+    const fetchMock = vi.fn(
+      async () => new Response('body-'.repeat(64 * 1024), { status: 200 }), // 320 KiB each
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    for (let i = 0; i < 8; i += 1) {
+      const res = await fetchProxiedMediaUrl(`${URL}?seq=${i}`);
+      expect(res.status).toBe(200);
+      await res.text(); // fully consumed, then dropped
+      expect(proxyMediaRetainedBodyCount()).toBe(0);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+  });
+
+  it('no response cache: a caller arriving AFTER settle starts a fresh fetch (R4-P2-2)', async () => {
+    // Deduplication covers only the concurrency window of a shared request —
+    // it must never cache the settled response: sequential callers to the
+    // same URL each fire a real request (the negative caches are the only
+    // session memory, and they never store a 2xx body).
+    const fetchMock = vi.fn(async () => new Response('bytes', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await fetchProxiedMediaUrl(URL);
+    expect(await first.text()).toBe('bytes');
+    expect(proxyMediaRetainedBodyCount()).toBe(0);
+    const second = await fetchProxiedMediaUrl(URL);
+    expect(await second.text()).toBe('bytes');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(proxyMediaRetainedBodyCount()).toBe(0);
+  });
+
+  it('the retention probe counts nothing while a request is still streaming (R4-P2-2)', async () => {
+    // The probe counts payloads the module HOLDS (settled Blobs inside joined
+    // entries). While the shared request is still in flight the bytes live in
+    // the network stream — never in the module — so the count is 0 before and
+    // after the fetch.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return new Response('bytes', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pending = fetchProxiedMediaUrl(URL);
+    expect(proxyMediaRetainedBodyCount()).toBe(0); // in flight, nothing buffered
+    release();
+    const res = await pending;
+    expect(proxyMediaRetainedBodyCount()).toBe(0); // delivered, entry dropped
+    await res.text();
+    expect(proxyMediaRetainedBodyCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
Classic (non-workbench) classroom media generation no longer allocates server asset-registry ids: generated bytes live in the browser media store keyed by their generation placeholder, hosted URLs are used directly, and playback renders the completed task's object URL — restoring the pre-registry classic chain. The registry read fallback stays additive so workbench-authored courses keep rendering, and export retains its manifest-driven resolution over both shapes. Also ports the shared proxy-media cache (negative/backoff caching with in-flight dedupe) for all proxied media fetches. Full suite (7k+ tests), typecheck, prettier, and build all green.