### PR TITLE
fix(workbench): persist Pro conversation titles

### DIFF
--- a/app/api/agent/sessions/[id]/route.ts
+++ b/app/api/agent/sessions/[id]/route.ts
@@ -1,5 +1,4 @@
-/** Agent runtime control plane for reading one owned session. */
-import type { AgentSessionTitleStore } from '@openmaic/storage';
+/** Agent runtime control plane for reading and updating an owned session title. */
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -34,10 +33,6 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
     const { id } = await params;
     const store = await getAgentSessionStore();
-    const titleStore = store as AgentSessionTitleStore;
-    if (typeof titleStore.setManualSessionTitle !== 'function') {
-      return new Response('Not found', { status: 404, headers: responseHeaders });
-    }
 
     let body: { title?: unknown } | null;
     try {
@@ -58,7 +53,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       return response;
     }
     const title = body.title?.trim().slice(0, 120) || null;
-    const meta = await titleStore.setManualSessionTitle(id, ownerId, title);
+    const meta = await store.setManualSessionTitle(id, ownerId, title);
     if (!meta) {
       return new Response('Not found', { status: 404, headers: responseHeaders });
     }

--- a/app/api/agent/sessions/[id]/route.ts
+++ b/app/api/agent/sessions/[id]/route.ts
@@ -1,8 +1,10 @@
 /** Agent runtime control plane for reading one owned session. */
+import type { AgentSessionTitleStore } from '@openmaic/storage';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
+import { apiError } from '@/lib/server/api-response';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
 import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
 
@@ -21,5 +23,45 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       return new Response('Not found', { status: 404, headers: responseHeaders });
     }
     return NextResponse.json(meta, { headers: responseHeaders });
+  });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAgentRuntimeConfigured()) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  return withRequestOwnerId(req, async (ownerId, responseHeaders) => {
+    const { id } = await params;
+    const store = await getAgentSessionStore();
+    const titleStore = store as AgentSessionTitleStore;
+    if (typeof titleStore.setManualSessionTitle !== 'function') {
+      return new Response('Not found', { status: 404, headers: responseHeaders });
+    }
+
+    let body: { title?: unknown } | null;
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      const response = apiError('INVALID_REQUEST', 400, 'invalid JSON body');
+      responseHeaders.forEach((value, name) => response.headers.append(name, value));
+      return response;
+    }
+    if (!body || typeof body !== 'object' || !Object.hasOwn(body, 'title')) {
+      const response = apiError('MISSING_REQUIRED_FIELD', 400, 'title is required');
+      responseHeaders.forEach((value, name) => response.headers.append(name, value));
+      return response;
+    }
+    if (body.title !== null && typeof body.title !== 'string') {
+      const response = apiError('INVALID_REQUEST', 400, 'title must be a string or null');
+      responseHeaders.forEach((value, name) => response.headers.append(name, value));
+      return response;
+    }
+    const title = body.title?.trim().slice(0, 120) || null;
+    const meta = await titleStore.setManualSessionTitle(id, ownerId, title);
+    if (!meta) {
+      return new Response('Not found', { status: 404, headers: responseHeaders });
+    }
+    return NextResponse.json({ title: meta.title ?? null }, { headers: responseHeaders });
   });
 }

--- a/app/api/agent/sessions/[id]/route.ts
+++ b/app/api/agent/sessions/[id]/route.ts
@@ -6,6 +6,7 @@ import { isAgentRuntimeConfigured } from '@/lib/config/feature-flags';
 import { apiError } from '@/lib/server/api-response';
 import { getAgentSessionStore } from '@/lib/server/agent-runtime/store';
 import { withRequestOwnerId } from '@/lib/server/agent-runtime/with-owner';
+import { normalizeSessionTitleOverride } from '@/lib/workbench/session-title';
 
 export const runtime = 'nodejs';
 
@@ -52,7 +53,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       responseHeaders.forEach((value, name) => response.headers.append(name, value));
       return response;
     }
-    const title = body.title?.trim().slice(0, 120) || null;
+    const title = normalizeSessionTitleOverride(body.title);
     const meta = await store.setManualSessionTitle(id, ownerId, title);
     if (!meta) {
       return new Response('Not found', { status: 404, headers: responseHeaders });

--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -104,7 +104,7 @@ import {
 import type { WorkbenchCourseSummary } from '@/lib/workbench/panel-context';
 import { useWorkbenchStore, type WorkbenchMaterial } from '@/lib/workbench/session-store';
 import { renameWorkbenchSession } from '@/lib/workbench/session-store';
-import { commitSessionRename } from '@/lib/workbench/session-title';
+import { commitSessionRename, createSessionRenameQueue } from '@/lib/workbench/session-title';
 import type { ElementRef } from '@/lib/workbench/element-refs';
 import type { CourseRef } from '@/lib/workbench/course-refs';
 import { useStageFreshnessSync, useWorkbenchStream } from '@/lib/workbench/use-workbench-session';
@@ -146,6 +146,16 @@ async function fetchSessions(): Promise<ProHomeSessionItem[]> {
   }
 }
 
+function syncAttachedSessionTitle(
+  sessionId: string,
+  title: string | null,
+  forceRevision = false,
+): void {
+  const store = useWorkbenchStore.getState();
+  if (store.sessionId !== sessionId || (!forceRevision && store.sessionTitle === title)) return;
+  store.setSessionTitle(title);
+}
+
 /**
  * Route seam: capture the deep link exactly once. Native History API writes
  * update Next's search-param readers, while the controller below keeps its own
@@ -166,14 +176,10 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
   const courses = useHomeDiscovery({ mode: 'discover-only' });
   const [sessions, setSessions] = useState<ProHomeSessionItem[]>(EMPTY_SESSIONS);
   /**
-   * The latest list, readable from a callback without making that callback a
-   * new function on every poll (the rail would then see a changed prop every
-   * few seconds for no reason). Synced in an effect, never during render.
+   * The latest list, readable from queued callbacks without waiting for React
+   * to commit another render. The owner publisher updates it before setState.
    */
   const sessionsRef = useRef(sessions);
-  useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
   const [sessionState, setSessionState] = useState<HomeDiscoveryState>('loading');
   const [composerReset, setComposerReset] = useState(0);
   /**
@@ -187,6 +193,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    */
   const [newConversationRequested, setNewConversationRequested] = useState(false);
   const ownerSessionClient = useRef<OwnerSessionClient | null>(null);
+  const [sessionRenameQueue] = useState(createSessionRenameQueue);
 
   const rootRef = useRef<HTMLDivElement>(null);
   const railWidth = useRailWidth(rootRef);
@@ -331,11 +338,26 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
     ownerSessionClient.current?.requestFullFetch(showLoading);
   }, []);
 
+  const publishOwnerSessions = useCallback(
+    (next: readonly ProHomeSessionItem[], source?: 'incremental' | 'snapshot') => {
+      const snapshot = [...next];
+      sessionsRef.current = snapshot;
+      setSessions(snapshot);
+      const attachedId = useWorkbenchStore.getState().sessionId;
+      const attached = snapshot.find((session) => session.id === attachedId);
+      if (attached) {
+        syncAttachedSessionTitle(attached.id, attached.title ?? null, source === 'snapshot');
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     const client = new OwnerSessionClient({
       fetchSessions,
       createEventSource: (url) => new EventSource(url),
-      onSessions: (next) => setSessions([...next]),
+      onSessions: publishOwnerSessions,
+      onSessionTitle: (sessionId, title) => syncAttachedSessionTitle(sessionId, title, true),
       onState: setSessionState,
     });
     ownerSessionClient.current = client;
@@ -344,7 +366,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
       ownerSessionClient.current = null;
       client.stop();
     };
-  }, []);
+  }, [publishOwnerSessions]);
 
   useEffect(() => {
     if (
@@ -529,12 +551,10 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    * which reads its own copy out of the session store.
    */
   const applySessionTitle = useCallback((sessionId: string, title: string | null) => {
-    ownerSessionClient.current?.updateSessions((current) =>
-      current.map((session) => (session.id === sessionId ? { ...session, title } : session)),
-    );
-    if (useWorkbenchStore.getState().sessionId === sessionId) {
-      useWorkbenchStore.getState().setSessionTitle(title);
-    }
+    syncAttachedSessionTitle(sessionId, title, true);
+    const client = ownerSessionClient.current;
+    const revision = client?.updateSessionTitle(sessionId, title) ?? null;
+    return { client, revision };
   }, []);
 
   /**
@@ -550,26 +570,36 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    * renames use.
    */
   const renameSession = useCallback(
-    async (sessionId: string, raw: string): Promise<string | null> => {
-      const row = sessionsRef.current.find((session) => session.id === sessionId);
-      const store = useWorkbenchStore.getState();
-      const attached = store.sessionId === sessionId;
-      const outcome = await commitSessionRename({
-        current: {
-          title: row?.title ?? (attached ? store.sessionTitle : null),
-          prompt: row?.prompt ?? (attached ? store.sessionPrompt : null),
-        },
-        raw,
-        apply: (title) => applySessionTitle(sessionId, title),
-        save: (title) => renameWorkbenchSession(sessionId, title),
-      });
-      if (outcome === 'renamed') ownerSessionClient.current?.requestFullFetch();
-      if (outcome !== 'failed') return null;
-      const message = t('workspace.renameSessionFailed');
-      toast.error(message);
-      return message;
-    },
-    [applySessionTitle, t],
+    (sessionId: string, raw: string): Promise<string | null> =>
+      sessionRenameQueue.run(sessionId, async () => {
+        const row = sessionsRef.current.find((session) => session.id === sessionId);
+        const store = useWorkbenchStore.getState();
+        const attached = store.sessionId === sessionId;
+        let decision: ReturnType<typeof applySessionTitle> | null = null;
+        const outcome = await commitSessionRename({
+          current: {
+            title: row?.title ?? (attached ? store.sessionTitle : null),
+            prompt: row?.prompt ?? (attached ? store.sessionPrompt : null),
+          },
+          raw,
+          apply: (title) => {
+            decision = applySessionTitle(sessionId, title);
+          },
+          save: (title) => renameWorkbenchSession(sessionId, title),
+          isCurrent: () =>
+            decision === null ||
+            decision.revision === null ||
+            decision.client === null ||
+            (ownerSessionClient.current === decision.client &&
+              decision.client.isSessionTitleRevisionCurrent(sessionId, decision.revision)),
+        });
+        if (outcome === 'renamed') ownerSessionClient.current?.requestFullFetch();
+        if (outcome !== 'failed') return null;
+        const message = t('workspace.renameSessionFailed');
+        toast.error(message);
+        return message;
+      }),
+    [applySessionTitle, sessionRenameQueue, t],
   );
 
   /**
@@ -717,6 +747,8 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
     // the meta fetch otherwise — a `?session=` deep link has neither yet, and
     // the chat needs neither.
     attach(panes.sessionId, paneSessionStageId);
+    const attached = sessionsRef.current.find((session) => session.id === panes.sessionId);
+    if (attached) syncAttachedSessionTitle(attached.id, attached.title ?? null);
   }, [panes.sessionId, paneSessionStageId, attach, detach]);
 
   // Attachment is workspace-scoped view state. Clear it when the shell leaves

--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -529,7 +529,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    * which reads its own copy out of the session store.
    */
   const applySessionTitle = useCallback((sessionId: string, title: string | null) => {
-    setSessions((current) =>
+    ownerSessionClient.current?.updateSessions((current) =>
       current.map((session) => (session.id === sessionId ? { ...session, title } : session)),
     );
     if (useWorkbenchStore.getState().sessionId === sessionId) {
@@ -563,6 +563,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
         apply: (title) => applySessionTitle(sessionId, title),
         save: (title) => renameWorkbenchSession(sessionId, title),
       });
+      if (outcome === 'renamed') ownerSessionClient.current?.requestFullFetch();
       if (outcome !== 'failed') return null;
       const message = t('workspace.renameSessionFailed');
       toast.error(message);

--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -554,12 +554,15 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    * rail row and — when this is the attached conversation — the pane header,
    * which reads its own copy out of the session store.
    */
-  const applySessionTitle = useCallback((sessionId: string, title: string | null) => {
-    syncAttachedSessionTitle(sessionId, title, true);
-    const client = ownerSessionClient.current;
-    const revision = client?.updateSessionTitle(sessionId, title) ?? null;
-    return { client, revision };
-  }, []);
+  const applySessionTitle = useCallback(
+    (sessionId: string, title: string | null, settled: boolean) => {
+      syncAttachedSessionTitle(sessionId, title, true);
+      const client = ownerSessionClient.current;
+      const revision = client?.updateSessionTitle(sessionId, title, settled) ?? null;
+      return { client, revision };
+    },
+    [],
+  );
 
   /**
    * Rename a conversation. ONE writer for both surfaces that offer it — the
@@ -586,8 +589,8 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
             prompt: row?.prompt ?? (attached ? store.sessionPrompt : null),
           },
           raw,
-          apply: (title) => {
-            decision = applySessionTitle(sessionId, title);
+          apply: (title, settled) => {
+            decision = applySessionTitle(sessionId, title, settled);
           },
           save: (title) => renameWorkbenchSession(sessionId, title),
           isCurrent: () =>

--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -128,6 +128,9 @@ const EMPTY_SESSIONS: ProHomeSessionItem[] = [];
  */
 const BOTH_PANES_MIN_PX = 1024;
 const SESSION_LIST_TIMEOUT_MS = 15_000;
+// A shell is replaceable navigation UI, not a persistence boundary. Keeping the
+// queue in this client module preserves one writer per session across remounts.
+const sessionRenameQueue = createSessionRenameQueue();
 
 async function fetchSessions(): Promise<ProHomeSessionItem[]> {
   const controller = new AbortController();
@@ -146,13 +149,9 @@ async function fetchSessions(): Promise<ProHomeSessionItem[]> {
   }
 }
 
-function syncAttachedSessionTitle(
-  sessionId: string,
-  title: string | null,
-  forceRevision = false,
-): void {
+function syncAttachedSessionTitle(sessionId: string, title: string | null): void {
   const store = useWorkbenchStore.getState();
-  if (store.sessionId !== sessionId || (!forceRevision && store.sessionTitle === title)) return;
+  if (store.sessionId !== sessionId) return;
   store.setSessionTitle(title);
 }
 
@@ -193,7 +192,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    */
   const [newConversationRequested, setNewConversationRequested] = useState(false);
   const ownerSessionClient = useRef<OwnerSessionClient | null>(null);
-  const [sessionRenameQueue] = useState(createSessionRenameQueue);
+  const shellGeneration = useRef(0);
 
   const rootRef = useRef<HTMLDivElement>(null);
   const railWidth = useRailWidth(rootRef);
@@ -351,7 +350,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
       if (source !== 'snapshot') return;
       const attachedId = useWorkbenchStore.getState().sessionId;
       const attached = snapshot.find((session) => session.id === attachedId);
-      if (attached) syncAttachedSessionTitle(attached.id, attached.title ?? null, true);
+      if (attached) syncAttachedSessionTitle(attached.id, attached.title ?? null);
     },
     [],
   );
@@ -361,12 +360,13 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
       fetchSessions,
       createEventSource: (url) => new EventSource(url),
       onSessions: publishOwnerSessions,
-      onSessionTitle: (sessionId, title) => syncAttachedSessionTitle(sessionId, title, true),
+      onSessionTitle: syncAttachedSessionTitle,
       onState: setSessionState,
     });
     ownerSessionClient.current = client;
     client.start();
     return () => {
+      shellGeneration.current += 1;
       ownerSessionClient.current = null;
       client.stop();
     };
@@ -556,7 +556,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    */
   const applySessionTitle = useCallback(
     (sessionId: string, title: string | null, settled: boolean) => {
-      syncAttachedSessionTitle(sessionId, title, true);
+      syncAttachedSessionTitle(sessionId, title);
       const client = ownerSessionClient.current;
       const revision = client?.updateSessionTitle(sessionId, title, settled) ?? null;
       return { client, revision };
@@ -577,8 +577,10 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    * renames use.
    */
   const renameSession = useCallback(
-    (sessionId: string, raw: string): Promise<string | null> =>
-      sessionRenameQueue.run(sessionId, async (queued) => {
+    (sessionId: string, raw: string): Promise<string | null> => {
+      const generation = shellGeneration.current;
+      const isOriginCurrent = () => shellGeneration.current === generation;
+      return sessionRenameQueue.run(sessionId, async (queued) => {
         const row = sessionsRef.current.find((session) => session.id === sessionId);
         const store = useWorkbenchStore.getState();
         const attached = store.sessionId === sessionId;
@@ -590,15 +592,19 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
           },
           raw,
           apply: (title, settled) => {
+            if (!isOriginCurrent()) return;
             decision = applySessionTitle(sessionId, title, settled);
           },
           save: (title) => renameWorkbenchSession(sessionId, title),
-          isCurrent: () =>
-            decision === null ||
-            decision.revision === null ||
-            decision.client === null ||
-            (ownerSessionClient.current === decision.client &&
-              decision.client.isSessionTitleRevisionCurrent(sessionId, decision.revision)),
+          isCurrent: () => {
+            if (!isOriginCurrent() || !decision?.client || decision.revision === null) {
+              return false;
+            }
+            return (
+              ownerSessionClient.current === decision.client &&
+              decision.client.isSessionTitleRevisionCurrent(sessionId, decision.revision)
+            );
+          },
           // A queued value that looks unchanged may be the user's explicit
           // attempt to undo the still-ambiguous write ahead of it.
           forceSave: queued,
@@ -607,13 +613,16 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
         // database may have committed before the response was lost, and an
         // optimistic mutation may have hidden a newer snapshot while it was in
         // flight. Reconcile every attempted change; unchanged input did no IO.
-        if (outcome !== 'unchanged') ownerSessionClient.current?.requestFullFetch();
+        if (isOriginCurrent() && outcome !== 'unchanged') {
+          ownerSessionClient.current?.requestFullFetch();
+        }
         if (outcome !== 'failed') return null;
         const message = t('workspace.renameSessionFailed');
-        toast.error(message);
+        if (isOriginCurrent()) toast.error(message);
         return message;
-      }),
-    [applySessionTitle, sessionRenameQueue, t],
+      });
+    },
+    [applySessionTitle, t],
   );
 
   /**
@@ -770,11 +779,11 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
     const mutation = ownerSessionClient.current?.getUnconfirmedSessionTitle(panes.sessionId);
     const attached = sessionsRef.current.find((session) => session.id === panes.sessionId);
     if (mutation) {
-      syncAttachedSessionTitle(panes.sessionId, mutation.title, true);
+      syncAttachedSessionTitle(panes.sessionId, mutation.title);
     } else if (attached) {
-      // Force even an equal null: the revision records that an owner title
+      // Apply even an equal null: the revision records that an owner title
       // source exists, so an older detail response cannot fill it back in.
-      syncAttachedSessionTitle(attached.id, attached.title ?? null, true);
+      syncAttachedSessionTitle(attached.id, attached.title ?? null);
     }
   }, [panes.sessionId, paneSessionStageId, attach, detach]);
 

--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -761,8 +761,21 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
     // the meta fetch otherwise — a `?session=` deep link has neither yet, and
     // the chat needs neither.
     attach(panes.sessionId, paneSessionStageId);
+    // A rename can still be awaiting its PATCH (or the confirming list read)
+    // when the user leaves this chat and comes back. The detail GET started by
+    // the new attachment may overtake that PATCH, so preserve the client's
+    // unconfirmed decision even when the owner row has not reached the list.
+    // The object wrapper distinguishes a real clear (`title: null`) from no
+    // decision. Otherwise the owner row is the title bootstrap authority.
+    const mutation = ownerSessionClient.current?.getUnconfirmedSessionTitle(panes.sessionId);
     const attached = sessionsRef.current.find((session) => session.id === panes.sessionId);
-    if (attached) syncAttachedSessionTitle(attached.id, attached.title ?? null);
+    if (mutation) {
+      syncAttachedSessionTitle(panes.sessionId, mutation.title, true);
+    } else if (attached) {
+      // Force even an equal null: the revision records that an owner title
+      // source exists, so an older detail response cannot fill it back in.
+      syncAttachedSessionTitle(attached.id, attached.title ?? null, true);
+    }
   }, [panes.sessionId, paneSessionStageId, attach, detach]);
 
   // Attachment is workspace-scoped view state. Clear it when the shell leaves

--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -343,11 +343,15 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
       const snapshot = [...next];
       sessionsRef.current = snapshot;
       setSessions(snapshot);
+      // Sparse owner events carry only their own field. A status publication
+      // therefore has no authority over the title it happens to copy from the
+      // client's current row; only a complete list snapshot may repair the
+      // attached header here. Local renames and title events use their explicit
+      // paths below.
+      if (source !== 'snapshot') return;
       const attachedId = useWorkbenchStore.getState().sessionId;
       const attached = snapshot.find((session) => session.id === attachedId);
-      if (attached) {
-        syncAttachedSessionTitle(attached.id, attached.title ?? null, source === 'snapshot');
-      }
+      if (attached) syncAttachedSessionTitle(attached.id, attached.title ?? null, true);
     },
     [],
   );
@@ -571,7 +575,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
    */
   const renameSession = useCallback(
     (sessionId: string, raw: string): Promise<string | null> =>
-      sessionRenameQueue.run(sessionId, async () => {
+      sessionRenameQueue.run(sessionId, async (queued) => {
         const row = sessionsRef.current.find((session) => session.id === sessionId);
         const store = useWorkbenchStore.getState();
         const attached = store.sessionId === sessionId;
@@ -592,8 +596,15 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
             decision.client === null ||
             (ownerSessionClient.current === decision.client &&
               decision.client.isSessionTitleRevisionCurrent(sessionId, decision.revision)),
+          // A queued value that looks unchanged may be the user's explicit
+          // attempt to undo the still-ambiguous write ahead of it.
+          forceSave: queued,
         });
-        if (outcome === 'renamed') ownerSessionClient.current?.requestFullFetch();
+        // A failed write is still ambiguous at the transport boundary: the
+        // database may have committed before the response was lost, and an
+        // optimistic mutation may have hidden a newer snapshot while it was in
+        // flight. Reconcile every attempted change; unchanged input did no IO.
+        if (outcome !== 'unchanged') ownerSessionClient.current?.requestFullFetch();
         if (outcome !== 'failed') return null;
         const message = t('workspace.renameSessionFailed');
         toast.error(message);

--- a/lib/workbench/owner-session-client.ts
+++ b/lib/workbench/owner-session-client.ts
@@ -133,7 +133,6 @@ export class OwnerSessionClient {
   private connectingSamples = 0;
   private streamDegraded = false;
   private titleMutationRevision = 0;
-  private titleDecisionRevisions = new Map<string, number>();
   private titleMutations = new Map<
     string,
     { readonly revision: number; readonly title: string | null; readonly settled: boolean }
@@ -168,7 +167,6 @@ export class OwnerSessionClient {
     this.connectingSamples = 0;
     this.streamDegraded = false;
     this.titleMutationRevision = 0;
-    this.titleDecisionRevisions.clear();
     this.titleMutations.clear();
   }
 
@@ -194,7 +192,6 @@ export class OwnerSessionClient {
   /** A local title decision retained until a post-settlement snapshot confirms it. */
   updateSessionTitle(sessionId: string, title: string | null, settled: boolean): number {
     const revision = (this.titleMutationRevision += 1);
-    this.titleDecisionRevisions.set(sessionId, revision);
     this.titleMutations.set(sessionId, {
       revision,
       title,
@@ -207,7 +204,7 @@ export class OwnerSessionClient {
   }
 
   isSessionTitleRevisionCurrent(sessionId: string, revision: number): boolean {
-    return this.titleDecisionRevisions.get(sessionId) === revision;
+    return this.titleMutations.get(sessionId)?.revision === revision;
   }
 
   /**
@@ -255,8 +252,11 @@ export class OwnerSessionClient {
         reduced.sessions === this.sessions;
       // `updatedAt` also contains app-clock lifecycle writes, so a small clock
       // skew can make a committed DB-clock title look old. A fresh list read
-      // distinguishes that case from a genuinely stale projection.
-      if (timestampStaleTitle) this.requestFullFetch();
+      // distinguishes that case from a genuinely stale projection. A title
+      // hidden by a retained local decision likewise needs a read after the
+      // current one: if that read fails, the received event must not remain
+      // hidden until the minute-scale periodic reconciliation.
+      if (timestampStaleTitle || unconfirmedTitleMutation) this.requestFullFetch();
       if (!timestampStaleTitle) {
         this.journal.push(event);
         if (this.journal.length > OWNER_SESSION_JOURNAL_LIMIT) {
@@ -264,7 +264,6 @@ export class OwnerSessionClient {
           this.requestFullFetch();
         }
         if (event.type === 'session_title' && !unconfirmedTitleMutation) {
-          this.titleDecisionRevisions.set(event.sessionId, (this.titleMutationRevision += 1));
           this.titleMutations.delete(event.sessionId);
           this.options.onSessionTitle?.(event.sessionId, event.title);
         }
@@ -369,6 +368,7 @@ export class OwnerSessionClient {
       .fetchSessions()
       .then((snapshot) => {
         if (this.stopped || epoch !== this.epoch) return;
+        const snapshotSessionIds = new Set(snapshot.map((session) => session.id));
         let merged: readonly ProHomeSessionItem[] = newestFirst(snapshot).map((session) => {
           const mutation = this.titleMutations.get(session.id);
           if (!mutation) return session;
@@ -379,10 +379,17 @@ export class OwnerSessionClient {
           }
           // This request began after the PATCH settled, so its row is now the
           // authoritative answer and may retire the local decision.
-          this.titleDecisionRevisions.set(session.id, (this.titleMutationRevision += 1));
           this.titleMutations.delete(session.id);
           return session;
         });
+        for (const [sessionId, revision] of settledTitleRevisions) {
+          if (snapshotSessionIds.has(sessionId)) continue;
+          const mutation = this.titleMutations.get(sessionId);
+          if (!mutation?.settled || mutation.revision !== revision) continue;
+          // A successful full read that began after settlement is equally
+          // authoritative when the answer is "this session no longer exists".
+          this.titleMutations.delete(sessionId);
+        }
         let needsFullFetch = false;
         for (const event of this.journal) {
           if (compareDecimalCursor(event.id, snapshotCursor) <= 0) continue;

--- a/lib/workbench/owner-session-client.ts
+++ b/lib/workbench/owner-session-client.ts
@@ -210,6 +210,16 @@ export class OwnerSessionClient {
     return this.titleDecisionRevisions.get(sessionId) === revision;
   }
 
+  /**
+   * The local title decision a full owner snapshot has not confirmed yet.
+   * The wrapper is intentional: `null` is a real decision (clear the manual
+   * title), while a null return means this client has no decision to preserve.
+   */
+  getUnconfirmedSessionTitle(sessionId: string): { readonly title: string | null } | null {
+    const mutation = this.titleMutations.get(sessionId);
+    return mutation ? { title: mutation.title } : null;
+  }
+
   private openStream(): void {
     const epoch = this.epoch;
     const source = this.options.createEventSource('/api/agent/owner-events', { headers: {} });

--- a/lib/workbench/owner-session-client.ts
+++ b/lib/workbench/owner-session-client.ts
@@ -16,6 +16,7 @@ export const OWNER_SESSION_EVENT_TYPES = [
   'session_deleted',
   'session_active_stage',
   'session_cancel_requested',
+  'session_title',
 ] as const;
 
 export const SESSION_RECONCILE_MIN_MS = 60_000;
@@ -51,7 +52,11 @@ export interface OwnerEventSourceInit {
 interface OwnerSessionClientOptions {
   readonly fetchSessions: () => Promise<ProHomeSessionItem[]>;
   readonly createEventSource: (url: string, init?: OwnerEventSourceInit) => OwnerEventSource;
-  readonly onSessions: (sessions: readonly ProHomeSessionItem[]) => void;
+  readonly onSessions: (
+    sessions: readonly ProHomeSessionItem[],
+    source?: 'incremental' | 'snapshot',
+  ) => void;
+  readonly onSessionTitle?: (sessionId: string, title: string | null) => void;
   readonly onState: (state: SessionListState) => void;
   readonly onInitialized?: () => void;
   /**
@@ -93,14 +98,15 @@ function parseData(event: Event): unknown {
 
 function isOwnerSessionEvent(value: unknown): value is OwnerSessionEvent {
   if (!value || typeof value !== 'object') return false;
-  const event = value as Partial<OwnerSessionEvent>;
-  return (
+  const event = value as Record<string, unknown>;
+  const validBase =
     typeof event.type === 'string' &&
     (OWNER_SESSION_EVENT_TYPES as readonly string[]).includes(event.type) &&
     isDecimalCursor(event.id) &&
     typeof event.sessionId === 'string' &&
-    typeof event.ts === 'number'
-  );
+    typeof event.ts === 'number';
+  if (!validBase) return false;
+  return event.type !== 'session_title' || event.title === null || typeof event.title === 'string';
 }
 
 /**
@@ -126,6 +132,12 @@ export class OwnerSessionClient {
   private malformedEventCount = 0;
   private connectingSamples = 0;
   private streamDegraded = false;
+  private titleMutationRevision = 0;
+  private titleDecisionRevisions = new Map<string, number>();
+  private titleMutations = new Map<
+    string,
+    { readonly revision: number; readonly title: string | null }
+  >();
   private reconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private streamHealthTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -155,6 +167,9 @@ export class OwnerSessionClient {
     this.malformedEventCount = 0;
     this.connectingSamples = 0;
     this.streamDegraded = false;
+    this.titleMutationRevision = 0;
+    this.titleDecisionRevisions.clear();
+    this.titleMutations.clear();
   }
 
   requestFullFetch(showLoading = false): void {
@@ -174,6 +189,24 @@ export class OwnerSessionClient {
     if (next === this.sessions) return;
     this.sessions = next;
     this.options.onSessions(next);
+  }
+
+  /** A local title decision that snapshots already in flight may not undo. */
+  updateSessionTitle(sessionId: string, title: string | null): number {
+    const revision = (this.titleMutationRevision += 1);
+    this.titleDecisionRevisions.set(sessionId, revision);
+    this.titleMutations.set(sessionId, {
+      revision,
+      title,
+    });
+    this.updateSessions((sessions) =>
+      sessions.map((session) => (session.id === sessionId ? { ...session, title } : session)),
+    );
+    return revision;
+  }
+
+  isSessionTitleRevisionCurrent(sessionId: string, revision: number): boolean {
+    return this.titleDecisionRevisions.get(sessionId) === revision;
   }
 
   private openStream(): void {
@@ -200,12 +233,23 @@ export class OwnerSessionClient {
       }
       this.malformedEventCount = 0;
       this.cursor = event.id;
-      this.journal.push(event);
-      if (this.journal.length > OWNER_SESSION_JOURNAL_LIMIT) {
-        this.journal.splice(0, this.journal.length - OWNER_SESSION_JOURNAL_LIMIT);
-        this.requestFullFetch();
-      }
       const reduced = reduceOwnerSessionEvent(this.sessions, event);
+      const ignoredStaleTitle =
+        event.type === 'session_title' &&
+        !reduced.needsFullFetch &&
+        reduced.sessions === this.sessions;
+      if (!ignoredStaleTitle) {
+        this.journal.push(event);
+        if (this.journal.length > OWNER_SESSION_JOURNAL_LIMIT) {
+          this.journal.splice(0, this.journal.length - OWNER_SESSION_JOURNAL_LIMIT);
+          this.requestFullFetch();
+        }
+        if (event.type === 'session_title') {
+          this.titleDecisionRevisions.set(event.sessionId, (this.titleMutationRevision += 1));
+          this.titleMutations.delete(event.sessionId);
+          this.options.onSessionTitle?.(event.sessionId, event.title);
+        }
+      }
       if (reduced.sessions !== this.sessions) {
         this.sessions = reduced.sessions;
         this.options.onSessions(this.sessions);
@@ -296,11 +340,18 @@ export class OwnerSessionClient {
     this.requestInFlight = true;
     const epoch = this.epoch;
     const snapshotCursor = this.cursor;
+    const titleRevisions = new Map(
+      [...this.titleMutations].map(([sessionId, mutation]) => [sessionId, mutation.revision]),
+    );
     void this.options
       .fetchSessions()
       .then((snapshot) => {
         if (this.stopped || epoch !== this.epoch) return;
-        let merged: readonly ProHomeSessionItem[] = newestFirst(snapshot);
+        let merged: readonly ProHomeSessionItem[] = newestFirst(snapshot).map((session) => {
+          const mutation = this.titleMutations.get(session.id);
+          if (!mutation || mutation.revision === titleRevisions.get(session.id)) return session;
+          return { ...session, title: mutation.title };
+        });
         let needsFullFetch = false;
         for (const event of this.journal) {
           if (compareDecimalCursor(event.id, snapshotCursor) <= 0) continue;
@@ -311,7 +362,7 @@ export class OwnerSessionClient {
         this.sessions = merged;
         this.journal = [];
         this.lastFullFetchFailed = false;
-        this.options.onSessions(merged);
+        this.options.onSessions(merged, 'snapshot');
         // Unconditionally authoritative: this snapshot is a full read of the
         // list, so it is correct even while the push channel is down. Gating
         // 'ready' on stream health left a dead stream + healthy REST stuck in

--- a/lib/workbench/owner-session-client.ts
+++ b/lib/workbench/owner-session-client.ts
@@ -136,7 +136,7 @@ export class OwnerSessionClient {
   private titleDecisionRevisions = new Map<string, number>();
   private titleMutations = new Map<
     string,
-    { readonly revision: number; readonly title: string | null }
+    { readonly revision: number; readonly title: string | null; readonly settled: boolean }
   >();
   private reconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private streamHealthTimer: ReturnType<typeof setInterval> | null = null;
@@ -191,13 +191,14 @@ export class OwnerSessionClient {
     this.options.onSessions(next);
   }
 
-  /** A local title decision that snapshots already in flight may not undo. */
-  updateSessionTitle(sessionId: string, title: string | null): number {
+  /** A local title decision retained until a post-settlement snapshot confirms it. */
+  updateSessionTitle(sessionId: string, title: string | null, settled: boolean): number {
     const revision = (this.titleMutationRevision += 1);
     this.titleDecisionRevisions.set(sessionId, revision);
     this.titleMutations.set(sessionId, {
       revision,
       title,
+      settled,
     });
     this.updateSessions((sessions) =>
       sessions.map((session) => (session.id === sessionId ? { ...session, title } : session)),
@@ -234,6 +235,10 @@ export class OwnerSessionClient {
       this.malformedEventCount = 0;
       this.cursor = event.id;
       const reduced = reduceOwnerSessionEvent(this.sessions, event);
+      // PATCH responses and owner events travel independently. Until a read
+      // confirms the write, no event can safely retire its local decision.
+      const unconfirmedTitleMutation =
+        event.type === 'session_title' && this.titleMutations.has(event.sessionId);
       const timestampStaleTitle =
         event.type === 'session_title' &&
         !reduced.needsFullFetch &&
@@ -248,14 +253,15 @@ export class OwnerSessionClient {
           this.journal.splice(0, this.journal.length - OWNER_SESSION_JOURNAL_LIMIT);
           this.requestFullFetch();
         }
-        if (event.type === 'session_title') {
+        if (event.type === 'session_title' && !unconfirmedTitleMutation) {
           this.titleDecisionRevisions.set(event.sessionId, (this.titleMutationRevision += 1));
           this.titleMutations.delete(event.sessionId);
           this.options.onSessionTitle?.(event.sessionId, event.title);
         }
       }
-      if (reduced.sessions !== this.sessions) {
-        this.sessions = reduced.sessions;
+      const nextSessions = this.overlaySessionTitleMutations(reduced.sessions);
+      if (nextSessions !== this.sessions) {
+        this.sessions = nextSessions;
         this.options.onSessions(this.sessions);
       }
       if (reduced.needsFullFetch) this.requestFullFetch();
@@ -344,8 +350,10 @@ export class OwnerSessionClient {
     this.requestInFlight = true;
     const epoch = this.epoch;
     const snapshotCursor = this.cursor;
-    const titleRevisions = new Map(
-      [...this.titleMutations].map(([sessionId, mutation]) => [sessionId, mutation.revision]),
+    const settledTitleRevisions = new Map(
+      [...this.titleMutations]
+        .filter(([, mutation]) => mutation.settled)
+        .map(([sessionId, mutation]) => [sessionId, mutation.revision]),
     );
     void this.options
       .fetchSessions()
@@ -354,14 +362,13 @@ export class OwnerSessionClient {
         let merged: readonly ProHomeSessionItem[] = newestFirst(snapshot).map((session) => {
           const mutation = this.titleMutations.get(session.id);
           if (!mutation) return session;
-          if (mutation.revision !== titleRevisions.get(session.id)) {
-            // This decision happened after the request began, so the response
-            // cannot contain it yet.
+          if (!mutation.settled || mutation.revision !== settledTitleRevisions.get(session.id)) {
+            // The PATCH was unresolved when this request began, or a newer
+            // decision arrived afterwards, so the response cannot confirm it.
             return { ...session, title: mutation.title };
           }
-          // This request began after the local decision and its row is now the
-          // authoritative answer. Fence the still-pending PATCH settlement so
-          // a later network failure cannot roll this snapshot back.
+          // This request began after the PATCH settled, so its row is now the
+          // authoritative answer and may retire the local decision.
           this.titleDecisionRevisions.set(session.id, (this.titleMutationRevision += 1));
           this.titleMutations.delete(session.id);
           return session;
@@ -370,9 +377,11 @@ export class OwnerSessionClient {
         for (const event of this.journal) {
           if (compareDecimalCursor(event.id, snapshotCursor) <= 0) continue;
           const reduced = reduceOwnerSessionEvent(merged, event);
+          const titleOrderAmbiguous = event.type === 'session_title' && reduced.sessions === merged;
           merged = reduced.sessions;
-          needsFullFetch ||= reduced.needsFullFetch;
+          needsFullFetch ||= reduced.needsFullFetch || titleOrderAmbiguous;
         }
+        merged = this.overlaySessionTitleMutations(merged);
         this.sessions = merged;
         this.journal = [];
         this.lastFullFetchFailed = false;
@@ -397,6 +406,19 @@ export class OwnerSessionClient {
           this.runFullFetch();
         }
       });
+  }
+
+  private overlaySessionTitleMutations(
+    sessions: readonly ProHomeSessionItem[],
+  ): readonly ProHomeSessionItem[] {
+    let changed = false;
+    const next = sessions.map((session) => {
+      const mutation = this.titleMutations.get(session.id);
+      if (!mutation || mutation.title === session.title) return session;
+      changed = true;
+      return { ...session, title: mutation.title };
+    });
+    return changed ? next : sessions;
   }
 
   private scheduleReconciliation(): void {

--- a/lib/workbench/owner-session-client.ts
+++ b/lib/workbench/owner-session-client.ts
@@ -234,11 +234,15 @@ export class OwnerSessionClient {
       this.malformedEventCount = 0;
       this.cursor = event.id;
       const reduced = reduceOwnerSessionEvent(this.sessions, event);
-      const ignoredStaleTitle =
+      const timestampStaleTitle =
         event.type === 'session_title' &&
         !reduced.needsFullFetch &&
         reduced.sessions === this.sessions;
-      if (!ignoredStaleTitle) {
+      // `updatedAt` also contains app-clock lifecycle writes, so a small clock
+      // skew can make a committed DB-clock title look old. A fresh list read
+      // distinguishes that case from a genuinely stale projection.
+      if (timestampStaleTitle) this.requestFullFetch();
+      if (!timestampStaleTitle) {
         this.journal.push(event);
         if (this.journal.length > OWNER_SESSION_JOURNAL_LIMIT) {
           this.journal.splice(0, this.journal.length - OWNER_SESSION_JOURNAL_LIMIT);
@@ -349,8 +353,18 @@ export class OwnerSessionClient {
         if (this.stopped || epoch !== this.epoch) return;
         let merged: readonly ProHomeSessionItem[] = newestFirst(snapshot).map((session) => {
           const mutation = this.titleMutations.get(session.id);
-          if (!mutation || mutation.revision === titleRevisions.get(session.id)) return session;
-          return { ...session, title: mutation.title };
+          if (!mutation) return session;
+          if (mutation.revision !== titleRevisions.get(session.id)) {
+            // This decision happened after the request began, so the response
+            // cannot contain it yet.
+            return { ...session, title: mutation.title };
+          }
+          // This request began after the local decision and its row is now the
+          // authoritative answer. Fence the still-pending PATCH settlement so
+          // a later network failure cannot roll this snapshot back.
+          this.titleDecisionRevisions.set(session.id, (this.titleMutationRevision += 1));
+          this.titleMutations.delete(session.id);
+          return session;
         });
         let needsFullFetch = false;
         for (const event of this.journal) {

--- a/lib/workbench/pro-home-data.ts
+++ b/lib/workbench/pro-home-data.ts
@@ -81,6 +81,10 @@ export type OwnerSessionEvent =
   | (OwnerSessionEventBase & {
       readonly type: 'session_active_stage';
       readonly activeStageId: string;
+    })
+  | (OwnerSessionEventBase & {
+      readonly type: 'session_title';
+      readonly title: string | null;
     });
 
 export interface OwnerSessionReduceResult {
@@ -112,12 +116,17 @@ export function reduceOwnerSessionEvent(
   }
 
   const current = sessions[index]!;
+  if (event.type === 'session_title' && event.ts < current.updatedAt) {
+    return { sessions, needsFullFetch: false };
+  }
   const changed: ProHomeSessionItem =
     event.type === 'session_status' || event.type === 'session_created'
       ? { ...current, status: event.status, updatedAt: event.ts }
       : event.type === 'session_active_stage'
         ? { ...current, stageId: event.activeStageId, updatedAt: event.ts }
-        : { ...current, updatedAt: event.ts };
+        : event.type === 'session_title'
+          ? { ...current, title: event.title, updatedAt: event.ts }
+          : { ...current, updatedAt: event.ts };
   const next = sessions.map((session, currentIndex) =>
     currentIndex === index ? changed : session,
   );

--- a/lib/workbench/pro-home-data.ts
+++ b/lib/workbench/pro-home-data.ts
@@ -116,7 +116,9 @@ export function reduceOwnerSessionEvent(
   }
 
   const current = sessions[index]!;
-  if (event.type === 'session_title' && event.ts < current.updatedAt) {
+  // PostgreSQL timestamps lose sub-millisecond ordering when projected to JS.
+  // An equal timestamp is ambiguous, so the client reconciles it with a read.
+  if (event.type === 'session_title' && event.ts <= current.updatedAt) {
     return { sessions, needsFullFetch: false };
   }
   const changed: ProHomeSessionItem =

--- a/lib/workbench/pro-home-data.ts
+++ b/lib/workbench/pro-home-data.ts
@@ -98,8 +98,9 @@ export interface OwnerSessionReduceResult {
  * Sparse events can update an existing row but cannot create one: prompt,
  * stageId and creation timestamps intentionally never enter the owner event
  * log. Any event for an unknown id therefore asks the IO layer for a complete
- * snapshot. Real transitions use their event timestamp as rail activity, so
- * heartbeats no longer reshuffle live rows between reconciliations.
+ * snapshot. Owner-visible transitions, including title changes, use their
+ * event timestamp as rail activity. Heartbeat-only updates affect order when
+ * the next full snapshot reconciles the row's generic updatedAt.
  */
 export function reduceOwnerSessionEvent(
   sessions: readonly ProHomeSessionItem[],

--- a/lib/workbench/session-store.ts
+++ b/lib/workbench/session-store.ts
@@ -454,7 +454,7 @@ export interface WorkbenchState extends WorkbenchSessionState {
   setSessionPrompt: (prompt: string | null) => void;
   /**
    * The rename's optimistic write, and its rollback: the caller sets the new
-   * title, POSTs, and puts the old one back if the write is refused.
+   * title, PATCHes, and puts the old one back if the write is refused.
    */
   setSessionTitle: (title: string | null) => void;
   /** Seed title / stage / idle status from session meta before any events arrive. */

--- a/lib/workbench/session-store.ts
+++ b/lib/workbench/session-store.ts
@@ -398,6 +398,12 @@ export interface WorkbenchFold {
 export interface WorkbenchSessionState extends WorkbenchFold {
   sessionId: string | null;
   attached: boolean;
+  /**
+   * Changes whenever this client makes a title decision. A detail request
+   * captures it so an older response cannot overwrite a rename (including an
+   * explicit clear) made while that request was in flight.
+   */
+  sessionTitleRevision: number;
   /** True until the replayed backlog is exhausted; the UI says "catching up". */
   replaying: boolean;
   /**
@@ -455,6 +461,7 @@ export interface WorkbenchState extends WorkbenchSessionState {
   setSessionBootstrap: (input: {
     prompt?: string | null;
     title?: string | null;
+    expectedTitleRevision?: number;
     status?: SessionStatus;
     stageId?: string | null;
   }) => void;
@@ -506,6 +513,7 @@ export function createInitialSessionState(): WorkbenchSessionState {
     // ── Attachment ──────────────────────────────────────────────────────
     sessionId: null,
     attached: false,
+    sessionTitleRevision: 0,
     // Nothing is attached, so there is nothing to replay. It used to be `true`
     // here, which is only ever read as "keep the catch-up spinner up" — and with
     // no session nothing would ever turn it off again (the stream hook returns
@@ -1870,11 +1878,19 @@ export const useWorkbenchStore = create<WorkbenchState>((set) => ({
     })),
   setError: (error) => set({ error }),
   setSessionPrompt: (sessionPrompt) => set({ sessionPrompt }),
-  setSessionTitle: (sessionTitle) => set({ sessionTitle }),
+  setSessionTitle: (sessionTitle) =>
+    set((state) => ({
+      sessionTitle,
+      sessionTitleRevision: state.sessionTitleRevision + 1,
+    })),
   setSessionBootstrap: (input) =>
     set((state) => ({
       ...(input.prompt !== undefined ? { sessionPrompt: input.prompt } : {}),
-      ...(input.title !== undefined ? { sessionTitle: input.title } : {}),
+      ...(input.title !== undefined &&
+      (input.expectedTitleRevision === undefined ||
+        input.expectedTitleRevision === state.sessionTitleRevision)
+        ? { sessionTitle: input.title }
+        : {}),
       ...(input.status && state.lastEventId === 0 ? { status: input.status } : {}),
       // Only ever FILLS the stage, never overwrites: the attach path knows it
       // first-hand when it has it, and a late meta response for a session the

--- a/lib/workbench/session-title.ts
+++ b/lib/workbench/session-title.ts
@@ -15,6 +15,29 @@
 /** The longest name a conversation may be given. Mirrors the server's cap. */
 export const SESSION_TITLE_MAX_LENGTH = 120;
 
+/**
+ * Normalize one stored title override at the shared client/server boundary.
+ *
+ * HTML's `maxLength` and JavaScript's `slice` both count UTF-16 code units, so
+ * that remains the budget here. The `Array.from` pass replaces NUL and lone
+ * surrogates, which PostgreSQL TEXT / JSONB cannot store, without requiring a
+ * newer browser built-in; the final guard prevents the cap itself from cutting
+ * a valid surrogate pair in half.
+ */
+export function normalizeSessionTitleOverride(value: string | null): string | null {
+  if (value === null) return null;
+  const wellFormed = Array.from(value.trim(), (character) => {
+    const codeUnit = character.charCodeAt(0);
+    const unstorable =
+      codeUnit === 0 || (character.length === 1 && codeUnit >= 0xd800 && codeUnit <= 0xdfff);
+    return unstorable ? '\ufffd' : character;
+  }).join('');
+  const truncated = wellFormed.slice(0, SESSION_TITLE_MAX_LENGTH);
+  if (!truncated) return null;
+  const last = truncated.charCodeAt(truncated.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? truncated.slice(0, -1) || null : truncated;
+}
+
 export interface WorkbenchSessionNaming {
   /** The stored override, if the user named this conversation. */
   readonly title?: string | null;
@@ -50,7 +73,7 @@ export function normalizeSessionTitleInput(
   session: WorkbenchSessionNaming,
   raw: string,
 ): string | null {
-  const next = raw.trim().slice(0, SESSION_TITLE_MAX_LENGTH);
+  const next = normalizeSessionTitleOverride(raw);
   if (!next) return null;
   return isDerivedSessionTitle(session, next) ? null : next;
 }

--- a/lib/workbench/session-title.ts
+++ b/lib/workbench/session-title.ts
@@ -91,8 +91,9 @@ export function createSessionRenameQueue(): {
  *
  * Here rather than in the component so the sequence — and especially the
  * rollback, the part nobody exercises by hand — is testable without a DOM. The
- * caller supplies `apply` (the surfaces showing this chat's name) and `save`
- * (the PATCH), which is what keeps the whole feature to a single writer.
+ * caller supplies `apply` (the surfaces showing this chat's name, plus whether
+ * the PATCH has settled) and `save` (the PATCH), which is what keeps the whole
+ * feature to a single writer.
  */
 export async function commitSessionRename({
   current,
@@ -104,7 +105,7 @@ export async function commitSessionRename({
 }: {
   readonly current: WorkbenchSessionNaming;
   readonly raw: string;
-  readonly apply: (title: string | null) => void;
+  readonly apply: (title: string | null, settled: boolean) => void;
   /** Resolves to the title the server stored — it caps the length. */
   readonly save: (title: string | null) => Promise<string | null>;
   /** False when another authoritative title decision arrived while PATCH was pending. */
@@ -116,13 +117,13 @@ export async function commitSessionRename({
   const previous = current.title?.trim() || null;
   // Unchanged is not a rename; do not spend a round trip saying so.
   if (!forceSave && next === previous) return 'unchanged';
-  apply(next);
+  apply(next, false);
   try {
     const stored = await save(next);
-    if (isCurrent()) apply(stored);
+    if (isCurrent()) apply(stored, true);
     return 'renamed';
   } catch {
-    if (isCurrent()) apply(previous);
+    if (isCurrent()) apply(previous, true);
     return 'failed';
   }
 }

--- a/lib/workbench/session-title.ts
+++ b/lib/workbench/session-title.ts
@@ -58,6 +58,32 @@ export function normalizeSessionTitleInput(
 export type SessionRenameOutcome = 'unchanged' | 'renamed' | 'failed';
 
 /**
+ * Keep saves for one conversation in submit order while leaving unrelated
+ * conversations independent. Each tail is settled even when its task fails,
+ * so one refused rename never poisons the next turn.
+ */
+export function createSessionRenameQueue(): {
+  run<T>(sessionId: string, task: () => Promise<T>): Promise<T>;
+} {
+  const tails = new Map<string, Promise<void>>();
+  return {
+    run<T>(sessionId: string, task: () => Promise<T>): Promise<T> {
+      const previous = tails.get(sessionId) ?? Promise.resolve();
+      const run = previous.then(task, task);
+      const tail = run.then(
+        () => undefined,
+        () => undefined,
+      );
+      tails.set(sessionId, tail);
+      void tail.then(() => {
+        if (tails.get(sessionId) === tail) tails.delete(sessionId);
+      });
+      return run;
+    },
+  };
+}
+
+/**
  * One rename, start to finish: write it everywhere it shows immediately, settle
  * on what the server actually stored, and put the old name back if the write is
  * refused.
@@ -72,12 +98,15 @@ export async function commitSessionRename({
   raw,
   apply,
   save,
+  isCurrent = () => true,
 }: {
   readonly current: WorkbenchSessionNaming;
   readonly raw: string;
   readonly apply: (title: string | null) => void;
   /** Resolves to the title the server stored — it caps the length. */
   readonly save: (title: string | null) => Promise<string | null>;
+  /** False when another authoritative title decision arrived while PATCH was pending. */
+  readonly isCurrent?: () => boolean;
 }): Promise<SessionRenameOutcome> {
   const next = normalizeSessionTitleInput(current, raw);
   const previous = current.title?.trim() || null;
@@ -85,10 +114,11 @@ export async function commitSessionRename({
   if (next === previous) return 'unchanged';
   apply(next);
   try {
-    apply(await save(next));
+    const stored = await save(next);
+    if (isCurrent()) apply(stored);
     return 'renamed';
   } catch {
-    apply(previous);
+    if (isCurrent()) apply(previous);
     return 'failed';
   }
 }

--- a/lib/workbench/session-title.ts
+++ b/lib/workbench/session-title.ts
@@ -63,13 +63,14 @@ export type SessionRenameOutcome = 'unchanged' | 'renamed' | 'failed';
  * so one refused rename never poisons the next turn.
  */
 export function createSessionRenameQueue(): {
-  run<T>(sessionId: string, task: () => Promise<T>): Promise<T>;
+  run<T>(sessionId: string, task: (queued: boolean) => Promise<T>): Promise<T>;
 } {
   const tails = new Map<string, Promise<void>>();
   return {
-    run<T>(sessionId: string, task: () => Promise<T>): Promise<T> {
-      const previous = tails.get(sessionId) ?? Promise.resolve();
-      const run = previous.then(task, task);
+    run<T>(sessionId: string, task: (queued: boolean) => Promise<T>): Promise<T> {
+      const predecessor = tails.get(sessionId);
+      const queued = predecessor !== undefined;
+      const run = (predecessor ?? Promise.resolve()).then(() => task(queued));
       const tail = run.then(
         () => undefined,
         () => undefined,
@@ -99,6 +100,7 @@ export async function commitSessionRename({
   apply,
   save,
   isCurrent = () => true,
+  forceSave = false,
 }: {
   readonly current: WorkbenchSessionNaming;
   readonly raw: string;
@@ -107,11 +109,13 @@ export async function commitSessionRename({
   readonly save: (title: string | null) => Promise<string | null>;
   /** False when another authoritative title decision arrived while PATCH was pending. */
   readonly isCurrent?: () => boolean;
+  /** Preserve an explicit decision queued behind a write whose outcome may still be ambiguous. */
+  readonly forceSave?: boolean;
 }): Promise<SessionRenameOutcome> {
   const next = normalizeSessionTitleInput(current, raw);
   const previous = current.title?.trim() || null;
   // Unchanged is not a rename; do not spend a round trip saying so.
-  if (next === previous) return 'unchanged';
+  if (!forceSave && next === previous) return 'unchanged';
   apply(next);
   try {
     const stored = await save(next);

--- a/lib/workbench/use-workbench-session.ts
+++ b/lib/workbench/use-workbench-session.ts
@@ -112,6 +112,7 @@ export function useWorkbenchStream(sessionId: string | null): void {
 
   useEffect(() => {
     if (!sessionId) return;
+    const expectedTitleRevision = useWorkbenchStore.getState().sessionTitleRevision;
     // The header title wants the prompt before the runner emits session_start
     // (a queued session can sit there a while), and a `?session=` deep link
     // arrives without the session's own stage — one meta fetch covers both.
@@ -135,6 +136,7 @@ export function useWorkbenchStream(sessionId: string | null): void {
             // Always seeded, including as null: a session with no override must
             // clear whatever the previously attached one had.
             title: typeof meta.title === 'string' && meta.title ? meta.title : null,
+            expectedTitleRevision,
             ...(status ? { status } : {}),
             ...(typeof meta.stageId === 'string' && meta.stageId ? { stageId: meta.stageId } : {}),
           });

--- a/lib/workbench/use-workbench-session.ts
+++ b/lib/workbench/use-workbench-session.ts
@@ -112,6 +112,8 @@ export function useWorkbenchStream(sessionId: string | null): void {
 
   useEffect(() => {
     if (!sessionId) return;
+    let active = true;
+    const isCurrent = () => active && useWorkbenchStore.getState().sessionId === sessionId;
     const expectedTitleRevision = useWorkbenchStore.getState().sessionTitleRevision;
     // The header title wants the prompt before the runner emits session_start
     // (a queued session can sit there a while), and a `?session=` deep link
@@ -119,9 +121,9 @@ export function useWorkbenchStream(sessionId: string | null): void {
     fetch(`/api/agent/sessions/${encodeURIComponent(sessionId)}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((meta) => {
-        // A switch to another session must not let this late response write
-        // the wrong prompt over it.
-        if (useWorkbenchStore.getState().sessionId !== sessionId) return;
+        // A switch away invalidates this attachment even if the user later
+        // returns to the same id before its old request settles.
+        if (!isCurrent()) return;
         if (meta && typeof meta.prompt === 'string') {
           const status =
             meta.status === 'queued' ||
@@ -152,9 +154,7 @@ export function useWorkbenchStream(sessionId: string | null): void {
 
     let connected = false;
     let caughtUp = false;
-    let active = true;
     const backlog: WorkbenchEvent[] = [];
-    const isCurrent = () => active && useWorkbenchStore.getState().sessionId === sessionId;
     const markAttached = () => {
       if (connected || !isCurrent()) return;
       connected = true;

--- a/lib/workbench/use-workbench-session.ts
+++ b/lib/workbench/use-workbench-session.ts
@@ -133,12 +133,13 @@ export function useWorkbenchStream(sessionId: string | null): void {
             meta.status === 'cancelled'
               ? meta.status
               : undefined;
+          const detailTitle = typeof meta.title === 'string' && meta.title ? meta.title : null;
           useWorkbenchStore.getState().setSessionBootstrap({
             prompt: meta.prompt,
-            // Always seeded, including as null: a session with no override must
-            // clear whatever the previously attached one had.
-            title: typeof meta.title === 'string' && meta.title ? meta.title : null,
-            expectedTitleRevision,
+            // Detail is only the cold-start title source. Once the owner list,
+            // an owner event, or a local decision has seeded this attachment,
+            // a GET that overtook an uncommitted PATCH must not replace it.
+            ...(expectedTitleRevision === 0 ? { title: detailTitle, expectedTitleRevision } : {}),
             ...(status ? { status } : {}),
             ...(typeof meta.stageId === 'string' && meta.stageId ? { stageId: meta.stageId } : {}),
           });

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -22,6 +22,7 @@ import {
   type AgentSessionHooks,
   type AgentSessionMeta,
   type AgentSessionStore,
+  type AgentSessionTitleStore,
   type AgentSessionTransaction,
   type AgentSessionUrlSource,
   type AgentSessionUrlStore,
@@ -82,6 +83,7 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   id                  TEXT PRIMARY KEY,
   owner_id            TEXT NOT NULL,
   prompt              TEXT NOT NULL,
+  title               TEXT,
   stage_id            TEXT NOT NULL,
   active_stage_id     TEXT,
   skill_id            TEXT,
@@ -105,6 +107,9 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
 
 ALTER TABLE agent_sessions
   ADD COLUMN IF NOT EXISTS delivered_user_message_seq INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE agent_sessions
+  ADD COLUMN IF NOT EXISTS title TEXT;
 
 CREATE INDEX IF NOT EXISTS agent_sessions_status_live_idx
   ON agent_sessions (status, created_at) WHERE deleted_at IS NULL;
@@ -255,6 +260,7 @@ interface SessionRow extends Record<string, unknown> {
   id: string;
   owner_id: string;
   prompt: string;
+  title: string | null;
   stage_id: string;
   skill_id: string | null;
   origin: string | null;
@@ -270,7 +276,7 @@ interface SessionRow extends Record<string, unknown> {
   updated_at: Date | string;
 }
 
-const SESSION_COLUMNS = `id, owner_id, prompt, stage_id, skill_id, origin,
+const SESSION_COLUMNS = `id, owner_id, prompt, title, stage_id, skill_id, origin,
   existing_course, status, attempt, delivered_user_message_seq, lease_worker_id, lease_worker_pid,
   lease_heartbeat_at, error, created_at, updated_at`;
 
@@ -292,6 +298,7 @@ function sessionMeta(row: SessionRow): AgentSessionMeta {
     id: row.id,
     ownerId: row.owner_id,
     prompt: row.prompt,
+    ...(row.title !== null ? { title: row.title } : {}),
     stageId: row.stage_id,
     ...(row.skill_id ? { skillId: row.skill_id } : {}),
     ...(row.origin ? { origin: row.origin } : {}),
@@ -334,6 +341,7 @@ let savepointSerial = 0;
 export class PgAgentSessionStore
   implements
     AgentSessionStore,
+    AgentSessionTitleStore,
     AgentSessionEventLog,
     AgentSessionEntryTree,
     OwnerSessionEventProjection,
@@ -447,6 +455,21 @@ export class PgAgentSessionStore
       [ownerId],
     );
     return result.rows.map(sessionMeta);
+  }
+
+  async setManualSessionTitle(
+    sessionId: string,
+    ownerId: string,
+    title: string | null,
+  ): Promise<AgentSessionMeta | null> {
+    const result = await this.queryable.query<SessionRow>(
+      `UPDATE ${this.table('sessions')}
+       SET title = $3, updated_at = now()
+       WHERE id = $1 AND owner_id = $2 AND deleted_at IS NULL
+       RETURNING ${SESSION_COLUMNS}`,
+      [sessionId, ownerId, title],
+    );
+    return result.rows[0] ? sessionMeta(result.rows[0]) : null;
   }
 
   async softDeleteSession(sessionId: string, ownerId: string): Promise<boolean> {

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -8,6 +8,7 @@
  */
 import { randomUUID } from 'node:crypto';
 
+import { splitSqlStatements } from '../document/pg.js';
 import type { Queryable, WithTransaction } from '../runtime/pg.js';
 import {
   AGENT_SESSION_LIFECYCLE,
@@ -163,14 +164,48 @@ CREATE TABLE IF NOT EXISTS agent_owner_session_events (
   attempt    INTEGER,
   data       JSONB NOT NULL,
   PRIMARY KEY (owner_id, id),
-  CONSTRAINT agent_owner_session_events_type_known CHECK (type IN
+  CONSTRAINT agent_owner_session_events_type_known_v2 CHECK (type IN
     ('session_created','session_status','session_deleted',
-     'session_active_stage','session_cancel_requested')),
+     'session_active_stage','session_cancel_requested','session_title')),
   CONSTRAINT agent_owner_session_events_status_known CHECK (status IS NULL OR status IN
     ('queued','running','succeeded','failed','cancelled')),
   CONSTRAINT agent_owner_session_events_attempt_nonnegative
     CHECK (attempt IS NULL OR attempt >= 0)
 );
+
+DO $agent_session_owner_event_type_constraint$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'agent_owner_session_events'::regclass
+      AND conname = 'agent_owner_session_events_type_known'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'agent_owner_session_events'::regclass
+      AND conname = 'agent_owner_session_events_type_known_v2'
+  ) THEN
+    LOCK TABLE agent_owner_session_events IN ACCESS EXCLUSIVE MODE;
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'agent_owner_session_events'::regclass
+        AND conname = 'agent_owner_session_events_type_known'
+    ) THEN
+      ALTER TABLE agent_owner_session_events
+        DROP CONSTRAINT agent_owner_session_events_type_known;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'agent_owner_session_events'::regclass
+        AND conname = 'agent_owner_session_events_type_known_v2'
+    ) THEN
+      ALTER TABLE agent_owner_session_events
+        ADD CONSTRAINT agent_owner_session_events_type_known_v2 CHECK (type IN
+          ('session_created','session_status','session_deleted',
+           'session_active_stage','session_cancel_requested','session_title'));
+    END IF;
+  END IF;
+END
+$agent_session_owner_event_type_constraint$;
 
 CREATE TABLE IF NOT EXISTS agent_session_urls (
   session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
@@ -250,9 +285,8 @@ export async function ensureAgentSessionSchema(
   tableNames?: Partial<AgentSessionTableNames>,
 ): Promise<void> {
   const schema = schemaFor(resolveTableNames(tableNames));
-  for (const sql of schema.split(';')) {
-    const statement = sql.trim();
-    if (statement !== '') await queryable.query(statement);
+  for (const statement of splitSqlStatements(schema)) {
+    await queryable.query(statement);
   }
 }
 
@@ -462,14 +496,23 @@ export class PgAgentSessionStore
     ownerId: string,
     title: string | null,
   ): Promise<AgentSessionMeta | null> {
-    const result = await this.queryable.query<SessionRow>(
-      `UPDATE ${this.table('sessions')}
-       SET title = $3, updated_at = now()
-       WHERE id = $1 AND owner_id = $2 AND deleted_at IS NULL
-       RETURNING ${SESSION_COLUMNS}`,
-      [sessionId, ownerId, title],
-    );
-    return result.rows[0] ? sessionMeta(result.rows[0]) : null;
+    return this.transaction(async (tx) => {
+      const result = await tx.query<SessionRow>(
+        `UPDATE ${this.table('sessions')}
+         SET title = $3, updated_at = now()
+         WHERE id = $1 AND owner_id = $2 AND deleted_at IS NULL
+         RETURNING ${SESSION_COLUMNS}`,
+        [sessionId, ownerId, title],
+      );
+      const row = result.rows[0];
+      if (!row) return null;
+      const meta = sessionMeta(row);
+      await this.appendProjection(
+        { type: 'session_title', sessionId, title, ts: meta.updatedAt },
+        tx,
+      );
+      return meta;
+    });
   }
 
   async softDeleteSession(sessionId: string, ownerId: string): Promise<boolean> {
@@ -1307,7 +1350,7 @@ export class PgAgentSessionStore
       if (!counter) throw new Error(`cannot allocate owner event id for ${session.owner_id}`);
       const status = 'status' in event ? event.status : null;
       const attempt = 'attempt' in event ? event.attempt : null;
-      const data = {};
+      const data = event.type === 'session_title' ? { title: event.title } : {};
       await transaction.query(
         `INSERT INTO ${this.table('ownerEvents')}
           (owner_id, id, ts, session_id, type, status, attempt, data)
@@ -1382,6 +1425,13 @@ export class PgAgentSessionStore
           type: row.type,
           status: row.status!,
           attempt: Number(row.attempt ?? 0),
+        };
+      }
+      if (row.type === 'session_title') {
+        return {
+          ...base,
+          type: row.type,
+          title: decodedObject(row.data).title as string | null,
         };
       }
       return { ...base, type: row.type } as PersistedOwnerSessionEvent;

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -61,6 +61,11 @@ export const DEFAULT_AGENT_SESSION_TABLE_NAMES: Readonly<AgentSessionTableNames>
   urls: 'agent_session_urls',
 };
 
+const OWNER_EVENT_TYPE_CONSTRAINT_V2 = 'agent_owner_session_events_type_known_v2';
+// Long custom names can truncate the v1/v2 constraints to one PG identifier.
+// This impossible custom name shelters v2 while table names are substituted.
+const OWNER_EVENT_TYPE_CONSTRAINT_V2_SENTINEL = '__OPENMAIC_OWNER_EVENT_TYPE_KNOWN_V2__';
+
 export interface AgentSessionLogger {
   error(message: string, context: Record<string, unknown>, error: unknown): void;
 }
@@ -178,7 +183,7 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM pg_constraint
     WHERE conrelid = 'agent_owner_session_events'::regclass
-      AND conname = 'agent_owner_session_events_type_known'
+      AND conname = 'agent_owner_session_events_type_known'::name
   ) OR NOT EXISTS (
     SELECT 1 FROM pg_constraint
     WHERE conrelid = 'agent_owner_session_events'::regclass
@@ -188,7 +193,7 @@ BEGIN
     IF EXISTS (
       SELECT 1 FROM pg_constraint
       WHERE conrelid = 'agent_owner_session_events'::regclass
-        AND conname = 'agent_owner_session_events_type_known'
+        AND conname = 'agent_owner_session_events_type_known'::name
     ) THEN
       ALTER TABLE agent_owner_session_events
         DROP CONSTRAINT agent_owner_session_events_type_known;
@@ -254,9 +259,10 @@ function schemaFor(names: AgentSessionTableNames): string {
   // same replaceAll that re-keys their tables, so no separate prefix rewriting
   // is performed or needed.
   return AGENT_SESSION_PG_SCHEMA.replaceAll(
-    'agent_owner_session_event_counters',
-    names.ownerEventCounters,
+    OWNER_EVENT_TYPE_CONSTRAINT_V2,
+    OWNER_EVENT_TYPE_CONSTRAINT_V2_SENTINEL,
   )
+    .replaceAll('agent_owner_session_event_counters', names.ownerEventCounters)
     .replaceAll('agent_owner_session_events', names.ownerEvents)
     .replaceAll('agent_session_entries', names.entries)
     .replaceAll('agent_session_events', names.events)
@@ -276,7 +282,8 @@ function schemaFor(names: AgentSessionTableNames): string {
       `CREATE TABLE IF NOT EXISTS ${names.ownerEvents}`,
       `CREATE TABLE IF NOT EXISTS ${o}`,
     )
-    .replaceAll(`CREATE TABLE IF NOT EXISTS ${names.urls}`, `CREATE TABLE IF NOT EXISTS ${u}`);
+    .replaceAll(`CREATE TABLE IF NOT EXISTS ${names.urls}`, `CREATE TABLE IF NOT EXISTS ${u}`)
+    .replaceAll(OWNER_EVENT_TYPE_CONSTRAINT_V2_SENTINEL, OWNER_EVENT_TYPE_CONSTRAINT_V2);
 }
 
 /** Create all backend-owned tables when absent; existing schemas require migrations. */
@@ -499,7 +506,7 @@ export class PgAgentSessionStore
     return this.transaction(async (tx) => {
       const result = await tx.query<SessionRow>(
         `UPDATE ${this.table('sessions')}
-         SET title = $3, updated_at = now()
+         SET title = $3, updated_at = clock_timestamp()
          WHERE id = $1 AND owner_id = $2 AND deleted_at IS NULL
          RETURNING ${SESSION_COLUMNS}`,
         [sessionId, ownerId, title],

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -190,14 +190,6 @@ BEGIN
       AND conname = 'agent_owner_session_events_type_known_v2'
   ) THEN
     LOCK TABLE agent_owner_session_events IN ACCESS EXCLUSIVE MODE;
-    IF EXISTS (
-      SELECT 1 FROM pg_constraint
-      WHERE conrelid = 'agent_owner_session_events'::regclass
-        AND conname = 'agent_owner_session_events_type_known'::name
-    ) THEN
-      ALTER TABLE agent_owner_session_events
-        DROP CONSTRAINT agent_owner_session_events_type_known;
-    END IF;
     IF NOT EXISTS (
       SELECT 1 FROM pg_constraint
       WHERE conrelid = 'agent_owner_session_events'::regclass
@@ -206,11 +198,26 @@ BEGIN
       ALTER TABLE agent_owner_session_events
         ADD CONSTRAINT agent_owner_session_events_type_known_v2 CHECK (type IN
           ('session_created','session_status','session_deleted',
-           'session_active_stage','session_cancel_requested','session_title'));
+           'session_active_stage','session_cancel_requested','session_title'))
+        NOT VALID;
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'agent_owner_session_events'::regclass
+        AND conname = 'agent_owner_session_events_type_known'::name
+    ) THEN
+      ALTER TABLE agent_owner_session_events
+        DROP CONSTRAINT agent_owner_session_events_type_known;
     END IF;
   END IF;
 END
 $agent_session_owner_event_type_constraint$;
+
+-- Installing the superset above is a catalog-only operation while the short
+-- ACCESS EXCLUSIVE lock is held. Validate separately so PostgreSQL scans an
+-- existing projection table under VALIDATE CONSTRAINT's weaker lock instead.
+ALTER TABLE agent_owner_session_events
+  VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2;
 
 CREATE TABLE IF NOT EXISTS agent_session_urls (
   session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -216,8 +216,20 @@ $agent_session_owner_event_type_constraint$;
 -- Installing the superset above is a catalog-only operation while the short
 -- ACCESS EXCLUSIVE lock is held. Validate separately so PostgreSQL scans an
 -- existing projection table under VALIDATE CONSTRAINT's weaker lock instead.
-ALTER TABLE agent_owner_session_events
-  VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2;
+-- Once validated, later initializers avoid taking that table lock altogether.
+DO $agent_session_owner_event_type_validation$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'agent_owner_session_events'::regclass
+      AND conname = 'agent_owner_session_events_type_known_v2'
+      AND NOT convalidated
+  ) THEN
+    ALTER TABLE agent_owner_session_events
+      VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2;
+  END IF;
+END
+$agent_session_owner_event_type_validation$;
 
 CREATE TABLE IF NOT EXISTS agent_session_urls (
   session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
@@ -275,6 +287,9 @@ function schemaFor(names: AgentSessionTableNames): string {
     .replaceAll('agent_session_events', names.events)
     .replaceAll('agent_session_urls', names.urls)
     .replaceAll('agent_sessions', names.sessions)
+    .replaceAll(`'${names.ownerEvents}'::regclass`, `'${o}'::regclass`)
+    .replaceAll(`LOCK TABLE ${names.ownerEvents} IN`, `LOCK TABLE ${o} IN`)
+    .replaceAll(`ALTER TABLE ${names.ownerEvents}\n`, `ALTER TABLE ${o}\n`)
     .replaceAll(`REFERENCES ${names.sessions}`, `REFERENCES ${s}`)
     .replaceAll(`ON ${names.sessions}`, `ON ${s}`)
     .replaceAll(`ON ${names.entries}`, `ON ${t}`)
@@ -293,7 +308,13 @@ function schemaFor(names: AgentSessionTableNames): string {
     .replaceAll(OWNER_EVENT_TYPE_CONSTRAINT_V2_SENTINEL, OWNER_EVENT_TYPE_CONSTRAINT_V2);
 }
 
-/** Create all backend-owned tables when absent; existing schemas require migrations. */
+/**
+ * Create all backend-owned tables when absent and apply their additive migrations.
+ *
+ * Call this on a queryable that is not already inside an explicit transaction.
+ * The owner-event constraint install and validation are separate statements so
+ * the install's ACCESS EXCLUSIVE lock is released before validation scans data.
+ */
 export async function ensureAgentSessionSchema(
   queryable: Queryable,
   tableNames?: Partial<AgentSessionTableNames>,
@@ -522,7 +543,7 @@ export class PgAgentSessionStore
       if (!row) return null;
       const meta = sessionMeta(row);
       await this.appendProjection(
-        { type: 'session_title', sessionId, title, ts: meta.updatedAt },
+        { type: 'session_title', sessionId, title: meta.title ?? null, ts: meta.updatedAt },
         tx,
       );
       return meta;

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -426,6 +426,7 @@ export const OWNER_SESSION_EVENT_TYPES = [
   'session_status',
   'session_deleted',
   'session_cancel_requested',
+  'session_title',
 ] as const;
 
 export type OwnerSessionEventType = (typeof OWNER_SESSION_EVENT_TYPES)[number];
@@ -441,7 +442,8 @@ export type NewOwnerSessionEvent =
       status: AgentSessionStatus;
       attempt: number;
     })
-  | (OwnerSessionEventBase & { type: 'session_deleted' | 'session_cancel_requested' });
+  | (OwnerSessionEventBase & { type: 'session_deleted' | 'session_cancel_requested' })
+  | (OwnerSessionEventBase & { type: 'session_title'; title: string | null });
 
 export type PersistedOwnerSessionEvent = NewOwnerSessionEvent & {
   /** Decimal bigint text avoids rounding a replay cursor in JavaScript. */

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -78,6 +78,7 @@ export interface AgentSessionMeta {
   id: string;
   ownerId: string;
   prompt: string;
+  title?: string;
   /** The immutable stage with which the conversation was created. */
   stageId: string;
   skillId?: string;
@@ -339,6 +340,14 @@ export interface AgentSessionStore {
    * remain responsible for merging product tables outside this package.
    */
   mergeOwner(fromOwnerId: string, toOwnerId: string): Promise<number>;
+}
+
+export interface AgentSessionTitleStore {
+  setManualSessionTitle(
+    sessionId: string,
+    ownerId: string,
+    title: string | null,
+  ): Promise<AgentSessionMeta | null>;
 }
 
 export interface NewAgentSessionEvent {

--- a/packages/@openmaic/storage/src/index.ts
+++ b/packages/@openmaic/storage/src/index.ts
@@ -151,6 +151,7 @@ export {
   type AgentSessionMeta,
   type AgentSessionStatus,
   type AgentSessionStore,
+  type AgentSessionTitleStore,
   type AgentSessionTransaction,
   type AgentSessionUrlSource,
   type AgentSessionUrlStore,

--- a/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
@@ -166,8 +166,8 @@ describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
         ensureAgentSessionSchema(pool as Queryable, { ownerEvents }),
       ]);
       const readTypeConstraints = () =>
-        pool.query<{ oid: number; conname: string }>(
-          `SELECT oid, conname FROM pg_constraint
+        pool.query<{ oid: number; conname: string; convalidated: boolean }>(
+          `SELECT oid, conname, convalidated FROM pg_constraint
            WHERE conrelid = $1::regclass
              AND conname IN ($2::name, $3::name)
            ORDER BY conname`,
@@ -175,14 +175,18 @@ describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
         );
       const migrated = await readTypeConstraints();
       expect(migrated.rows).toEqual([
-        expect.objectContaining({ conname: currentConstraint, oid: expect.any(Number) }),
+        expect.objectContaining({
+          conname: currentConstraint,
+          convalidated: true,
+          oid: expect.any(Number),
+        }),
       ]);
       const constraintOid = migrated.rows[0]!.oid;
 
       await ensureAgentSessionSchema(pool as Queryable, { ownerEvents });
 
       await expect(readTypeConstraints()).resolves.toMatchObject({
-        rows: [{ oid: constraintOid, conname: currentConstraint }],
+        rows: [{ oid: constraintOid, conname: currentConstraint, convalidated: true }],
       });
     } finally {
       await pool.query(`DROP TABLE IF EXISTS ${ownerEvents}`);

--- a/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
@@ -12,7 +12,7 @@ import {
   truncateAgentSessionTables,
 } from './pg-agent-session-contract-helpers.js';
 import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
-import { runAgentSessionStoreContract } from './agent-session-contract.js';
+import { makeAgentSessionInput, runAgentSessionStoreContract } from './agent-session-contract.js';
 import { runAgentSessionUrlContract } from './agent-session-url-contract.js';
 
 const contractUrl = process.env.PG_CONTRACT_URL;
@@ -43,6 +43,23 @@ function transactionFor(pool: Pool): WithTransaction {
       client.release();
     }
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function waitForDatabaseMillisecondAfter(pool: Pool, timestamp: number): Promise<void> {
+  for (;;) {
+    const result = await pool.query<{ now_ms: string }>(
+      `SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint AS now_ms`,
+    );
+    if (Number(result.rows[0]!.now_ms) > timestamp) return;
+  }
 }
 
 describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
@@ -76,6 +93,101 @@ describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
     genuineConcurrency: true,
   });
   runAgentSessionUrlContract('PostgreSQL 16 (node-postgres)', () => store);
+
+  test('orders title projection timestamps by the actual locked update', async () => {
+    await store.createSession(makeAgentSessionInput());
+    const transactionStarted = deferred<number>();
+    const releaseTransaction = deferred<void>();
+    const delayedStore = new PgAgentSessionStore(pool as Queryable, {
+      withTransaction: async (body) => {
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+          const started = await client.query<{ started_ms: string }>(
+            `SELECT floor(extract(epoch FROM now()) * 1000)::bigint AS started_ms`,
+          );
+          transactionStarted.resolve(Number(started.rows[0]!.started_ms));
+          await releaseTransaction.promise;
+          const result = await body(client as Queryable);
+          await client.query('COMMIT');
+          return result;
+        } catch (error) {
+          await client.query('ROLLBACK').catch(() => {});
+          throw error;
+        } finally {
+          client.release();
+        }
+      },
+    });
+
+    const laterCommit = delayedStore.setManualSessionTitle('session-1', 'owner-a', 'Second commit');
+    const delayedTransactionStartedAt = await transactionStarted.promise;
+    await waitForDatabaseMillisecondAfter(pool, delayedTransactionStartedAt);
+    try {
+      await store.setManualSessionTitle('session-1', 'owner-a', 'First commit');
+    } finally {
+      releaseTransaction.resolve(undefined);
+    }
+    await laterCommit;
+
+    const titleEvents = (await store.readAfter('owner-a', BigInt(0))).filter(
+      (event) => event.type === 'session_title',
+    );
+    expect(titleEvents.map((event) => event.title)).toEqual(['First commit', 'Second commit']);
+    expect(titleEvents[1]!.ts).toBeGreaterThanOrEqual(titleEvents[0]!.ts);
+    await expect(store.getSession('session-1')).resolves.toMatchObject({ title: 'Second commit' });
+  });
+
+  test('upgrades a legacy owner-event constraint for a long custom table name once', async () => {
+    const ownerEvents = 'owner_events_with_a_very_long_custom_table_name_for_migration';
+    const legacyConstraint = `${ownerEvents}_type_known`;
+    const currentConstraint = 'agent_owner_session_events_type_known_v2';
+    await pool.query(`DROP TABLE IF EXISTS ${ownerEvents}`);
+    try {
+      await pool.query(`
+        CREATE TABLE ${ownerEvents} (
+          owner_id TEXT NOT NULL,
+          id BIGINT NOT NULL,
+          ts BIGINT NOT NULL,
+          session_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          status TEXT,
+          attempt INTEGER,
+          data JSONB NOT NULL,
+          PRIMARY KEY (owner_id, id),
+          CONSTRAINT ${legacyConstraint} CHECK (type IN
+            ('session_created','session_status','session_deleted',
+             'session_active_stage','session_cancel_requested'))
+        )
+      `);
+
+      await Promise.all([
+        ensureAgentSessionSchema(pool as Queryable, { ownerEvents }),
+        ensureAgentSessionSchema(pool as Queryable, { ownerEvents }),
+      ]);
+      const readTypeConstraints = () =>
+        pool.query<{ oid: number; conname: string }>(
+          `SELECT oid, conname FROM pg_constraint
+           WHERE conrelid = $1::regclass
+             AND conname IN ($2::name, $3::name)
+           ORDER BY conname`,
+          [ownerEvents, legacyConstraint, currentConstraint],
+        );
+      const migrated = await readTypeConstraints();
+      expect(migrated.rows).toEqual([
+        expect.objectContaining({ conname: currentConstraint, oid: expect.any(Number) }),
+      ]);
+      const constraintOid = migrated.rows[0]!.oid;
+
+      await ensureAgentSessionSchema(pool as Queryable, { ownerEvents });
+
+      await expect(readTypeConstraints()).resolves.toMatchObject({
+        rows: [{ oid: constraintOid, conname: currentConstraint }],
+      });
+    } finally {
+      await pool.query(`DROP TABLE IF EXISTS ${ownerEvents}`);
+    }
+  });
 
   test('beforeEach cleanup reaches FK-referencing tables the suite does not list', async () => {
     // Simulate the next store that references agent_sessions (the way the

--- a/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.pg.test.ts
@@ -193,6 +193,63 @@ describe.skipIf(!contractUrl)('PgAgentSessionStore with PostgreSQL 16', () => {
     }
   });
 
+  test('quotes a reserved custom owner-event table throughout its migration', async () => {
+    const ownerEvents = 'user';
+    const sessions = 'user_sessions';
+    await pool.query(`DROP TABLE IF EXISTS "${ownerEvents}"`);
+    await pool.query(`DROP TABLE IF EXISTS ${sessions}`);
+    try {
+      await pool.query(`
+        CREATE TABLE "${ownerEvents}" (
+          owner_id TEXT NOT NULL,
+          id BIGINT NOT NULL,
+          ts BIGINT NOT NULL,
+          session_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          status TEXT,
+          attempt INTEGER,
+          data JSONB NOT NULL,
+          PRIMARY KEY (owner_id, id),
+          CONSTRAINT user_type_known CHECK (type IN
+            ('session_created','session_status','session_deleted',
+             'session_active_stage','session_cancel_requested'))
+        )
+      `);
+
+      await ensureAgentSessionSchema(pool as Queryable, { ownerEvents, sessions });
+      await ensureAgentSessionSchema(pool as Queryable, { ownerEvents, sessions });
+
+      await expect(
+        pool.query<{ convalidated: boolean }>(
+          `SELECT convalidated FROM pg_constraint
+           WHERE conrelid = $1::regclass
+             AND conname = 'agent_owner_session_events_type_known_v2'`,
+          [`"${ownerEvents}"`],
+        ),
+      ).resolves.toMatchObject({ rows: [{ convalidated: true }] });
+    } finally {
+      await pool.query(`DROP TABLE IF EXISTS "${ownerEvents}"`);
+      await pool.query(`DROP TABLE IF EXISTS ${sessions}`);
+    }
+  });
+
+  test('skips the validation table lock once the v2 constraint is valid', async () => {
+    const blocker = await pool.connect();
+    const initializer = await pool.connect();
+    try {
+      await blocker.query('BEGIN');
+      await blocker.query('LOCK TABLE agent_owner_session_events IN SHARE MODE');
+      await initializer.query(`SET lock_timeout = '500ms'`);
+
+      await expect(ensureAgentSessionSchema(initializer as Queryable)).resolves.toBeUndefined();
+    } finally {
+      await initializer.query('RESET lock_timeout').catch(() => {});
+      initializer.release();
+      await blocker.query('ROLLBACK').catch(() => {});
+      blocker.release();
+    }
+  });
+
   test('beforeEach cleanup reaches FK-referencing tables the suite does not list', async () => {
     // Simulate the next store that references agent_sessions (the way the
     // material store did) without editing this suite: its table must be

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -13,6 +13,7 @@ import {
   AgentSessionLeaseLostError,
   AGENT_SESSION_LIFECYCLE,
 } from '../src/agent-session/types.js';
+import type { AgentSessionTitleStore } from '../src/index.js';
 import { runAgentSessionConcurrencyContract } from './agent-session-concurrency-contract.js';
 import { makeAgentSessionInput, runAgentSessionStoreContract } from './agent-session-contract.js';
 import { runAgentSessionUrlContract } from './agent-session-url-contract.js';
@@ -52,6 +53,106 @@ describe('PgAgentSessionStore with PGlite', () => {
     expect(result.rows.map((row) => row.table_name)).toEqual(
       Object.values(DEFAULT_AGENT_SESSION_TABLE_NAMES).sort(),
     );
+  });
+
+  test('persists a manual title in session detail and owner lists', async () => {
+    await store.createSession(makeAgentSessionInput());
+    await db.query(`UPDATE agent_sessions SET updated_at = '2000-01-01T00:00:00Z' WHERE id = $1`, [
+      'session-1',
+    ]);
+    const titles: AgentSessionTitleStore = store;
+
+    await expect(titles.setManualSessionTitle('session-1', 'owner-a', 'Focused question')).resolves.toMatchObject({
+      id: 'session-1',
+      title: 'Focused question',
+    });
+    await expect(store.getSession('session-1')).resolves.toMatchObject({
+      title: 'Focused question',
+      updatedAt: expect.any(Number),
+    });
+    expect((await store.getSession('session-1'))!.updatedAt).toBeGreaterThan(
+      new Date('2000-01-01T00:00:00Z').getTime(),
+    );
+    await expect(store.listSessionsByOwner('owner-a')).resolves.toMatchObject([
+      { id: 'session-1', title: 'Focused question' },
+    ]);
+  });
+
+  test('clears a manual title without emitting a null title field', async () => {
+    await store.createSession(makeAgentSessionInput());
+    const titles: AgentSessionTitleStore = store;
+    await titles.setManualSessionTitle('session-1', 'owner-a', 'Temporary title');
+
+    await expect(titles.setManualSessionTitle('session-1', 'owner-a', null)).resolves.toMatchObject({
+      id: 'session-1',
+    });
+    expect(await store.getSession('session-1')).not.toHaveProperty('title');
+    expect((await store.listSessionsByOwner('owner-a'))[0]).not.toHaveProperty('title');
+  });
+
+  test('does not set a title for another owner session', async () => {
+    await store.createSession(makeAgentSessionInput());
+    const titles: AgentSessionTitleStore = store;
+
+    await expect(titles.setManualSessionTitle('session-1', 'owner-b', 'Unauthorized')).resolves.toBeNull();
+    expect(await store.getSession('session-1')).not.toHaveProperty('title');
+  });
+
+  test('does not set a title for a soft-deleted session', async () => {
+    await store.createSession(makeAgentSessionInput());
+    const titles: AgentSessionTitleStore = store;
+    await store.softDeleteSession('session-1', 'owner-a');
+
+    await expect(titles.setManualSessionTitle('session-1', 'owner-a', 'Gone')).resolves.toBeNull();
+  });
+
+  test('upgrades an old session schema with existing data intact', async () => {
+    const legacyTables = { sessions: 'legacy_sessions' };
+    await db.query(`
+      CREATE TABLE legacy_sessions (
+        id TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        stage_id TEXT NOT NULL,
+        active_stage_id TEXT,
+        skill_id TEXT,
+        origin TEXT,
+        existing_course BOOLEAN NOT NULL DEFAULT FALSE,
+        status TEXT NOT NULL DEFAULT 'queued',
+        attempt INTEGER NOT NULL DEFAULT 0,
+        delivered_user_message_seq INTEGER NOT NULL DEFAULT 0,
+        lease_worker_id TEXT,
+        lease_worker_pid INTEGER,
+        lease_heartbeat_at BIGINT,
+        cancel_requested_at BIGINT,
+        error TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        deleted_at TIMESTAMPTZ
+      )
+    `);
+    await db.query(
+      `INSERT INTO legacy_sessions (id, owner_id, prompt, stage_id) VALUES ($1, $2, $3, $4)`,
+      ['legacy-1', 'owner-a', 'Existing prompt', 'stage-legacy'],
+    );
+
+    await ensureAgentSessionSchema(db, legacyTables);
+    const legacyStore = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      tableNames: legacyTables,
+    });
+
+    await expect(legacyStore.getSession('legacy-1')).resolves.toMatchObject({
+      id: 'legacy-1',
+      prompt: 'Existing prompt',
+    });
+    expect(await legacyStore.getSession('legacy-1')).not.toHaveProperty('title');
+    await expect(
+      db.query<{ is_nullable: string }>(
+        `SELECT is_nullable FROM information_schema.columns
+         WHERE table_name = 'legacy_sessions' AND column_name = 'title'`,
+      ),
+    ).resolves.toMatchObject({ rows: [{ is_nullable: 'YES' }] });
   });
 
   test('requires a correctly pinned transaction hook', () => {

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -225,6 +225,19 @@ describe('PgAgentSessionStore with PGlite', () => {
     const legacyTables = { ownerEvents: 'legacy_owner_events' };
     await expect(ensureAgentSessionSchema(db, legacyTables)).resolves.toBeUndefined();
     await expect(ensureAgentSessionSchema(db, legacyTables)).resolves.toBeUndefined();
+    const constraints = await db.query<{ conname: string; convalidated: boolean }>(
+      `SELECT conname, convalidated FROM pg_constraint
+       WHERE conrelid = 'legacy_owner_events'::regclass
+         AND conname IN ('legacy_owner_events_type_known'::name,
+                         'agent_owner_session_events_type_known_v2')
+       ORDER BY conname`,
+    );
+    expect(constraints.rows).toEqual([
+      {
+        conname: 'agent_owner_session_events_type_known_v2',
+        convalidated: true,
+      },
+    ]);
     await expect(
       db.query(
         `INSERT INTO legacy_owner_events

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -94,6 +94,49 @@ describe('PgAgentSessionStore with PGlite', () => {
     expect((await store.listSessionsByOwner('owner-a'))[0]).not.toHaveProperty('title');
   });
 
+  test('projects manual title changes, including clear, through owner replay', async () => {
+    await store.createSession(makeAgentSessionInput());
+    const titles: AgentSessionTitleStore = store;
+
+    await titles.setManualSessionTitle('session-1', 'owner-a', 'Focused question');
+    await titles.setManualSessionTitle('session-1', 'owner-a', null);
+
+    await expect(store.readAfter('owner-a', BigInt(1))).resolves.toMatchObject([
+      { type: 'session_title', sessionId: 'session-1', title: 'Focused question' },
+      { type: 'session_title', sessionId: 'session-1', title: null },
+    ]);
+    const stored = await db.query<{ data: unknown }>(
+      `SELECT data FROM agent_owner_session_events
+       WHERE owner_id = 'owner-a' AND type = 'session_title' ORDER BY id`,
+    );
+    expect(stored.rows).toEqual([
+      { data: { title: 'Focused question' } },
+      { data: { title: null } },
+    ]);
+  });
+
+  test('keeps a manual title when its owner projection fails', async () => {
+    const logged: unknown[] = [];
+    const titles = new PgAgentSessionStore(db, {
+      ...optionsFor(db),
+      logger: { error: (...args) => logged.push(args) },
+    });
+    await titles.createSession(makeAgentSessionInput());
+    await db.query(
+      `ALTER TABLE agent_owner_session_events
+       ADD CONSTRAINT reject_title_projection CHECK (type <> 'session_title')`,
+    );
+
+    await expect(
+      titles.setManualSessionTitle('session-1', 'owner-a', 'Still committed'),
+    ).resolves.toMatchObject({ title: 'Still committed' });
+    await expect(titles.getSession('session-1')).resolves.toMatchObject({
+      title: 'Still committed',
+    });
+    expect(await titles.readMaxId('owner-a')).toBe(BigInt(1));
+    expect(logged).toHaveLength(1);
+  });
+
   test('does not set a title for another owner session', async () => {
     await store.createSession(makeAgentSessionInput());
     const titles: AgentSessionTitleStore = store;
@@ -159,6 +202,44 @@ describe('PgAgentSessionStore with PGlite', () => {
          WHERE table_name = 'legacy_sessions' AND column_name = 'title'`,
       ),
     ).resolves.toMatchObject({ rows: [{ is_nullable: 'YES' }] });
+  });
+
+  test('upgrades the closed owner-event constraint for custom table names idempotently', async () => {
+    await db.query(`
+      CREATE TABLE legacy_owner_events (
+        owner_id TEXT NOT NULL,
+        id BIGINT NOT NULL,
+        ts BIGINT NOT NULL,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        status TEXT,
+        attempt INTEGER,
+        data JSONB NOT NULL,
+        PRIMARY KEY (owner_id, id),
+        CONSTRAINT legacy_owner_events_type_known CHECK (type IN
+          ('session_created','session_status','session_deleted',
+           'session_active_stage','session_cancel_requested'))
+      )
+    `);
+
+    const legacyTables = { ownerEvents: 'legacy_owner_events' };
+    await expect(ensureAgentSessionSchema(db, legacyTables)).resolves.toBeUndefined();
+    await expect(ensureAgentSessionSchema(db, legacyTables)).resolves.toBeUndefined();
+    await expect(
+      db.query(
+        `INSERT INTO legacy_owner_events
+           (owner_id, id, ts, session_id, type, status, attempt, data)
+         VALUES ('owner-a', 1, 1, 'session-1', 'session_title', NULL, NULL,
+                 '{"title":"Migrated"}'::jsonb)`,
+      ),
+    ).resolves.toBeDefined();
+    await expect(
+      db.query(
+        `INSERT INTO legacy_owner_events
+           (owner_id, id, ts, session_id, type, status, attempt, data)
+         VALUES ('owner-a', 2, 1, 'session-1', 'session_retry', NULL, NULL, '{}'::jsonb)`,
+      ),
+    ).rejects.toThrow();
   });
 
   test('requires a correctly pinned transaction hook', () => {

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -68,13 +68,12 @@ describe('PgAgentSessionStore with PGlite', () => {
       id: 'session-1',
       title: 'Focused question',
     });
-    await expect(store.getSession('session-1')).resolves.toMatchObject({
+    const detail = await store.getSession('session-1');
+    expect(detail).toMatchObject({
       title: 'Focused question',
       updatedAt: expect.any(Number),
     });
-    expect((await store.getSession('session-1'))!.updatedAt).toBeGreaterThan(
-      new Date('2000-01-01T00:00:00Z').getTime(),
-    );
+    expect(detail!.updatedAt).toBeGreaterThan(new Date('2000-01-01T00:00:00Z').getTime());
     await expect(store.listSessionsByOwner('owner-a')).resolves.toMatchObject([
       { id: 'session-1', title: 'Focused question' },
     ]);
@@ -191,11 +190,12 @@ describe('PgAgentSessionStore with PGlite', () => {
       tableNames: legacyTables,
     });
 
-    await expect(legacyStore.getSession('legacy-1')).resolves.toMatchObject({
+    const detail = await legacyStore.getSession('legacy-1');
+    expect(detail).toMatchObject({
       id: 'legacy-1',
       prompt: 'Existing prompt',
     });
-    expect(await legacyStore.getSession('legacy-1')).not.toHaveProperty('title');
+    expect(detail).not.toHaveProperty('title');
     await expect(
       db.query<{ is_nullable: string }>(
         `SELECT is_nullable FROM information_schema.columns
@@ -253,6 +253,36 @@ describe('PgAgentSessionStore with PGlite', () => {
          VALUES ('owner-a', 2, 1, 'session-1', 'session_retry', NULL, NULL, '{}'::jsonb)`,
       ),
     ).rejects.toThrow();
+  });
+
+  test('quotes a reserved custom owner-event table throughout its migration', async () => {
+    await db.query(`
+      CREATE TABLE "user" (
+        owner_id TEXT NOT NULL,
+        id BIGINT NOT NULL,
+        ts BIGINT NOT NULL,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        status TEXT,
+        attempt INTEGER,
+        data JSONB NOT NULL,
+        PRIMARY KEY (owner_id, id),
+        CONSTRAINT user_type_known CHECK (type IN
+          ('session_created','session_status','session_deleted',
+           'session_active_stage','session_cancel_requested'))
+      )
+    `);
+
+    const custom = { ownerEvents: 'user', sessions: 'user_sessions' };
+    await expect(ensureAgentSessionSchema(db, custom)).resolves.toBeUndefined();
+    await expect(ensureAgentSessionSchema(db, custom)).resolves.toBeUndefined();
+    await expect(
+      db.query<{ convalidated: boolean }>(
+        `SELECT convalidated FROM pg_constraint
+         WHERE conrelid = '"user"'::regclass
+           AND conname = 'agent_owner_session_events_type_known_v2'`,
+      ),
+    ).resolves.toMatchObject({ rows: [{ convalidated: true }] });
   });
 
   test('requires a correctly pinned transaction hook', () => {

--- a/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
+++ b/packages/@openmaic/storage/test/pg-agent-session-store.test.ts
@@ -62,7 +62,9 @@ describe('PgAgentSessionStore with PGlite', () => {
     ]);
     const titles: AgentSessionTitleStore = store;
 
-    await expect(titles.setManualSessionTitle('session-1', 'owner-a', 'Focused question')).resolves.toMatchObject({
+    await expect(
+      titles.setManualSessionTitle('session-1', 'owner-a', 'Focused question'),
+    ).resolves.toMatchObject({
       id: 'session-1',
       title: 'Focused question',
     });
@@ -83,9 +85,11 @@ describe('PgAgentSessionStore with PGlite', () => {
     const titles: AgentSessionTitleStore = store;
     await titles.setManualSessionTitle('session-1', 'owner-a', 'Temporary title');
 
-    await expect(titles.setManualSessionTitle('session-1', 'owner-a', null)).resolves.toMatchObject({
-      id: 'session-1',
-    });
+    await expect(titles.setManualSessionTitle('session-1', 'owner-a', null)).resolves.toMatchObject(
+      {
+        id: 'session-1',
+      },
+    );
     expect(await store.getSession('session-1')).not.toHaveProperty('title');
     expect((await store.listSessionsByOwner('owner-a'))[0]).not.toHaveProperty('title');
   });
@@ -94,7 +98,9 @@ describe('PgAgentSessionStore with PGlite', () => {
     await store.createSession(makeAgentSessionInput());
     const titles: AgentSessionTitleStore = store;
 
-    await expect(titles.setManualSessionTitle('session-1', 'owner-b', 'Unauthorized')).resolves.toBeNull();
+    await expect(
+      titles.setManualSessionTitle('session-1', 'owner-b', 'Unauthorized'),
+    ).resolves.toBeNull();
     expect(await store.getSession('session-1')).not.toHaveProperty('title');
   });
 

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -325,14 +325,48 @@ CREATE TABLE IF NOT EXISTS agent_owner_session_events (
   attempt    INTEGER,
   data       JSONB NOT NULL,
   PRIMARY KEY (owner_id, id),
-  CONSTRAINT agent_owner_session_events_type_known CHECK (type IN
+  CONSTRAINT agent_owner_session_events_type_known_v2 CHECK (type IN
     ('session_created','session_status','session_deleted',
-     'session_active_stage','session_cancel_requested')),
+     'session_active_stage','session_cancel_requested','session_title')),
   CONSTRAINT agent_owner_session_events_status_known CHECK (status IS NULL OR status IN
     ('queued','running','succeeded','failed','cancelled')),
   CONSTRAINT agent_owner_session_events_attempt_nonnegative
     CHECK (attempt IS NULL OR attempt >= 0)
 );
+
+DO $agent_session_owner_event_type_constraint$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'agent_owner_session_events'::regclass
+      AND conname = 'agent_owner_session_events_type_known'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'agent_owner_session_events'::regclass
+      AND conname = 'agent_owner_session_events_type_known_v2'
+  ) THEN
+    LOCK TABLE agent_owner_session_events IN ACCESS EXCLUSIVE MODE;
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'agent_owner_session_events'::regclass
+        AND conname = 'agent_owner_session_events_type_known'
+    ) THEN
+      ALTER TABLE agent_owner_session_events
+        DROP CONSTRAINT agent_owner_session_events_type_known;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'agent_owner_session_events'::regclass
+        AND conname = 'agent_owner_session_events_type_known_v2'
+    ) THEN
+      ALTER TABLE agent_owner_session_events
+        ADD CONSTRAINT agent_owner_session_events_type_known_v2 CHECK (type IN
+          ('session_created','session_status','session_deleted',
+           'session_active_stage','session_cancel_requested','session_title'));
+    END IF;
+  END IF;
+END
+$agent_session_owner_event_type_constraint$;
 
 CREATE TABLE IF NOT EXISTS agent_session_urls (
   session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
@@ -499,9 +533,14 @@ describe.each(schemas)('$name is a pinned contract', ({ name, actual, expected, 
       // The splitter keeps leading `--` comment lines attached to the
       // statement that follows them; strip them before judging the DDL.
       const sql = statement.replace(/^(--[^\n]*\n?)+/, '').trim();
+      const localConstraintMigration =
+        /^DO \$agent_session_[a-z_]+_constraint\$/.test(sql) &&
+        /LOCK TABLE [a-z_]+ IN ACCESS EXCLUSIVE MODE/.test(sql) &&
+        /IF NOT EXISTS/.test(sql);
       expect(
         /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(sql) ||
           /^ALTER TABLE [a-z_]+\s+ADD COLUMN IF NOT EXISTS /.test(sql) ||
+          localConstraintMigration ||
           /^CREATE OR REPLACE FUNCTION /.test(sql) ||
           /^DROP TRIGGER IF EXISTS /.test(sql) ||
           // CREATE TRIGGER is made idempotent by the paired DROP TRIGGER IF

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -245,6 +245,7 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
   id                  TEXT PRIMARY KEY,
   owner_id            TEXT NOT NULL,
   prompt              TEXT NOT NULL,
+  title               TEXT,
   stage_id            TEXT NOT NULL,
   active_stage_id     TEXT,
   skill_id            TEXT,
@@ -268,6 +269,9 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
 
 ALTER TABLE agent_sessions
   ADD COLUMN IF NOT EXISTS delivered_user_message_seq INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE agent_sessions
+  ADD COLUMN IF NOT EXISTS title TEXT;
 
 CREATE INDEX IF NOT EXISTS agent_sessions_status_live_idx
   ON agent_sessions (status, created_at) WHERE deleted_at IS NULL;

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -346,14 +346,6 @@ BEGIN
       AND conname = 'agent_owner_session_events_type_known_v2'
   ) THEN
     LOCK TABLE agent_owner_session_events IN ACCESS EXCLUSIVE MODE;
-    IF EXISTS (
-      SELECT 1 FROM pg_constraint
-      WHERE conrelid = 'agent_owner_session_events'::regclass
-        AND conname = 'agent_owner_session_events_type_known'::name
-    ) THEN
-      ALTER TABLE agent_owner_session_events
-        DROP CONSTRAINT agent_owner_session_events_type_known;
-    END IF;
     IF NOT EXISTS (
       SELECT 1 FROM pg_constraint
       WHERE conrelid = 'agent_owner_session_events'::regclass
@@ -362,11 +354,26 @@ BEGIN
       ALTER TABLE agent_owner_session_events
         ADD CONSTRAINT agent_owner_session_events_type_known_v2 CHECK (type IN
           ('session_created','session_status','session_deleted',
-           'session_active_stage','session_cancel_requested','session_title'));
+           'session_active_stage','session_cancel_requested','session_title'))
+        NOT VALID;
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'agent_owner_session_events'::regclass
+        AND conname = 'agent_owner_session_events_type_known'::name
+    ) THEN
+      ALTER TABLE agent_owner_session_events
+        DROP CONSTRAINT agent_owner_session_events_type_known;
     END IF;
   END IF;
 END
 $agent_session_owner_event_type_constraint$;
+
+-- Installing the superset above is a catalog-only operation while the short
+-- ACCESS EXCLUSIVE lock is held. Validate separately so PostgreSQL scans an
+-- existing projection table under VALIDATE CONSTRAINT's weaker lock instead.
+ALTER TABLE agent_owner_session_events
+  VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2;
 
 CREATE TABLE IF NOT EXISTS agent_session_urls (
   session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
@@ -465,6 +472,33 @@ function statementsOf(schema: string): string[] {
   return splitSqlStatements(schema);
 }
 
+describe('agent-session owner-event constraint migration', () => {
+  it('installs the v2 constraint without a locked scan, then validates it separately', () => {
+    const statements = statementsOf(AGENT_SESSION_PG_SCHEMA);
+    const installIndex = statements.findIndex((statement) =>
+      statement.includes('$agent_session_owner_event_type_constraint$'),
+    );
+    const validationIndex = statements.findIndex((statement) =>
+      /ALTER TABLE agent_owner_session_events\s+VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2/.test(
+        statement,
+      ),
+    );
+    const install = statements[installIndex] ?? '';
+    const addIndex = install.indexOf('ADD CONSTRAINT agent_owner_session_events_type_known_v2');
+    const notValidIndex = install.indexOf('NOT VALID', addIndex);
+    const dropIndex = install.indexOf(
+      'DROP CONSTRAINT agent_owner_session_events_type_known',
+      addIndex,
+    );
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(addIndex).toBeGreaterThanOrEqual(0);
+    expect(notValidIndex).toBeGreaterThan(addIndex);
+    expect(dropIndex).toBeGreaterThan(notValidIndex);
+    expect(validationIndex).toBeGreaterThan(installIndex);
+  });
+});
+
 const schemas = [
   {
     name: 'DOCUMENT_PG_SCHEMA',
@@ -532,15 +566,22 @@ describe.each(schemas)('$name is a pinned contract', ({ name, actual, expected, 
     for (const statement of statements) {
       // The splitter keeps leading `--` comment lines attached to the
       // statement that follows them; strip them before judging the DDL.
-      const sql = statement.replace(/^(--[^\n]*\n?)+/, '').trim();
+      const sql = statement
+        .trim()
+        .replace(/^(--[^\n]*\n?)+/, '')
+        .trim();
       const localConstraintMigration =
         /^DO \$agent_session_[a-z_]+_constraint\$/.test(sql) &&
-        /LOCK TABLE [a-z_]+ IN ACCESS EXCLUSIVE MODE/.test(sql) &&
+        /LOCK TABLE [a-z0-9_]+ IN ACCESS EXCLUSIVE MODE/.test(sql) &&
         /IF NOT EXISTS/.test(sql);
+      const constraintValidation = /^ALTER TABLE [a-z0-9_]+\s+VALIDATE CONSTRAINT [a-z0-9_]+$/.test(
+        sql,
+      );
       expect(
         /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(sql) ||
           /^ALTER TABLE [a-z_]+\s+ADD COLUMN IF NOT EXISTS /.test(sql) ||
           localConstraintMigration ||
+          constraintValidation ||
           /^CREATE OR REPLACE FUNCTION /.test(sql) ||
           /^DROP TRIGGER IF EXISTS /.test(sql) ||
           // CREATE TRIGGER is made idempotent by the paired DROP TRIGGER IF

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -372,8 +372,20 @@ $agent_session_owner_event_type_constraint$;
 -- Installing the superset above is a catalog-only operation while the short
 -- ACCESS EXCLUSIVE lock is held. Validate separately so PostgreSQL scans an
 -- existing projection table under VALIDATE CONSTRAINT's weaker lock instead.
-ALTER TABLE agent_owner_session_events
-  VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2;
+-- Once validated, later initializers avoid taking that table lock altogether.
+DO $agent_session_owner_event_type_validation$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'agent_owner_session_events'::regclass
+      AND conname = 'agent_owner_session_events_type_known_v2'
+      AND NOT convalidated
+  ) THEN
+    ALTER TABLE agent_owner_session_events
+      VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2;
+  END IF;
+END
+$agent_session_owner_event_type_validation$;
 
 CREATE TABLE IF NOT EXISTS agent_session_urls (
   session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
@@ -473,17 +485,16 @@ function statementsOf(schema: string): string[] {
 }
 
 describe('agent-session owner-event constraint migration', () => {
-  it('installs the v2 constraint without a locked scan, then validates it separately', () => {
+  it('installs without a locked scan, then conditionally validates in a separate statement', () => {
     const statements = statementsOf(AGENT_SESSION_PG_SCHEMA);
     const installIndex = statements.findIndex((statement) =>
       statement.includes('$agent_session_owner_event_type_constraint$'),
     );
     const validationIndex = statements.findIndex((statement) =>
-      /ALTER TABLE agent_owner_session_events\s+VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2/.test(
-        statement,
-      ),
+      statement.includes('$agent_session_owner_event_type_validation$'),
     );
     const install = statements[installIndex] ?? '';
+    const validation = statements[validationIndex] ?? '';
     const addIndex = install.indexOf('ADD CONSTRAINT agent_owner_session_events_type_known_v2');
     const notValidIndex = install.indexOf('NOT VALID', addIndex);
     const dropIndex = install.indexOf(
@@ -496,6 +507,10 @@ describe('agent-session owner-event constraint migration', () => {
     expect(notValidIndex).toBeGreaterThan(addIndex);
     expect(dropIndex).toBeGreaterThan(notValidIndex);
     expect(validationIndex).toBeGreaterThan(installIndex);
+    expect(validation).toContain('AND NOT convalidated');
+    expect(validation).toMatch(
+      /ALTER TABLE agent_owner_session_events\s+VALIDATE CONSTRAINT agent_owner_session_events_type_known_v2/,
+    );
   });
 });
 
@@ -574,9 +589,10 @@ describe.each(schemas)('$name is a pinned contract', ({ name, actual, expected, 
         /^DO \$agent_session_[a-z_]+_constraint\$/.test(sql) &&
         /LOCK TABLE [a-z0-9_]+ IN ACCESS EXCLUSIVE MODE/.test(sql) &&
         /IF NOT EXISTS/.test(sql);
-      const constraintValidation = /^ALTER TABLE [a-z0-9_]+\s+VALIDATE CONSTRAINT [a-z0-9_]+$/.test(
-        sql,
-      );
+      const constraintValidation =
+        /^DO \$agent_session_[a-z_]+_validation\$/.test(sql) &&
+        /AND NOT convalidated/.test(sql) &&
+        /VALIDATE CONSTRAINT [a-z0-9_]+/.test(sql);
       expect(
         /^CREATE (TABLE|INDEX|UNIQUE INDEX) IF NOT EXISTS /.test(sql) ||
           /^ALTER TABLE [a-z_]+\s+ADD COLUMN IF NOT EXISTS /.test(sql) ||

--- a/packages/@openmaic/storage/test/pg-schema-contract.test.ts
+++ b/packages/@openmaic/storage/test/pg-schema-contract.test.ts
@@ -339,7 +339,7 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM pg_constraint
     WHERE conrelid = 'agent_owner_session_events'::regclass
-      AND conname = 'agent_owner_session_events_type_known'
+      AND conname = 'agent_owner_session_events_type_known'::name
   ) OR NOT EXISTS (
     SELECT 1 FROM pg_constraint
     WHERE conrelid = 'agent_owner_session_events'::regclass
@@ -349,7 +349,7 @@ BEGIN
     IF EXISTS (
       SELECT 1 FROM pg_constraint
       WHERE conrelid = 'agent_owner_session_events'::regclass
-        AND conname = 'agent_owner_session_events_type_known'
+        AND conname = 'agent_owner_session_events_type_known'::name
     ) THEN
       ALTER TABLE agent_owner_session_events
         DROP CONSTRAINT agent_owner_session_events_type_known;

--- a/tests/agent-runtime/session-detail-route.test.ts
+++ b/tests/agent-runtime/session-detail-route.test.ts
@@ -1,20 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
-const mocks = vi.hoisted(() => ({ getSession: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  runtimeEnabled: true,
+  getSession: vi.fn(),
+  setManualSessionTitle: vi.fn(),
+}));
 
 vi.mock('@/lib/config/feature-flags', () => ({
-  isAgentRuntimeEnabled: () => true,
-  isAgentRuntimeConfigured: () => true,
+  isAgentRuntimeEnabled: () => mocks.runtimeEnabled,
+  isAgentRuntimeConfigured: () => mocks.runtimeEnabled,
 }));
 vi.mock('@/lib/server/agent-runtime/owner', () => ({
-  resolveRequestOwnerId: () => 'owner-1',
+  resolveRequestOwnerId: (_request: NextRequest, headers: Headers) => {
+    headers.append('Set-Cookie', 'anonymous_id=test; Path=/; HttpOnly');
+    return 'owner-1';
+  },
 }));
 vi.mock('@/lib/server/agent-runtime/store', () => ({
-  getAgentSessionStore: async () => ({ getSession: mocks.getSession }),
+  getAgentSessionStore: async () => ({
+    getSession: mocks.getSession,
+    setManualSessionTitle: mocks.setManualSessionTitle,
+  }),
 }));
 
-import { GET } from '@/app/api/agent/sessions/[id]/route';
+import { GET, PATCH } from '@/app/api/agent/sessions/[id]/route';
 
 function call() {
   return GET(new NextRequest('http://localhost/api/agent/sessions/session-1'), {
@@ -22,9 +32,24 @@ function call() {
   });
 }
 
+function patch(body: BodyInit, id = 'session-1') {
+  return PATCH(
+    new NextRequest(`http://localhost/api/agent/sessions/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body,
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.runtimeEnabled = true;
   mocks.getSession.mockResolvedValue({ id: 'session-1', ownerId: 'owner-1', status: 'running' });
+  mocks.setManualSessionTitle.mockImplementation(
+    async (id: string, ownerId: string, title: string | null) => ({ id, ownerId, title }),
+  );
 });
 
 describe('GET one agent session', () => {
@@ -52,4 +77,57 @@ describe('GET one agent session', () => {
       expect(response.status).toBe(404);
     },
   );
+});
+
+describe('PATCH agent session title', () => {
+  it('returns the persisted normalized title for its owner', async () => {
+    const response = await patch(JSON.stringify({ title: '  Focused question  ' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+    await expect(response.json()).resolves.toEqual({ title: 'Focused question' });
+  });
+
+  it.each([null, '   '])('clears a title when it receives %j', async (title) => {
+    const response = await patch(JSON.stringify({ title }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ title: null });
+  });
+
+  it('trims before applying the 120-character title limit', async () => {
+    const response = await patch(JSON.stringify({ title: `  ${'x'.repeat(121)}  ` }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ title: 'x'.repeat(120) });
+  });
+
+  it.each([
+    ['malformed JSON', '{'],
+    ['a missing title', JSON.stringify({})],
+    ['a numeric title', JSON.stringify({ title: 42 })],
+    ['an object title', JSON.stringify({ title: { value: 'nope' } })],
+  ])('rejects %s', async (_name, body) => {
+    const response = await patch(body);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+  });
+
+  it('stays behind the runtime feature gate', async () => {
+    mocks.runtimeEnabled = false;
+
+    const response = await patch(JSON.stringify({ title: 'Hidden' }));
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+  });
+
+  it.each(['missing', 'foreign', 'deleted'])('hides a %s session as not found', async () => {
+    mocks.setManualSessionTitle.mockResolvedValue(null);
+
+    const response = await patch(JSON.stringify({ title: 'Hidden' }));
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+  });
 });

--- a/tests/agent-runtime/session-detail-route.test.ts
+++ b/tests/agent-runtime/session-detail-route.test.ts
@@ -122,7 +122,7 @@ describe('PATCH agent session title', () => {
     expect(await response.text()).toBe('Not found');
   });
 
-  it.each(['missing', 'foreign', 'deleted'])('hides a %s session as not found', async () => {
+  it('hides any session rejected by the owner-scoped store as not found', async () => {
     mocks.setManualSessionTitle.mockResolvedValue(null);
 
     const response = await patch(JSON.stringify({ title: 'Hidden' }));

--- a/tests/agent-runtime/session-detail-route.test.ts
+++ b/tests/agent-runtime/session-detail-route.test.ts
@@ -80,26 +80,21 @@ describe('GET one agent session', () => {
 });
 
 describe('PATCH agent session title', () => {
-  it('returns the persisted normalized title for its owner', async () => {
-    const response = await patch(JSON.stringify({ title: '  Focused question  ' }));
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
-    await expect(response.json()).resolves.toEqual({ title: 'Focused question' });
-  });
-
-  it.each([null, '   '])('clears a title when it receives %j', async (title) => {
+  it.each([
+    ['trim', '  Focused question  ', 'Focused question'],
+    ['explicit clear', null, null],
+    ['blank clear', '   ', null],
+    ['length cap', `  ${'x'.repeat(121)}  `, 'x'.repeat(120)],
+    ['surrogate-pair boundary', `${'x'.repeat(119)}😀tail`, 'x'.repeat(119)],
+    ['unpaired surrogate', `Safe\ud83d title`, 'Safe� title'],
+    ['NUL', `Safe\u0000 title`, 'Safe� title'],
+  ])('normalizes %s before persisting', async (_name, title, expected) => {
     const response = await patch(JSON.stringify({ title }));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ title: null });
-  });
-
-  it('trims before applying the 120-character title limit', async () => {
-    const response = await patch(JSON.stringify({ title: `  ${'x'.repeat(121)}  ` }));
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ title: 'x'.repeat(120) });
+    expect(response.headers.get('set-cookie')).toContain('anonymous_id=test');
+    expect(mocks.setManualSessionTitle).toHaveBeenCalledWith('session-1', 'owner-1', expected);
+    await expect(response.json()).resolves.toEqual({ title: expected });
   });
 
   it.each([

--- a/tests/workbench/draft-conversation-reset.test.ts
+++ b/tests/workbench/draft-conversation-reset.test.ts
@@ -127,6 +127,7 @@ function driveARunningSession(): void {
   // non-vacuous while still exercising the historical stage-link baseline.
   store.setReplaying(true);
   store.setSessionBootstrap({ prompt: '给我做一门光的折射', title: '光的折射课' });
+  store.setSessionTitle('光的折射课');
   store.setAttached(true);
   store.setError('stream hiccup');
   store.setPlaybackOn(true);

--- a/tests/workbench/owner-session-client.test.ts
+++ b/tests/workbench/owner-session-client.test.ts
@@ -51,16 +51,51 @@ function row(status: ProHomeSessionItem['status'], updatedAt: number): ProHomeSe
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function emitTitle(
+  source: FakeEventSource,
+  {
+    title,
+    id = '40',
+    sessionId = 'session-1',
+    ts = 500,
+    phase = 'live',
+  }: {
+    title: string | null;
+    id?: string;
+    sessionId?: string;
+    ts?: number;
+    phase?: 'live' | 'backlog';
+  },
+): void {
+  source.emit('session_title', { id, sessionId, ts, phase, type: 'session_title', title });
+}
+
+function titleClient(fetchSessions: () => Promise<ProHomeSessionItem[]>) {
+  const source = new FakeEventSource();
+  const updates: (readonly ProHomeSessionItem[])[] = [];
+  const onSessionTitle = vi.fn();
+  const client = new OwnerSessionClient({
+    fetchSessions,
+    createEventSource: () => source,
+    onSessions: (sessions) => updates.push(sessions),
+    onSessionTitle,
+    onState: vi.fn(),
+  });
+  return { client, source, updates, onSessionTitle };
 }
 
 afterEach(() => {
@@ -92,11 +127,7 @@ describe('owner session client', () => {
     client.stop();
   });
 
-  it.each([
-    { name: 'pending rename', title: 'Local title', settled: false },
-    { name: 'pending clear', title: null, settled: false },
-    { name: 'settled rename awaiting confirmation', title: 'Stored title', settled: true },
-  ])('exposes an unconfirmed $name without confusing clear with absence', ({ title, settled }) => {
+  it('exposes an unconfirmed clear without confusing it with absence', () => {
     const client = new OwnerSessionClient({
       fetchSessions: vi.fn(async () => []),
       createEventSource: () => new FakeEventSource(),
@@ -105,8 +136,8 @@ describe('owner session client', () => {
     });
 
     expect(client.getUnconfirmedSessionTitle('session-1')).toBeNull();
-    client.updateSessionTitle('session-1', title, settled);
-    expect(client.getUnconfirmedSessionTitle('session-1')).toEqual({ title });
+    client.updateSessionTitle('session-1', null, false);
+    expect(client.getUnconfirmedSessionTitle('session-1')).toEqual({ title: null });
   });
 
   it.each([
@@ -144,41 +175,28 @@ describe('owner session client', () => {
     },
   );
 
-  it.each([
-    { name: 'rename', local: 'Local title' },
-    { name: 'clear', local: null },
-  ])(
-    'keeps a pending local $name over a snapshot that read before its PATCH committed',
-    async ({ local }) => {
-      const reconciliation = deferred<ProHomeSessionItem[]>();
-      const fetchSessions = vi
-        .fn<() => Promise<ProHomeSessionItem[]>>()
-        .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
-        .mockReturnValueOnce(reconciliation.promise);
-      const updates: (readonly ProHomeSessionItem[])[] = [];
-      const client = new OwnerSessionClient({
-        fetchSessions,
-        createEventSource: () => new FakeEventSource(),
-        onSessions: (sessions) => updates.push(sessions),
-        onState: vi.fn(),
-      });
+  it('keeps a pending title over a snapshot started before its PATCH settled', async () => {
+    const snapshot = deferred<ProHomeSessionItem[]>();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
+      .mockReturnValueOnce(snapshot.promise);
+    const { client, updates } = titleClient(fetchSessions);
 
-      client.start();
-      await flushPromises();
-      const revision = client.updateSessionTitle('session-1', local, false);
-      client.requestFullFetch();
-      reconciliation.resolve([{ ...row('succeeded', 200), title: 'Old title' }]);
-      await flushPromises();
+    client.start();
+    await flushPromises();
+    const revision = client.updateSessionTitle('session-1', 'Pending title', false);
+    client.requestFullFetch();
+    snapshot.resolve([{ ...row('succeeded', 200), title: 'Snapshot title' }]);
+    await flushPromises();
 
-      expect(updates.at(-1)?.[0]?.title).toBe(local);
-      expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
-      client.stop();
-    },
-  );
+    expect(updates.at(-1)?.[0]?.title).toBe('Pending title');
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
+    client.stop();
+  });
 
   it.each([
     { name: 'different title', local: 'Local title', snapshot: 'Other tab title' },
-    { name: 'equal title', local: 'Local title', snapshot: 'Local title' },
     { name: 'equal clear', local: null, snapshot: null },
   ])(
     'lets a snapshot begun after a settled $name become authoritative',
@@ -209,6 +227,29 @@ describe('owner session client', () => {
       client.stop();
     },
   );
+
+  it('retires a settled title when an authoritative snapshot omits the session', async () => {
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
+      .mockResolvedValueOnce([]);
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => new FakeEventSource(),
+      onSessions: vi.fn(),
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    const revision = client.updateSessionTitle('session-1', 'Stored title', true);
+    client.requestFullFetch();
+    await flushPromises();
+
+    expect(client.getUnconfirmedSessionTitle('session-1')).toBeNull();
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
+    client.stop();
+  });
 
   it('keeps the settled result over a snapshot that began while its PATCH was pending', async () => {
     const reconciliation = deferred<ProHomeSessionItem[]>();
@@ -289,28 +330,12 @@ describe('owner session client', () => {
       .fn<() => Promise<ProHomeSessionItem[]>>()
       .mockResolvedValueOnce([{ ...row('running', 150), title: 'Before' }])
       .mockReturnValueOnce(slowReconciliation.promise);
-    const source = new FakeEventSource();
-    const updates: (readonly ProHomeSessionItem[])[] = [];
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions,
-      createEventSource: () => source,
-      onSessions: (sessions) => updates.push(sessions),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const { client, source, updates, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
     client.requestFullFetch();
-    source.emit('session_title', {
-      id: '90071992547409932',
-      sessionId: 'session-1',
-      ts: 500,
-      phase: 'live',
-      type: 'session_title',
-      title: 'Newest title',
-    });
+    emitTitle(source, { id: '90071992547409932', title: 'Newest title' });
     slowReconciliation.resolve([{ ...row('running', 200), title: 'Stale snapshot' }]);
     await flushPromises();
 
@@ -320,19 +345,11 @@ describe('owner session client', () => {
   });
 
   it('accepts a title event after a snapshot confirms the local decision', async () => {
-    const source = new FakeEventSource();
-    const updates: (readonly ProHomeSessionItem[])[] = [];
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions: vi
-        .fn<() => Promise<ProHomeSessionItem[]>>()
-        .mockResolvedValueOnce([{ ...row('running', 150), title: 'Before' }])
-        .mockResolvedValueOnce([{ ...row('running', 400), title: 'Local title' }]),
-      createEventSource: () => source,
-      onSessions: (sessions) => updates.push(sessions),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('running', 150), title: 'Before' }])
+      .mockResolvedValueOnce([{ ...row('running', 400), title: 'Local title' }]);
+    const { client, source, updates, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
@@ -342,14 +359,7 @@ describe('owner session client', () => {
     await flushPromises();
     expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
 
-    source.emit('session_title', {
-      id: '39',
-      sessionId: 'session-1',
-      ts: 500,
-      phase: 'live',
-      type: 'session_title',
-      title: 'Other tab title',
-    });
+    emitTitle(source, { id: '39', title: 'Other tab title' });
 
     expect(updates.at(-1)?.[0]?.title).toBe('Other tab title');
     expect(onSessionTitle).toHaveBeenCalledWith('session-1', 'Other tab title');
@@ -367,30 +377,13 @@ describe('owner session client', () => {
       .mockResolvedValueOnce([{ ...row('running', 150), title: 'Title A' }])
       .mockReturnValueOnce(staleReconciliation.promise)
       .mockReturnValueOnce(confirmation.promise);
-    const source = new FakeEventSource();
-    const updates: (readonly ProHomeSessionItem[])[] = [];
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions,
-      createEventSource: () => source,
-      onSessions: (sessions) => updates.push(sessions),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const { client, source, updates, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
     const pendingRevision = client.updateSessionTitle('session-1', 'Title B', false);
     client.requestFullFetch();
-    const emitDelayedTitle = () =>
-      source.emit('session_title', {
-        id: '39',
-        sessionId: 'session-1',
-        ts: 500,
-        phase: 'live',
-        type: 'session_title',
-        title: 'Title A',
-      });
+    const emitDelayedTitle = () => emitTitle(source, { id: '39', title: 'Title A' });
 
     if (!settleBeforeEvent) emitDelayedTitle();
 
@@ -429,29 +422,13 @@ describe('owner session client', () => {
       .mockResolvedValueOnce([{ ...row('running', 150), title: 'Title A' }])
       .mockReturnValueOnce(confirmation.promise)
       .mockReturnValueOnce(finalReconciliation.promise);
-    const source = new FakeEventSource();
-    const updates: (readonly ProHomeSessionItem[])[] = [];
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions,
-      createEventSource: () => source,
-      onSessions: (sessions) => updates.push(sessions),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const { client, source, updates, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
     client.updateSessionTitle('session-1', 'Title B', true);
     client.requestFullFetch();
-    source.emit('session_title', {
-      id: '40',
-      sessionId: 'session-1',
-      ts: 600,
-      phase: 'live',
-      type: 'session_title',
-      title: 'Title C',
-    });
+    emitTitle(source, { title: 'Title C', ts: 600 });
 
     expect(updates.at(-1)?.[0]?.title).toBe('Title B');
     expect(onSessionTitle).not.toHaveBeenCalled();
@@ -469,35 +446,41 @@ describe('owner session client', () => {
     client.stop();
   });
 
-  it.each([
-    { relation: 'older than', eventTimestamp: 499 },
-    { relation: 'from the same millisecond as', eventTimestamp: 500 },
-  ])('reconciles a title event $relation the current snapshot', async ({ eventTimestamp }) => {
-    const source = new FakeEventSource();
+  it('retries once when a hidden remote title outlives a failed confirmation read', async () => {
+    const confirmation = deferred<ProHomeSessionItem[]>();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('running', 150), title: 'Title A' }])
+      .mockReturnValueOnce(confirmation.promise)
+      .mockResolvedValueOnce([{ ...row('running', 600), title: 'Title C' }]);
+    const { client, source, updates } = titleClient(fetchSessions);
+
+    client.start();
+    await flushPromises();
+    const revision = client.updateSessionTitle('session-1', 'Title B', true);
+    client.requestFullFetch();
+    emitTitle(source, { title: 'Title C', ts: 600 });
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+    confirmation.reject(new Error('temporary read failure'));
+    await flushPromises();
+
+    expect(fetchSessions).toHaveBeenCalledTimes(3);
+    expect(updates.at(-1)?.[0]?.title).toBe('Title C');
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
+    client.stop();
+  });
+
+  it('reconciles a title event from the same millisecond as the current snapshot', async () => {
     const fetchSessions = vi
       .fn<() => Promise<ProHomeSessionItem[]>>()
       .mockResolvedValueOnce([{ ...row('running', 500), title: 'Snapshot title' }])
       .mockResolvedValueOnce([{ ...row('running', 600), title: 'Committed title' }]);
-    const updates: (readonly ProHomeSessionItem[])[] = [];
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions,
-      createEventSource: () => source,
-      onSessions: (sessions) => updates.push(sessions),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const { client, source, updates, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
-    source.emit('session_title', {
-      id: '40',
-      sessionId: 'session-1',
-      ts: eventTimestamp,
-      phase: 'live',
-      type: 'session_title',
-      title: 'Committed title',
-    });
+    emitTitle(source, { title: 'Committed title' });
     await flushPromises();
 
     expect(fetchSessions).toHaveBeenCalledTimes(2);
@@ -507,27 +490,12 @@ describe('owner session client', () => {
   });
 
   it('publishes a title event even when the attached row has not reached the list yet', async () => {
-    const source = new FakeEventSource();
     const fetchSessions = vi.fn(async () => [] as ProHomeSessionItem[]);
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions,
-      createEventSource: () => source,
-      onSessions: vi.fn(),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const { client, source, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
-    source.emit('session_title', {
-      id: '40',
-      sessionId: 'session-not-listed',
-      ts: 500,
-      phase: 'live',
-      type: 'session_title',
-      title: 'Arrived first',
-    });
+    emitTitle(source, { sessionId: 'session-not-listed', title: 'Arrived first' });
     await flushPromises();
 
     expect(onSessionTitle).toHaveBeenCalledWith('session-not-listed', 'Arrived first');
@@ -536,27 +504,15 @@ describe('owner session client', () => {
   });
 
   it('does not publish an attached-title callback for a known stale projection', async () => {
-    const source = new FakeEventSource();
-    const onSessionTitle = vi.fn();
-    const client = new OwnerSessionClient({
-      fetchSessions: vi.fn(async () => [{ ...row('running', 500), title: 'Authoritative title' }]),
-      createEventSource: () => source,
-      onSessions: vi.fn(),
-      onSessionTitle,
-      onState: vi.fn(),
-    });
+    const fetchSessions = vi.fn(async () => [
+      { ...row('running', 500), title: 'Authoritative title' },
+    ]);
+    const { client, source, onSessionTitle } = titleClient(fetchSessions);
 
     client.start();
     await flushPromises();
     const revision = client.updateSessionTitle('session-1', 'Local title', false);
-    source.emit('session_title', {
-      id: '41',
-      sessionId: 'session-1',
-      ts: 499,
-      phase: 'backlog',
-      type: 'session_title',
-      title: 'Stale title',
-    });
+    emitTitle(source, { id: '41', title: 'Stale title', ts: 499, phase: 'backlog' });
 
     expect(onSessionTitle).not.toHaveBeenCalled();
     expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);

--- a/tests/workbench/owner-session-client.test.ts
+++ b/tests/workbench/owner-session-client.test.ts
@@ -115,7 +115,7 @@ describe('owner session client', () => {
       client.start();
       await flushPromises();
       client.requestFullFetch();
-      const revision = client.updateSessionTitle('session-1', title);
+      const revision = client.updateSessionTitle('session-1', title, false);
       client.requestFullFetch();
       oldSnapshot.resolve([{ ...row('succeeded', 150), title: 'Old title' }]);
       await flushPromises();
@@ -128,11 +128,43 @@ describe('owner session client', () => {
   );
 
   it.each([
+    { name: 'rename', local: 'Local title' },
+    { name: 'clear', local: null },
+  ])(
+    'keeps a pending local $name over a snapshot that read before its PATCH committed',
+    async ({ local }) => {
+      const reconciliation = deferred<ProHomeSessionItem[]>();
+      const fetchSessions = vi
+        .fn<() => Promise<ProHomeSessionItem[]>>()
+        .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
+        .mockReturnValueOnce(reconciliation.promise);
+      const updates: (readonly ProHomeSessionItem[])[] = [];
+      const client = new OwnerSessionClient({
+        fetchSessions,
+        createEventSource: () => new FakeEventSource(),
+        onSessions: (sessions) => updates.push(sessions),
+        onState: vi.fn(),
+      });
+
+      client.start();
+      await flushPromises();
+      const revision = client.updateSessionTitle('session-1', local, false);
+      client.requestFullFetch();
+      reconciliation.resolve([{ ...row('succeeded', 200), title: 'Old title' }]);
+      await flushPromises();
+
+      expect(updates.at(-1)?.[0]?.title).toBe(local);
+      expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
+      client.stop();
+    },
+  );
+
+  it.each([
     { name: 'different title', local: 'Local title', snapshot: 'Other tab title' },
     { name: 'equal title', local: 'Local title', snapshot: 'Local title' },
     { name: 'equal clear', local: null, snapshot: null },
   ])(
-    'lets a full snapshot with a $name fence an older pending decision',
+    'lets a snapshot begun after a settled $name become authoritative',
     async ({ local, snapshot }) => {
       const reconciliation = deferred<ProHomeSessionItem[]>();
       const fetchSessions = vi
@@ -149,16 +181,44 @@ describe('owner session client', () => {
 
       client.start();
       await flushPromises();
-      const revision = client.updateSessionTitle('session-1', local);
+      client.updateSessionTitle('session-1', local, false);
+      const settledRevision = client.updateSessionTitle('session-1', local, true);
       client.requestFullFetch();
       reconciliation.resolve([{ ...row('succeeded', 200), title: snapshot }]);
       await flushPromises();
 
       expect(updates.at(-1)?.[0]?.title).toBe(snapshot);
-      expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
+      expect(client.isSessionTitleRevisionCurrent('session-1', settledRevision)).toBe(false);
       client.stop();
     },
   );
+
+  it('keeps the settled result over a snapshot that began while its PATCH was pending', async () => {
+    const reconciliation = deferred<ProHomeSessionItem[]>();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
+      .mockReturnValueOnce(reconciliation.promise);
+    const updates: (readonly ProHomeSessionItem[])[] = [];
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => new FakeEventSource(),
+      onSessions: (sessions) => updates.push(sessions),
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    client.updateSessionTitle('session-1', 'Local title', false);
+    client.requestFullFetch();
+    const settledRevision = client.updateSessionTitle('session-1', 'Stored title', true);
+    reconciliation.resolve([{ ...row('succeeded', 200), title: 'Old title' }]);
+    await flushPromises();
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Stored title');
+    expect(client.isSessionTitleRevisionCurrent('session-1', settledRevision)).toBe(true);
+    client.stop();
+  });
 
   it('keeps bigint cursors as decimal strings and compares beyond Number precision', () => {
     expect.soft(compareDecimalCursor('90071992547409931', '90071992547409930')).toBe(1);
@@ -242,19 +302,28 @@ describe('owner session client', () => {
     client.stop();
   });
 
-  it('invalidates a pending local title decision when a newer owner title event is accepted', async () => {
+  it('accepts a title event after a snapshot confirms the local decision', async () => {
     const source = new FakeEventSource();
+    const updates: (readonly ProHomeSessionItem[])[] = [];
+    const onSessionTitle = vi.fn();
     const client = new OwnerSessionClient({
-      fetchSessions: vi.fn(async () => [{ ...row('running', 150), title: 'Before' }]),
+      fetchSessions: vi
+        .fn<() => Promise<ProHomeSessionItem[]>>()
+        .mockResolvedValueOnce([{ ...row('running', 150), title: 'Before' }])
+        .mockResolvedValueOnce([{ ...row('running', 400), title: 'Local title' }]),
       createEventSource: () => source,
-      onSessions: vi.fn(),
+      onSessions: (sessions) => updates.push(sessions),
+      onSessionTitle,
       onState: vi.fn(),
     });
 
     client.start();
     await flushPromises();
-    const revision = client.updateSessionTitle('session-1', 'Local title');
+    const revision = client.updateSessionTitle('session-1', 'Local title', true);
     expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
+    client.requestFullFetch();
+    await flushPromises();
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
 
     source.emit('session_title', {
       id: '39',
@@ -265,11 +334,128 @@ describe('owner session client', () => {
       title: 'Other tab title',
     });
 
-    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
+    expect(updates.at(-1)?.[0]?.title).toBe('Other tab title');
+    expect(onSessionTitle).toHaveBeenCalledWith('session-1', 'Other tab title');
     client.stop();
   });
 
-  it('immediately reconciles a title event that only appears stale by timestamp', async () => {
+  it.each([
+    { name: 'while its PATCH is pending', settleBeforeEvent: false },
+    { name: 'after its PATCH settles but before confirmation', settleBeforeEvent: true },
+  ])('keeps a local rename over a delayed title event $name', async ({ settleBeforeEvent }) => {
+    const staleReconciliation = deferred<ProHomeSessionItem[]>();
+    const confirmation = deferred<ProHomeSessionItem[]>();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('running', 150), title: 'Title A' }])
+      .mockReturnValueOnce(staleReconciliation.promise)
+      .mockReturnValueOnce(confirmation.promise);
+    const source = new FakeEventSource();
+    const updates: (readonly ProHomeSessionItem[])[] = [];
+    const onSessionTitle = vi.fn();
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => source,
+      onSessions: (sessions) => updates.push(sessions),
+      onSessionTitle,
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    const pendingRevision = client.updateSessionTitle('session-1', 'Title B', false);
+    client.requestFullFetch();
+    const emitDelayedTitle = () =>
+      source.emit('session_title', {
+        id: '39',
+        sessionId: 'session-1',
+        ts: 500,
+        phase: 'live',
+        type: 'session_title',
+        title: 'Title A',
+      });
+
+    if (!settleBeforeEvent) emitDelayedTitle();
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+    expect(client.isSessionTitleRevisionCurrent('session-1', pendingRevision)).toBe(true);
+    expect(onSessionTitle).not.toHaveBeenCalled();
+
+    const settledRevision = client.updateSessionTitle('session-1', 'Title B', true);
+    client.requestFullFetch();
+    if (settleBeforeEvent) emitDelayedTitle();
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+    expect(client.isSessionTitleRevisionCurrent('session-1', settledRevision)).toBe(true);
+    expect(onSessionTitle).not.toHaveBeenCalled();
+
+    staleReconciliation.resolve([{ ...row('running', 200), title: 'Title A' }]);
+    await flushPromises();
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+    expect(client.isSessionTitleRevisionCurrent('session-1', settledRevision)).toBe(true);
+    expect(fetchSessions).toHaveBeenCalledTimes(3);
+
+    confirmation.resolve([{ ...row('running', 600), title: 'Title B' }]);
+    await flushPromises();
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+    expect(client.isSessionTitleRevisionCurrent('session-1', settledRevision)).toBe(false);
+    client.stop();
+  });
+
+  it('reconciles an equal-millisecond title event hidden by an unconfirmed write', async () => {
+    const confirmation = deferred<ProHomeSessionItem[]>();
+    const finalReconciliation = deferred<ProHomeSessionItem[]>();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('running', 150), title: 'Title A' }])
+      .mockReturnValueOnce(confirmation.promise)
+      .mockReturnValueOnce(finalReconciliation.promise);
+    const source = new FakeEventSource();
+    const updates: (readonly ProHomeSessionItem[])[] = [];
+    const onSessionTitle = vi.fn();
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => source,
+      onSessions: (sessions) => updates.push(sessions),
+      onSessionTitle,
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    client.updateSessionTitle('session-1', 'Title B', true);
+    client.requestFullFetch();
+    source.emit('session_title', {
+      id: '40',
+      sessionId: 'session-1',
+      ts: 600,
+      phase: 'live',
+      type: 'session_title',
+      title: 'Title C',
+    });
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+    expect(onSessionTitle).not.toHaveBeenCalled();
+
+    confirmation.resolve([{ ...row('running', 600), title: 'Title B' }]);
+    await flushPromises();
+
+    expect(fetchSessions).toHaveBeenCalledTimes(3);
+    expect(updates.at(-1)?.[0]?.title).toBe('Title B');
+
+    finalReconciliation.resolve([{ ...row('running', 600), title: 'Title C' }]);
+    await flushPromises();
+
+    expect(updates.at(-1)?.[0]?.title).toBe('Title C');
+    client.stop();
+  });
+
+  it.each([
+    { relation: 'older than', eventTimestamp: 499 },
+    { relation: 'from the same millisecond as', eventTimestamp: 500 },
+  ])('reconciles a title event $relation the current snapshot', async ({ eventTimestamp }) => {
     const source = new FakeEventSource();
     const fetchSessions = vi
       .fn<() => Promise<ProHomeSessionItem[]>>()
@@ -290,7 +476,7 @@ describe('owner session client', () => {
     source.emit('session_title', {
       id: '40',
       sessionId: 'session-1',
-      ts: 499,
+      ts: eventTimestamp,
       phase: 'live',
       type: 'session_title',
       title: 'Committed title',
@@ -345,7 +531,7 @@ describe('owner session client', () => {
 
     client.start();
     await flushPromises();
-    const revision = client.updateSessionTitle('session-1', 'Local title');
+    const revision = client.updateSessionTitle('session-1', 'Local title', false);
     source.emit('session_title', {
       id: '41',
       sessionId: 'session-1',

--- a/tests/workbench/owner-session-client.test.ts
+++ b/tests/workbench/owner-session-client.test.ts
@@ -92,6 +92,40 @@ describe('owner session client', () => {
     client.stop();
   });
 
+  it.each([
+    { name: 'rename', title: 'New title' },
+    { name: 'clear', title: null },
+  ])(
+    'keeps a local title $name over an older in-flight snapshot when the queued repair fails',
+    async ({ title }) => {
+      const oldSnapshot = deferred<ProHomeSessionItem[]>();
+      const fetchSessions = vi
+        .fn<() => Promise<ProHomeSessionItem[]>>()
+        .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
+        .mockReturnValueOnce(oldSnapshot.promise)
+        .mockRejectedValueOnce(new Error('queued repair failed'));
+      const updates: (readonly ProHomeSessionItem[])[] = [];
+      const client = new OwnerSessionClient({
+        fetchSessions,
+        createEventSource: () => new FakeEventSource(),
+        onSessions: (sessions) => updates.push(sessions),
+        onState: vi.fn(),
+      });
+
+      client.start();
+      await flushPromises();
+      client.requestFullFetch();
+      client.updateSessionTitle('session-1', title);
+      client.requestFullFetch();
+      oldSnapshot.resolve([{ ...row('succeeded', 150), title: 'Old title' }]);
+      await flushPromises();
+
+      expect(fetchSessions).toHaveBeenCalledTimes(3);
+      expect(updates.at(-1)?.[0]?.title).toBe(title);
+      client.stop();
+    },
+  );
+
   it('keeps bigint cursors as decimal strings and compares beyond Number precision', () => {
     expect.soft(compareDecimalCursor('90071992547409931', '90071992547409930')).toBe(1);
     expect.soft(compareDecimalCursor('90071992547409930', '90071992547409931')).toBe(-1);
@@ -135,6 +169,126 @@ describe('owner session client', () => {
     expect.soft(updates.at(-1)?.[0]?.status).toBe('succeeded');
     expect.soft(updates.at(-1)?.[0]?.updatedAt).toBe(500);
     expect.soft(fetchSessions).toHaveBeenCalledTimes(2);
+    client.stop();
+  });
+
+  it('replays a newer title event over a slow full snapshot and publishes the narrow callback', async () => {
+    const slowReconciliation = deferred<ProHomeSessionItem[]>();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('running', 150), title: 'Before' }])
+      .mockReturnValueOnce(slowReconciliation.promise);
+    const source = new FakeEventSource();
+    const updates: (readonly ProHomeSessionItem[])[] = [];
+    const onSessionTitle = vi.fn();
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => source,
+      onSessions: (sessions) => updates.push(sessions),
+      onSessionTitle,
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    client.requestFullFetch();
+    source.emit('session_title', {
+      id: '90071992547409932',
+      sessionId: 'session-1',
+      ts: 500,
+      phase: 'live',
+      type: 'session_title',
+      title: 'Newest title',
+    });
+    slowReconciliation.resolve([{ ...row('running', 200), title: 'Stale snapshot' }]);
+    await flushPromises();
+
+    expect(updates.at(-1)?.[0]).toMatchObject({ title: 'Newest title', updatedAt: 500 });
+    expect(onSessionTitle).toHaveBeenCalledWith('session-1', 'Newest title');
+    client.stop();
+  });
+
+  it('invalidates a pending local title decision when a newer owner title event is accepted', async () => {
+    const source = new FakeEventSource();
+    const client = new OwnerSessionClient({
+      fetchSessions: vi.fn(async () => [{ ...row('running', 150), title: 'Before' }]),
+      createEventSource: () => source,
+      onSessions: vi.fn(),
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    const revision = client.updateSessionTitle('session-1', 'Local title');
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
+
+    source.emit('session_title', {
+      id: '39',
+      sessionId: 'session-1',
+      ts: 500,
+      phase: 'live',
+      type: 'session_title',
+      title: 'Other tab title',
+    });
+
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
+    client.stop();
+  });
+
+  it('publishes a title event even when the attached row has not reached the list yet', async () => {
+    const source = new FakeEventSource();
+    const fetchSessions = vi.fn(async () => [] as ProHomeSessionItem[]);
+    const onSessionTitle = vi.fn();
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => source,
+      onSessions: vi.fn(),
+      onSessionTitle,
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    source.emit('session_title', {
+      id: '40',
+      sessionId: 'session-not-listed',
+      ts: 500,
+      phase: 'live',
+      type: 'session_title',
+      title: 'Arrived first',
+    });
+    await flushPromises();
+
+    expect(onSessionTitle).toHaveBeenCalledWith('session-not-listed', 'Arrived first');
+    expect(fetchSessions).toHaveBeenCalledTimes(2);
+    client.stop();
+  });
+
+  it('does not publish an attached-title callback for a known stale projection', async () => {
+    const source = new FakeEventSource();
+    const onSessionTitle = vi.fn();
+    const client = new OwnerSessionClient({
+      fetchSessions: vi.fn(async () => [{ ...row('running', 500), title: 'Authoritative title' }]),
+      createEventSource: () => source,
+      onSessions: vi.fn(),
+      onSessionTitle,
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    const revision = client.updateSessionTitle('session-1', 'Local title');
+    source.emit('session_title', {
+      id: '41',
+      sessionId: 'session-1',
+      ts: 499,
+      phase: 'backlog',
+      type: 'session_title',
+      title: 'Stale title',
+    });
+
+    expect(onSessionTitle).not.toHaveBeenCalled();
+    expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
     client.stop();
   });
 

--- a/tests/workbench/owner-session-client.test.ts
+++ b/tests/workbench/owner-session-client.test.ts
@@ -93,6 +93,23 @@ describe('owner session client', () => {
   });
 
   it.each([
+    { name: 'pending rename', title: 'Local title', settled: false },
+    { name: 'pending clear', title: null, settled: false },
+    { name: 'settled rename awaiting confirmation', title: 'Stored title', settled: true },
+  ])('exposes an unconfirmed $name without confusing clear with absence', ({ title, settled }) => {
+    const client = new OwnerSessionClient({
+      fetchSessions: vi.fn(async () => []),
+      createEventSource: () => new FakeEventSource(),
+      onSessions: vi.fn(),
+      onState: vi.fn(),
+    });
+
+    expect(client.getUnconfirmedSessionTitle('session-1')).toBeNull();
+    client.updateSessionTitle('session-1', title, settled);
+    expect(client.getUnconfirmedSessionTitle('session-1')).toEqual({ title });
+  });
+
+  it.each([
     { name: 'rename', title: 'New title' },
     { name: 'clear', title: null },
   ])(

--- a/tests/workbench/owner-session-client.test.ts
+++ b/tests/workbench/owner-session-client.test.ts
@@ -115,13 +115,47 @@ describe('owner session client', () => {
       client.start();
       await flushPromises();
       client.requestFullFetch();
-      client.updateSessionTitle('session-1', title);
+      const revision = client.updateSessionTitle('session-1', title);
       client.requestFullFetch();
       oldSnapshot.resolve([{ ...row('succeeded', 150), title: 'Old title' }]);
       await flushPromises();
 
       expect(fetchSessions).toHaveBeenCalledTimes(3);
       expect(updates.at(-1)?.[0]?.title).toBe(title);
+      expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(true);
+      client.stop();
+    },
+  );
+
+  it.each([
+    { name: 'different title', local: 'Local title', snapshot: 'Other tab title' },
+    { name: 'equal title', local: 'Local title', snapshot: 'Local title' },
+    { name: 'equal clear', local: null, snapshot: null },
+  ])(
+    'lets a full snapshot with a $name fence an older pending decision',
+    async ({ local, snapshot }) => {
+      const reconciliation = deferred<ProHomeSessionItem[]>();
+      const fetchSessions = vi
+        .fn<() => Promise<ProHomeSessionItem[]>>()
+        .mockResolvedValueOnce([{ ...row('succeeded', 100), title: 'Old title' }])
+        .mockReturnValueOnce(reconciliation.promise);
+      const updates: (readonly ProHomeSessionItem[])[] = [];
+      const client = new OwnerSessionClient({
+        fetchSessions,
+        createEventSource: () => new FakeEventSource(),
+        onSessions: (sessions) => updates.push(sessions),
+        onState: vi.fn(),
+      });
+
+      client.start();
+      await flushPromises();
+      const revision = client.updateSessionTitle('session-1', local);
+      client.requestFullFetch();
+      reconciliation.resolve([{ ...row('succeeded', 200), title: snapshot }]);
+      await flushPromises();
+
+      expect(updates.at(-1)?.[0]?.title).toBe(snapshot);
+      expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
       client.stop();
     },
   );
@@ -232,6 +266,40 @@ describe('owner session client', () => {
     });
 
     expect(client.isSessionTitleRevisionCurrent('session-1', revision)).toBe(false);
+    client.stop();
+  });
+
+  it('immediately reconciles a title event that only appears stale by timestamp', async () => {
+    const source = new FakeEventSource();
+    const fetchSessions = vi
+      .fn<() => Promise<ProHomeSessionItem[]>>()
+      .mockResolvedValueOnce([{ ...row('running', 500), title: 'Snapshot title' }])
+      .mockResolvedValueOnce([{ ...row('running', 600), title: 'Committed title' }]);
+    const updates: (readonly ProHomeSessionItem[])[] = [];
+    const onSessionTitle = vi.fn();
+    const client = new OwnerSessionClient({
+      fetchSessions,
+      createEventSource: () => source,
+      onSessions: (sessions) => updates.push(sessions),
+      onSessionTitle,
+      onState: vi.fn(),
+    });
+
+    client.start();
+    await flushPromises();
+    source.emit('session_title', {
+      id: '40',
+      sessionId: 'session-1',
+      ts: 499,
+      phase: 'live',
+      type: 'session_title',
+      title: 'Committed title',
+    });
+    await flushPromises();
+
+    expect(fetchSessions).toHaveBeenCalledTimes(2);
+    expect(updates.at(-1)?.[0]?.title).toBe('Committed title');
+    expect(onSessionTitle).not.toHaveBeenCalled();
     client.stop();
   });
 

--- a/tests/workbench/pro-home-data.test.ts
+++ b/tests/workbench/pro-home-data.test.ts
@@ -190,11 +190,19 @@ describe('owner session event projection', () => {
         phase: 'live',
         type: 'session_cancel_requested',
       }),
+      event({
+        id: '90071992547409936',
+        sessionId: 'missing',
+        ts: 305,
+        phase: 'live',
+        type: 'session_title',
+        title: 'Generated title',
+      }),
     ];
 
     expect(
       unknownEvents.map((ownerEvent) => reduceOwnerSessionEvent([], ownerEvent).needsFullFetch),
-    ).toEqual([true, true, true, true, true]);
+    ).toEqual([true, true, true, true, true, true]);
   });
 
   it('removes a deleted row without disturbing its neighbours', () => {
@@ -236,6 +244,53 @@ describe('owner session event projection', () => {
       stageId: 'course-reassigned',
       updatedAt: 500,
     });
+  });
+
+  it('sets and clears a title through the owner projection', () => {
+    const source = [session('active', { title: 'Old title', updatedAt: 200 })];
+    const renamed = reduceOwnerSessionEvent(
+      source,
+      event({
+        id: '43',
+        sessionId: 'active',
+        ts: 300,
+        phase: 'live',
+        type: 'session_title',
+        title: 'New title',
+      }),
+    );
+    const cleared = reduceOwnerSessionEvent(
+      renamed.sessions,
+      event({
+        id: '44',
+        sessionId: 'active',
+        ts: 400,
+        phase: 'backlog',
+        type: 'session_title',
+        title: null,
+      }),
+    );
+
+    expect(renamed.sessions[0]).toEqual({ ...source[0], title: 'New title', updatedAt: 300 });
+    expect(cleared.sessions[0]).toEqual({ ...source[0], title: null, updatedAt: 400 });
+  });
+
+  it('ignores a title projection older than the matching owner snapshot', () => {
+    const source = [session('active', { title: 'Newest title', updatedAt: 500 })];
+    const result = reduceOwnerSessionEvent(
+      source,
+      event({
+        id: '45',
+        sessionId: 'active',
+        ts: 499,
+        phase: 'backlog',
+        type: 'session_title',
+        title: 'Stale title',
+      }),
+    );
+
+    expect(result).toEqual({ sessions: source, needsFullFetch: false });
+    expect(result.sessions).toBe(source);
   });
 
   it('treats degraded catch-up as non-authoritative and initializes only once after recovery', () => {

--- a/tests/workbench/pro-home-data.test.ts
+++ b/tests/workbench/pro-home-data.test.ts
@@ -275,6 +275,28 @@ describe('owner session event projection', () => {
     expect(cleared.sessions[0]).toEqual({ ...source[0], title: null, updatedAt: 400 });
   });
 
+  it('treats a title change as recent rail activity', () => {
+    const source = [
+      session('newer', { updatedAt: 250 }),
+      session('renamed', { title: 'Old title', updatedAt: 200 }),
+    ];
+    const result = reduceOwnerSessionEvent(
+      source,
+      event({
+        id: '45',
+        sessionId: 'renamed',
+        ts: 300,
+        phase: 'live',
+        type: 'session_title',
+        title: 'New title',
+      }),
+    );
+
+    expect(result.needsFullFetch).toBe(false);
+    expect(result.sessions.map((item) => item.id)).toEqual(['renamed', 'newer']);
+    expect(result.sessions[0]).toEqual({ ...source[1], title: 'New title', updatedAt: 300 });
+  });
+
   it.each([
     { relation: 'older than', eventTimestamp: 499 },
     { relation: 'from the same millisecond as', eventTimestamp: 500 },

--- a/tests/workbench/pro-home-data.test.ts
+++ b/tests/workbench/pro-home-data.test.ts
@@ -275,14 +275,17 @@ describe('owner session event projection', () => {
     expect(cleared.sessions[0]).toEqual({ ...source[0], title: null, updatedAt: 400 });
   });
 
-  it('ignores a title projection older than the matching owner snapshot', () => {
+  it.each([
+    { relation: 'older than', eventTimestamp: 499 },
+    { relation: 'from the same millisecond as', eventTimestamp: 500 },
+  ])('ignores a title projection $relation the matching owner snapshot', ({ eventTimestamp }) => {
     const source = [session('active', { title: 'Newest title', updatedAt: 500 })];
     const result = reduceOwnerSessionEvent(
       source,
       event({
         id: '45',
         sessionId: 'active',
-        ts: 499,
+        ts: eventTimestamp,
         phase: 'backlog',
         type: 'session_title',
         title: 'Stale title',

--- a/tests/workbench/session-title.test.ts
+++ b/tests/workbench/session-title.test.ts
@@ -6,7 +6,7 @@
  * about which is showing (the pane header and the rail row). Both read the
  * derivation here; both write through `commitSessionRename`.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   commitSessionRename,
@@ -15,7 +15,12 @@ import {
   SESSION_TITLE_MAX_LENGTH,
   workbenchSessionTitle,
 } from '@/lib/workbench/session-title';
-import { foldEvents, type WorkbenchEvent, type WorkbenchFold } from '@/lib/workbench/session-store';
+import {
+  foldEvents,
+  useWorkbenchStore,
+  type WorkbenchEvent,
+  type WorkbenchFold,
+} from '@/lib/workbench/session-store';
 
 describe('what a conversation is called', () => {
   it('prefers the name the user gave it', () => {
@@ -115,6 +120,40 @@ describe('committing a rename', () => {
     });
     expect(outcome).toBe('unchanged');
     expect(save).not.toHaveBeenCalled();
+  });
+});
+
+describe('late session metadata after a local rename', () => {
+  afterEach(() => useWorkbenchStore.getState().detach());
+
+  it('keeps the newer local title while accepting the rest of the bootstrap', () => {
+    const store = useWorkbenchStore.getState();
+    store.attach('session-1', null);
+    const expectedTitleRevision = store.sessionTitleRevision;
+    store.setSessionTitle('新名字');
+
+    store.setSessionBootstrap({
+      prompt: '第一条消息',
+      title: '旧名字',
+      expectedTitleRevision,
+      stageId: 'stage-1',
+    });
+
+    const current = useWorkbenchStore.getState();
+    expect(current.sessionTitle).toBe('新名字');
+    expect(current.sessionPrompt).toBe('第一条消息');
+    expect(current.stageId).toBe('stage-1');
+  });
+
+  it('keeps an explicit clear when older metadata still contains a title', () => {
+    const store = useWorkbenchStore.getState();
+    store.attach('session-1', null);
+    const expectedTitleRevision = store.sessionTitleRevision;
+    store.setSessionTitle(null);
+
+    store.setSessionBootstrap({ prompt: '第一条消息', title: '旧名字', expectedTitleRevision });
+
+    expect(useWorkbenchStore.getState().sessionTitle).toBeNull();
   });
 });
 

--- a/tests/workbench/session-title.test.ts
+++ b/tests/workbench/session-title.test.ts
@@ -96,6 +96,44 @@ describe('committing a rename', () => {
     expect(applied).toEqual(['新名字', '旧名字']);
   });
 
+  it('does not settle over a newer authoritative title', async () => {
+    const applied: (string | null)[] = [];
+    let current = true;
+    const outcome = await commitSessionRename({
+      current: session,
+      raw: '本地名字',
+      apply: (title) => {
+        applied.push(title);
+        current = false;
+      },
+      save: async () => '服务端名字',
+      isCurrent: () => current,
+    });
+
+    expect(outcome).toBe('renamed');
+    expect(applied).toEqual(['本地名字']);
+  });
+
+  it('does not roll back over a newer authoritative title', async () => {
+    const applied: (string | null)[] = [];
+    let current = true;
+    const outcome = await commitSessionRename({
+      current: { title: '旧名字', prompt: '帮我做一节课' },
+      raw: '本地名字',
+      apply: (title) => {
+        applied.push(title);
+        current = false;
+      },
+      save: async () => {
+        throw new Error('500');
+      },
+      isCurrent: () => current,
+    });
+
+    expect(outcome).toBe('failed');
+    expect(applied).toEqual(['本地名字']);
+  });
+
   it('clears the override on an empty box, so the derived title comes back', async () => {
     const applied: (string | null)[] = [];
     const save = vi.fn(async () => null);

--- a/tests/workbench/session-title.test.ts
+++ b/tests/workbench/session-title.test.ts
@@ -159,6 +159,22 @@ describe('committing a rename', () => {
     expect(outcome).toBe('unchanged');
     expect(save).not.toHaveBeenCalled();
   });
+
+  it('preserves an explicit same-value decision queued behind an ambiguous write', async () => {
+    const applied: (string | null)[] = [];
+    const save = vi.fn(async () => '旧名字');
+    const outcome = await commitSessionRename({
+      current: { title: '旧名字', prompt: '帮我做一节课' },
+      raw: '旧名字',
+      apply: (title) => applied.push(title),
+      save,
+      forceSave: true,
+    });
+
+    expect(outcome).toBe('renamed');
+    expect(save).toHaveBeenCalledWith('旧名字');
+    expect(applied).toEqual(['旧名字', '旧名字']);
+  });
 });
 
 describe('late session metadata after a local rename', () => {

--- a/tests/workbench/session-title.test.ts
+++ b/tests/workbench/session-title.test.ts
@@ -6,21 +6,17 @@
  * about which is showing (the pane header and the rail row). Both read the
  * derivation here; both write through `commitSessionRename`.
  */
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   commitSessionRename,
   isDerivedSessionTitle,
   normalizeSessionTitleInput,
+  normalizeSessionTitleOverride,
   SESSION_TITLE_MAX_LENGTH,
   workbenchSessionTitle,
 } from '@/lib/workbench/session-title';
-import {
-  foldEvents,
-  useWorkbenchStore,
-  type WorkbenchEvent,
-  type WorkbenchFold,
-} from '@/lib/workbench/session-store';
+import { foldEvents, type WorkbenchEvent, type WorkbenchFold } from '@/lib/workbench/session-store';
 
 describe('what a conversation is called', () => {
   it('prefers the name the user gave it', () => {
@@ -50,6 +46,16 @@ describe('what a rename sends', () => {
     expect(normalizeSessionTitleInput(session, 'x'.repeat(400))).toHaveLength(
       SESSION_TITLE_MAX_LENGTH,
     );
+  });
+
+  it('uses the input maxLength budget without splitting a surrogate pair', () => {
+    expect(normalizeSessionTitleOverride(`${'x'.repeat(118)}😀`)).toBe(`${'x'.repeat(118)}😀`);
+    expect(normalizeSessionTitleOverride(`${'x'.repeat(119)}😀tail`)).toBe('x'.repeat(119));
+  });
+
+  it('makes PostgreSQL-invalid API text safe for storage and projection', () => {
+    expect(normalizeSessionTitleOverride(`Safe\ud83d title`)).toBe('Safe� title');
+    expect(normalizeSessionTitleOverride(`Safe\u0000 title`)).toBe('Safe� title');
   });
 
   it('reads an empty box as "clear the name", not as a blank title', () => {
@@ -102,25 +108,16 @@ describe('committing a rename', () => {
     ]);
   });
 
-  it('does not settle over a newer authoritative title', async () => {
-    const applied: (string | null)[] = [];
-    let current = true;
-    const outcome = await commitSessionRename({
-      current: session,
-      raw: '本地名字',
-      apply: (title) => {
-        applied.push(title);
-        current = false;
+  it.each([
+    { settlement: 'success', save: async () => '服务端名字', outcome: 'renamed' },
+    {
+      settlement: 'failure',
+      save: async () => {
+        throw new Error('500');
       },
-      save: async () => '服务端名字',
-      isCurrent: () => current,
-    });
-
-    expect(outcome).toBe('renamed');
-    expect(applied).toEqual(['本地名字']);
-  });
-
-  it('does not roll back over a newer authoritative title', async () => {
+      outcome: 'failed',
+    },
+  ])('does not apply a stale $settlement settlement', async ({ save, outcome: expected }) => {
     const applied: (string | null)[] = [];
     let current = true;
     const outcome = await commitSessionRename({
@@ -130,13 +127,11 @@ describe('committing a rename', () => {
         applied.push(title);
         current = false;
       },
-      save: async () => {
-        throw new Error('500');
-      },
+      save,
       isCurrent: () => current,
     });
 
-    expect(outcome).toBe('failed');
+    expect(outcome).toBe(expected);
     expect(applied).toEqual(['本地名字']);
   });
 
@@ -180,40 +175,6 @@ describe('committing a rename', () => {
     expect(outcome).toBe('renamed');
     expect(save).toHaveBeenCalledWith('旧名字');
     expect(applied).toEqual(['旧名字', '旧名字']);
-  });
-});
-
-describe('late session metadata after a local rename', () => {
-  afterEach(() => useWorkbenchStore.getState().detach());
-
-  it('keeps the newer local title while accepting the rest of the bootstrap', () => {
-    const store = useWorkbenchStore.getState();
-    store.attach('session-1', null);
-    const expectedTitleRevision = store.sessionTitleRevision;
-    store.setSessionTitle('新名字');
-
-    store.setSessionBootstrap({
-      prompt: '第一条消息',
-      title: '旧名字',
-      expectedTitleRevision,
-      stageId: 'stage-1',
-    });
-
-    const current = useWorkbenchStore.getState();
-    expect(current.sessionTitle).toBe('新名字');
-    expect(current.sessionPrompt).toBe('第一条消息');
-    expect(current.stageId).toBe('stage-1');
-  });
-
-  it('keeps an explicit clear when older metadata still contains a title', () => {
-    const store = useWorkbenchStore.getState();
-    store.attach('session-1', null);
-    const expectedTitleRevision = store.sessionTitleRevision;
-    store.setSessionTitle(null);
-
-    store.setSessionBootstrap({ prompt: '第一条消息', title: '旧名字', expectedTitleRevision });
-
-    expect(useWorkbenchStore.getState().sessionTitle).toBeNull();
   });
 });
 

--- a/tests/workbench/session-title.test.ts
+++ b/tests/workbench/session-title.test.ts
@@ -68,32 +68,38 @@ describe('committing a rename', () => {
   const session = { title: null, prompt: '帮我做一节课' };
 
   it('writes it locally first, then settles on what the server stored', async () => {
-    const applied: (string | null)[] = [];
+    const applied: { title: string | null; settled: boolean }[] = [];
     const save = vi.fn(async () => '期末复习');
     const outcome = await commitSessionRename({
       current: session,
       raw: '期末复习课',
-      apply: (title) => applied.push(title),
+      apply: (title, settled) => applied.push({ title, settled }),
       save,
     });
     expect(outcome).toBe('renamed');
     expect(save).toHaveBeenCalledWith('期末复习课');
     // Optimistic value, then the server's — which can differ (it caps).
-    expect(applied).toEqual(['期末复习课', '期末复习']);
+    expect(applied).toEqual([
+      { title: '期末复习课', settled: false },
+      { title: '期末复习', settled: true },
+    ]);
   });
 
   it('puts the old name back when the write is refused', async () => {
-    const applied: (string | null)[] = [];
+    const applied: { title: string | null; settled: boolean }[] = [];
     const outcome = await commitSessionRename({
       current: { title: '旧名字', prompt: '帮我做一节课' },
       raw: '新名字',
-      apply: (title) => applied.push(title),
+      apply: (title, settled) => applied.push({ title, settled }),
       save: async () => {
         throw new Error('500');
       },
     });
     expect(outcome).toBe('failed');
-    expect(applied).toEqual(['新名字', '旧名字']);
+    expect(applied).toEqual([
+      { title: '新名字', settled: false },
+      { title: '旧名字', settled: true },
+    ]);
   });
 
   it('does not settle over a newer authoritative title', async () => {

--- a/tests/workbench/use-workbench-session-metadata.test.ts
+++ b/tests/workbench/use-workbench-session-metadata.test.ts
@@ -31,11 +31,19 @@ function jsonResponse(value: unknown): Response {
   return { ok: true, json: async () => value } as Response;
 }
 
-function Harness({ sessionId }: { readonly sessionId: string }) {
+function Harness({
+  sessionId,
+  seedTitle,
+}: {
+  readonly sessionId: string;
+  readonly seedTitle?: { readonly title: string | null };
+}) {
   const attach = useWorkbenchStore((state) => state.attach);
+  const setSessionTitle = useWorkbenchStore((state) => state.setSessionTitle);
   useLayoutEffect(() => {
     attach(sessionId, null);
-  }, [attach, sessionId]);
+    if (seedTitle) setSessionTitle(seedTitle.title);
+  }, [attach, seedTitle, sessionId, setSessionTitle]);
   useWorkbenchStream(sessionId);
   return null;
 }
@@ -149,4 +157,47 @@ describe('session detail bootstrap attachment lifetime', () => {
       stageId: 'stage-a',
     });
   });
+
+  it.each([
+    { name: 'rename', title: 'Pending title' },
+    { name: 'clear', title: null },
+  ])(
+    'keeps a pending $name seeded before the detail request while bootstrapping other metadata',
+    async ({ title }) => {
+      const detail = deferred<Response>();
+      vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockReturnValueOnce(detail.promise));
+
+      await act(async () =>
+        root.render(
+          createElement(Harness, {
+            sessionId: 'session-a',
+            seedTitle: { title },
+          }),
+        ),
+      );
+      expect(useWorkbenchStore.getState().sessionTitleRevision).toBe(1);
+
+      await act(async () => {
+        detail.resolve(
+          jsonResponse({
+            prompt: 'Current prompt',
+            title: 'Old title',
+            status: 'running',
+            stageId: 'stage-a',
+          }),
+        );
+        await detail.promise;
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(useWorkbenchStore.getState()).toMatchObject({
+        sessionId: 'session-a',
+        sessionPrompt: 'Current prompt',
+        sessionTitle: title,
+        status: 'running',
+        stageId: 'stage-a',
+      });
+    },
+  );
 });

--- a/tests/workbench/use-workbench-session-metadata.test.ts
+++ b/tests/workbench/use-workbench-session-metadata.test.ts
@@ -125,20 +125,16 @@ describe('session detail bootstrap attachment lifetime', () => {
     });
   });
 
-  it('keeps an authoritative clear that arrives before an older detail response', async () => {
+  it('keeps an authoritative clear made while the detail request is in flight', async () => {
     const detail = deferred<Response>();
     vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockReturnValueOnce(detail.promise));
 
     await act(async () => root.render(createElement(Harness, { sessionId: 'session-a' })));
-    expect(useWorkbenchStore.getState().sessionTitle).toBeNull();
-
-    // An owner title event uses this same store decision, even when the visible
-    // value is already null, so the bootstrap revision must still advance.
     act(() => useWorkbenchStore.getState().setSessionTitle(null));
     await act(async () => {
       detail.resolve(
         jsonResponse({
-          prompt: 'Stale prompt',
+          prompt: 'Current prompt',
           title: 'Stale title',
           status: 'running',
           stageId: 'stage-a',
@@ -150,8 +146,7 @@ describe('session detail bootstrap attachment lifetime', () => {
     });
 
     expect(useWorkbenchStore.getState()).toMatchObject({
-      sessionId: 'session-a',
-      sessionPrompt: 'Stale prompt',
+      sessionPrompt: 'Current prompt',
       sessionTitle: null,
       status: 'running',
       stageId: 'stage-a',

--- a/tests/workbench/use-workbench-session-metadata.test.ts
+++ b/tests/workbench/use-workbench-session-metadata.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useLayoutEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWorkbenchStore } from '@/lib/workbench/session-store';
+import { useWorkbenchStream } from '@/lib/workbench/use-workbench-session';
+
+class FakeEventSource {
+  static readonly CLOSED = 2;
+  readonly readyState = 1;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(readonly url: string) {}
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  close(): void {}
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function jsonResponse(value: unknown): Response {
+  return { ok: true, json: async () => value } as Response;
+}
+
+function Harness({ sessionId }: { readonly sessionId: string }) {
+  const attach = useWorkbenchStore((state) => state.attach);
+  useLayoutEffect(() => {
+    attach(sessionId, null);
+  }, [attach, sessionId]);
+  useWorkbenchStream(sessionId);
+  return null;
+}
+
+describe('session detail bootstrap attachment lifetime', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal('EventSource', FakeEventSource);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    useWorkbenchStore.getState().detach();
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('ignores an old A detail response after navigating A to B to A', async () => {
+    const firstA = deferred<Response>();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockReturnValueOnce(firstA.promise)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          prompt: 'B prompt',
+          title: 'B title',
+          status: 'running',
+          stageId: 'stage-b',
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          prompt: 'Current A prompt',
+          title: 'Current A title',
+          status: 'succeeded',
+          stageId: 'stage-a-current',
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => root.render(createElement(Harness, { sessionId: 'session-a' })));
+    await act(async () => root.render(createElement(Harness, { sessionId: 'session-b' })));
+    await act(async () => root.render(createElement(Harness, { sessionId: 'session-a' })));
+
+    expect(useWorkbenchStore.getState()).toMatchObject({
+      sessionId: 'session-a',
+      sessionPrompt: 'Current A prompt',
+      sessionTitle: 'Current A title',
+      status: 'succeeded',
+      stageId: 'stage-a-current',
+    });
+
+    await act(async () => {
+      firstA.resolve(
+        jsonResponse({
+          prompt: 'Stale A prompt',
+          title: 'Stale A title',
+          status: 'failed',
+          stageId: 'stage-a-stale',
+        }),
+      );
+      await firstA.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useWorkbenchStore.getState()).toMatchObject({
+      sessionId: 'session-a',
+      sessionPrompt: 'Current A prompt',
+      sessionTitle: 'Current A title',
+      status: 'succeeded',
+      stageId: 'stage-a-current',
+    });
+  });
+
+  it('keeps an authoritative clear that arrives before an older detail response', async () => {
+    const detail = deferred<Response>();
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockReturnValueOnce(detail.promise));
+
+    await act(async () => root.render(createElement(Harness, { sessionId: 'session-a' })));
+    expect(useWorkbenchStore.getState().sessionTitle).toBeNull();
+
+    // An owner title event uses this same store decision, even when the visible
+    // value is already null, so the bootstrap revision must still advance.
+    act(() => useWorkbenchStore.getState().setSessionTitle(null));
+    await act(async () => {
+      detail.resolve(
+        jsonResponse({
+          prompt: 'Stale prompt',
+          title: 'Stale title',
+          status: 'running',
+          stageId: 'stage-a',
+        }),
+      );
+      await detail.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useWorkbenchStore.getState()).toMatchObject({
+      sessionId: 'session-a',
+      sessionPrompt: 'Stale prompt',
+      sessionTitle: null,
+      status: 'running',
+      stageId: 'stage-a',
+    });
+  });
+});

--- a/tests/workbench/workspace-course-chat-bootstrap.test.ts
+++ b/tests/workbench/workspace-course-chat-bootstrap.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   startFirstMessage: vi.fn(),
   requestFullFetch: vi.fn(),
   updateSessions: vi.fn(),
+  updateSessionTitle: vi.fn(),
   renameWorkbenchSession: vi.fn(),
   classroomMounts: 0,
   classroomProps: null as Record<string, unknown> | null,
@@ -126,6 +127,7 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
     private sessions: typeof mocks.sessionRows = [];
     private titleRevision = 0;
     private readonly titleRevisions = new Map<string, number>();
+    private readonly titleMutations = new Map<string, { settled: boolean }>();
 
     constructor(
       private readonly options: {
@@ -148,10 +150,11 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
       this.sessions = update(this.sessions);
       this.options.onSessions(this.sessions);
     }
-    updateSessionTitle(sessionId: string, title: string | null) {
-      mocks.updateSessions(sessionId, title);
+    updateSessionTitle(sessionId: string, title: string | null, settled: boolean) {
+      mocks.updateSessionTitle(sessionId, title, settled);
       const revision = (this.titleRevision += 1);
       this.titleRevisions.set(sessionId, revision);
+      this.titleMutations.set(sessionId, { settled });
       this.sessions = this.sessions.map((session) =>
         session.id === sessionId ? { ...session, title } : session,
       );
@@ -168,7 +171,9 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
       this.options.onSessions(this.sessions);
     }
     emitSessionTitle(sessionId: string, title: string | null) {
+      if (this.titleMutations.has(sessionId)) return;
       this.titleRevisions.set(sessionId, (this.titleRevision += 1));
+      this.titleMutations.delete(sessionId);
       this.options.onSessionTitle?.(sessionId, title);
       this.sessions = this.sessions.map((session) =>
         session.id === sessionId ? { ...session, title } : session,
@@ -297,6 +302,7 @@ beforeEach(() => {
   mocks.routerReplace.mockClear();
   mocks.requestFullFetch.mockClear();
   mocks.updateSessions.mockClear();
+  mocks.updateSessionTitle.mockClear();
   mocks.renameWorkbenchSession.mockReset();
   mocks.setSessionTitle.mockReset();
   mocks.setSessionTitle.mockImplementation((title: string | null) => {
@@ -908,7 +914,13 @@ describe('renaming a conversation from the workspace shell', () => {
       mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
     ).find((row) => row.id === 'session-1');
     expect(session?.title).toBe('New title');
-    expect(mocks.updateSessions).toHaveBeenCalled();
+    expect(mocks.updateSessionTitle.mock.calls).toEqual([
+      ['session-1', 'New title', false],
+      ['session-1', 'New title', true],
+    ]);
+    expect(mocks.updateSessionTitle.mock.invocationCallOrder[1]).toBeLessThan(
+      mocks.requestFullFetch.mock.invocationCallOrder[0]!,
+    );
     expect(mocks.requestFullFetch).toHaveBeenCalledTimes(1);
     expect(mocks.requestFullFetch).toHaveBeenLastCalledWith();
   });
@@ -940,6 +952,13 @@ describe('renaming a conversation from the workspace shell', () => {
 
     expect(mocks.requestFullFetch).toHaveBeenCalledTimes(1);
     expect(mocks.requestFullFetch).toHaveBeenLastCalledWith();
+    expect(mocks.updateSessionTitle.mock.calls).toEqual([
+      ['session-1', 'New title', false],
+      ['session-1', 'Old title', true],
+    ]);
+    expect(mocks.updateSessionTitle.mock.invocationCallOrder[1]).toBeLessThan(
+      mocks.requestFullFetch.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('finishes two same-session renames in submit order when the first one fails', async () => {
@@ -1062,7 +1081,7 @@ describe('renaming a conversation from the workspace shell', () => {
     expect(mocks.store.sessionTitle).toBe('Title A');
   });
 
-  it('does not settle a pending PATCH over a newer owner title event', async () => {
+  it('keeps a successful PATCH authoritative while an owner title event is uncorrelated', async () => {
     mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
     mocks.store.sessionId = 'session-1';
     mocks.store.sessionTitle = 'Old title';
@@ -1086,11 +1105,11 @@ describe('renaming a conversation from the workspace shell', () => {
     const session = (
       mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
     ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('Other tab title');
-    expect(mocks.store.sessionTitle).toBe('Other tab title');
+    expect(session?.title).toBe('Local title');
+    expect(mocks.store.sessionTitle).toBe('Local title');
   });
 
-  it('does not roll a failed PATCH back over a newer owner title event', async () => {
+  it('rolls back a failed PATCH while an owner title event is uncorrelated', async () => {
     mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
     mocks.store.sessionId = 'session-1';
     mocks.store.sessionTitle = 'Old title';
@@ -1114,8 +1133,8 @@ describe('renaming a conversation from the workspace shell', () => {
     const session = (
       mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
     ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('Other tab title');
-    expect(mocks.store.sessionTitle).toBe('Other tab title');
+    expect(session?.title).toBe('Old title');
+    expect(mocks.store.sessionTitle).toBe('Old title');
   });
 });
 

--- a/tests/workbench/workspace-course-chat-bootstrap.test.ts
+++ b/tests/workbench/workspace-course-chat-bootstrap.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   updateSessions: vi.fn(),
   updateSessionTitle: vi.fn(),
   renameWorkbenchSession: vi.fn(),
+  toastError: vi.fn(),
   classroomMounts: 0,
   classroomProps: null as Record<string, unknown> | null,
   chatPaneProps: null as Record<string, unknown> | null,
@@ -92,6 +93,7 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => mocks.searchParams,
 }));
 vi.mock('@/lib/hooks/use-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }));
 vi.mock('@/lib/hooks/use-home-discovery', () => ({
   useHomeDiscovery: () => mocks.courses,
 }));
@@ -127,11 +129,13 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
   OwnerSessionClient: class {
     private sessions: typeof mocks.sessionRows = [];
     private titleRevision = 0;
-    private readonly titleRevisions = new Map<string, number>();
-    private readonly titleMutations = new Map<string, { title: string | null; settled: boolean }>(
+    private readonly titleMutations = new Map<
+      string,
+      { title: string | null; settled: boolean; revision: number }
+    >(
       [...mocks.unconfirmedSessionTitles].map(([sessionId, title]) => [
         sessionId,
-        { title, settled: false },
+        { title, settled: false, revision: (this.titleRevision += 1) },
       ]),
     );
 
@@ -159,8 +163,7 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
     updateSessionTitle(sessionId: string, title: string | null, settled: boolean) {
       mocks.updateSessionTitle(sessionId, title, settled);
       const revision = (this.titleRevision += 1);
-      this.titleRevisions.set(sessionId, revision);
-      this.titleMutations.set(sessionId, { title, settled });
+      this.titleMutations.set(sessionId, { title, settled, revision });
       this.sessions = this.sessions.map((session) =>
         session.id === sessionId ? { ...session, title } : session,
       );
@@ -168,7 +171,7 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
       return revision;
     }
     isSessionTitleRevisionCurrent(sessionId: string, revision: number) {
-      return this.titleRevisions.get(sessionId) === revision;
+      return this.titleMutations.get(sessionId)?.revision === revision;
     }
     getUnconfirmedSessionTitle(sessionId: string) {
       const mutation = this.titleMutations.get(sessionId);
@@ -182,8 +185,6 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
     }
     emitSessionTitle(sessionId: string, title: string | null) {
       if (this.titleMutations.has(sessionId)) return;
-      this.titleRevisions.set(sessionId, (this.titleRevision += 1));
-      this.titleMutations.delete(sessionId);
       this.options.onSessionTitle?.(sessionId, title);
       this.sessions = this.sessions.map((session) =>
         session.id === sessionId ? { ...session, title } : session,
@@ -315,6 +316,7 @@ beforeEach(() => {
   mocks.updateSessions.mockClear();
   mocks.updateSessionTitle.mockClear();
   mocks.renameWorkbenchSession.mockReset();
+  mocks.toastError.mockReset();
   mocks.setSessionTitle.mockReset();
   mocks.setSessionTitle.mockImplementation((title: string | null) => {
     mocks.store.sessionTitle = title;
@@ -907,24 +909,30 @@ describe('renaming a conversation from the workspace shell', () => {
     updatedAt: 9,
   });
 
-  it('keeps a changed title in the owner snapshot through a later status event', async () => {
+  const renderNamedSession = async (title: string | null = 'Old title') => {
     mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
     mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionTitle = title;
     mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
-    mocks.renameWorkbenchSession.mockResolvedValue('New title');
+    mocks.sessionRows = [namedSession(title)];
     await render();
+  };
+
+  const visibleTitle = () =>
+    (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]).find(
+      (row) => row.id === 'session-1',
+    )?.title;
+
+  it('keeps a changed title in the owner snapshot through a later status event', async () => {
+    mocks.renameWorkbenchSession.mockResolvedValue('New title');
+    await renderNamedSession();
 
     await act(async () => {
       await rename()('session-1', 'New title');
     });
     await act(async () => mocks.ownerClient?.emitSessionStatus('session-1'));
 
-    const session = (
-      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
-    ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('New title');
+    expect(visibleTitle()).toBe('New title');
     expect(mocks.updateSessionTitle.mock.calls).toEqual([
       ['session-1', 'New title', false],
       ['session-1', 'New title', true],
@@ -936,26 +944,9 @@ describe('renaming a conversation from the workspace shell', () => {
     expect(mocks.requestFullFetch).toHaveBeenLastCalledWith();
   });
 
-  it('does not reconcile an unchanged title', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.sessionRows = [namedSession()];
-    await render();
-
-    await act(async () => {
-      await rename()('session-1', ' Old title ');
-    });
-
-    expect(mocks.renameWorkbenchSession).not.toHaveBeenCalled();
-    expect(mocks.requestFullFetch).not.toHaveBeenCalled();
-  });
-
   it('reconciles a refused title in case the response was lost after commit', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.sessionRows = [namedSession()];
     mocks.renameWorkbenchSession.mockRejectedValue(new Error('500'));
-    await render();
+    await renderNamedSession();
 
     await act(async () => {
       await rename()('session-1', 'New title');
@@ -972,61 +963,13 @@ describe('renaming a conversation from the workspace shell', () => {
     );
   });
 
-  it('finishes two same-session renames in submit order when the first one fails', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
-    mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
-    const first = deferred<string | null>();
-    const second = deferred<string | null>();
-    mocks.renameWorkbenchSession
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise);
-    await render();
-
-    let renameA!: Promise<string | null>;
-    let renameB!: Promise<string | null>;
-    await act(async () => {
-      renameA = rename()('session-1', 'Title A');
-      renameB = rename()('session-1', 'Title B');
-      await Promise.resolve();
-    });
-
-    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(1);
-    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Title A');
-
-    await act(async () => {
-      first.reject(new Error('500'));
-      await renameA;
-      await Promise.resolve();
-    });
-    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(2);
-    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Title B');
-
-    await act(async () => {
-      second.resolve('Title B');
-      await renameB;
-    });
-    const session = (
-      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
-    ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('Title B');
-    expect(mocks.store.sessionTitle).toBe('Title B');
-  });
-
   it('persists a queued undo after the first PATCH response fails ambiguously', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
-    mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
     const first = deferred<string | null>();
     const second = deferred<string | null>();
     mocks.renameWorkbenchSession
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
-    await render();
+    await renderNamedSession();
 
     let renameA!: Promise<string | null>;
     let restoreOld!: Promise<string | null>;
@@ -1035,6 +978,8 @@ describe('renaming a conversation from the workspace shell', () => {
       restoreOld = rename()('session-1', 'Old title');
       await Promise.resolve();
     });
+    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(1);
+    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Title A');
 
     await act(async () => {
       first.reject(new Error('lost response'));
@@ -1051,49 +996,79 @@ describe('renaming a conversation from the workspace shell', () => {
     expect(mocks.store.sessionTitle).toBe('Old title');
   });
 
-  it('does not let a late PATCH from an unmounted shell overwrite the new header', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
-    mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
-    const pending = deferred<string | null>();
-    mocks.renameWorkbenchSession.mockReturnValueOnce(pending.promise);
-    await render();
+  it('keeps queued PATCHes in user order across a workspace shell replacement', async () => {
+    const requests = new Map([
+      ['Title A', deferred<string | null>()],
+      ['Title B', deferred<string | null>()],
+      ['Title C', deferred<string | null>()],
+    ]);
+    mocks.renameWorkbenchSession.mockImplementation(
+      (_sessionId: string, title: string | null) => requests.get(title ?? '')!.promise,
+    );
+    await renderNamedSession();
 
-    let staleRename!: Promise<string | null>;
+    let renameA!: Promise<string | null>;
+    let renameB!: Promise<string | null>;
     await act(async () => {
-      staleRename = rename()('session-1', 'Stale local title');
+      renameA = rename()('session-1', 'Title A');
+      renameB = rename()('session-1', 'Title B');
       await Promise.resolve();
     });
+    expect(mocks.renameWorkbenchSession.mock.calls.map((call) => call[1])).toEqual(['Title A']);
 
     await act(async () => root?.unmount());
     root = null;
-    mocks.sessionRows = [namedSession('New header title')];
+    mocks.sessionRows = [namedSession()];
+    mocks.store.sessionTitle = 'Old title';
     await render();
     mocks.setSessionTitle.mockClear();
 
+    let renameC!: Promise<string | null>;
     await act(async () => {
-      pending.resolve('Stale local title');
-      await staleRename;
+      renameC = rename()('session-1', 'Title C');
+      await Promise.resolve();
     });
+    // A component replacement must not create a second writer for this session.
+    expect(mocks.renameWorkbenchSession.mock.calls.map((call) => call[1])).toEqual(['Title A']);
 
-    expect(mocks.store.sessionTitle).toBe('New header title');
-    expect(mocks.setSessionTitle).not.toHaveBeenCalledWith('Stale local title');
+    await act(async () => {
+      requests.get('Title A')!.resolve('Title A');
+      await renameA;
+      await Promise.resolve();
+    });
+    expect(mocks.setSessionTitle).not.toHaveBeenCalledWith('Title A');
+    expect(mocks.renameWorkbenchSession.mock.calls.map((call) => call[1])).toEqual([
+      'Title A',
+      'Title B',
+    ]);
+
+    await act(async () => {
+      requests.get('Title B')!.reject(new Error('retired request failed'));
+      await renameB;
+      await Promise.resolve();
+    });
+    expect(mocks.renameWorkbenchSession.mock.calls.map((call) => call[1])).toEqual([
+      'Title A',
+      'Title B',
+      'Title C',
+    ]);
+
+    await act(async () => {
+      requests.get('Title C')!.resolve('Title C');
+      await renameC;
+    });
+    expect(mocks.setSessionTitle).not.toHaveBeenCalledWith('Title B');
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.store.sessionTitle).toBe('Title C');
   });
 
   it('rolls a refused second rename back to the first committed title', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
-    mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
     const first = deferred<string | null>();
     const second = deferred<string | null>();
     mocks.renameWorkbenchSession
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
-    await render();
+    await renderNamedSession();
 
     let renameA!: Promise<string | null>;
     let renameB!: Promise<string | null>;
@@ -1115,67 +1090,8 @@ describe('renaming a conversation from the workspace shell', () => {
       second.reject(new Error('500'));
       await renameB;
     });
-    const session = (
-      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
-    ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('Title A');
+    expect(visibleTitle()).toBe('Title A');
     expect(mocks.store.sessionTitle).toBe('Title A');
-  });
-
-  it('keeps a successful PATCH authoritative while an owner title event is uncorrelated', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
-    mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
-    const pending = deferred<string | null>();
-    mocks.renameWorkbenchSession.mockReturnValueOnce(pending.promise);
-    await render();
-
-    let localRename!: Promise<string | null>;
-    await act(async () => {
-      localRename = rename()('session-1', 'Local title');
-      await Promise.resolve();
-    });
-    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', 'Other tab title'));
-    await act(async () => {
-      pending.resolve('Local title');
-      await localRename;
-    });
-
-    const session = (
-      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
-    ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('Local title');
-    expect(mocks.store.sessionTitle).toBe('Local title');
-  });
-
-  it('rolls back a failed PATCH while an owner title event is uncorrelated', async () => {
-    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
-    mocks.store.sessionId = 'session-1';
-    mocks.store.sessionTitle = 'Old title';
-    mocks.store.sessionPrompt = 'Build a course';
-    mocks.sessionRows = [namedSession()];
-    const pending = deferred<string | null>();
-    mocks.renameWorkbenchSession.mockReturnValueOnce(pending.promise);
-    await render();
-
-    let localRename!: Promise<string | null>;
-    await act(async () => {
-      localRename = rename()('session-1', 'Local title');
-      await Promise.resolve();
-    });
-    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', 'Other tab title'));
-    await act(async () => {
-      pending.reject(new Error('500'));
-      await localRename;
-    });
-
-    const session = (
-      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
-    ).find((row) => row.id === 'session-1');
-    expect(session?.title).toBe('Old title');
-    expect(mocks.store.sessionTitle).toBe('Old title');
   });
 });
 
@@ -1196,25 +1112,29 @@ describe('owner title projection in the workspace shell', () => {
     mocks.store.sessionTitle = 'Attached title';
   });
 
-  it('syncs a title event to the rail and attached header', async () => {
-    mocks.sessionRows = [session('session-1', 'Attached title')];
+  it.each([
+    { name: 'rename', initial: 'Attached title', next: 'Event title' },
+    { name: 'equal-value clear', initial: null, next: null },
+  ])('syncs a title-event $name to the rail and attached header', async ({ initial, next }) => {
+    mocks.store.sessionTitle = initial;
+    mocks.sessionRows = [session('session-1', initial)];
     await render();
     mocks.setSessionTitle.mockClear();
 
-    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', 'Event title'));
+    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', next));
 
     expect(
       (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[])[0]?.title,
-    ).toBe('Event title');
-    expect(mocks.setSessionTitle).toHaveBeenCalledWith('Event title');
+    ).toBe(next);
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith(next);
   });
 
   it.each([
     { name: 'rename', title: 'Pending title' },
     { name: 'clear', title: null },
   ])('force-seeds a pending $name even before its owner row exists', async ({ title }) => {
-    // Deliberately equal: the force flag, rather than a value change, must mark
-    // this title source as authoritative. This is essential for null -> null.
+    // Deliberately equal: writing this source, rather than observing a value
+    // change, must mark it authoritative. This is essential for null -> null.
     mocks.store.sessionTitle = title;
     mocks.sessionRows = [];
     mocks.unconfirmedSessionTitles.set('session-1', title);
@@ -1225,30 +1145,21 @@ describe('owner title projection in the workspace shell', () => {
     expect(mocks.store.sessionTitle).toBe(title);
   });
 
-  it('advances the attached title revision for an authoritative clear already shown as empty', async () => {
-    mocks.store.sessionTitle = null;
-    mocks.sessionRows = [session('session-1', null)];
+  it.each([
+    { name: 'changed title', initial: 'Attached title', next: 'Recovered title' },
+    { name: 'equal-value clear', initial: null, next: null },
+  ])('applies a full owner-list snapshot with a $name', async ({ initial, next }) => {
+    mocks.store.sessionTitle = initial;
+    mocks.sessionRows = [session('session-1', initial)];
     await render();
     mocks.setSessionTitle.mockClear();
 
-    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', null));
-
-    expect(mocks.setSessionTitle).toHaveBeenCalledWith(null);
-  });
-
-  it('repairs the attached header from a full owner-list reconciliation', async () => {
-    mocks.sessionRows = [session('session-1', 'Attached title')];
-    await render();
-    mocks.setSessionTitle.mockClear();
-
-    await act(async () =>
-      mocks.ownerClient?.reconcileSessions([session('session-1', 'Recovered title')]),
-    );
+    await act(async () => mocks.ownerClient?.reconcileSessions([session('session-1', next)]));
 
     expect(
       (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[])[0]?.title,
-    ).toBe('Recovered title');
-    expect(mocks.setSessionTitle).toHaveBeenCalledWith('Recovered title');
+    ).toBe(next);
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith(next);
   });
 
   it('does not let a sparse status publication overwrite a newer detail title', async () => {
@@ -1261,18 +1172,5 @@ describe('owner title projection in the workspace shell', () => {
 
     expect(mocks.setSessionTitle).not.toHaveBeenCalled();
     expect(mocks.store.sessionTitle).toBe('Detail title');
-  });
-
-  it('advances the title revision for an equal-value full snapshot, but not a status update', async () => {
-    mocks.store.sessionTitle = null;
-    mocks.sessionRows = [session('session-1', null)];
-    await render();
-    mocks.setSessionTitle.mockClear();
-
-    await act(async () => mocks.ownerClient?.emitSessionStatus('session-1'));
-    expect(mocks.setSessionTitle).not.toHaveBeenCalled();
-
-    await act(async () => mocks.ownerClient?.reconcileSessions([session('session-1', null)]));
-    expect(mocks.setSessionTitle).toHaveBeenCalledWith(null);
   });
 });

--- a/tests/workbench/workspace-course-chat-bootstrap.test.ts
+++ b/tests/workbench/workspace-course-chat-bootstrap.test.ts
@@ -22,6 +22,8 @@ const mocks = vi.hoisted(() => ({
   setPlaybackOn: vi.fn(),
   startFirstMessage: vi.fn(),
   requestFullFetch: vi.fn(),
+  updateSessions: vi.fn(),
+  renameWorkbenchSession: vi.fn(),
   classroomMounts: 0,
   classroomProps: null as Record<string, unknown> | null,
   chatPaneProps: null as Record<string, unknown> | null,
@@ -30,6 +32,8 @@ const mocks = vi.hoisted(() => ({
     id: string;
     stageId: string;
     updatedAt: number;
+    title?: string | null;
+    prompt?: string;
     status?: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
   }[],
   sessionListState: 'ready' as 'loading' | 'ready' | 'error',
@@ -37,6 +41,7 @@ const mocks = vi.hoisted(() => ({
     onSessions: (rows: readonly { id: string; stageId: string; updatedAt: number }[]) => void;
     onState: (state: 'loading' | 'ready' | 'error') => void;
   },
+  ownerClient: null as null | { emitSessionStatus: (sessionId: string) => void },
   router: null as {
     push: (...args: unknown[]) => unknown;
     replace: (...args: unknown[]) => unknown;
@@ -66,7 +71,10 @@ const mocks = vi.hoisted(() => ({
     pages: {} as Record<number, unknown>,
     panelOpen: false,
     courseTitle: null as string | null,
+    sessionTitle: null as string | null,
+    sessionPrompt: null as string | null,
   },
+  setSessionTitle: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -77,16 +85,23 @@ vi.mock('@/lib/hooks/use-i18n', () => ({ useI18n: () => ({ t: (key: string) => k
 vi.mock('@/lib/hooks/use-home-discovery', () => ({
   useHomeDiscovery: () => mocks.courses,
 }));
-vi.mock('@/lib/workbench/session-store', () => ({
-  useWorkbenchStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
-      ...mocks.store,
-      attach: mocks.attach,
-      detach: mocks.detach,
-      setPanelOpen: mocks.setPanelOpen,
-      setPlaybackOn: mocks.setPlaybackOn,
-    }),
-}));
+vi.mock('@/lib/workbench/session-store', () => {
+  const state = () => ({
+    ...mocks.store,
+    attach: mocks.attach,
+    detach: mocks.detach,
+    setPanelOpen: mocks.setPanelOpen,
+    setPlaybackOn: mocks.setPlaybackOn,
+    setSessionTitle: mocks.setSessionTitle,
+  });
+  return {
+    useWorkbenchStore: Object.assign(
+      (selector: (value: Record<string, unknown>) => unknown) => selector(state()),
+      { getState: state },
+    ),
+    renameWorkbenchSession: mocks.renameWorkbenchSession,
+  };
+});
 vi.mock('@/lib/store/stage', () => ({
   useStageStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({ isOwner: true }),
@@ -100,6 +115,8 @@ vi.mock('@/lib/workbench/first-message-session', () => ({
 }));
 vi.mock('@/lib/workbench/owner-session-client', () => ({
   OwnerSessionClient: class {
+    private sessions: typeof mocks.sessionRows = [];
+
     constructor(
       private readonly options: {
         onSessions: (rows: readonly { id: string; stageId: string; updatedAt: number }[]) => void;
@@ -108,12 +125,24 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
     ) {}
     start() {
       mocks.ownerOptions = this.options;
-      this.options.onSessions(mocks.sessionRows);
+      mocks.ownerClient = this;
+      this.sessions = mocks.sessionRows;
+      this.options.onSessions(this.sessions);
       this.options.onState(mocks.sessionListState);
     }
     stop() {}
     requestFullFetch = mocks.requestFullFetch;
-    updateSessions() {}
+    updateSessions(update: (sessions: typeof mocks.sessionRows) => typeof mocks.sessionRows) {
+      mocks.updateSessions(update);
+      this.sessions = update(this.sessions);
+      this.options.onSessions(this.sessions);
+    }
+    emitSessionStatus(sessionId: string) {
+      this.sessions = this.sessions.map((session) =>
+        session.id === sessionId ? { ...session, status: 'succeeded' as const } : session,
+      );
+      this.options.onSessions(this.sessions);
+    }
   },
 }));
 vi.mock('@/lib/workbench/pro-swap', () => ({ startProSwap: vi.fn() }));
@@ -209,15 +238,21 @@ beforeEach(() => {
   mocks.sessionRows = [];
   mocks.sessionListState = 'ready';
   mocks.ownerOptions = null;
+  mocks.ownerClient = null;
   mocks.store.sessionId = null;
   mocks.store.stageId = null;
   mocks.store.status = 'succeeded';
+  mocks.store.sessionTitle = null;
+  mocks.store.sessionPrompt = null;
   mocks.store.stageLinkStageIds = [];
   mocks.store.replayedStageLinkCount = 0;
   mocks.store.touchedStageIds = [];
   mocks.routerPush.mockClear();
   mocks.routerReplace.mockClear();
   mocks.requestFullFetch.mockClear();
+  mocks.updateSessions.mockClear();
+  mocks.renameWorkbenchSession.mockReset();
+  mocks.setSessionTitle.mockClear();
   mocks.startFirstMessage.mockReset();
   mocks.startFirstMessage.mockResolvedValue({
     sessionId: 'session-new',
@@ -786,5 +821,74 @@ describe('opening a course from a card in the conversation', () => {
     // a tab. With the cue gone the contract does not carry it, and nothing can
     // grow a conditional card off it again.
     expect(navigation()).not.toHaveProperty('openCourseIds');
+  });
+});
+
+describe('renaming a conversation from the workspace shell', () => {
+  const rename = () =>
+    mocks.railProps?.onRenameSession as (
+      sessionId: string,
+      title: string,
+    ) => Promise<string | null>;
+
+  const namedSession = (title: string | null = 'Old title') => ({
+    id: 'session-1',
+    stageId: 'stage-1',
+    prompt: 'Build a course',
+    title,
+    status: 'succeeded' as const,
+    createdAt: 1,
+    updatedAt: 9,
+  });
+
+  it('keeps a changed title in the owner snapshot through a later status event', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    mocks.renameWorkbenchSession.mockResolvedValue('New title');
+    await render();
+
+    await act(async () => {
+      await rename()('session-1', 'New title');
+    });
+    await act(async () => mocks.ownerClient?.emitSessionStatus('session-1'));
+
+    const session = (
+      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
+    ).find((row) => row.id === 'session-1');
+    expect(session?.title).toBe('New title');
+    expect(mocks.updateSessions).toHaveBeenCalled();
+    expect(mocks.requestFullFetch).toHaveBeenCalledTimes(1);
+    expect(mocks.requestFullFetch).toHaveBeenLastCalledWith();
+  });
+
+  it('does not reconcile an unchanged title', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.sessionRows = [namedSession()];
+    await render();
+
+    await act(async () => {
+      await rename()('session-1', ' Old title ');
+    });
+
+    expect(mocks.renameWorkbenchSession).not.toHaveBeenCalled();
+    expect(mocks.requestFullFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile a refused title', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.sessionRows = [namedSession()];
+    mocks.renameWorkbenchSession.mockRejectedValue(new Error('500'));
+    await render();
+
+    await act(async () => {
+      await rename()('session-1', 'New title');
+    });
+
+    expect(mocks.requestFullFetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/workbench/workspace-course-chat-bootstrap.test.ts
+++ b/tests/workbench/workspace-course-chat-bootstrap.test.ts
@@ -927,7 +927,7 @@ describe('renaming a conversation from the workspace shell', () => {
     expect(mocks.requestFullFetch).not.toHaveBeenCalled();
   });
 
-  it('does not reconcile a refused title', async () => {
+  it('reconciles a refused title in case the response was lost after commit', async () => {
     mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
     mocks.store.sessionId = 'session-1';
     mocks.sessionRows = [namedSession()];
@@ -938,7 +938,8 @@ describe('renaming a conversation from the workspace shell', () => {
       await rename()('session-1', 'New title');
     });
 
-    expect(mocks.requestFullFetch).not.toHaveBeenCalled();
+    expect(mocks.requestFullFetch).toHaveBeenCalledTimes(1);
+    expect(mocks.requestFullFetch).toHaveBeenLastCalledWith();
   });
 
   it('finishes two same-session renames in submit order when the first one fails', async () => {
@@ -982,6 +983,43 @@ describe('renaming a conversation from the workspace shell', () => {
     ).find((row) => row.id === 'session-1');
     expect(session?.title).toBe('Title B');
     expect(mocks.store.sessionTitle).toBe('Title B');
+  });
+
+  it('persists a queued attempt to undo an in-flight rename even when the projection matches', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    mocks.renameWorkbenchSession
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    await render();
+
+    let renameA!: Promise<string | null>;
+    let restoreOld!: Promise<string | null>;
+    await act(async () => {
+      renameA = rename()('session-1', 'Title A');
+      await Promise.resolve();
+      mocks.ownerClient?.emitSessionTitle('session-1', 'Old title');
+      restoreOld = rename()('session-1', 'Old title');
+    });
+
+    await act(async () => {
+      first.resolve('Title A');
+      await renameA;
+      await Promise.resolve();
+    });
+    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(2);
+    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Old title');
+
+    await act(async () => {
+      second.resolve('Old title');
+      await restoreOld;
+    });
+    expect(mocks.store.sessionTitle).toBe('Old title');
   });
 
   it('rolls a refused second rename back to the first committed title', async () => {
@@ -1135,6 +1173,18 @@ describe('owner title projection in the workspace shell', () => {
       (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[])[0]?.title,
     ).toBe('Recovered title');
     expect(mocks.setSessionTitle).toHaveBeenCalledWith('Recovered title');
+  });
+
+  it('does not let a sparse status publication overwrite a newer detail title', async () => {
+    mocks.sessionRows = [session('session-1', 'List title')];
+    await render();
+    mocks.store.sessionTitle = 'Detail title';
+    mocks.setSessionTitle.mockClear();
+
+    await act(async () => mocks.ownerClient?.emitSessionStatus('session-1'));
+
+    expect(mocks.setSessionTitle).not.toHaveBeenCalled();
+    expect(mocks.store.sessionTitle).toBe('Detail title');
   });
 
   it('advances the title revision for an equal-value full snapshot, but not a status update', async () => {

--- a/tests/workbench/workspace-course-chat-bootstrap.test.ts
+++ b/tests/workbench/workspace-course-chat-bootstrap.test.ts
@@ -13,6 +13,16 @@ import { act, createElement, StrictMode, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+interface MockSessionRow {
+  readonly id: string;
+  readonly stageId: string;
+  readonly updatedAt: number;
+  readonly createdAt?: number;
+  readonly title?: string | null;
+  readonly prompt?: string;
+  readonly status?: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+}
+
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   routerReplace: vi.fn(),
@@ -28,20 +38,18 @@ const mocks = vi.hoisted(() => ({
   classroomProps: null as Record<string, unknown> | null,
   chatPaneProps: null as Record<string, unknown> | null,
   searchParams: new URLSearchParams('course=stage-1'),
-  sessionRows: [] as readonly {
-    id: string;
-    stageId: string;
-    updatedAt: number;
-    title?: string | null;
-    prompt?: string;
-    status?: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
-  }[],
+  sessionRows: [] as readonly MockSessionRow[],
   sessionListState: 'ready' as 'loading' | 'ready' | 'error',
   ownerOptions: null as null | {
-    onSessions: (rows: readonly { id: string; stageId: string; updatedAt: number }[]) => void;
+    onSessions: (rows: readonly MockSessionRow[], source?: 'incremental' | 'snapshot') => void;
+    onSessionTitle?: (sessionId: string, title: string | null) => void;
     onState: (state: 'loading' | 'ready' | 'error') => void;
   },
-  ownerClient: null as null | { emitSessionStatus: (sessionId: string) => void },
+  ownerClient: null as null | {
+    emitSessionStatus: (sessionId: string) => void;
+    emitSessionTitle: (sessionId: string, title: string | null) => void;
+    reconcileSessions: (rows: readonly MockSessionRow[]) => void;
+  },
   router: null as {
     push: (...args: unknown[]) => unknown;
     replace: (...args: unknown[]) => unknown;
@@ -116,10 +124,13 @@ vi.mock('@/lib/workbench/first-message-session', () => ({
 vi.mock('@/lib/workbench/owner-session-client', () => ({
   OwnerSessionClient: class {
     private sessions: typeof mocks.sessionRows = [];
+    private titleRevision = 0;
+    private readonly titleRevisions = new Map<string, number>();
 
     constructor(
       private readonly options: {
-        onSessions: (rows: readonly { id: string; stageId: string; updatedAt: number }[]) => void;
+        onSessions: (rows: readonly MockSessionRow[], source?: 'incremental' | 'snapshot') => void;
+        onSessionTitle?: (sessionId: string, title: string | null) => void;
         onState: (state: 'loading' | 'ready' | 'error') => void;
       },
     ) {}
@@ -127,7 +138,7 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
       mocks.ownerOptions = this.options;
       mocks.ownerClient = this;
       this.sessions = mocks.sessionRows;
-      this.options.onSessions(this.sessions);
+      this.options.onSessions(this.sessions, 'snapshot');
       this.options.onState(mocks.sessionListState);
     }
     stop() {}
@@ -137,11 +148,36 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
       this.sessions = update(this.sessions);
       this.options.onSessions(this.sessions);
     }
+    updateSessionTitle(sessionId: string, title: string | null) {
+      mocks.updateSessions(sessionId, title);
+      const revision = (this.titleRevision += 1);
+      this.titleRevisions.set(sessionId, revision);
+      this.sessions = this.sessions.map((session) =>
+        session.id === sessionId ? { ...session, title } : session,
+      );
+      this.options.onSessions(this.sessions);
+      return revision;
+    }
+    isSessionTitleRevisionCurrent(sessionId: string, revision: number) {
+      return this.titleRevisions.get(sessionId) === revision;
+    }
     emitSessionStatus(sessionId: string) {
       this.sessions = this.sessions.map((session) =>
         session.id === sessionId ? { ...session, status: 'succeeded' as const } : session,
       );
       this.options.onSessions(this.sessions);
+    }
+    emitSessionTitle(sessionId: string, title: string | null) {
+      this.titleRevisions.set(sessionId, (this.titleRevision += 1));
+      this.options.onSessionTitle?.(sessionId, title);
+      this.sessions = this.sessions.map((session) =>
+        session.id === sessionId ? { ...session, title } : session,
+      );
+      this.options.onSessions(this.sessions);
+    }
+    reconcileSessions(rows: readonly MockSessionRow[]) {
+      this.sessions = rows;
+      this.options.onSessions(this.sessions, 'snapshot');
     }
   },
 }));
@@ -196,6 +232,16 @@ const render = async (node: ReactNode = createElement(WorkspaceShell)) => {
   root ??= createRoot(container);
   await act(async () => root?.render(node));
 };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
 
 /** The draft-conversation capability the shell hands its chat pane, if any. */
 const draft = () =>
@@ -252,7 +298,10 @@ beforeEach(() => {
   mocks.requestFullFetch.mockClear();
   mocks.updateSessions.mockClear();
   mocks.renameWorkbenchSession.mockReset();
-  mocks.setSessionTitle.mockClear();
+  mocks.setSessionTitle.mockReset();
+  mocks.setSessionTitle.mockImplementation((title: string | null) => {
+    mocks.store.sessionTitle = title;
+  });
   mocks.startFirstMessage.mockReset();
   mocks.startFirstMessage.mockResolvedValue({
     sessionId: 'session-new',
@@ -890,5 +939,214 @@ describe('renaming a conversation from the workspace shell', () => {
     });
 
     expect(mocks.requestFullFetch).not.toHaveBeenCalled();
+  });
+
+  it('finishes two same-session renames in submit order when the first one fails', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    mocks.renameWorkbenchSession
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    await render();
+
+    let renameA!: Promise<string | null>;
+    let renameB!: Promise<string | null>;
+    await act(async () => {
+      renameA = rename()('session-1', 'Title A');
+      renameB = rename()('session-1', 'Title B');
+      await Promise.resolve();
+    });
+
+    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(1);
+    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Title A');
+
+    await act(async () => {
+      first.reject(new Error('500'));
+      await renameA;
+      await Promise.resolve();
+    });
+    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(2);
+    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Title B');
+
+    await act(async () => {
+      second.resolve('Title B');
+      await renameB;
+    });
+    const session = (
+      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
+    ).find((row) => row.id === 'session-1');
+    expect(session?.title).toBe('Title B');
+    expect(mocks.store.sessionTitle).toBe('Title B');
+  });
+
+  it('rolls a refused second rename back to the first committed title', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    mocks.renameWorkbenchSession
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    await render();
+
+    let renameA!: Promise<string | null>;
+    let renameB!: Promise<string | null>;
+    await act(async () => {
+      renameA = rename()('session-1', 'Title A');
+      renameB = rename()('session-1', 'Title B');
+      await Promise.resolve();
+    });
+    expect(mocks.renameWorkbenchSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      first.resolve('Title A');
+      await renameA;
+      await Promise.resolve();
+    });
+    expect(mocks.renameWorkbenchSession).toHaveBeenLastCalledWith('session-1', 'Title B');
+
+    await act(async () => {
+      second.reject(new Error('500'));
+      await renameB;
+    });
+    const session = (
+      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
+    ).find((row) => row.id === 'session-1');
+    expect(session?.title).toBe('Title A');
+    expect(mocks.store.sessionTitle).toBe('Title A');
+  });
+
+  it('does not settle a pending PATCH over a newer owner title event', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    const pending = deferred<string | null>();
+    mocks.renameWorkbenchSession.mockReturnValueOnce(pending.promise);
+    await render();
+
+    let localRename!: Promise<string | null>;
+    await act(async () => {
+      localRename = rename()('session-1', 'Local title');
+      await Promise.resolve();
+    });
+    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', 'Other tab title'));
+    await act(async () => {
+      pending.resolve('Local title');
+      await localRename;
+    });
+
+    const session = (
+      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
+    ).find((row) => row.id === 'session-1');
+    expect(session?.title).toBe('Other tab title');
+    expect(mocks.store.sessionTitle).toBe('Other tab title');
+  });
+
+  it('does not roll a failed PATCH back over a newer owner title event', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    const pending = deferred<string | null>();
+    mocks.renameWorkbenchSession.mockReturnValueOnce(pending.promise);
+    await render();
+
+    let localRename!: Promise<string | null>;
+    await act(async () => {
+      localRename = rename()('session-1', 'Local title');
+      await Promise.resolve();
+    });
+    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', 'Other tab title'));
+    await act(async () => {
+      pending.reject(new Error('500'));
+      await localRename;
+    });
+
+    const session = (
+      mocks.railProps?.sessions as readonly { id: string; title?: string | null }[]
+    ).find((row) => row.id === 'session-1');
+    expect(session?.title).toBe('Other tab title');
+    expect(mocks.store.sessionTitle).toBe('Other tab title');
+  });
+});
+
+describe('owner title projection in the workspace shell', () => {
+  const session = (id: string, title: string | null) => ({
+    id,
+    stageId: `stage-${id}`,
+    prompt: `${id} prompt`,
+    title,
+    status: 'succeeded' as const,
+    createdAt: 1,
+    updatedAt: 9,
+  });
+
+  beforeEach(() => {
+    mocks.searchParams = new URLSearchParams('session=session-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Attached title';
+  });
+
+  it('syncs a title event to the rail and attached header', async () => {
+    mocks.sessionRows = [session('session-1', 'Attached title')];
+    await render();
+    mocks.setSessionTitle.mockClear();
+
+    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', 'Event title'));
+
+    expect(
+      (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[])[0]?.title,
+    ).toBe('Event title');
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith('Event title');
+  });
+
+  it('advances the attached title revision for an authoritative clear already shown as empty', async () => {
+    mocks.store.sessionTitle = null;
+    mocks.sessionRows = [session('session-1', null)];
+    await render();
+    mocks.setSessionTitle.mockClear();
+
+    await act(async () => mocks.ownerClient?.emitSessionTitle('session-1', null));
+
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith(null);
+  });
+
+  it('repairs the attached header from a full owner-list reconciliation', async () => {
+    mocks.sessionRows = [session('session-1', 'Attached title')];
+    await render();
+    mocks.setSessionTitle.mockClear();
+
+    await act(async () =>
+      mocks.ownerClient?.reconcileSessions([session('session-1', 'Recovered title')]),
+    );
+
+    expect(
+      (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[])[0]?.title,
+    ).toBe('Recovered title');
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith('Recovered title');
+  });
+
+  it('advances the title revision for an equal-value full snapshot, but not a status update', async () => {
+    mocks.store.sessionTitle = null;
+    mocks.sessionRows = [session('session-1', null)];
+    await render();
+    mocks.setSessionTitle.mockClear();
+
+    await act(async () => mocks.ownerClient?.emitSessionStatus('session-1'));
+    expect(mocks.setSessionTitle).not.toHaveBeenCalled();
+
+    await act(async () => mocks.ownerClient?.reconcileSessions([session('session-1', null)]));
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith(null);
   });
 });

--- a/tests/workbench/workspace-course-chat-bootstrap.test.ts
+++ b/tests/workbench/workspace-course-chat-bootstrap.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
     emitSessionTitle: (sessionId: string, title: string | null) => void;
     reconcileSessions: (rows: readonly MockSessionRow[]) => void;
   },
+  unconfirmedSessionTitles: new Map<string, string | null>(),
   router: null as {
     push: (...args: unknown[]) => unknown;
     replace: (...args: unknown[]) => unknown;
@@ -127,7 +128,12 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
     private sessions: typeof mocks.sessionRows = [];
     private titleRevision = 0;
     private readonly titleRevisions = new Map<string, number>();
-    private readonly titleMutations = new Map<string, { settled: boolean }>();
+    private readonly titleMutations = new Map<string, { title: string | null; settled: boolean }>(
+      [...mocks.unconfirmedSessionTitles].map(([sessionId, title]) => [
+        sessionId,
+        { title, settled: false },
+      ]),
+    );
 
     constructor(
       private readonly options: {
@@ -154,7 +160,7 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
       mocks.updateSessionTitle(sessionId, title, settled);
       const revision = (this.titleRevision += 1);
       this.titleRevisions.set(sessionId, revision);
-      this.titleMutations.set(sessionId, { settled });
+      this.titleMutations.set(sessionId, { title, settled });
       this.sessions = this.sessions.map((session) =>
         session.id === sessionId ? { ...session, title } : session,
       );
@@ -163,6 +169,10 @@ vi.mock('@/lib/workbench/owner-session-client', () => ({
     }
     isSessionTitleRevisionCurrent(sessionId: string, revision: number) {
       return this.titleRevisions.get(sessionId) === revision;
+    }
+    getUnconfirmedSessionTitle(sessionId: string) {
+      const mutation = this.titleMutations.get(sessionId);
+      return mutation ? { title: mutation.title } : null;
     }
     emitSessionStatus(sessionId: string) {
       this.sessions = this.sessions.map((session) =>
@@ -290,6 +300,7 @@ beforeEach(() => {
   mocks.sessionListState = 'ready';
   mocks.ownerOptions = null;
   mocks.ownerClient = null;
+  mocks.unconfirmedSessionTitles.clear();
   mocks.store.sessionId = null;
   mocks.store.stageId = null;
   mocks.store.status = 'succeeded';
@@ -1004,7 +1015,7 @@ describe('renaming a conversation from the workspace shell', () => {
     expect(mocks.store.sessionTitle).toBe('Title B');
   });
 
-  it('persists a queued attempt to undo an in-flight rename even when the projection matches', async () => {
+  it('persists a queued undo after the first PATCH response fails ambiguously', async () => {
     mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
     mocks.store.sessionId = 'session-1';
     mocks.store.sessionTitle = 'Old title';
@@ -1021,13 +1032,12 @@ describe('renaming a conversation from the workspace shell', () => {
     let restoreOld!: Promise<string | null>;
     await act(async () => {
       renameA = rename()('session-1', 'Title A');
-      await Promise.resolve();
-      mocks.ownerClient?.emitSessionTitle('session-1', 'Old title');
       restoreOld = rename()('session-1', 'Old title');
+      await Promise.resolve();
     });
 
     await act(async () => {
-      first.resolve('Title A');
+      first.reject(new Error('lost response'));
       await renameA;
       await Promise.resolve();
     });
@@ -1039,6 +1049,37 @@ describe('renaming a conversation from the workspace shell', () => {
       await restoreOld;
     });
     expect(mocks.store.sessionTitle).toBe('Old title');
+  });
+
+  it('does not let a late PATCH from an unmounted shell overwrite the new header', async () => {
+    mocks.searchParams = new URLSearchParams('session=session-1&course=stage-1');
+    mocks.store.sessionId = 'session-1';
+    mocks.store.sessionTitle = 'Old title';
+    mocks.store.sessionPrompt = 'Build a course';
+    mocks.sessionRows = [namedSession()];
+    const pending = deferred<string | null>();
+    mocks.renameWorkbenchSession.mockReturnValueOnce(pending.promise);
+    await render();
+
+    let staleRename!: Promise<string | null>;
+    await act(async () => {
+      staleRename = rename()('session-1', 'Stale local title');
+      await Promise.resolve();
+    });
+
+    await act(async () => root?.unmount());
+    root = null;
+    mocks.sessionRows = [namedSession('New header title')];
+    await render();
+    mocks.setSessionTitle.mockClear();
+
+    await act(async () => {
+      pending.resolve('Stale local title');
+      await staleRename;
+    });
+
+    expect(mocks.store.sessionTitle).toBe('New header title');
+    expect(mocks.setSessionTitle).not.toHaveBeenCalledWith('Stale local title');
   });
 
   it('rolls a refused second rename back to the first committed title', async () => {
@@ -1166,6 +1207,22 @@ describe('owner title projection in the workspace shell', () => {
       (mocks.railProps?.sessions as readonly { id: string; title?: string | null }[])[0]?.title,
     ).toBe('Event title');
     expect(mocks.setSessionTitle).toHaveBeenCalledWith('Event title');
+  });
+
+  it.each([
+    { name: 'rename', title: 'Pending title' },
+    { name: 'clear', title: null },
+  ])('force-seeds a pending $name even before its owner row exists', async ({ title }) => {
+    // Deliberately equal: the force flag, rather than a value change, must mark
+    // this title source as authoritative. This is essential for null -> null.
+    mocks.store.sessionTitle = title;
+    mocks.sessionRows = [];
+    mocks.unconfirmedSessionTitles.set('session-1', title);
+
+    await render();
+
+    expect(mocks.setSessionTitle).toHaveBeenCalledWith(title);
+    expect(mocks.store.sessionTitle).toBe(title);
   });
 
   it('advances the attached title revision for an authoritative clear already shown as empty', async () => {


### PR DESCRIPTION
## Summary

Persist manual Pro conversation titles end to end so a rename survives reloads and cannot be rolled back by later owner-session status updates.

## Related Issues

Fixes #1263

## Changes

- Add a nullable agent_sessions.title column with an idempotent upgrade path and expose an additive AgentSessionTitleStore capability without changing AgentSessionStore.
- Add the missing owner-scoped PATCH /api/agent/sessions/:id route with strict validation, trim/120-character normalization, blank-to-null clearing, and uniform not-found behavior.
- Update the OwnerSessionClient authoritative snapshot during optimistic rename, server settle, and rollback; request one no-loading reconciliation after a changed successful write.
- Fence session-detail title bootstraps with a per-session revision so an older response cannot overwrite a rename or explicit clear made while it was in flight.
- Add real PGlite migration/isolation coverage, route boundary tests, and a shell regression test for the late status-event rollback race.
- Bump @openmaic/storage from 0.26.0 to 0.26.1.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Rename a Pro conversation from the rail or attached header and reload the workspace.
2. Clear the title and verify the original prompt-derived fallback returns.
3. Deliver a later owner session_status update and verify it does not restore the previous title.
4. Delay the initial session-detail response, rename before it arrives, and compare the rail, attached header, and stored title after release.

### What you personally verified

- Previous-head full verification: Node 22 package/dependency gates, Prettier, root TypeScript, i18n, ESLint, production build, root Vitest (7051 passed, 26 skipped), and package suites all passed.
- Current-head focused verification: all 77 workbench files passed (990 tests); root TypeScript, changed-file ESLint, Prettier, and diff checks passed.
- Manual browser verification against local PostgreSQL 16: rename + reload passed; clear + reload restored the prompt fallback.
- Deterministic delayed-response verification passed: after an older session-detail response carrying `Race Start` was captured, the title was changed to `Race New`; releasing the old response left the rail, attached header, and database on `Race New`. The same check passed for an explicit clear, preserving the prompt fallback instead of restoring the stale title.

### Evidence

- Local verification results are summarized above; all four GitHub checks passed for the latest head.
- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally, including delayed session-detail responses during rename and clear
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
