### PR TITLE
fix(agent): carry reasoning through the completions dialect so the thinking strip renders

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1601,6 +1601,17 @@ function getCompatThinkingBodyParams(
   modelId: string,
   config: ThinkingConfig,
 ): Record<string, unknown> | undefined {
+  // This model is served through an OpenAI-compatible gateway even when the
+  // deployment uses the `openai` provider slot. The gateway's chat template
+  // toggle is neither OpenAI's `reasoning_effort` nor DeepSeek's native
+  // `thinking` object: it requires this exact vLLM template argument.
+  if (providerId === 'openai' && modelId === 'deepseek-v4-flash-vision-exp') {
+    const mode = getThinkingMode(config);
+    return mode === undefined
+      ? undefined
+      : { chat_template_kwargs: { thinking: mode === 'enabled' } };
+  }
+
   const capability = getCatalogThinkingCapability(providerId, modelId);
   if (!capability || capability.control === 'none') return undefined;
 
@@ -2074,15 +2085,16 @@ export function getModel(config: ModelConfig): ModelWithInfo {
         name: config.providerId,
       };
 
-      if (useStreamingChatCompat) {
-        openaiOptions.fetch = fetchCustomOpenAIChat as typeof globalThis.fetch;
-      }
-
-      // For OpenAI-compatible providers (not native OpenAI), add a fetch
-      // wrapper that injects vendor-specific thinking params into the HTTP
-      // body. The thinking config is read from AsyncLocalStorage, set by
-      // callLLM / streamLLM at call time.
-      if (config.providerId !== 'openai') {
+      // A custom base URL makes the `openai` slot an OpenAI-compatible gateway,
+      // not the native OpenAI service. Give it the same request/response seam
+      // as named compatible providers: inject the gateway's thinking control
+      // and recover reasoning_content before the SDK schema can discard it.
+      const usesOpenAIResponses =
+        !useStreamingChatCompat && shouldUseOpenAIResponsesApi(config.providerId, config.modelId);
+      const usesCompatTransport =
+        config.providerId !== 'openai' ||
+        (usesCustomOpenAIBaseUrl(config.baseUrl) && !usesOpenAIResponses);
+      if (usesCompatTransport) {
         const providerId = config.providerId;
         const compatFetch = async (url: RequestInfo | URL, init?: RequestInit) => {
           // Read thinking config from globalThis (set by thinking-context.ts)
@@ -2125,7 +2137,9 @@ export function getModel(config: ModelConfig): ModelWithInfo {
               /* leave body as-is */
             }
           }
-          const response = await globalThis.fetch(url, init);
+          const response = useStreamingChatCompat
+            ? await fetchCustomOpenAIChat(url, init)
+            : await globalThis.fetch(url, init);
 
           // Recover reasoning that @ai-sdk/openai's chat schema drops: rewrite
           // streamed `reasoning_content` deltas into an inline <think> block
@@ -2186,17 +2200,14 @@ export function getModel(config: ModelConfig): ModelWithInfo {
       }
 
       const openai = createOpenAI(openaiOptions);
-      model =
-        !useStreamingChatCompat && shouldUseOpenAIResponsesApi(config.providerId, config.modelId)
-          ? openai.responses(config.modelId)
-          : openai.chat(config.modelId);
-      // OpenAI-compatible providers (e.g. DeepSeek, Qwen) stream reasoning
+      model = usesOpenAIResponses ? openai.responses(config.modelId) : openai.chat(config.modelId);
+      // OpenAI-compatible providers (e.g. DeepSeek, Qwen), including a custom
+      // gateway configured through the `openai` slot, stream reasoning
       // either as a separate `reasoning_content` field (normalized to an inline
       // <think> block by compatFetch) or as native inline <think>.
       // Split it into first-class reasoning parts so the agent stream and UI can
-      // show a thinking panel and the answer text stays clean. Native OpenAI
-      // handles reasoning itself, so it is excluded.
-      if (config.providerId !== 'openai') {
+      // show a thinking panel and the answer text stays clean.
+      if (usesCompatTransport) {
         const middleware =
           config.providerId === 'kimi' && config.modelId === 'kimi-k3'
             ? [

--- a/tests/ai/openai-provider.test.ts
+++ b/tests/ai/openai-provider.test.ts
@@ -27,6 +27,7 @@ async function captureInjectedRequestBody(
   providerId: ProviderId,
   modelId: string,
   thinkingConfig?: Record<string, unknown>,
+  baseUrl?: string,
 ) {
   const originalFetch = globalThis.fetch;
   const globalRecord = globalThis as Record<string, unknown>;
@@ -48,6 +49,7 @@ async function captureInjectedRequestBody(
       providerId,
       modelId,
       apiKey: 'sk-test',
+      baseUrl,
     });
 
     const lastCall = openAiMock.createOpenAI.mock.calls.at(-1);
@@ -649,6 +651,57 @@ describe('OpenAI provider defaults', () => {
       expect(body).toMatchObject(expected);
     },
   );
+
+  it('sends the driver route thinking toggle required by the custom OpenAI gateway', async () => {
+    const body = await captureInjectedRequestBody(
+      'openai',
+      'deepseek-v4-flash-vision-exp',
+      { enabled: true },
+      'https://gateway.example/v1',
+    );
+
+    expect(body).toMatchObject({
+      chat_template_kwargs: { thinking: true },
+    });
+    expect(body).not.toHaveProperty('reasoning_effort');
+    expect(body).not.toHaveProperty('enable_thinking');
+  });
+
+  it('recovers reasoning_content from a custom OpenAI gateway stream', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async () => {
+      const payload = {
+        choices: [{ index: 0, delta: { reasoning_content: 'Inspect the evidence' } }],
+      };
+      return new Response(`data: ${JSON.stringify(payload)}\n\ndata: [DONE]\n\n`, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    });
+
+    try {
+      globalThis.fetch = fetchMock as typeof fetch;
+      getModel({
+        providerId: 'openai',
+        modelId: 'deepseek-v4-flash-vision-exp',
+        apiKey: 'sk-test',
+        baseUrl: 'https://gateway.example/v1',
+      });
+      const options = openAiMock.createOpenAI.mock.calls.at(-1)?.[0] as
+        | { fetch?: typeof fetch }
+        | undefined;
+      const response = await options?.fetch?.('https://gateway.example/v1/chat/completions', {
+        method: 'POST',
+        body: JSON.stringify({ stream: true }),
+      });
+      const normalized = await response?.text();
+
+      expect(normalized).toContain('<think>Inspect the evidence');
+      expect(normalized).not.toContain('reasoning_content');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
   it('omits a zero SiliconFlow thinking budget when thinking is disabled', async () => {
     const body = await captureInjectedRequestBody('siliconflow', 'deepseek-ai/DeepSeek-V3.2', {

--- a/tests/ai/openai-sdk-integration.test.ts
+++ b/tests/ai/openai-sdk-integration.test.ts
@@ -3,10 +3,78 @@ import { generateText, stepCountIs, streamText, tool } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
-import { resolveThinkingProviderOptions } from '@/lib/ai/llm';
+import { resolveThinkingProviderOptions, streamLLM } from '@/lib/ai/llm';
 import { getModel } from '@/lib/ai/providers';
 
 describe('OpenAI SDK integration', () => {
+  it('carries the custom gateway toggle in and reasoning_content back out', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      const chunks = [
+        {
+          id: 'chatcmpl-thinking',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model: 'deepseek-v4-flash-vision-exp',
+          choices: [
+            {
+              index: 0,
+              delta: { reasoning_content: 'Inspect the evidence' },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: 'chatcmpl-thinking',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model: 'deepseek-v4-flash-vision-exp',
+          choices: [{ index: 0, delta: { content: 'Done' }, finish_reason: null }],
+        },
+        {
+          id: 'chatcmpl-thinking',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model: 'deepseek-v4-flash-vision-exp',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        },
+      ];
+      return new Response(
+        `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`,
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+    }) as typeof globalThis.fetch;
+
+    try {
+      const { model } = getModel({
+        providerId: 'openai',
+        modelId: 'deepseek-v4-flash-vision-exp',
+        apiKey: 'sk-test',
+        baseUrl: 'https://gateway.example/v1',
+      });
+      const result = streamLLM(
+        { model, prompt: 'hi', maxRetries: 0 },
+        'agent-runtime-thinking-seam',
+        { enabled: true },
+      );
+      const parts: Array<Record<string, unknown>> = [];
+      for await (const part of result.fullStream) parts.push(part as Record<string, unknown>);
+
+      expect(requestBody).toMatchObject({
+        chat_template_kwargs: { thinking: true },
+      });
+      expect(parts).toContainEqual(
+        expect.objectContaining({ type: 'reasoning-delta', text: 'Inspect the evidence' }),
+      );
+      expect(parts).toContainEqual(expect.objectContaining({ type: 'text-delta', text: 'Done' }));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('accepts GPT-5.6 max reasoning effort and sends it to the Responses API', async () => {
     let requestBody: Record<string, unknown> | undefined;
     const fetchMock = async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/tests/server/resolve-model.test.ts
+++ b/tests/server/resolve-model.test.ts
@@ -221,6 +221,24 @@ describe('resolveModel — per-stage resolution order', () => {
     expect(r.thinkingConfig).toEqual({ enabled: true, budgetTokens: 8000 });
   });
 
+  it('carries the agent driver thinking toggle onto its resolved connection', async () => {
+    process.env.MODEL_ROUTES = JSON.stringify({
+      'maic-agent-driver': {
+        model: 'openai:deepseek-v4-flash-vision-exp',
+        api: 'openai-completions',
+        thinking: { enabled: true },
+      },
+    });
+    const { resolveModel } = await import('@/lib/server/resolve-model');
+    const r = await resolveModel({ stage: 'maic-agent-driver' });
+
+    expect(r).toMatchObject({
+      providerId: 'openai',
+      modelId: 'deepseek-v4-flash-vision-exp',
+      thinkingConfig: { enabled: true },
+    });
+  });
+
   it('routed-without-thinking drops client thinking (routed model uses its default)', async () => {
     process.env.MODEL_ROUTES = JSON.stringify({ 'scene-content': 'deepseek:deepseek-v4-pro' });
     const { resolveModel } = await import('@/lib/server/resolve-model');


### PR DESCRIPTION
The workbench thinking strip never rendered on OpenAI-compatible gateways: the provider layer treated the openai provider id as native OpenAI, so custom-base-URL Chat Completions requests got no thinking parameter and the gateway's streamed reasoning_content was discarded by the SDK schema before the driver mapper ran. Ported the reference's repointed-OpenAI transport rule narrowed to custom-base-URL Chat Completions: the route's thinking toggle maps to the gateway-verified chat_template_kwargs knob, and the reasoning_content rewriter plus extraction middleware are installed on that transport. Runner, SSE, fold, and UI needed no change (verified link by link). Real-SDK seam tests prove the request knob goes out and reasoning-delta comes back.