### PR TITLE
fix: expose branded media providers in settings

### DIFF
--- a/components/generation/media-popover.tsx
+++ b/components/generation/media-popover.tsx
@@ -66,9 +66,19 @@ const TABS: Array<{ id: TabId; icon: LucideIcon; label: string }> = [
 
 function providerModels<T extends { id: string; name: string }>(
   builtInModels: T[],
-  config?: { customModels?: T[]; replaceBuiltInModels?: boolean },
+  config?: {
+    customModels?: T[];
+    replaceBuiltInModels?: boolean;
+    serverModels?: string[];
+  },
 ): T[] {
   const customModels = config?.customModels || [];
+  if (config?.serverModels?.length) {
+    return config.serverModels.map((id) => {
+      const knownModel = [...builtInModels, ...customModels].find((model) => model.id === id);
+      return knownModel ?? ({ id, name: id } as T);
+    });
+  }
   if (config?.replaceBuiltInModels && customModels.length > 0) {
     return customModels;
   }
@@ -157,8 +167,10 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
 
           return {
             groupId: p.id,
-            groupName: p.name,
-            groupIcon: IMAGE_PROVIDER_ICONS[p.id],
+            groupName: imageProvidersConfig[p.id]?.serverDisplayName || p.name,
+            groupIcon: imageProvidersConfig[p.id]?.serverDisplayName
+              ? undefined
+              : IMAGE_PROVIDER_ICONS[p.id],
             available: true,
             // Map to a consistent format here
             items: items.map((m) => ({
@@ -176,8 +188,10 @@ export function MediaPopover({ onSettingsOpen }: MediaPopoverProps) {
         .filter((p) => cfgOk(videoProvidersConfig, p.id, p.requiresApiKey))
         .map((p) => ({
           groupId: p.id,
-          groupName: p.name,
-          groupIcon: VIDEO_PROVIDER_ICONS[p.id],
+          groupName: videoProvidersConfig[p.id]?.serverDisplayName || p.name,
+          groupIcon: videoProvidersConfig[p.id]?.serverDisplayName
+            ? undefined
+            : VIDEO_PROVIDER_ICONS[p.id],
           available: true,
           items: providerModels(p.models, videoProvidersConfig[p.id]).map((m) => ({
             id: m.id,

--- a/components/settings/image-settings.tsx
+++ b/components/settings/image-settings.tsx
@@ -90,10 +90,17 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
 
   const currentConfig = imageProvidersConfig[selectedProviderId];
   const currentProvider = IMAGE_PROVIDERS[selectedProviderId];
-  const builtInModels = currentProvider?.models || [];
+  const builtInModels = useMemo(() => {
+    const registryModels = currentProvider?.models || [];
+    if (!currentConfig?.serverModels?.length) return registryModels;
+    const knownModels = [...registryModels, ...(currentConfig.customModels || [])];
+    return currentConfig.serverModels.map(
+      (id) => knownModels.find((model) => model.id === id) || { id, name: id },
+    );
+  }, [currentConfig?.customModels, currentConfig?.serverModels, currentProvider?.models]);
   const customModels = useMemo(
-    () => currentConfig?.customModels || [],
-    [currentConfig?.customModels],
+    () => (currentConfig?.serverModels?.length ? [] : currentConfig?.customModels || []),
+    [currentConfig?.customModels, currentConfig?.serverModels],
   );
   const isServerConfigured = !!currentConfig?.isServerConfigured;
   const requiresApiKey = currentProvider?.requiresApiKey ?? true;

--- a/components/settings/index.tsx
+++ b/components/settings/index.tsx
@@ -195,6 +195,41 @@ const VIDEO_PROVIDER_ICONS: Record<VideoProviderId, string> = {
   happyhorse: '/logos/qwen.svg',
 };
 
+type ServerMediaDisplayConfig = { serverDisplayName?: string } | undefined;
+
+function getImageProviderDisplayName(
+  providerId: ImageProviderId,
+  config: ServerMediaDisplayConfig,
+  t: (key: string) => string,
+): string {
+  return (
+    config?.serverDisplayName ||
+    t(`settings.${IMAGE_PROVIDER_NAMES[providerId]}`) ||
+    IMAGE_PROVIDERS[providerId]?.name
+  );
+}
+
+function getVideoProviderDisplayName(
+  providerId: VideoProviderId,
+  config: ServerMediaDisplayConfig,
+  t: (key: string) => string,
+): string {
+  return (
+    config?.serverDisplayName ||
+    t(`settings.${VIDEO_PROVIDER_NAMES[providerId]}`) ||
+    VIDEO_PROVIDERS[providerId]?.name
+  );
+}
+
+function getServerAwareIcon(
+  defaultIcon: string | undefined,
+  config: ServerMediaDisplayConfig,
+): string | undefined {
+  // A compatibility adapter must not retain the upstream vendor's logo after
+  // the operator gives it a different provider identity.
+  return config?.serverDisplayName ? undefined : defaultIcon;
+}
+
 interface SettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -641,14 +676,18 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
         );
       }
       case 'image': {
-        const imgProvider = IMAGE_PROVIDERS[selectedImageProviderId];
-        const imgIcon = IMAGE_PROVIDER_ICONS[selectedImageProviderId];
+        const imgConfig = imageProvidersConfig[selectedImageProviderId];
+        const imgName = getImageProviderDisplayName(selectedImageProviderId, imgConfig, t);
+        const imgIcon = getServerAwareIcon(
+          IMAGE_PROVIDER_ICONS[selectedImageProviderId],
+          imgConfig,
+        );
         return (
           <>
             {imgIcon ? (
               <img
                 src={imgIcon}
-                alt={imgProvider?.name}
+                alt={imgName}
                 className="w-8 h-8 rounded"
                 onError={(e) => {
                   (e.target as HTMLImageElement).style.display = 'none';
@@ -657,21 +696,23 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
             ) : (
               <Box className="h-8 w-8 text-muted-foreground" />
             )}
-            <h2 className="text-lg font-semibold">
-              {t(`settings.${IMAGE_PROVIDER_NAMES[selectedImageProviderId]}`) || imgProvider?.name}
-            </h2>
+            <h2 className="text-lg font-semibold">{imgName}</h2>
           </>
         );
       }
       case 'video': {
-        const vidProvider = VIDEO_PROVIDERS[selectedVideoProviderId];
-        const vidIcon = VIDEO_PROVIDER_ICONS[selectedVideoProviderId];
+        const vidConfig = videoProvidersConfig[selectedVideoProviderId];
+        const vidName = getVideoProviderDisplayName(selectedVideoProviderId, vidConfig, t);
+        const vidIcon = getServerAwareIcon(
+          VIDEO_PROVIDER_ICONS[selectedVideoProviderId],
+          vidConfig,
+        );
         return (
           <>
             {vidIcon ? (
               <img
                 src={vidIcon}
-                alt={vidProvider?.name}
+                alt={vidName}
                 className="w-8 h-8 rounded"
                 onError={(e) => {
                   (e.target as HTMLImageElement).style.display = 'none';
@@ -680,9 +721,7 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
             ) : (
               <Box className="h-8 w-8 text-muted-foreground" />
             )}
-            <h2 className="text-lg font-semibold">
-              {t(`settings.${VIDEO_PROVIDER_NAMES[selectedVideoProviderId]}`) || vidProvider?.name}
-            </h2>
+            <h2 className="text-lg font-semibold">{vidName}</h2>
           </>
         );
       }
@@ -943,8 +982,8 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
               <ProviderListColumn
                 providers={Object.values(IMAGE_PROVIDERS).map((p) => ({
                   id: p.id,
-                  name: t(`settings.${IMAGE_PROVIDER_NAMES[p.id]}`) || p.name,
-                  icon: IMAGE_PROVIDER_ICONS[p.id],
+                  name: getImageProviderDisplayName(p.id, imageProvidersConfig[p.id], t),
+                  icon: getServerAwareIcon(IMAGE_PROVIDER_ICONS[p.id], imageProvidersConfig[p.id]),
                 }))}
                 configs={imageProvidersConfig}
                 selectedId={selectedImageProviderId}
@@ -966,8 +1005,8 @@ export function SettingsDialog({ open, onOpenChange, initialSection }: SettingsD
               <ProviderListColumn
                 providers={Object.values(VIDEO_PROVIDERS).map((p) => ({
                   id: p.id,
-                  name: t(`settings.${VIDEO_PROVIDER_NAMES[p.id]}`) || p.name,
-                  icon: VIDEO_PROVIDER_ICONS[p.id],
+                  name: getVideoProviderDisplayName(p.id, videoProvidersConfig[p.id], t),
+                  icon: getServerAwareIcon(VIDEO_PROVIDER_ICONS[p.id], videoProvidersConfig[p.id]),
                 }))}
                 configs={videoProvidersConfig}
                 selectedId={selectedVideoProviderId}

--- a/components/settings/video-settings.tsx
+++ b/components/settings/video-settings.tsx
@@ -53,10 +53,17 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
 
   const currentConfig = videoProvidersConfig[selectedProviderId];
   const currentProvider = VIDEO_PROVIDERS[selectedProviderId];
-  const builtInModels = currentProvider?.models || [];
+  const builtInModels = useMemo(() => {
+    const registryModels = currentProvider?.models || [];
+    if (!currentConfig?.serverModels?.length) return registryModels;
+    const knownModels = [...registryModels, ...(currentConfig.customModels || [])];
+    return currentConfig.serverModels.map(
+      (id) => knownModels.find((model) => model.id === id) || { id, name: id },
+    );
+  }, [currentConfig?.customModels, currentConfig?.serverModels, currentProvider?.models]);
   const customModels = useMemo(
-    () => currentConfig?.customModels || [],
-    [currentConfig?.customModels],
+    () => (currentConfig?.serverModels?.length ? [] : currentConfig?.customModels || []),
+    [currentConfig?.customModels, currentConfig?.serverModels],
   );
   const isServerConfigured = !!currentConfig?.isServerConfigured;
 

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -26,6 +26,8 @@ interface ServerProviderEntry {
   apiKey: string;
   baseUrl?: string;
   models?: string[];
+  /** Operator-facing label exposed to clients; credentials and base URLs remain server-only. */
+  displayName?: string;
   proxy?: string;
   /** Aliyun AccessKey ID (AliDocMind — uses AK/SK instead of a single apiKey). */
   accessKeyId?: string;
@@ -262,6 +264,7 @@ function loadEnvSection(
           apiKey: entry.apiKey || '',
           baseUrl: entry.baseUrl,
           models: normalizeModelList(entry.models),
+          displayName: entry.displayName?.trim() || undefined,
           proxy: entry.proxy,
         };
       }
@@ -279,12 +282,14 @@ function loadEnvSection(
           .map((m) => m.trim())
           .filter(Boolean)
       : undefined;
+    const envDisplayName = process.env[`${prefix}_DISPLAY_NAME`]?.trim() || undefined;
 
     if (result[providerId]) {
       // YAML entry exists — env vars override individual fields
       if (envApiKey) result[providerId].apiKey = envApiKey;
       if (envBaseUrl) result[providerId].baseUrl = envBaseUrl;
       if (envModels) result[providerId].models = envModels;
+      if (envDisplayName) result[providerId].displayName = envDisplayName;
       continue;
     }
 
@@ -299,6 +304,7 @@ function loadEnvSection(
       apiKey: envApiKey || '',
       baseUrl: envBaseUrl,
       models: envModels,
+      displayName: envDisplayName,
     };
   }
 
@@ -836,13 +842,15 @@ export function resolvePDFBaseUrl(providerId: string, clientBaseUrl?: string): s
  */
 export function getServerImageProviders(): Record<
   string,
-  { models?: string[]; disabled?: boolean }
+  { models?: string[]; displayName?: string; disabled?: boolean }
 > {
   const cfg = getConfig();
-  const result: Record<string, { models?: string[]; disabled?: boolean }> = {};
+  const result: Record<string, { models?: string[]; displayName?: string; disabled?: boolean }> =
+    {};
   for (const [id, entry] of Object.entries(cfg.image)) {
     result[id] = {};
     if (entry.models && entry.models.length > 0) result[id].models = entry.models;
+    if (entry.displayName) result[id].displayName = entry.displayName;
   }
   for (const id of cfg.disabled.image) result[id] = { disabled: true };
   return result;
@@ -890,13 +898,21 @@ export function resolveImageModel(providerId: string, clientModel?: string): str
 
 /**
  * Returns video providers the client must know about: server-managed providers
- * (presence = managed flag) plus operator force-disabled providers
+ * (allowed models and operator display name, never base URLs) plus operator force-disabled providers
  * (`{ disabled: true }`), mirroring the TTS listing — disable wins (#665).
  */
-export function getServerVideoProviders(): Record<string, { disabled?: boolean }> {
+export function getServerVideoProviders(): Record<
+  string,
+  { models?: string[]; displayName?: string; disabled?: boolean }
+> {
   const cfg = getConfig();
-  const result: Record<string, { disabled?: boolean }> = {};
-  for (const id of Object.keys(cfg.video)) result[id] = {};
+  const result: Record<string, { models?: string[]; displayName?: string; disabled?: boolean }> =
+    {};
+  for (const [id, entry] of Object.entries(cfg.video)) {
+    result[id] = {};
+    if (entry.models && entry.models.length > 0) result[id].models = entry.models;
+    if (entry.displayName) result[id].displayName = entry.displayName;
+  }
   for (const id of cfg.disabled.video) result[id] = { disabled: true };
   return result;
 }

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -166,6 +166,10 @@ export interface SettingsState {
       baseUrl: string;
       enabled: boolean;
       isServerConfigured?: boolean;
+      /** Operator-facing label for a server-managed compatibility adapter. */
+      serverDisplayName?: string;
+      /** Server-managed model allowlist, kept separate from user-defined custom models. */
+      serverModels?: string[];
       /** Admin/server-level force-off (server-providers.yml / env). Overrides `enabled`. */
       serverDisabled?: boolean;
       customModels?: Array<{ id: string; name: string }>;
@@ -183,6 +187,10 @@ export interface SettingsState {
       baseUrl: string;
       enabled: boolean;
       isServerConfigured?: boolean;
+      /** Operator-facing label for a server-managed compatibility adapter. */
+      serverDisplayName?: string;
+      /** Server-managed model allowlist, kept separate from user-defined custom models. */
+      serverModels?: string[];
       /** Admin/server-level force-off (server-providers.yml / env). Overrides `enabled`. */
       serverDisabled?: boolean;
       customModels?: Array<{ id: string; name: string }>;
@@ -457,9 +465,15 @@ function resolveSelectedLLMModel(
 
 function resolveMediaModels<T extends { id: string; name: string }>(
   builtInModels: T[],
-  config?: { customModels?: T[]; replaceBuiltInModels?: boolean },
+  config?: { customModels?: T[]; replaceBuiltInModels?: boolean; serverModels?: string[] },
 ): T[] {
   const customModels = config?.customModels ?? [];
+  if (config?.serverModels?.length) {
+    return config.serverModels.map((id) => {
+      const knownModel = [...builtInModels, ...customModels].find((model) => model.id === id);
+      return knownModel ?? ({ id, name: id } as T);
+    });
+  }
   return config?.replaceBuiltInModels && customModels.length > 0
     ? customModels
     : [...builtInModels, ...customModels];
@@ -1409,8 +1423,14 @@ export const useSettingsStore = create<SettingsState>()(
               tts: Record<string, { disabled?: boolean }>;
               asr: Record<string, { disabled?: boolean }>;
               pdf: Record<string, Record<string, never>>;
-              image: Record<string, { models?: string[]; disabled?: boolean }>;
-              video: Record<string, { disabled?: boolean }>;
+              image: Record<
+                string,
+                { models?: string[]; displayName?: string; disabled?: boolean }
+              >;
+              video: Record<
+                string,
+                { models?: string[]; displayName?: string; disabled?: boolean }
+              >;
               webSearch: Record<string, { disabled?: boolean }>;
               generation?: { parallelSceneConcurrency?: number };
             };
@@ -1549,6 +1569,8 @@ export const useSettingsStore = create<SettingsState>()(
                     ...newImageConfig[key],
                     isServerConfigured: false,
                     serverDisabled: false,
+                    serverDisplayName: undefined,
+                    serverModels: undefined,
                   };
                 }
               }
@@ -1559,6 +1581,8 @@ export const useSettingsStore = create<SettingsState>()(
                     ...newImageConfig[key],
                     isServerConfigured: !info.disabled,
                     serverDisabled: info.disabled === true,
+                    serverDisplayName: info.displayName,
+                    serverModels: info.models,
                   };
                 }
               }
@@ -1574,6 +1598,8 @@ export const useSettingsStore = create<SettingsState>()(
                     ...newVideoConfig[key],
                     isServerConfigured: false,
                     serverDisabled: false,
+                    serverDisplayName: undefined,
+                    serverModels: undefined,
                   };
                 }
               }
@@ -1585,6 +1611,8 @@ export const useSettingsStore = create<SettingsState>()(
                       ...newVideoConfig[key],
                       isServerConfigured: !info.disabled,
                       serverDisabled: info.disabled === true,
+                      serverDisplayName: info.displayName,
+                      serverModels: info.models,
                     };
                   }
                 }
@@ -1795,7 +1823,10 @@ export const useSettingsStore = create<SettingsState>()(
                   !newImageConfig[state.imageProviderId]?.isServerConfigured
                 ) {
                   autoImageProvider = serverImageIds[0];
-                  const models = IMAGE_PROVIDERS[autoImageProvider]?.models;
+                  const models = resolveMediaModels(
+                    IMAGE_PROVIDERS[autoImageProvider]?.models ?? [],
+                    newImageConfig[autoImageProvider],
+                  );
                   if (models?.length) autoImageModel = models[0].id;
                 }
                 if (serverImageIds.length > 0 && !state.imageGenerationEnabled) {
@@ -1812,7 +1843,10 @@ export const useSettingsStore = create<SettingsState>()(
                   !newVideoConfig[state.videoProviderId]?.isServerConfigured
                 ) {
                   autoVideoProvider = serverVideoIds[0];
-                  const models = VIDEO_PROVIDERS[autoVideoProvider]?.models;
+                  const models = resolveMediaModels(
+                    VIDEO_PROVIDERS[autoVideoProvider]?.models ?? [],
+                    newVideoConfig[autoVideoProvider],
+                  );
                   if (models?.length) autoVideoModel = models[0].id;
                 }
                 if (serverVideoIds.length > 0 && !state.videoGenerationEnabled) {

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -64,6 +64,7 @@ function clearProviderEnv() {
     delete process.env[`${prefix}_API_KEY`];
     delete process.env[`${prefix}_BASE_URL`];
     delete process.env[`${prefix}_MODELS`];
+    delete process.env[`${prefix}_DISPLAY_NAME`];
     delete process.env[`${prefix}_ENABLED`];
   }
   delete process.env.TAVILY_API_KEY;
@@ -522,6 +523,30 @@ pdf:
   });
 
   describe('image and video provider metadata', () => {
+    it('exposes an operator display name and model catalog for a managed image provider', async () => {
+      vi.stubEnv('IMAGE_OPENAI_API_KEY', 'image-key');
+      vi.stubEnv('IMAGE_OPENAI_DISPLAY_NAME', 'Higgsfield');
+      vi.stubEnv('IMAGE_OPENAI_MODELS', 'gpt_image_2,nano_banana_flash');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+
+      expect(getServerImageProviders()['openai-image']).toEqual({
+        displayName: 'Higgsfield',
+        models: ['gpt_image_2', 'nano_banana_flash'],
+      });
+    });
+
+    it('exposes an operator display name and model catalog for a managed video provider', async () => {
+      vi.stubEnv('VIDEO_SEEDANCE_API_KEY', 'video-key');
+      vi.stubEnv('VIDEO_SEEDANCE_DISPLAY_NAME', 'Higgsfield');
+      vi.stubEnv('VIDEO_SEEDANCE_MODELS', 'kling3_0_turbo,seedance_2_0');
+      const { getServerVideoProviders } = await import('@/lib/server/provider-config');
+
+      expect(getServerVideoProviders().seedance).toEqual({
+        displayName: 'Higgsfield',
+        models: ['kling3_0_turbo', 'seedance_2_0'],
+      });
+    });
+
     it('uses standard OpenAI env vars for OpenAI image generation fallback', async () => {
       vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
       vi.stubEnv('OPENAI_BASE_URL', 'https://proxy.example.com/v1');

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -208,8 +208,14 @@ interface MockServerResponse {
   tts?: Record<string, { baseUrl?: string; disabled?: boolean }>;
   asr?: Record<string, { baseUrl?: string; disabled?: boolean }>;
   pdf?: Record<string, { baseUrl?: string }>;
-  image?: Record<string, { baseUrl?: string; disabled?: boolean }>;
-  video?: Record<string, { baseUrl?: string; disabled?: boolean }>;
+  image?: Record<
+    string,
+    { baseUrl?: string; disabled?: boolean; displayName?: string; models?: string[] }
+  >;
+  video?: Record<
+    string,
+    { baseUrl?: string; disabled?: boolean; displayName?: string; models?: string[] }
+  >;
   webSearch?: Record<string, { baseUrl?: string; disabled?: boolean }>;
 }
 
@@ -995,6 +1001,27 @@ describe('fetchServerProviders — Image stale selection', () => {
     return useSettingsStore;
   }
 
+  it('syncs a managed image provider display name and replaces its model catalog', async () => {
+    const store = await getStore();
+    mockServerResponse({
+      image: {
+        seedream: {
+          displayName: 'Higgsfield',
+          models: ['gpt_image_2', 'nano_banana_flash'],
+        },
+      },
+    });
+
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().imageProvidersConfig.seedream).toMatchObject({
+      isServerConfigured: true,
+      serverDisplayName: 'Higgsfield',
+      serverModels: ['gpt_image_2', 'nano_banana_flash'],
+    });
+    expect(store.getState().imageModelId).toBe('gpt_image_2');
+  });
+
   it('clears imageProviderId and imageModelId when provider loses server config', async () => {
     const store = await getStore();
 
@@ -1156,6 +1183,27 @@ describe('fetchServerProviders — Video stale selection', () => {
     await useSettingsStore.persist.rehydrate();
     return useSettingsStore;
   }
+
+  it('syncs a managed video provider display name and replaces its model catalog', async () => {
+    const store = await getStore();
+    mockServerResponse({
+      video: {
+        seedance: {
+          displayName: 'Higgsfield',
+          models: ['kling3_0_turbo', 'seedance_2_0'],
+        },
+      },
+    });
+
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().videoProvidersConfig.seedance).toMatchObject({
+      isServerConfigured: true,
+      serverDisplayName: 'Higgsfield',
+      serverModels: ['kling3_0_turbo', 'seedance_2_0'],
+    });
+    expect(store.getState().videoModelId).toBe('kling3_0_turbo');
+  });
 
   it('clears videoProviderId and videoModelId when provider loses server config', async () => {
     const store = await getStore();


### PR DESCRIPTION
## Summary

- expose operator-defined display names for server-managed image and video providers without changing adapter IDs
- synchronize server-managed media model allowlists into settings and generation selectors
- avoid showing an upstream vendor logo when a compatibility adapter has a different operator identity

## Verification

- 193 focused tests passed
- ESLint passed for changed files
- TypeScript check passed
- production build passed
- browser-verified both Image Generation and Video Generation settings against the rebuilt local server