### PR TITLE
fix(providers): apply server-pinned models for image and video providers

### DIFF
--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -893,10 +893,16 @@ export function resolveImageModel(providerId: string, clientModel?: string): str
  * (presence = managed flag) plus operator force-disabled providers
  * (`{ disabled: true }`), mirroring the TTS listing — disable wins (#665).
  */
-export function getServerVideoProviders(): Record<string, { disabled?: boolean }> {
+export function getServerVideoProviders(): Record<
+  string,
+  { models?: string[]; disabled?: boolean }
+> {
   const cfg = getConfig();
-  const result: Record<string, { disabled?: boolean }> = {};
-  for (const id of Object.keys(cfg.video)) result[id] = {};
+  const result: Record<string, { models?: string[]; disabled?: boolean }> = {};
+  for (const [id, entry] of Object.entries(cfg.video)) {
+    result[id] = {};
+    if (entry.models && entry.models.length > 0) result[id].models = entry.models;
+  }
   for (const id of cfg.disabled.video) result[id] = { disabled: true };
   return result;
 }

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -1410,7 +1410,7 @@ export const useSettingsStore = create<SettingsState>()(
               asr: Record<string, { disabled?: boolean }>;
               pdf: Record<string, Record<string, never>>;
               image: Record<string, { models?: string[]; disabled?: boolean }>;
-              video: Record<string, { disabled?: boolean }>;
+              video: Record<string, { models?: string[]; disabled?: boolean }>;
               webSearch: Record<string, { disabled?: boolean }>;
               generation?: { parallelSceneConcurrency?: number };
             };
@@ -1559,6 +1559,12 @@ export const useSettingsStore = create<SettingsState>()(
                     ...newImageConfig[key],
                     isServerConfigured: !info.disabled,
                     serverDisabled: info.disabled === true,
+                    ...(info.models?.length
+                      ? {
+                          customModels: info.models.map((id) => ({ id, name: id })),
+                          replaceBuiltInModels: true,
+                        }
+                      : {}),
                   };
                 }
               }
@@ -1585,6 +1591,12 @@ export const useSettingsStore = create<SettingsState>()(
                       ...newVideoConfig[key],
                       isServerConfigured: !info.disabled,
                       serverDisabled: info.disabled === true,
+                      ...(info.models?.length
+                        ? {
+                            customModels: info.models.map((id) => ({ id, name: id })),
+                            replaceBuiltInModels: true,
+                          }
+                        : {}),
                     };
                   }
                 }

--- a/tests/server/provider-config.test.ts
+++ b/tests/server/provider-config.test.ts
@@ -557,6 +557,28 @@ pdf:
       expect(resolveVideoBaseUrl('grok-video')).toBe('https://proxy.example.com/video');
     });
 
+    it('exposes server-pinned image models in getServerImageProviders', async () => {
+      vi.stubEnv('IMAGE_SEEDREAM_API_KEY', 'sk-seedream');
+      vi.stubEnv('IMAGE_SEEDREAM_MODELS', 'doubao-seedream-5.0-lite,doubao-seedream-5.0-pro');
+      const { getServerImageProviders } = await import('@/lib/server/provider-config');
+
+      const providers = getServerImageProviders();
+      expect(providers.seedream).toEqual({
+        models: ['doubao-seedream-5.0-lite', 'doubao-seedream-5.0-pro'],
+      });
+    });
+
+    it('exposes server-pinned video models in getServerVideoProviders', async () => {
+      vi.stubEnv('VIDEO_SEEDANCE_API_KEY', 'sk-seedance');
+      vi.stubEnv('VIDEO_SEEDANCE_MODELS', 'doubao-seedance-2-0,doubao-seedance-3-0');
+      const { getServerVideoProviders } = await import('@/lib/server/provider-config');
+
+      const providers = getServerVideoProviders();
+      expect(providers.seedance).toEqual({
+        models: ['doubao-seedance-2-0', 'doubao-seedance-3-0'],
+      });
+    });
+
     it('activates keyless image providers (lemonade) from a base URL alone', async () => {
       vi.stubEnv('IMAGE_LEMONADE_BASE_URL', 'http://localhost:13305/v1');
       const { getServerImageProviders, resolveImageApiKey, isServerConfiguredProvider } =

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -1838,7 +1838,9 @@ describe('TTS provider enablement (#665)', () => {
 
     const config = store.getState().imageProvidersConfig.seedream;
     expect(config.isServerConfigured).toBe(true);
-    expect(config.customModels).toEqual([{ id: 'doubao-seedream-5.0-lite', name: 'doubao-seedream-5.0-lite' }]);
+    expect(config.customModels).toEqual([
+      { id: 'doubao-seedream-5.0-lite', name: 'doubao-seedream-5.0-lite' },
+    ]);
     expect(config.replaceBuiltInModels).toBe(true);
   });
 

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -208,8 +208,8 @@ interface MockServerResponse {
   tts?: Record<string, { baseUrl?: string; disabled?: boolean }>;
   asr?: Record<string, { baseUrl?: string; disabled?: boolean }>;
   pdf?: Record<string, { baseUrl?: string }>;
-  image?: Record<string, { baseUrl?: string; disabled?: boolean }>;
-  video?: Record<string, { baseUrl?: string; disabled?: boolean }>;
+  image?: Record<string, { models?: string[]; baseUrl?: string; disabled?: boolean }>;
+  video?: Record<string, { models?: string[]; baseUrl?: string; disabled?: boolean }>;
   webSearch?: Record<string, { baseUrl?: string; disabled?: boolean }>;
 }
 
@@ -1827,5 +1827,47 @@ describe('TTS provider enablement (#665)', () => {
     mockServerResponse({ tts: {} });
     await store.getState().fetchServerProviders();
     expect(store.getState().ttsProvidersConfig['openai-tts'].serverDisabled).toBe(false);
+  });
+
+  it('applies server-pinned image models as customModels with replaceBuiltInModels', async () => {
+    const store = await getStore();
+    mockServerResponse({
+      image: { seedream: { models: ['doubao-seedream-5.0-lite'] } },
+    });
+    await store.getState().fetchServerProviders();
+
+    const config = store.getState().imageProvidersConfig.seedream;
+    expect(config.isServerConfigured).toBe(true);
+    expect(config.customModels).toEqual([{ id: 'doubao-seedream-5.0-lite', name: 'doubao-seedream-5.0-lite' }]);
+    expect(config.replaceBuiltInModels).toBe(true);
+  });
+
+  it('applies server-pinned video models as customModels with replaceBuiltInModels', async () => {
+    const store = await getStore();
+    mockServerResponse({
+      video: { seedance: { models: ['doubao-seedance-2-0', 'doubao-seedance-3-0'] } },
+    });
+    await store.getState().fetchServerProviders();
+
+    const config = store.getState().videoProvidersConfig.seedance;
+    expect(config.isServerConfigured).toBe(true);
+    expect(config.customModels).toEqual([
+      { id: 'doubao-seedance-2-0', name: 'doubao-seedance-2-0' },
+      { id: 'doubao-seedance-3-0', name: 'doubao-seedance-3-0' },
+    ]);
+    expect(config.replaceBuiltInModels).toBe(true);
+  });
+
+  it('does not set customModels when server reports no models for image provider', async () => {
+    const store = await getStore();
+    mockServerResponse({
+      image: { seedream: {} },
+    });
+    await store.getState().fetchServerProviders();
+
+    const config = store.getState().imageProvidersConfig.seedream;
+    expect(config.isServerConfigured).toBe(true);
+    expect(config.customModels).toBeUndefined();
+    expect(config.replaceBuiltInModels).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1251 — server-configured image/video model allowlists are not applied to the client, causing generation to fall back to built-in model IDs that fail on endpoints requiring different aliases.

**Root cause:** Two gaps in the server-to-client model pipeline:

1. `getServerVideoProviders()` omitted the `models` field entirely from its response, despite the server resolving them internally via `resolveVideoModel()`.
2. `fetchServerProviders()` on the client discarded the `models` payload for both image and video providers — it only set `isServerConfigured` and `serverDisabled`, never populating `customModels`.

This meant the client always used built-in dated model IDs (e.g. `doubao-seedream-5-0-260128`) even when the server pinned different ones (e.g. `doubao-seedream-5.0-lite`), causing `UnsupportedModel` errors on endpoints that require the pinned aliases.

**Fix:**
- Server: `getServerVideoProviders()` now exposes `models`, mirroring `getServerImageProviders()`.
- Client: `fetchServerProviders()` stores the server model list as `customModels` with `replaceBuiltInModels: true` for both image and video, matching the existing LLM provider model-filtering pattern.

## Changed files

- `lib/server/provider-config.ts` — `getServerVideoProviders()` now includes models in response
- `lib/store/settings.ts` — `fetchServerProviders()` processes `models` for image and video
- `tests/server/provider-config.test.ts` — 2 regression tests for model exposure
- `tests/store/settings-server-sync.test.ts` — 3 regression tests for client-side model merge

## Test plan

- [x] `vitest run tests/server/provider-config.test.ts` — 109 passed
- [x] `vitest run tests/store/settings-server-sync.test.ts` — 82 passed
- [x] `tsc --noEmit` — clean, exit 0