### PR TITLE
fix(agent): bound import_pptx parse with size cap and timeout

### DIFF
--- a/lib/server/agent-runtime/import-pptx.ts
+++ b/lib/server/agent-runtime/import-pptx.ts
@@ -39,6 +39,8 @@ export { isPptxMaterial, PPTX_MIME } from './pptx-mime';
 export const IMPORT_PPTX_TOOL_NAME = 'import_pptx';
 export const IMPORT_PPTX_REQUIREMENT_PREFIX = 'import_pptx:';
 export const MAX_IMPORT_SLIDES = 80;
+export const MAX_IMPORT_BYTES = 8 * 1024 * 1024;
+export const PARSE_PPTX_TIMEOUT_MS = 90_000;
 
 /** Next-step hint after import. Inspection and repair come before TTS. */
 export const AFTER_IMPORT_NEXT_STEP =
@@ -58,12 +60,25 @@ const ImportParams = Type.Object({
   ),
 });
 
+export interface ParsePptxWorker {
+  once(event: string, listener: (...args: unknown[]) => void): unknown;
+  terminate(): unknown;
+}
+
+export interface ParsePptxOptions {
+  upload?: OssUpload;
+  signal?: AbortSignal;
+  /** Parse deadline; tests may inject a shorter value. */
+  timeoutMs?: number;
+  Worker?: new (filename: string | URL, options?: { workerData?: unknown }) => ParsePptxWorker;
+}
+
 export interface ImportPptxToolDeps extends CourseToolDeps {
   getMaterial?: (sessionId: string, materialId: string) => Promise<AgentSessionMaterial | null>;
   readMaterialBytes?: (
     record: AgentSessionMaterial,
   ) => Promise<{ bytes: Buffer; mime: string } | null>;
-  parsePptx?: (buffer: ArrayBuffer, options?: { upload?: OssUpload }) => Promise<Slide[]>;
+  parsePptx?: (buffer: ArrayBuffer, options?: ParsePptxOptions) => Promise<Slide[]>;
   uploadImportedMedia?: OssUpload;
 }
 
@@ -230,26 +245,75 @@ async function rewriteDataUrls(value: unknown, upload: OssUpload): Promise<unkno
   return value;
 }
 
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function parseTimeoutMessage(timeoutMs: number): string {
+  const label = timeoutMs % 1000 === 0 ? `${timeoutMs / 1000}s` : `${timeoutMs}ms`;
+  return `PowerPoint parse exceeded ${label}`;
+}
+
 /** Parse in a worker thread so DOM shims never land on the request process. */
 export async function parsePptxIsolated(
   buffer: ArrayBuffer,
-  options: { upload?: OssUpload } = {},
+  options: ParsePptxOptions = {},
 ): Promise<Slide[]> {
+  const signal = options.signal;
+  if (signal?.aborted) {
+    throw new Error('aborted');
+  }
   const workerFile = importerWorkerPath();
   if (!workerFile) {
     throw new Error('PPTX import worker is missing from the deployment.');
   }
   const copy = toArrayBuffer(new Uint8Array(buffer));
+  const WorkerImpl = options.Worker ?? Worker;
+  const timeoutMs = options.timeoutMs ?? PARSE_PPTX_TIMEOUT_MS;
   const slides = await new Promise<Slide[]>((resolve, reject) => {
-    const worker = new Worker(workerFile, { workerData: { buffer: copy } });
-    const fail = (error: unknown) => {
+    let worker: ParsePptxWorker;
+    try {
+      worker = new WorkerImpl(workerFile, { workerData: { buffer: copy } });
+    } catch (error) {
+      reject(asError(error));
+      return;
+    }
+
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
       void worker.terminate();
-      reject(error instanceof Error ? error : new Error(String(error)));
     };
-    worker.once('message', (message: { slides?: Slide[]; error?: string }) => {
-      void worker.terminate();
-      if (message.error) fail(new Error(message.error));
-      else resolve(message.slides ?? []);
+
+    const finish = (apply: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      apply();
+    };
+
+    const fail = (error: unknown) => {
+      finish(() => reject(asError(error)));
+    };
+
+    const onAbort = () => fail(new Error('aborted'));
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => fail(new Error(parseTimeoutMessage(timeoutMs))), timeoutMs);
+    }
+
+    worker.once('message', (message: unknown) => {
+      const payload = message as { slides?: Slide[]; error?: string };
+      if (payload?.error) fail(new Error(payload.error));
+      else finish(() => resolve(payload?.slides ?? []));
     });
     worker.once('error', fail);
   });
@@ -259,7 +323,7 @@ export async function parsePptxIsolated(
 
 export async function parsePptxBuffer(
   buffer: ArrayBuffer,
-  options: { upload?: OssUpload } = {},
+  options: ParsePptxOptions = {},
 ): Promise<Slide[]> {
   return parsePptxIsolated(buffer, options);
 }
@@ -337,6 +401,20 @@ export function buildImportPptxTool(
         );
       }
 
+      const byteLength = raw.bytes.byteLength;
+      if (byteLength > MAX_IMPORT_BYTES) {
+        return toolResult(
+          `This PowerPoint (${record.title ?? record.id}) is too large to import (${byteLength} bytes; maximum is ${MAX_IMPORT_BYTES}). Ask the user to compress or split the file and upload again.`,
+          {
+            status: 'too_large',
+            materialId: record.id,
+            bytes: byteLength,
+            maxBytes: MAX_IMPORT_BYTES,
+          },
+          true,
+        );
+      }
+
       const digest = createHash('sha256').update(raw.bytes).digest('hex');
       const requirement = importRequirementFor({ id: record.id, sha256: digest });
       const legacyRequirement = `${IMPORT_PPTX_REQUIREMENT_PREFIX}${record.id}`;
@@ -406,7 +484,10 @@ export function buildImportPptxTool(
 
       let slides: Slide[];
       try {
-        slides = await parsePptx(arrayBuffer, { upload });
+        slides = await parsePptx(arrayBuffer, {
+          upload,
+          signal: signal ?? deps.abortSignal,
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (message === 'aborted') throw error;

--- a/tests/agent-runtime/import-pptx.test.ts
+++ b/tests/agent-runtime/import-pptx.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { Slide } from '@openmaic/dsl';
 import type { AgentSessionMaterial } from '@openmaic/storage';
 
@@ -12,7 +12,9 @@ import {
 } from '@/lib/server/agent-runtime/course-tools';
 import {
   IMPORT_PPTX_TOOL_NAME,
+  MAX_IMPORT_BYTES,
   MAX_IMPORT_SLIDES,
+  PARSE_PPTX_TIMEOUT_MS,
   PPTX_MIME,
   parsePptxBuffer,
   parsePptxIsolated,
@@ -20,6 +22,7 @@ import {
   titleFromSlide,
   toArrayBuffer,
   isPptxMaterial,
+  type ParsePptxOptions,
 } from '@/lib/server/agent-runtime/import-pptx';
 import { installNodeXmlHttpRequest, NodeXMLHttpRequest } from '@/lib/server/agent-runtime/node-xhr';
 import { sessionMaterialsPromptBlock } from '@/lib/server/agent-runtime/session-materials';
@@ -148,9 +151,11 @@ async function runImport(
     signal?: AbortSignal;
     bytes?: Buffer;
     mime?: string;
+    parsePptx?: (buffer: ArrayBuffer, options?: ParsePptxOptions) => Promise<Slide[]>;
   },
 ) {
   const checkpoints: { tool: string; detail: string }[] = [];
+  const parsePptx = args.parsePptx ?? (async () => args.slides ?? [textSlide('s1', '<p>封面</p>')]);
   const tools = buildDslCourseToolset({
     stageAccess: async () => ({ kind: 'owned' as const }),
     store,
@@ -161,7 +166,7 @@ async function runImport(
       bytes: args.bytes ?? Buffer.from(`deck-${record.id}`),
       mime: args.mime ?? PPTX_MIME,
     }),
-    parsePptx: async () => args.slides ?? [textSlide('s1', '<p>封面</p>')],
+    parsePptx,
   });
   const tool = tools.find((item) => item.name === IMPORT_PPTX_TOOL_NAME);
   if (!tool) throw new Error('import_pptx missing');
@@ -547,6 +552,29 @@ describe('import_pptx tool', () => {
       }),
     ).rejects.toThrow('aborted');
   });
+
+  it('rejects an oversized pptx before parse and asks the user to compress or split it', async () => {
+    const parsePptx = vi.fn(async () => [textSlide('s1', '<p>封面</p>')]);
+    const { result } = await runImport(stageStore(), {
+      params: { materialId: 'mat_ppt' },
+      record: sourceRecord(),
+      bytes: Buffer.alloc(MAX_IMPORT_BYTES + 1),
+      parsePptx,
+    });
+    expect(result.isError).toBe(true);
+    expect(parsePptx).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: 'too_large',
+      materialId: 'mat_ppt',
+      bytes: MAX_IMPORT_BYTES + 1,
+      maxBytes: MAX_IMPORT_BYTES,
+    });
+    const text = String(
+      result.content[0] && 'text' in result.content[0] ? result.content[0].text : '',
+    );
+    expect(text).toMatch(/too large/i);
+    expect(text).toMatch(/compress or split/i);
+  });
 });
 
 describe('session material prompt', () => {
@@ -585,6 +613,64 @@ describe('session material prompt', () => {
     ]);
     expect(pptx).toContain('import_pptx');
     expect(pptx).toContain('layout-preserving');
+  });
+});
+
+function hungWorkerHarness() {
+  const constructed: Array<{ terminate: ReturnType<typeof vi.fn> }> = [];
+  class HungWorker {
+    terminate = vi.fn(async () => 0);
+    constructor() {
+      constructed.push(this);
+    }
+    once() {
+      return this;
+    }
+  }
+  return { HungWorker, constructed };
+}
+
+describe('parsePptxIsolated bounds', () => {
+  it('exports a 90s parse timeout and an 8 MiB byte cap', () => {
+    expect(PARSE_PPTX_TIMEOUT_MS).toBe(90_000);
+    expect(MAX_IMPORT_BYTES).toBe(8 * 1024 * 1024);
+  });
+
+  it('rejects a hung worker when the parse timeout elapses and terminates it', async () => {
+    const { HungWorker, constructed } = hungWorkerHarness();
+    await expect(
+      parsePptxIsolated(new ArrayBuffer(8), { Worker: HungWorker, timeoutMs: 20 }),
+    ).rejects.toThrow(/parse exceeded 20ms/i);
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0]?.terminate).toHaveBeenCalled();
+  });
+
+  it('does not start a worker when the signal is already aborted', async () => {
+    const { HungWorker, constructed } = hungWorkerHarness();
+    const abort = new AbortController();
+    abort.abort();
+    await expect(
+      parsePptxIsolated(new ArrayBuffer(8), {
+        Worker: HungWorker,
+        signal: abort.signal,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow('aborted');
+    expect(constructed).toHaveLength(0);
+  });
+
+  it('terminates the worker when the parse is aborted', async () => {
+    const { HungWorker, constructed } = hungWorkerHarness();
+    const abort = new AbortController();
+    const pending = parsePptxIsolated(new ArrayBuffer(8), {
+      Worker: HungWorker,
+      signal: abort.signal,
+      timeoutMs: 5_000,
+    });
+    abort.abort();
+    await expect(pending).rejects.toThrow('aborted');
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0]?.terminate).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Fixes #1268.

`import_pptx` could hang the Pro turn while parsing a large PowerPoint: the isolated worker had no deadline, ignored AbortSignal, and `MAX_IMPORT_SLIDES` only applied after a successful parse.

This PR:
- Rejects decks larger than 8 MiB before parse (`MAX_IMPORT_BYTES`)
- Terminates the parse worker on abort or a 90s timeout (`PARSE_PPTX_TIMEOUT_MS`)
- Keeps the existing parse-failed tool error path

Tests cover oversized reject-without-parse, hung-worker timeout, and abort.