### PR TITLE
fix(classroom): center adapted canvases in the stage and send back navigation home during generation

### DIFF
--- a/components/edit/EditShell/CommandBar.tsx
+++ b/components/edit/EditShell/CommandBar.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { ArrowLeft, Redo2, Undo2 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { cn } from '@/lib/utils';
 import type { EditorCommand, SurfaceHistory } from '@/lib/edit/scene-editor-surface';
+import { classroomExitLabelKey, exitClassroom } from '@/lib/workbench/classroom-exit';
 
 interface CommandBarProps {
   readonly title: string;
@@ -35,13 +36,19 @@ interface CommandBarProps {
 export function CommandBar({ title, history, commands, trailing }: CommandBarProps) {
   const { t } = useI18n();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const exitLabel = t(classroomExitLabelKey(searchParams));
 
   return (
     <header className="flex h-20 shrink-0 items-center gap-3 border-b border-zinc-200/60 px-8 dark:border-zinc-800/60">
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        {/* Back-to-home — mirrors playback Header's leftmost button so the
-            user has the same global-out affordance across modes. */}
-        <IconButton title={t('generation.backToHome')} onClick={() => router.push('/')}>
+        {/* Classroom exit mirrors playback Header's leftmost button so the
+            user has the same global-out affordance across standalone modes. */}
+        <IconButton
+          title={exitLabel}
+          aria-label={exitLabel}
+          onClick={() => exitClassroom(router, searchParams)}
+        >
           <ArrowLeft className="h-4 w-4" />
         </IconButton>
         {history && (

--- a/components/slide-renderer/Editor/Canvas/hooks/useViewportSize.ts
+++ b/components/slide-renderer/Editor/Canvas/hooks/useViewportSize.ts
@@ -15,6 +15,13 @@ export interface ViewportStyles {
 export function useViewportSize(canvasRef: RefObject<HTMLElement | null>) {
   const [viewportLeft, setViewportLeft] = useState(0);
   const [viewportTop, setViewportTop] = useState(0);
+  // Local mirror of the computed scale. `canvasScale` in the store is GLOBAL:
+  // every mounted canvas writes it (crossfade-exiting panes, keep-alive tabs),
+  // so a sibling's settle can overwrite the scale this canvas renders with
+  // until this canvas's own observer fires again — the first-open mis-scale
+  // that a seam drag "fixed" by forcing a re-measure. Render from the local
+  // value; the store keeps being written for out-of-tree consumers.
+  const [fitScale, setFitScale] = useState(() => useCanvasStore.getState().canvasScale);
 
   const canvasPercentage = useCanvasStore.use.canvasPercentage();
   const canvasDragged = useCanvasStore.use.canvasDragged();
@@ -32,12 +39,16 @@ export function useViewportSize(canvasRef: RefObject<HTMLElement | null>) {
 
     if (canvasHeight / canvasWidth > viewportRatio) {
       const viewportActualWidth = canvasWidth * (canvasPercentage / 100);
-      setCanvasScale(viewportActualWidth / viewportSize);
+      const nextScale = viewportActualWidth / viewportSize;
+      setCanvasScale(nextScale);
+      setFitScale(nextScale);
       setViewportLeft((canvasWidth - viewportActualWidth) / 2);
       setViewportTop((canvasHeight - viewportActualWidth * viewportRatio) / 2);
     } else {
       const viewportActualHeight = canvasHeight * (canvasPercentage / 100);
-      setCanvasScale(viewportActualHeight / (viewportSize * viewportRatio));
+      const nextScale = viewportActualHeight / (viewportSize * viewportRatio);
+      setCanvasScale(nextScale);
+      setFitScale(nextScale);
       setViewportLeft((canvasWidth - viewportActualHeight / viewportRatio) / 2);
       setViewportTop((canvasHeight - viewportActualHeight) / 2);
     }
@@ -56,7 +67,9 @@ export function useViewportSize(canvasRef: RefObject<HTMLElement | null>) {
         const newViewportActualHeight = newViewportActualWidth * viewportRatio;
         const oldViewportActualHeight = oldViewportActualWidth * viewportRatio;
 
-        setCanvasScale(newViewportActualWidth / viewportSize);
+        const nextScale = newViewportActualWidth / viewportSize;
+        setCanvasScale(nextScale);
+        setFitScale(nextScale);
 
         setViewportLeft((prev) => prev - (newViewportActualWidth - oldViewportActualWidth) / 2);
         setViewportTop((prev) => prev - (newViewportActualHeight - oldViewportActualHeight) / 2);
@@ -66,7 +79,9 @@ export function useViewportSize(canvasRef: RefObject<HTMLElement | null>) {
         const newViewportActualWidth = newViewportActualHeight / viewportRatio;
         const oldViewportActualWidth = oldViewportActualHeight / viewportRatio;
 
-        setCanvasScale(newViewportActualHeight / (viewportSize * viewportRatio));
+        const nextScale = newViewportActualHeight / (viewportSize * viewportRatio);
+        setCanvasScale(nextScale);
+        setFitScale(nextScale);
 
         setViewportLeft((prev) => prev - (newViewportActualWidth - oldViewportActualWidth) / 2);
         setViewportTop((prev) => prev - (newViewportActualHeight - oldViewportActualHeight) / 2);
@@ -161,5 +176,6 @@ export function useViewportSize(canvasRef: RefObject<HTMLElement | null>) {
   return {
     viewportStyles,
     dragViewport,
+    fitScale,
   };
 }

--- a/components/slide-renderer/Editor/Canvas/index.tsx
+++ b/components/slide-renderer/Editor/Canvas/index.tsx
@@ -71,7 +71,6 @@ export function Canvas(_props: CanvasProps) {
   );
 
   // Canvas UI state
-  const canvasScale = useCanvasStore.use.canvasScale();
   const activeElementIdList = useCanvasStore.use.activeElementIdList();
   const activeGroupElementId = useCanvasStore.use.activeGroupElementId();
   const handleElementId = useCanvasStore.use.handleElementId();
@@ -102,8 +101,14 @@ export function Canvas(_props: CanvasProps) {
     setElementList(newElements);
   }, [elements]);
 
-  // Viewport size and positioning
-  const { viewportStyles, dragViewport } = useViewportSize(canvasRef);
+  // Viewport size and positioning. Render with the hook's LOCAL fitScale (not
+  // the global store canvasScale): sibling canvases (crossfade-exiting pane,
+  // keep-alive tabs) write the shared store value, which could leave this
+  // canvas rendering a scale computed for another container until a seam drag
+  // forced a re-measure. The store is still written by the hook for
+  // out-of-tree consumers.
+  const { viewportStyles, dragViewport, fitScale } = useViewportSize(canvasRef);
+  const canvasScale = fitScale;
 
   // Initialize drop handler
   useDrop(canvasRef);

--- a/lib/workbench/classroom-exit.ts
+++ b/lib/workbench/classroom-exit.ts
@@ -1,24 +1,27 @@
-export type ClassroomExitDecision =
-  | { readonly kind: 'push'; readonly href: '/workspace' | '/' }
-  | { readonly kind: 'back' };
+export type ClassroomExitDecision = { readonly kind: 'push'; readonly href: '/workspace' | '/' };
 
 interface ClassroomExitContext {
   readonly searchParams: Pick<URLSearchParams, 'get'>;
-  readonly historyLength: number;
 }
 
 interface ClassroomExitRouter {
   readonly push: (href: string) => void;
-  readonly back: () => void;
 }
 
 /**
  * Resolve where a standalone classroom should exit without depending on
  * browser globals, so direct links and SSR callers get the same safe default.
+ *
+ * A classic classroom always exits to home. The previous history entry is
+ * often an entry-time flow (generation-preview) that is not a return target —
+ * backing into it shows a dead "no generation in progress" page — so browser
+ * history is never used for the classic arrow, which is labeled "back to
+ * home" anyway. Only workbench-attached classrooms get a different
+ * destination, via their explicit URL contract (`from=workspace` /
+ * `returnTo=home`).
  */
 export function resolveClassroomExit({
   searchParams,
-  historyLength,
 }: ClassroomExitContext): ClassroomExitDecision {
   // An explicit source wins over history: classroom state changes may push
   // intermediate entries onto the stack, while `from` survives refreshes and
@@ -27,12 +30,11 @@ export function resolveClassroomExit({
     return { kind: 'push', href: '/workspace' };
   }
   // Leaving Pro playback opens the ordinary classroom with an explicit home
-  // return contract. Browser history still contains the Pro workspace, so the
-  // generic `back()` fallback would otherwise contradict the home arrow.
+  // return contract. Browser history still contains the Pro workspace, so
+  // without this rule the home arrow would contradict the workspace link.
   if (searchParams.get('returnTo') === 'home') {
     return { kind: 'push', href: '/' };
   }
-  if (historyLength > 1) return { kind: 'back' };
   return { kind: 'push', href: '/' };
 }
 
@@ -41,13 +43,7 @@ export function exitClassroom(
   router: ClassroomExitRouter,
   searchParams: Pick<URLSearchParams, 'get'>,
 ): void {
-  const historyLength = typeof window === 'undefined' ? 0 : window.history.length;
-  const decision = resolveClassroomExit({ searchParams, historyLength });
-  if (decision.kind === 'back') {
-    router.back();
-    return;
-  }
-  router.push(decision.href);
+  router.push(resolveClassroomExit({ searchParams }).href);
 }
 
 export function classroomExitLabelKey(

--- a/tests/edit/canvas-fit-scale-wiring.test.ts
+++ b/tests/edit/canvas-fit-scale-wiring.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+/**
+ * The legacy editor canvas must render its box from the viewport hook's LOCAL
+ * fit scale, never from the shared global `canvasScale` in the canvas store:
+ * sibling canvases (crossfade-exiting panes, keep-alive course tabs) write the
+ * global value, so a canvas that reads it can stick at a scale computed for
+ * another container — the slide then renders mis-sized (overflowing the 16:9
+ * card, or under-filling it) until a seam drag forces a re-measure. The hook
+ * publishes the local value and the store write is kept for out-of-tree
+ * consumers, matching the reference.
+ */
+describe('canvas fit-scale wiring', () => {
+  it('renders the legacy editor canvas from the local fitScale', () => {
+    const canvas = source('components/slide-renderer/Editor/Canvas/index.tsx');
+    expect(canvas).toContain('fitScale');
+    expect(canvas).toContain('const canvasScale = fitScale;');
+    expect(canvas).not.toContain('useCanvasStore.use.canvasScale()');
+  });
+
+  it('publishes a local fitScale from the viewport hook', () => {
+    const hook = source('components/slide-renderer/Editor/Canvas/hooks/useViewportSize.ts');
+    expect(hook).toContain('const [fitScale, setFitScale] = useState(() =>');
+    expect(hook).toContain('setFitScale(nextScale)');
+    expect(hook).toContain('fitScale,');
+  });
+});

--- a/tests/edit/contain-box.test.ts
+++ b/tests/edit/contain-box.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+import {
+  CLASSROOM_ASPECT_RATIO,
+  clampWorkbenchPanelWidth,
+  containBox,
+  fillWidthBox,
+  idealWorkbenchPanelWidth,
+  WORKBENCH_CHAT_MIN_PX,
+  WORKBENCH_PANEL_MIN_PX,
+} from '@/lib/edit/contain-box';
+
+describe('containBox', () => {
+  test('height-limits a wide host so a 16:9 canvas fills the height', () => {
+    const box = containBox(1200, 500, CLASSROOM_ASPECT_RATIO);
+    expect(box.height).toBe(500);
+    expect(box.width).toBeCloseTo(500 * (16 / 9));
+  });
+
+  test('width-limits a tall host so a 16:9 canvas fills the width', () => {
+    const box = containBox(800, 900, CLASSROOM_ASPECT_RATIO);
+    expect(box.width).toBe(800);
+    expect(box.height).toBeCloseTo(800 * (9 / 16));
+  });
+
+  test('returns the container itself when it is already 16:9', () => {
+    expect(containBox(1600, 900, CLASSROOM_ASPECT_RATIO)).toEqual({
+      width: 1600,
+      height: 900,
+    });
+  });
+
+  test('returns a zero box for non-positive or non-finite input', () => {
+    expect(containBox(0, 500, CLASSROOM_ASPECT_RATIO)).toEqual({ width: 0, height: 0 });
+    expect(containBox(800, -1, CLASSROOM_ASPECT_RATIO)).toEqual({ width: 0, height: 0 });
+    expect(containBox(Number.NaN, 500, CLASSROOM_ASPECT_RATIO)).toEqual({
+      width: 0,
+      height: 0,
+    });
+  });
+});
+
+describe('fillWidthBox', () => {
+  test('uses the full host width and derives 16:9 height', () => {
+    expect(fillWidthBox(1600, CLASSROOM_ASPECT_RATIO)).toEqual({ width: 1600, height: 900 });
+  });
+});
+
+describe('clampWorkbenchPanelWidth', () => {
+  test('keeps the conversation at its minimum', () => {
+    expect(clampWorkbenchPanelWidth(1200, 900)).toBe(800);
+  });
+
+  test('does not shrink the classroom below its minimum', () => {
+    expect(clampWorkbenchPanelWidth(2000, 100)).toBe(WORKBENCH_PANEL_MIN_PX);
+  });
+});
+
+describe('idealWorkbenchPanelWidth', () => {
+  test('on an ultrawide, sizes the panel to the 16:9 stage and leaves the rest to chat', () => {
+    const panel = idealWorkbenchPanelWidth(3440, 1080, { playback: true });
+    expect(panel).toBeLessThan(3440 * 0.55);
+    expect(3440 - panel).toBeGreaterThan(WORKBENCH_CHAT_MIN_PX);
+    expect(panel).toBeGreaterThan(WORKBENCH_PANEL_MIN_PX);
+  });
+
+  test('never steals the conversation below its minimum', () => {
+    const panel = idealWorkbenchPanelWidth(1200, 900);
+    expect(panel).toBe(1200 - WORKBENCH_CHAT_MIN_PX);
+  });
+
+  test('playback chrome (roundtable) makes the panel narrower than edit', () => {
+    const edit = idealWorkbenchPanelWidth(3440, 1440, { playback: false });
+    const playback = idealWorkbenchPanelWidth(3440, 1440, { playback: true });
+    expect(playback).toBeLessThan(edit);
+  });
+});

--- a/tests/workbench/classroom-exit-wiring.test.ts
+++ b/tests/workbench/classroom-exit-wiring.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('classroom exit wiring', () => {
+  it.each(['components/header.tsx', 'components/edit/EditShell/CommandBar.tsx'])(
+    '%s uses the shared exit helper and has no hardcoded home push',
+    (path) => {
+      const text = source(path);
+      expect(text).toContain('exitClassroom(router, searchParams)');
+      expect(text).toContain('classroomExitLabelKey(searchParams)');
+      expect(text).toContain('aria-label={exitLabel}');
+      expect(text).not.toContain("router.push('/')");
+      expect(text).not.toContain("title={t('generation.backToHome')}");
+    },
+  );
+});

--- a/tests/workbench/classroom-exit.test.ts
+++ b/tests/workbench/classroom-exit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  classroomEntryHref,
+  classroomExitLabelKey,
+  exitClassroom,
+  resolveClassroomExit,
+} from '@/lib/workbench/classroom-exit';
+
+const params = (query = '') => new URLSearchParams(query);
+
+describe('resolveClassroomExit', () => {
+  it('returns to the workspace for an explicit workspace source', () => {
+    expect(resolveClassroomExit({ searchParams: params('from=workspace') })).toEqual({
+      kind: 'push',
+      href: '/workspace',
+    });
+  });
+
+  it('goes home for a classic classroom even when browser history exists', () => {
+    // The previous history entry is often an entry-time flow (generation-preview)
+    // that must never be a return target, so the classic arrow always pushes home.
+    expect(resolveClassroomExit({ searchParams: params() })).toEqual({ kind: 'push', href: '/' });
+  });
+
+  it('falls back to home for a direct link such as /shared/<token>', () => {
+    expect(resolveClassroomExit({ searchParams: params() })).toEqual({ kind: 'push', href: '/' });
+  });
+
+  it('prioritizes an explicit workspace source over everything else', () => {
+    expect(resolveClassroomExit({ searchParams: params('from=workspace') })).toEqual({
+      kind: 'push',
+      href: '/workspace',
+    });
+  });
+
+  it('returns to home explicitly instead of reopening Pro through browser history', () => {
+    expect(resolveClassroomExit({ searchParams: params('returnTo=home') })).toEqual({
+      kind: 'push',
+      href: '/',
+    });
+  });
+});
+
+describe('exitClassroom', () => {
+  it('pushes the resolved destination and never uses browser history', () => {
+    const router = { push: vi.fn() };
+
+    exitClassroom(router, params());
+
+    expect(router.push).toHaveBeenCalledWith('/');
+  });
+
+  it('returns to the workspace for a workspace-attached classroom', () => {
+    const router = { push: vi.fn() };
+
+    exitClassroom(router, params('from=workspace'));
+
+    expect(router.push).toHaveBeenCalledWith('/workspace');
+  });
+});
+
+describe('classroom navigation metadata', () => {
+  it('marks workspace entries and leaves classic entries unchanged', () => {
+    expect(classroomEntryHref('course-1', true)).toBe('/classroom/course-1?from=workspace');
+    expect(classroomEntryHref('course-1', false)).toBe('/classroom/course-1');
+  });
+
+  it('uses workspace copy instead of home copy for workspace exits', () => {
+    expect(classroomExitLabelKey(params('from=workspace'))).toBe(
+      'workbench.common.backToWorkspace',
+    );
+    expect(classroomExitLabelKey(params())).toBe('generation.backToHome');
+  });
+});


### PR DESCRIPTION
Two acceptance fixes for classic mode. (1) Since the canvas adopted each deck's real viewport ratio (#1237), imported decks whose ratio differs from the stage slot anchored to the top with an empty band below; the stage now centers the fitted canvas box in both classic playback and workbench playback surfaces without regressing the interactive-scene slot. (2) Backing out of a classroom during (or after) classic generation used history back(), landing on the generation-preview page whose session was already consumed — a dead 'no generation in progress' card; the classic classroom back control now always goes home, while the workspace and returnTo URL contracts keep their own destinations.