### PR TITLE
fix(interactive): contain scrolling and regenerate code

### DIFF
--- a/components/scene-renderers/InteractiveIframeHost.tsx
+++ b/components/scene-renderers/InteractiveIframeHost.tsx
@@ -17,6 +17,10 @@ import { intersectClientBoxes } from '@/lib/edit/visible-client-rect';
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useElementRefsStore } from '@/lib/store/element-refs';
 import { useI18n } from '@/lib/hooks/use-i18n';
+import { RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { regenerateCodeSceneContent } from '@/lib/interactive/regenerate-code-scene';
+import { useStageStore } from '@/lib/store/stage';
 import {
   ELEMENT_REF_SELECTOR_MAX,
   ELEMENT_SNAPSHOT_MAX,
@@ -155,11 +159,13 @@ interface PooledIframeProps {
  */
 function PooledIframe({ sceneId, entry, visible }: PooledIframeProps) {
   const { t } = useI18n();
+  const [regeneratingCode, setRegeneratingCode] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const registerIframe = useWidgetIframeStore((s) => s.registerIframe);
   const getSendMessage = useWidgetIframeStore((s) => s.getSendMessage);
   const pickTarget = useCanvasStore.use.pickTarget();
   const refs = useElementRefsStore.use.refs();
+  const canRegenerate = useStageStore((s) => s.isOwner && !s.readOnly);
   const armed = pickTarget?.purpose === 'element-ref' && pickTarget.sceneId === sceneId;
   const selectors = useMemo(
     () =>
@@ -270,6 +276,29 @@ function PooledIframe({ sceneId, entry, visible }: PooledIframeProps) {
     transformOrigin: 'top left',
   };
 
+  const handleRegenerateCode = async () => {
+    if (regeneratingCode) return;
+    setRegeneratingCode(true);
+    try {
+      const result = await regenerateCodeSceneContent(sceneId);
+      if (result.ok) {
+        toast.success(t('interactiveRuntime.regenerateCodeSuccess'));
+        return;
+      }
+      if (result.reason !== 'stale') {
+        toast.error(
+          result.reason === 'locked'
+            ? t('interactiveRuntime.regenerateCodeLocked')
+            : t('interactiveRuntime.regenerateCodeFailed'),
+        );
+      }
+    } catch {
+      toast.error(t('interactiveRuntime.regenerateCodeFailed'));
+    } finally {
+      setRegeneratingCode(false);
+    }
+  };
+
   return (
     <div style={wrapStyle}>
       <iframe
@@ -280,6 +309,23 @@ function PooledIframe({ sceneId, entry, visible }: PooledIframeProps) {
         title={`Interactive Scene ${sceneId}`}
         sandbox="allow-scripts allow-forms allow-popups"
       />
+      {shown && canRegenerate && entry.widgetType === 'code' ? (
+        <button
+          type="button"
+          onClick={() => void handleRegenerateCode()}
+          disabled={regeneratingCode}
+          aria-label={t('interactiveRuntime.regenerateCode')}
+          title={t('interactiveRuntime.regenerateCode')}
+          className="absolute right-3 top-3 z-10 inline-flex h-9 items-center gap-2 rounded-md border border-border/80 bg-background/95 px-3 text-sm font-medium text-foreground shadow-md backdrop-blur transition-colors hover:bg-accent disabled:cursor-wait disabled:opacity-70"
+        >
+          <RefreshCw className={`h-4 w-4 ${regeneratingCode ? 'animate-spin' : ''}`} />
+          <span className="hidden sm:inline">
+            {regeneratingCode
+              ? t('interactiveRuntime.regeneratingCode')
+              : t('interactiveRuntime.regenerateCode')}
+          </span>
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/components/scene-renderers/interactive-renderer.tsx
+++ b/components/scene-renderers/interactive-renderer.tsx
@@ -43,11 +43,22 @@ export function InteractiveRenderer({ content, sceneId }: InteractiveRendererPro
     mount(sceneId, {
       srcDoc: patchedHtml,
       src: patchedHtml ? undefined : content.url,
+      widgetType: content.widgetType,
     });
     setActive(sceneId);
     claim(sceneId, owner);
     return () => release(sceneId, owner);
-  }, [sceneId, owner, patchedHtml, content.url, mount, setActive, claim, release]);
+  }, [
+    sceneId,
+    owner,
+    patchedHtml,
+    content.url,
+    content.widgetType,
+    mount,
+    setActive,
+    claim,
+    release,
+  ]);
 
   // Track this slot's screen rect for the host. rAF loop mirrors useTrackedRect:
   // one getBoundingClientRect read resolves canvas scale, viewport offset and

--- a/e2e/tests/interactive-code-regeneration.spec.ts
+++ b/e2e/tests/interactive-code-regeneration.spec.ts
@@ -100,24 +100,6 @@ for (const viewport of [
     page,
   }) => {
     test.setTimeout(180_000);
-    const consoleErrors: string[] = [];
-    const failedRequests: string[] = [];
-    const badResponses: string[] = [];
-    page.on('console', (message) => {
-      if (message.type() === 'error') consoleErrors.push(message.text());
-    });
-    page.on('requestfailed', (request) => {
-      const errorText = request.failure()?.errorText;
-      // Navigating from the IndexedDB seed page into the classroom can cancel
-      // still-streaming Next development chunks. Keep API/document failures
-      // strict while excluding that browser-controlled navigation cleanup.
-      if (errorText === 'net::ERR_ABORTED' && request.url().includes('/_next/static/')) return;
-      failedRequests.push(`${request.method()} ${request.url()}: ${errorText}`);
-    });
-    page.on('response', (response) => {
-      if (response.status() >= 400) badResponses.push(`${response.status()} ${response.url()}`);
-    });
-
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await seedCodeClassroom(page);
     // This fixture is deliberately local-only, so provide the viewer metadata
@@ -152,6 +134,19 @@ for (const viewport of [
     const classroom = new ClassroomPage(page);
     await classroom.goto(STAGE_ID);
     await classroom.waitForLoaded();
+
+    const consoleErrors: string[] = [];
+    const failedRequests: string[] = [];
+    const badResponses: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('requestfailed', (request) => {
+      failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText}`);
+    });
+    page.on('response', (response) => {
+      if (response.status() >= 400) badResponses.push(`${response.status()} ${response.url()}`);
+    });
 
     const frame = page.frameLocator(`iframe[title="${IFRAME_TITLE}"]`);
     await expect(frame.locator('#old-code')).toBeVisible();

--- a/e2e/tests/interactive-code-regeneration.spec.ts
+++ b/e2e/tests/interactive-code-regeneration.spec.ts
@@ -1,0 +1,213 @@
+import { expect, test } from '../fixtures/base';
+import { ClassroomPage } from '../pages/classroom.page';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+
+const STAGE_ID = 'e2e-code-regeneration';
+const SCENE_ID = 'scene-code';
+const OUTLINE_ID = 'outline-code';
+const IFRAME_TITLE = `Interactive Scene ${SCENE_ID}`;
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+const OLD_HTML = `<!doctype html><html><head><style>
+  html, body { min-height: 100vh; overflow-y: auto; }
+  #oversized-chart { height: 5000px; }
+</style></head><body><main id="old-code"><div id="oversized-chart">old Python code</div></main></body></html>`;
+
+const NEW_HTML =
+  '<!doctype html><html><head></head><body><main id="new-code">new Python code</main></body></html>';
+
+async function seedCodeClassroom(page: import('@playwright/test').Page) {
+  await page.addInitScript((settings) => {
+    localStorage.setItem('maic:account:settings-storage', settings);
+  }, SETTINGS_STORAGE);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+  await page.evaluate(
+    ({ stageId, sceneId, outlineId, html }) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('maic-documents', 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          db.createObjectStore('stages', { keyPath: 'id' });
+          const scenes = db.createObjectStore('scenes', { keyPath: ['stageId', 'id'] });
+          scenes.createIndex('by-stage', 'stageId');
+          db.createObjectStore('outlines', { keyPath: 'stageId' });
+        };
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction(['stages', 'scenes', 'outlines'], 'readwrite');
+          const now = Date.now();
+          const outline = {
+            id: outlineId,
+            type: 'interactive',
+            title: 'Normal MLE coding',
+            description: 'Implement the normal-distribution MLE.',
+            keyPoints: ['log likelihood', 'mean', 'variance'],
+            order: 0,
+            widgetType: 'code',
+            widgetOutline: { language: 'python' },
+          };
+
+          tx.objectStore('stages').put({
+            id: stageId,
+            name: 'Code regeneration test',
+            description: '',
+            languageDirective: 'Write learner-facing text in English.',
+            style: 'professional',
+            createdAt: now,
+            updatedAt: now,
+            dslVersion: '0.1.0',
+          });
+          tx.objectStore('scenes').put({
+            id: sceneId,
+            outlineId,
+            stageId,
+            type: 'interactive',
+            title: outline.title,
+            order: 0,
+            actions: [{ id: 'speech-1', type: 'speech', text: 'Keep this narration.' }],
+            content: { type: 'interactive', url: '', html, widgetType: 'code' },
+            createdAt: now,
+            updatedAt: now,
+          });
+          tx.objectStore('outlines').put({
+            stageId,
+            outline: {
+              outlines: [outline],
+              generationComplete: true,
+              createdAt: now,
+              updatedAt: now,
+            },
+          });
+
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+        request.onerror = () => reject(request.error);
+      }),
+    { stageId: STAGE_ID, sceneId: SCENE_ID, outlineId: OUTLINE_ID, html: OLD_HTML },
+  );
+}
+
+for (const viewport of [
+  { name: 'desktop', width: 1280, height: 900 },
+  { name: 'mobile', width: 390, height: 844 },
+] as const) {
+  test(`bounds generated root scrolling and regenerates the code widget on ${viewport.name}`, async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const consoleErrors: string[] = [];
+    const failedRequests: string[] = [];
+    const badResponses: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('requestfailed', (request) => {
+      const errorText = request.failure()?.errorText;
+      // Navigating from the IndexedDB seed page into the classroom can cancel
+      // still-streaming Next development chunks. Keep API/document failures
+      // strict while excluding that browser-controlled navigation cleanup.
+      if (errorText === 'net::ERR_ABORTED' && request.url().includes('/_next/static/')) return;
+      failedRequests.push(`${request.method()} ${request.url()}: ${errorText}`);
+    });
+    page.on('response', (response) => {
+      if (response.status() >= 400) badResponses.push(`${response.status()} ${response.url()}`);
+    });
+
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await seedCodeClassroom(page);
+    // This fixture is deliberately local-only, so provide the viewer metadata
+    // that a persisted server-backed classroom would return for its owner.
+    await page.route(`**/api/stage-meta/${STAGE_ID}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          isOwner: true,
+          isPublic: false,
+          publishedAt: null,
+          generationComplete: true,
+          source: 'e2e-fixture',
+        }),
+      });
+    });
+    await page.route('**/api/generate/scene-content', async (route) => {
+      const body = route.request().postDataJSON();
+      expect(body.outline.id).toBe(OUTLINE_ID);
+      expect(body.stageId).toBe(STAGE_ID);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          content: { html: NEW_HTML, widgetType: 'code' },
+        }),
+      });
+    });
+
+    const classroom = new ClassroomPage(page);
+    await classroom.goto(STAGE_ID);
+    await classroom.waitForLoaded();
+
+    const frame = page.frameLocator(`iframe[title="${IFRAME_TITLE}"]`);
+    await expect(frame.locator('#old-code')).toBeVisible();
+    const rootMetrics = await frame.locator('html').evaluate(() => ({
+      viewportHeight: window.innerHeight,
+      htmlClientHeight: document.documentElement.clientHeight,
+      bodyClientHeight: document.body.clientHeight,
+      bodyScrollHeight: document.body.scrollHeight,
+      htmlOverflowY: getComputedStyle(document.documentElement).overflowY,
+      bodyOverflowY: getComputedStyle(document.body).overflowY,
+    }));
+    expect(rootMetrics).toMatchObject({
+      viewportHeight: 720,
+      htmlClientHeight: 720,
+      bodyClientHeight: 720,
+      htmlOverflowY: 'hidden',
+      bodyOverflowY: 'auto',
+    });
+    expect(rootMetrics.bodyScrollHeight).toBeGreaterThan(720);
+
+    const regenerate = page.getByRole('button', { name: 'Regenerate code' });
+    await expect(regenerate).toBeVisible();
+    const buttonBox = await regenerate.boundingBox();
+    expect(buttonBox).not.toBeNull();
+    expect(buttonBox!.x).toBeGreaterThanOrEqual(0);
+    expect(buttonBox!.y).toBeGreaterThanOrEqual(0);
+    expect(buttonBox!.x + buttonBox!.width).toBeLessThanOrEqual(viewport.width + 1);
+    expect(buttonBox!.y + buttonBox!.height).toBeLessThanOrEqual(viewport.height + 1);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 2)).toBe(
+      true,
+    );
+    await page.screenshot({
+      path: `/tmp/openmaic-code-regeneration-${viewport.name}-before.png`,
+      fullPage: true,
+    });
+
+    await frame.locator('body').evaluate((body) => {
+      body.scrollTop = 900;
+    });
+    expect(await frame.locator('body').evaluate((body) => body.scrollTop)).toBe(900);
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    await frame.locator('body').evaluate((body) => {
+      body.scrollTop = 0;
+    });
+
+    await regenerate.click();
+    await expect(page.getByText('Code regenerated')).toBeVisible();
+    await expect(frame.locator('#new-code')).toBeVisible();
+    await expect(frame.locator('#old-code')).toHaveCount(0);
+    await page.screenshot({
+      path: `/tmp/openmaic-code-regeneration-${viewport.name}-after.png`,
+      fullPage: true,
+    });
+
+    expect(badResponses).toEqual([]);
+    expect(failedRequests).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+}

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -9,6 +9,13 @@
     "retry": "إعادة المحاولة",
     "close": "إغلاق"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "إعادة إنشاء الكود",
+    "regeneratingCode": "جارٍ إعادة إنشاء الكود…",
+    "regenerateCodeSuccess": "تمت إعادة إنشاء الكود",
+    "regenerateCodeFailed": "تعذرت إعادة إنشاء الكود",
+    "regenerateCodeLocked": "اخرج من وضع التحرير قبل إعادة إنشاء الكود"
+  },
   "home": {
     "slogan": "التعلّم التوليدي في فصل تفاعلي متعدد الوكلاء",
     "greetingWithName": "مرحبًا، {{name}}"

--- a/lib/i18n/locales/de-DE.json
+++ b/lib/i18n/locales/de-DE.json
@@ -9,6 +9,13 @@
     "retry": "Erneut versuchen",
     "close": "Schließen"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Code neu generieren",
+    "regeneratingCode": "Code wird neu generiert…",
+    "regenerateCodeSuccess": "Code wurde neu generiert",
+    "regenerateCodeFailed": "Code konnte nicht neu generiert werden",
+    "regenerateCodeLocked": "Beende den Bearbeitungsmodus, bevor du Code neu generierst"
+  },
   "home": {
     "slogan": "Generatives Lernen im interaktiven Lernraum mit mehreren KI-Agenten",
     "greetingWithName": "Hallo, {{name}}"

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -9,6 +9,13 @@
     "retry": "Retry",
     "close": "Close"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Regenerate code",
+    "regeneratingCode": "Regenerating code…",
+    "regenerateCodeSuccess": "Code regenerated",
+    "regenerateCodeFailed": "Could not regenerate code",
+    "regenerateCodeLocked": "Exit edit mode before regenerating code"
+  },
   "home": {
     "slogan": "Generative Learning in Multi-Agent Interactive Classroom",
     "greetingWithName": "Hi, {{name}}"

--- a/lib/i18n/locales/es-MX.json
+++ b/lib/i18n/locales/es-MX.json
@@ -9,6 +9,13 @@
     "retry": "Reintentar",
     "close": "Cerrar"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Regenerar código",
+    "regeneratingCode": "Regenerando código…",
+    "regenerateCodeSuccess": "Código regenerado",
+    "regenerateCodeFailed": "No se pudo regenerar el código",
+    "regenerateCodeLocked": "Sal del modo de edición antes de regenerar el código"
+  },
   "home": {
     "slogan": "Aprendizaje generativo en un aula interactiva multiagente",
     "greetingWithName": "Hola, {{name}}"

--- a/lib/i18n/locales/fr-FR.json
+++ b/lib/i18n/locales/fr-FR.json
@@ -9,6 +9,13 @@
     "retry": "Réessayer",
     "close": "Fermer"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Régénérer le code",
+    "regeneratingCode": "Régénération du code…",
+    "regenerateCodeSuccess": "Code régénéré",
+    "regenerateCodeFailed": "Impossible de régénérer le code",
+    "regenerateCodeLocked": "Quittez le mode édition avant de régénérer le code"
+  },
   "home": {
     "slogan": "L’apprentissage génératif en classe interactive multi-agents",
     "greetingWithName": "Bonjour, {{name}}"

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -9,6 +9,13 @@
     "retry": "再試行",
     "close": "閉じる"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "コードを再生成",
+    "regeneratingCode": "コードを再生成中…",
+    "regenerateCodeSuccess": "コードを再生成しました",
+    "regenerateCodeFailed": "コードを再生成できませんでした",
+    "regenerateCodeLocked": "コードを再生成する前に編集モードを終了してください"
+  },
   "home": {
     "slogan": "マルチエージェント対話型教室で生成的に学ぶ",
     "greetingWithName": "こんにちは、{{name}}さん"

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -9,6 +9,13 @@
     "retry": "다시 시도",
     "close": "닫기"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "코드 다시 생성",
+    "regeneratingCode": "코드 다시 생성 중…",
+    "regenerateCodeSuccess": "코드를 다시 생성했습니다",
+    "regenerateCodeFailed": "코드를 다시 생성하지 못했습니다",
+    "regenerateCodeLocked": "코드를 다시 생성하려면 편집 모드에서 나가세요"
+  },
   "home": {
     "slogan": "멀티 에이전트 인터랙티브 교실에서 펼치는 생성형 학습",
     "greetingWithName": "안녕하세요, {{name}}!"

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -9,6 +9,13 @@
     "retry": "Tentar novamente",
     "close": "Fechar"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Gerar código novamente",
+    "regeneratingCode": "Gerando código novamente…",
+    "regenerateCodeSuccess": "Código gerado novamente",
+    "regenerateCodeFailed": "Não foi possível gerar o código novamente",
+    "regenerateCodeLocked": "Saia do modo de edição antes de gerar o código novamente"
+  },
   "home": {
     "slogan": "Aprendizagem Generativa em Sala de Aula Interativa Multi-Agente",
     "greetingWithName": "Olá, {{name}}"

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -9,6 +9,13 @@
     "retry": "Повторить",
     "close": "Закрыть"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Перегенерировать код",
+    "regeneratingCode": "Код перегенерируется…",
+    "regenerateCodeSuccess": "Код перегенерирован",
+    "regenerateCodeFailed": "Не удалось перегенерировать код",
+    "regenerateCodeLocked": "Выйдите из режима редактирования перед перегенерацией кода"
+  },
   "home": {
     "slogan": "Generative Learning in Multi-Agent Interactive Classroom",
     "greetingWithName": "Привет, {{name}}"

--- a/lib/i18n/locales/vi-VN.json
+++ b/lib/i18n/locales/vi-VN.json
@@ -9,6 +9,13 @@
     "retry": "Thử lại",
     "close": "Đóng"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "Tạo lại mã",
+    "regeneratingCode": "Đang tạo lại mã…",
+    "regenerateCodeSuccess": "Đã tạo lại mã",
+    "regenerateCodeFailed": "Không thể tạo lại mã",
+    "regenerateCodeLocked": "Thoát chế độ chỉnh sửa trước khi tạo lại mã"
+  },
   "home": {
     "slogan": "Học tập sinh tạo trong lớp học tương tác đa tác nhân",
     "greetingWithName": "Chào {{name}}"

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -9,6 +9,13 @@
     "retry": "重试",
     "close": "关闭"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "重新生成代码",
+    "regeneratingCode": "正在重新生成代码…",
+    "regenerateCodeSuccess": "代码已重新生成",
+    "regenerateCodeFailed": "无法重新生成代码",
+    "regenerateCodeLocked": "请先退出编辑模式再重新生成代码"
+  },
   "home": {
     "slogan": "Generative Learning in Multi-Agent Interactive Classroom",
     "greetingWithName": "嗨，{{name}}"

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -9,6 +9,13 @@
     "retry": "重试",
     "close": "關閉"
   },
+  "interactiveRuntime": {
+    "regenerateCode": "重新產生程式碼",
+    "regeneratingCode": "正在重新產生程式碼…",
+    "regenerateCodeSuccess": "程式碼已重新產生",
+    "regenerateCodeFailed": "無法重新產生程式碼",
+    "regenerateCodeLocked": "請先離開編輯模式再重新產生程式碼"
+  },
   "home": {
     "slogan": "多智能體互動課室中的生成式學習",
     "greetingWithName": "嗨，{{name}}"

--- a/lib/interactive/regenerate-code-scene.ts
+++ b/lib/interactive/regenerate-code-scene.ts
@@ -81,7 +81,7 @@ function asGeneratedCodeContent(value: unknown): InteractiveContent | null {
  *
  * Narration/actions and the scene id stay untouched. The source outline is
  * resolved by stable outlineId first, with order retained only for legacy
- * classrooms. A stage switch or generation-epoch change drops the late result.
+ * classrooms. A stage switch, generation-epoch change, or scene edit drops the late result.
  */
 export async function regenerateCodeSceneContent(
   sceneId: string,
@@ -138,7 +138,7 @@ export async function regenerateCodeSceneContent(
   if (
     after.stage?.id !== stageId ||
     after.generationEpoch !== generationEpoch ||
-    !after.scenes.some((candidate) => candidate.id === sceneId)
+    after.scenes.find((candidate) => candidate.id === sceneId) !== scene
   ) {
     return { ok: false, reason: 'stale' };
   }

--- a/lib/interactive/regenerate-code-scene.ts
+++ b/lib/interactive/regenerate-code-scene.ts
@@ -1,0 +1,148 @@
+import type { AgentInfo } from '@openmaic/generation';
+import { fetchSceneContent } from '@/lib/hooks/use-scene-generator';
+import { isSceneEditLocked } from '@/lib/edit/regen-lock';
+import { useAgentRegistry } from '@/lib/orchestration/registry/store';
+import { useStageStore } from '@/lib/store/stage';
+import type { SceneOutline } from '@/lib/types/generation';
+import type { InteractiveContent, Scene, ScenePatch, Stage, StageMode } from '@/lib/types/stage';
+
+export type CodeSceneRegenerationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | 'not-code'
+        | 'forbidden'
+        | 'locked'
+        | 'missing-outline'
+        | 'generation-failed'
+        | 'stale';
+      message?: string;
+    };
+
+interface CodeSceneRegenerationState {
+  readonly stage: Stage | null;
+  readonly scenes: Scene[];
+  readonly outlines: SceneOutline[];
+  readonly generationEpoch: number;
+  readonly mode: StageMode;
+  readonly currentSceneId: string | null;
+  readonly isOwner: boolean;
+  readonly readOnly: boolean;
+  updateScene: (sceneId: string, updates: ScenePatch) => void;
+}
+
+export interface CodeSceneRegenerationDeps {
+  getState: () => CodeSceneRegenerationState;
+  fetchContent: typeof fetchSceneContent;
+  listAgents: () => AgentInfo[];
+}
+
+const defaultDeps: CodeSceneRegenerationDeps = {
+  getState: () => useStageStore.getState(),
+  fetchContent: fetchSceneContent,
+  listAgents: () => useAgentRegistry.getState().listAgents(),
+};
+
+function findSourceOutline(scene: Scene, outlines: SceneOutline[]): SceneOutline | undefined {
+  if (scene.outlineId) {
+    const exact = outlines.find((outline) => outline.id === scene.outlineId);
+    if (exact) return exact;
+  }
+  return outlines.find((outline) => outline.order === scene.order);
+}
+
+function asGeneratedCodeContent(value: unknown): InteractiveContent | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const generated = value as Record<string, unknown>;
+  if (typeof generated.html !== 'string' || generated.html.trim() === '') return null;
+  if (generated.widgetType !== undefined && generated.widgetType !== 'code') return null;
+
+  const widgetConfig = generated.widgetConfig;
+  const validWidgetConfig =
+    typeof widgetConfig === 'object' &&
+    widgetConfig !== null &&
+    !Array.isArray(widgetConfig) &&
+    (widgetConfig as Record<string, unknown>).type === 'code';
+
+  return {
+    type: 'interactive',
+    url: '',
+    html: generated.html,
+    widgetType: 'code',
+    ...(validWidgetConfig
+      ? { widgetConfig: widgetConfig as NonNullable<InteractiveContent['widgetConfig']> }
+      : {}),
+  };
+}
+
+/**
+ * Regenerate only a code widget's interactive content.
+ *
+ * Narration/actions and the scene id stay untouched. The source outline is
+ * resolved by stable outlineId first, with order retained only for legacy
+ * classrooms. A stage switch or generation-epoch change drops the late result.
+ */
+export async function regenerateCodeSceneContent(
+  sceneId: string,
+  deps: CodeSceneRegenerationDeps = defaultDeps,
+): Promise<CodeSceneRegenerationResult> {
+  const before = deps.getState();
+  const scene = before.scenes.find((candidate) => candidate.id === sceneId);
+  if (
+    !scene ||
+    scene.content.type !== 'interactive' ||
+    scene.content.widgetType !== 'code' ||
+    !before.stage
+  ) {
+    return { ok: false, reason: 'not-code' };
+  }
+  if (!before.isOwner || before.readOnly) return { ok: false, reason: 'forbidden' };
+  if (
+    isSceneEditLocked({
+      sceneId,
+      mode: before.mode,
+      currentSceneId: before.currentSceneId,
+    })
+  ) {
+    return { ok: false, reason: 'locked' };
+  }
+
+  const outline = findSourceOutline(scene, before.outlines);
+  if (!outline) return { ok: false, reason: 'missing-outline' };
+
+  const stageId = before.stage.id;
+  const generationEpoch = before.generationEpoch;
+  const result = await deps.fetchContent({
+    outline,
+    allOutlines: before.outlines,
+    stageId,
+    stageInfo: {
+      name: before.stage.name,
+      description: before.stage.description,
+      style: before.stage.style,
+    },
+    agents: deps.listAgents(),
+    languageDirective: before.stage.languageDirective,
+  });
+  const content = result.success ? asGeneratedCodeContent(result.content) : null;
+  if (!content) {
+    return {
+      ok: false,
+      reason: 'generation-failed',
+      message: result.error,
+    };
+  }
+
+  const after = deps.getState();
+  if (
+    after.stage?.id !== stageId ||
+    after.generationEpoch !== generationEpoch ||
+    !after.scenes.some((candidate) => candidate.id === sceneId)
+  ) {
+    return { ok: false, reason: 'stale' };
+  }
+
+  after.updateScene(sceneId, { content });
+  return { ok: true };
+}

--- a/lib/store/interactive-iframe-pool.ts
+++ b/lib/store/interactive-iframe-pool.ts
@@ -17,6 +17,7 @@
  */
 
 import { create } from 'zustand';
+import type { WidgetType } from '@openmaic/dsl';
 
 export const IFRAME_POOL_CAP = 3;
 
@@ -32,6 +33,8 @@ export interface IframePoolEntry {
   readonly srcDoc?: string;
   /** URL for `src`, when the scene points at an external page. */
   readonly src?: string;
+  /** Widget kind, used by host-owned recovery controls outside the sandbox. */
+  readonly widgetType?: WidgetType;
   /** Full available slot rect. The host contain-fits one fixed logical viewport inside it. */
   readonly rect: IframeRect | null;
   /** Visible intersection of the slot with overflow ancestors. The host clips to this. */
@@ -53,6 +56,7 @@ export interface IframePoolEntry {
 interface MountInput {
   readonly srcDoc?: string;
   readonly src?: string;
+  readonly widgetType?: WidgetType;
 }
 
 interface InteractiveIframePoolState {
@@ -108,7 +112,12 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
       // existing srcDoc/src reference so the host never re-sets it (which would
       // reload the iframe). String `===` is by value, so a remount that produces
       // an equal-but-new srcDoc string still hits this keep-alive fast path.
-      if (existing && existing.srcDoc === input.srcDoc && existing.src === input.src) {
+      if (
+        existing &&
+        existing.srcDoc === input.srcDoc &&
+        existing.src === input.src &&
+        existing.widgetType === input.widgetType
+      ) {
         const entries = { ...state.entries, [sceneId]: { ...existing, tick } };
         return { entries, tick };
       }
@@ -117,6 +126,7 @@ export const useInteractiveIframePool = create<InteractiveIframePoolState>((set)
       const entry: IframePoolEntry = {
         srcDoc: input.srcDoc,
         src: input.src,
+        widgetType: input.widgetType,
         rect: existing?.rect ?? null,
         clip: existing?.clip ?? null,
         owner: existing?.owner ?? null,

--- a/lib/utils/html-document.ts
+++ b/lib/utils/html-document.ts
@@ -40,3 +40,21 @@ export function injectIntoDocumentHead(html: string, injection: string): string 
 
   return `<head>${injection}</head>${html}`;
 }
+
+/** Inject markup at the end of the parsed head so it wins normal authored CSS. */
+export function injectBeforeDocumentHeadEnd(html: string, injection: string): string {
+  const document = parse(html, { sourceCodeLocationInfo: true });
+  const htmlElement = document.childNodes.find(
+    (node): node is DefaultTreeAdapterTypes.Element => isElement(node) && node.tagName === 'html',
+  );
+  const headElement = htmlElement?.childNodes.find(
+    (node): node is DefaultTreeAdapterTypes.Element => isElement(node) && node.tagName === 'head',
+  );
+  const explicitHeadEnd = headElement?.sourceCodeLocation?.endTag?.startOffset;
+  if (explicitHeadEnd !== undefined) return insertAt(html, explicitHeadEnd, injection);
+
+  // Documents without an explicit </head> need the parser-safe creation path.
+  // Keeping that fallback in one helper also preserves malformed/generated HTML
+  // instead of serializing and rewriting the whole document.
+  return injectIntoDocumentHead(html, injection);
+}

--- a/lib/utils/iframe.ts
+++ b/lib/utils/iframe.ts
@@ -1,4 +1,4 @@
-import { injectIntoDocumentHead } from './html-document';
+import { injectBeforeDocumentHeadEnd, injectIntoDocumentHead } from './html-document';
 
 /**
  * In-memory localStorage/sessionStorage shim, injected as the FIRST thing in the
@@ -287,21 +287,34 @@ const ELEMENT_PICKER_SHIM = `<script data-iframe-element-picker-shim>
  */
 export function patchHtmlForIframe(html: string): string {
   const iframeCss = `<style data-iframe-patch>
-  html, body {
+  html {
     width: 100%;
     height: 100%;
+    max-height: 100%;
     margin: 0;
     padding: 0;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden !important;
   }
-  /* Fix min-h-screen: in iframes 100vh is the iframe height, which is correct,
-     but ensure body actually fills it */
-  body { min-height: 100vh; }
+  body {
+    width: 100%;
+    height: 100%;
+    max-height: 100%;
+    min-height: 0 !important;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain;
+  }
 </style>`;
 
-  const injection =
-    '\n' + ERROR_CAPTURE_SHIM + '\n' + ELEMENT_PICKER_SHIM + '\n' + STORAGE_SHIM + '\n' + iframeCss;
+  // Runtime shims must execute before authored scripts. The viewport CSS has
+  // the opposite ordering requirement: place it after authored head styles so
+  // generated `html, body { overflow: auto }` rules cannot create two nested
+  // root scrollers whose measured height feeds back into responsive charts.
+  const shimInjection =
+    '\n' + ERROR_CAPTURE_SHIM + '\n' + ELEMENT_PICKER_SHIM + '\n' + STORAGE_SHIM;
+  const withShims = injectIntoDocumentHead(html, shimInjection);
 
-  return injectIntoDocumentHead(html, injection);
+  return injectBeforeDocumentHeadEnd(withShims, '\n' + iframeCss + '\n');
 }

--- a/tests/lib/interactive/regenerate-code-scene.test.ts
+++ b/tests/lib/interactive/regenerate-code-scene.test.ts
@@ -129,6 +129,31 @@ describe('regenerateCodeSceneContent', () => {
     expect(h.updateScene).not.toHaveBeenCalled();
   });
 
+  it('drops a late response after the same scene is edited', async () => {
+    const h = harness();
+    h.fetchContent.mockImplementation(async () => {
+      h.setState({
+        ...h.getState(),
+        scenes: [
+          {
+            ...codeScene,
+            content: { ...codeScene.content, html: '<html><body>user edit</body></html>' },
+          },
+        ],
+      });
+      return {
+        success: true,
+        content: { html: '<html><body>stale</body></html>', widgetType: 'code' },
+      };
+    });
+
+    await expect(regenerateCodeSceneContent(codeScene.id, h.deps)).resolves.toEqual({
+      ok: false,
+      reason: 'stale',
+    });
+    expect(h.updateScene).not.toHaveBeenCalled();
+  });
+
   it('refuses to overwrite the current scene while it is edit-locked', async () => {
     const h = harness();
     h.setState({ ...h.getState(), mode: 'edit' });

--- a/tests/lib/interactive/regenerate-code-scene.test.ts
+++ b/tests/lib/interactive/regenerate-code-scene.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  regenerateCodeSceneContent,
+  type CodeSceneRegenerationDeps,
+} from '@/lib/interactive/regenerate-code-scene';
+import type { SceneOutline } from '@/lib/types/generation';
+import type { Scene, ScenePatch, Stage, StageMode } from '@/lib/types/stage';
+
+const stage: Stage = {
+  id: 'stage-1',
+  name: 'MLE course',
+  description: 'Practice maximum-likelihood estimation',
+  languageDirective: 'Write learner-facing text in Korean.',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const outline: SceneOutline = {
+  id: 'outline-code',
+  type: 'interactive',
+  title: 'Normal MLE coding',
+  description: 'Implement the normal-distribution MLE.',
+  keyPoints: ['log likelihood', 'mean', 'variance'],
+  order: 3,
+  widgetType: 'code',
+  widgetOutline: { language: 'python' },
+};
+
+const codeScene: Scene = {
+  id: 'scene-code',
+  stageId: stage.id,
+  outlineId: outline.id,
+  type: 'interactive',
+  title: outline.title,
+  order: outline.order,
+  actions: [{ id: 'speech-1', type: 'speech', text: 'Keep this narration.' }],
+  content: {
+    type: 'interactive',
+    widgetType: 'code',
+    html: '<html><body>old code</body></html>',
+  },
+};
+
+function harness(overrides: Partial<CodeSceneRegenerationDeps> = {}) {
+  type HarnessState = {
+    stage: Stage | null;
+    scenes: Scene[];
+    outlines: SceneOutline[];
+    generationEpoch: number;
+    mode: StageMode;
+    currentSceneId: string | null;
+    isOwner: boolean;
+    readOnly: boolean;
+    updateScene: (sceneId: string, patch: ScenePatch) => void;
+  };
+  let state: HarnessState = {
+    stage,
+    scenes: [codeScene],
+    outlines: [outline],
+    generationEpoch: 4,
+    mode: 'playback',
+    currentSceneId: codeScene.id,
+    isOwner: true,
+    readOnly: false,
+    updateScene: vi.fn(),
+  };
+  const fetchContent = vi.fn().mockResolvedValue({
+    success: true,
+    content: {
+      html: '<html><body>new code</body></html>',
+      widgetType: 'code',
+    },
+  });
+  const deps = {
+    getState: () => state,
+    fetchContent,
+    listAgents: () => [],
+    ...overrides,
+  } as unknown as CodeSceneRegenerationDeps;
+  return {
+    deps,
+    fetchContent,
+    updateScene: state.updateScene,
+    setState: (next: typeof state) => {
+      state = next;
+    },
+    getState: () => state,
+  };
+}
+
+describe('regenerateCodeSceneContent', () => {
+  it('regenerates only interactive code content from the persisted outline', async () => {
+    const h = harness();
+
+    await expect(regenerateCodeSceneContent(codeScene.id, h.deps)).resolves.toEqual({ ok: true });
+
+    expect(h.fetchContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outline,
+        allOutlines: [outline],
+        stageId: stage.id,
+        languageDirective: stage.languageDirective,
+      }),
+    );
+    expect(h.updateScene).toHaveBeenCalledWith(codeScene.id, {
+      content: {
+        type: 'interactive',
+        url: '',
+        widgetType: 'code',
+        html: '<html><body>new code</body></html>',
+      },
+    });
+  });
+
+  it('drops a late response after the classroom generation epoch changes', async () => {
+    const h = harness();
+    h.fetchContent.mockImplementation(async () => {
+      h.setState({ ...h.getState(), generationEpoch: 5 });
+      return {
+        success: true,
+        content: { html: '<html><body>stale</body></html>', widgetType: 'code' },
+      };
+    });
+
+    await expect(regenerateCodeSceneContent(codeScene.id, h.deps)).resolves.toEqual({
+      ok: false,
+      reason: 'stale',
+    });
+    expect(h.updateScene).not.toHaveBeenCalled();
+  });
+
+  it('refuses to overwrite the current scene while it is edit-locked', async () => {
+    const h = harness();
+    h.setState({ ...h.getState(), mode: 'edit' });
+
+    await expect(regenerateCodeSceneContent(codeScene.id, h.deps)).resolves.toEqual({
+      ok: false,
+      reason: 'locked',
+    });
+    expect(h.fetchContent).not.toHaveBeenCalled();
+  });
+
+  it('refuses regeneration for a read-only classroom even when called outside the UI', async () => {
+    const h = harness();
+    h.setState({ ...h.getState(), readOnly: true });
+
+    await expect(regenerateCodeSceneContent(codeScene.id, h.deps)).resolves.toEqual({
+      ok: false,
+      reason: 'forbidden',
+    });
+    expect(h.fetchContent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/utils/iframe-viewport.browser.test.ts
+++ b/tests/lib/utils/iframe-viewport.browser.test.ts
@@ -1,0 +1,65 @@
+/** Chromium regression proof for the generated-document root scroll contract. */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser } from '@playwright/test';
+import { patchHtmlForIframe } from '@/lib/utils/iframe';
+
+const REQUIRED = process.env.INTERACTIVE_VIEWPORT_BROWSER === '1';
+
+describe.skipIf(!REQUIRED)('interactive iframe viewport in Chromium', () => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    browser = await chromium.launch({
+      headless: true,
+      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      args: ['--disable-crash-reporter', '--disable-crashpad'],
+    });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  it('keeps the viewport fixed and delegates tall generated content to body only', async () => {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+    try {
+      await page.setContent(
+        patchHtmlForIframe(`<!doctype html><html><head>
+          <style>
+            html, body { min-height: 100vh; overflow-y: auto; }
+            #generated-chart { height: 5000px; }
+          </style>
+        </head><body><main id="generated-chart">chart</main></body></html>`),
+      );
+
+      const before = await page.evaluate(() => ({
+        viewportHeight: window.innerHeight,
+        htmlClientHeight: document.documentElement.clientHeight,
+        bodyClientHeight: document.body.clientHeight,
+        bodyScrollHeight: document.body.scrollHeight,
+        htmlOverflowY: getComputedStyle(document.documentElement).overflowY,
+        bodyOverflowY: getComputedStyle(document.body).overflowY,
+      }));
+      await page.evaluate(() => {
+        document.body.scrollTop = 900;
+      });
+      const after = await page.evaluate(() => ({
+        htmlScrollTop: document.documentElement.scrollTop,
+        bodyScrollTop: document.body.scrollTop,
+        viewportHeight: window.innerHeight,
+      }));
+
+      expect(before).toMatchObject({
+        viewportHeight: 720,
+        htmlClientHeight: 720,
+        bodyClientHeight: 720,
+        htmlOverflowY: 'hidden',
+        bodyOverflowY: 'auto',
+      });
+      expect(before.bodyScrollHeight).toBeGreaterThan(720);
+      expect(after).toEqual({ htmlScrollTop: 0, bodyScrollTop: 900, viewportHeight: 720 });
+    } finally {
+      await page.close();
+    }
+  });
+});

--- a/tests/lib/utils/iframe.test.ts
+++ b/tests/lib/utils/iframe.test.ts
@@ -10,6 +10,20 @@ describe('patchHtmlForIframe', () => {
     expect(out).toContain('data-iframe-patch');
   });
 
+  it('keeps exactly one bounded root scroller and applies that contract after authored CSS', () => {
+    const authoredCss = '<style>html, body { min-height: 100vh; overflow-y: auto; }</style>';
+    const out = patchHtmlForIframe(
+      `<!DOCTYPE html><html><head>${authoredCss}</head><body><main>chart</main></body></html>`,
+    );
+
+    expect(out.indexOf(authoredCss)).toBeLessThan(out.indexOf('data-iframe-patch'));
+    expect(out).toContain('html {');
+    expect(out).toContain('overflow: hidden !important');
+    expect(out).toContain('max-height: 100%');
+    expect(out).toContain('overflow-y: auto !important');
+    expect(out).toContain('min-height: 0 !important');
+  });
+
   it('runs the storage shim before the page scripts', () => {
     const html =
       '<!DOCTYPE html><html><head><script>window.__x = localStorage.getItem("k");</script></head><body></body></html>';

--- a/tests/store/interactive-iframe-pool.test.ts
+++ b/tests/store/interactive-iframe-pool.test.ts
@@ -11,10 +11,11 @@ beforeEach(reset);
 
 describe('mount', () => {
   test('creates an entry with the given content', () => {
-    pool().mount('s1', { srcDoc: '<p>1</p>' });
+    pool().mount('s1', { srcDoc: '<p>1</p>', widgetType: 'code' });
     const e = pool().entries['s1'];
     expect(e).toBeDefined();
     expect(e.srcDoc).toBe('<p>1</p>');
+    expect(e.widgetType).toBe('code');
   });
 
   test('re-mounting with equal content keeps the entry (no reload)', () => {


### PR DESCRIPTION
## Summary

Fixes runaway scrolling in generated interactive content and adds a host-owned recovery control that regenerates failed Python/code widgets without replacing narration or scene actions.

## Related Issues

Related to #314 and #202. No existing issue exactly matched the runaway root-scroller behavior shown in the reproduction.

## Changes

- enforce a single bounded root scroller inside generated iframes, with the viewport patch injected after authored head styles
- expose widget type to the host and add an owner-only Regenerate code control outside the sandbox
- regenerate content from the persisted outline while preserving scene identity, narration, and actions
- guard read-only/edit-locked/stale responses and localize the control in all 12 locales
- add unit, real-Chromium, and headed desktop/mobile regression coverage

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Open a generated interactive code scene whose authored CSS sets `html, body` as root scrollers and whose content exceeds the viewport.
2. Confirm scrolling stays inside the iframe and does not grow the page indefinitely.
3. Click Regenerate code and confirm only the code-widget content is replaced.

### What you personally verified

- 28 targeted unit tests passed.
- Real Chromium root-scroll regression passed.
- Headed Playwright passed at 1280x900 and 390x844, including scroll ownership, regeneration, clean page console/API responses, and before/after screenshots.
- Full `tsc --noEmit`, targeted ESLint/Prettier, and 12-locale key alignment passed.
- Read-only, edit-lock, missing/stale generation boundaries are covered by hard gates/tests.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings