### PR TITLE
fix(media): persist origin-independent classroom-media references from the agent runtime

### DIFF
--- a/lib/server/agent-runtime/course-edit/tools.ts
+++ b/lib/server/agent-runtime/course-edit/tools.ts
@@ -109,7 +109,6 @@ export function buildCourseAudioAndDeckTools(deps: CourseToolDeps): AgentTool<ne
         scene,
         force: params.force ?? false,
         roster: doc.stage.generatedAgentConfigs,
-        baseUrl: deps.baseUrl,
         signal,
       });
       if (!summary.available) {

--- a/lib/server/agent-runtime/course-tools.ts
+++ b/lib/server/agent-runtime/course-tools.ts
@@ -89,8 +89,6 @@ export interface CourseToolDeps {
   onCheckpoint: (info: CheckpointInfo) => void;
   /** The session id, recorded on the document as the producer reference. */
   sessionId?: string;
-  /** Request origin used to build local classroom-media URLs. */
-  baseUrl?: string;
   /** Cancel generation, preview, and synthesis when the run stops. */
   abortSignal?: AbortSignal;
   /** Test seam for the neutral TTS path. */
@@ -215,9 +213,7 @@ export function buildDslCourseToolset(
     buildGenerateImageTool(deps),
     ...(hasConfiguredVideoGeneration(deps) ? [buildGenerateVideoTool(deps)] : []),
     ...buildCourseAudioAndDeckTools(deps),
-    ...(deps.sessionId
-      ? [buildMaterialMediaTool({ sessionId: deps.sessionId, baseUrl: deps.baseUrl })]
-      : []),
+    ...(deps.sessionId ? [buildMaterialMediaTool({ sessionId: deps.sessionId })] : []),
     ...buildDslCourseTools(deps),
   ] as unknown as AgentTool<never, never>[];
   return markDocumentWritersSequential(withOwnerStageAuthorization(tools, deps));

--- a/lib/server/agent-runtime/generate-image.ts
+++ b/lib/server/agent-runtime/generate-image.ts
@@ -31,7 +31,6 @@ import {
   readResponseBodyWithLimit,
 } from '@/lib/server/bounded-download';
 import { CLASSROOMS_DIR } from '@/lib/server/classroom-storage';
-import { resolveMediaServingOrigin } from '@/lib/server/media-origin';
 import type { CourseToolDeps } from './course-tools';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
 import { errorResult, MEDIA_TOOL_ERROR_REASONS } from './media-tool-result';
@@ -69,16 +68,12 @@ type GenerateConfiguredImage = (
 interface PersistImageInput {
   result: ImageGenerationResult;
   stageId: string;
-  baseUrl?: string;
   signal: AbortSignal;
 }
 
 type PersistGeneratedImage = (input: PersistImageInput) => Promise<string>;
 
-export interface GenerateImageToolDeps extends Pick<
-  CourseToolDeps,
-  'sessionId' | 'baseUrl' | 'abortSignal'
-> {
+export interface GenerateImageToolDeps extends Pick<CourseToolDeps, 'sessionId' | 'abortSignal'> {
   getConfiguredProviders?: typeof getServerImageProviders;
   resolveProviderConfig?: (providerId: ImageProviderId) => ImageGenerationConfig;
   generateConfiguredImage?: GenerateConfiguredImage;
@@ -155,11 +150,17 @@ async function imageBytes(
   return { bytes, mime };
 }
 
-/** Persist through the same local classroom-media path used by classic mode. */
+/**
+ * Persist through the same local classroom-media path used by classic mode,
+ * returning an origin-independent RELATIVE serving path. The agent runtime has
+ * no request to derive an origin from, and the durable value must stay valid
+ * regardless of the origin the app is served from; the browser resolves the
+ * relative path against the page origin. Classic request-bearing routes build
+ * absolute URLs through `resolveMediaServingOrigin` instead.
+ */
 export async function defaultPersistGeneratedImage({
   result,
   stageId,
-  baseUrl,
   signal,
 }: PersistImageInput): Promise<string> {
   const { bytes, mime } = await imageBytes(result, signal);
@@ -172,7 +173,7 @@ export async function defaultPersistGeneratedImage({
   throwIfAborted(signal);
   await fs.writeFile(path.join(mediaDir, filename), bytes);
   throwIfAborted(signal);
-  return `${resolveMediaServingOrigin(baseUrl)}/api/classroom-media/${stageId}/media/${filename}`;
+  return `/api/classroom-media/${stageId}/media/${filename}`;
 }
 
 /**
@@ -319,7 +320,7 @@ export function buildGenerateImageTool(
         });
         throwIfAborted(ioSignal);
 
-        const src = await persist({ result, stageId, baseUrl: deps.baseUrl, signal: ioSignal });
+        const src = await persist({ result, stageId, signal: ioSignal });
         throwIfAborted(ioSignal);
         void recordGenerationUsage({
           kind: 'image',

--- a/lib/server/agent-runtime/generate-video.ts
+++ b/lib/server/agent-runtime/generate-video.ts
@@ -25,7 +25,6 @@ import { recordGenerationUsage } from '@/lib/server/usage-storage';
 import { validateUrlForSSRF } from '@/lib/server/ssrf-guard';
 import { readResponseBodyWithLimit } from '@/lib/server/bounded-download';
 import { CLASSROOMS_DIR } from '@/lib/server/classroom-storage';
-import { resolveMediaServingOrigin } from '@/lib/server/media-origin';
 import type { CourseToolDeps } from './course-tools';
 import { COURSE_STAGE_ID_DESCRIPTION } from './course-stage';
 import { errorResult, MEDIA_TOOL_ERROR_REASONS } from './media-tool-result';
@@ -77,7 +76,6 @@ type GenerateConfiguredVideo = (
 interface PersistVideoInput {
   result: VideoGenerationResult;
   stageId: string;
-  baseUrl?: string;
   signal: AbortSignal;
 }
 
@@ -88,10 +86,7 @@ interface PersistedVideo {
 
 type PersistGeneratedVideo = (input: PersistVideoInput) => Promise<PersistedVideo>;
 
-export interface GenerateVideoToolDeps extends Pick<
-  CourseToolDeps,
-  'sessionId' | 'baseUrl' | 'abortSignal'
-> {
+export interface GenerateVideoToolDeps extends Pick<CourseToolDeps, 'sessionId' | 'abortSignal'> {
   getConfiguredVideoProviders?: () => Record<string, { models?: string[]; disabled?: boolean }>;
   resolveVideoProviderConfig?: (providerId: VideoProviderId) => VideoGenerationConfig;
   generateConfiguredVideo?: GenerateConfiguredVideo;
@@ -150,12 +145,15 @@ async function fetchGeneratedVideo(url: string, signal: AbortSignal): Promise<Re
 
 /**
  * Video providers return hosted URLs that may expire. Materialize those bytes
- * through the same local classroom-media path as generate_image and classic mode.
+ * through the same local classroom-media path as generate_image and classic
+ * mode, returning an origin-independent RELATIVE serving path: the agent
+ * runtime has no request to derive an origin from, and the durable value must
+ * stay valid regardless of the origin the app is served from (the browser
+ * resolves the relative path against the page origin).
  */
 export async function defaultPersistGeneratedVideo({
   result,
   stageId,
-  baseUrl,
   signal,
 }: PersistVideoInput): Promise<PersistedVideo> {
   throwIfAborted(signal);
@@ -186,7 +184,7 @@ export async function defaultPersistGeneratedVideo({
   await fs.writeFile(path.join(mediaDir, filename), bytes);
   throwIfAborted(signal);
   return {
-    src: `${resolveMediaServingOrigin(baseUrl)}/api/classroom-media/${stageId}/media/${filename}`,
+    src: `/api/classroom-media/${stageId}/media/${filename}`,
     mime,
   };
 }
@@ -314,7 +312,6 @@ export function buildGenerateVideoTool(
         const stored = await persist({
           result,
           stageId,
-          baseUrl: deps.baseUrl,
           signal: ioSignal,
         });
         throwIfAborted(ioSignal);

--- a/lib/server/agent-runtime/generation-tools.ts
+++ b/lib/server/agent-runtime/generation-tools.ts
@@ -459,7 +459,6 @@ export function buildGenerationTools(deps: GenerationToolDeps): AgentTool<never,
           scene: next,
           force: false,
           roster: doc.stage.generatedAgentConfigs,
-          baseUrl: deps.baseUrl,
           signal,
         });
         if (audio.changed) {

--- a/lib/server/agent-runtime/material-media.ts
+++ b/lib/server/agent-runtime/material-media.ts
@@ -12,7 +12,6 @@ const Params = Type.Object({
 
 export interface MaterialMediaDeps {
   sessionId: string;
-  baseUrl?: string;
   getMaterial?: typeof getSessionMaterial;
   readRawBytes?: typeof resolveSessionMaterialRawAsset;
 }
@@ -62,7 +61,6 @@ export function buildMaterialMediaTool(deps: MaterialMediaDeps): AgentTool<never
         bytes: source.bytes,
         mime: source.mime,
         prefix: `material-${material.id}`,
-        baseUrl: deps.baseUrl,
         signal,
       });
       return {

--- a/lib/server/agent-runtime/scene-tts.ts
+++ b/lib/server/agent-runtime/scene-tts.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TTS_MODELS, DEFAULT_TTS_VOICES, TTS_PROVIDERS } from '@/lib/aud
 import { generateTTS, TTSRequestTimeoutError } from '@/lib/audio/tts-providers';
 import type { TTSProviderId } from '@/lib/audio/types';
 import { BROWSER_NATIVE_TTS_PROVIDER_ID } from '@/lib/audio/provider-enablement';
-import type { SpeechAction } from '@/lib/types/action';
+import type { LegacySpeechAction, SpeechAction } from '@/lib/types/action';
 import type { GeneratedAgentConfig, Scene } from '@/lib/types/stage';
 import {
   getServerTTSProviders,
@@ -24,7 +24,6 @@ export interface SceneTtsInput {
   scene: Scene;
   force: boolean;
   roster?: readonly GeneratedAgentConfig[] | null;
-  baseUrl?: string;
   signal?: AbortSignal;
 }
 
@@ -94,14 +93,23 @@ export async function synthesizeSceneNarration(input: SceneTtsInput): Promise<Sc
         speech.text,
       );
       if (input.signal?.aborted) throw new Error('aborted');
-      speech.audioId = await persistClassroomMediaBytes({
+      // The persisted reference is the RELATIVE classroom-media path (the
+      // agent runtime has no request origin; relative stays valid on any
+      // deployment origin — see classroom-media-bytes.ts). The browser's
+      // narration consumers (timeline status/preview, playback, exports)
+      // resolve a speech line through the legacy (audioId, audioUrl) pair:
+      // `audioId` alone is never resolvable to bytes client-side, while a
+      // present `audioUrl` marks the line voiced and is what the audio
+      // element / fetch fallback plays. Stamp the same relative path on both.
+      const audioId = await persistClassroomMediaBytes({
         stageId: input.scene.stageId,
         bytes: Buffer.from(audio.audio),
         mime: audioMime(audio.format),
         prefix: `tts-${action.id}`,
-        baseUrl: input.baseUrl,
         signal: input.signal,
       });
+      speech.audioId = audioId;
+      (speech as LegacySpeechAction).audioUrl = audioId;
       generated += 1;
     } catch (error) {
       if (input.signal?.aborted) throw error;

--- a/lib/server/classroom-media-bytes.ts
+++ b/lib/server/classroom-media-bytes.ts
@@ -3,7 +3,6 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { CLASSROOMS_DIR } from '@/lib/server/classroom-storage';
-import { resolveMediaServingOrigin } from '@/lib/server/media-origin';
 
 function extensionForMime(mime: string): string {
   const known: Record<string, string> = {
@@ -21,12 +20,25 @@ function extensionForMime(mime: string): string {
   return known[mime] ?? 'bin';
 }
 
+/**
+ * Persist raw media bytes under the stage's classroom-media path and return
+ * an origin-independent serving reference.
+ *
+ * The returned reference is a RELATIVE path (`/api/classroom-media/...`), not
+ * an absolute URL. This is the agent runtime's only byte-persist path: it runs
+ * with no HTTP request to derive an origin from, and the durable value must
+ * stay valid regardless of which origin serves the app. The browser resolves
+ * the relative path against the page origin (image/video `src`, narration
+ * `audioUrl` playback), and every server-side consumer of the reference reads
+ * the local file or fetches it relative to the same origin. Request-bearing
+ * routes that DO have an origin build absolute URLs through
+ * `resolveMediaServingOrigin` (`classroom-media-generation.ts`).
+ */
 export async function persistClassroomMediaBytes(input: {
   stageId: string;
   bytes: Buffer | Uint8Array;
   mime: string;
   prefix?: string;
-  baseUrl?: string;
   signal?: AbortSignal;
 }): Promise<string> {
   if (input.signal?.aborted) throw new Error('aborted');
@@ -37,5 +49,5 @@ export async function persistClassroomMediaBytes(input: {
   if (input.signal?.aborted) throw new Error('aborted');
   await fs.writeFile(path.join(mediaDir, filename), input.bytes);
   if (input.signal?.aborted) throw new Error('aborted');
-  return `${resolveMediaServingOrigin(input.baseUrl)}/api/classroom-media/${input.stageId}/media/${filename}`;
+  return `/api/classroom-media/${input.stageId}/media/${filename}`;
 }

--- a/lib/server/media-origin.ts
+++ b/lib/server/media-origin.ts
@@ -19,6 +19,12 @@
  * the classroom-media route does not exist and every request is rejected.
  * That env stays available for its other legitimate uses (auth redirects
  * etc.) — it must simply never be used to build media URLs.
+ *
+ * The agent RUNTIME persist paths (`classroom-media-bytes.ts`,
+ * `generate-image.ts`, `generate-video.ts`) never call this resolver: they
+ * run without an HTTP request and persist origin-independent RELATIVE
+ * `/api/classroom-media/...` references instead, which stay valid no matter
+ * which origin serves the app.
  */
 import type { NextRequest } from 'next/server';
 
@@ -29,7 +35,9 @@ import type { NextRequest } from 'next/server';
  * background/agent-runner context with no origin captured yet, the only
  * same-origin-safe guess is this app's own localhost. Production deployments
  * always thread a real origin (request-derived, or persisted at session
- * creation), so this fallback only ever fires in dev/tests.
+ * creation), so this fallback only ever fires in dev/tests. The agent
+ * runtime's own persist paths do not use this resolver at all — they persist
+ * relative references (see the module comment).
  */
 export const LOCAL_MEDIA_ORIGIN = 'http://localhost:3000';
 

--- a/tests/agent-runtime/generate-image.test.ts
+++ b/tests/agent-runtime/generate-image.test.ts
@@ -142,7 +142,6 @@ describe('generate_image tool', () => {
     const generateConfiguredImage = vi.fn().mockResolvedValue(generated);
     const tool = buildGenerateImageTool({
       sessionId: 'session-owner',
-      baseUrl: 'https://openmaic.test',
       getConfiguredProviders: () => ({ 'openai-image': { models: ['gpt-image-1'] } }),
       resolveProviderConfig: () => ({
         providerId: 'openai-image',
@@ -187,10 +186,12 @@ describe('generate_image tool', () => {
     );
     // Success details are provider-neutral: no provider id leaks into the
     // transcript. The vendor choice stays in the server-side log, correlated
-    // by the tool-call id.
+    // by the tool-call id. The persisted src is an origin-independent RELATIVE
+    // classroom-media path (the agent runtime has no request origin), which
+    // the browser resolves against the page origin.
     expect(result.details).toEqual({
       src: expect.stringMatching(
-        /^https:\/\/openmaic\.test\/api\/classroom-media\/stage-owner\/media\/generated-[a-f0-9]{64}\.png$/,
+        /^\/api\/classroom-media\/stage-owner\/media\/generated-[a-f0-9]{64}\.png$/,
       ),
       width: 1024,
       height: 576,
@@ -233,10 +234,9 @@ describe('generate_image tool', () => {
       defaultPersistGeneratedImage({
         result: { url: 'https://cdn.example.com/generated/photo.jpg', width: 1024, height: 576 },
         stageId: 'stage-owner',
-        baseUrl: 'https://openmaic.test',
         signal: new AbortController().signal,
       }),
-    ).resolves.toMatch(/^https:\/\/openmaic\.test\/api\/classroom-media\/stage-owner\/media\//);
+    ).resolves.toMatch(/^\/api\/classroom-media\/stage-owner\/media\//);
     expect(mocks.writeFile).toHaveBeenCalledWith(
       expect.stringMatching(/\.jpg$/),
       Buffer.from('real-image-bytes'),

--- a/tests/agent-runtime/generate-video.test.ts
+++ b/tests/agent-runtime/generate-video.test.ts
@@ -159,7 +159,6 @@ describe('generate_video tool', () => {
     expect(persistGeneratedVideo).toHaveBeenCalledWith({
       result: expect.objectContaining({ url: 'https://cdn.example.com/generated/lesson.webm' }),
       stageId: 'stage-owner',
-      baseUrl: undefined,
       signal: expect.any(AbortSignal),
     });
     // Success details are provider-neutral: no provider id leaks into the
@@ -197,12 +196,11 @@ describe('generate_video tool', () => {
           height: 720,
         },
         stageId: 'stage-owner',
-        baseUrl: 'https://openmaic.test',
         signal: new AbortController().signal,
       }),
     ).resolves.toEqual({
       src: expect.stringMatching(
-        /^https:\/\/openmaic\.test\/api\/classroom-media\/stage-owner\/media\/generated-[a-f0-9]{64}\.mov$/,
+        /^\/api\/classroom-media\/stage-owner\/media\/generated-[a-f0-9]{64}\.mov$/,
       ),
       mime: 'video/quicktime',
     });

--- a/tests/agent-runtime/generation-media.test.ts
+++ b/tests/agent-runtime/generation-media.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AgentSessionMaterial } from '@openmaic/storage';
 
 const mocks = vi.hoisted(() => ({
-  persist: vi.fn(async () => 'https://openmaic.test/api/classroom-media/stage-a/media/image.png'),
+  persist: vi.fn(async () => '/api/classroom-media/stage-a/media/image.png'),
 }));
 
 vi.mock('@/lib/server/classroom-media-bytes', () => ({
@@ -50,7 +50,7 @@ describe('generation media tools', () => {
       expect.objectContaining({ stageId: 'stage-a', mime: 'image/png' }),
     );
     expect(response.details).toMatchObject({
-      src: 'https://openmaic.test/api/classroom-media/stage-a/media/image.png',
+      src: '/api/classroom-media/stage-a/media/image.png',
       mimeType: 'image/png',
     });
   });

--- a/tests/agent-runtime/scene-tts.test.ts
+++ b/tests/agent-runtime/scene-tts.test.ts
@@ -49,14 +49,18 @@ describe('scene TTS capability routing', () => {
   it('stores generated narration bytes in classroom media', async () => {
     mocks.providers.mockReturnValue({ 'configured-tts': {} });
     mocks.generate.mockResolvedValue({ audio: new Uint8Array([1, 2]), format: 'mp3' });
-    mocks.persist.mockResolvedValue(
-      'https://openmaic.test/api/classroom-media/stage-a/media/tts.mp3',
-    );
+    mocks.persist.mockResolvedValue('/api/classroom-media/stage-a/media/tts-speech-a-abc123.mp3');
     const target = structuredClone(scene);
     const summary = await synthesizeSceneNarration({ scene: target, force: false });
     expect(summary).toMatchObject({ available: true, changed: true, generated: 1 });
+    // The durable reference is the RELATIVE classroom-media path (origin-
+    // independent), stamped on both `audioId` and the legacy `audioUrl` pair
+    // the browser's narration consumers resolve (timeline status/preview,
+    // playback fetch, exports) — so agent-generated narration is voiced and
+    // playable on any deployment origin.
     expect(target.actions?.[0]).toMatchObject({
-      audioId: 'https://openmaic.test/api/classroom-media/stage-a/media/tts.mp3',
+      audioId: '/api/classroom-media/stage-a/media/tts-speech-a-abc123.mp3',
+      audioUrl: '/api/classroom-media/stage-a/media/tts-speech-a-abc123.mp3',
     });
     expect(mocks.persist).toHaveBeenCalledWith(
       expect.objectContaining({ stageId: 'stage-a', mime: 'audio/mpeg' }),

--- a/tests/media/classroom-media-bytes.test.ts
+++ b/tests/media/classroom-media-bytes.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isConcreteMediaAddress } from '@/lib/media/resolve-media-ref';
+
+const mocks = vi.hoisted(() => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('node:fs', () => ({ promises: { mkdir: mocks.mkdir, writeFile: mocks.writeFile } }));
+
+import { persistClassroomMediaBytes } from '@/lib/server/classroom-media-bytes';
+import { CLASSROOMS_DIR } from '@/lib/server/classroom-storage';
+
+/**
+ * Regression coverage for the agent-runtime byte persist path (#media-origin):
+ * durable classroom-media references must be origin-independent RELATIVE paths
+ * (`/api/classroom-media/<stageId>/media/<filename>`), never absolute URLs
+ * baked from `LOCAL_MEDIA_ORIGIN` — the agent runner has no HTTP request to
+ * derive an origin from, so any deployment not on localhost:3000 would persist
+ * references the browser can never fetch.
+ */
+describe('persistClassroomMediaBytes', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a relative classroom-media path with no baked origin', async () => {
+    const ref = await persistClassroomMediaBytes({
+      stageId: 'stage-owner',
+      bytes: Buffer.from('real-media-bytes'),
+      mime: 'image/png',
+      prefix: 'generated',
+    });
+
+    // Relative, origin-independent: no scheme, host, or port anywhere.
+    expect(ref).toMatch(
+      /^\/api\/classroom-media\/stage-owner\/media\/generated-[a-f0-9]{64}\.png$/,
+    );
+    expect(ref).not.toMatch(/^https?:\/\//);
+    expect(ref).not.toContain('localhost');
+    expect(ref).not.toContain(':3000');
+    // The browser treats it as a concrete media address and renders it raw,
+    // resolving the relative path against the page origin.
+    expect(isConcreteMediaAddress(ref)).toBe(true);
+  });
+
+  it('persists bytes under the stage media directory and derives the filename from content', async () => {
+    const bytes = Buffer.from('real-media-bytes');
+    const ref = await persistClassroomMediaBytes({
+      stageId: 'stage-owner',
+      bytes,
+      mime: 'audio/mpeg',
+      prefix: 'tts-speech-a',
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.mkdir).toHaveBeenCalledWith(`${CLASSROOMS_DIR}/stage-owner/media`, {
+      recursive: true,
+    });
+    expect(mocks.writeFile).toHaveBeenCalledWith(
+      expect.stringMatching(/tts-speech-a-[a-f0-9]{64}\.mp3$/),
+      bytes,
+    );
+    // The same bytes always resolve to the same stable reference.
+    const again = await persistClassroomMediaBytes({
+      stageId: 'stage-owner',
+      bytes,
+      mime: 'audio/mpeg',
+      prefix: 'tts-speech-a',
+    });
+    expect(again).toBe(ref);
+  });
+
+  it('honors a pre-aborted signal before any I/O', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      persistClassroomMediaBytes({
+        stageId: 'stage-owner',
+        bytes: Buffer.from('x'),
+        mime: 'image/png',
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('aborted');
+    expect(mocks.mkdir).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Agent-runtime generated media (narration TTS, generate_image/video, use_material_media) persisted absolute URLs built from a localhost:3000 fallback because the runner has no HTTP request to derive an origin from — any deployment on another origin durably stored unreachable references (acceptance repro: narration synthesized successfully but every audioId pointed at port 3000). The reference threads the session-creating request's origin, but its durable audio reference is a deterministic id with the URL as a one-time bootstrap; this tree's audioId IS the reference, so the correct adaptation (matching the DSL's own audioUrl-abolition rationale: a raw URL bakes in the deployment that minted it) is to persist RELATIVE /api/classroom-media/... paths. Full consumer audit in-branch: renderer src pass-through, timeline preview/status, playback and export fetches all resolve relative paths against the page origin; existing absolute rows keep working; request-bearing classic routes keep their absolute behavior. New regression suite pins the relative, deterministic reference shape.