### PR TITLE
fix: enforce LF line endings for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Keep detected text files on LF across platforms so formatting checks see the
+# same contents on Windows, macOS, and Linux.
+* text=auto eol=lf
+
 # Shell scripts must keep LF endings even when checked out on Windows.
 #
 # With Git's default `core.autocrlf=true` on Windows, docker-entrypoint.sh is


### PR DESCRIPTION
## Summary

Add a repository-wide LF checkout policy for detected text files. This keeps a clean Windows checkout compatible with the repository's Prettier `endOfLine: "lf"` setting even when `core.autocrlf=true`.

Fixes #1293

## Changes

- add `* text=auto eol=lf` to `.gitattributes`
- keep the existing explicit shell-script LF rule and its rationale
- leave all existing tracked source blobs unchanged (no bulk renormalization)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Clone this branch on Windows with `core.autocrlf=true`.
2. Run `corepack pnpm install --frozen-lockfile`.
3. Run `corepack pnpm format`, then confirm the tracked worktree remains clean.
4. Run `corepack pnpm check`.
5. Run `corepack pnpm lint`.
6. Run `corepack pnpm exec tsc --noEmit`.
7. Run `corepack pnpm test` to record the native-Windows baseline.

### What I personally verified

- Fresh Windows checkout at this commit: 2,822 tracked paths; the three files already stored as CRLF remain unchanged, while Git no longer rewrites the LF-normalized text blobs to CRLF.
- `pnpm format` completed and left the tracked worktree clean.
- `pnpm check` passed.
- `pnpm lint` passed with 0 errors and 18 existing warnings.
- `pnpm exec tsc --noEmit` passed.
- The commit changes only `.gitattributes`; a tree comparison excluding that file is byte-for-byte identical to `main`.
- Full `pnpm test` is not green on native Windows: 6,934 passed, 148 failed, and 81 skipped. Remaining failures include suites that invoke `/bin/bash`, Windows path assumptions, and timing-sensitive tests. This PR does not touch those suites.
- `pnpm lint --fix` exits successfully but also removes two pre-existing unused ESLint-disable comments. I excluded those unrelated auto-fixes to keep this PR focused.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (not applicable; no UI change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings

## AI assistance

AI-assisted with Codex. I reviewed the entire one-file diff, verified the Git attribute behavior in a fresh Windows checkout, checked that no existing source blobs were renormalized, and audited the outgoing commit for sensitive information and unrelated changes.