### PR TITLE
fix(workbench): render LaTeX in assistant messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,7 @@
    Tailwind must scan its dist so those classes get generated. */
 @source '../node_modules/streamdown/dist/*.js';
 @source '../node_modules/@streamdown/code/dist/*.js';
+@source '../node_modules/@streamdown/math/dist/*.js';
 @source "../node_modules/@openmaic/renderer/dist/**/*.{js,cjs}";
 /* slide-renderer-demo is gitignored (local sandbox), which makes Tailwind v4's
    auto source detection skip it. Re-include it explicitly so the demo's

--- a/components/workbench/chat/course-link.tsx
+++ b/components/workbench/chat/course-link.tsx
@@ -60,7 +60,7 @@ export function CourseLink({
    * workspace's own name for the course wins when it has one — the rail, the
    * tab and this link must not disagree about what a course is called.
    */
-  readonly label?: string;
+  readonly label?: React.ReactNode;
   /**
    * What to render with no workspace around us: the classic workbench hosts
    * this same timeline and has no right pane to open anything into, so an
@@ -74,12 +74,19 @@ export function CourseLink({
   if (!navigation) return <>{fallback ?? label ?? courseId}</>;
 
   const summary = navigation.lookupCourse(courseId);
-  const name = summary?.name || label || t('workspace.untitledCourse');
+  const fallbackName = t('workspace.untitledCourse');
+  const name = summary?.name || label || fallbackName;
   const pageCount = summary?.pageCount ?? null;
   // One sentence, whatever the pane is currently showing — the press is the
   // same in every case, so describing it three ways only invited the reader to
   // look for a difference that is not there.
-  const hint = t('workspace.courseLinkHint', { name });
+  const richLabel = label != null && typeof label !== 'string';
+  // Rich labels carry their own accessible content (including KaTeX MathML).
+  // Do not replace it with an inaccurate "untitled" accessible name.
+  const hint =
+    richLabel && !summary?.name
+      ? undefined
+      : t('workspace.courseLinkHint', { name: summary?.name || label || fallbackName });
 
   return (
     <button

--- a/components/workbench/chat/text-block.tsx
+++ b/components/workbench/chat/text-block.tsx
@@ -21,191 +21,19 @@
  *    there is no right pane — the pill falls back to the plain anchor.
  */
 import { createMathPlugin } from '@streamdown/math';
-import { Streamdown, defaultRemarkPlugins, type StreamdownProps } from 'streamdown';
+import { Streamdown, defaultRemarkPlugins } from 'streamdown';
 import remarkCjkFriendly from 'remark-cjk-friendly';
 import { courseIdFromHref } from '@/lib/workbench/course-link';
 import { CourseLink } from './course-link';
 
-interface MarkdownNode {
-  type: string;
-  value?: string;
-  meta?: string | null;
-  data?: Record<string, unknown>;
-  position?: {
-    start: { line?: number; column?: number; offset?: number };
-    end: { line?: number; column?: number; offset?: number };
-  };
-  children?: MarkdownNode[];
-}
-
-function displayMathData(value: string): Record<string, unknown> {
-  return {
-    hName: 'pre',
-    hChildren: [
-      {
-        type: 'element',
-        tagName: 'code',
-        properties: { className: ['language-math', 'math-display'] },
-        children: [{ type: 'text', value }],
-      },
-    ],
-  };
-}
-
-function nodeSource(node: MarkdownNode, source: string): string | undefined {
-  const start = node.position?.start.offset;
-  const end = node.position?.end.offset;
-  if (typeof start !== 'number' || typeof end !== 'number') return undefined;
-  return source.slice(start, end);
-}
-
-function isDoubleDollarMath(node: MarkdownNode, source: string): boolean {
-  if (node.type !== 'inlineMath') return false;
-
-  const raw = nodeSource(node, source);
-  return Boolean(
-    raw?.startsWith('$$') && raw.endsWith('$$') && raw[2] !== '$' && raw[raw.length - 3] !== '$',
-  );
-}
-
-function mathBlock(node: MarkdownNode): MarkdownNode {
-  return {
-    type: 'math',
-    value: node.value,
-    position: node.position,
-    data: displayMathData(node.value ?? ''),
-  };
-}
-
-function mathNodeValue(node: MarkdownNode): string {
-  let body = node.value ?? '';
-  if (body.endsWith('$$') && body[body.length - 3] !== '$') body = body.slice(0, -2);
-
-  if (typeof node.meta !== 'string' || node.meta.length === 0) return body;
-  return body ? `${node.meta}\n${body}` : node.meta;
-}
-
-function literalDollarBlock(node: MarkdownNode, openingFence: string, raw: string): MarkdownNode {
-  let value = raw.match(/^\$+[^\S\r\n]*/)?.[0] ?? openingFence;
-  if (typeof node.meta === 'string') value += node.meta;
-  if (node.value) value += `\n${node.value}`;
-
-  const closingFence = raw.match(/(?:^|\n)[^\S\r\n]*(?:>\s*)*(\${3,})[^\S\r\n]*$/)?.[1];
-  if (closingFence && closingFence.length >= openingFence.length) value += `\n${closingFence}`;
-
-  return {
-    type: 'paragraph',
-    position: node.position,
-    children: [{ type: 'text', value, position: node.position }],
-  };
-}
-
-function normalizeMathBlock(node: MarkdownNode, source: string): MarkdownNode {
-  if (node.type !== 'math') return node;
-
-  const raw = nodeSource(node, source);
-  const openingFence = raw?.match(/^\$+/)?.[0];
-  if (!raw || !openingFence || openingFence.length < 2) return node;
-
-  // Longer dollar runs are inline syntax, even when an unfinished message
-  // temporarily makes remark-math parse them as a flow node.
-  if (openingFence.length > 2) return literalDollarBlock(node, openingFence, raw);
-
-  // remark-math stores content beside the opening fence in `meta`; its `value`
-  // has already removed blockquote/list markers from the following lines.
-  const value = mathNodeValue(node);
-  node.value = value;
-  node.meta = null;
-  node.data = displayMathData(value);
-  return node;
-}
-
-function splitDisplayMath(paragraph: MarkdownNode, source: string): MarkdownNode[] | undefined {
-  if (
-    paragraph.type !== 'paragraph' ||
-    !paragraph.children?.some((node) => isDoubleDollarMath(node, source))
-  ) {
-    return undefined;
-  }
-
-  const blocks: MarkdownNode[] = [];
-  let inlineNodes: MarkdownNode[] = [];
-
-  const flushInlineNodes = () => {
-    if (inlineNodes.length === 0) return;
-
-    blocks.push({
-      ...paragraph,
-      children: inlineNodes,
-      position: {
-        start: inlineNodes[0].position?.start ?? paragraph.position?.start ?? {},
-        end: inlineNodes[inlineNodes.length - 1].position?.end ?? paragraph.position?.end ?? {},
-      },
-    });
-    inlineNodes = [];
-  };
-
-  for (const node of paragraph.children) {
-    if (isDoubleDollarMath(node, source)) {
-      flushInlineNodes();
-      blocks.push(mathBlock(node));
-    } else {
-      inlineNodes.push(node);
-    }
-  }
-  flushInlineNodes();
-
-  return blocks;
-}
-
-function remarkNormalizeDisplayMath() {
-  return (tree: MarkdownNode, file: { value: unknown }) => {
-    const source = file.value;
-    if (typeof source !== 'string') return;
-
-    const visit = (parent: MarkdownNode) => {
-      if (!parent.children) return;
-
-      for (let index = 0; index < parent.children.length; index += 1) {
-        const node = parent.children[index];
-
-        const normalized = normalizeMathBlock(node, source);
-        if (normalized !== node) {
-          parent.children[index] = normalized;
-          continue;
-        }
-
-        // remark-math parses one-line `$$...$$` as inline math. Split only
-        // top-level paragraph children so the double-dollar form keeps block semantics.
-        const blocks = splitDisplayMath(node, source);
-        if (blocks) {
-          parent.children.splice(index, 1, ...blocks);
-          index += blocks.length - 1;
-          continue;
-        }
-
-        visit(node);
-      }
-    };
-
-    visit(tree);
-  };
-}
-
-const REMARK_PLUGINS: NonNullable<StreamdownProps['remarkPlugins']> = [
-  remarkCjkFriendly,
-  ...Object.values(defaultRemarkPlugins),
-  remarkNormalizeDisplayMath,
-];
+const REMARK_PLUGINS = [remarkCjkFriendly, ...Object.values(defaultRemarkPlugins)];
 
 const STREAMDOWN_PLUGINS = {
-  // `$...$` is part of the workbench contract; literal currency uses `\$`.
   math: createMathPlugin({ singleDollarTextMath: true }),
 } as const;
 
-// The normalizer above already keeps unfinished display math visible. Remend's
-// generic `$$` completion is container-unaware and can alter fenced code or add
-// a second formula outside a list/blockquote while a message is streaming.
+// remark-math already accepts an unterminated flow fence through EOF. Generic
+// dollar completion can instead turn a delimiter inside fenced code into math.
 const REMEND = { katex: false } as const;
 
 // Table chrome (fullscreen/download) is workbench-irrelevant; the code block's
@@ -249,7 +77,6 @@ export function TextBlock({ text, streaming = false }: { text: string; streaming
       {/* No typewriter caret, no block animation: streaming text just streams,
           quietly. (Walkthrough verdict: the caret read as too heavy.) */}
       <Streamdown
-        mode={streaming ? 'streaming' : 'static'}
         remarkPlugins={REMARK_PLUGINS}
         plugins={STREAMDOWN_PLUGINS}
         remend={REMEND}

--- a/components/workbench/chat/text-block.tsx
+++ b/components/workbench/chat/text-block.tsx
@@ -3,8 +3,9 @@
 /**
  * Assistant Markdown renderer for the workbench chat.
  *
- * Streamdown owns the parse and render; three things are added:
+ * Streamdown owns the parse and render; four things are added:
  *
+ *  - KaTeX math through Streamdown's stable math plugin configuration.
  *  - `remark-cjk-friendly` BEFORE `remark-gfm`, because CommonMark's emphasis
  *    flanking rules misfire next to fullwidth CJK punctuation — e.g. `**smart**`
  *    quotes otherwise reach the user with their asterisks on (the spike's S10
@@ -19,12 +20,17 @@
  *    link renders exactly as it did before, and outside `/workspace` — where
  *    there is no right pane — the pill falls back to the plain anchor.
  */
+import { createMathPlugin } from '@streamdown/math';
 import { Streamdown, defaultRemarkPlugins } from 'streamdown';
 import remarkCjkFriendly from 'remark-cjk-friendly';
 import { courseIdFromHref } from '@/lib/workbench/course-link';
 import { CourseLink } from './course-link';
 
 const REMARK_PLUGINS = [remarkCjkFriendly, ...Object.values(defaultRemarkPlugins)];
+
+const STREAMDOWN_PLUGINS = {
+  math: createMathPlugin({ singleDollarTextMath: true }),
+} as const;
 
 // Table chrome (fullscreen/download) is workbench-irrelevant; the code block's
 // copy action stays.
@@ -68,6 +74,7 @@ export function TextBlock({ text, streaming = false }: { text: string; streaming
           quietly. (Walkthrough verdict: the caret read as too heavy.) */}
       <Streamdown
         remarkPlugins={REMARK_PLUGINS}
+        plugins={STREAMDOWN_PLUGINS}
         controls={CONTROLS}
         components={COMPONENTS}
         parseIncompleteMarkdown={streaming}

--- a/components/workbench/chat/text-block.tsx
+++ b/components/workbench/chat/text-block.tsx
@@ -59,7 +59,7 @@ const COMPONENTS = {
       <CourseLink
         courseId={courseId}
         variant="inline"
-        label={typeof children === 'string' ? children : undefined}
+        label={children}
         fallback={
           <a href={href} {...anchor}>
             {children}

--- a/components/workbench/chat/text-block.tsx
+++ b/components/workbench/chat/text-block.tsx
@@ -5,7 +5,8 @@
  *
  * Streamdown owns the parse and render; four things are added:
  *
- *  - KaTeX math through Streamdown's stable math plugin configuration.
+ *  - KaTeX math through Streamdown's stable math plugin configuration, with a
+ *    same-parser guard that keeps ordinary currency and shell dollars literal.
  *  - `remark-cjk-friendly` BEFORE `remark-gfm`, because CommonMark's emphasis
  *    flanking rules misfire next to fullwidth CJK punctuation — e.g. `**smart**`
  *    quotes otherwise reach the user with their asterisks on (the spike's S10
@@ -24,12 +25,19 @@ import { createMathPlugin } from '@streamdown/math';
 import { Streamdown, defaultRemarkPlugins } from 'streamdown';
 import remarkCjkFriendly from 'remark-cjk-friendly';
 import { courseIdFromHref } from '@/lib/workbench/course-link';
+import { remarkSelectiveSingleDollarMath } from '@/lib/workbench/markdown-math';
 import { CourseLink } from './course-link';
 
-const REMARK_PLUGINS = [remarkCjkFriendly, ...Object.values(defaultRemarkPlugins)];
+const REMARK_PLUGINS = [
+  remarkCjkFriendly,
+  remarkSelectiveSingleDollarMath,
+  ...Object.values(defaultRemarkPlugins),
+];
 
 const STREAMDOWN_PLUGINS = {
-  math: createMathPlugin({ singleDollarTextMath: true }),
+  // The official tokenizer handles `$$`; the Workbench extension validates
+  // single-dollar candidates before accepting them as math.
+  math: createMathPlugin({ singleDollarTextMath: false }),
 } as const;
 
 // remark-math already accepts an unterminated flow fence through EOF. Generic

--- a/components/workbench/chat/text-block.tsx
+++ b/components/workbench/chat/text-block.tsx
@@ -86,7 +86,7 @@ function mathNodeValue(node: MarkdownNode): string {
 }
 
 function literalDollarBlock(node: MarkdownNode, openingFence: string, raw: string): MarkdownNode {
-  let value = openingFence;
+  let value = raw.match(/^\$+[^\S\r\n]*/)?.[0] ?? openingFence;
   if (typeof node.meta === 'string') value += node.meta;
   if (node.value) value += `\n${node.value}`;
 
@@ -203,6 +203,11 @@ const STREAMDOWN_PLUGINS = {
   math: createMathPlugin({ singleDollarTextMath: true }),
 } as const;
 
+// The normalizer above already keeps unfinished display math visible. Remend's
+// generic `$$` completion is container-unaware and can alter fenced code or add
+// a second formula outside a list/blockquote while a message is streaming.
+const REMEND = { katex: false } as const;
+
 // Table chrome (fullscreen/download) is workbench-irrelevant; the code block's
 // copy action stays.
 const CONTROLS = { table: false } as const;
@@ -247,6 +252,7 @@ export function TextBlock({ text, streaming = false }: { text: string; streaming
         mode={streaming ? 'streaming' : 'static'}
         remarkPlugins={REMARK_PLUGINS}
         plugins={STREAMDOWN_PLUGINS}
+        remend={REMEND}
         controls={CONTROLS}
         components={COMPONENTS}
         parseIncompleteMarkdown={streaming}

--- a/components/workbench/chat/text-block.tsx
+++ b/components/workbench/chat/text-block.tsx
@@ -21,14 +21,185 @@
  *    there is no right pane — the pill falls back to the plain anchor.
  */
 import { createMathPlugin } from '@streamdown/math';
-import { Streamdown, defaultRemarkPlugins } from 'streamdown';
+import { Streamdown, defaultRemarkPlugins, type StreamdownProps } from 'streamdown';
 import remarkCjkFriendly from 'remark-cjk-friendly';
 import { courseIdFromHref } from '@/lib/workbench/course-link';
 import { CourseLink } from './course-link';
 
-const REMARK_PLUGINS = [remarkCjkFriendly, ...Object.values(defaultRemarkPlugins)];
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  meta?: string | null;
+  data?: Record<string, unknown>;
+  position?: {
+    start: { line?: number; column?: number; offset?: number };
+    end: { line?: number; column?: number; offset?: number };
+  };
+  children?: MarkdownNode[];
+}
+
+function displayMathData(value: string): Record<string, unknown> {
+  return {
+    hName: 'pre',
+    hChildren: [
+      {
+        type: 'element',
+        tagName: 'code',
+        properties: { className: ['language-math', 'math-display'] },
+        children: [{ type: 'text', value }],
+      },
+    ],
+  };
+}
+
+function nodeSource(node: MarkdownNode, source: string): string | undefined {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (typeof start !== 'number' || typeof end !== 'number') return undefined;
+  return source.slice(start, end);
+}
+
+function isDoubleDollarMath(node: MarkdownNode, source: string): boolean {
+  if (node.type !== 'inlineMath') return false;
+
+  const raw = nodeSource(node, source);
+  return Boolean(
+    raw?.startsWith('$$') && raw.endsWith('$$') && raw[2] !== '$' && raw[raw.length - 3] !== '$',
+  );
+}
+
+function mathBlock(node: MarkdownNode): MarkdownNode {
+  return {
+    type: 'math',
+    value: node.value,
+    position: node.position,
+    data: displayMathData(node.value ?? ''),
+  };
+}
+
+function mathNodeValue(node: MarkdownNode): string {
+  let body = node.value ?? '';
+  if (body.endsWith('$$') && body[body.length - 3] !== '$') body = body.slice(0, -2);
+
+  if (typeof node.meta !== 'string' || node.meta.length === 0) return body;
+  return body ? `${node.meta}\n${body}` : node.meta;
+}
+
+function literalDollarBlock(node: MarkdownNode, openingFence: string, raw: string): MarkdownNode {
+  let value = openingFence;
+  if (typeof node.meta === 'string') value += node.meta;
+  if (node.value) value += `\n${node.value}`;
+
+  const closingFence = raw.match(/(?:^|\n)[^\S\r\n]*(?:>\s*)*(\${3,})[^\S\r\n]*$/)?.[1];
+  if (closingFence && closingFence.length >= openingFence.length) value += `\n${closingFence}`;
+
+  return {
+    type: 'paragraph',
+    position: node.position,
+    children: [{ type: 'text', value, position: node.position }],
+  };
+}
+
+function normalizeMathBlock(node: MarkdownNode, source: string): MarkdownNode {
+  if (node.type !== 'math') return node;
+
+  const raw = nodeSource(node, source);
+  const openingFence = raw?.match(/^\$+/)?.[0];
+  if (!raw || !openingFence || openingFence.length < 2) return node;
+
+  // Longer dollar runs are inline syntax, even when an unfinished message
+  // temporarily makes remark-math parse them as a flow node.
+  if (openingFence.length > 2) return literalDollarBlock(node, openingFence, raw);
+
+  // remark-math stores content beside the opening fence in `meta`; its `value`
+  // has already removed blockquote/list markers from the following lines.
+  const value = mathNodeValue(node);
+  node.value = value;
+  node.meta = null;
+  node.data = displayMathData(value);
+  return node;
+}
+
+function splitDisplayMath(paragraph: MarkdownNode, source: string): MarkdownNode[] | undefined {
+  if (
+    paragraph.type !== 'paragraph' ||
+    !paragraph.children?.some((node) => isDoubleDollarMath(node, source))
+  ) {
+    return undefined;
+  }
+
+  const blocks: MarkdownNode[] = [];
+  let inlineNodes: MarkdownNode[] = [];
+
+  const flushInlineNodes = () => {
+    if (inlineNodes.length === 0) return;
+
+    blocks.push({
+      ...paragraph,
+      children: inlineNodes,
+      position: {
+        start: inlineNodes[0].position?.start ?? paragraph.position?.start ?? {},
+        end: inlineNodes[inlineNodes.length - 1].position?.end ?? paragraph.position?.end ?? {},
+      },
+    });
+    inlineNodes = [];
+  };
+
+  for (const node of paragraph.children) {
+    if (isDoubleDollarMath(node, source)) {
+      flushInlineNodes();
+      blocks.push(mathBlock(node));
+    } else {
+      inlineNodes.push(node);
+    }
+  }
+  flushInlineNodes();
+
+  return blocks;
+}
+
+function remarkNormalizeDisplayMath() {
+  return (tree: MarkdownNode, file: { value: unknown }) => {
+    const source = file.value;
+    if (typeof source !== 'string') return;
+
+    const visit = (parent: MarkdownNode) => {
+      if (!parent.children) return;
+
+      for (let index = 0; index < parent.children.length; index += 1) {
+        const node = parent.children[index];
+
+        const normalized = normalizeMathBlock(node, source);
+        if (normalized !== node) {
+          parent.children[index] = normalized;
+          continue;
+        }
+
+        // remark-math parses one-line `$$...$$` as inline math. Split only
+        // top-level paragraph children so the double-dollar form keeps block semantics.
+        const blocks = splitDisplayMath(node, source);
+        if (blocks) {
+          parent.children.splice(index, 1, ...blocks);
+          index += blocks.length - 1;
+          continue;
+        }
+
+        visit(node);
+      }
+    };
+
+    visit(tree);
+  };
+}
+
+const REMARK_PLUGINS: NonNullable<StreamdownProps['remarkPlugins']> = [
+  remarkCjkFriendly,
+  ...Object.values(defaultRemarkPlugins),
+  remarkNormalizeDisplayMath,
+];
 
 const STREAMDOWN_PLUGINS = {
+  // `$...$` is part of the workbench contract; literal currency uses `\$`.
   math: createMathPlugin({ singleDollarTextMath: true }),
 } as const;
 
@@ -73,6 +244,7 @@ export function TextBlock({ text, streaming = false }: { text: string; streaming
       {/* No typewriter caret, no block animation: streaming text just streams,
           quietly. (Walkthrough verdict: the caret read as too heavy.) */}
       <Streamdown
+        mode={streaming ? 'streaming' : 'static'}
         remarkPlugins={REMARK_PLUGINS}
         plugins={STREAMDOWN_PLUGINS}
         controls={CONTROLS}

--- a/components/workbench/chat/workbench-chat.css
+++ b/components/workbench/chat/workbench-chat.css
@@ -211,6 +211,13 @@
     text-wrap: pretty;
   }
 
+  /* ---------- math ---------- */
+  .wb-prose .katex-display {
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
   /* ---------- headings ---------- */
   /* Ladder 22/20/18 against the 14px body, weight 600 — BELOW the 700 of
      inline <strong>. Hierarchy comes from the size ladder; weight is reserved

--- a/lib/workbench/markdown-math.ts
+++ b/lib/workbench/markdown-math.ts
@@ -1,0 +1,126 @@
+import { math } from 'micromark-extension-math';
+
+const FORMULA_CHAR_RE = /^[\s0-9A-Za-z\p{Script=Greek}\\{}()[\]^_+\-*/=<>≤≥≈.,:;'|!%√]+$/u;
+const LATEX_COMMAND_RE = /\\(?:[A-Za-z]+|[%{}_$#&])/;
+const UNICODE_MATH_SYMBOL_RE = /(?=[^\x00-\x7f])\p{Sm}/u;
+const LONG_WORD_RE = /[A-Za-z]{3,}/g;
+const NUMBER_RE = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const SINGLE_SYMBOL_RE = /^(?:[A-Za-z]|\p{Script=Greek})$/u;
+const EQUATION_OR_SCRIPT_RE = /[=<>≤≥≈^_]/;
+const COMPLETE_OPERATOR_RE =
+  /[A-Za-z0-9\p{Script=Greek})\]}]\s*[+\-*/]\s*[A-Za-z0-9\p{Script=Greek}({\\]/u;
+const FUNCTION_OR_GROUP_RE = /[([{|].*[)\]}|]/;
+const MONOMIAL_RE = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)?[A-Za-z\p{Script=Greek}]{1,3}\d*$/u;
+const NUMERIC_ATOM_RE = /^\d+(?:\.\d+)?$/;
+const NUMERIC_POSTFIX_RE = /^\d+(?:\.\d+)?[!']+$/;
+const BARE_SHELL_ENV_FRAGMENT_RE = /^(?:[A-Z][A-Z0-9_]*|[A-Z][A-Z0-9_]+\S+)$/;
+const BRACED_SHELL_FRAGMENT_RE = /^\{[^{}\s]+\}\S*$/;
+const PAREN_SHELL_FRAGMENT_RE = /^\(.+\)\S*$/;
+const ASCII_TOKEN_RE = /[A-Za-z0-9_\\]/;
+const SHELL_TOKEN_RE = /[A-Za-z0-9_({\\]/;
+const STRONG_SHELL_TOKEN_RE = /[A-Z0-9_({\\]/;
+const TRAILING_OPERATOR_RE = /[+\-*/=<>≤≥≈^_]$/;
+const SCRIPT_OPERATOR_RE = /[\^_][+\-*/]$/;
+const SEQUENCE_EXPRESSION_RE = /[^,:\s]\s*[,:]\s*[^,:\s]/;
+const POSTFIX_OPERATOR_RE = /[A-Za-z0-9\p{Script=Greek})\]}][!']+$/u;
+
+/**
+ * Single-dollar Markdown is inherently ambiguous. Keep the accepted subset
+ * deliberately formula-shaped; ordinary prose must remain literal text.
+ */
+function isLikelySingleDollarMath(value: string, nextCharacter = ''): boolean {
+  const text = value.trim();
+  if (!text || text !== value) return false;
+
+  // A parsed closer can actually be the opener of an adjacent currency or
+  // shell token. Keep common prose suffixes such as `$n$th` working.
+  if (
+    (NUMERIC_ATOM_RE.test(text) || NUMERIC_POSTFIX_RE.test(text)) &&
+    ASCII_TOKEN_RE.test(nextCharacter)
+  ) {
+    return false;
+  }
+  if (BARE_SHELL_ENV_FRAGMENT_RE.test(text) && STRONG_SHELL_TOKEN_RE.test(nextCharacter)) {
+    return false;
+  }
+  if (BRACED_SHELL_FRAGMENT_RE.test(text) && SHELL_TOKEN_RE.test(nextCharacter)) return false;
+  if (PAREN_SHELL_FRAGMENT_RE.test(text) && STRONG_SHELL_TOKEN_RE.test(nextCharacter)) return false;
+  if (TRAILING_OPERATOR_RE.test(text) && !SCRIPT_OPERATOR_RE.test(text)) return false;
+
+  // Explicit LaTeX commands are a stronger signal than the character guard:
+  // text-like commands intentionally contain spaces and Unicode prose.
+  if (LATEX_COMMAND_RE.test(text) || UNICODE_MATH_SYMBOL_RE.test(text)) return true;
+  if (!FORMULA_CHAR_RE.test(text)) return false;
+  if (NUMBER_RE.test(text) || SINGLE_SYMBOL_RE.test(text)) return true;
+  if (EQUATION_OR_SCRIPT_RE.test(text)) return true;
+
+  const proseWords = text.match(LONG_WORD_RE) ?? [];
+  if (proseWords.length > 1) return false;
+
+  if (COMPLETE_OPERATOR_RE.test(text)) return true;
+  if (FUNCTION_OR_GROUP_RE.test(text)) return true;
+  if (proseWords.length === 0 && SEQUENCE_EXPRESSION_RE.test(text)) return true;
+  if (proseWords.length === 0 && POSTFIX_OPERATOR_RE.test(text)) return true;
+  return MONOMIAL_RE.test(text);
+}
+
+function normalizeMathTextPadding(value: string): string {
+  const leading = value.match(/^(?: |\r\n|[\r\n])/);
+  const trailing = value.match(/(?: |\r\n|[\r\n])$/);
+
+  // micromark removes one symmetric space/line ending around non-empty math.
+  if (!leading || !trailing || !/[^ \r\n]/.test(value)) return value;
+  return value.slice(leading[0].length, value.length - trailing[0].length);
+}
+
+const officialMathText = math({ singleDollarTextMath: true }).text?.[36];
+
+if (!officialMathText || Array.isArray(officialMathText)) {
+  throw new Error('Expected the official math-text tokenizer');
+}
+
+const selectiveSingleDollarMathText: typeof officialMathText = {
+  ...officialMathText,
+  name: 'workbenchSingleDollarMathText',
+  tokenize(effects, ok, nok) {
+    let mathTextToken: ReturnType<typeof effects.enter> | undefined;
+    const guardedEffects: typeof effects = {
+      ...effects,
+      enter(type, fields) {
+        const token = effects.enter(type, fields);
+        if (type === 'mathText') mathTextToken = token;
+        return token;
+      },
+    };
+
+    const acceptIfFormulaShaped: typeof ok = (code) => {
+      if (!mathTextToken) return nok(code);
+
+      const raw = this.sliceSerialize(mathTextToken);
+      const singleDollar =
+        raw[0] === '$' && raw[1] !== '$' && raw.at(-1) === '$' && raw.at(-2) !== '$';
+      const nextCharacter = typeof code === 'number' && code >= 0 ? String.fromCodePoint(code) : '';
+
+      const value = normalizeMathTextPadding(raw.slice(1, -1));
+
+      return singleDollar && isLikelySingleDollarMath(value, nextCharacter) ? ok(code) : nok(code);
+    };
+
+    return officialMathText.tokenize.call(this, guardedEffects, acceptIfFormulaShaped, nok);
+  },
+};
+
+interface MarkdownProcessor {
+  data(): object;
+}
+
+/**
+ * Adds formula-aware single-dollar math to the same micromark parser used by
+ * Streamdown. Rejected candidates roll back as ordinary Markdown text, so the
+ * next dollar is considered without source rewriting or reparsing.
+ */
+export function remarkSelectiveSingleDollarMath(this: MarkdownProcessor): void {
+  const data = this.data() as { micromarkExtensions?: ReturnType<typeof math>[] };
+  const extensions = data.micromarkExtensions ?? (data.micromarkExtensions = []);
+  extensions.push({ text: { [36]: selectiveSingleDollarMathText } });
+}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.562.0",
     "mathml2omml": "workspace:*",
+    "micromark-extension-math": "^3.1.0",
     "mitt": "^3.0.1",
     "motion": "^12.27.5",
     "nanoid": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@streamdown/code": "^1.1.1",
+    "@streamdown/math": "^1.0.2",
     "@types/js-yaml": "^4.0.9",
     "@xyflow/react": "^12.10.0",
     "ai": "^6.0.168",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@streamdown/code':
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.3)
+      '@streamdown/math':
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.2.3)
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -6032,6 +6035,11 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
+  '@streamdown/math@1.0.2':
+    resolution: {integrity: sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
   '@stylistic/eslint-plugin@4.4.1':
     resolution: {integrity: sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -9238,8 +9246,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
@@ -9258,6 +9278,9 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -10824,6 +10847,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -10932,6 +10958,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -12218,6 +12247,9 @@ packages:
   rehype-harden@1.1.8:
     resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
@@ -12236,6 +12268,9 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -13390,11 +13425,17 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -19884,6 +19925,15 @@ snapshots:
       react: 19.2.3
       shiki: 3.23.0
 
+  '@streamdown/math@1.0.2(react@19.2.3)':
+    dependencies:
+      katex: 0.16.38
+      react: 19.2.3
+      rehype-katex: 7.0.1
+      remark-math: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@stylistic/eslint-plugin@4.4.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -23757,6 +23807,28 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
   hast-util-from-parse5@8.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -23767,6 +23839,10 @@ snapshots:
       vfile: 6.0.3
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-parse-selector@4.0.0:
     dependencies:
@@ -23837,6 +23913,13 @@ snapshots:
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -25594,6 +25677,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -25821,6 +25916,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.38
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -27400,6 +27505,16 @@ snapshots:
     dependencies:
       unist-util-visit: 5.1.0
 
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.38
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+
   rehype-raw@7.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -27429,6 +27544,15 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -28824,6 +28948,11 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -28831,6 +28960,11 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       mathml2omml:
         specifier: workspace:*
         version: link:packages/mathml2omml
+      micromark-extension-math:
+        specifier: ^3.1.0
+        version: 3.1.0
       mitt:
         specifier: ^3.0.1
         version: 3.0.1

--- a/tests/workbench/text-block-lifecycle.test.ts
+++ b/tests/workbench/text-block-lifecycle.test.ts
@@ -25,64 +25,27 @@ function mountText(text: string, streaming: boolean) {
 }
 
 describe('Workbench assistant Markdown lifecycle', () => {
-  it.each([
-    ['identifier', '$$x', ['x']],
-    ['invalid formula', String.raw`$$\frac{1}{`, [String.raw`\frac{1}{`]],
-    ['multiline formula', '$$x\ny', ['x', 'y']],
-    ['longer dollar run', '$$$x', ['$$$x']],
-  ])(
-    'keeps an incomplete %s visible when streaming ends without new text',
-    (_case, text, visibleText) => {
-      const live = mountText(text, true);
+  it('renders a display formula as its standard flow fence streams in', () => {
+    const live = mountText('$$\n', true);
 
-      act(() => live.root.render(createElement(TextBlock, { text, streaming: false })));
-      const replay = mountText(text, false);
+    act(() => live.root.render(createElement(TextBlock, { text: '$$\nx', streaming: true })));
+    expect(live.host.querySelector('.katex-display')).not.toBeNull();
+    expect(live.host.querySelector('annotation')?.textContent).toBe('x');
 
-      for (const fragment of visibleText) expect(live.host.textContent).toContain(fragment);
-      expect(live.host.innerHTML).toBe(replay.host.innerHTML);
-    },
-  );
-
-  it('keeps the first line visible while a display formula streams across lines', () => {
-    const live = mountText('$$x', true);
-    expect(live.host.textContent).toContain('x');
-
-    act(() => live.root.render(createElement(TextBlock, { text: '$$x\n', streaming: true })));
-    expect(live.host.textContent).toContain('x');
-
-    const complete = '$$x\nmore\n$$';
+    const complete = '$$\nx + y\n$$';
     act(() => live.root.render(createElement(TextBlock, { text: complete, streaming: true })));
-    expect(live.host.textContent).toContain('x');
-    expect(live.host.textContent).toContain('more');
+    expect(live.host.querySelector('annotation')?.textContent).toBe('x + y');
 
     act(() => live.root.render(createElement(TextBlock, { text: complete, streaming: false })));
     const replay = mountText(complete, false);
     expect(live.host.innerHTML).toBe(replay.host.innerHTML);
   });
 
-  it('keeps a longer dollar run visible while it streams across lines', () => {
-    const live = mountText('$$$x', true);
-    expect(live.host.textContent).toContain('x');
-
-    act(() => live.root.render(createElement(TextBlock, { text: '$$$x\n', streaming: true })));
-    expect(live.host.textContent).toContain('x');
-
-    const incomplete = '$$$x\ny';
-    act(() => live.root.render(createElement(TextBlock, { text: incomplete, streaming: true })));
-    expect(live.host.textContent).toContain('x');
-    expect(live.host.textContent).toContain('y');
-
-    act(() => live.root.render(createElement(TextBlock, { text: incomplete, streaming: false })));
-    const replay = mountText(incomplete, false);
-    expect(live.host.innerHTML).toBe(replay.host.innerHTML);
-  });
-
   it.each([
-    ['a list', '- $$x\n  y'],
-    ['a blockquote', '> $$x\n> y'],
-  ])('does not add an empty formula to an unfinished display inside %s', (_case, text) => {
+    ['complete', '$$\nx\n$$'],
+    ['unfinished', '$$\nx'],
+  ])('settles a %s display formula without changing its rendered result', (_case, text) => {
     const live = mountText(text, true);
-    expect(live.host.querySelectorAll('.katex-display')).toHaveLength(1);
 
     act(() => live.root.render(createElement(TextBlock, { text, streaming: false })));
     const replay = mountText(text, false);

--- a/tests/workbench/text-block-lifecycle.test.ts
+++ b/tests/workbench/text-block-lifecycle.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TextBlock } from '@/components/workbench/chat/text-block';
+
+const roots: Root[] = [];
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount());
+  document.body.replaceChildren();
+});
+
+function mountText(text: string, streaming: boolean) {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.push(root);
+  act(() => root.render(createElement(TextBlock, { text, streaming })));
+  return { host, root };
+}
+
+describe('Workbench assistant Markdown lifecycle', () => {
+  it.each([
+    ['identifier', '$$x', ['x']],
+    ['invalid formula', String.raw`$$\frac{1}{`, [String.raw`\frac{1}{`]],
+    ['multiline formula', '$$x\ny', ['x', 'y']],
+    ['longer dollar run', '$$$x', ['$$$x']],
+  ])(
+    'keeps an incomplete %s visible when streaming ends without new text',
+    (_case, text, visibleText) => {
+      const live = mountText(text, true);
+
+      act(() => live.root.render(createElement(TextBlock, { text, streaming: false })));
+      const replay = mountText(text, false);
+
+      for (const fragment of visibleText) expect(live.host.textContent).toContain(fragment);
+      expect(live.host.innerHTML).toBe(replay.host.innerHTML);
+    },
+  );
+
+  it('keeps the first line visible while a display formula streams across lines', () => {
+    const live = mountText('$$x', true);
+    expect(live.host.textContent).toContain('x');
+
+    act(() => live.root.render(createElement(TextBlock, { text: '$$x\n', streaming: true })));
+    expect(live.host.textContent).toContain('x');
+
+    const complete = '$$x\nmore\n$$';
+    act(() => live.root.render(createElement(TextBlock, { text: complete, streaming: true })));
+    expect(live.host.textContent).toContain('x');
+    expect(live.host.textContent).toContain('more');
+
+    act(() => live.root.render(createElement(TextBlock, { text: complete, streaming: false })));
+    const replay = mountText(complete, false);
+    expect(live.host.innerHTML).toBe(replay.host.innerHTML);
+  });
+
+  it('keeps a longer dollar run visible while it streams across lines', () => {
+    const live = mountText('$$$x', true);
+    expect(live.host.textContent).toContain('x');
+
+    act(() => live.root.render(createElement(TextBlock, { text: '$$$x\n', streaming: true })));
+    expect(live.host.textContent).toContain('x');
+
+    const incomplete = '$$$x\ny';
+    act(() => live.root.render(createElement(TextBlock, { text: incomplete, streaming: true })));
+    expect(live.host.textContent).toContain('x');
+    expect(live.host.textContent).toContain('y');
+
+    act(() => live.root.render(createElement(TextBlock, { text: incomplete, streaming: false })));
+    const replay = mountText(incomplete, false);
+    expect(live.host.innerHTML).toBe(replay.host.innerHTML);
+  });
+});

--- a/tests/workbench/text-block-lifecycle.test.ts
+++ b/tests/workbench/text-block-lifecycle.test.ts
@@ -76,4 +76,18 @@ describe('Workbench assistant Markdown lifecycle', () => {
     const replay = mountText(incomplete, false);
     expect(live.host.innerHTML).toBe(replay.host.innerHTML);
   });
+
+  it.each([
+    ['a list', '- $$x\n  y'],
+    ['a blockquote', '> $$x\n> y'],
+  ])('does not add an empty formula to an unfinished display inside %s', (_case, text) => {
+    const live = mountText(text, true);
+    expect(live.host.querySelectorAll('.katex-display')).toHaveLength(1);
+
+    act(() => live.root.render(createElement(TextBlock, { text, streaming: false })));
+    const replay = mountText(text, false);
+
+    expect(live.host.querySelectorAll('.katex-display')).toHaveLength(1);
+    expect(live.host.innerHTML).toBe(replay.host.innerHTML);
+  });
 });

--- a/tests/workbench/text-block.test.ts
+++ b/tests/workbench/text-block.test.ts
@@ -153,6 +153,217 @@ $$`,
     expect(html).not.toContain('katex-error');
   });
 
+  it.each([
+    'Plans cost $5 and $10 per month.',
+    'Prices: $5 $10.',
+    'Prices: $5,$10.',
+    'Costs $5 + tax; $10 + tax.',
+    'Cost $5/month, or $10/year.',
+    'Cost $5/mo or $10/mo.',
+    '$5 / item, or $10 / pair',
+    'Set $HOME and $PATH before continuing.',
+    'echo $A$B',
+    'echo $LD_LIBRARY_PATH:$PATH',
+    'cd ${HOME}/$PROJECT',
+    'echo ${HOME}${PATH}',
+    'echo ${HOME}:${PATH}',
+    'echo ${FILE_NAME}.${EXT}',
+    'echo ${WIDTH}x${HEIGHT}',
+    'echo ${file}.${ext}',
+    'echo ${FOO:-0}${BAR}',
+    'echo $(date)$(whoami)',
+    'echo $(pwd)$HOME',
+    'echo $(date)${USER}',
+    'Use $OPENAI_API_KEY or $ANTHROPIC_API_KEY.',
+  ])('preserves ordinary dollar text in settled and streaming messages: %s', (text) => {
+    for (const streaming of [false, true]) {
+      const document = parseHTML(renderText(text, streaming)).document;
+
+      expect(document.querySelector('.wb-prose')?.textContent).toContain(text);
+      expect(document.querySelector('.katex')).toBeNull();
+    }
+  });
+
+  it.each([
+    ['Cost $5; formula $x^2$.', 'x^2'],
+    ['Cost $5; formula $X^2$.', 'X^2'],
+    ['Cost $5; formula $2x$.', '2x'],
+    ['Cost $5; formula $10^2$.', '10^2'],
+    ['Cost $5; formula ${x+1}$.', '{x+1}'],
+    ['Cost $5; formula $(x+1)$.', '(x+1)'],
+    ['Cost $5; formula $_x$.', '_x'],
+    ['Cost $5; formula $C^+$.', 'C^+'],
+    ['Set $HOME, then solve $x^2$.', 'x^2'],
+    ['$5 and $10 $x^2$', 'x^2'],
+    ['Prices $5 and $10; fees $2 and $3 $x^2$.', 'x^2'],
+    ['Cost $5 $x$', 'x'],
+    ['Cost $5,$x$', 'x'],
+    ['Cost $5!$x$', 'x'],
+  ])('keeps literal dollars from stealing a later formula delimiter: %s', (text, latex) => {
+    for (const streaming of [false, true]) {
+      const document = parseHTML(renderText(text, streaming)).document;
+
+      expect(document.querySelector('.wb-prose')?.textContent).toContain(
+        text.slice(0, text.indexOf(`$${latex}$`)),
+      );
+      expect(document.querySelectorAll('.katex')).toHaveLength(1);
+      expect(document.querySelector('annotation')?.textContent).toBe(latex);
+    }
+  });
+
+  it('recovers every formula after a literal dollar in the same message', () => {
+    const text = 'Cost $5; formula $x^2$. The ratio $a:b$ and $x ≠ 0$ still render as math.';
+
+    for (const streaming of [false, true]) {
+      const document = parseHTML(renderText(text, streaming)).document;
+
+      expect(document.querySelector('.wb-prose')?.textContent).toContain('Cost $5; formula');
+      expect(
+        Array.from(document.querySelectorAll('annotation'), (node) => node.textContent),
+      ).toEqual(['x^2', 'a:b', 'x ≠ 0']);
+    }
+  });
+
+  it('handles many literal dollar pairs before later formulas in one pass', () => {
+    const prices = Array.from(
+      { length: 400 },
+      (_, index) => `$${index + 1} and $${index + 2}`,
+    ).join('; ');
+    const text = `${prices}; formulas ` + '$2x$, ${x+1}$, and $(x+1)$.';
+    const document = parseHTML(renderText(text)).document;
+
+    expect(document.querySelector('.wb-prose')?.textContent).toContain('$1 and $2');
+    expect(document.querySelector('.wb-prose')?.textContent).toContain('$400 and $401');
+    expect(Array.from(document.querySelectorAll('annotation'), (node) => node.textContent)).toEqual(
+      ['2x', '{x+1}', '(x+1)'],
+    );
+  });
+
+  it('recovers math after currency inside a Markdown link label', () => {
+    const document = parseHTML(renderText('[Cost $5; solve $x^2$](https://example.com)')).document;
+    const link = document.querySelector('a');
+
+    expect(link?.textContent).toContain('Cost $5; solve');
+    expect(link?.querySelector('annotation')?.textContent).toBe('x^2');
+  });
+
+  it('restores Markdown structures swallowed by a rejected dollar candidate', () => {
+    const url = 'https://example.com/?a=$HOME&b=$PATH';
+    const text = `Cost $5; **bold**; \`echo $HOME\`; [docs](${url}); formula $x$.`;
+    const document = parseHTML(renderText(text)).document;
+
+    expect(document.querySelector('.wb-prose')?.textContent).toContain('Cost $5');
+    expect(document.querySelector('[data-streamdown="strong"]')?.textContent).toBe('bold');
+    expect(document.querySelector('code')?.textContent).toBe('echo $HOME');
+    expect(document.querySelector('a')?.getAttribute('href')).toBe(url);
+    expect(document.querySelector('annotation')?.textContent).toBe('x');
+  });
+
+  it.each([
+    '$x_i$',
+    '$x*y*z$',
+    '$α+β$',
+    '$x+β$',
+    '$-1$',
+    '$a,b$',
+    '$x, y$',
+    '$f(x)$',
+    String.raw`$f'(x)$`,
+    '$n!$',
+    String.raw`$x'$`,
+    String.raw`$θ'$`,
+    '$θ!$',
+    '$x^*$',
+    '$C^+$',
+    '$-x$',
+    '$-2x$',
+    '$2xy$',
+    '$xyz$',
+    '$τ$',
+    '$∞$',
+    '$x ≠ 0$',
+    '$a ± b$',
+    '$a:b$',
+    '$1:2$',
+    '$velocity = distance / time$',
+    String.raw`$\frac{a}{b}$`,
+    String.raw`$\text{速度}$`,
+  ])('preserves valid single-dollar math syntax: %s', (text) => {
+    const document = parseHTML(renderText(text)).document;
+
+    expect(document.querySelectorAll('.katex')).toHaveLength(1);
+    expect(document.querySelector('annotation')?.textContent).toBe(text.slice(1, -1));
+  });
+
+  it.each([
+    ['$ x $', 'x'],
+    ['$\nx\n$', 'x'],
+  ])('preserves micromark math padding semantics: %s', (text, latex) => {
+    for (const streaming of [false, true]) {
+      const document = parseHTML(renderText(text, streaming)).document;
+
+      expect(document.querySelectorAll('.katex')).toHaveLength(1);
+      expect(document.querySelector('annotation')?.textContent).toBe(latex);
+    }
+  });
+
+  it('keeps adjacent prose after a closed single-dollar formula', () => {
+    const document = parseHTML(renderText('the $n$th term')).document;
+
+    expect(document.querySelector('annotation')?.textContent).toBe('n');
+    expect(document.querySelector('.wb-prose')?.textContent).toContain('th term');
+  });
+
+  it('keeps a parenthesized formula before an adjacent prose suffix', () => {
+    const document = parseHTML(renderText('the $(n+1)$th term')).document;
+
+    expect(document.querySelector('annotation')?.textContent).toBe('(n+1)');
+    expect(document.querySelector('.wb-prose')?.textContent).toContain('th term');
+  });
+
+  it.each([
+    [String.raw`\\$x$`, true],
+    [String.raw`\\\$x$`, false],
+  ])('respects Markdown escape parity: %s', (text, rendersMath) => {
+    const document = parseHTML(renderText(text)).document;
+
+    expect(document.querySelector('.katex') !== null).toBe(rendersMath);
+  });
+
+  it('does not treat a backslash before the second dollar as an escaped math closer', () => {
+    const text = String.raw`$5 and \$10`;
+
+    for (const streaming of [false, true]) {
+      const document = parseHTML(renderText(text, streaming)).document;
+
+      expect(document.querySelector('.wb-prose')?.textContent).toContain('$5 and $10');
+      expect(document.querySelector('.katex')).toBeNull();
+    }
+  });
+
+  it('keeps dollar-prefixed query values inside a GFM autolink', () => {
+    const url = 'https://example.com/?a=$HOME&b=$PATH';
+    const document = parseHTML(renderText(url)).document;
+    const link = document.querySelector('a');
+
+    expect(link?.getAttribute('href')).toBe(url);
+    expect(link?.textContent).toBe(url);
+  });
+
+  it('does not add an escape inside incomplete inline code while streaming', () => {
+    const document = parseHTML(renderText('Use `$5 and $10', true)).document;
+
+    expect(document.querySelector('code')?.textContent).toBe('$5 and $10');
+  });
+
+  it('keeps delimiter offsets aligned when a message starts with a byte-order mark', () => {
+    const document = parseHTML(renderText('\uFEFFCost $5; formula $x^2$.')).document;
+
+    expect(document.querySelector('.wb-prose')?.textContent).toContain('Cost $5; formula');
+    expect(document.querySelectorAll('.katex')).toHaveLength(1);
+    expect(document.querySelector('annotation')?.textContent).toBe('x^2');
+  });
+
   it('leaves math delimiters inside inline and fenced code untouched', () => {
     const html = renderText(['Inline: `$inline$`', '', '```tex', '$$fenced$$', '```'].join('\n'));
 
@@ -184,5 +395,17 @@ $$`,
     expect(html).toContain('data-streamdown="table-cell"');
     expect(html).toContain('>A</th>');
     expect(html).toContain('>2</td>');
+  });
+
+  it('keeps currency literal and math rendered across GFM table cells', () => {
+    const document = parseHTML(
+      renderText(`| Price | Formula |
+| --- | --- |
+| $5 | $x$ |`),
+    ).document;
+
+    expect(document.querySelector('tbody')?.textContent).toContain('$5');
+    expect(document.querySelectorAll('tbody .katex')).toHaveLength(1);
+    expect(document.querySelector('tbody annotation')?.textContent).toBe('x');
   });
 });

--- a/tests/workbench/text-block.test.ts
+++ b/tests/workbench/text-block.test.ts
@@ -1,0 +1,43 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { TextBlock } from '@/components/workbench/chat/text-block';
+
+const renderText = (text: string, streaming = false) =>
+  renderToStaticMarkup(createElement(TextBlock, { text, streaming }));
+
+describe('Workbench assistant Markdown', () => {
+  it.each([
+    ['settled', false],
+    ['streaming', true],
+  ])('renders inline and display math in a %s message', (_state, streaming) => {
+    const inline = renderText('Inline: $x^2$', streaming);
+    const display = renderText(
+      String.raw`$$
+\frac{a}{b}
+$$`,
+      streaming,
+    );
+
+    expect(inline).toContain('class="katex"');
+    expect(inline).not.toContain('$x^2$');
+    expect(display).toContain('class="katex-display"');
+    expect(display).toContain('class="katex"');
+    expect(display).not.toContain('$$');
+  });
+
+  it('does not throw on an incomplete streaming display formula', () => {
+    const incomplete = String.raw`$$
+\frac{1}{`;
+
+    expect(() => renderText(incomplete, true)).not.toThrow();
+  });
+
+  it('preserves the existing CJK, emphasis, and ordinary-link pipeline', () => {
+    const html = renderText('你好，**重点**；[指南](/docs)。');
+
+    expect(html).toContain('data-streamdown="strong"');
+    expect(html).toContain('href="/docs"');
+    expect(html).toContain('指南');
+  });
+});

--- a/tests/workbench/text-block.test.ts
+++ b/tests/workbench/text-block.test.ts
@@ -3,9 +3,39 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { parseHTML } from 'linkedom';
 import { describe, expect, it } from 'vitest';
 import { TextBlock } from '@/components/workbench/chat/text-block';
+import { I18nProvider } from '@/lib/hooks/use-i18n';
+import {
+  WorkbenchCourseNavigationProvider,
+  type WorkbenchCourseNavigation,
+} from '@/lib/workbench/panel-context';
 
 const renderText = (text: string, streaming = false) =>
   renderToStaticMarkup(createElement(TextBlock, { text, streaming }));
+
+const renderI18nText = (text: string) =>
+  renderToStaticMarkup(createElement(I18nProvider, null, createElement(TextBlock, { text })));
+
+const renderWorkspaceText = (
+  text: string,
+  lookupCourse: WorkbenchCourseNavigation['lookupCourse'] = () => null,
+) => {
+  const providerProps: React.ComponentProps<typeof WorkbenchCourseNavigationProvider> = {
+    navigation: {
+      activeCourseId: null,
+      courseOptions: [],
+      lookupCourse,
+      openCourse: () => undefined,
+    },
+    children: createElement(TextBlock, { text }),
+  };
+  return renderToStaticMarkup(
+    createElement(
+      I18nProvider,
+      null,
+      createElement(WorkbenchCourseNavigationProvider, providerProps),
+    ),
+  );
+};
 
 describe('Workbench assistant Markdown', () => {
   it.each([
@@ -77,6 +107,42 @@ $$`,
     expect(html).toContain('重点');
     expect(html).toContain('href="/docs"');
     expect(html).toContain('指南');
+  });
+
+  it('keeps a rich course label as an anchor outside the workspace', () => {
+    const document = parseHTML(renderI18nText('[Solving $x^2$](/classroom/stage-1)')).document;
+    const link = document.querySelector('a[href="/classroom/stage-1"]');
+
+    expect(link?.textContent).toContain('Solving');
+    expect(link?.querySelector('.katex')).not.toBeNull();
+    expect(document.querySelector('[data-testid="workbench-course-link-stage-1"]')).toBeNull();
+  });
+
+  it('keeps math in an unresolved workspace course label', () => {
+    const html = renderWorkspaceText('[Solving $x^2$](/classroom/stage-1)');
+    const document = parseHTML(html).document;
+    const link = document.querySelector('[data-testid="workbench-course-link-stage-1"]');
+
+    expect(link?.tagName).toBe('BUTTON');
+    expect(link?.textContent).toContain('Solving');
+    expect(link?.querySelector('.katex')).not.toBeNull();
+    expect(link?.querySelector('annotation')?.textContent).toBe('x^2');
+    expect(link?.getAttribute('aria-label')).toBeNull();
+    expect(link?.getAttribute('title')).toBeNull();
+  });
+
+  it('keeps the workspace course name ahead of a rich link label', () => {
+    const html = renderWorkspaceText('[Solving $x^2$](/classroom/stage-1)', () => ({
+      id: 'stage-1',
+      name: 'Limits course',
+      pageCount: 3,
+    }));
+    const document = parseHTML(html).document;
+    const link = document.querySelector('[data-testid="workbench-course-link-stage-1"]');
+
+    expect(link?.textContent).toContain('Limits course');
+    expect(link?.querySelector('.katex')).toBeNull();
+    expect(link?.getAttribute('aria-label')).toContain('Limits course');
   });
 
   it('preserves escaped currency next to single-dollar math', () => {

--- a/tests/workbench/text-block.test.ts
+++ b/tests/workbench/text-block.test.ts
@@ -1,5 +1,6 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { parseHTML } from 'linkedom';
 import { describe, expect, it } from 'vitest';
 import { TextBlock } from '@/components/workbench/chat/text-block';
 
@@ -67,7 +68,7 @@ Explanation`,
     expect(html).not.toContain('class="katex-display"');
   });
 
-  it.each(['$$$$x\ny\n$$$', '$$$x\ny\n$$$$'])(
+  it.each(['$$$$x\ny\n$$$', '$$$x\ny\n$$$$', '$$$$   tag\ny\n$$$$'])(
     'preserves a multiline longer dollar run literally: %s',
     (text) => {
       const html = renderText(text);
@@ -141,6 +142,19 @@ more$$`,
     expect(html).toContain('$inline$');
     expect(html).toContain('$$fenced$$');
     expect(html).not.toContain('class="katex"');
+  });
+
+  it.each([
+    ['an unfinished fence', ['```tex', '$$x'].join('\n')],
+    ['a closed fence', ['```tex', '$$x', '```'].join('\n')],
+  ])('does not complete math inside %s while streaming', (_case, text) => {
+    const streaming = parseHTML(renderText(text, true)).document;
+    const settled = parseHTML(renderText(text)).document;
+
+    expect(streaming.querySelector('code')?.textContent).toBe('$$x');
+    expect(settled.querySelector('code')?.textContent).toBe('$$x');
+    expect(streaming.querySelectorAll('.katex-display')).toHaveLength(0);
+    expect(settled.querySelectorAll('.katex-display')).toHaveLength(0);
   });
 
   it('preserves the default GFM table pipeline', () => {

--- a/tests/workbench/text-block.test.ts
+++ b/tests/workbench/text-block.test.ts
@@ -20,24 +20,138 @@ $$`,
     );
 
     expect(inline).toContain('class="katex"');
+    expect(inline).toContain('>x^2</annotation>');
     expect(inline).not.toContain('$x^2$');
     expect(display).toContain('class="katex-display"');
     expect(display).toContain('class="katex"');
+    expect(display).toContain(String.raw`>\frac{a}{b}</annotation>`);
     expect(display).not.toContain('$$');
   });
 
-  it('does not throw on an incomplete streaming display formula', () => {
+  it.each([
+    ['settled', false],
+    ['streaming', true],
+  ])(
+    'treats a standalone same-line $$ formula as display math in a %s message',
+    (_state, streaming) => {
+      const html = renderText(String.raw`$$\frac{a}{b}$$`, streaming);
+
+      expect(html).toContain('class="katex-display"');
+      expect(html).toContain(String.raw`>\frac{a}{b}</annotation>`);
+      expect(html).not.toContain('$$');
+    },
+  );
+
+  it.each([
+    ['leading text', String.raw`Result: $$\frac{a}{b}$$`, 'Result:'],
+    ['trailing text', String.raw`$$\frac{a}{b}$$ is the result.`, 'is the result.'],
+    [
+      'a soft line break',
+      String.raw`$$\frac{a}{b}$$
+Explanation`,
+      'Explanation',
+    ],
+  ])('keeps $$ display semantics next to %s', (_case, text, adjacentText) => {
+    const html = renderText(text);
+
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain(String.raw`>\frac{a}{b}</annotation>`);
+    expect(html).toContain(adjacentText);
+  });
+
+  it('leaves a longer dollar fence as inline math', () => {
+    const html = renderText('$$$x$$$');
+
+    expect(html).toContain('class="katex"');
+    expect(html).toContain('>x</annotation>');
+    expect(html).not.toContain('class="katex-display"');
+  });
+
+  it.each(['$$$$x\ny\n$$$', '$$$x\ny\n$$$$'])(
+    'preserves a multiline longer dollar run literally: %s',
+    (text) => {
+      const html = renderText(text);
+
+      expect(html).toContain(`>${text}</p>`);
+      expect(html).not.toContain('class="katex"');
+    },
+  );
+
+  it('keeps Markdown container markers out of display formulas', () => {
+    const html = renderText(String.raw`> $$\frac{a}{b}
+> more
+> $$`);
+
+    expect(html).toContain(String.raw`>\frac{a}{b}
+more</annotation>`);
+    expect(html).not.toContain(String.raw`>\frac{a}{b}
+> more</annotation>`);
+  });
+
+  it.each([
+    [
+      'a closing fence on its own line',
+      String.raw`$$\frac{a}{b}
+more
+$$`,
+    ],
+    [
+      'a closing fence after the last formula line',
+      String.raw`$$\frac{a}{b}
+more$$`,
+    ],
+  ])('preserves the first formula line with %s', (_case, text) => {
+    const html = renderText(text);
+
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain(String.raw`\frac{a}{b}`);
+    expect(html).toContain('more');
+  });
+
+  it('renders a visible fallback for an incomplete streaming display formula', () => {
     const incomplete = String.raw`$$
 \frac{1}{`;
+    const html = renderText(incomplete, true);
 
-    expect(() => renderText(incomplete, true)).not.toThrow();
+    expect(html).toContain('class="katex-error"');
+    expect(html).toContain(String.raw`\frac{1}{`);
+    expect(html).not.toContain('$$');
   });
 
   it('preserves the existing CJK, emphasis, and ordinary-link pipeline', () => {
     const html = renderText('你好，**重点**；[指南](/docs)。');
 
     expect(html).toContain('data-streamdown="strong"');
+    expect(html).toContain('重点');
     expect(html).toContain('href="/docs"');
     expect(html).toContain('指南');
+  });
+
+  it('preserves escaped currency next to single-dollar math', () => {
+    const html = renderText(String.raw`Cost is \$5 and budget is \$10; formula: $x^2$.`);
+
+    expect(html).toContain('Cost is $5 and budget is $10; formula:');
+    expect(html).toContain('class="katex"');
+    expect(html).not.toContain('katex-error');
+  });
+
+  it('leaves math delimiters inside inline and fenced code untouched', () => {
+    const html = renderText(['Inline: `$inline$`', '', '```tex', '$$fenced$$', '```'].join('\n'));
+
+    expect(html).toContain('$inline$');
+    expect(html).toContain('$$fenced$$');
+    expect(html).not.toContain('class="katex"');
+  });
+
+  it('preserves the default GFM table pipeline', () => {
+    const html = renderText(`| A | B |
+| --- | --- |
+| 1 | 2 |`);
+
+    expect(html).toContain('data-streamdown="table"');
+    expect(html).toContain('data-streamdown="table-header-cell"');
+    expect(html).toContain('data-streamdown="table-cell"');
+    expect(html).toContain('>A</th>');
+    expect(html).toContain('>2</td>');
   });
 });

--- a/tests/workbench/text-block.test.ts
+++ b/tests/workbench/text-block.test.ts
@@ -24,95 +24,46 @@ $$`,
     expect(inline).toContain('>x^2</annotation>');
     expect(inline).not.toContain('$x^2$');
     expect(display).toContain('class="katex-display"');
-    expect(display).toContain('class="katex"');
     expect(display).toContain(String.raw`>\frac{a}{b}</annotation>`);
     expect(display).not.toContain('$$');
   });
 
-  it.each([
-    ['settled', false],
-    ['streaming', true],
-  ])(
-    'treats a standalone same-line $$ formula as display math in a %s message',
-    (_state, streaming) => {
-      const html = renderText(String.raw`$$\frac{a}{b}$$`, streaming);
-
-      expect(html).toContain('class="katex-display"');
-      expect(html).toContain(String.raw`>\frac{a}{b}</annotation>`);
-      expect(html).not.toContain('$$');
-    },
-  );
-
-  it.each([
-    ['leading text', String.raw`Result: $$\frac{a}{b}$$`, 'Result:'],
-    ['trailing text', String.raw`$$\frac{a}{b}$$ is the result.`, 'is the result.'],
-    [
-      'a soft line break',
-      String.raw`$$\frac{a}{b}$$
-Explanation`,
-      'Explanation',
-    ],
-  ])('keeps $$ display semantics next to %s', (_case, text, adjacentText) => {
-    const html = renderText(text);
-
-    expect(html).toContain('class="katex-display"');
-    expect(html).toContain(String.raw`>\frac{a}{b}</annotation>`);
-    expect(html).toContain(adjacentText);
-  });
-
-  it('leaves a longer dollar fence as inline math', () => {
-    const html = renderText('$$$x$$$');
+  it('renders same-line double-dollar input without exposing its delimiters', () => {
+    const html = renderText(String.raw`$$\frac{a}{b}$$`);
 
     expect(html).toContain('class="katex"');
-    expect(html).toContain('>x</annotation>');
-    expect(html).not.toContain('class="katex-display"');
-  });
-
-  it.each(['$$$$x\ny\n$$$', '$$$x\ny\n$$$$', '$$$$   tag\ny\n$$$$'])(
-    'preserves a multiline longer dollar run literally: %s',
-    (text) => {
-      const html = renderText(text);
-
-      expect(html).toContain(`>${text}</p>`);
-      expect(html).not.toContain('class="katex"');
-    },
-  );
-
-  it('keeps Markdown container markers out of display formulas', () => {
-    const html = renderText(String.raw`> $$\frac{a}{b}
-> more
-> $$`);
-
-    expect(html).toContain(String.raw`>\frac{a}{b}
-more</annotation>`);
-    expect(html).not.toContain(String.raw`>\frac{a}{b}
-> more</annotation>`);
+    expect(html).toContain(String.raw`>\frac{a}{b}</annotation>`);
+    expect(html).not.toContain('$$');
   });
 
   it.each([
     [
-      'a closing fence on its own line',
-      String.raw`$$\frac{a}{b}
-more
-$$`,
+      'a list',
+      String.raw`- $$
+  x + y
+  $$`,
+      'li',
     ],
     [
-      'a closing fence after the last formula line',
-      String.raw`$$\frac{a}{b}
-more$$`,
+      'a blockquote',
+      String.raw`> $$
+> x + y
+> $$`,
+      'blockquote',
     ],
-  ])('preserves the first formula line with %s', (_case, text) => {
-    const html = renderText(text);
+  ])('renders display math inside %s', (_case, text, container) => {
+    const document = parseHTML(renderText(text, true)).document;
 
-    expect(html).toContain('class="katex-display"');
-    expect(html).toContain(String.raw`\frac{a}{b}`);
-    expect(html).toContain('more');
+    expect(document.querySelector(`${container} .katex-display`)).not.toBeNull();
+    expect(document.querySelector('annotation')?.textContent).toBe('x + y');
   });
 
   it('renders a visible fallback for an incomplete streaming display formula', () => {
-    const incomplete = String.raw`$$
-\frac{1}{`;
-    const html = renderText(incomplete, true);
+    const html = renderText(
+      String.raw`$$
+\frac{1}{`,
+      true,
+    );
 
     expect(html).toContain('class="katex-error"');
     expect(html).toContain(String.raw`\frac{1}{`);
@@ -129,9 +80,9 @@ more$$`,
   });
 
   it('preserves escaped currency next to single-dollar math', () => {
-    const html = renderText(String.raw`Cost is \$5 and budget is \$10; formula: $x^2$.`);
+    const html = renderText(String.raw`Cost is \$5 and \$10; formula: $x^2$.`);
 
-    expect(html).toContain('Cost is $5 and budget is $10; formula:');
+    expect(html).toContain('Cost is $5 and $10; formula:');
     expect(html).toContain('class="katex"');
     expect(html).not.toContain('katex-error');
   });
@@ -153,8 +104,8 @@ more$$`,
 
     expect(streaming.querySelector('code')?.textContent).toBe('$$x');
     expect(settled.querySelector('code')?.textContent).toBe('$$x');
-    expect(streaming.querySelectorAll('.katex-display')).toHaveLength(0);
-    expect(settled.querySelectorAll('.katex-display')).toHaveLength(0);
+    expect(streaming.querySelector('.katex')).toBeNull();
+    expect(settled.querySelector('.katex')).toBeNull();
   });
 
   it('preserves the default GFM table pipeline', () => {


### PR DESCRIPTION
## Summary

Render inline and display LaTeX in Pro Workbench assistant messages through the official Streamdown math plugin, while keeping ordinary currency and shell-variable dollars as literal text.

## Related Issues

Fixes #1301

## Changes

- keep Streamdown's official `remark-math` pipeline for display math and mdast conversion
- validate single-dollar candidates inside the same micromark parser, rolling non-formulas back to ordinary Markdown text
- preserve unescaped currency and shell variables such as `$5`, `$HOME`, and `$OPENAI_API_KEY` in settled and streaming messages
- recover later formulas after literal dollars without rewriting source or reparsing the document
- support standard multiline `$$` display fences in streaming and settled messages
- disable only generic KaTeX delimiter completion so dollar signs inside fenced code remain literal
- include the math plugin in Tailwind source discovery and contain wide formulas with horizontal scrolling
- preserve KaTeX inside unresolved workspace course-link labels without overriding their text/MathML accessible name
- add focused regressions for currency, shell syntax, mixed literal/formula messages, escapes, Markdown/GFM boundaries, parser padding, and long-message performance

Block math follows standard `remark-math` syntax: the opening and closing `$$` fences are on their own lines, as in the issue reproduction. Same-line `$$...$$` still renders as math using upstream inline semantics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run `pnpm install --frozen-lockfile` with Node 22.
2. Run `pnpm test`.
3. Open a Pro Workbench session whose assistant response contains `$x^2$`, `$$...$$`, ordinary prices, and shell variables.

### Verified locally on the final tree

- Focused renderer/lifecycle coverage: 96/96 tests passed.
- Full suite: 653 test files passed (9 skipped); 7,315 tests passed (26 skipped).
- Prettier, TypeScript, i18n alignment, package-version, frozen-lockfile, and diff checks pass.
- ESLint reports 0 errors and the existing 18 warnings.
- Production build completes; its three existing Turbopack warnings remain unchanged.
- Final independent adversarial review found no blocking issues; 10,000 randomized parser inputs completed without exceptions or invalid positions.
- A 52 KB price-heavy input parses in about 11 ms in the parser benchmark, with near-linear scaling.

### Visual evidence

| Before — raw LaTeX | After — rendered KaTeX |
| --- | --- |
| <img width="1028" height="343" alt="Pro Workbench before LaTeX rendering fix" src="https://github.com/user-attachments/assets/a33da10b-b84b-48be-be44-bdd177c52be1"> | <img width="1028" height="343" alt="Pro Workbench after LaTeX rendering fix" src="https://github.com/user-attachments/assets/4f34ea95-60fe-4850-98cd-357717289f85"> |

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots attached

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review
- [x] I have added or updated documentation where needed
- [x] My changes do not introduce new warnings