### PR TITLE
fix(generation): load micropip before generated imports

### DIFF
--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/templates/code-content/system.md
+++ b/packages/@openmaic/generation/templates/code-content/system.md
@@ -59,6 +59,20 @@ If user code needs packages like numpy, load them during initialization:
 await pyodide.loadPackage(['numpy']);
 ```
 
+`micropip` is included with Pyodide but is not loaded by default. If generated
+code installs PyPI packages with `micropip`, load it before importing it:
+
+```javascript
+await pyodide.loadPackage('micropip');
+await pyodide.runPythonAsync(`
+    import micropip
+    await micropip.install('package-name')
+`);
+```
+
+Never run `import micropip` before `loadPackage('micropip')` resolves, because
+that aborts widget initialization with `ModuleNotFoundError`.
+
 ### 4. Wait for Pyodide Initialization
 
 - Disable the run button until Pyodide is fully loaded

--- a/packages/@openmaic/generation/test/assets.test.ts
+++ b/packages/@openmaic/generation/test/assets.test.ts
@@ -77,6 +77,23 @@ describe('packaged prompt assets', () => {
     expect(actualFiles).toEqual(expectedFiles);
   });
 
+  test('instructs Pyodide widgets to load micropip before importing it', () => {
+    const source = readFileSync(
+      join(PACKAGE_ROOT, 'templates', 'code-content', 'system.md'),
+      'utf8',
+    );
+    const loadIndex = source.search(
+      /await pyodide\.loadPackage\(\s*(?:['"]micropip['"]|\[[^\]]*['"]micropip['"][^\]]*\])\s*\)/,
+    );
+    const firstImportIndex = source.indexOf('import micropip');
+    const orderedExample =
+      /await pyodide\.loadPackage\(\s*(?:['"]micropip['"]|\[[^\]]*['"]micropip['"][^\]]*\])\s*\);\s*await pyodide\.runPythonAsync\(`\s*import micropip\b/;
+
+    expect(loadIndex).toBeGreaterThanOrEqual(0);
+    expect(firstImportIndex).toBeGreaterThan(loadIndex);
+    expect(source).toMatch(orderedExample);
+  });
+
   test.each(PBL_PROMPT_FILES)('ships prompts-pbl/%s', (filename) => {
     expect(
       readFileSync(join(PACKAGE_ROOT, 'prompts-pbl', filename), 'utf8').length,


### PR DESCRIPTION
## Summary

Generated Pyodide widgets can import `micropip` before Pyodide loads it, which aborts initialization and leaves the Run button disabled. This change teaches the packaged code-content prompt to load `micropip` first and locks that order with a regression test.

## Related Issues

Fixes #1008

## Changes

- add conditional `micropip` loading guidance and an ordered Pyodide example
- verify the packaged prompt loads `micropip` before its first import
- bump `@openmaic/generation` from `0.3.1` to `0.3.2`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. `pnpm --filter @openmaic/generation exec vitest run test/assets.test.ts`
2. `pnpm --filter @openmaic/generation test && pnpm --filter @openmaic/generation run typecheck && pnpm --filter @openmaic/generation run build`
3. `pnpm check && pnpm lint && npx tsc --noEmit && pnpm check:i18n-keys`
4. `pnpm exec vitest run --maxWorkers=2`
5. `node scripts/check-package-version-bumps.mjs upstream/main`

### What you personally verified

- The regression failed before the prompt change with no `micropip` load instruction, then passed after the ordered example was added.
- The generation suite passed all 137 tests; the full root suite passed 7,084 tests with 79 skipped.
- Importer, DSL, and storage package suites passed, along with the generation Node consumer smoke.
- Existing saved classroom HTML is deliberately not rewritten; this remains a prompt-only fix for newly generated widgets.

### Evidence

- [x] CI-equivalent checks pass locally
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (not applicable; no UI change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings

## AI assistance

This PR was prepared with Codex assistance and received independent AI self-review. The review finding about a possible false-positive ordering test was addressed before submission.
