### PR TITLE
fix(docs): isolate standalone build from product middleware

### DIFF
--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -1,7 +1,10 @@
 import { createMDX } from 'fumadocs-mdx/next';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { DOCS_BASE_PATH } from './lib/locales.mjs';
 
 const withMDX = createMDX();
+const docsRoot = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -10,6 +13,12 @@ const config = {
   output: 'export',
   // Target deploy path: open.maic.chat/docs
   basePath: DOCS_BASE_PATH,
+  // This package is a standalone Next.js app with its own lockfile and alias
+  // map. Without an explicit boundary, Turbopack walks up to the repository
+  // root and compiles the product middleware as part of the docs application.
+  turbopack: {
+    root: docsRoot,
+  },
   // Static export cannot optimize images at runtime.
   images: {
     unoptimized: true,


### PR DESCRIPTION
> AI-assisted contribution. I reproduced the regression on current main, verified the isolated fix, and completed an AI self-review before opening this PR.

## Summary

Bound the standalone Fumadocs application's Turbopack project to `packages/docs`. This prevents it from walking up to the repository root and compiling the product middleware with the docs app's alias map.

## Related Issues

Fixes #1306

Related to #1304, whose localized documentation validation exposed this existing main-branch regression. The Node engine work remains on a separate branch and is not included here.

## Changes

- Resolve the absolute docs package directory from `packages/docs/next.config.mjs`.
- Configure that directory as `turbopack.root` for the standalone docs build.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. On current main, run `pnpm install --frozen-lockfile --ignore-workspace` from `packages/docs`.
2. Run `pnpm build`; Turbopack imports the repository-root middleware and fails to resolve `@/lib/config/feature-flags` inside the docs project.
3. Apply this change and rerun the standalone docs build and type check.

### What you personally verified

- RED on `upstream/main`: docs build failed while compiling the product middleware.
- GREEN: docs build generated 34 static pages and completed every English/zh-cn/zh-tw/ja/ru/ar postexport check.
- `packages/docs`: `pnpm types:check` passed.
- Root Prettier, TypeScript, and i18n gates passed.
- Root ESLint: 0 errors; only the existing 18 repository warnings.
- Root unit suite: 7,137 passed, 81 skipped.
- AI self-review found no root product middleware, alias, basePath, static-export, or Webpack behavior changes.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (not applicable: build-boundary change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (the issue contains the regression timeline; no user docs change)
- [x] My changes do not introduce new warnings
