### PR TITLE
fix(import): adapt imported PPTX canvas size so decks render without overflow

### DIFF
--- a/components/edit/surfaces/slide/RendererEditorCanvas.tsx
+++ b/components/edit/surfaces/slide/RendererEditorCanvas.tsx
@@ -12,11 +12,13 @@ import { useResolvedSlide } from '@/components/slide-renderer/use-resolved-slide
 import { createElementId } from '@/lib/edit/element-id';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useCanvasStore } from '@/lib/store/canvas';
+import { useSyncCanvasViewportFromSlide } from '@/lib/store/sync-canvas-viewport';
 import { EDITABLE_ELEMENT_ID_PREFIX } from './renderer-element-dom';
 import { useSlideEditSession } from './slide-edit-session';
 import { useResolvedSlideContent } from './use-slide-surface';
 
 export function RendererEditorCanvas() {
+  useSyncCanvasViewportFromSlide();
   const { locale, t } = useI18n();
   const content = useResolvedSlideContent();
   const slide = useResolvedSlide(content.canvas);

--- a/components/slide-renderer/Editor/Canvas/index.tsx
+++ b/components/slide-renderer/Editor/Canvas/index.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from 'react';
 import { useCanvasStore } from '@/lib/store/canvas';
+import { useSyncCanvasViewportFromSlide } from '@/lib/store/sync-canvas-viewport';
 import { useSceneSelector } from '@/lib/contexts/scene-context';
 import { useKeyboardStore } from '@/lib/store/keyboard';
 import { useViewportSize } from './hooks/useViewportSize';
@@ -62,6 +63,7 @@ export interface CanvasProps {
 export function Canvas(_props: CanvasProps) {
   const canvasRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
+  useSyncCanvasViewportFromSlide();
 
   // Subscribe to specific parts for performance optimization
   const elements = useSceneSelector<SlideContent, PPTElement[]>(

--- a/components/slide-renderer/Editor/ScreenCanvas.tsx
+++ b/components/slide-renderer/Editor/ScreenCanvas.tsx
@@ -7,6 +7,7 @@ import { LaserOverlay } from './LaserOverlay';
 import { RendererScreenCanvas } from './RendererScreenCanvas';
 import { useSlideBackgroundStyle } from '@/lib/hooks/use-slide-background-style';
 import { useCanvasStore } from '@/lib/store';
+import { useSyncCanvasViewportFromSlide } from '@/lib/store/sync-canvas-viewport';
 import { useSceneSelector } from '@/lib/contexts/scene-context';
 import { findElementGeometry } from '@/lib/utils/geometry';
 import type { SlideContent } from '@/lib/types/stage';
@@ -18,6 +19,7 @@ import { AnimatePresence } from 'motion/react';
 import { isPlaybackRendererEnabled } from '@/lib/config/feature-flags';
 
 export function ScreenCanvas() {
+  useSyncCanvasViewportFromSlide();
   const canvasScale = useCanvasStore.use.canvasScale();
   const elements = useSceneSelector<SlideContent, PPTElement[]>(
     (content) => content.canvas.elements,

--- a/lib/store/sync-canvas-viewport.ts
+++ b/lib/store/sync-canvas-viewport.ts
@@ -1,0 +1,59 @@
+/**
+ * Keep the editor/playback viewport in the canvas store aligned with the
+ * current slide. Thumbnails already auto-fit using `slide.viewportSize`;
+ * the main canvas sizes its box from the store (default 1000×16:9). Imported
+ * PPTX decks are often 1280×16:9 (or 4:3), so without this sync the right
+ * and bottom of the slide are clipped while the rail looks complete.
+ *
+ * The canvas store is a singleton, so only the active scene may write it.
+ * Keep-alive / crossfade siblings that stay mounted for another scene skip
+ * the write; otherwise the last effect would stretch every canvas.
+ */
+import { useLayoutEffect } from 'react';
+import { useSceneData, useSceneSelector } from '@/lib/contexts/scene-context';
+import type { SlideContent } from '@/lib/types/stage';
+import { useCanvasStore } from './canvas';
+import { useStageStore } from './stage';
+
+const DEFAULT_VIEWPORT_SIZE = 1000;
+const DEFAULT_VIEWPORT_RATIO = 0.5625;
+
+function finitePositive(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function isActiveCanvasScene(
+  sceneId: string | undefined,
+  currentSceneId: string | undefined | null,
+): boolean {
+  if (currentSceneId && sceneId && sceneId !== currentSceneId) return false;
+  return true;
+}
+
+export function syncCanvasViewportFromSlide(slide: {
+  viewportSize?: number;
+  viewportRatio?: number;
+}): boolean {
+  const size = finitePositive(slide.viewportSize) ? slide.viewportSize : DEFAULT_VIEWPORT_SIZE;
+  const ratio = finitePositive(slide.viewportRatio) ? slide.viewportRatio : DEFAULT_VIEWPORT_RATIO;
+  const store = useCanvasStore.getState();
+  if (store.viewportSize === size && store.viewportRatio === ratio) return false;
+  store.setViewportSize(size);
+  store.setViewportRatio(ratio);
+  return true;
+}
+
+export function useSyncCanvasViewportFromSlide(): void {
+  const { sceneId } = useSceneData();
+  const currentSceneId = useStageStore((state) => state.currentSceneId);
+  const viewportSize = useSceneSelector<SlideContent, number | undefined>(
+    (content) => content.canvas?.viewportSize,
+  );
+  const viewportRatio = useSceneSelector<SlideContent, number | undefined>(
+    (content) => content.canvas?.viewportRatio,
+  );
+  useLayoutEffect(() => {
+    if (!isActiveCanvasScene(sceneId, currentSceneId)) return;
+    syncCanvasViewportFromSlide({ viewportSize, viewportRatio });
+  }, [viewportSize, viewportRatio, sceneId, currentSceneId]);
+}

--- a/packages/@openmaic/importer/test/transformParsedToSlides.viewport.test.ts
+++ b/packages/@openmaic/importer/test/transformParsedToSlides.viewport.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { parsedToSlides } from '../src/import-pipeline';
+
+/**
+ * The deck-size adaptation contract at the conversion boundary: the parsed
+ * deck's native size (pt) drives both the emitted canvas (`viewportSize` is
+ * the deck width × 96/72 px-per-pt, `viewportRatio` is height/width) and the
+ * transform-time element clamp, so a 4:3 or custom deck renders on a canvas
+ * that matches its real geometry instead of the 16:9 default. These fixtures
+ * mirror the reference's expected geometry (16:9 default → 1280×0.5625,
+ * 4:3 → 960×0.75).
+ */
+
+const deck = (size: { width: number; height: number }, elements: unknown[]) => ({
+  size,
+  themeColors: [],
+  slides: [
+    {
+      fill: { type: 'color', value: '#ffffff' },
+      note: '',
+      layoutElements: [],
+      elements,
+    },
+  ],
+});
+
+const textElement = (overrides: Record<string, unknown>) => ({
+  type: 'text',
+  left: 90,
+  top: 67.5,
+  width: 360,
+  height: 90,
+  name: 'text',
+  order: 1,
+  rotate: 0,
+  content: '<div style="padding: 0px;"><p style="font-size: 24pt"><span>Hello</span></p></div>',
+  fill: { type: 'color', value: 'transparent' },
+  borderWidth: 0,
+  borderColor: '#000000',
+  borderType: 'solid',
+  borderStrokeDasharray: '0',
+  isVertical: false,
+  vAlign: 'up',
+  autoFit: { type: 'shape' },
+  ...overrides,
+});
+
+type TextGeometry = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  content: string;
+};
+
+describe('transformParsedToSlides · deck viewport adaptation', () => {
+  it('sizes a 4:3 deck (720×540pt) to a 960×0.75 canvas and scales elements by 96/72', async () => {
+    const slides = await parsedToSlides(
+      deck({ width: 720, height: 540 }, [
+        textElement({}),
+        textElement({ left: 600, top: 400, width: 200, height: 200, name: 'edge' }),
+      ]) as unknown as Parameters<typeof parsedToSlides>[0],
+    );
+
+    expect(slides).toHaveLength(1);
+    const slide = slides[0];
+    // 720pt × 96/72 px-per-pt → 960px wide; 540/720 → 0.75 ratio (4:3).
+    expect(slide.viewportSize).toBe(960);
+    expect(slide.viewportRatio).toBe(0.75);
+    expect(slide.viewportSize * slide.viewportRatio).toBe(720);
+
+    const [title, edge] = slide.elements as unknown as TextGeometry[];
+
+    // A free-standing box scales by 96/72 with no edge clamp.
+    expect(title.left).toBe(120);
+    expect(title.top).toBe(90);
+    expect(title.width).toBe(480);
+    expect(title.height).toBe(120);
+    // Inline pt sizes are scaled to px on the same 96/72 factor.
+    expect(title.content).toContain('font-size: 32.0px');
+
+    // A box hanging past the canvas edge is clamped so it fits exactly.
+    expect(edge.left).toBe(800);
+    expect(edge.top).toBeCloseTo(533.33, 2);
+    expect(edge.width).toBe(160);
+    expect(edge.height).toBeCloseTo(186.67, 2);
+    expect(edge.left + edge.width).toBe(slide.viewportSize);
+    expect(edge.top + edge.height).toBeCloseTo(slide.viewportSize * slide.viewportRatio, 2);
+  });
+
+  it('keeps the default 16:9 deck (960×540pt) at the reference 1280×0.5625 canvas', async () => {
+    const slides = await parsedToSlides(
+      deck({ width: 960, height: 540 }, [textElement({})]) as unknown as Parameters<
+        typeof parsedToSlides
+      >[0],
+    );
+
+    expect(slides).toHaveLength(1);
+    expect(slides[0].viewportSize).toBe(1280);
+    expect(slides[0].viewportRatio).toBe(0.5625);
+  });
+
+  it('handles a custom deck size generically', async () => {
+    const slides = await parsedToSlides(
+      deck({ width: 1000, height: 700 }, [textElement({})]) as unknown as Parameters<
+        typeof parsedToSlides
+      >[0],
+    );
+
+    expect(slides).toHaveLength(1);
+    expect(slides[0].viewportSize).toBeCloseTo(1000 * (96 / 72), 6);
+    expect(slides[0].viewportRatio).toBe(0.7);
+
+    const [title] = slides[0].elements as unknown as TextGeometry[];
+    expect(title.left).toBeCloseTo(120, 6);
+    expect(title.left + title.width).toBeLessThanOrEqual(slides[0].viewportSize);
+    expect(title.top + title.height).toBeLessThanOrEqual(
+      slides[0].viewportSize * slides[0].viewportRatio,
+    );
+  });
+});

--- a/tests/edit/surfaces/slide/slide-canvas-renderer-flag.test.ts
+++ b/tests/edit/surfaces/slide/slide-canvas-renderer-flag.test.ts
@@ -68,6 +68,8 @@ vi.mock('@/components/slide-renderer/Editor/LaserPointerOverlay', () => ({
 
 vi.mock('@/lib/contexts/scene-context', () => ({
   SceneProvider: ({ children }: { children: ReactNode }) => children,
+  useSceneData: () => ({ sceneId: 'scene-1' }),
+  useSceneSelector: () => undefined,
 }));
 
 vi.mock('@/components/edit/surfaces/slide/AnchoredTextBar', () => ({

--- a/tests/store/sync-canvas-viewport.test.ts
+++ b/tests/store/sync-canvas-viewport.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useCanvasStore } from '@/lib/store/canvas';
+import { isActiveCanvasScene, syncCanvasViewportFromSlide } from '@/lib/store/sync-canvas-viewport';
+
+const original = {
+  viewportSize: useCanvasStore.getState().viewportSize,
+  viewportRatio: useCanvasStore.getState().viewportRatio,
+};
+
+afterEach(() => {
+  useCanvasStore.getState().setViewportSize(original.viewportSize);
+  useCanvasStore.getState().setViewportRatio(original.viewportRatio);
+});
+
+describe('syncCanvasViewportFromSlide', () => {
+  it('copies the slide viewport into the canvas store', () => {
+    expect(syncCanvasViewportFromSlide({ viewportSize: 1280, viewportRatio: 0.5625 })).toBe(true);
+    expect(useCanvasStore.getState().viewportSize).toBe(1280);
+    expect(useCanvasStore.getState().viewportRatio).toBe(0.5625);
+  });
+
+  it('is a no-op when the store already matches', () => {
+    useCanvasStore.getState().setViewportSize(1280);
+    useCanvasStore.getState().setViewportRatio(0.5625);
+    expect(syncCanvasViewportFromSlide({ viewportSize: 1280, viewportRatio: 0.5625 })).toBe(false);
+  });
+
+  it('falls back to 1000×16:9 when the slide has no viewport metadata', () => {
+    useCanvasStore.getState().setViewportSize(1280);
+    useCanvasStore.getState().setViewportRatio(0.75);
+    expect(syncCanvasViewportFromSlide({})).toBe(true);
+    expect(useCanvasStore.getState().viewportSize).toBe(1000);
+    expect(useCanvasStore.getState().viewportRatio).toBe(0.5625);
+  });
+
+  it('does not write the store for a keep-alive scene that is not current', () => {
+    expect(isActiveCanvasScene('scene-a', 'scene-b')).toBe(false);
+    expect(isActiveCanvasScene('scene-a', 'scene-a')).toBe(true);
+    expect(isActiveCanvasScene('scene-a', undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
Imported decks overflowed the main canvas because the editor/playback canvas stayed at the hard-coded 1000x16:9 default while the importer already emits each slide's real deck-derived viewportSize/viewportRatio (4:3 -> 960x0.75, custom sizes generically). Restores the reference's sync-canvas-viewport store hook and wires it into the three canvas surfaces (RendererEditorCanvas, editor Canvas, playback ScreenCanvas), with the active-scene guard so keep-alive siblings cannot leak their size. Adds a conversion-boundary regression suite (4:3 / 16:9 / custom decks) in the importer package plus the store-sync tests.