### PR TITLE
fix(workbench): single-source the chat gutter so timeline and composer share a left edge

### DIFF
--- a/components/workbench/WorkbenchChat.tsx
+++ b/components/workbench/WorkbenchChat.tsx
@@ -95,7 +95,7 @@ import {
 } from '@/lib/workbench/composer-keys';
 import { useDoubleEscapeStop } from './chat/composer-escape';
 import { useWorkbenchAutoscroll } from './chat/autoscroll';
-import { composerLayout, wbStyles as styles } from './chat/chat-styles';
+import { chatColumn, composerLayout, wbStyles as styles } from './chat/chat-styles';
 import { ChatTimeline } from './chat/chat-timeline';
 import { pendingQuestion } from './chat/question-card-state';
 import { QuestionForm } from './chat/question-form';
@@ -286,6 +286,22 @@ export function WorkbenchChat({
 
   const { scrollRef, contentRef, isNearBottom, scrollToBottom } =
     useWorkbenchAutoscroll(displayedChat);
+  // The transcript's column centers inside the scroll viewport, whose content box
+  // is narrower than the footer's by however much the scrollbar reserves — 0 with
+  // overlay scrollbars, ~15px classic. The footer pads its right by that MEASURED
+  // width, so both columns center inside boxes of the same width and their left
+  // edges are equal at every pane width. Measured, never assumed: guessing a
+  // scrollbar width is exactly the class of numeric fix that already failed here.
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const readScrollbar = () => setScrollbarWidth(el.offsetWidth - el.clientWidth);
+    readScrollbar();
+    const observer = new ResizeObserver(readScrollbar);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [scrollRef, catchingUp, retainedTranscript]);
   // How to put a classroom on screen. There is deliberately no derived list of
   // "the classrooms this conversation is involved with" any more: a classroom is
   // picked per answer, and what an answer touched is a row in the transcript
@@ -721,10 +737,13 @@ export function WorkbenchChat({
     }
   }
 
-  // Full-width conversation uses a reading measure. Beside the classroom the
-  // chat is the flex leftover (min 400), so dragging the splitter moves the
-  // border instead of a right-side gutter.
-  const measure = effectivePanelOpen ? '' : 'mx-auto w-full max-w-[760px]';
+  // The transcript and the composer share ONE column class — see `chatColumn`.
+  // The scroll viewport stays full pane width so the scrollbar sits on the
+  // pane's edge, and the footer pads its right by the MEASURED scrollbar width
+  // (`scrollbarWidth` above), so both copies of the column center inside boxes
+  // of the same width: one shared class + one measured compensation, no pair of
+  // numbers to keep equal by hand.
+  const column = chatColumn(!effectivePanelOpen);
 
   return (
     <div
@@ -735,7 +754,11 @@ export function WorkbenchChat({
     >
       {/* Nothing the user has not read may sit under the composer: `composerLayout`
           is where that rule lives, and `data-composer` is it, visible. */}
-      <div className="relative flex min-h-0 flex-1 flex-col" data-composer={layout.mode}>
+      <div
+        className="relative flex min-h-0 flex-1 flex-col"
+        data-composer={layout.mode}
+        data-testid="workbench-chat-column"
+      >
         <div className="relative min-h-0 flex-1">
           {catchingUp && !retainedTranscript ? (
             <div
@@ -753,11 +776,11 @@ export function WorkbenchChat({
               data-testid="workbench-chat-scroll"
               aria-busy={catchingUp ? 'true' : undefined}
               inert={retainedTranscript ? true : undefined}
-              // The same horizontal inset as the composer footer (`px-3`), so
-              // the timeline's left edge lines up with the composer box's left
-              // edge instead of sitting to its right.
+              // Full pane width — the scrollbar belongs on the pane's edge. The
+              // column (gutter + measure) is on the content wrapper below, and
+              // the footer mirrors it against the measured scrollbar width.
               className={cn(
-                'h-full overflow-y-auto px-3 pt-3',
+                'h-full overflow-y-auto pt-3',
                 layout.scrollPadding,
                 retainedTranscript ? 'pointer-events-none select-none' : undefined,
               )}
@@ -766,7 +789,7 @@ export function WorkbenchChat({
                 ref={contentRef}
                 className={cn(
                   'min-h-full',
-                  measure,
+                  column,
                   showEmptyState ? 'flex flex-col items-center justify-center' : undefined,
                 )}
               >
@@ -816,10 +839,16 @@ export function WorkbenchChat({
 
         <footer
           data-testid="workbench-composer-footer"
-          className={cn('inset-x-0 z-20 px-3', layout.footer)}
+          className={cn('inset-x-0 z-20', layout.footer)}
+          // The transcript's copy of the column centers inside the scroll
+          // viewport's content box, which is narrower than this footer by the
+          // scrollbar. Reserve that MEASURED width here so both copies center
+          // inside boxes of the same width — left edges equal at every pane
+          // width, whatever the platform's scrollbar is (0 when overlay).
+          style={scrollbarWidth ? { paddingRight: scrollbarWidth } : undefined}
         >
           <div className={styles.composer.seamFade} aria-hidden="true" />
-          <div className={cn('pointer-events-auto relative', measure)}>
+          <div className={cn('pointer-events-auto relative', column)}>
             {/* The agent's open question, IN PLACE OF the composer rather than
                 stacked above it: there is nothing else to type while it waits,
                 and one surface with one focus beats two that both look live. The

--- a/components/workbench/chat/chat-styles.ts
+++ b/components/workbench/chat/chat-styles.ts
@@ -196,8 +196,12 @@ export const wbStyles = {
      * wash. It is a bookmark in the transcript ("the hand-over happened here"),
      * and the form two centimetres below it is the thing to read — so this must
      * not read as a second place to answer.
+     *
+     * No horizontal padding: it has no frame, so its text is on the column's own
+     * left edge like the agent's prose. `box` keeps its `px-3` because that is a
+     * bordered card's inner padding, and the CARD's edge is what lines up.
      */
-    summaryBox: 'group/question flex flex-col px-3 py-1',
+    summaryBox: 'group/question flex flex-col py-1',
     summaryPointer: 'font-normal text-[var(--wb-text-faint)]',
   },
   /**
@@ -334,6 +338,54 @@ export const wbStyles = {
   scrollToBottom:
     'absolute left-1/2 z-30 inline-flex -translate-x-1/2 cursor-pointer items-center gap-1 rounded-full border border-[var(--wb-line)] bg-[var(--wb-surface-raised)] px-2.5 py-1 text-[length:var(--wb-text-xs)] text-[var(--wb-text-muted)] shadow-sm transition-colors hover:text-[var(--wb-text)]',
 } as const;
+
+/**
+ * The chat column's horizontal gutter — the ONE inset between the pane's edge and
+ * both the transcript's text and the composer box's left border.
+ *
+ * It is a single class in a single place on purpose. It used to be written twice
+ * (once on the scroll viewport, once on the composer footer) and the two were
+ * expected to stay equal by hand.
+ */
+const WB_CHAT_GUTTER = 'px-3';
+
+/**
+ * THE one column class that decides where the transcript and the composer begin.
+ *
+ * Both regions used to write their own column out by hand: each carried its own
+ * `px-*` gutter AND its own `mx-auto w-full max-w-*` centering wrapper. Equal
+ * paddings were never enough, because the two columns center inside DIFFERENT
+ * containing blocks — the transcript's is a scroll container, whose content box
+ * is narrower than the composer footer's by the scrollbar's width. Writing the
+ * offsets out:
+ *
+ *   transcript text left = pad + (paneWidth - 2*pad - scrollbar - measure) / 2
+ *   composer box  left   = pad + (paneWidth - 2*pad            - measure) / 2
+ *
+ * the padding cancels out of the difference entirely and what is left is
+ * `-scrollbar/2`: the transcript sits half a scrollbar to the LEFT of the
+ * composer, at every padding value. That is why tuning the two `px-*` classes
+ * against each other could not fix it, and must not be tried again.
+ *
+ * So both regions now spend this ONE class — the transcript's content wrapper
+ * inside the scroll viewport (so the scrollbar stays on the pane's edge and the
+ * whole pane scrolls), and the composer's wrapper inside the footer — and the
+ * footer cancels the one remaining difference by reserving the MEASURED
+ * scrollbar width as `padding-right` (see `WorkbenchChat`). Both copies then
+ * center inside boxes of the same width, so the left edges are equal at every
+ * pane width and every scrollbar width, with no pair of numbers to keep equal
+ * by hand.
+ *
+ * `760px` is the reading measure of the text itself; the cap carries the gutter
+ * on top of it (760 + 2 * 12) so the measure stays exactly what it was.
+ *
+ * @param measured Full-width conversation. Beside the classroom the chat is the
+ *   flex leftover (min 400), so dragging the splitter moves the border instead
+ *   of a right-side gutter — there the column is the pane.
+ */
+export function chatColumn(measured: boolean): string {
+  return measured ? `mx-auto w-full max-w-[784px] ${WB_CHAT_GUTTER}` : WB_CHAT_GUTTER;
+}
 
 /**
  * Where the composer sits — the one rule that decides whether the transcript can

--- a/tests/workbench/chat-gutter.test.ts
+++ b/tests/workbench/chat-gutter.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+/**
+ * One column, one left edge.
+ *
+ * The transcript and the composer used to establish a column each: their own
+ * `px-*` gutter, and their own `mx-auto w-full max-w-*` centering wrapper. Equal
+ * padding values were not enough, because the two columns are centered inside
+ * DIFFERENT containing blocks — the transcript's is a scroll container, whose
+ * content box is narrower than the composer footer's by the scrollbar's width:
+ *
+ *   transcript text left = pad + (pane - 2*pad - scrollbar - measure) / 2
+ *   composer box  left   = pad + (pane - 2*pad             - measure) / 2
+ *
+ * The padding cancels out of the difference and what remains is `-scrollbar/2`,
+ * at EVERY padding value — the transcript half a scrollbar to the left of the
+ * composer, which is exactly what tuning the two `px-*` classes against each
+ * other failed to move.
+ *
+ * So both regions spend ONE shared class (`chatColumn`) — the transcript's
+ * content wrapper and the composer's wrapper — while the scroll viewport keeps
+ * the full pane width so the scrollbar stays on the pane's edge, and the footer
+ * cancels the scrollbar difference by reserving the MEASURED scrollbar width as
+ * `padding-right`. What is pinned here is that single source: the gutter and
+ * the measure live in `chatColumn`, both regions apply the same `column` value,
+ * and neither region writes its own `px-*` / `mx-auto` / `max-w-*` beside it.
+ * Editing one side back to its own hand-written padding breaks these tests.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { chatColumn, wbStyles as styles } from '@/components/workbench/chat/chat-styles';
+import { ChatTimeline } from '@/components/workbench/chat/chat-timeline';
+import type { ChatNode } from '@/lib/workbench/session-store';
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+/** Tailwind's spacing unit, so `px-3` can be read as 12px. */
+const SPACING_PX = 4;
+
+/** Horizontal insets, ignoring variant-prefixed classes (`data-[…]:px-2.5`). */
+const tokens = (classes: string) => classes.split(/\s+/).filter((c) => c && !c.includes(':'));
+const horizontalPadding = (classes: string) =>
+  tokens(classes).filter((c) => /^(?:px|pl|pr)-/.test(c));
+const horizontalMargin = (classes: string) =>
+  tokens(classes).filter((c) => /^(?:mx|ml|mr)-/.test(c));
+const centering = (classes: string) =>
+  tokens(classes).filter((c) => c === 'mx-auto' || c.startsWith('max-w-'));
+
+/**
+ * The opening tag carrying `anchor`. Attribute expressions in the chat shell
+ * contain no `>` of their own (pinned by the shell using truthiness, not `> 0`,
+ * in its one inline style), so the first one after the anchor closes the tag.
+ */
+function openingTag(source: string, anchor: string): string {
+  const at = source.indexOf(anchor);
+  expect(at, `anchor ${anchor} in WorkbenchChat.tsx`).toBeGreaterThan(-1);
+  return source.slice(source.lastIndexOf('<', at), source.indexOf('>', at) + 1);
+}
+
+describe('chatColumn — the single source of the chat gutter', () => {
+  it('spends one gutter class on both column modes', () => {
+    const full = chatColumn(false);
+    const measured = chatColumn(true);
+
+    // Beside the classroom the column IS the pane: the gutter, and nothing else.
+    expect(tokens(full)).toHaveLength(1);
+    expect(horizontalPadding(full)).toEqual(tokens(full));
+    // The full-width conversation adds the reading measure ON TOP of that same
+    // gutter — it does not restate it.
+    expect(tokens(measured)).toContain(tokens(full)[0]);
+    expect(horizontalPadding(measured)).toEqual(horizontalPadding(full));
+    expect(centering(measured)).toContain('mx-auto');
+  });
+
+  it('caps the column at the reading measure PLUS the gutter on both sides', () => {
+    // Moving the gutter out of the two regions and onto the column must not
+    // narrow the text: the cap is a border-box width, so it has to carry the
+    // gutter it now owns.
+    const cap = /max-w-\[(\d+)px\]/.exec(chatColumn(true));
+    const pad = /\bpx-(\d+)\b/.exec(chatColumn(false));
+    expect(cap, 'the column cap').not.toBeNull();
+    expect(pad, 'the column gutter').not.toBeNull();
+    expect(Number(cap![1])).toBe(760 + 2 * Number(pad![1]) * SPACING_PX);
+  });
+});
+
+describe('WorkbenchChat — the transcript and the composer share that column', () => {
+  const shell = read('components/workbench/WorkbenchChat.tsx');
+
+  it('spends the one column value on both regions, from one call site', () => {
+    expect(shell.match(/chatColumn\(/g), 'chatColumn call sites').toHaveLength(1);
+
+    // The transcript's copy: on the content wrapper inside the scroll viewport,
+    // so the viewport itself keeps the full pane width and the scrollbar stays
+    // on the pane's edge.
+    const content = openingTag(shell, 'ref={contentRef}');
+    expect(content, "the transcript's content wrapper spends the column").toContain('column');
+
+    // The composer's copy: on the wrapper inside the footer.
+    const composerWrapper = openingTag(shell, "'pointer-events-auto relative'");
+    expect(composerWrapper, "the composer's wrapper spends the column").toContain('column');
+
+    // Ordering sanity: viewport before footer inside the shared shell.
+    const scrollAt = shell.indexOf('data-testid="workbench-chat-scroll"');
+    const footerAt = shell.indexOf('data-testid="workbench-composer-footer"');
+    expect(scrollAt).toBeGreaterThan(-1);
+    expect(scrollAt).toBeLessThan(footerAt);
+  });
+
+  it('cancels the scrollbar with a measured reserve, not a guessed number', () => {
+    // The footer reserves the MEASURED scrollbar width, so the two copies of the
+    // column center inside boxes of the same width on every platform.
+    const footer = openingTag(shell, 'data-testid="workbench-composer-footer"');
+    expect(footer).toContain('paddingRight: scrollbarWidth');
+    expect(shell).toContain('offsetWidth - el.clientWidth');
+  });
+
+  it('writes no hand-written inset or centering beside the shared column', () => {
+    const regions = {
+      'the scroll viewport': openingTag(shell, 'data-testid="workbench-chat-scroll"'),
+      'the timeline content wrapper': openingTag(shell, 'ref={contentRef}'),
+      'the composer footer': openingTag(shell, 'data-testid="workbench-composer-footer"'),
+      "the composer's wrapper": openingTag(shell, "'pointer-events-auto relative'"),
+    };
+    for (const [name, tag] of Object.entries(regions)) {
+      expect(horizontalPadding(tag), `${name} re-added its own gutter`).toEqual([]);
+      expect(horizontalMargin(tag), `${name} re-added a horizontal margin`).toEqual([]);
+      expect(centering(tag), `${name} re-added its own centering wrapper`).toEqual([]);
+    }
+    // The per-region hand-written measure is gone for good: the only centering
+    // classes in the file come out of `chatColumn`.
+    expect(shell).not.toContain('const measure');
+    expect(shell).not.toContain('mx-auto');
+  });
+});
+
+describe('every timeline row starts on that column edge', () => {
+  /**
+   * Frameless rows carry no horizontal inset at all: their text IS the column's
+   * left edge, alongside the agent's prose.
+   */
+  const frameless: Record<string, string> = {
+    'timeline root': styles.timeline.root,
+    'user bubble row': styles.userBubble.row,
+    'system notice row': styles.systemNotice.row,
+    'run boundary row': styles.boundary.row,
+    'waiting bar': styles.waiting.root,
+    'handed-over question row': styles.questionCard.summaryBox,
+    'course card set': styles.courseLink.set,
+    'empty state': styles.emptyState.root,
+    'action cluster with a wait': styles.actionCluster.withWait,
+  };
+
+  /**
+   * Framed rows are bordered boxes, so what lines up is the FRAME. Inner padding
+   * is that card's own; a horizontal margin would push the frame off the column.
+   */
+  const framed: Record<string, string> = {
+    'thinking block': styles.thinking.box,
+    'tool card': styles.toolCard.box,
+    'tool group': styles.toolGroup.group,
+    'action cluster': styles.actionCluster.root,
+    'question card': styles.questionCard.box,
+    'course card': styles.courseLink.block,
+  };
+
+  it('gives frameless rows no horizontal inset', () => {
+    for (const [name, classes] of Object.entries(frameless)) {
+      expect(horizontalPadding(classes), `${name} is indented past the column`).toEqual([]);
+      expect(horizontalMargin(classes), `${name} is offset from the column`).toEqual([]);
+    }
+  });
+
+  it('puts every framed row’s border on the column edge', () => {
+    for (const [name, classes] of Object.entries(framed)) {
+      expect(horizontalMargin(classes), `${name}'s frame is offset from the column`).toEqual([]);
+    }
+  });
+
+  it('renders the agent’s prose with no wrapper inset of its own', () => {
+    const nodes: ChatNode[] = [
+      { key: 'a', kind: 'assistant', text: 'aligned' },
+      { key: 's', kind: 'system', text: 'a notice' },
+      { key: 'w', kind: 'waiting', text: '' },
+    ];
+    for (const node of nodes) {
+      const host = document.createElement('div');
+      host.innerHTML = renderToStaticMarkup(
+        createElement(ChatTimeline, { chat: [node], plan: [] }),
+      );
+      const row = host.firstElementChild?.firstElementChild;
+      expect(row, `${node.kind} row`).not.toBeNull();
+      const classes = row!.getAttribute('class') ?? '';
+      expect(horizontalPadding(classes), `${node.kind} row is indented`).toEqual([]);
+      expect(horizontalMargin(classes), `${node.kind} row is offset`).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Bug

In the workbench chat, the transcript's left edge did not line up with the composer box's left edge, and a previous padding tweak (#1247) failed to move it.

## Why padding tweaks could not fix it

The transcript's column centers inside a scroll container, whose content box is narrower than the composer footer's by the scrollbar width. Writing the offsets out, the padding cancels from the difference entirely and what remains is `-scrollbar/2` — at every padding value. Numeric fixes were structurally incapable of closing the gap.

## Fix

- `chatColumn()` in `chat-styles.ts` is now the single source of the chat column (gutter + 760px reading measure), computed at one call site and spent by exactly two consumers: the transcript's content wrapper and the composer's wrapper.
- The scroll viewport keeps the full pane width, so the scrollbar stays on the pane's right edge (wheel works over the side whitespace).
- The composer footer reserves the MEASURED scrollbar width (`offsetWidth - clientWidth`, tracked by a ResizeObserver) as `padding-right`, so both copies of the column center inside boxes of the same width — left edges equal at every pane width and every platform scrollbar (overlay = 0, classic ~15px).
- `questionCard.summaryBox` drops a stray `px-3` that indented the handed-over question row past the prose.

## Tests

`tests/workbench/chat-gutter.test.ts` pins the mechanism: one `chatColumn` call site spent by both regions, the measured scrollbar reserve on the footer, no hand-written `px-*`/`mx-auto`/`max-w-*` beside the shared column, and per-row-type zero-inset checks across every timeline node kind.

Verified: workbench vitest (75 files), `tsc --noEmit`, `pnpm check`, `pnpm build` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)