### PR TITLE
fix(settings): turn TTS and media generation on from the Settings page

### DIFF
--- a/components/settings/image-settings.tsx
+++ b/components/settings/image-settings.tsx
@@ -102,11 +102,17 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
   const requiresApiKey = currentProvider?.requiresApiKey ?? true;
 
   const handleApiKeyChange = (apiKey: string) => {
-    setImageProviderConfig(selectedProviderId, { apiKey });
+    setImageProviderConfig(selectedProviderId, {
+      apiKey,
+      ...(apiKey.trim() ? { enabled: true } : {}),
+    });
   };
 
   const handleBaseUrlChange = (baseUrl: string) => {
-    setImageProviderConfig(selectedProviderId, { baseUrl });
+    setImageProviderConfig(selectedProviderId, {
+      baseUrl,
+      ...(baseUrl.trim() ? { enabled: true } : {}),
+    });
   };
 
   const handleTest = async () => {
@@ -188,7 +194,11 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
             {t('settings.imageGenerationDisabledHint')}
           </p>
         </div>
-        <Switch checked={imageGenerationEnabled} onCheckedChange={setImageGenerationEnabled} />
+        <Switch
+          checked={imageGenerationEnabled}
+          onCheckedChange={setImageGenerationEnabled}
+          aria-label={t('settings.enableImageGeneration')}
+        />
       </div>
 
       {/* Server-configured notice */}

--- a/components/settings/image-settings.tsx
+++ b/components/settings/image-settings.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect } from 'react';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useSettingsStore } from '@/lib/store/settings';
@@ -37,6 +38,8 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
 
   const imageModelId = useSettingsStore((state) => state.imageModelId);
   const imageProvidersConfig = useSettingsStore((state) => state.imageProvidersConfig);
+  const imageGenerationEnabled = useSettingsStore((state) => state.imageGenerationEnabled);
+  const setImageGenerationEnabled = useSettingsStore((state) => state.setImageGenerationEnabled);
   const _setImageModelId = useSettingsStore((state) => state.setImageModelId);
   const setImageProvider = useSettingsStore((state) => state.setImageProvider);
   const setImageProviderConfig = useSettingsStore((state) => state.setImageProviderConfig);
@@ -178,6 +181,16 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
 
   return (
     <div className="space-y-6 max-w-3xl">
+      <div className="flex items-center justify-between rounded-lg border border-border/60 bg-background px-3 py-2.5">
+        <div className="min-w-0 pr-3">
+          <p className="text-sm font-medium">{t('settings.enableImageGeneration')}</p>
+          <p className="text-[11px] text-muted-foreground">
+            {t('settings.imageGenerationDisabledHint')}
+          </p>
+        </div>
+        <Switch checked={imageGenerationEnabled} onCheckedChange={setImageGenerationEnabled} />
+      </div>
+
       {/* Server-configured notice */}
       {isServerConfigured && (
         <div className="rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30 p-3 text-sm text-blue-700 dark:text-blue-300">

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -91,6 +91,8 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
   const ttsVoice = useSettingsStore((state) => state.ttsVoice);
   const ttsSpeed = useSettingsStore((state) => state.ttsSpeed);
   const setTTSSpeed = useSettingsStore((state) => state.setTTSSpeed);
+  const ttsEnabled = useSettingsStore((state) => state.ttsEnabled);
+  const setTTSEnabled = useSettingsStore((state) => state.setTTSEnabled);
   const ttsProvidersConfig = useSettingsStore((state) => state.ttsProvidersConfig);
   const setTTSProviderConfig = useSettingsStore((state) => state.setTTSProviderConfig);
   const activeProviderId = useSettingsStore((state) => state.ttsProviderId);
@@ -248,6 +250,14 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
 
   return (
     <div className={cn('space-y-6', isVoxCPM ? 'max-w-5xl' : 'max-w-3xl')}>
+      <div className="flex items-center justify-between rounded-lg border border-border/60 bg-background px-3 py-2.5">
+        <div className="min-w-0 pr-3">
+          <p className="text-sm font-medium">{t('settings.enableTTS')}</p>
+          <p className="text-[11px] text-muted-foreground">{t('settings.ttsEnabledDescription')}</p>
+        </div>
+        <Switch checked={ttsEnabled} onCheckedChange={setTTSEnabled} />
+      </div>
+
       {/* Browser-native TTS can't produce managed audio files, so the Pro-mode
           timeline's per-line audio (preview / regenerate / bulk voiceover) is
           unavailable on it — surface that when this provider is selected. */}

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -255,7 +255,11 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
           <p className="text-sm font-medium">{t('settings.enableTTS')}</p>
           <p className="text-[11px] text-muted-foreground">{t('settings.ttsEnabledDescription')}</p>
         </div>
-        <Switch checked={ttsEnabled} onCheckedChange={setTTSEnabled} />
+        <Switch
+          checked={ttsEnabled}
+          onCheckedChange={setTTSEnabled}
+          aria-label={t('settings.enableTTS')}
+        />
       </div>
 
       {/* Browser-native TTS can't produce managed audio files, so the Pro-mode

--- a/components/settings/video-settings.tsx
+++ b/components/settings/video-settings.tsx
@@ -64,11 +64,17 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
   const isServerConfigured = !!currentConfig?.isServerConfigured;
 
   const handleApiKeyChange = (apiKey: string) => {
-    setVideoProviderConfig(selectedProviderId, { apiKey });
+    setVideoProviderConfig(selectedProviderId, {
+      apiKey,
+      ...(apiKey.trim() ? { enabled: true } : {}),
+    });
   };
 
   const handleBaseUrlChange = (baseUrl: string) => {
-    setVideoProviderConfig(selectedProviderId, { baseUrl });
+    setVideoProviderConfig(selectedProviderId, {
+      baseUrl,
+      ...(baseUrl.trim() ? { enabled: true } : {}),
+    });
   };
 
   const handleTest = async () => {
@@ -150,7 +156,11 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
             {t('settings.videoGenerationDisabledHint')}
           </p>
         </div>
-        <Switch checked={videoGenerationEnabled} onCheckedChange={setVideoGenerationEnabled} />
+        <Switch
+          checked={videoGenerationEnabled}
+          onCheckedChange={setVideoGenerationEnabled}
+          aria-label={t('settings.enableVideoGeneration')}
+        />
       </div>
 
       {/* Server-configured notice */}

--- a/components/settings/video-settings.tsx
+++ b/components/settings/video-settings.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { useI18n } from '@/lib/hooks/use-i18n';
 import { useSettingsStore } from '@/lib/store/settings';
@@ -31,6 +32,8 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
 
   const videoModelId = useSettingsStore((state) => state.videoModelId);
   const videoProvidersConfig = useSettingsStore((state) => state.videoProvidersConfig);
+  const videoGenerationEnabled = useSettingsStore((state) => state.videoGenerationEnabled);
+  const setVideoGenerationEnabled = useSettingsStore((state) => state.setVideoGenerationEnabled);
   const setVideoProviderConfig = useSettingsStore((state) => state.setVideoProviderConfig);
 
   const [showApiKey, setShowApiKey] = useState(false);
@@ -140,6 +143,16 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
 
   return (
     <div className="space-y-6 max-w-3xl">
+      <div className="flex items-center justify-between rounded-lg border border-border/60 bg-background px-3 py-2.5">
+        <div className="min-w-0 pr-3">
+          <p className="text-sm font-medium">{t('settings.enableVideoGeneration')}</p>
+          <p className="text-[11px] text-muted-foreground">
+            {t('settings.videoGenerationDisabledHint')}
+          </p>
+        </div>
+        <Switch checked={videoGenerationEnabled} onCheckedChange={setVideoGenerationEnabled} />
+      </div>
+
       {/* Server-configured notice */}
       {isServerConfigured && (
         <div className="rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30 p-3 text-sm text-blue-700 dark:text-blue-300">

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -466,12 +466,25 @@ function resolveMediaModels<T extends { id: string; name: string }>(
     : [...builtInModels, ...customModels];
 }
 
+function hasMediaCredential(value: string | undefined): boolean {
+  return !!value && value.trim().length > 0;
+}
+
 function isUsableMediaProvider(
   provider: { requiresApiKey: boolean } | undefined,
-  config: { apiKey?: string; enabled?: boolean; isServerConfigured?: boolean } | undefined,
+  config:
+    | {
+        apiKey?: string;
+        baseUrl?: string;
+        enabled?: boolean;
+        isServerConfigured?: boolean;
+      }
+    | undefined,
 ): boolean {
   if (!provider || config?.enabled === false) return false;
-  return !provider.requiresApiKey || !!config?.apiKey || !!config?.isServerConfigured;
+  if (config?.isServerConfigured) return true;
+  if (provider.requiresApiKey) return hasMediaCredential(config?.apiKey);
+  return hasMediaCredential(config?.baseUrl);
 }
 
 function shouldTurnOn(currentlyEnabled: boolean, usable: boolean): boolean {
@@ -1194,17 +1207,16 @@ export const useSettingsStore = create<SettingsState>()(
               ...state.imageProvidersConfig,
               [providerId]: mergedProvider,
             };
-            const hadImageCredential = !!(
-              state.imageProvidersConfig[providerId]?.apiKey ||
-              state.imageProvidersConfig[providerId]?.isServerConfigured
+            // Same usable-transition as TTS: empty -> usable turns the global
+            // flag on. A force-disabled provider (enabled: false) stays unused,
+            // and keyless providers (comfyui-image, lemonade) become usable
+            // from a baseUrl, not an API key.
+            const wasUsable = isUsableMediaProvider(
+              IMAGE_PROVIDERS[providerId],
+              state.imageProvidersConfig[providerId],
             );
-            const hasImageCredential = !!(
-              mergedProvider.apiKey || mergedProvider.isServerConfigured
-            );
-            const turnOnImage = shouldTurnOn(
-              state.imageGenerationEnabled,
-              !hadImageCredential && hasImageCredential,
-            );
+            const nowUsable = isUsableMediaProvider(IMAGE_PROVIDERS[providerId], mergedProvider);
+            const turnOnImage = shouldTurnOn(state.imageGenerationEnabled, !wasUsable && nowUsable);
             const base = {
               imageProvidersConfig,
               ...(turnOnImage ? { imageGenerationEnabled: true } : {}),
@@ -1272,17 +1284,12 @@ export const useSettingsStore = create<SettingsState>()(
               ...state.videoProvidersConfig,
               [providerId]: mergedProvider,
             };
-            const hadVideoCredential = !!(
-              state.videoProvidersConfig[providerId]?.apiKey ||
-              state.videoProvidersConfig[providerId]?.isServerConfigured
+            const wasUsable = isUsableMediaProvider(
+              VIDEO_PROVIDERS[providerId],
+              state.videoProvidersConfig[providerId],
             );
-            const hasVideoCredential = !!(
-              mergedProvider.apiKey || mergedProvider.isServerConfigured
-            );
-            const turnOnVideo = shouldTurnOn(
-              state.videoGenerationEnabled,
-              !hadVideoCredential && hasVideoCredential,
-            );
+            const nowUsable = isUsableMediaProvider(VIDEO_PROVIDERS[providerId], mergedProvider);
+            const turnOnVideo = shouldTurnOn(state.videoGenerationEnabled, !wasUsable && nowUsable);
             const base = {
               videoProvidersConfig,
               ...(turnOnVideo ? { videoGenerationEnabled: true } : {}),

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -40,6 +40,7 @@ import {
   isLLMProviderConfigured,
 } from '@/lib/store/settings-validation';
 import { createKVPersistStorage, purgeLegacyPersistKey } from '@/lib/store/kv-persist';
+import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
 
 const log = createLogger('Settings');
 
@@ -471,6 +472,10 @@ function isUsableMediaProvider(
 ): boolean {
   if (!provider || config?.enabled === false) return false;
   return !provider.requiresApiKey || !!config?.apiKey || !!config?.isServerConfigured;
+}
+
+function shouldTurnOn(currentlyEnabled: boolean, usable: boolean): boolean {
+  return !currentlyEnabled && usable;
 }
 
 // Initialize default audio config
@@ -1104,12 +1109,13 @@ export const useSettingsStore = create<SettingsState>()(
 
         setTTSProviderConfig: (providerId, config) =>
           set((state) => {
+            const mergedProvider = {
+              ...state.ttsProvidersConfig[providerId],
+              ...config,
+            };
             const ttsProvidersConfig = {
               ...state.ttsProvidersConfig,
-              [providerId]: {
-                ...state.ttsProvidersConfig[providerId],
-                ...config,
-              },
+              [providerId]: mergedProvider,
             };
             // Disabling the active provider (e.g. removing a token plan) switches
             // the selection back to the always-available browser TTS so playback
@@ -1121,7 +1127,22 @@ export const useSettingsStore = create<SettingsState>()(
                 ttsVoice: 'default',
               };
             }
-            return { ttsProvidersConfig };
+            // Settings can configure a hosted provider after first-run auto-config
+            // has already run. The global flag has no control on that page, so
+            // becoming usable (empty -> key) must also turn narration on (#1288).
+            // Do not re-enable on later edits if the user turned the flag off.
+            const wasUsable = isTTSProviderEnabled(
+              providerId,
+              state.ttsProvidersConfig[providerId],
+            );
+            const nowUsable = isTTSProviderEnabled(providerId, mergedProvider);
+            const turnOnNarration =
+              providerId !== 'browser-native-tts' &&
+              shouldTurnOn(state.ttsEnabled, !wasUsable && nowUsable);
+            return {
+              ttsProvidersConfig,
+              ...(turnOnNarration ? { ttsEnabled: true } : {}),
+            };
           }),
 
         setASRProviderConfig: (providerId, config) =>
@@ -1173,7 +1194,21 @@ export const useSettingsStore = create<SettingsState>()(
               ...state.imageProvidersConfig,
               [providerId]: mergedProvider,
             };
-            const base = { imageProvidersConfig };
+            const hadImageCredential = !!(
+              state.imageProvidersConfig[providerId]?.apiKey ||
+              state.imageProvidersConfig[providerId]?.isServerConfigured
+            );
+            const hasImageCredential = !!(
+              mergedProvider.apiKey || mergedProvider.isServerConfigured
+            );
+            const turnOnImage = shouldTurnOn(
+              state.imageGenerationEnabled,
+              !hadImageCredential && hasImageCredential,
+            );
+            const base = {
+              imageProvidersConfig,
+              ...(turnOnImage ? { imageGenerationEnabled: true } : {}),
+            };
             if (state.imageProviderId === providerId) {
               // Disabling the active provider (e.g. removing a token plan) must
               // switch the selection away to the default, or generation paths
@@ -1237,7 +1272,21 @@ export const useSettingsStore = create<SettingsState>()(
               ...state.videoProvidersConfig,
               [providerId]: mergedProvider,
             };
-            const base = { videoProvidersConfig };
+            const hadVideoCredential = !!(
+              state.videoProvidersConfig[providerId]?.apiKey ||
+              state.videoProvidersConfig[providerId]?.isServerConfigured
+            );
+            const hasVideoCredential = !!(
+              mergedProvider.apiKey || mergedProvider.isServerConfigured
+            );
+            const turnOnVideo = shouldTurnOn(
+              state.videoGenerationEnabled,
+              !hadVideoCredential && hasVideoCredential,
+            );
+            const base = {
+              videoProvidersConfig,
+              ...(turnOnVideo ? { videoGenerationEnabled: true } : {}),
+            };
             if (state.videoProviderId === providerId) {
               // Symmetric with image: disabling the active provider switches the
               // selection back to the default so nothing keeps pointing at a

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -1829,3 +1829,82 @@ describe('TTS provider enablement (#665)', () => {
     expect(store.getState().ttsProvidersConfig['openai-tts'].serverDisabled).toBe(false);
   });
 });
+
+describe('settings media enable flags (#1288)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    storage.clear();
+    mockFetch.mockReset();
+  });
+
+  async function getStore() {
+    const { useSettingsStore } = await import('@/lib/store/settings');
+    await useSettingsStore.persist.rehydrate();
+    return useSettingsStore;
+  }
+
+  it('turns ttsEnabled on when a hosted TTS provider gets an API key', async () => {
+    const store = await getStore();
+    expect(store.getState().ttsEnabled).toBe(false);
+
+    store.getState().setTTSProviderConfig('openai-tts', { apiKey: 'sk-test' });
+
+    expect(store.getState().ttsEnabled).toBe(true);
+    expect(store.getState().ttsProvidersConfig['openai-tts'].apiKey).toBe('sk-test');
+  });
+
+  it('does not re-enable ttsEnabled when an already-usable provider is edited', async () => {
+    const store = await getStore();
+    store.getState().setTTSProviderConfig('openai-tts', { apiKey: 'sk-test' });
+    expect(store.getState().ttsEnabled).toBe(true);
+
+    store.getState().setTTSEnabled(false);
+    store.getState().setTTSProviderConfig('openai-tts', { apiKey: 'sk-other' });
+
+    expect(store.getState().ttsEnabled).toBe(false);
+  });
+
+  it('does not turn ttsEnabled on for an empty key or for browser-native TTS', async () => {
+    const store = await getStore();
+
+    store.getState().setTTSProviderConfig('openai-tts', { apiKey: '' });
+    expect(store.getState().ttsEnabled).toBe(false);
+
+    store.getState().setTTSProviderConfig('browser-native-tts', { enabled: true });
+    expect(store.getState().ttsEnabled).toBe(false);
+  });
+
+  it('turns imageGenerationEnabled on when an image provider gets an API key', async () => {
+    const store = await getStore();
+    expect(store.getState().imageGenerationEnabled).toBe(false);
+
+    store.getState().setImageProviderConfig('seedream', { apiKey: 'img-key' });
+
+    expect(store.getState().imageGenerationEnabled).toBe(true);
+  });
+
+  it('turns videoGenerationEnabled on when a video provider gets an API key', async () => {
+    const store = await getStore();
+    expect(store.getState().videoGenerationEnabled).toBe(false);
+
+    store.getState().setVideoProviderConfig('seedance', { apiKey: 'vid-key' });
+
+    expect(store.getState().videoGenerationEnabled).toBe(true);
+  });
+
+  it('leaves a user-disabled image flag off across later server syncs', async () => {
+    const store = await getStore();
+    mockServerResponse({});
+    await store.getState().fetchServerProviders();
+
+    store.setState({
+      imageProviderId: 'seedream',
+      imageGenerationEnabled: false,
+    });
+
+    mockServerResponse({ image: { seedream: {} } });
+    await store.getState().fetchServerProviders();
+
+    expect(store.getState().imageGenerationEnabled).toBe(false);
+  });
+});

--- a/tests/store/settings-server-sync.test.ts
+++ b/tests/store/settings-server-sync.test.ts
@@ -138,6 +138,16 @@ vi.mock('@/lib/media/image-providers', () => ({
       requiresApiKey: true,
       models: [{ id: 'qwen-image-max', name: 'Qwen Image Max' }],
     },
+    lemonade: {
+      id: 'lemonade',
+      requiresApiKey: false,
+      models: [{ id: 'Qwen-Image-GGUF', name: 'Qwen Image GGUF' }],
+    },
+    'comfyui-image': {
+      id: 'comfyui-image',
+      requiresApiKey: false,
+      models: [],
+    },
   },
 }));
 
@@ -1878,16 +1888,48 @@ describe('settings media enable flags (#1288)', () => {
     const store = await getStore();
     expect(store.getState().imageGenerationEnabled).toBe(false);
 
-    store.getState().setImageProviderConfig('seedream', { apiKey: 'img-key' });
+    store.getState().setImageProviderConfig('seedream', { apiKey: 'img-key', enabled: true });
 
     expect(store.getState().imageGenerationEnabled).toBe(true);
+  });
+
+  it('does not turn imageGenerationEnabled on when a disabled provider gets a key', async () => {
+    const store = await getStore();
+    store.getState().setImageProviderConfig('seedream', { enabled: false });
+
+    store.getState().setImageProviderConfig('seedream', { apiKey: 'img-key' });
+
+    expect(store.getState().imageGenerationEnabled).toBe(false);
+    expect(store.getState().imageProvidersConfig.seedream.apiKey).toBe('img-key');
+  });
+
+  it('turns imageGenerationEnabled on when a keyless provider gets a baseUrl', async () => {
+    const store = await getStore();
+    expect(store.getState().imageGenerationEnabled).toBe(false);
+
+    store.getState().setImageProviderConfig('lemonade', {
+      baseUrl: 'http://127.0.0.1:13305/v1',
+      enabled: true,
+    });
+
+    expect(store.getState().imageGenerationEnabled).toBe(true);
+  });
+
+  it('does not turn imageGenerationEnabled on for whitespace-only credentials', async () => {
+    const store = await getStore();
+
+    store.getState().setImageProviderConfig('seedream', { apiKey: '   ', enabled: true });
+    expect(store.getState().imageGenerationEnabled).toBe(false);
+
+    store.getState().setImageProviderConfig('lemonade', { baseUrl: '   ', enabled: true });
+    expect(store.getState().imageGenerationEnabled).toBe(false);
   });
 
   it('turns videoGenerationEnabled on when a video provider gets an API key', async () => {
     const store = await getStore();
     expect(store.getState().videoGenerationEnabled).toBe(false);
 
-    store.getState().setVideoProviderConfig('seedance', { apiKey: 'vid-key' });
+    store.getState().setVideoProviderConfig('seedance', { apiKey: 'vid-key', enabled: true });
 
     expect(store.getState().videoGenerationEnabled).toBe(true);
   });


### PR DESCRIPTION
## Summary

The global `ttsEnabled` / `imageGenerationEnabled` / `videoGenerationEnabled` flags only auto-set on the first provider sync. After that, Settings could store a working API key (Test TTS plays) while the flags stayed off, so course generation skipped narration and media.

This puts the existing enable switches on the Settings pages and turns each flag on when that provider first becomes usable (empty credential to a real key). Later edits do not force the flag back on if the user turned it off.

A provider configured server-side only after that first sync still does not auto-flip the flag. The Settings toggle is the recovery for that case.

## Related Issues

Closes #1288

## Changes

- Add Settings toggles for TTS, image generation, and video generation (existing i18n strings).
- When a hosted TTS / image / video provider first becomes usable, turn the matching global flag on. Image and video use `isUsableMediaProvider` (force-disabled providers stay off; keyless ones can come up from a baseUrl).
- Cover the store behavior in `tests/store/settings-server-sync.test.ts`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open the app once with no TTS/image/video server providers so first-run auto-config is consumed.
2. Settings, Speech Synthesis: paste a Qwen (or other hosted) TTS key and click Test TTS. Confirm it plays.
3. Generate a course and play it. Before this change, slides advance with no narration. After it, speech audio is generated.
4. Confirm Settings now has an Enable Text-to-Speech switch, and the same pattern for image and video.

### What you personally verified

- `pnpm exec vitest run tests/store/settings-server-sync.test.ts tests/store/settings-validation.test.ts` (128 passed), including: key paste turns the flag on, a force-disabled media provider gaining a key does not, a keyless provider with a baseUrl does, empty key and browser-native TTS do not, later key edits do not re-enable after the user turns the flag off, and a later server sync still does not force-enable a user-disabled image flag.
- I did not run the full app UI against a live TTS provider in this environment.

### Evidence

Store tests in `tests/store/settings-server-sync.test.ts` (`settings media enable flags (#1288)`).

## Checklist

- [x] I have tested these changes locally
- [x] I have linked related issues
- [ ] I have updated documentation (if needed)
- [x] I have added/updated tests (if applicable)
- [x] My code follows the project's style guidelines
- [x] I have considered the impact on existing features (playback, generation, export, i18n, etc.)
- [ ] I have provided screenshots or recordings (for UI changes)


