### PR TITLE
fix(workbench): align the chat timeline's left edge with the composer

### DIFF
--- a/components/workbench/WorkbenchChat.tsx
+++ b/components/workbench/WorkbenchChat.tsx
@@ -753,8 +753,11 @@ export function WorkbenchChat({
               data-testid="workbench-chat-scroll"
               aria-busy={catchingUp ? 'true' : undefined}
               inert={retainedTranscript ? true : undefined}
+              // The same horizontal inset as the composer footer (`px-3`), so
+              // the timeline's left edge lines up with the composer box's left
+              // edge instead of sitting to its right.
               className={cn(
-                'h-full overflow-y-auto px-4 pt-3',
+                'h-full overflow-y-auto px-3 pt-3',
                 layout.scrollPadding,
                 retainedTranscript ? 'pointer-events-none select-none' : undefined,
               )}

--- a/components/workbench/chat/chat-styles.ts
+++ b/components/workbench/chat/chat-styles.ts
@@ -50,7 +50,7 @@ export const wbStyles = {
    * the app's shadcn variables (`--destructive` flips with `.dark`).
    */
   systemNotice: {
-    row: 'flex items-start gap-2 py-0.5 pl-0.5 data-[tone=error]:rounded-[var(--wb-radius-md)] data-[tone=error]:border data-[tone=error]:border-[var(--wb-danger-line)] data-[tone=error]:bg-[var(--wb-danger-soft)] data-[tone=error]:px-2.5 data-[tone=error]:py-2',
+    row: 'flex items-start gap-2 py-0.5 data-[tone=error]:rounded-[var(--wb-radius-md)] data-[tone=error]:border data-[tone=error]:border-[var(--wb-danger-line)] data-[tone=error]:bg-[var(--wb-danger-soft)] data-[tone=error]:px-2.5 data-[tone=error]:py-2',
     // Optically centered on the first line (13px glyph in a 17px line box)
     // rather than hung from its top edge.
     icon: 'mt-[2px] inline-flex shrink-0 items-center text-[var(--wb-text-faint)] data-[tone=error]:text-[var(--wb-danger)] data-[tone=success]:text-[var(--wb-success)]',

--- a/components/workbench/chat/chat-timeline.tsx
+++ b/components/workbench/chat/chat-timeline.tsx
@@ -282,7 +282,7 @@ function ChatNodeView({
       // visual difference the rail has: prose floats, actions are boxed.
       // Streaming is quiet: no caret anywhere (PR walkthrough).
       return (
-        <div className="px-0.5 text-[var(--wb-text)]">
+        <div className="text-[var(--wb-text)]">
           <TextBlock text={node.text} streaming={node.streaming} />
         </div>
       );


### PR DESCRIPTION
The chat scroll region used px-4 while the composer footer uses px-3, so every boxed timeline node started 4px right of the composer's left edge; assistant prose and system notices carried a further 2px inset. Normalized the scroll region to the composer's inset and removed the per-node left offsets, keeping right-edge symmetry. Checked across node kinds (prose, tool cards, thinking strip, question cards, skill chips) and narrow pane widths.