### PR TITLE
test(media): isolate force-off test from OpenAI fallback

### DIFF
--- a/tests/server/classroom-media-generation.test.ts
+++ b/tests/server/classroom-media-generation.test.ts
@@ -108,6 +108,10 @@ describe('generateMediaForClassroom model fallback', () => {
   });
 
   test('gracefully skips media when every configured provider is force-disabled', async () => {
+    // The generic key enables OpenAI's image fallback. This test owns only the
+    // explicitly force-disabled providers below, so keep shell credentials out
+    // of its provider set (and out of fetch-mock failure output).
+    vi.stubEnv('OPENAI_API_KEY', '');
     vi.stubEnv('IMAGE_SEEDREAM_API_KEY', 'sk-seedream');
     vi.stubEnv('IMAGE_SEEDREAM_ENABLED', 'false');
     vi.stubEnv('VIDEO_SEEDANCE_API_KEY', 'sk-seedance');


### PR DESCRIPTION
> AI-assisted contribution. I manually reproduced the failure with a non-secret sentinel, reviewed the final diff, and completed the verification below.

## Summary

Keep the force-disabled classroom-media unit test independent of a developer's shell-exported generic OpenAI key. This prevents the test from taking the OpenAI image fallback path and avoids expanding a real Authorization value in fetch-mock failure output.

Production provider behavior is unchanged.

## Related Issues

Fixes #1302

Related context: #1162 intentionally preserves shell-exported variables globally; this PR isolates only the test that does not own the generic OpenAI fallback.

## Changes

- Mask `OPENAI_API_KEY` inside the force-disabled media test before resetting and importing provider configuration.
- Reuse the existing `vi.unstubAllEnvs()` cleanup to restore the caller's environment after the test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. On the base revision, run the focused test with `OPENAI_API_KEY=openmaic-test-sentinel`; it calls the OpenAI image endpoint and prints the sentinel Authorization value in the failed mock assertion.
2. Apply this change and rerun the same command; the focused test passes without making a fetch call.
3. Run the complete media/provider tests and the full root suite under Node 22.

### What you personally verified

- RED on `upstream/main`: the focused test failed with one OpenAI image fetch and exposed the non-secret sentinel in its assertion output.
- GREEN with the change: focused test passed with the sentinel; the complete media file passed both with and without it (8/8 each).
- `tests/server/provider-config.test.ts`: 107/107 passed, retaining dedicated generic fallback coverage.
- Full root suite with the sentinel exported: 7,137 passed, 81 skipped.
- Prettier, ESLint, TypeScript, and i18n gates passed. ESLint reports only the existing 18 repository warnings and no errors.
- AI self-review found no production behavior, global environment-policy, secret-storage, or cleanup changes.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (not applicable: test-only change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (issue documents the behavior; no product docs are affected)
- [x] My changes do not introduce new warnings
