### PR TITLE
fix(workbench): lock pane-embedded classroom to edit mode

### DIFF
--- a/components/stage.tsx
+++ b/components/stage.tsx
@@ -18,7 +18,7 @@ import {
 import { InteractiveIframeHost } from '@/components/scene-renderers/InteractiveIframeHost';
 import { CHROME_EASE } from '@/lib/edit/transitions';
 import { enterEditMode } from '@/lib/edit/enter-edit-mode';
-import { preloadEditor } from '@/lib/edit/preload-editor';
+import { isEditorPreloaded, preloadEditor } from '@/lib/edit/preload-editor';
 import { WorkbenchReturnControl } from '@/components/workbench/WorkbenchReturnControl';
 import { resolveClassroomBackControl } from '@/lib/workbench/classroom-back-control';
 import { resolveClassroomHeaderControls } from '@/lib/workbench/classroom-header-controls';
@@ -38,8 +38,13 @@ import { exitProPlaybackToStandalone } from '@/lib/workbench/pro-playback-exit';
  * pane rather than filling a route — the dispatch below is not replaced, it is
  * merely stripped of the chrome that the host already provides: no header, no
  * global controls or Pro switch (the pane IS Pro-locked). Hosted chrome is
- * derived synchronously from workspace intent and scene eligibility, so its
- * first render does not pass through playback. Deliberately not a third
+ * EDIT-LOCKED: the pane declares the lock once (`WorkbenchPanelState.editPinned`)
+ * and this component reads it back, so no entry path — a course the agent just
+ * created, a restored tab, a tab switch, a reload — gets to decide otherwise.
+ * The learning chrome is reachable only through Start Learning, which clears
+ * the lock at the pane. Everything else resolves synchronously between the
+ * neutral loading shell and edit, so a hosted first paint can never be
+ * playback. Deliberately not a third
  * `StageMode` — `StageMode` lives in the
  * published `@openmaic/dsl` and is persisted with the stage, whereas "this is
  * rendered inside the workspace right now" is view state that must not outlive
@@ -105,9 +110,12 @@ export function Stage({
   // its panelOpen bit here made the keyed edit/playback roots swap for one
   // frame and produced a full classroom flash.
   const workbenchPlayback = workbenchPanel.playback;
-  // The classroom is showing exactly when it is hosted, its pane is expanded,
-  // and the user has not stepped into full-screen playback.
-  const workbenchShowingClassroom = hosted && workbenchPanel.visible && !workbenchPlayback;
+  // The classroom is showing exactly when it is hosted and the pane says it is
+  // edit-locked. The lock is computed once, at the provider the workspace
+  // mounts the classroom through (`WorkbenchPanelProvider`), so this is the
+  // pane's answer being read back rather than a second derivation that could
+  // disagree with it.
+  const workbenchShowingClassroom = hosted && workbenchPanel.editPinned;
 
   // Single decision for the classroom chrome's top-left back affordance:
   // plain classroom → home arrow; full-screen playback → "Back to workspace";
@@ -144,12 +152,23 @@ export function Stage({
     hasCurrentScene: !!currentScene,
   });
   const chromeEditable = hosted ? hostedSceneEditable : isEditable;
+  // Seeded from the module-level registry rather than always starting at
+  // `idle`: once the editor chunk has been imported in this tab, a remount
+  // (course switch, reopened tab) must resolve to the edit chrome during the
+  // FIRST render. Starting at `idle` would spend a paint on the neutral
+  // loading shell waiting for an import that already finished.
   const [editorPreloadState, setEditorPreloadState] = useState<
     'idle' | 'loading' | 'ready' | 'failed'
-  >('idle');
+  >(() => (isEditorPreloaded() ? 'ready' : 'idle'));
 
   useEffect(() => {
     if (!hosted || !workbenchShowingClassroom || !hostedSceneEditable) return;
+    // Already registered — do not knock the state back to `loading`, which
+    // would blank an edit chrome that is on screen and correct.
+    if (isEditorPreloaded()) {
+      setEditorPreloadState('ready');
+      return;
+    }
     let cancelled = false;
     setEditorPreloadState('loading');
     preloadEditor()
@@ -165,15 +184,17 @@ export function Stage({
     };
   }, [hosted, workbenchShowingClassroom, hostedSceneEditable]);
 
-  // The workspace owns the edit/playback intent: a visible eligible pane is
-  // editing, while Start Learning (`workbenchPlayback`) is playback. Resolve
-  // that intent in render rather than mutating the transient stage-store mode
-  // in an effect — otherwise every hosted course paints PlaybackChromeRoot
-  // once before the effect can run, and a course switch can inherit stale mode.
+  // The workspace owns the edit/playback intent: the pane's edit lock is the
+  // edit intent, while Start Learning (`workbenchPlayback`) is the one signal
+  // that releases it. Resolve that intent in render rather than mutating the
+  // transient stage-store mode in an effect — otherwise every hosted course
+  // paints PlaybackChromeRoot once before the effect can run, and a course
+  // switch can inherit stale mode.
   const chromeMode = resolveStageChromeMode({
     storedMode: mode,
     hosted,
     workbenchShowingClassroom,
+    workbenchLearning: hosted && workbenchPlayback,
     isEditable: chromeEditable,
     hasCurrentScene: !!currentScene,
     stageMatchesHost: currentStageMatchesHost,
@@ -290,14 +311,12 @@ export function Stage({
   // structural rather than aspirational.
   const classroomChrome = (
     <AnimatePresence initial={false}>
-      {chromeMode === 'loading' ? (
-        <div
-          key="loading"
-          data-testid="stage-editor-loading"
-          className="absolute inset-0 flex bg-background"
-          aria-busy="true"
-        />
-      ) : chromeMode === 'edit' && currentScene ? (
+      {/* The dispatch is exhaustive on `chromeMode` on purpose. The learning
+          chrome is reached ONLY by an explicit playback resolution, so it can
+          no longer be inherited as the else-branch of a condition about
+          something else — a resolved `edit` with no scene to hand shows the
+          neutral shell and waits, exactly as `loading` does. */}
+      {chromeMode === 'edit' && currentScene ? (
         <motion.div
           key="edit"
           initial={{ opacity: 0 }}
@@ -312,7 +331,7 @@ export function Stage({
             onToggleEditMode={chromeToggleHandler}
           />
         </motion.div>
-      ) : (
+      ) : chromeMode === 'playback' || chromeMode === 'autonomous' ? (
         <motion.div
           key="playback"
           initial={{ opacity: 0 }}
@@ -336,6 +355,13 @@ export function Stage({
             hideHeaderCourseActions={!classroomHeaderControls.showCourseActions}
           />
         </motion.div>
+      ) : (
+        <div
+          key="loading"
+          data-testid="stage-editor-loading"
+          className="absolute inset-0 flex bg-background"
+          aria-busy="true"
+        />
       )}
     </AnimatePresence>
   );

--- a/components/workbench/workspace/WorkspaceClassroomPane.tsx
+++ b/components/workbench/workspace/WorkspaceClassroomPane.tsx
@@ -154,7 +154,15 @@ export const WorkspaceClassroomPane = memo(function WorkspaceClassroomPane({
       )}
 
       {/* The real classroom chrome. Course identity alone owns its lifecycle;
-          chat/session activity is deliberately absent from this boundary. */}
+          chat/session activity is deliberately absent from this boundary.
+
+          This provider is also the EDIT LOCK. Every way a classroom reaches
+          the right pane — the agent creating one mid-conversation, a restored
+          tab, a tab switch, a reload — comes through this one element, so the
+          lock is a property of the pane rather than a default each entry path
+          has to remember. `visible && !playback` is the whole rule: what the
+          classroom document or the stage store says about play/edit does not
+          participate. */}
       <div className="ws-classroom-body relative flex min-h-0 flex-1">
         <WorkbenchPanelProvider visible={!hidden} playback={playback}>
           <ClassroomSurface classroomId={courseId} variant="pane" />

--- a/lib/edit/preload-editor.ts
+++ b/lib/edit/preload-editor.ts
@@ -15,14 +15,38 @@
  * suspenders caller share one in-flight import.
  */
 let editorReady: Promise<void> | null = null;
+let editorLoaded = false;
+
+/**
+ * Whether the editor chunk is ALREADY registered, answered synchronously.
+ *
+ * The workspace pane is edit-locked, so a remount there (a course switch, a
+ * reopened tab) must be able to resolve straight to the edit chrome during
+ * render. Waiting for `preloadEditor()` to resolve again would cost a paint of
+ * the neutral loading shell for an import that finished long ago.
+ */
+export function isEditorPreloaded(): boolean {
+  return editorLoaded;
+}
 
 export function preloadEditor(): Promise<void> {
   if (!editorReady) {
-    editorReady = Promise.all([
+    const attempt = Promise.all([
       import('@/app/editor-fonts'),
       import('@/components/edit/surfaces/slide'),
       import('@/components/edit/surfaces/quiz'),
-    ]).then(() => undefined);
+    ]).then(() => {
+      editorLoaded = true;
+    });
+    editorReady = attempt;
+    // A cached REJECTION would be permanent, and the edit-locked pane has no
+    // learning chrome to fall back to — it would sit on the neutral shell for
+    // the rest of the session. Forget the failed attempt so the next hosted
+    // classroom retries the import. The extra handler only clears the cache;
+    // the rejection itself still reaches whoever awaited `attempt`.
+    attempt.catch(() => {
+      if (editorReady === attempt) editorReady = null;
+    });
   }
   return editorReady;
 }

--- a/lib/edit/stage-mode.ts
+++ b/lib/edit/stage-mode.ts
@@ -50,8 +50,16 @@ export interface StageChromeModeContext {
   storedMode: StageMode;
   /** Whether the classroom is mounted inside the workspace host. */
   hosted: boolean;
-  /** The workspace pane is visible and has not entered full-screen learning. */
+  /**
+   * The pane's edit lock (`WorkbenchPanelState.editPinned`): the pane is on
+   * screen and the user has not pressed Start Learning.
+   */
   workbenchShowingClassroom: boolean;
+  /**
+   * The user pressed Start Learning: the pane went full-screen and IS the
+   * learning surface. The single door out of the edit lock.
+   */
+  workbenchLearning: boolean;
   /** Owner and scene eligibility have both been resolved for this render. */
   isEditable: boolean;
   /** Prevents mounting an editor shell before a current scene exists. */
@@ -60,7 +68,7 @@ export interface StageChromeModeContext {
   stageMatchesHost: boolean;
   /** Editor-only side effects have registered their authoring surfaces. */
   editorReady: boolean;
-  /** Loading failed, so the classroom must remain usable in read-only mode. */
+  /** The editor chunk failed to load, so the edit chrome cannot mount. */
   editorLoadFailed: boolean;
 }
 
@@ -69,8 +77,19 @@ export type StageChromeResolution = StageMode | 'loading';
 /**
  * Resolve the chrome synchronously for the current host.
  *
- * A hosted classroom is edit-first: workspace visibility is the edit intent,
- * while Start Learning is represented by `workbenchShowingClassroom=false`.
+ * A hosted classroom is EDIT-LOCKED, not merely edit-first. Inside the
+ * workspace pane there is exactly one way to reach the learning chrome:
+ * `workbenchLearning`, which is the user pressing Start Learning. Every other
+ * input below only says how far along the edit chrome is — and an unready edit
+ * chrome resolves to the neutral `loading` shell, never to playback.
+ *
+ * That asymmetry is the whole fix. The learning chrome used to be the default
+ * branch, so any transient shortfall painted it: a course the agent had just
+ * created has no scenes for a beat, and the pane answered with the full
+ * playback chrome — speed control, play button, learner avatars, mic bar —
+ * then flipped to edit once the first scene landed. Readiness is now a
+ * spectrum between `loading` and `edit`; playback is not on it.
+ *
  * This deliberately does not round-trip through the transient stage-store
  * mode, so the first paint and course switches cannot inherit playback/edit
  * state from a previous course. Standalone classrooms retain their stored
@@ -78,13 +97,23 @@ export type StageChromeResolution = StageMode | 'loading';
  */
 export function resolveStageChromeMode(ctx: StageChromeModeContext): StageChromeResolution {
   if (!ctx.hosted) return ctx.storedMode;
+  // Start Learning, and nothing else, opens the learning chrome in the pane.
+  if (ctx.workbenchLearning) return 'playback';
   // During a course switch the shared store can briefly still contain the
   // previous course. Neither chrome may mount against that stale document.
   if (!ctx.stageMatchesHost) return 'loading';
-  if (!ctx.workbenchShowingClassroom || !ctx.isEditable || !ctx.hasCurrentScene) {
-    return 'playback';
-  }
-  if (ctx.editorLoadFailed) return 'playback';
+  // Folded away. The edit chrome drops (it holds editor resources for a pane
+  // nobody is looking at) but the learning chrome must NOT take its place
+  // behind the fold: unfolding would then cross-fade a full classroom's
+  // playback chrome out over the pane the user just reopened.
+  if (!ctx.workbenchShowingClassroom) return 'loading';
+  // Not editable YET (no scenes, the pending placeholder, no current scene
+  // resolved) — a stage of the load, not a request to learn.
+  if (!ctx.isEditable || !ctx.hasCurrentScene) return 'loading';
+  // The editor chunk did not arrive. The pane still refuses the learning
+  // chrome; `preloadEditor` drops its cached failure so the next mount of a
+  // hosted classroom retries the import.
+  if (ctx.editorLoadFailed) return 'loading';
   // Surface registration is intentionally non-reactive. Mounting edit before
   // preload resolves would strand EditShell on its NOOP fallback, so show a
   // neutral shell rather than flashing playback while the chunk arrives.

--- a/lib/workbench/panel-context.tsx
+++ b/lib/workbench/panel-context.tsx
@@ -15,12 +15,28 @@ export interface WorkbenchPanelState {
   readonly visible: boolean;
   /** Whether the hosted classroom is in full-screen learning playback. */
   readonly playback: boolean;
+  /**
+   * The pane's chrome lock: the hosted classroom is EDIT, full stop.
+   *
+   * Computed here, at the one place the workspace mounts a classroom, rather
+   * than re-derived by whatever renders inside it. That is the difference
+   * between "every entry path remembers to ask for edit mode" and "the pane
+   * decides and no entry path is consulted": a freshly created course, a
+   * restored tab, a tab switch and a reload all arrive through this single
+   * provider, so they all get the same answer.
+   *
+   * False in exactly two cases, both of them the user's own doing: the pane is
+   * folded away (nothing is on screen to lock), or the user pressed Start
+   * Learning and stepped into full-screen playback.
+   */
+  readonly editPinned: boolean;
 }
 
 const OUTSIDE_WORKBENCH: WorkbenchPanelState = {
   hosted: false,
   visible: true,
   playback: false,
+  editPinned: false,
 };
 
 const WorkbenchPanelContext = createContext<WorkbenchPanelState>(OUTSIDE_WORKBENCH);
@@ -35,7 +51,7 @@ export function WorkbenchPanelProvider({
   readonly playback?: boolean;
 }) {
   const value = useMemo<WorkbenchPanelState>(
-    () => ({ hosted: true, visible, playback }),
+    () => ({ hosted: true, visible, playback, editPinned: visible && !playback }),
     [playback, visible],
   );
   return <WorkbenchPanelContext.Provider value={value}>{children}</WorkbenchPanelContext.Provider>;

--- a/tests/edit/stage-mode.test.ts
+++ b/tests/edit/stage-mode.test.ts
@@ -93,6 +93,7 @@ describe('workspace classroom chrome', () => {
     storedMode: 'playback' as const,
     hosted: true,
     workbenchShowingClassroom: true,
+    workbenchLearning: false,
     isEditable: true,
     hasCurrentScene: true,
     stageMatchesHost: true,
@@ -105,15 +106,64 @@ describe('workspace classroom chrome', () => {
   });
 
   test('Start Learning is the explicit hosted transition back to playback', () => {
-    expect(resolveStageChromeMode({ ...eligible, workbenchShowingClassroom: false })).toBe(
-      'playback',
-    );
+    expect(resolveStageChromeMode({ ...eligible, workbenchLearning: true })).toBe('playback');
   });
 
   test('standalone classrooms keep their own stored presentation', () => {
     expect(resolveStageChromeMode({ ...eligible, hosted: false, storedMode: 'autonomous' })).toBe(
       'autonomous',
     );
+  });
+
+  test('a hosted course that is not editable yet waits instead of showing playback', () => {
+    // The agent has just created the course: the document is in the store but
+    // no scene has materialised, so the edit chrome has nothing to mount on.
+    expect(resolveStageChromeMode({ ...eligible, isEditable: false, hasCurrentScene: false })).toBe(
+      'loading',
+    );
+  });
+
+  test('a failed editor chunk never falls back to the learning chrome', () => {
+    expect(resolveStageChromeMode({ ...eligible, editorLoadFailed: true })).toBe('loading');
+  });
+
+  test('a folded pane drops the editor without mounting playback behind the fold', () => {
+    expect(resolveStageChromeMode({ ...eligible, workbenchShowingClassroom: false })).toBe(
+      'loading',
+    );
+  });
+
+  test('playback is unreachable in a hosted pane without Start Learning', () => {
+    // Exhaustive over every other input: with `workbenchLearning` false, no
+    // combination of readiness, ownership or stored mode yields playback.
+    const booleans = [false, true];
+    for (const workbenchShowingClassroom of booleans) {
+      for (const isEditable of booleans) {
+        for (const hasCurrentScene of booleans) {
+          for (const stageMatchesHost of booleans) {
+            for (const editorReady of booleans) {
+              for (const editorLoadFailed of booleans) {
+                for (const storedMode of ['playback', 'edit', 'autonomous'] as const) {
+                  expect(
+                    resolveStageChromeMode({
+                      storedMode,
+                      hosted: true,
+                      workbenchLearning: false,
+                      workbenchShowingClassroom,
+                      isEditable,
+                      hasCurrentScene,
+                      stageMatchesHost,
+                      editorReady,
+                      editorLoadFailed,
+                    }),
+                  ).not.toBe('playback');
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   });
 });
 

--- a/tests/workbench/classroom-pane-edit-lock.test.ts
+++ b/tests/workbench/classroom-pane-edit-lock.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+/**
+ * The right pane's classroom is edit-locked.
+ *
+ * The lock lives at the pane, not in the entry paths: `WorkspaceClassroomPane`
+ * is the single element that mounts a classroom into the workspace, so this
+ * exercises the real chain — pane → `WorkbenchPanelProvider` → the panel state
+ * a hosted classroom reads → `resolveStageChromeMode` — instead of asserting
+ * the resolver in isolation. What the classroom document or the stage store
+ * says about play/edit is deliberately fed in as hostile input.
+ */
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveStageChromeMode, type StageChromeModeContext } from '@/lib/edit/stage-mode';
+import { useWorkbenchPanelState, type WorkbenchPanelState } from '@/lib/workbench/panel-context';
+
+const probe = vi.hoisted(() => ({ states: [] as WorkbenchPanelState[] }));
+const setPlaybackOn = vi.fn();
+
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+// Stand in for the real classroom and report the panel state it would host
+// its chrome decision on.
+vi.mock('@/components/classroom/ClassroomSurface', () => ({
+  ClassroomSurface: () => {
+    probe.states.push(useWorkbenchPanelState());
+    return null;
+  },
+}));
+vi.mock('@/lib/workbench/use-workbench-pro-edit', () => ({
+  useWorkbenchProEditing: () => undefined,
+}));
+vi.mock('@/components/workbench/workspace/WorkspaceCourseTabs', () => ({
+  WorkspaceCourseTabs: () => null,
+}));
+vi.mock('@/lib/store/stage', () => ({
+  useStageStore: (selector: (state: { scenes: unknown[] }) => unknown) =>
+    selector({ scenes: [{ id: 'scene-1' }] }),
+}));
+vi.mock('@/lib/workbench/session-store', () => ({
+  useWorkbenchStore: (selector: (state: { setPlaybackOn: () => void }) => unknown) =>
+    selector({ setPlaybackOn }),
+}));
+
+import { WorkspaceClassroomPane } from '@/components/workbench/workspace/WorkspaceClassroomPane';
+
+let root: Root | null = null;
+
+async function mountPane(props: { hidden: boolean; playback: boolean }): Promise<void> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () =>
+    root?.render(
+      createElement(WorkspaceClassroomPane, {
+        browser: {
+          tabs: [{ id: 'stage-1', name: 'Course' }],
+          activeCourseId: 'stage-1',
+          onActivateCourse: vi.fn(),
+          onCloseCourse: vi.fn(),
+        },
+        readOnly: false,
+        ...props,
+      }),
+    ),
+  );
+}
+
+/** The chrome a hosted classroom would resolve for the pane's first render. */
+function hostedChrome(panel: WorkbenchPanelState, overrides: Partial<StageChromeModeContext> = {}) {
+  return resolveStageChromeMode({
+    // Hostile input: the stage store's transient mode always says playback for
+    // a course that has just been loaded (`loadFromStorage` resets it), and a
+    // stage persisted mid-learning would say the same.
+    storedMode: 'playback',
+    hosted: panel.hosted,
+    workbenchShowingClassroom: panel.hosted && panel.editPinned,
+    workbenchLearning: panel.hosted && panel.playback,
+    isEditable: true,
+    hasCurrentScene: true,
+    stageMatchesHost: true,
+    editorReady: true,
+    editorLoadFailed: false,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  probe.states.length = 0;
+  setPlaybackOn.mockClear();
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  document.body.innerHTML = '';
+});
+
+describe('workspace classroom pane edit lock', () => {
+  it('locks the classroom it mounts to edit on the first render', async () => {
+    await mountPane({ hidden: false, playback: false });
+
+    expect(probe.states.length).toBeGreaterThan(0);
+    // Not "the first render happened to be edit": every render the pane
+    // produced declared the lock.
+    for (const panel of probe.states) {
+      expect(panel.hosted).toBe(true);
+      expect(panel.editPinned).toBe(true);
+      expect(hostedChrome(panel)).toBe('edit');
+    }
+  });
+
+  it('holds the lock for a freshly created classroom that has no scene yet', async () => {
+    await mountPane({ hidden: false, playback: false });
+    const panel = probe.states[0];
+
+    // The agent has just created the course: the document is in the store but
+    // generation has not produced a scene, so the edit chrome cannot mount
+    // yet. This used to resolve to the full playback chrome — speed control,
+    // play button, learner avatars, mic bar — and flip to edit once the first
+    // scene landed.
+    expect(hostedChrome(panel, { isEditable: false, hasCurrentScene: false })).toBe('loading');
+    // ...and the moment the first scene exists it is edit, with no playback
+    // frame in between.
+    expect(hostedChrome(panel)).toBe('edit');
+  });
+
+  it('cannot be flipped by classroom state that says playback', async () => {
+    await mountPane({ hidden: false, playback: false });
+    const panel = probe.states[0];
+
+    for (const storedMode of ['playback', 'autonomous', 'edit'] as const) {
+      expect(hostedChrome(panel, { storedMode })).toBe('edit');
+    }
+  });
+
+  it('never resolves playback while the pane holds the lock', async () => {
+    await mountPane({ hidden: false, playback: false });
+    const panel = probe.states[0];
+    const booleans = [false, true];
+
+    for (const isEditable of booleans) {
+      for (const hasCurrentScene of booleans) {
+        for (const stageMatchesHost of booleans) {
+          for (const editorReady of booleans) {
+            for (const editorLoadFailed of booleans) {
+              expect(
+                hostedChrome(panel, {
+                  isEditable,
+                  hasCurrentScene,
+                  stageMatchesHost,
+                  editorReady,
+                  editorLoadFailed,
+                }),
+              ).not.toBe('playback');
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it('does not park the learning chrome behind a folded pane', async () => {
+    await mountPane({ hidden: true, playback: false });
+    const panel = probe.states[0];
+
+    expect(panel.editPinned).toBe(false);
+    // Folded is not learning: the editor drops, but unfolding must not
+    // cross-fade a classroom's playback chrome out over the reopened pane.
+    expect(hostedChrome(panel)).toBe('loading');
+  });
+
+  it('releases the lock only through Start Learning', async () => {
+    await mountPane({ hidden: false, playback: false });
+    const button = document.querySelector<HTMLButtonElement>(
+      '[data-testid="workbench-start-learning"]',
+    );
+    expect(button).not.toBeNull();
+    await act(async () => button?.click());
+    expect(setPlaybackOn).toHaveBeenCalledWith(true);
+
+    // The pane re-rendered with that intent is the one state that hands the
+    // classroom back to the learning chrome.
+    await act(async () => root?.unmount());
+    root = null;
+    probe.states.length = 0;
+    await mountPane({ hidden: false, playback: true });
+    const panel = probe.states[0];
+
+    expect(panel.editPinned).toBe(false);
+    expect(hostedChrome(panel)).toBe('playback');
+  });
+});


### PR DESCRIPTION
## Bug

The workspace right pane painted the full learning chrome (speed control, play button, learner avatars, mic bar) for a course the agent had just created, then flipped to edit once the first scene landed. The pane-embedded classroom must always present in edit mode — locked mechanically, with no gap or flicker.

## Root cause

`resolveStageChromeMode` made the learning chrome the DEFAULT branch for a hosted classroom: any transient shortfall (no scenes yet at `stage_link` time, editability not yet resolved, folded pane, failed editor chunk) fell into playback. Two adjacent holes on the same branch: a folded pane parked the playback root behind the fold (cross-fading it out on unfold), and a failed editor import was cached forever, stranding the pane in playback.

## Fix — a lock, not a default

- `WorkbenchPanelProvider` — the single element that mounts a classroom into the workspace (one call site, verified) — publishes `editPinned`; no entry path decides for itself.
- The hosted resolution can no longer degrade to playback: `workbenchLearning` (the user pressing Start Learning, split out from pane visibility) is the one door. Everything else resolves between the neutral `loading` shell and `edit`; playback is not on the readiness spectrum.
- The chrome dispatch in `stage.tsx` is exhaustive on `chromeMode`, so the playback root is no longer the else-branch of a scene-readiness condition.
- No first-frame flicker: `chromeMode` resolves during render, and `preloadEditor` answers synchronously via `isEditorPreloaded()` so a remount with the chunk cached paints edit immediately; a failed import is no longer cached forever.

Standalone classrooms keep their stored mode unchanged.

## Tests

`tests/workbench/classroom-pane-edit-lock.test.ts` (new) renders the real pane → provider → resolver; `tests/edit/stage-mode.test.ts` extended with an exhaustive case sweep asserting playback is unreachable without Start Learning. Non-vacuity checked: reverting the resolver body makes 8 tests fail.

Verified: vitest workbench+edit (125 files, 1331 tests), `tsc --noEmit`, `pnpm check`, `pnpm build` — all exit 0 (independently re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)