### PR TITLE
fix(agent): bound generate_scene retries per page

### DIFF
--- a/lib/agent/runtime/build-agent.ts
+++ b/lib/agent/runtime/build-agent.ts
@@ -4,8 +4,8 @@
  * Stands up a pi `Agent` with:
  * - injected StreamFn (-> OpenMAIC connector),
  * - request-scoped tools supplied by the route,
- * - a caller-supplied `beforeToolCall` allowlist gate,
- * - a `afterToolCall` quota hook (v0 stub: unlimited).
+ * - the shared allowlist gate plus an optional request-scoped pre-call policy,
+ * - the shared quota hook (v0 stub: unlimited) plus an optional post-call policy.
  */
 import {
   Agent,
@@ -14,6 +14,8 @@ import {
   type AgentMessage,
   type AgentOptions,
   type AgentTool,
+  type BeforeToolCallContext,
+  type BeforeToolCallResult,
   type StreamFn,
 } from '@earendil-works/pi-agent-core';
 import type { Api, Model } from '@earendil-works/pi-ai';
@@ -55,6 +57,11 @@ export interface BuildAgentOptions {
   transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
   /** Optional Pi message conversion, required when a context transform emits custom roles. */
   convertToLlm?: AgentOptions['convertToLlm'];
+  /** Optional request-scoped policy applied after the shared allowlist gate. */
+  beforeToolCall?: (
+    context: BeforeToolCallContext,
+    signal?: AbortSignal,
+  ) => Promise<BeforeToolCallResult | undefined> | BeforeToolCallResult | undefined;
   /** Optional request-scoped hook composed with the shared quota hook. */
   afterToolCall?: (
     context: AfterToolCallContext,
@@ -64,6 +71,7 @@ export interface BuildAgentOptions {
 
 export function buildAgent(opts: BuildAgentOptions): Agent {
   const quotaHook = makeQuotaHook({ remaining: () => Number.MAX_SAFE_INTEGER });
+  const allowlistGate = makeAllowlistGate(opts.allowedToolNames);
   const agent = new Agent({
     streamFn: opts.streamFn,
     transformContext: opts.transformContext,
@@ -79,7 +87,11 @@ export function buildAgent(opts: BuildAgentOptions): Agent {
       // conversation in context — without this the agent is stateless per turn.
       ...(opts.history && opts.history.length > 0 ? { messages: opts.history } : {}),
     },
-    beforeToolCall: makeAllowlistGate(opts.allowedToolNames),
+    beforeToolCall: async (context, signal) => {
+      const allowlistResult = await allowlistGate(context);
+      if (allowlistResult?.block) return allowlistResult;
+      return opts.beforeToolCall?.(context, signal);
+    },
     afterToolCall: async (context, signal) => {
       const markerIsError =
         typeof context.result === 'object' &&

--- a/lib/server/agent-runtime/generate-scene-retry-budget.ts
+++ b/lib/server/agent-runtime/generate-scene-retry-budget.ts
@@ -1,0 +1,111 @@
+import type {
+  AfterToolCallContext,
+  AfterToolCallResult,
+  BeforeToolCallContext,
+  BeforeToolCallResult,
+} from '@earendil-works/pi-agent-core';
+
+export const GENERATE_SCENE_MAX_CONSECUTIVE_FAILURES = 2;
+
+interface GenerateSceneTarget {
+  stageId: string;
+  order: number;
+}
+
+interface GenerateSceneRetryState {
+  target: GenerateSceneTarget;
+  failedAttempts: number;
+  maxFailedAttempts: number;
+  attemptsRemaining: number;
+  exhausted: boolean;
+}
+
+function generateSceneTarget(args: unknown): GenerateSceneTarget | null {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return null;
+  const { stageId, order } = args as { stageId?: unknown; order?: unknown };
+  if (typeof stageId !== 'string' || stageId.length === 0) return null;
+  if (!Number.isInteger(order) || (order as number) < 1) return null;
+  return { stageId, order: order as number };
+}
+
+function sameTarget(left: GenerateSceneTarget | null, right: GenerateSceneTarget): boolean {
+  return left?.stageId === right.stageId && left.order === right.order;
+}
+
+function retryGuidance(state: GenerateSceneRetryState): string {
+  const target = `stageId=${JSON.stringify(state.target.stageId)}, order=${state.target.order}`;
+  if (!state.exhausted) {
+    return `Recovery policy: one retry remains for generate_scene target ${target}.`;
+  }
+  return `Recovery policy: retry budget exhausted for generate_scene target ${target}. Do not call generate_scene for this target again in this run. Leave completed pages intact, continue with later pages when possible, and include this target in the final rework list.`;
+}
+
+function withRetryState(details: unknown, state: GenerateSceneRetryState): Record<string, unknown> {
+  const existing =
+    details && typeof details === 'object' && !Array.isArray(details)
+      ? (details as Record<string, unknown>)
+      : details === undefined
+        ? {}
+        : { originalDetails: details };
+  return { ...existing, generateSceneRetry: state };
+}
+
+/**
+ * Bound consecutive `generate_scene` failures for one semantic page target.
+ *
+ * The first attempt and one retry may execute. A second failure tells the
+ * model to move on, and any further consecutive call for the same stage/order
+ * is blocked before it can reach a generation provider. A successful call or
+ * a call for another page starts a fresh budget.
+ */
+export function createGenerateSceneRetryBudget(): {
+  beforeToolCall(context: BeforeToolCallContext): BeforeToolCallResult | undefined;
+  afterToolCall(context: AfterToolCallContext): AfterToolCallResult | undefined;
+} {
+  let activeTarget: GenerateSceneTarget | null = null;
+  let failedAttempts = 0;
+
+  const selectTarget = (target: GenerateSceneTarget): void => {
+    if (sameTarget(activeTarget, target)) return;
+    activeTarget = target;
+    failedAttempts = 0;
+  };
+
+  const stateFor = (target: GenerateSceneTarget): GenerateSceneRetryState => ({
+    target,
+    failedAttempts,
+    maxFailedAttempts: GENERATE_SCENE_MAX_CONSECUTIVE_FAILURES,
+    attemptsRemaining: Math.max(0, GENERATE_SCENE_MAX_CONSECUTIVE_FAILURES - failedAttempts),
+    exhausted: failedAttempts >= GENERATE_SCENE_MAX_CONSECUTIVE_FAILURES,
+  });
+
+  return {
+    beforeToolCall(context) {
+      if (context.toolCall.name !== 'generate_scene') return undefined;
+      const target = generateSceneTarget(context.args);
+      if (!target) return undefined;
+      selectTarget(target);
+      const state = stateFor(target);
+      return state.exhausted ? { block: true, reason: retryGuidance(state) } : undefined;
+    },
+    afterToolCall(context) {
+      if (context.toolCall.name !== 'generate_scene') return undefined;
+      const target = generateSceneTarget(context.args);
+      if (!target) return undefined;
+      selectTarget(target);
+      if (!context.isError) {
+        activeTarget = null;
+        failedAttempts = 0;
+        return undefined;
+      }
+
+      failedAttempts += 1;
+      const state = stateFor(target);
+      return {
+        content: [...context.result.content, { type: 'text', text: retryGuidance(state) }],
+        details: withRetryState(context.result.details, state),
+        isError: true,
+      };
+    },
+  };
+}

--- a/lib/server/agent-runtime/runner.ts
+++ b/lib/server/agent-runtime/runner.ts
@@ -95,6 +95,7 @@ import {
   createPersonalHistorySource,
   PERSONAL_HISTORY_TOOL_NAMES,
 } from './personal-history-tools';
+import { createGenerateSceneRetryBudget } from './generate-scene-retry-budget';
 
 const log = createLogger('AgentRunner');
 const WORKER_ID = `${randomUUID().slice(0, 8)}:${process.pid}`;
@@ -1457,6 +1458,7 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
       personalHistoryTools,
     );
     const askUserLatch = createAskUserTerminateLatch();
+    const generateSceneRetryBudget = createGenerateSceneRetryBudget();
     let toolCalls = 0;
     const agent = buildAgent({
       streamFn,
@@ -1490,12 +1492,14 @@ export async function runSession(ctx: RunContext, meta: ClaimedAgentSession): Pr
         ...(voiceRegistrationEnabled ? VOICE_CLONE_TOOL_NAMES : ['clip_audio']),
       ]),
       ...(plan.kind === 'start' ? {} : { history: modelMessages }),
+      beforeToolCall: (toolContext) => generateSceneRetryBudget.beforeToolCall(toolContext),
       afterToolCall: (toolContext) => {
         toolCalls += 1;
+        const retryResult = generateSceneRetryBudget.afterToolCall(toolContext);
         if (askUserLatch.shouldTerminate(toolContext.toolCall.name, toolContext.isError)) {
-          return { terminate: true };
+          return { ...retryResult, terminate: true };
         }
-        return undefined;
+        return retryResult;
       },
     });
 

--- a/tests/agent-runtime/generate-scene-retry-budget.test.ts
+++ b/tests/agent-runtime/generate-scene-retry-budget.test.ts
@@ -1,0 +1,125 @@
+import type { AfterToolCallContext, BeforeToolCallContext } from '@earendil-works/pi-agent-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createGenerateSceneRetryBudget,
+  GENERATE_SCENE_MAX_CONSECUTIVE_FAILURES,
+} from '@/lib/server/agent-runtime/generate-scene-retry-budget';
+
+type RetryBudget = ReturnType<typeof createGenerateSceneRetryBudget>;
+
+const TARGET_A = { stageId: 'stage-a', order: 3 };
+const TARGET_B = { stageId: 'stage-a', order: 4 };
+
+function before(budget: RetryBudget, toolName: string, args: unknown) {
+  return budget.beforeToolCall({ toolCall: { name: toolName }, args } as BeforeToolCallContext);
+}
+
+function after(
+  budget: RetryBudget,
+  toolName: string,
+  args: unknown,
+  isError: boolean,
+  details: unknown = { source: 'generation' },
+) {
+  return budget.afterToolCall({
+    toolCall: { name: toolName },
+    args,
+    isError,
+    result: {
+      content: [{ type: 'text', text: isError ? 'generation failed' : 'generated' }],
+      details,
+    },
+  } as AfterToolCallContext);
+}
+
+describe('generate_scene retry budget', () => {
+  it('allows one real retry, then blocks the same page before a third execution', () => {
+    const budget = createGenerateSceneRetryBudget();
+
+    expect(before(budget, 'generate_scene', TARGET_A)).toBeUndefined();
+    const firstFailure = after(budget, 'generate_scene', TARGET_A, true, {
+      providerError: 'empty response',
+    });
+    expect(firstFailure).toMatchObject({
+      isError: true,
+      details: {
+        providerError: 'empty response',
+        generateSceneRetry: {
+          target: TARGET_A,
+          failedAttempts: 1,
+          maxFailedAttempts: GENERATE_SCENE_MAX_CONSECUTIVE_FAILURES,
+          attemptsRemaining: 1,
+          exhausted: false,
+        },
+      },
+    });
+    expect(JSON.stringify(firstFailure?.content)).toContain('one retry remains');
+
+    expect(before(budget, 'generate_scene', TARGET_A)).toBeUndefined();
+    const secondFailure = after(budget, 'generate_scene', TARGET_A, true);
+    expect(secondFailure).toMatchObject({
+      isError: true,
+      details: {
+        generateSceneRetry: {
+          failedAttempts: 2,
+          attemptsRemaining: 0,
+          exhausted: true,
+        },
+      },
+    });
+    expect(JSON.stringify(secondFailure?.content)).toContain('retry budget exhausted');
+    expect(JSON.stringify(secondFailure?.content)).toContain('final rework list');
+
+    const blocked = before(budget, 'generate_scene', TARGET_A);
+    expect(blocked).toMatchObject({ block: true });
+    expect(blocked?.reason).toContain('retry budget exhausted');
+    expect(blocked?.reason).toContain('order=3');
+  });
+
+  it('does not consume or reset a page budget for unrelated tool calls', () => {
+    const budget = createGenerateSceneRetryBudget();
+
+    before(budget, 'generate_scene', TARGET_A);
+    after(budget, 'generate_scene', TARGET_A, true);
+    expect(before(budget, 'list_scenes', { stageId: TARGET_A.stageId })).toBeUndefined();
+    expect(after(budget, 'list_scenes', { stageId: TARGET_A.stageId }, false)).toBeUndefined();
+    expect(before(budget, 'generate_scene', TARGET_A)).toBeUndefined();
+    after(budget, 'generate_scene', TARGET_A, true);
+    expect(before(budget, 'read_stage', TARGET_A)).toBeUndefined();
+    expect(before(budget, 'generate_scene', TARGET_A)).toMatchObject({ block: true });
+  });
+
+  it('starts a fresh budget after a successful generation', () => {
+    const budget = createGenerateSceneRetryBudget();
+
+    before(budget, 'generate_scene', TARGET_A);
+    after(budget, 'generate_scene', TARGET_A, true);
+    before(budget, 'generate_scene', TARGET_A);
+    expect(after(budget, 'generate_scene', TARGET_A, false)).toBeUndefined();
+
+    expect(before(budget, 'generate_scene', TARGET_A)).toBeUndefined();
+    const nextFailure = after(budget, 'generate_scene', TARGET_A, true);
+    expect(nextFailure?.details).toMatchObject({
+      generateSceneRetry: { failedAttempts: 1, attemptsRemaining: 1, exhausted: false },
+    });
+  });
+
+  it('starts a fresh budget when generation moves to another page target', () => {
+    const budget = createGenerateSceneRetryBudget();
+
+    before(budget, 'generate_scene', TARGET_A);
+    after(budget, 'generate_scene', TARGET_A, true);
+    before(budget, 'generate_scene', TARGET_A);
+    after(budget, 'generate_scene', TARGET_A, true);
+    expect(before(budget, 'generate_scene', TARGET_A)).toMatchObject({ block: true });
+
+    expect(before(budget, 'generate_scene', TARGET_B)).toBeUndefined();
+    const firstFailureForB = after(budget, 'generate_scene', TARGET_B, true);
+    expect(firstFailureForB?.details).toMatchObject({
+      generateSceneRetry: { target: TARGET_B, failedAttempts: 1, attemptsRemaining: 1 },
+    });
+
+    expect(before(budget, 'generate_scene', TARGET_A)).toBeUndefined();
+  });
+});

--- a/tests/agent-runtime/runner-tool-call-integrity.test.ts
+++ b/tests/agent-runtime/runner-tool-call-integrity.test.ts
@@ -14,10 +14,16 @@
  *   while leaving the durable tree untouched, and reports the repaired id on
  *   the session_resumed event.
  */
-import type { AgentEvent, AgentMessage } from '@earendil-works/pi-agent-core';
+import type {
+  AfterToolCallContext,
+  AgentEvent,
+  AgentMessage,
+  BeforeToolCallContext,
+} from '@earendil-works/pi-agent-core';
 import { InMemorySessionRepo, Session } from '@earendil-works/pi-agent-core';
 import type { ClaimedAgentSession } from '@openmaic/storage';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BuildAgentOptions } from '@/lib/agent/runtime/build-agent';
 
 const mocks = vi.hoisted(() => ({
   randomUUID: vi.fn(() => 'runner-test-uuid'),
@@ -392,5 +398,58 @@ describe('read-time repair of an orphaned durable tool call', () => {
     expect(after.messages.map((message) => message.role)).toEqual(['user', 'assistant']);
     expect(after.messages[0]).toBe(seedUser);
     expect(after.messages[1]).toBe(seedAssistant);
+  });
+});
+
+describe('generate_scene retry policy wiring', () => {
+  it('installs a request-scoped budget that blocks a third consecutive failure target', async () => {
+    const meta = makeMeta();
+    const session = await makeEntryTree();
+    const store = makeStore(meta);
+    mocks.openEntryStorage.mockResolvedValue(session.getStorage());
+    mocks.getAgentSessionStore.mockResolvedValue(store);
+
+    let options: BuildAgentOptions | undefined;
+    mocks.buildAgent.mockImplementation((agentOptions: BuildAgentOptions) => {
+      options = agentOptions;
+      return makeFakeAgent({});
+    });
+
+    await runSession({ running: new Map(), shuttingDown: false }, meta);
+
+    expect(options?.beforeToolCall).toBeTypeOf('function');
+    expect(options?.afterToolCall).toBeTypeOf('function');
+    const target = { stageId: 'stage-1', order: 2 };
+    const beforeContext = {
+      toolCall: { name: 'generate_scene' },
+      args: target,
+    } as BeforeToolCallContext;
+    const failedContext = {
+      toolCall: { name: 'generate_scene' },
+      args: target,
+      result: {
+        content: [{ type: 'text', text: 'generation failed' }],
+        details: { providerError: 'empty response' },
+      },
+      isError: true,
+    } as AfterToolCallContext;
+
+    expect(await options!.beforeToolCall!(beforeContext)).toBeUndefined();
+    expect(await options!.afterToolCall!(failedContext)).toMatchObject({
+      isError: true,
+      details: { generateSceneRetry: { failedAttempts: 1, exhausted: false } },
+    });
+    expect(await options!.beforeToolCall!(beforeContext)).toBeUndefined();
+    expect(await options!.afterToolCall!(failedContext)).toMatchObject({
+      isError: true,
+      details: { generateSceneRetry: { failedAttempts: 2, exhausted: true } },
+    });
+    expect(await options!.beforeToolCall!(beforeContext)).toMatchObject({ block: true });
+    expect(
+      await options!.beforeToolCall!({
+        ...beforeContext,
+        args: { ...target, order: 3 },
+      }),
+    ).toBeUndefined();
   });
 });

--- a/tests/lib/agent/runtime/build-agent-runtime.test.ts
+++ b/tests/lib/agent/runtime/build-agent-runtime.test.ts
@@ -69,6 +69,7 @@ const DemoParams = Type.Object({ value: Type.Number() });
 
 function makeAgent(options: {
   tool?: AgentTool<typeof DemoParams>;
+  beforeToolCall?: Parameters<typeof buildAgent>[0]['beforeToolCall'];
   afterToolCall?: Parameters<typeof buildAgent>[0]['afterToolCall'];
   allowedToolNames?: ReadonlySet<string>;
 }) {
@@ -77,6 +78,7 @@ function makeAgent(options: {
     systemPrompt: 'system',
     tools: [options.tool ?? makeTool()],
     allowedToolNames: options.allowedToolNames ?? new Set(['demo']),
+    beforeToolCall: options.beforeToolCall,
     afterToolCall: options.afterToolCall,
   });
 }
@@ -112,6 +114,54 @@ describe('buildAgent shared transport lifecycle', () => {
     expect(execute).toHaveBeenCalledTimes(1);
     expect(mocks.streamLLM).toHaveBeenCalledTimes(2);
     expect(toolOutputType(1)).toBe('text');
+  });
+
+  it('lets a request-scoped pre-call policy block an allowed tool before execution', async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'must not run' }],
+      details: {},
+    }));
+    const beforeToolCall = vi.fn(() => ({ block: true, reason: 'request budget exhausted' }));
+    const afterToolCall = vi.fn();
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'acknowledged' }, finish('stop')],
+    ]);
+    const agent = makeAgent({
+      tool: makeTool(execute),
+      beforeToolCall,
+      afterToolCall,
+    });
+
+    await agent.prompt('start');
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+    expect(afterToolCall).not.toHaveBeenCalled();
+    expect(toolOutputType(1)).toBe('error-text');
+  });
+
+  it('keeps the shared allowlist authoritative over request-scoped pre-call policies', async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'must not run' }],
+      details: {},
+    }));
+    const beforeToolCall = vi.fn();
+    useResponses([
+      [toolCall(), finish('tool-calls')],
+      [{ type: 'text-delta', text: 'acknowledged' }, finish('stop')],
+    ]);
+    const agent = makeAgent({
+      tool: makeTool(execute),
+      beforeToolCall,
+      allowedToolNames: new Set(),
+    });
+
+    await agent.prompt('start');
+
+    expect(beforeToolCall).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    expect(toolOutputType(1)).toBe('error-text');
   });
 
   it('makes length plus parsed toolCall terminal and side-effect-free', async () => {


### PR DESCRIPTION
## Summary

Bound repeated `generate_scene` failures for the same page within one server-workbench run. The initial generation and one retry may execute; further consecutive calls for the same `stageId + order` are rejected before reaching the generation provider.

## Related Issues

Fixes #1308.

## Changes

- add a request-scoped retry budget keyed by the semantic page target (`stageId + order`)
- preserve the original failure content/details while adding structured retry state and clear recovery guidance
- block calls after the second consecutive failure, before another generation request can run
- reset the budget after a successful generation or when generation moves to another page
- keep unrelated tool calls outside the budget and keep the shared tool allowlist authoritative
- add focused policy, Agent-hook, and runner-wiring regression coverage

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run the focused retry-policy, Agent-hook, and runner-wiring tests.
2. Run the complete agent-runtime test directories under Node 22.
3. Run the complete repository test suite under Node 22.
4. Run formatting, lint, and TypeScript checks.

### What you personally verified

- the first failed page generation leaves exactly one real retry available
- a second consecutive failure returns exhausted-state guidance and a third call is blocked before tool execution
- a successful generation resets the budget
- moving to a different page target resets the budget
- unrelated tools neither consume nor reset the active page budget
- existing error details are preserved when retry metadata is added
- the shared allowlist still runs before the new request-scoped pre-call hook
- Node 22 full suite: 652 test files passed, 9 skipped; 7,170 tests passed, 81 skipped
- Node 22 agent-runtime suites: 85 test files passed, 4 skipped; 1,044 tests passed, 11 skipped
- local lint completed with 0 errors; 18 unrelated baseline warnings remain

### Evidence

- Before: every new tool-call ID for the same failing page could reach generation again.
- After: only the initial attempt and one retry can execute consecutively for a page; later same-target calls return a deterministic blocked result while later page targets remain available.
- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually verified locally with focused and complete automated suites
- [ ] Screenshots / recordings attached (no UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
