### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ Or manually:
 3. Set environment variables (at minimum one LLM API key)
 4. Deploy
 
+### RepoCloud Deployment
+
+[<img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="32">](https://repocloud.io/details/OpenMAIC/)
+
 ### Docker Deployment
 
 ```bash


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io/details/OpenMAIC/) as a one-click deployment option alongside Vercel and Docker in the Quick Start deployment sections.

RepoCloud provides dedicated VPS hosting for open-source applications with one-click deployment, guaranteed CPU/RAM/NVMe SSD resources, root SSH access, and built-in web management.

- Adds new "RepoCloud Deployment" subsection to `README.md`
- Uses matching 32px height to maintain visual parity with the adjacent Vercel deploy button
- Links to: https://repocloud.io/details/OpenMAIC/

*Note for maintainers:* If preferred, a shields.io badge (e.g., `https://img.shields.io/badge/Deploy%20on-RepoCloud-blue?style=flat-square` or `https://dnk92k33or340.cloudfront.net/deploy-20px.png`) can also be added into the header badge bar alongside the other shields.io badges.