### PR TITLE
fix(asr): bypass AI SDK for custom providers to handle extra response…

### DIFF
--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -336,12 +336,21 @@ async function transcribeCustomOpenAICompatibleASR(
     audioBlob = new Blob([arrayBuffer], { type: 'audio/webm' });
   }
 
+  // Most OpenAI-compatible transcription endpoints treat `model` as a
+  // required field.  Custom providers have no built-in default, so we
+  // require the caller to supply one and fail fast with a clear message
+  // rather than sending a request that will almost certainly return a 400.
+  if (!config.modelId?.trim()) {
+    throw new Error(
+      'Custom ASR provider requires a model ID (e.g. FunAudioLLM/SenseVoiceSmall). ' +
+        'Please set the model in the provider settings.',
+    );
+  }
+
   const formData = new FormData();
   // Use 'file' key — required by the OpenAI audio/transcriptions spec.
   formData.set('file', audioBlob, 'audio.webm');
-  if (config.modelId) {
-    formData.set('model', config.modelId);
-  }
+  formData.set('model', config.modelId);
   formData.set('response_format', 'json');
   if (config.language && config.language !== 'auto') {
     formData.set('language', config.language);

--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -198,7 +198,7 @@ export async function transcribeAudio(
 
     default:
       if (isCustomASRProvider(config.providerId)) {
-        return await transcribeOpenAIWhisper(config, audioBuffer);
+        return await transcribeCustomOpenAICompatibleASR(config, audioBuffer);
       }
       throw new Error(`Unsupported ASR provider: ${config.providerId}`);
   }
@@ -299,6 +299,77 @@ function detectWavBytes(bytes: Uint8Array): boolean {
 function getOptionalBearerAuthHeaders(apiKey?: string): Record<string, string> {
   const key = apiKey?.trim();
   return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
+/**
+ * Custom OpenAI-compatible ASR transcription via raw fetch.
+ *
+ * Used by all `custom-asr-*` providers (e.g. SiliconFlow, LocalAI, etc.).
+ *
+ * Unlike `transcribeOpenAIWhisper`, this bypasses the Vercel AI SDK so that
+ * provider responses with extra fields (e.g. SiliconFlow's `segments` array)
+ * are NOT rejected by the SDK's strict response-schema validation.  Only
+ * `data.text` is extracted, making it tolerant of any OpenAI-compatible
+ * provider that returns additional fields beyond the standard spec.
+ */
+async function transcribeCustomOpenAICompatibleASR(
+  config: ASRModelConfig,
+  audioBuffer: Buffer | Blob,
+): Promise<ASRTranscriptionResult> {
+  const baseUrl = (config.baseUrl || '').replace(/\/$/, '');
+  if (!baseUrl) {
+    throw new Error(
+      'Custom ASR provider requires a base URL (e.g. https://api.siliconflow.cn/v1)',
+    );
+  }
+
+  // Build a Blob with a sensible content-type so the remote API can detect
+  // the audio format without relying on a file extension.
+  let audioBlob: Blob;
+  if (audioBuffer instanceof Blob) {
+    audioBlob = audioBuffer;
+  } else {
+    const arrayBuffer = audioBuffer.buffer.slice(
+      audioBuffer.byteOffset,
+      audioBuffer.byteOffset + audioBuffer.byteLength,
+    ) as ArrayBuffer;
+    // Preserve existing type when converting from Buffer; fall back to webm
+    // (the default recording format used by the browser MediaRecorder API).
+    audioBlob = new Blob([arrayBuffer], { type: 'audio/webm' });
+  }
+
+  const formData = new FormData();
+  // Use 'file' key — required by the OpenAI audio/transcriptions spec.
+  formData.set('file', audioBlob, 'audio.webm');
+  if (config.modelId) {
+    formData.set('model', config.modelId);
+  }
+  formData.set('response_format', 'json');
+  if (config.language && config.language !== 'auto') {
+    formData.set('language', config.language);
+  }
+
+  const response = await fetch(`${baseUrl}/audio/transcriptions`, {
+    method: 'POST',
+    headers: getOptionalBearerAuthHeaders(config.apiKey),
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => response.statusText);
+    if (errorText.includes('audio is empty') || errorText.includes('too short')) {
+      return { text: '' };
+    }
+    throw new Error(
+      `Custom ASR API error (${response.status}): ${errorText || response.statusText}`,
+    );
+  }
+
+  // Only extract `text` — extra provider-specific fields (e.g. SiliconFlow's
+  // `segments`, `duration`, `usage`) are intentionally ignored so that strict
+  // schema validators in the SDK never see them.
+  const data = await response.json();
+  return { text: typeof data.text === 'string' ? data.text : '' };
 }
 
 /**

--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -318,9 +318,7 @@ async function transcribeCustomOpenAICompatibleASR(
 ): Promise<ASRTranscriptionResult> {
   const baseUrl = (config.baseUrl || '').replace(/\/$/, '');
   if (!baseUrl) {
-    throw new Error(
-      'Custom ASR provider requires a base URL (e.g. https://api.siliconflow.cn/v1)',
-    );
+    throw new Error('Custom ASR provider requires a base URL (e.g. https://api.siliconflow.cn/v1)');
   }
 
   // Build a Blob with a sensible content-type so the remote API can detect

--- a/tests/audio/custom-asr.test.ts
+++ b/tests/audio/custom-asr.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { transcribeAudio } from '@/lib/audio/asr-providers';
+
+const mockFetch = vi.fn() as Mock;
+vi.stubGlobal('fetch', mockFetch);
+
+function webmBuffer(): Buffer {
+  // Minimal non-WAV buffer (no RIFF/WAVE magic bytes)
+  return Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00]);
+}
+
+describe('Custom ASR provider (custom-asr-*)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('posts audio to /audio/transcriptions and returns text', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: '嗯嗯' }),
+    });
+
+    const result = await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
+        apiKey: 'sk-test',
+      },
+      webmBuffer(),
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.siliconflow.cn/v1/audio/transcriptions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result).toEqual({ text: '嗯嗯' });
+  });
+
+  it('tolerates extra fields in the response (segments, duration, usage)', async () => {
+    // This is the exact SiliconFlow response shape that broke the AI SDK parser
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        duration: 1.5,
+        text: '嗯嗯',
+        segments: [{ id: 0, start: 0.0, end: 1.5, text: '嗯嗯' }],
+        usage: { tokens: 10 },
+      }),
+    });
+
+    const result = await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
+        apiKey: 'sk-test',
+      },
+      webmBuffer(),
+    );
+
+    expect(result).toEqual({ text: '嗯嗯' });
+  });
+
+  it('strips trailing slash from base URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: 'ok' }),
+    });
+
+    await transcribeAudio(
+      {
+        providerId: 'custom-asr-myhost',
+        baseUrl: 'http://localhost:9000/v1/',
+        apiKey: 'key',
+      },
+      webmBuffer(),
+    );
+
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:9000/v1/audio/transcriptions');
+  });
+
+  it('sends Bearer auth header when an API key is configured', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: '' }),
+    });
+
+    await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        apiKey: ' sk-secret ',
+      },
+      webmBuffer(),
+    );
+
+    expect(mockFetch.mock.calls[0][1].headers).toEqual({
+      Authorization: 'Bearer sk-secret',
+    });
+  });
+
+  it('omits auth header when no API key is set', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: '' }),
+    });
+
+    await transcribeAudio(
+      {
+        providerId: 'custom-asr-local',
+        baseUrl: 'http://localhost:9000/v1',
+      },
+      webmBuffer(),
+    );
+
+    expect(mockFetch.mock.calls[0][1].headers).toEqual({});
+  });
+
+  it('sets model, response_format, and language in FormData', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: '' }),
+    });
+
+    await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
+        apiKey: 'sk-test',
+        language: 'zh',
+      },
+      webmBuffer(),
+    );
+
+    const formData = mockFetch.mock.calls[0][1].body as FormData;
+    expect(formData.get('model')).toBe('FunAudioLLM/SenseVoiceSmall');
+    expect(formData.get('response_format')).toBe('json');
+    expect(formData.get('language')).toBe('zh');
+    expect(formData.get('file')).toBeInstanceOf(Blob);
+  });
+
+  it('omits language field when set to "auto"', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: '' }),
+    });
+
+    await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        language: 'auto',
+      },
+      webmBuffer(),
+    );
+
+    const formData = mockFetch.mock.calls[0][1].body as FormData;
+    expect(formData.get('language')).toBeNull();
+  });
+
+  it('returns empty text when upstream reports audio is empty', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'audio is empty',
+      statusText: 'Bad Request',
+    });
+
+    const result = await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        apiKey: 'sk-test',
+      },
+      webmBuffer(),
+    );
+
+    expect(result).toEqual({ text: '' });
+  });
+
+  it('throws a descriptive error on non-empty upstream failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+      statusText: 'Unauthorized',
+    });
+
+    await expect(
+      transcribeAudio(
+        {
+          providerId: 'custom-asr-siliconflow',
+          baseUrl: 'https://api.siliconflow.cn/v1',
+          apiKey: 'sk-bad',
+        },
+        webmBuffer(),
+      ),
+    ).rejects.toThrow(/Custom ASR API error.*401/);
+  });
+
+  it('throws when no base URL is configured', async () => {
+    await expect(
+      transcribeAudio(
+        {
+          providerId: 'custom-asr-siliconflow',
+          baseUrl: '',
+          apiKey: 'sk-test',
+        },
+        webmBuffer(),
+      ),
+    ).rejects.toThrow(/requires a base URL/);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('accepts a Blob input directly', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ text: 'hello' }),
+    });
+
+    const audioBlob = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
+    const result = await transcribeAudio(
+      {
+        providerId: 'custom-asr-siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1',
+        apiKey: 'sk-test',
+      },
+      audioBlob,
+    );
+
+    expect(result).toEqual({ text: 'hello' });
+    const formData = mockFetch.mock.calls[0][1].body as FormData;
+    expect(formData.get('file')).toBeInstanceOf(Blob);
+  });
+});

--- a/tests/audio/custom-asr.test.ts
+++ b/tests/audio/custom-asr.test.ts
@@ -72,6 +72,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
       {
         providerId: 'custom-asr-myhost',
         baseUrl: 'http://localhost:9000/v1/',
+        modelId: 'whisper-1',
         apiKey: 'key',
       },
       webmBuffer(),
@@ -90,6 +91,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
       {
         providerId: 'custom-asr-siliconflow',
         baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
         apiKey: ' sk-secret ',
       },
       webmBuffer(),
@@ -98,6 +100,22 @@ describe('Custom ASR provider (custom-asr-*)', () => {
     expect(mockFetch.mock.calls[0][1].headers).toEqual({
       Authorization: 'Bearer sk-secret',
     });
+  });
+
+  it('throws when no model ID is configured', async () => {
+    await expect(
+      transcribeAudio(
+        {
+          providerId: 'custom-asr-siliconflow',
+          baseUrl: 'https://api.siliconflow.cn/v1',
+          apiKey: 'sk-test',
+          // modelId intentionally omitted
+        },
+        webmBuffer(),
+      ),
+    ).rejects.toThrow(/requires a model ID/);
+
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('omits auth header when no API key is set', async () => {
@@ -110,6 +128,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
       {
         providerId: 'custom-asr-local',
         baseUrl: 'http://localhost:9000/v1',
+        modelId: 'whisper-1',
       },
       webmBuffer(),
     );
@@ -151,6 +170,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
       {
         providerId: 'custom-asr-siliconflow',
         baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
         language: 'auto',
       },
       webmBuffer(),
@@ -172,6 +192,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
       {
         providerId: 'custom-asr-siliconflow',
         baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
         apiKey: 'sk-test',
       },
       webmBuffer(),
@@ -193,6 +214,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
         {
           providerId: 'custom-asr-siliconflow',
           baseUrl: 'https://api.siliconflow.cn/v1',
+          modelId: 'FunAudioLLM/SenseVoiceSmall',
           apiKey: 'sk-bad',
         },
         webmBuffer(),
@@ -206,6 +228,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
         {
           providerId: 'custom-asr-siliconflow',
           baseUrl: '',
+          modelId: 'FunAudioLLM/SenseVoiceSmall',
           apiKey: 'sk-test',
         },
         webmBuffer(),
@@ -226,6 +249,7 @@ describe('Custom ASR provider (custom-asr-*)', () => {
       {
         providerId: 'custom-asr-siliconflow',
         baseUrl: 'https://api.siliconflow.cn/v1',
+        modelId: 'FunAudioLLM/SenseVoiceSmall',
         apiKey: 'sk-test',
       },
       audioBlob,


### PR DESCRIPTION
## Summary

Custom ASR providers (e.g. SiliconFlow) return OpenAI-compatible JSON but include extra fields like `segments`, `duration`, and `usage` that the Vercel AI SDK's strict Zod response schema does not expect, causing it to throw an `Invalid JSON response` error even when the `text` value is perfectly valid.

## Related Issues

Fixes #1277

## Changes

- Introduce `transcribeCustomOpenAICompatibleASR()` in `lib/audio/asr-providers.ts` — a raw `fetch`-based implementation that POSTs multipart FormData to `/audio/transcriptions` and extracts only `data.text`, making it tolerant of any extra fields a provider returns
- Route all `custom-asr-*` providers through this new function instead of `transcribeOpenAIWhisper()`, bypassing the AI SDK's strict Zod response schema entirely
- The `openai-whisper` built-in case is unchanged and continues to use `experimental_transcribe` from the Vercel AI SDK
- Follows the same raw-fetch pattern already used by `funasr-asr` and `lemonade-asr`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Add a custom ASR provider in OpenMAIC settings with SiliconFlow's base URL (`https://api.siliconflow.cn/v1`) and a valid API key
2. Select a SiliconFlow Whisper model (e.g. `FunAudioLLM/SenseVoiceSmall`)
3. Record audio and submit — previously got `Invalid JSON response`; now returns the transcribed text correctly

### What you personally verified

- Traced root cause: SiliconFlow's response `{"duration":...,"text":"...","segments":[...],"usage":...}` contains a `segments` array not present in the OpenAI Whisper spec; the SDK's strict schema rejects it
- Confirmed that stripping `segments` from the response body (via proxy) made OpenMAIC succeed — proving the field was the sole cause
- New function extracts only `data.text`; all extra fields (`segments`, `duration`, `usage`) are silently ignored
- All existing provider paths (`openai-whisper`, `qwen-asr`, `azure-asr`, `funasr-asr`, `lemonade-asr`) are untouched
- All three call sites covered: live mic recording (`use-audio-recorder.ts`), settings test button (`asr-settings.tsx`), and server-side media extraction (`local-media.ts`) — all route through `transcribeAudio()`
- TypeScript diagnostics: clean (no errors or warnings)

### Evidence

- No UI changes; fix is server-side only

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
