### PR TITLE
fix(agent): settle-time rescue tracks real delivery instead of a count offset

### DIFF
--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -337,20 +337,24 @@ export type UndeliveredRequeueAction = 'none' | 'reset' | 'retry';
 /** Classify undelivered work relative to the exact claim watermark. */
 export function planUndeliveredRequeue(input: {
   logged: { seq: number; ts: number }[];
-  handled: number;
+  deliveredThrough: number;
   claimSeq: number;
   atVerdict: boolean;
 }): UndeliveredRequeueAction {
-  const undelivered = input.logged.slice(input.handled);
+  const undelivered = input.logged.filter((message) => message.seq > input.deliveredThrough);
   if (undelivered.length === 0) return 'none';
   if (undelivered.some((message) => message.seq > input.claimSeq)) return 'reset';
   return input.atVerdict ? 'none' : 'retry';
 }
 
-export type RunStart = { kind: 'prompt'; text: string } | { kind: 'continue' };
+export type RunStart =
+  | { kind: 'prompt'; text: string; durableMessageSeq?: number }
+  | { kind: 'continue' };
 
 export interface FollowUpMessage {
   text: string;
+  /** Event-log sequence of the durable user message this frame consumes. */
+  durableMessageSeq?: number;
   materials?: Array<{
     materialId?: string;
     originalName?: string;
@@ -672,19 +676,18 @@ export function elementRefsPromptBlock(targets: readonly ResolvedElementRef[]): 
   ].join('\n');
 }
 
-/** Derive delivery from the immutable entry sequence, not in-memory state. */
-export function loggedMessageCursor(input: {
-  transcriptUserCount: number;
-  firstTranscriptUserText?: string;
-  loggedCount: number;
-  firstLoggedText?: string;
-  idleAttach?: boolean;
-}): { idle: boolean; delivered: number } {
-  const idle = input.idleAttach === true;
-  return {
-    idle,
-    delivered: idle ? input.transcriptUserCount : Math.max(0, input.transcriptUserCount - 1),
-  };
+const DURABLE_USER_MESSAGE_SEQ = 'openmaicDurableUserMessageSeq';
+
+/** Tag the exact durable message represented by a user transcript frame. */
+export function tagDurableUserMessage(message: AgentMessage, seq: number): AgentMessage {
+  return { ...message, [DURABLE_USER_MESSAGE_SEQ]: seq } as unknown as AgentMessage;
+}
+
+/** Recover a delivery tag from the finalized frame before advancing storage. */
+export function durableUserMessageSeq(message: AgentMessage): number | null {
+  if (message.role !== 'user') return null;
+  const value = (message as AgentMessage & Record<string, unknown>)[DURABLE_USER_MESSAGE_SEQ];
+  return Number.isSafeInteger(value) && Number(value) > 0 ? Number(value) : null;
 }
 
 /**
@@ -774,7 +777,12 @@ export function planRunStart(input: {
   idleAttach?: boolean;
 }): RunStart {
   if (input.plan.kind === 'start' && input.pending.length > 0 && input.idleAttach) {
-    return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
+    const opening = input.pending[0]!;
+    return {
+      kind: 'prompt',
+      text: composeFollowUpText(opening),
+      ...(opening.durableMessageSeq ? { durableMessageSeq: opening.durableMessageSeq } : {}),
+    };
   }
   if (input.plan.kind === 'start') {
     // A session created with opening context requeues its opening message as a
@@ -787,18 +795,33 @@ export function planRunStart(input: {
       return {
         kind: 'prompt',
         text: composeFollowUpText({ ...opening, text: input.prompt, materials: undefined }),
+        ...(opening.durableMessageSeq ? { durableMessageSeq: opening.durableMessageSeq } : {}),
       };
     }
-    return { kind: 'prompt', text: input.prompt };
+    return {
+      kind: 'prompt',
+      text: input.prompt,
+      ...(opening?.durableMessageSeq ? { durableMessageSeq: opening.durableMessageSeq } : {}),
+    };
   }
   if (input.plan.kind === 'already-complete' && input.pending.length > 0) {
     // A worker may die after the successful ask_user checkpoint but before
     // finishSession. Once a nonblank answer clears the durable claim gate, the
     // takeover is technically orphaned but semantically starts the next turn.
-    return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
+    const pending = input.pending[0]!;
+    return {
+      kind: 'prompt',
+      text: composeFollowUpText(pending),
+      ...(pending.durableMessageSeq ? { durableMessageSeq: pending.durableMessageSeq } : {}),
+    };
   }
   if (input.claimReason === 'queued' && input.pending.length > 0) {
-    return { kind: 'prompt', text: composeFollowUpText(input.pending[0]!) };
+    const pending = input.pending[0]!;
+    return {
+      kind: 'prompt',
+      text: composeFollowUpText(pending),
+      ...(pending.durableMessageSeq ? { durableMessageSeq: pending.durableMessageSeq } : {}),
+    };
   }
   return { kind: 'continue' };
 }
@@ -843,6 +866,7 @@ function toFollowUp(message: AgentSessionUserMessage): FollowUpMessage {
   );
   return {
     text: message.text,
+    durableMessageSeq: message.seq,
     ...(message.materials.length
       ? { materials: message.materials as FollowUpMessage['materials'] }
       : {}),
@@ -1013,24 +1037,17 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
   const requeueIfUndelivered = async (why: string, atVerdict = false): Promise<void> => {
     try {
       const logged = await listAgentUserMessages(store, id);
-      const history = await loadEntryHistory();
-      const users = history.cursorMessages.filter((message) => message.role === 'user');
-      const handled = loggedMessageCursor({
-        transcriptUserCount: users.length,
-        firstTranscriptUserText:
-          typeof users[0]?.content === 'string' ? users[0].content : undefined,
-        loggedCount: logged.length,
-        firstLoggedText: logged[0]?.text,
-        idleAttach: meta.existingCourse,
-      }).delivered;
-      const action = planUndeliveredRequeue({ logged, handled, claimSeq, atVerdict });
+      const current = await store.getSession(id);
+      const deliveredThrough = current?.deliveredUserMessageSeq ?? 0;
+      const action = planUndeliveredRequeue({ logged, deliveredThrough, claimSeq, atVerdict });
+      const undelivered = logged.filter((message) => message.seq > deliveredThrough).length;
       if (action === 'reset' && (await store.requeueSession(id))) {
         log.info(
-          `session ${id}: ${logged.length - handled} fresh undelivered message(s) at ${why}; requeued with attempt reset`,
+          `session ${id}: ${undelivered} fresh undelivered message(s) at ${why}; requeued with attempt reset`,
         );
       } else if (action === 'retry' && (await store.requeueForRetry(id))) {
         log.info(
-          `session ${id}: ${logged.length - handled} stranded message(s) at ${why}; requeued preserving attempt`,
+          `session ${id}: ${undelivered} stranded message(s) at ${why}; requeued preserving attempt`,
         );
       }
     } catch (error) {
@@ -1175,32 +1192,25 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
     };
 
     const loggedMessages = await listAgentUserMessages(store, id);
-    const historyUsers = recovery.cursorMessages.filter((message) => message.role === 'user');
-    const cursor = loggedMessageCursor({
-      transcriptUserCount: historyUsers.length,
-      firstTranscriptUserText:
-        typeof historyUsers[0]?.content === 'string' ? historyUsers[0].content : undefined,
-      loggedCount: loggedMessages.length,
-      firstLoggedText: loggedMessages[0]?.text,
-      idleAttach: meta.existingCourse,
-    });
-    const followUpsDelivered = cursor.delivered;
+    let deliveredThrough = meta.deliveredUserMessageSeq ?? 0;
     // Resolve the classrooms each pending message named against the owner's
     // library BEFORE the prompt is built: the run must be told the course's
     // current name (reference semantics), and the same resolved refs feed the
     // `session_start` receipt when the opening message is a durable message.
     const pending = await Promise.all(
-      loggedMessages.slice(followUpsDelivered).map(async (message) => {
-        const followUp = toFollowUp(message);
-        return followUp.courseRefs?.length
-          ? {
-              ...followUp,
-              courseRefs: await resolveCourseRefsForContext(meta.ownerId, followUp.courseRefs),
-            }
-          : followUp;
-      }),
+      loggedMessages
+        .filter((message) => message.seq > deliveredThrough)
+        .map(async (message) => {
+          const followUp = toFollowUp(message);
+          return followUp.courseRefs?.length
+            ? {
+                ...followUp,
+                courseRefs: await resolveCourseRefsForContext(meta.ownerId, followUp.courseRefs),
+              }
+            : followUp;
+        }),
     );
-    const idleAttach = cursor.idle;
+    const idleAttach = meta.existingCourse;
 
     if (plan.kind === 'already-complete' && pending.length === 0) {
       emit(LIFECYCLE.sessionEnd, {
@@ -1487,6 +1497,19 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         if (event.message.role === 'user') userFramesSeen += 1;
         enqueue(async () => {
           await entrySession!.appendMessage(event.message);
+          const deliveredSeq = durableUserMessageSeq(event.message);
+          if (deliveredSeq !== null) {
+            const marked = await store.markUserMessageDelivered(
+              id,
+              WORKER_ID,
+              attempt,
+              deliveredSeq,
+            );
+            if (!marked) {
+              throw new AgentSessionLeaseLostError(id, WORKER_ID, attempt);
+            }
+            deliveredThrough = Math.max(deliveredThrough, deliveredSeq);
+          }
           if (event.message.role === 'toolResult') {
             trackToolCallMessage(inFlightToolCalls, event.message);
           }
@@ -1516,11 +1539,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
 
     // Same-run steering needs a guard because steer() accepts a message before
     // its eventual message_end has reached the durable tree.
-    let steeredThisAttempt = 0;
-    const deliveredFollowUps = (): number => {
-      const users = agent.state.messages.filter((message) => message.role === 'user').length;
-      return cursor.idle ? users : Math.max(0, users - 1);
-    };
+    const acceptedMessageSeqs = new Set<number>();
     const drainMessages = async (): Promise<number> => {
       if (questionEmitted || askUserLatch.isCommitted()) return 0;
       // These reads deliberately avoid a shared transaction: a message added
@@ -1532,10 +1551,9 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         markLeaseLost();
         return 0;
       }
-      const handled = Math.max(deliveredFollowUps(), steeredThisAttempt);
       let delivered = 0;
-      for (const [index, message] of all.entries()) {
-        if (index < handled) continue;
+      for (const message of all) {
+        if (message.seq <= deliveredThrough || acceptedMessageSeqs.has(message.seq)) continue;
         const followUp = toFollowUp(message);
         // Same resolution as the start path: a steered message names its
         // classrooms on the durable event, and the model must be told the
@@ -1547,14 +1565,19 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
             }
           : followUp;
         const resolved = await resolveFollowUpElementContext(courseResolved);
-        agent.steer({
-          role: 'user',
-          content: composeFollowUpText(resolved),
-        } as unknown as AgentMessage);
+        agent.steer(
+          tagDurableUserMessage(
+            {
+              role: 'user',
+              content: composeFollowUpText(resolved),
+            } as unknown as AgentMessage,
+            message.seq,
+          ),
+        );
+        acceptedMessageSeqs.add(message.seq);
         delivered += 1;
       }
       if (delivered > 0) {
-        steeredThisAttempt = handled + delivered;
         log.info(`session ${id}: steered ${delivered} follow-up message(s)`);
       }
       return delivered;
@@ -1588,11 +1611,10 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
     try {
       if (plannedStart.kind === 'prompt') {
         // A follow-up-driven prompt is already in the event log; here it
-        // enters the transcript. The bump keeps the 500ms poll from
-        // re-steering that same message before the transcript folds it
-        // (only relevant when the prompt came from `pending`).
-        if (plan.kind !== 'start' || pending.length > 0) {
-          steeredThisAttempt = followUpsDelivered + 1;
+        // enters the transcript. Track its exact sequence immediately so the
+        // wakeup poll cannot steer it again before the durable mark lands.
+        if (plannedStart.durableMessageSeq !== undefined) {
+          acceptedMessageSeqs.add(plannedStart.durableMessageSeq);
         }
         // ── Forced skill loading ─────────────────────────────────────────────
         //
@@ -1622,10 +1644,15 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
             }),
         });
         adoptPreload(preload, true);
-        if (preload.messages.length === 0) {
+        if (preload.messages.length === 0 && plannedStart.durableMessageSeq === undefined) {
           await agent.prompt(preload.text);
         } else {
-          await agent.prompt([preloadUserMessage(preload.text), ...preload.messages]);
+          const promptMessage = preloadUserMessage(preload.text);
+          const deliveredPrompt =
+            plannedStart.durableMessageSeq === undefined
+              ? promptMessage
+              : tagDurableUserMessage(promptMessage, plannedStart.durableMessageSeq);
+          await agent.prompt([deliveredPrompt, ...preload.messages]);
         }
       } else {
         // ── Resume repair ─────────────────────────────────────────────────────
@@ -1655,9 +1682,8 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         // of `user` messages in the transcript, and moving it would mark a
         // real user message delivered and drop it.
         const resumedTurnText =
-          followUpsDelivered > 0
-            ? (loggedMessages[followUpsDelivered - 1]?.text ?? meta.prompt)
-            : meta.prompt;
+          loggedMessages.findLast((message) => message.seq <= deliveredThrough)?.text ??
+          meta.prompt;
         const repair = await buildSkillPreload({
           text: resumedTurnText,
           skills: installedSkills,
@@ -1687,10 +1713,10 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         await agent.waitForIdle();
         if (abort.signal.aborted) break;
         if (questionEmitted || askUserLatch.isCommitted()) break;
-        const before = steeredThisAttempt;
+        const before = acceptedMessageSeqs.size;
         const delivered = await requestDrain();
         if (abort.signal.aborted) break;
-        if (delivered === 0 || steeredThisAttempt === before) break;
+        if (delivered === 0 || acceptedMessageSeqs.size === before) break;
       }
 
       // A tool call that was still in flight when the loop wound down has no

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   existing_course     BOOLEAN NOT NULL DEFAULT FALSE,
   status              TEXT NOT NULL DEFAULT 'queued',
   attempt             INTEGER NOT NULL DEFAULT 0,
+  delivered_user_message_seq INTEGER NOT NULL DEFAULT 0,
   lease_worker_id     TEXT,
   lease_worker_pid    INTEGER,
   lease_heartbeat_at  BIGINT,
@@ -101,6 +102,9 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   CONSTRAINT agent_sessions_status_known
     CHECK (status IN ('queued','running','succeeded','failed','cancelled'))
 );
+
+ALTER TABLE agent_sessions
+  ADD COLUMN IF NOT EXISTS delivered_user_message_seq INTEGER NOT NULL DEFAULT 0;
 
 CREATE INDEX IF NOT EXISTS agent_sessions_status_live_idx
   ON agent_sessions (status, created_at) WHERE deleted_at IS NULL;
@@ -257,6 +261,7 @@ interface SessionRow extends Record<string, unknown> {
   existing_course: boolean;
   status: AgentSessionMeta['status'];
   attempt: number;
+  delivered_user_message_seq: number;
   lease_worker_id: string | null;
   lease_worker_pid: number | null;
   lease_heartbeat_at: number | string | null;
@@ -266,7 +271,7 @@ interface SessionRow extends Record<string, unknown> {
 }
 
 const SESSION_COLUMNS = `id, owner_id, prompt, stage_id, skill_id, origin,
-  existing_course, status, attempt, lease_worker_id, lease_worker_pid,
+  existing_course, status, attempt, delivered_user_message_seq, lease_worker_id, lease_worker_pid,
   lease_heartbeat_at, error, created_at, updated_at`;
 
 function epoch(value: Date | string): number {
@@ -293,6 +298,7 @@ function sessionMeta(row: SessionRow): AgentSessionMeta {
     existingCourse: row.existing_course,
     status: row.status,
     attempt: Number(row.attempt),
+    deliveredUserMessageSeq: Number(row.delivered_user_message_seq),
     createdAt: epoch(row.created_at),
     updatedAt: epoch(row.updated_at),
     ...(row.lease_worker_id
@@ -614,6 +620,23 @@ export class PgAgentSessionStore
        SET lease_heartbeat_at = $3, updated_at = now()
        WHERE id = $1 AND lease_worker_id = $2 AND deleted_at IS NULL RETURNING id`,
       [sessionId, workerId, this.clock()],
+    );
+    return result.rows.length > 0;
+  }
+
+  async markUserMessageDelivered(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    messageSeq: number,
+  ): Promise<boolean> {
+    const result = await this.queryable.query<{ id: string }>(
+      `UPDATE ${this.table('sessions')}
+       SET delivered_user_message_seq = GREATEST(delivered_user_message_seq, $4),
+           updated_at = now()
+       WHERE id = $1 AND lease_worker_id = $2 AND attempt = $3
+         AND deleted_at IS NULL RETURNING id`,
+      [sessionId, workerId, attempt, messageSeq],
     );
     return result.rows.length > 0;
   }

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -86,6 +86,8 @@ export interface AgentSessionMeta {
   status: AgentSessionStatus;
   /** The consecutive-failure generation, incremented by every successful claim. */
   attempt: number;
+  /** Highest durable user-message event sequence appended to the run transcript. */
+  deliveredUserMessageSeq: number;
   createdAt: number;
   updatedAt: number;
   lease?: AgentSessionLease;
@@ -290,6 +292,13 @@ export interface AgentSessionStore {
     options: ClaimAgentSessionOptions,
   ): Promise<ClaimedAgentSession | null>;
   heartbeat(sessionId: string, workerId: string): Promise<boolean>;
+  /** Advance the durable delivery watermark under the active lease fence. */
+  markUserMessageDelivered(
+    sessionId: string,
+    workerId: string,
+    attempt: number,
+    messageSeq: number,
+  ): Promise<boolean>;
   assertActiveLease(
     sessionId: string,
     workerId: string,

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -109,6 +109,26 @@ export function runAgentSessionStoreContract(
         claimSeq: 0,
       });
       expect(await store.heartbeat('session-1', 'worker-a')).toBe(true);
+      const messageSeq = await store.appendUserMessage('session-1', {
+        text: 'Opening prompt',
+        delivery: 'steer',
+      });
+      expect(await store.markUserMessageDelivered('session-1', 'worker-b', 1, messageSeq)).toBe(
+        false,
+      );
+      expect(await store.markUserMessageDelivered('session-1', 'worker-a', 2, messageSeq)).toBe(
+        false,
+      );
+      expect(await store.markUserMessageDelivered('session-1', 'worker-a', 1, messageSeq)).toBe(
+        true,
+      );
+      expect(await store.getSession('session-1')).toMatchObject({
+        deliveredUserMessageSeq: messageSeq,
+      });
+      expect(await store.markUserMessageDelivered('session-1', 'worker-a', 1, 0)).toBe(true);
+      expect(await store.getSession('session-1')).toMatchObject({
+        deliveredUserMessageSeq: messageSeq,
+      });
       expect(
         await store.appendRunEvent('session-1', 'worker-a', {
           ts: 2,
@@ -132,7 +152,7 @@ export function runAgentSessionStoreContract(
           type: AGENT_SESSION_LIFECYCLE.sessionStart,
           data: { ok: true },
         }),
-      ).toBe(1);
+      ).toBe(2);
       expect(await store.finishSession('session-1', 'worker-b', { status: 'failed' })).toBe(false);
       expect(
         await store.finishSession('session-1', 'worker-a', {
@@ -141,6 +161,9 @@ export function runAgentSessionStoreContract(
         }),
       ).toBe(true);
       expect(await store.heartbeat('session-1', 'worker-a')).toBe(false);
+      expect(await store.markUserMessageDelivered('session-1', 'worker-a', 1, messageSeq + 1)).toBe(
+        false,
+      );
       expect(await store.getSession('session-1')).toMatchObject({
         status: 'succeeded',
         attempt: 0,
@@ -356,6 +379,7 @@ export function runAgentSessionStoreContract(
       await store.claimNextSession('worker-a', 101, { leaseTtlMs: 10_000, maxAttempts: 3 });
       await store.finishSession('session-1', 'worker-a', { status: 'failed' });
       expect(await store.requeueSession('session-1')).toBe(true);
+      expect(await store.requeueSession('session-1')).toBe(false);
       expect(await store.getSession('session-1')).toMatchObject({ status: 'queued', attempt: 0 });
     });
 

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -252,6 +252,7 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   existing_course     BOOLEAN NOT NULL DEFAULT FALSE,
   status              TEXT NOT NULL DEFAULT 'queued',
   attempt             INTEGER NOT NULL DEFAULT 0,
+  delivered_user_message_seq INTEGER NOT NULL DEFAULT 0,
   lease_worker_id     TEXT,
   lease_worker_pid    INTEGER,
   lease_heartbeat_at  BIGINT,
@@ -264,6 +265,9 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   CONSTRAINT agent_sessions_status_known
     CHECK (status IN ('queued','running','succeeded','failed','cancelled'))
 );
+
+ALTER TABLE agent_sessions
+  ADD COLUMN IF NOT EXISTS delivered_user_message_seq INTEGER NOT NULL DEFAULT 0;
 
 CREATE INDEX IF NOT EXISTS agent_sessions_status_live_idx
   ON agent_sessions (status, created_at) WHERE deleted_at IS NULL;

--- a/tests/agent-runtime/attempt-cap.test.ts
+++ b/tests/agent-runtime/attempt-cap.test.ts
@@ -39,7 +39,7 @@ describe('one knock, one redemption', () => {
     expect(
       planUndeliveredRequeue({
         logged: [message(1)],
-        handled: 1,
+        deliveredThrough: 1,
         claimSeq: 10,
         atVerdict: false,
       }),
@@ -50,7 +50,7 @@ describe('one knock, one redemption', () => {
     expect(
       planUndeliveredRequeue({
         logged: [message(11)],
-        handled: 0,
+        deliveredThrough: 0,
         claimSeq: 10,
         atVerdict: true,
       }),
@@ -58,8 +58,25 @@ describe('one knock, one redemption', () => {
   });
 
   it('preserves the chain for inherited work and stops at the verdict', () => {
-    const input = { logged: [message(9)], handled: 0, claimSeq: 10 };
+    const input = { logged: [message(9)], deliveredThrough: 0, claimSeq: 10 };
     expect(planUndeliveredRequeue({ ...input, atVerdict: false })).toBe('retry');
     expect(planUndeliveredRequeue({ ...input, atVerdict: true })).toBe('none');
+  });
+
+  it('does not rescue an opening message already delivered by the run', () => {
+    const input = { logged: [message(1)], deliveredThrough: 1, claimSeq: 1 };
+    expect(planUndeliveredRequeue({ ...input, atVerdict: false })).toBe('none');
+    expect(planUndeliveredRequeue({ ...input, atVerdict: false })).toBe('none');
+  });
+
+  it('rescues only a message beyond the final delivery watermark', () => {
+    expect(
+      planUndeliveredRequeue({
+        logged: [message(1), message(3)],
+        deliveredThrough: 1,
+        claimSeq: 1,
+        atVerdict: false,
+      }),
+    ).toBe('reset');
   });
 });

--- a/tests/agent-runtime/run-start.test.ts
+++ b/tests/agent-runtime/run-start.test.ts
@@ -7,9 +7,10 @@ import {
   composeCourseRefsText,
   composeFollowUpText,
   composeFollowUpTextWithElementRefs,
-  loggedMessageCursor,
+  durableUserMessageSeq,
   planRunStart,
   resolveCourseRefsForContext,
+  tagDurableUserMessage,
 } from '@/lib/server/agent-runtime/runner';
 import type { CourseRef } from '@/lib/workbench/course-refs';
 import type { ElementRef } from '@/lib/workbench/element-refs';
@@ -105,15 +106,10 @@ describe('planRunStart', () => {
   });
 });
 
-describe('loggedMessageCursor', () => {
-  it('accounts for the synthetic first prompt only on new sessions', () => {
-    expect(
-      loggedMessageCursor({ transcriptUserCount: 1, loggedCount: 1, idleAttach: true }),
-    ).toEqual({ idle: true, delivered: 1 });
-    expect(loggedMessageCursor({ transcriptUserCount: 1, loggedCount: 1 })).toEqual({
-      idle: false,
-      delivered: 0,
-    });
+describe('durable user-message delivery tags', () => {
+  it('round-trips the exact durable sequence on a user frame', () => {
+    expect(durableUserMessageSeq(tagDurableUserMessage(user('Open'), 7))).toBe(7);
+    expect(durableUserMessageSeq(assistant('Done'))).toBeNull();
   });
 });
 

--- a/tests/agent-runtime/runner-event-order.test.ts
+++ b/tests/agent-runtime/runner-event-order.test.ts
@@ -86,6 +86,7 @@ describe('runSession durable event ordering', () => {
         updatedAt: 1,
         claimReason: 'queued',
         claimSeq: 0,
+        deliveredUserMessageSeq: 0,
       },
     );
 

--- a/tests/agent-runtime/runner-skills-registration.test.ts
+++ b/tests/agent-runtime/runner-skills-registration.test.ts
@@ -124,6 +124,7 @@ function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSes
     updatedAt: 1,
     claimReason: 'queued',
     claimSeq: 0,
+    deliveredUserMessageSeq: 0,
     ...overrides,
   };
 }

--- a/tests/agent-runtime/runner-tool-call-integrity.test.ts
+++ b/tests/agent-runtime/runner-tool-call-integrity.test.ts
@@ -121,6 +121,7 @@ function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSes
     updatedAt: 1,
     claimReason: 'queued',
     claimSeq: 0,
+    deliveredUserMessageSeq: 0,
     ...overrides,
   };
 }

--- a/tests/agent-runtime/runner-tool-timeout-cancel.test.ts
+++ b/tests/agent-runtime/runner-tool-timeout-cancel.test.ts
@@ -152,6 +152,7 @@ function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSes
     updatedAt: 1,
     claimReason: 'queued',
     claimSeq: 0,
+    deliveredUserMessageSeq: 0,
     ...overrides,
   };
 }

--- a/tests/agent-runtime/runner-voice-registration.test.ts
+++ b/tests/agent-runtime/runner-voice-registration.test.ts
@@ -153,6 +153,7 @@ function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSes
     updatedAt: 1,
     claimReason: 'queued',
     claimSeq: 0,
+    deliveredUserMessageSeq: 0,
     ...overrides,
   };
 }

--- a/tests/agent-runtime/runner-wakeup.test.ts
+++ b/tests/agent-runtime/runner-wakeup.test.ts
@@ -20,8 +20,9 @@ const mocks = vi.hoisted(() => {
   // (the runner passes WORKER_ID as its second argument) and hand it back
   // through getSession so `leaseMatches` sees a live, owned session.
   let workerId: string | undefined;
+  let deliveredUserMessageSeq = 0;
   const store = {
-    appendRunEvent: vi.fn(async (_id: string, worker: string) => {
+    appendRunEvent: vi.fn(async (_id: string, worker: string, _event?: { type?: string }) => {
       workerId = worker;
       return 1;
     }),
@@ -34,12 +35,17 @@ const mocks = vi.hoisted(() => {
             ownerId: 'owner-1',
             status: 'running',
             attempt: 1,
+            deliveredUserMessageSeq,
             lease: { workerId, workerPid: process.pid, heartbeatAt: Date.now() },
           }
         : null,
     ),
     hasSessionRunHistory: vi.fn(async () => false),
     heartbeat: vi.fn(async () => true),
+    markUserMessageDelivered: vi.fn(async (_id, _worker, _attempt, messageSeq: number) => {
+      deliveredUserMessageSeq = Math.max(deliveredUserMessageSeq, messageSeq);
+      return true;
+    }),
     getCancelRequestedAt: vi.fn(async () => null),
     isCancelRequested: vi.fn(async () => false),
     listUserMessages: vi.fn(
@@ -56,7 +62,14 @@ const mocks = vi.hoisted(() => {
     wake: undefined as undefined | (() => void),
     unsubscribeWakeup: vi.fn(),
   };
-  return { store, bus, resetWorker: () => (workerId = undefined) };
+  return {
+    store,
+    bus,
+    resetWorker: () => {
+      workerId = undefined;
+      deliveredUserMessageSeq = 0;
+    },
+  };
 });
 
 vi.mock('@/lib/server/agent-runtime/store', () => ({
@@ -198,13 +211,18 @@ const fake = vi.hoisted(() => {
       // which this harness never produces.
     }
 
-    async prompt(text: string): Promise<void> {
+    async prompt(input: unknown): Promise<void> {
       this.promptCalls += 1;
       // The prompt becomes the first user message of the conversation (real pi
       // behaviour) — folded into the entry tree via message_end so the
       // runner's post-settle undelivered-message check counts it as delivered.
-      this.state.messages.push({ role: 'user', content: text });
-      this.emitMessageEnd({ role: 'user', content: text });
+      const message = Array.isArray(input)
+        ? input[0]
+        : input && typeof input === 'object'
+          ? input
+          : { role: 'user', content: input };
+      this.state.messages.push(message);
+      this.emitMessageEnd(message as { role: string; content: unknown });
       await new Promise<void>((resolve) => {
         this.release = resolve;
       });
@@ -265,7 +283,8 @@ const SESSION = {
   createdAt: 1,
   updatedAt: 1,
   claimReason: 'queued' as const,
-  claimSeq: 0,
+  claimSeq: 1,
+  deliveredUserMessageSeq: 0,
 };
 
 async function waitForReady(): Promise<void> {
@@ -313,7 +332,7 @@ describe('runSession NOTIFY wakeup wiring', () => {
     mocks.bus.wake?.();
     await vi.waitFor(() => {
       expect(fake.current.instance?.steerCalls).toEqual([
-        { role: 'user', content: 'follow-up from the control plane' },
+        expect.objectContaining({ role: 'user', content: 'follow-up from the control plane' }),
       ]);
     });
     // The wake runs BOTH cheap point reads: the drain above and the cancel
@@ -325,7 +344,62 @@ describe('runSession NOTIFY wakeup wiring', () => {
     // go away with it.
     fake.current.instance?.releasePrompt();
     await run;
+    expect(mocks.store.markUserMessageDelivered).toHaveBeenCalledWith(
+      'session-wake',
+      expect.any(String),
+      1,
+      2,
+    );
+    expect(mocks.store.requeueSession).not.toHaveBeenCalled();
     expect(mocks.bus.unsubscribeWakeup).toHaveBeenCalledOnce();
+  });
+
+  it('delivers the durable opening message once and does not requeue after settlement', async () => {
+    mocks.store.listUserMessages.mockResolvedValue([
+      { seq: 1, ts: 1, text: 'Build a lesson', delivery: 'queued', materials: [] },
+    ]);
+
+    const run = runSession({ running: new Map(), shuttingDown: false }, SESSION);
+    await waitForReady();
+    fake.current.instance?.releasePrompt();
+    await run;
+
+    expect(mocks.store.markUserMessageDelivered).toHaveBeenCalledWith(
+      'session-wake',
+      expect.any(String),
+      1,
+      1,
+    );
+    expect(fake.current.instance?.promptCalls).toBe(1);
+    expect(mocks.store.requeueSession).not.toHaveBeenCalled();
+    expect(mocks.store.requeueForRetry).not.toHaveBeenCalled();
+  });
+
+  it('rescues exactly once when a message lands after the final drain', async () => {
+    const opening = { seq: 1, ts: 1, text: 'Build a lesson', delivery: 'queued', materials: [] };
+    const late = { seq: 2, ts: 2, text: 'One more change', delivery: 'steer', materials: [] };
+    mocks.store.listUserMessages.mockResolvedValue([opening]);
+    mocks.store.requeueSession.mockResolvedValueOnce(true).mockResolvedValue(false);
+
+    const run = runSession({ running: new Map(), shuttingDown: false }, SESSION);
+    await waitForReady();
+    mocks.store.appendRunEvent.mockImplementation(async (_id, _worker, event) => {
+      if (event?.type === 'session_end') {
+        mocks.store.listUserMessages.mockResolvedValue([opening, late]);
+      }
+      return 10;
+    });
+    fake.current.instance?.releasePrompt();
+    await run;
+
+    expect(mocks.store.markUserMessageDelivered).toHaveBeenCalledWith(
+      'session-wake',
+      expect.any(String),
+      1,
+      1,
+    );
+    expect(mocks.store.requeueSession).toHaveBeenCalledOnce();
+    expect(mocks.store.requeueForRetry).not.toHaveBeenCalled();
   });
 
   it('still unsubscribes when setup fails before the agent is built', async () => {

--- a/tests/agent-runtime/runner-web-search-registration.test.ts
+++ b/tests/agent-runtime/runner-web-search-registration.test.ts
@@ -127,6 +127,7 @@ function makeMeta(overrides: Partial<ClaimedAgentSession> = {}): ClaimedAgentSes
     updatedAt: 1,
     claimReason: 'queued',
     claimSeq: 0,
+    deliveredUserMessageSeq: 0,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Problem

Every settled workbench turn auto-continued with an unprompted ghost round. `loggedMessageCursor` derived delivered follow-ups as `transcriptUserCount - 1`, encoding the retired assumption that the opening prompt has no durable counterpart. Since the create-then-requeue opening rework (#1229, #1234) the opening message IS durable, so settlement always saw one phantom undelivered message and `requeueIfUndelivered` queued a fresh run after every turn.

## Fix

Replace the count heuristic with exact delivery tracking:

- Session rows gain a `delivered_user_message_seq` high-water mark (storage 0.26.0, idempotent `ADD COLUMN IF NOT EXISTS` migration).
- Every durable message consumed by a run (opening prompt, queued follow-up, mid-run steer) is tagged with its event sequence; when the finalized user frame lands in the durable transcript, the runner advances the watermark via `markUserMessageDelivered` (fenced by worker id + attempt, monotonic via `GREATEST`).
- Settlement classifies undelivered work strictly as `seq > delivered_user_message_seq`; `claimSeq` keeps its fresh-vs-stranded role.
- Double rescue is impossible: rescue requires a terminal->queued transition that only succeeds once, and the next run advances the watermark past the rescued message.

## Tests

- Opening-context session settles without requeue (the exact ghost repro).
- Mid-run steer does not trigger settle-time requeue.
- A message arriving in the settle window is rescued exactly once; repeat requeue returns false.
- Ask-user claim-fence interleaving tests untouched and green.
- PGlite contract: watermark default, monotonic advance, wrong-worker/attempt fencing, schema migration.

Verification: agent-runtime+workbench vitest 1868 passed / 10 skipped; storage vitest 995 passed / 119 skipped; tsc, pnpm check green.