### PR TITLE
fix(agent): fence session claims while an ask_user question is outstanding

### DIFF
--- a/lib/agent-runtime/lifecycle.ts
+++ b/lib/agent-runtime/lifecycle.ts
@@ -58,13 +58,15 @@ export const HOST_AGENT_LIFECYCLE = {
    *     multiSelect?: boolean
    *   }
    *
-   * The user answers through the ordinary message channel (postUserMessage),
-   * which requeues the session for a new run; there is deliberately NO
+   * The user answers through a nonblank ordinary message (postUserMessage),
+   * which requeues the session for a new run; a textless material attachment
+   * stays queued behind the question. There is deliberately NO
    * answer-correlation id — the question is a UI affordance (a question card,
    * `components/workbench/chat/question-card.tsx`, plus the pinned panel above
-   * the composer), and the answer is simply the next user message, which is
-   * also what retires it. An old frontend that does not know this type ignores
-   * it (the chat fold's default case) and loses nothing but the affordance.
+   * the composer), and the answer is simply the next nonblank user message,
+   * which is also what retires it. An old frontend that does not know this
+   * type ignores it (the chat fold's default case) and loses nothing but the
+   * affordance.
    */
   userQuestion: 'user_question',
   /**

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -791,6 +791,12 @@ export function planRunStart(input: {
     }
     return { kind: 'prompt', text: input.prompt };
   }
+  if (input.plan.kind === 'already-complete' && input.pending.length > 0) {
+    // A worker may die after the successful ask_user checkpoint but before
+    // finishSession. Once a nonblank answer clears the durable claim gate, the
+    // takeover is technically orphaned but semantically starts the next turn.
+    return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
+  }
   if (input.claimReason === 'queued' && input.pending.length > 0) {
     return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
   }
@@ -804,11 +810,15 @@ export function shouldTerminateAfterToolCall(toolName: string, isError: boolean)
 /** Make successful ask_user termination sticky across a mixed tool batch. */
 export function createAskUserTerminateLatch(): {
   shouldTerminate(toolName: string, isError: boolean): boolean;
+  isCommitted(): boolean;
 } {
   let committed = false;
   return {
     shouldTerminate(toolName, isError) {
       if (shouldTerminateAfterToolCall(toolName, isError)) committed = true;
+      return committed;
+    },
+    isCommitted() {
       return committed;
     },
   };
@@ -1238,8 +1248,15 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       source: 'agent-runtime',
       abortSignal: abort.signal,
     });
+    let questionEmitted = false;
     const askUserTool = buildAskUserTool({
-      onUserQuestion: (question) => emit(LIFECYCLE.userQuestion, question),
+      onUserQuestion: (question) => {
+        // Fence the live steer drain at the same instant the question enters
+        // the durable write chain. afterToolCall commits the terminal latch a
+        // moment later; either fact means no follow-up belongs in this run.
+        questionEmitted = true;
+        emit(LIFECYCLE.userQuestion, question);
+      },
     });
     // web_search is capability-registered: the tool exists in the toolset
     // exactly when this deployment has a working web-search backend. An
@@ -1505,6 +1522,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       return cursor.idle ? users : Math.max(0, users - 1);
     };
     const drainMessages = async (): Promise<number> => {
+      if (questionEmitted || askUserLatch.isCommitted()) return 0;
       // These reads deliberately avoid a shared transaction: a message added
       // between them is left for the next serialized drain, while the lease
       // snapshot prevents steering after ownership has already changed.
@@ -1668,6 +1686,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       for (;;) {
         await agent.waitForIdle();
         if (abort.signal.aborted) break;
+        if (questionEmitted || askUserLatch.isCommitted()) break;
         const before = steeredThisAttempt;
         const delivered = await requestDrain();
         if (abort.signal.aborted) break;

--- a/lib/workbench/session-store.ts
+++ b/lib/workbench/session-store.ts
@@ -752,17 +752,21 @@ function settleStreamingThinking(chat: ChatNode[], ts: number): ChatNode[] {
  * Retire every question card above a user message that is about to land.
  *
  * `ask_user` has no answer-correlation id on purpose (the answer is simply the
- * next message through `postUserMessage`), so this is the whole of what the log
- * can tell us: a user message BELOW a question card means that question has
- * been answered — by its buttons, by typing, or by ignoring it and saying
- * something else entirely. All three make the card history, and none of them
- * should leave live buttons on the timeline.
+ * next nonblank message through `postUserMessage`), so this is the whole of
+ * what the log can tell us: nonblank user text BELOW a question card means that
+ * question has been answered — by its buttons, by typing, or by ignoring it
+ * and saying something else entirely. All three make the card history, and
+ * none of them should leave live buttons on the timeline. A textless material
+ * attachment is queued context, not an answer.
  *
  * Being part of the fold rather than a component effect is what makes a cold
  * replay agree with the live session: a historical card is already answered
  * when it is first painted, so it never flashes as clickable.
  */
-function answerOpenQuestions(chat: ChatNode[]): ChatNode[] {
+function answerOpenQuestions(chat: ChatNode[], answerText: unknown): ChatNode[] {
+  // A textless user event is an implicit material attachment. It stays queued
+  // behind ask_user and must not make the durable question look answered.
+  if (!String(answerText ?? '').trim()) return chat;
   if (!chat.some((n) => n.kind === 'question' && !n.questionAnswered)) return chat;
   return chat.map((n) =>
     n.kind === 'question' && !n.questionAnswered ? { ...n, questionAnswered: true } : n,
@@ -972,7 +976,7 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
       if (!openingAlreadyPainted) {
         const startCourseRefs = parseCourseRefs(data.courseRefs);
         next.chat = [
-          ...answerOpenQuestions(state.chat),
+          ...answerOpenQuestions(state.chat, startPrompt),
           {
             key: `${key}-u`,
             kind: 'user',
@@ -1071,7 +1075,11 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
       // the message between steps — the quiet line sets that expectation.
       // `delivery: 'queued'` means the session was idle and the message drives
       // a new run; the bubble alone carries it (the header says the rest).
-      const steer = data.delivery === 'steer';
+      const messageText = String(data.text ?? '');
+      const blockedByQuestion =
+        !messageText.trim() &&
+        state.chat.some((node) => node.kind === 'question' && !node.questionAnswered);
+      const steer = data.delivery === 'steer' && !blockedByQuestion;
       // Two shapes exist in the durable log: structured {path, originalName}
       // and the first PR4 build's string form `materials/x.pdf (display name)`.
       const attachments = Array.isArray(data.materials)
@@ -1094,11 +1102,11 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
       // session-level list of what the conversation is "about".
       const courseRefs = parseCourseRefs(data.courseRefs);
       next.chat = [
-        ...answerOpenQuestions(state.chat),
+        ...answerOpenQuestions(state.chat, messageText),
         {
           key,
           kind: 'user',
-          text: String(data.text ?? ''),
+          text: messageText,
           ...(attachments.length ? { materials: attachments } : {}),
           ...(elementRefs.length ? { elementRefs } : {}),
           ...(courseRefs.length ? { courseRefs } : {}),
@@ -1115,12 +1123,15 @@ export function foldEvent(state: WorkbenchFold, event: WorkbenchEvent): Workbenc
             ]
           : []),
       ];
+      // The attachment bubble is the durable pending receipt. No run is
+      // admitted while blockedByQuestion, so do not paint a thinking gap or
+      // claim that the current run will steer it.
       if (steer) {
         // The current step is still active (the side note says exactly that):
         // opening the gap bar over live streaming text would be a lie, so it
         // is ARMED and opens at the next step boundary instead.
         next.waitingArmed = true;
-      } else {
+      } else if (!blockedByQuestion) {
         next.generationOpen = true;
         openWaiting(next, `${key}-w`, event.ts);
       }

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -470,6 +470,25 @@ export class PgAgentSessionStore
     const staleBefore = this.clock() - options.leaseTtlMs;
     const params: unknown[] = [staleBefore, workerId, options.maxAttempts + 1];
     const targeted = options.sessionId ? ` AND id = $${params.push(options.sessionId)}` : '';
+    // A successful ask_user is durable in the event log before the run settles.
+    // Textless user messages may carry newly attached materials, but they are
+    // not answers. Keep such work queued until a later nonblank user message
+    // answers or supersedes the question. This predicate is repeated after the
+    // row lock below; the locked check is the authority, while this one keeps
+    // fenced rows out of the optimistic candidate batch.
+    const askAdmission = `
+         AND (cancel_requested_at IS NOT NULL OR NOT EXISTS (
+           SELECT 1 FROM ${this.table('events')} question
+           WHERE question.session_id = ${this.table('sessions')}.id
+             AND question.type = '${AGENT_SESSION_LIFECYCLE.userQuestion}'
+             AND NOT EXISTS (
+               SELECT 1 FROM ${this.table('events')} answer
+               WHERE answer.session_id = question.session_id
+                 AND answer.seq > question.seq
+                 AND answer.type = '${AGENT_SESSION_LIFECYCLE.userMessage}'
+                 AND length(btrim(COALESCE(answer.data->>'text', ''))) > 0
+             )
+         ))`;
     const candidates = await this.queryable.query<{ id: string }>(
       `SELECT id FROM ${this.table('sessions')}
        WHERE deleted_at IS NULL
@@ -477,7 +496,7 @@ export class PgAgentSessionStore
               (status = 'running'
                AND (lease_heartbeat_at IS NULL OR lease_heartbeat_at < $1)
                AND (lease_worker_id IS NULL OR lease_worker_id <> $2)))
-         AND (attempt < $3 OR status = 'running')${targeted}
+         AND (attempt < $3 OR status = 'running')${askAdmission}${targeted}
        ORDER BY created_at LIMIT 5`,
       params,
     );
@@ -495,6 +514,7 @@ export class PgAgentSessionStore
                    AND (lease_heartbeat_at IS NULL OR lease_heartbeat_at < $2)
                    AND (lease_worker_id IS NULL OR lease_worker_id <> $3)))
              AND (attempt < $4 OR status = 'running')
+             ${askAdmission}
            FOR UPDATE`,
           [candidate.id, staleBefore, workerId, options.maxAttempts + 1],
         );
@@ -787,7 +807,25 @@ export class PgAgentSessionStore
       if (options.expectedOwnerId && parent.owner_id !== options.expectedOwnerId) {
         throw new AgentSessionAccessError(sessionId);
       }
-      const live = parent.status === 'running';
+      const pendingAsk = await tx.query<{ pending: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM ${this.table('events')} question
+           WHERE question.session_id = $1
+             AND question.type = $2
+             AND NOT EXISTS (
+               SELECT 1 FROM ${this.table('events')} answer
+               WHERE answer.session_id = question.session_id
+                 AND answer.seq > question.seq
+                 AND answer.type = $3
+                 AND length(btrim(COALESCE(answer.data->>'text', ''))) > 0
+             )
+         ) AS pending`,
+        [sessionId, AGENT_SESSION_LIFECYCLE.userQuestion, AGENT_SESSION_LIFECYCLE.userMessage],
+      );
+      // Once ask_user is durable, even a textual answer belongs to the next
+      // turn. Label it queued so the UI and wake drain do not promise a steer
+      // into the run whose terminal question it is answering.
+      const live = parent.status === 'running' && pendingAsk.rows[0]?.pending !== true;
       const delivery = live ? 'steer' : 'queued';
       const seq = await this.insertEvent(tx, sessionId, {
         ts: this.clock(),

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -39,6 +39,26 @@ export function runAgentSessionStoreContract(
   makeStore: () => AgentSessionContractStore,
 ): void {
   describe(`AgentSessionStore contract: ${name}`, () => {
+    async function settleOnQuestion(store: AgentSessionContractStore): Promise<void> {
+      await store.createSession(makeAgentSessionInput());
+      const claim = await store.claimNextSession('ask-worker', 101, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      expect(claim).not.toBeNull();
+      await store.appendRunEvent('session-1', 'ask-worker', {
+        ts: 2,
+        attempt: claim!.attempt,
+        type: AGENT_SESSION_LIFECYCLE.userQuestion,
+        data: { question: 'Continue?' },
+      });
+      await store.finishSession('session-1', 'ask-worker', {
+        status: 'succeeded',
+        resetAttempt: true,
+        expectedAttempt: claim!.attempt,
+      });
+    }
+
     test('creates, reads, and lists sessions', async () => {
       const store = makeStore();
       const created = await store.createSession(
@@ -125,6 +145,73 @@ export function runAgentSessionStoreContract(
         status: 'succeeded',
         attempt: 0,
       });
+    });
+
+    test('keeps a material-only message queued behind an outstanding ask', async () => {
+      const store = makeStore();
+      await settleOnQuestion(store);
+
+      await store.postUserMessage('session-1', {
+        text: '',
+        materials: [{ materialId: 'material-1', originalName: 'notes.pdf' }],
+      });
+
+      expect(await store.getSession('session-1')).toMatchObject({ status: 'queued' });
+      await expect(
+        store.claimNextSession('material-worker', 102, {
+          leaseTtlMs: 10_000,
+          maxAttempts: 3,
+        }),
+      ).resolves.toBeNull();
+    });
+
+    test('an answer after queued material resumes the ask exactly once', async () => {
+      const store = makeStore();
+      await settleOnQuestion(store);
+      await store.postUserMessage('session-1', {
+        text: '',
+        materials: [{ materialId: 'material-1' }],
+      });
+      await store.postUserMessage('session-1', { text: 'Continue' });
+
+      const resumed = await store.claimNextSession('answer-worker', 102, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      expect(resumed).toMatchObject({ id: 'session-1', claimReason: 'queued' });
+      await expect(
+        store.claimNextSession('duplicate-worker', 103, {
+          leaseTtlMs: 10_000,
+          maxAttempts: 3,
+        }),
+      ).resolves.toBeNull();
+    });
+
+    test('a plain user message deterministically supersedes an outstanding ask', async () => {
+      const store = makeStore();
+      await settleOnQuestion(store);
+      await store.postUserMessage('session-1', { text: 'Ignore that; change the title instead.' });
+
+      const resumed = await store.claimNextSession('supersede-worker', 102, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      });
+      expect(resumed).toMatchObject({ id: 'session-1', claimReason: 'queued' });
+    });
+
+    test('a pending cancellation outranks the outstanding-ask claim fence', async () => {
+      const store = makeStore();
+      await settleOnQuestion(store);
+      await store.postUserMessage('session-1', { text: '', materials: [{ materialId: 'm1' }] });
+      await store.requestCancel('session-1');
+
+      await expect(
+        store.claimNextSession('cancel-worker', 102, {
+          leaseTtlMs: 10_000,
+          maxAttempts: 3,
+        }),
+      ).resolves.toBeNull();
+      expect(await store.getSession('session-1')).toMatchObject({ status: 'cancelled' });
     });
 
     test('appends ordered events and compacts only middle message updates on replay', async () => {

--- a/tests/agent-runtime/ask-user-claim-interleaving.test.ts
+++ b/tests/agent-runtime/ask-user-claim-interleaving.test.ts
@@ -1,0 +1,109 @@
+import { PGlite } from '@electric-sql/pglite';
+import {
+  PgAgentSessionStore,
+  ensureAgentSessionSchema,
+  type Queryable,
+} from '@openmaic/storage/agent-session/pg';
+import { AGENT_SESSION_LIFECYCLE } from '@openmaic/storage';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+describe('ask_user claim-boundary interleavings', () => {
+  let db: PGlite;
+  let store: PgAgentSessionStore;
+  let askAttempt: number;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await ensureAgentSessionSchema(db);
+    store = new PgAgentSessionStore(db, {
+      withTransaction: (body) => db.transaction((tx: Queryable) => body(tx)),
+    });
+  });
+
+  beforeEach(async () => {
+    await db.query(
+      'TRUNCATE agent_owner_session_events, agent_owner_session_event_counters, ' +
+        'agent_session_entries, agent_session_events, agent_sessions CASCADE',
+    );
+    await store.createSession({
+      id: 'session-ask',
+      ownerId: 'owner-1',
+      prompt: 'Build a lesson',
+      stageId: 'stage-1',
+    });
+    const claim = await store.claimNextSession('ask-worker', 101, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 3,
+    });
+    expect(claim).not.toBeNull();
+    askAttempt = claim!.attempt;
+    await store.appendRunEvent('session-ask', 'ask-worker', {
+      ts: 2,
+      attempt: askAttempt,
+      type: AGENT_SESSION_LIFECYCLE.userQuestion,
+      data: { question: 'Continue?' },
+    });
+  });
+
+  async function finishAsk(): Promise<void> {
+    await store.finishSession('session-ask', 'ask-worker', {
+      status: 'succeeded',
+      resetAttempt: true,
+      expectedAttempt: askAttempt,
+    });
+  }
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('ask pending -> material attach -> no run starts', async () => {
+    const posted = await store.postUserMessage('session-ask', {
+      text: '',
+      materials: [{ materialId: 'material-1', originalName: 'notes.pdf' }],
+    });
+    expect(posted.delivery).toBe('queued');
+    await finishAsk();
+    await store.requeueSession('session-ask');
+
+    expect(await store.getSession('session-ask')).toMatchObject({ status: 'queued' });
+    await expect(
+      store.claimNextSession('material-worker', 102, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('ask pending -> answer -> one run resumes', async () => {
+    const posted = await store.postUserMessage('session-ask', { text: 'Continue' });
+    expect(posted.delivery).toBe('queued');
+    await finishAsk();
+    await store.requeueSession('session-ask');
+
+    const claim = await store.claimNextSession('answer-worker', 102, {
+      leaseTtlMs: 10_000,
+      maxAttempts: 3,
+    });
+    expect(claim).toMatchObject({ id: 'session-ask', claimReason: 'queued' });
+    await expect(
+      store.claimNextSession('duplicate-worker', 103, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('ask pending -> plain user message -> the ask is superseded', async () => {
+    await finishAsk();
+    await store.postUserMessage('session-ask', { text: 'Ignore that; change the title.' });
+
+    await expect(
+      store.claimNextSession('supersede-worker', 102, {
+        leaseTtlMs: 10_000,
+        maxAttempts: 3,
+      }),
+    ).resolves.toMatchObject({ id: 'session-ask', claimReason: 'queued' });
+  });
+});

--- a/tests/agent-runtime/run-start.test.ts
+++ b/tests/agent-runtime/run-start.test.ts
@@ -39,6 +39,13 @@ const toolResult = () =>
     toolName: 'finish',
     content: [{ type: 'text', text: 'Done' }],
   }) as unknown as AgentMessage;
+const askUserResult = () =>
+  ({
+    role: 'toolResult',
+    toolCallId: 'ask-1',
+    toolName: 'ask_user',
+    content: [{ type: 'text', text: 'Question sent.' }],
+  }) as unknown as AgentMessage;
 
 describe('planRunStart', () => {
   it('uses the original prompt on a first run', () => {
@@ -82,6 +89,19 @@ describe('planRunStart', () => {
         prompt: 'Start',
       }),
     ).toEqual({ kind: 'continue' });
+  });
+
+  it('prompts an answer after an ask checkpoint even when the claim is orphaned', () => {
+    const plan = planResume([user('Start'), askUserResult()]);
+    expect(plan.kind).toBe('already-complete');
+    expect(
+      planRunStart({
+        plan,
+        claimReason: 'orphaned',
+        pending: [{ text: 'Continue' }],
+        prompt: 'Start',
+      }),
+    ).toEqual({ kind: 'prompt', text: 'Continue' });
   });
 });
 

--- a/tests/workbench/session-fold.test.ts
+++ b/tests/workbench/session-fold.test.ts
@@ -1231,6 +1231,26 @@ describe('user_question (the ask_user card)', () => {
     expect(contentOf(answered).at(-1)).toMatchObject({ kind: 'user', text: '算了，换个话题' });
   });
 
+  it('a textless material attachment stays pending behind the open question', () => {
+    const state = foldAll([
+      question({ question: 'Continue?', options: [{ id: 'yes', label: 'Yes' }] }),
+      ev('user_message', {
+        text: '',
+        delivery: 'queued',
+        materials: [{ materialId: 'material-1', originalName: 'notes.pdf' }],
+      }),
+    ]);
+
+    expect(state.chat.find((node) => node.kind === 'question')?.questionAnswered).toBeUndefined();
+    expect(contentOf(state).at(-1)).toMatchObject({
+      kind: 'user',
+      text: '',
+      materials: ['notes.pdf'],
+    });
+    expect(state.generationOpen).toBe(false);
+    expect(state.chat.some((node) => node.kind === 'waiting')).toBe(false);
+  });
+
   it('a second question is live while the first one is already answered', () => {
     const state = foldAll([
       ev('session_start', { prompt: 'p' }),


### PR DESCRIPTION
Acceptance race: while an ask_user question was still unanswered, attaching a material requeued the ask-settled session and a whole new turn ran concurrently with the outstanding question. The ask existed only as an event-log row with no claim predicate; any durable message (including textless material-only posts) flipped the terminal row back to queued. The claim transaction now checks, after locking the candidate row, that the latest user_question has a later nonempty user_message before admitting the session (multi-instance safe, same lease machinery as cancel consumption); the successful-ask latch also stops the same-run steer drain from injecting follow-ups past a committed question. A textless attachment stays durably queued but unclaimable and renders as a pending receipt without retiring the question; the next nonempty message resolves or deterministically supersedes the ask and makes exactly one claim eligible. Deterministic interleaving tests cover attach-while-pending, answer-resumes-once, and plain-text supersession; storage 0.24.0 -> 0.25.0 with contract coverage.