### PR TITLE
fix(storage): prune redundant intermediate message_update frames

### DIFF
--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -966,7 +966,17 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         type,
         data: snapshot,
       });
-      if (seq === null) markLeaseLost();
+      if (seq === null) {
+        markLeaseLost();
+        return;
+      }
+      if (type === 'message_end') {
+        try {
+          await store.pruneMessageUpdates(id, seq);
+        } catch (error) {
+          log.error(`session ${id}: message update prune failed`, error);
+        }
+      }
     });
   };
 

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -777,33 +777,33 @@ export class PgAgentSessionStore
 
   async pruneMessageUpdates(sessionId: string, messageEndSeq: number): Promise<number> {
     const result = await this.queryable.query<{ seq: number }>(
-      `WITH RECURSIVE update_run(seq) AS (
-         SELECT previous.seq
+      `WITH completed_message AS (
+         SELECT message_end.seq AS end_seq, boundary.seq AS start_seq
          FROM ${this.table('events')} message_end
          JOIN LATERAL (
            SELECT e.seq, e.type
            FROM ${this.table('events')} e
            WHERE e.session_id = message_end.session_id AND e.seq < message_end.seq
+             AND e.type IN ('message_start', 'message_end')
            ORDER BY e.seq DESC LIMIT 1
-         ) previous ON previous.type = 'message_update'
+         ) boundary ON boundary.type = 'message_start'
          WHERE message_end.session_id = $1 AND message_end.seq = $2
            AND message_end.type = 'message_end'
-         UNION ALL
-         SELECT previous.seq
-         FROM update_run current
-         JOIN LATERAL (
-           SELECT e.seq, e.type
-           FROM ${this.table('events')} e
-           WHERE e.session_id = $1 AND e.seq < current.seq
-           ORDER BY e.seq DESC LIMIT 1
-         ) previous ON previous.type = 'message_update'
-       ), bounds AS (
-         SELECT min(seq) AS first_seq, max(seq) AS last_seq FROM update_run
+       ), message_events AS (
+         SELECT e.seq, e.type
+         FROM ${this.table('events')} e
+         INNER JOIN completed_message message
+           ON e.seq >= message.start_seq AND e.seq <= message.end_seq
+         WHERE e.session_id = $1
+       ), ranked AS (
+         SELECT seq, type, lag(type) OVER (ORDER BY seq) AS prev_type,
+                lead(type) OVER (ORDER BY seq) AS next_type
+         FROM message_events
        )
-       DELETE FROM ${this.table('events')} e USING bounds
-       WHERE e.session_id = $1 AND e.type = 'message_update'
-         AND e.seq > bounds.first_seq AND e.seq < bounds.last_seq
-         AND e.seq < $2
+       DELETE FROM ${this.table('events')} e USING ranked r
+       WHERE e.session_id = $1 AND e.seq = r.seq AND e.seq < $2
+         AND r.type = 'message_update'
+         AND r.prev_type = 'message_update' AND r.next_type = 'message_update'
        RETURNING e.seq`,
       [sessionId, messageEndSeq],
     );

--- a/packages/@openmaic/storage/src/agent-session/pg.ts
+++ b/packages/@openmaic/storage/src/agent-session/pg.ts
@@ -775,6 +775,41 @@ export class PgAgentSessionStore
     });
   }
 
+  async pruneMessageUpdates(sessionId: string, messageEndSeq: number): Promise<number> {
+    const result = await this.queryable.query<{ seq: number }>(
+      `WITH RECURSIVE update_run(seq) AS (
+         SELECT previous.seq
+         FROM ${this.table('events')} message_end
+         JOIN LATERAL (
+           SELECT e.seq, e.type
+           FROM ${this.table('events')} e
+           WHERE e.session_id = message_end.session_id AND e.seq < message_end.seq
+           ORDER BY e.seq DESC LIMIT 1
+         ) previous ON previous.type = 'message_update'
+         WHERE message_end.session_id = $1 AND message_end.seq = $2
+           AND message_end.type = 'message_end'
+         UNION ALL
+         SELECT previous.seq
+         FROM update_run current
+         JOIN LATERAL (
+           SELECT e.seq, e.type
+           FROM ${this.table('events')} e
+           WHERE e.session_id = $1 AND e.seq < current.seq
+           ORDER BY e.seq DESC LIMIT 1
+         ) previous ON previous.type = 'message_update'
+       ), bounds AS (
+         SELECT min(seq) AS first_seq, max(seq) AS last_seq FROM update_run
+       )
+       DELETE FROM ${this.table('events')} e USING bounds
+       WHERE e.session_id = $1 AND e.type = 'message_update'
+         AND e.seq > bounds.first_seq AND e.seq < bounds.last_seq
+         AND e.seq < $2
+       RETURNING e.seq`,
+      [sessionId, messageEndSeq],
+    );
+    return result.rows.length;
+  }
+
   async appendControlEvent(
     sessionId: string,
     event: Omit<NewAgentSessionEvent, 'attempt'>,

--- a/packages/@openmaic/storage/src/agent-session/types.ts
+++ b/packages/@openmaic/storage/src/agent-session/types.ts
@@ -370,6 +370,8 @@ export interface AgentSessionEventLog {
     workerId: string,
     event: NewAgentSessionEvent,
   ): Promise<number | null>;
+  /** Keeps only the first and last frame in the update run before a completed message. */
+  pruneMessageUpdates(sessionId: string, messageEndSeq: number): Promise<number>;
   /**
    * Append a control-plane event without borrowing the runner's lease. The
    * stored attempt is the session's current generation, read under the session

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -262,6 +262,51 @@ export function runAgentSessionStoreContract(
       expect(replay.events.map((event) => event.id)).toEqual([1, 2, 4, 5]);
     });
 
+    test('prunes only middle updates from the completed message immediately before its end', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      const frames = [
+        { type: 'message_start', data: { message: { role: 'assistant', content: [] } } },
+        ...Array.from({ length: 5 }, (_, index) => ({
+          type: 'message_update',
+          data: {
+            message: { role: 'assistant', content: [{ type: 'text', text: `part-${index}` }] },
+          },
+        })),
+        { type: 'message_end', data: { message: { role: 'assistant', content: [] } } },
+        { type: 'tool_execution_end', data: { toolCallId: 'tool-1' } },
+        { type: 'message_start', data: { message: { role: 'assistant', content: [] } } },
+        ...Array.from({ length: 3 }, (_, index) => ({
+          type: 'message_update',
+          data: {
+            message: { role: 'assistant', content: [{ type: 'text', text: `next-${index}` }] },
+          },
+        })),
+      ];
+      for (const [index, frame] of frames.entries()) {
+        await store.appendControlEvent('session-1', { ts: index + 1, ...frame });
+      }
+
+      const before = await store.readEventsAfterForReplay('session-1', 0);
+      expect(await store.pruneMessageUpdates('session-1', 7)).toBe(3);
+      expect(await store.pruneMessageUpdates('session-1', 7)).toBe(0);
+
+      const raw = await store.readEventsAfter('session-1', 0);
+      expect(raw.map((event) => [event.id, event.type])).toEqual([
+        [1, 'message_start'],
+        [2, 'message_update'],
+        [6, 'message_update'],
+        [7, 'message_end'],
+        [8, 'tool_execution_end'],
+        [9, 'message_start'],
+        [10, 'message_update'],
+        [11, 'message_update'],
+        [12, 'message_update'],
+      ]);
+      const after = await store.readEventsAfterForReplay('session-1', 0);
+      expect(after.events).toEqual(before.events);
+    });
+
     test('carries first-and-last message_update compaction across page boundaries', async () => {
       const store = makeStore();
       await store.createSession(makeAgentSessionInput());

--- a/packages/@openmaic/storage/test/agent-session-contract.ts
+++ b/packages/@openmaic/storage/test/agent-session-contract.ts
@@ -307,6 +307,55 @@ export function runAgentSessionStoreContract(
       expect(after.events).toEqual(before.events);
     });
 
+    test('prunes every update run separated by reasoning and tool lifecycle events', async () => {
+      const store = makeStore();
+      await store.createSession(makeAgentSessionInput());
+      const updates = (prefix: string, count: number) =>
+        Array.from({ length: count }, (_, index) => ({
+          type: 'message_update',
+          data: {
+            message: {
+              role: 'assistant',
+              content: [{ type: 'text', text: `${prefix}-${index}` }],
+            },
+          },
+        }));
+      const frames = [
+        { type: 'message_start', data: { message: { role: 'assistant', content: [] } } },
+        ...updates('reasoning', 5),
+        { type: 'thinking_end', data: {} },
+        ...updates('answer', 4),
+        { type: 'tool_execution_start', data: { toolCallId: 'tool-1' } },
+        { type: 'tool_execution_end', data: { toolCallId: 'tool-1' } },
+        ...updates('after-tool', 3),
+        { type: 'message_end', data: { message: { role: 'assistant', content: [] } } },
+      ];
+      for (const [index, frame] of frames.entries()) {
+        await store.appendControlEvent('session-1', { ts: index + 1, ...frame });
+      }
+
+      const before = await store.readEventsAfterForReplay('session-1', 0);
+      expect(await store.pruneMessageUpdates('session-1', 17)).toBe(6);
+      expect(await store.pruneMessageUpdates('session-1', 17)).toBe(0);
+
+      const raw = await store.readEventsAfter('session-1', 0);
+      expect(raw.map((event) => [event.id, event.type])).toEqual([
+        [1, 'message_start'],
+        [2, 'message_update'],
+        [6, 'message_update'],
+        [7, 'thinking_end'],
+        [8, 'message_update'],
+        [11, 'message_update'],
+        [12, 'tool_execution_start'],
+        [13, 'tool_execution_end'],
+        [14, 'message_update'],
+        [16, 'message_update'],
+        [17, 'message_end'],
+      ]);
+      const after = await store.readEventsAfterForReplay('session-1', 0);
+      expect(after.events).toEqual(before.events);
+    });
+
     test('carries first-and-last message_update compaction across page boundaries', async () => {
       const store = makeStore();
       await store.createSession(makeAgentSessionInput());

--- a/tests/agent-runtime/runner-tool-call-integrity.test.ts
+++ b/tests/agent-runtime/runner-tool-call-integrity.test.ts
@@ -139,6 +139,7 @@ function makeStore(meta: ClaimedAgentSession, options: { hasSessionRunHistory?: 
         return seq;
       },
     ),
+    pruneMessageUpdates: vi.fn(async () => 0),
     clearCancel: vi.fn(async () => undefined),
     finishSession: vi.fn(async () => true),
     getSession: vi.fn(async () => ({ ...meta, lease: { workerId: WORKER_ID } })),
@@ -283,6 +284,19 @@ describe('write-time settlement of interrupted tool calls', () => {
         (event.data?.message as { role?: string } | undefined)?.role === 'toolResult',
     );
     expect(toolResultEvents).toEqual([]);
+
+    const messageEndSeqs = store.appendRunEvent.mock.calls.flatMap((call, index) =>
+      call[2].type === 'message_end' ? [index + 1] : [],
+    );
+    expect(store.pruneMessageUpdates.mock.calls).toEqual(
+      messageEndSeqs.map((seq) => [SESSION_ID, seq]),
+    );
+    for (const [index, seq] of messageEndSeqs.entries()) {
+      const appendCallOrder = store.appendRunEvent.mock.invocationCallOrder[seq - 1]!;
+      expect(store.pruneMessageUpdates.mock.invocationCallOrder[index]).toBeGreaterThan(
+        appendCallOrder,
+      );
+    }
   });
 
   it('parks a shutdown-interrupted run with a durable receipt for the orphaned call', async () => {


### PR DESCRIPTION
Fixes #1278.

## What

After a `message_end` is durably appended, prune the **intermediate** `message_update` rows of that message's contiguous update run, keeping only the first and last. This materializes at write-time exactly what the read path already discards.

## Why

pi streams an assistant message as many `message_update` events and every frame is persisted carrying the **full accumulated message**. The read path (`readEventsAfterForReplay` / client `compactReplayEvents`) already keeps only the first+last of each contiguous run, `message_end` carries the full text, and crash/resume never reads `message_update` (it reconstructs from the entry tree + pi transcript). So intermediate frames are persisted but never consumed — pure write amplification (measured ~74% of rows / ~89% of bytes in one deployment).

## How

- New `PgAgentSessionStore.pruneMessageUpdates(sessionId, messageEndSeq)`: walks backward from the persisted `message_end` via the `(session_id, seq)` primary-key index, bounds the contiguous `message_update` run immediately preceding it, and deletes only rows strictly between the run's first and last frames. O(run length), not O(session); never touches rows at/after `messageEndSeq` (in-flight next message).
- Runner calls it after `message_end` is durably appended, ordered in the write chain after that append, off the live-stream path; prune failures are logged and do not fail the run.

## Safety

- No schema change; read path untouched.
- Replay output verified byte-equivalent before/after pruning.
- In-flight (not-yet-ended) frames untouched; single-frame/empty runs are no-ops.
- Crash/resume unaffected (doesn't use `message_update`).

## Tests

- Physical first+last retention + deletion count; idempotent second call.
- Preservation of message boundaries, unrelated events, and next-message frames.
- Replay equivalence before/after pruning.
- Runner invocation with the committed `message_end` seq and correct ordering.
- Existing agent-session contract suite: no assertions changed, all pass.

## Validation

`tsc --noEmit`, storage schema suites (66 passed / 37 env-gated skipped), runner suites (9 passed), ESLint, repo-wide `pnpm check`.