### PR TITLE
fix(persistence): migrate owner_material to oss_key and drop legacy asset_id

### DIFF
--- a/lib/persistence/owner-materials.ts
+++ b/lib/persistence/owner-materials.ts
@@ -21,7 +21,7 @@
  * its object first, then the reservation, so a crash mid-reclaim never loses
  * the pointer to the bytes.
  */
-import type { Queryable } from '@openmaic/storage/document/pg';
+import { splitSqlStatements, type Queryable } from '@openmaic/storage/document/pg';
 import {
   nodePostgresTransaction,
   type ConnectableQueryable,
@@ -118,12 +118,23 @@ CREATE TABLE IF NOT EXISTS owner_material (
 
 CREATE INDEX IF NOT EXISTS owner_material_owner_created_idx
   ON owner_material (owner_id, created_at);
+
+-- Databases created before the byte-store model have this table without
+-- oss_key (they tracked an asset id instead); CREATE TABLE IF NOT EXISTS
+-- leaves such tables untouched, so the column must be added here. The ''
+-- default is the existing "no bytes recorded" sentinel the stale-upload
+-- sweeper already understands. The old NOT NULL asset_id column must also
+-- go, or its constraint rejects every insert of the new row shape.
+ALTER TABLE owner_material ADD COLUMN IF NOT EXISTS oss_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE owner_material DROP COLUMN IF EXISTS asset_id;
 `;
 
 export async function ensureOwnerMaterialSchema(queryable: Queryable): Promise<void> {
-  for (const sql of OWNER_MATERIAL_SCHEMA.split(';')) {
-    const statement = sql.trim();
-    if (statement !== '') await queryable.query(statement);
+  // splitSqlStatements skips `--` line comments (and quoted strings), so a
+  // semicolon in the migration's prose can never split a statement mid-text
+  // the way a plain `split(';')` does.
+  for (const statement of splitSqlStatements(OWNER_MATERIAL_SCHEMA)) {
+    await queryable.query(statement);
   }
 }
 

--- a/tests/persistence/owner-materials.test.ts
+++ b/tests/persistence/owner-materials.test.ts
@@ -276,6 +276,63 @@ describe('owner material reservations', () => {
     expect(await rowById(pool.db, 'mat_old_ready')).toMatchObject({ status: 'ready' });
   });
 
+  it('upgrades a table created by the asset-id era schema', async () => {
+    const db = new PGlite();
+    await db.waitReady;
+    await db.query(`CREATE TABLE owner_material (
+      id TEXT PRIMARY KEY,
+      owner_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      derived_from TEXT,
+      mime TEXT,
+      bytes DOUBLE PRECISION NOT NULL,
+      original_name TEXT,
+      asset_id TEXT NOT NULL,
+      sha256 TEXT,
+      status TEXT NOT NULL DEFAULT 'ready',
+      extraction JSONB,
+      created_at DOUBLE PRECISION NOT NULL,
+      deleted_at DOUBLE PRECISION
+    )`);
+    // A real pre-existing deployment has rows: the legacy row must survive the
+    // upgrade, its dropped asset_id discarded and its oss_key backfilled with
+    // the '' "no bytes recorded" sentinel.
+    await db.query(
+      `INSERT INTO owner_material
+         (id, owner_id, kind, mime, bytes, original_name, asset_id, sha256,
+          status, extraction, created_at)
+       VALUES ($1, 'owner-1', 'source', 'application/pdf', 2048, 'legacy.pdf',
+               'legacy-asset-1', NULL, 'ready', NULL, $2)`,
+      ['mat_legacy', 1_600_000_000_000],
+    );
+    await ensureOwnerMaterialSchema(db);
+    // Idempotency on the real deployment shape: a second pass must be a clean
+    // no-op (ADD COLUMN IF NOT EXISTS / DROP COLUMN IF EXISTS), not a DDL error.
+    await ensureOwnerMaterialSchema(db);
+    const legacyRow = await db.query<{ oss_key: string; status: string }>(
+      'SELECT oss_key, status FROM owner_material WHERE id = $1',
+      ['mat_legacy'],
+    );
+    expect(legacyRow.rows[0]).toMatchObject({ oss_key: '', status: 'ready' });
+    const oldPool = new PGlitePool(db);
+    const record = await registerOwnerMaterial(
+      oldPool as unknown as ConnectableQueryable,
+      input(),
+      // The legacy row above already consumes bytes toward the quota; leave
+      // headroom so the post-upgrade reservation goes through.
+      { maxCount: 10, maxTotalBytes: 10_000 },
+    );
+    expect(record.status).toBe('uploading');
+    expect(record.ossKey).toBe('materials/owner-1/mat_1');
+    const columns = await db.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'owner_material'`,
+    );
+    const names = columns.rows.map((row) => row.column_name);
+    expect(names).toContain('oss_key');
+    expect(names).not.toContain('asset_id');
+    await oldPool.end();
+  });
+
   it('derives a namespaced per-owner quota lock key', () => {
     expect(ownerMaterialQuotaLockKey('owner-1')).toBe('owner-materials:owner-1:quota');
     expect(ownerMaterialQuotaLockKey('owner-1')).not.toBe('owner-materials:owner-1');


### PR DESCRIPTION
## Problem

Deployments whose `owner_material` table predates the asset-registry retirement (#1242) still carry a NOT NULL `asset_id` column and lack `oss_key`, so material uploads fail with insert errors (observed as 500s on the acceptance environment; the table there had to be hot-patched by hand).

## Fix

`ensureOwnerMaterialSchema` now runs an idempotent upgrade:

```sql
ALTER TABLE owner_material ADD COLUMN IF NOT EXISTS oss_key TEXT NOT NULL DEFAULT '';
ALTER TABLE owner_material DROP COLUMN IF EXISTS asset_id;
```

so a legacy-shaped table upgrades cleanly on boot and inserts work afterwards.

## Tests

Upgrade-path test creates the legacy shape (NOT NULL `asset_id`, no `oss_key`), runs ensure, and asserts the new shape plus a working insert; it fails if the ALTERs are removed. Full `tests/persistence/` suite green.

Verification: persistence vitest green, tsc green, pnpm check green (exit codes checked explicitly).