### PR TITLE
fix(workbench): show newly created folders in the sidebar without reload

### DIFF
--- a/lib/utils/stage-storage.ts
+++ b/lib/utils/stage-storage.ts
@@ -729,9 +729,10 @@ async function performStageDeletion(stageId: string): Promise<void> {
  * id and listings owner-only, so the home's course list must not ask for an
  * unscoped listing at all. `GET /api/stages` IS the owner listing — it resolves
  * the anonymous owner from the same cookie the workbench uses and returns that
- * owner's stage documents. Folders stay device-local (Dexie), so the same
- * membership overlay the local path applies keeps courses filed in this browser
- * grouped.
+ * owner's stage documents. Folders list through the owner-scoped
+ * `GET /api/folders` (see `listOwnerFoldersFromServer`), while membership stays
+ * device-local (Dexie), so the same membership overlay the local path applies
+ * keeps courses filed in this browser grouped.
  */
 async function listOwnerStagesFromServer(): Promise<StageListItem[]> {
   const res = await fetch('/api/stages', { credentials: 'include' });
@@ -1094,15 +1095,84 @@ export async function stageExists(stageId: string): Promise<boolean> {
 
 // ==================== Course Folders ====================
 //
-// Folders are device-local course-grouping metadata. They live in this Dexie
-// database (`folders` + `stageFolders` tables) and never touch the course
-// document aggregate owned by the `@openmaic/storage` DocumentStore. A course
-// with no `stageFolders` row (or one with `folderId === undefined`) is unfiled.
+// Folders are course-grouping metadata. Without server persistence they are
+// device-local, living in this Dexie database (`folders` + `stageFolders`
+// tables) and never touching the course document aggregate owned by the
+// `@openmaic/storage` DocumentStore. With server persistence on (`listStages`
+// reads `/api/stages`, the workspace rail's folder family writes
+// `/api/folders`), the folder list and every folder mutation go through the
+// same owner-scoped server store, so a folder created there is visible to the
+// very list that rendered the create action. A course with no `stageFolders`
+// row (or one with `folderId === undefined`) is unfiled.
+
+/** The wire shape of the owner-scoped folder routes (`/api/folders`). */
+type FolderRouteBody = {
+  readonly error?: { readonly code?: unknown; readonly message?: unknown };
+  readonly folder?: FolderRecord;
+  readonly folders?: readonly FolderRecord[];
+  readonly removedStageIds?: readonly string[];
+};
+
+/**
+ * Map a route refusal (`{ error: { code, message } }`) onto the shared
+ * `FolderNameError`, exactly like the local storage boundary throws — one
+ * error type for every dialog, whichever store refused the name.
+ */
+function folderRouteError(body: FolderRouteBody | null | undefined): Error {
+  const code = body?.error?.code;
+  const message = typeof body?.error?.message === 'string' ? body.error.message : undefined;
+  if (code === 'FOLDER_NAME_DUPLICATE') {
+    return new FolderNameError(message ?? 'A folder with this name already exists', 'duplicate');
+  }
+  if (code === 'FOLDER_NAME_TOO_LONG') {
+    return new FolderNameError(message ?? 'Folder name is too long', 'tooLong');
+  }
+  if (code === 'FOLDER_NAME_EMPTY') {
+    return new FolderNameError(message ?? 'Folder name must not be empty', 'empty');
+  }
+  if (code === 'FOLDER_LIMIT_REACHED') {
+    return new FolderNameError(message ?? 'Folder count limit reached', 'limit');
+  }
+  return new Error(message ?? 'folder request failed');
+}
+
+/** The owner-scoped routes return the reference's `FolderItem` (row + userKey). */
+function toFolderRecord(folder: FolderRecord): FolderRecord {
+  return {
+    id: folder.id,
+    name: folder.name,
+    order: folder.order,
+    createdAt: folder.createdAt,
+    updatedAt: folder.updatedAt,
+  };
+}
+
+/**
+ * PG mode: the owner-scoped folder listing — the same store the workspace
+ * rail's `/api/folders` family and the agent's `create_folder` tool write to.
+ * With server persistence on, a Dexie snapshot can never contain a
+ * server-created folder, so the list the sidebar renders must read the server
+ * or a created folder would not appear without a reload.
+ */
+async function listOwnerFoldersFromServer(): Promise<FolderRecord[]> {
+  const res = await fetch('/api/folders', { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`Failed to list owner folders: HTTP ${res.status}`);
+  }
+  const body = (await res.json().catch(() => null)) as FolderRouteBody | null;
+  if (!body || !Array.isArray(body.folders)) {
+    throw new Error('Malformed /api/folders response: expected { folders: [...] }');
+  }
+  return body.folders.map(toFolderRecord);
+}
 
 /**
  * List all folders, ordered by their `order` field (ascending).
  */
 export async function listFolders(): Promise<FolderRecord[]> {
+  if (isBrowserPersistenceEnabled()) {
+    return await listOwnerFoldersFromServer();
+  }
   const folders = await db.folders.toArray();
   return folders.sort((a, b) => a.order - b.order);
 }
@@ -1124,12 +1194,37 @@ function assertFolderName(name: string, existing: FolderRecord[], currentId?: st
 }
 
 /**
+ * PG mode: create a folder through the owner-scoped route. The route re-checks
+ * duplicates and the count limit inside its owner-scoped transaction; its
+ * refusals map onto the same `FolderNameError` the local path throws, so the
+ * classic home and the workbench dialogs map one error type.
+ */
+async function createOwnerFolderFromServer(name: string): Promise<FolderRecord> {
+  const res = await fetch('/api/folders', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  const body = (await res.json().catch(() => null)) as FolderRouteBody | null;
+  if (!res.ok) throw folderRouteError(body);
+  if (!body?.folder) {
+    throw new Error('Malformed /api/folders response: expected { folder: { ... } }');
+  }
+  return toFolderRecord(body.folder);
+}
+
+/**
  * Create a folder. `order` is placed after the current maximum so new folders
  * land at the end of the list. Validates the name (width + uniqueness) at the
  * storage boundary, with the read-check-write inside a read-write transaction
  * so two tabs cannot both pass the duplicate check before either write commits.
+ * With server persistence on, the create goes through `POST /api/folders` —
+ * the same store the workspace rail and this module's `listFolders` read.
  */
 export async function createFolder(name: string): Promise<FolderRecord> {
+  if (isBrowserPersistenceEnabled()) {
+    return await createOwnerFolderFromServer(name);
+  }
   const now = Date.now();
   return db.transaction('rw', db.folders, async () => {
     const existing = await db.folders.toArray();
@@ -1151,12 +1246,29 @@ export async function createFolder(name: string): Promise<FolderRecord> {
   });
 }
 
+/** PG mode: rename a folder through the owner-scoped route. */
+async function renameOwnerFolderFromServer(id: string, name: string): Promise<void> {
+  const res = await fetch(`/api/folders/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) {
+    throw folderRouteError((await res.json().catch(() => null)) as FolderRouteBody | null);
+  }
+}
+
 /**
  * Rename a folder. Validates the name (width + uniqueness excluding itself) at
  * the storage boundary, with the read-check-write inside a read-write
  * transaction so the UI invariant cannot be bypassed or raced across tabs.
+ * With server persistence on, the rename goes through `PATCH /api/folders/:id`.
  */
 export async function renameFolder(id: string, name: string): Promise<void> {
+  if (isBrowserPersistenceEnabled()) {
+    await renameOwnerFolderFromServer(id, name);
+    return;
+  }
   const now = Date.now();
   await db.transaction('rw', db.folders, async () => {
     const existing = await db.folders.toArray();
@@ -1171,6 +1283,24 @@ export async function renameFolder(id: string, name: string): Promise<void> {
 export type DeleteFolderMode = 'ungroup' | 'remove';
 
 /**
+ * PG mode: delete a folder through the owner-scoped route. `mode=remove`
+ * returns the captured member course ids, which this module then runs through
+ * the same `deleteStageData` cascade the local path uses, so both modes leave
+ * the server store and the device-side mirrors in the same state.
+ */
+async function deleteOwnerFolderFromServer(id: string, mode: DeleteFolderMode): Promise<void> {
+  const res = await fetch(`/api/folders/${encodeURIComponent(id)}?mode=${mode}`, {
+    method: 'DELETE',
+  });
+  const body = (await res.json().catch(() => null)) as FolderRouteBody | null;
+  if (!res.ok) throw folderRouteError(body);
+  if (mode === 'remove') {
+    const removedStageIds = body?.removedStageIds ?? [];
+    await Promise.all(removedStageIds.map((stageId) => deleteStageData(stageId)));
+  }
+}
+
+/**
  * Delete a folder.
  *
  * - `'ungroup'` (default): drop the folder; its courses become unfiled (their
@@ -1179,8 +1309,15 @@ export type DeleteFolderMode = 'ungroup' | 'remove';
  * - `'remove'`: drop the folder AND delete every course that was filed in it,
  *   running each through {@link deleteStageData} so the full deletion cascade
  *   (document, scenes, chats, runtime, mirrors) applies.
+ *
+ * With server persistence on, the delete goes through `DELETE /api/folders/:id`
+ * and the `remove` cascade deletes the returned member ids.
  */
 export async function deleteFolder(id: string, mode: DeleteFolderMode = 'ungroup'): Promise<void> {
+  if (isBrowserPersistenceEnabled()) {
+    await deleteOwnerFolderFromServer(id, mode);
+    return;
+  }
   // Atomically capture members, delete the folder row, and clear all membership
   // rows in ONE transaction BEFORE the course-deletion cascade. This makes the
   // folder invisible to `setStageFolder` (which checks folder existence in its
@@ -1208,6 +1345,14 @@ export async function deleteFolder(id: string, mode: DeleteFolderMode = 'ungroup
 /**
  * Move a course into a folder, or out of all folders when `folderId` is
  * `undefined`. Idempotent.
+ *
+ * Membership is device-local either way (the `stageFolders` overlay keeps
+ * courses filed in this browser even when the folders themselves live on the
+ * server), so only the destination's existence check differs between modes:
+ * locally the `folders` table is checked inside the same transaction, while
+ * with server persistence on the folder list came from `/api/folders` and the
+ * local table has no row for it — the id is trusted from the rendered tree,
+ * and the server re-checks existence on its own membership writes.
  */
 export async function setStageFolder(stageId: string, folderId: string | undefined): Promise<void> {
   const now = Date.now();
@@ -1218,8 +1363,10 @@ export async function setStageFolder(stageId: string, folderId: string | undefin
   // (folderId undefined) always succeeds — it just removes the membership.
   if (folderId !== undefined) {
     await db.transaction('rw', [db.folders, db.stageFolders], async () => {
-      const folder = await db.folders.get(folderId);
-      if (!folder) throw new Error(`Folder not found: ${folderId}`);
+      if (!isBrowserPersistenceEnabled()) {
+        const folder = await db.folders.get(folderId);
+        if (!folder) throw new Error(`Folder not found: ${folderId}`);
+      }
       await db.stageFolders.put({ stageId, folderId, updatedAt: now });
     });
   } else {

--- a/tests/workbench/pg-mode-folder-listing.test.ts
+++ b/tests/workbench/pg-mode-folder-listing.test.ts
@@ -1,0 +1,343 @@
+// @vitest-environment jsdom
+
+/**
+ * PG-mode folder data flow — the create/list seam the workspace rail depends on.
+ *
+ * With server persistence on (`NEXT_PUBLIC_PERSISTENCE=1`) the workspace rail
+ * creates folders through `POST /api/folders` (and renames/deletes through the
+ * `/api/folders/:id` family), so the list the sidebar renders must read the
+ * same owner-scoped server store. This suite pins that contract at the storage
+ * boundary: a successful create is visible to the very next `listFolders`, and
+ * a duplicate refusal surfaces as `FolderNameError` with the list unchanged —
+ * the two halves of the acceptance finding (the new folder never appearing
+ * until reload, while a second create reports a duplicate).
+ *
+ * The storage seams (IndexedDB document store, Dexie folder tables) are mocked
+ * so the local fallback path is inert; the real PG-mode branches of
+ * `listFolders` / `createFolder` / `renameFolder` / `deleteFolder` are what
+ * runs. The final test mounts `useHomeDiscovery` the way `WorkspaceShell` does
+ * and drives the rail's own create-then-reload sequence.
+ */
+import { act, createElement, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  listLegacyStages: vi.fn(),
+  readLegacyStage: vi.fn(),
+  folders: vi.fn(),
+  stageFolders: vi.fn(),
+  toastError: vi.fn(),
+  mutateDocument: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError, success: vi.fn() } }));
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}));
+vi.mock('@/lib/store/media-generation', () => ({
+  useMediaGenerationStore: {
+    getState: () => ({ revokeObjectUrls: vi.fn() }),
+    setState: vi.fn(),
+  },
+}));
+vi.mock('@/components/discovery/folder-dialogs', () => ({ NewFolderDialog: () => null }));
+vi.mock('@/lib/import/use-import-classroom', () => ({
+  useImportClassroom: () => ({
+    importing: false,
+    fileInputRef: { current: null },
+    triggerFileSelect: vi.fn(),
+    handleFileChange: vi.fn(),
+  }),
+}));
+vi.mock('@/lib/document-store', () => ({
+  getDocumentStore: () => ({ listDocuments: mocks.listDocuments }),
+  getLegacyDocumentStore: () => ({
+    listStages: mocks.listLegacyStages,
+    read: mocks.readLegacyStage,
+  }),
+  mutateDocument: mocks.mutateDocument,
+  accessDocument: vi.fn(),
+  clearCurrentScene: vi.fn().mockResolvedValue(undefined),
+  loadCurrentScene: vi.fn().mockResolvedValue(null),
+  saveCurrentScene: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/utils/database', () => ({
+  db: {
+    folders: { toArray: mocks.folders },
+    stageFolders: { toArray: mocks.stageFolders },
+  },
+}));
+vi.mock('@/lib/utils/chat-storage', () => ({
+  ChatStorageLockUnavailableError: class extends Error {},
+  saveChatSessions: vi.fn(),
+  loadChatSessions: vi.fn(),
+  deleteChatSessions: vi.fn(),
+}));
+vi.mock('@/lib/playback/cursor', () => ({ clearCursor: vi.fn() }));
+vi.mock('@/lib/quiz/persistence', () => ({ clearAllForScene: vi.fn() }));
+vi.mock('@/lib/runtime/store', () => ({ beginStageRuntimeDeletionSafely: vi.fn() }));
+vi.mock('@/lib/pbl/v2/runtime/drain', () => ({ clearStageDrainWatermarks: vi.fn() }));
+vi.mock('@/lib/utils/chat-storage-lock', () => ({
+  withRuntimeStorageExclusiveLockUntilSettled: vi.fn(),
+  withRuntimeStorageSharedLock: vi.fn(),
+}));
+vi.mock('@/lib/pbl/v2/runtime/document-persistence', () => ({
+  preparePBLScenesForDocumentPersistence: vi.fn(async (_id: string, scenes: unknown[]) => scenes),
+}));
+
+import { useHomeDiscovery, type HomeDiscovery } from '@/lib/hooks/use-home-discovery';
+
+type FetchHandler = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+
+/** One stub per URL/method; anything else fails the test loudly. */
+function stubFolderRoutes(
+  handlers: ReadonlyArray<{
+    readonly method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+    readonly url: string;
+    readonly respond: FetchHandler;
+  }>,
+) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? 'GET') as 'GET' | 'POST' | 'PATCH' | 'DELETE';
+    const match = handlers.find((handler) => handler.method === method && handler.url === url);
+    if (!match) throw new Error(`unexpected fetch: ${method} ${url}`);
+    return match.respond(input, init);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const OWNER_STAGES = [
+  { id: 'stage-1', name: '光的折射', sceneCount: 12, createdAt: 1, updatedAt: 2 },
+];
+
+const OWNER_FOLDERS = [
+  { id: 'folder-1', name: 'Math', order: 0, createdAt: 1, updatedAt: 2, userKey: 'owner' },
+];
+
+const NEW_FOLDER = {
+  id: 'folder-9',
+  name: 'References',
+  order: 1,
+  createdAt: 100,
+  updatedAt: 100,
+  userKey: 'owner',
+};
+
+let root: Root | null = null;
+let discovery: HomeDiscovery | null = null;
+
+function Harness({ onDiscovery }: { onDiscovery: (value: HomeDiscovery) => void }) {
+  const value = useHomeDiscovery({ mode: 'discover-only' });
+  useEffect(() => onDiscovery(value), [onDiscovery, value]);
+  return null;
+}
+
+describe('PG-mode folder listing and creation', () => {
+  beforeEach(() => {
+    discovery = null;
+    vi.stubEnv('NEXT_PUBLIC_PERSISTENCE', '1');
+    vi.stubGlobal('fetch', vi.fn());
+    mocks.listDocuments.mockClear();
+    mocks.listLegacyStages.mockClear();
+    mocks.folders.mockClear();
+    mocks.stageFolders.mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    if (root) await act(async () => root?.unmount());
+    root = null;
+    document.body.innerHTML = '';
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('lists the owner folders through /api/folders and never consults Dexie', async () => {
+    const fetchMock = stubFolderRoutes([
+      {
+        method: 'GET',
+        url: '/api/folders',
+        respond: () => jsonResponse(200, { folders: OWNER_FOLDERS }),
+      },
+    ]);
+
+    const { listFolders } = await import('@/lib/utils/stage-storage');
+    const folders = await listFolders();
+
+    expect(folders).toEqual([
+      { id: 'folder-1', name: 'Math', order: 0, createdAt: 1, updatedAt: 2 },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith('/api/folders', expect.objectContaining({}));
+    expect(mocks.folders).not.toHaveBeenCalled();
+  });
+
+  it('makes a created folder visible to the very next listFolders', async () => {
+    stubFolderRoutes([
+      {
+        method: 'POST',
+        url: '/api/folders',
+        respond: () => jsonResponse(200, { folder: NEW_FOLDER }),
+      },
+      {
+        method: 'GET',
+        url: '/api/folders',
+        respond: () => jsonResponse(200, { folders: [...OWNER_FOLDERS, NEW_FOLDER] }),
+      },
+    ]);
+
+    const { createFolder, listFolders } = await import('@/lib/utils/stage-storage');
+    const created = await createFolder('References');
+
+    expect(created).toEqual({
+      id: 'folder-9',
+      name: 'References',
+      order: 1,
+      createdAt: 100,
+      updatedAt: 100,
+    });
+
+    const folders = await listFolders();
+    expect(folders.map((folder) => folder.id)).toContain('folder-9');
+    expect(folders.find((folder) => folder.id === 'folder-9')?.name).toBe('References');
+  });
+
+  it('surfaces a duplicate create as FolderNameError and leaves the list unchanged', async () => {
+    stubFolderRoutes([
+      {
+        method: 'POST',
+        url: '/api/folders',
+        respond: () =>
+          jsonResponse(409, {
+            error: { code: 'FOLDER_NAME_DUPLICATE', message: 'already exists' },
+          }),
+      },
+      {
+        method: 'GET',
+        url: '/api/folders',
+        respond: () => jsonResponse(200, { folders: OWNER_FOLDERS }),
+      },
+    ]);
+
+    const { createFolder, listFolders, FolderNameError } =
+      await import('@/lib/utils/stage-storage');
+    await expect(createFolder('Math')).rejects.toBeInstanceOf(FolderNameError);
+    await expect(createFolder('Math')).rejects.toMatchObject({ kind: 'duplicate' });
+
+    const folders = await listFolders();
+    expect(folders).toHaveLength(1);
+    expect(folders[0]).toMatchObject({ id: 'folder-1', name: 'Math' });
+  });
+
+  it('renames and deletes through the owner-scoped route family', async () => {
+    const fetchMock = stubFolderRoutes([
+      {
+        method: 'PATCH',
+        url: '/api/folders/folder%2Fone',
+        respond: () => jsonResponse(200, { folder: { ...OWNER_FOLDERS[0], name: 'Reading' } }),
+      },
+      {
+        method: 'DELETE',
+        url: '/api/folders/folder%2Fone?mode=ungroup',
+        respond: () => jsonResponse(200, { ok: true }),
+      },
+    ]);
+
+    const { renameFolder, deleteFolder } = await import('@/lib/utils/stage-storage');
+    await renameFolder('folder/one', 'Reading');
+    await deleteFolder('folder/one', 'ungroup');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/folders/folder%2Fone',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/folders/folder%2Fone?mode=ungroup',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('keeps the device-local Dexie listing when server persistence is off', async () => {
+    vi.stubEnv('NEXT_PUBLIC_PERSISTENCE', '');
+    mocks.folders.mockResolvedValue([
+      { id: 'local-1', name: 'Local', order: 0, createdAt: 1, updatedAt: 2 },
+    ]);
+
+    const { listFolders } = await import('@/lib/utils/stage-storage');
+    const folders = await listFolders();
+
+    expect(folders).toEqual([expect.objectContaining({ id: 'local-1', name: 'Local' })]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows a folder created through the rail adapter in the mounted list after reload', async () => {
+    // The server-side list converges only after the create lands: the first
+    // GET (mount) does not know the folder, the GET after the POST does.
+    let created = false;
+    stubFolderRoutes([
+      {
+        method: 'GET',
+        url: '/api/stages',
+        respond: () => jsonResponse(200, { stages: OWNER_STAGES }),
+      },
+      {
+        method: 'GET',
+        url: '/api/folders',
+        respond: () =>
+          jsonResponse(200, { folders: created ? [...OWNER_FOLDERS, NEW_FOLDER] : OWNER_FOLDERS }),
+      },
+      {
+        method: 'POST',
+        url: '/api/folders',
+        respond: () => {
+          created = true;
+          return jsonResponse(200, { folder: NEW_FOLDER });
+        },
+      },
+    ]);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () =>
+      root?.render(
+        createElement(Harness, {
+          onDiscovery: (value) => {
+            discovery = value;
+          },
+        }),
+      ),
+    );
+
+    // The rail renders its course tree from `useHomeDiscovery`'s folders; the
+    // initial list arrives from the server, not Dexie.
+    expect(discovery?.folders.map((folder) => folder.id)).toEqual(['folder-1']);
+
+    // The workspace rail's create handler: POST /api/folders, then reload the
+    // authoritative list. The list state the sidebar renders must now hold the
+    // new folder — the exact acceptance flow.
+    const { workspaceFolderAdapter } =
+      await import('@/components/workbench/workspace/workspace-folder-seam');
+    await act(async () => {
+      await workspaceFolderAdapter.create('References');
+      await discovery?.reload();
+    });
+
+    expect(discovery?.folders.map((folder) => folder.id)).toEqual(['folder-1', 'folder-9']);
+  });
+});

--- a/tests/workbench/pg-mode-home-listing.test.ts
+++ b/tests/workbench/pg-mode-home-listing.test.ts
@@ -101,6 +101,25 @@ function stagesResponse() {
   });
 }
 
+function foldersResponse() {
+  return new Response(JSON.stringify({ folders: [] }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Route the mounted hook's owner-scoped listings: stages + folders. */
+function ownerListingsFetch() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url === '/api/stages') return stagesResponse();
+    if (url === '/api/folders') return foldersResponse();
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 describe('PG-mode home listing', () => {
   beforeEach(() => {
     discovery = null;
@@ -144,8 +163,7 @@ describe('PG-mode home listing', () => {
   });
 
   it('mounts the home library on the owner listing with no persistence warning', async () => {
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue(stagesResponse());
+    const fetchMock = ownerListingsFetch();
 
     const container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
## Bug

In the Pro workbench, creating a folder from the sidebar rail appeared to do nothing — the new folder never rendered. It *was* persisted (creating the same name again hit the server's 409 duplicate refusal), so the write succeeded while the list stayed stale.

## Root cause

With server persistence on, the rail's create writes through `POST /api/folders` (owner-scoped PG store), but the sidebar tree renders from `listFolders()` in `lib/utils/stage-storage.ts` — a device-local Dexie read. The two stores never meet: the post-create `reload()` refetched the same Dexie snapshot. `listStages()` already had a server-persistence branch; `listFolders()` did not.

## Fix

- `listFolders()` reads `GET /api/folders` in PG mode — the same store every folder mutation writes to, so create → reload converges without a page reload.
- `createFolder` / `renameFolder` / `deleteFolder` gained matching PG-mode branches (delete cascades returned member ids through `deleteStageData`), keeping the classic home consistent too.
- Route refusals map onto the shared `FolderNameError`, so duplicate names surface in both the rail dialog and the classic home instead of failing silently.
- `setStageFolder` skips the Dexie existence check in PG mode (folders live on the server).

No change to `WorkspaceRail.tsx` — its create → reload flow was already correct once the list read the right store.

## Tests

`tests/workbench/pg-mode-folder-listing.test.ts` (6 tests): create→list-contains, duplicate→`FolderNameError` with list unchanged, rename/delete routing, non-PG Dexie fallback, and a mounted-hook test driving the rail's exact `adapter.create → reload` sequence.

Verified: workbench vitest, full vitest (6991 tests), `tsc --noEmit`, `pnpm check`, `pnpm build` — all exit 0 (independently re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)