### PR TITLE
fix: replace rm -rf with cross-platform fs.rmSync in package scripts

### DIFF
--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/dsl",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The MAIC slide DSL: the pure, dependency-free contract (types + JSON Schema + validators + version/migration helpers) that @openmaic/renderer and @openmaic/importer both depend on.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/dsl/package.json
+++ b/packages/@openmaic/dsl/package.json
@@ -20,8 +20,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json && node scripts/gen-schema.mjs",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json && node scripts/gen-schema.mjs",
     "build:schema": "node scripts/gen-schema.mjs",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/@openmaic/editor/package.json
+++ b/packages/@openmaic/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/editor",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Composable slide editing core, React surface, and UI for OpenMAIC.",
   "type": "module",
   "main": "./dist/core/index.js",

--- a/packages/@openmaic/editor/package.json
+++ b/packages/@openmaic/editor/package.json
@@ -34,7 +34,7 @@
     "directory": "packages/@openmaic/editor"
   },
   "scripts": {
-    "build": "rm -rf dist && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm run build"

--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -22,8 +22,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",

--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/importer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A javascript tool for parsing .pptx file",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -20,8 +20,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean:dist": "rimraf dist",
-    "build": "rm -rf dist && rollup -c && tsc --emitDeclarationOnly",
+    "clean:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && rollup -c && tsc --emitDeclarationOnly",
     "dev": "rollup -c -w",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "test": "vitest run",

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/renderer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "React component for rendering PPTist-style Slide JSON, extracted from OpenMAIC.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/renderer/package.json
+++ b/packages/@openmaic/renderer/package.json
@@ -35,10 +35,10 @@
     "font-licenses"
   ],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "genfonts": "node scripts/generate-fonts-css.mjs",
     "gen-katex-fonts": "node scripts/generate-katex-fonts.mjs",
-    "build": "node scripts/generate-fonts-css.mjs && node scripts/generate-katex-fonts.mjs && rm -rf dist && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
+    "build": "node scripts/generate-fonts-css.mjs && node scripts/generate-katex-fonts.mjs && node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && rollup -c && tsc --emitDeclarationOnly --declarationDir dist",
     "dev": "rollup -c -w",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -79,8 +79,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",

--- a/packages/@openmaic/storage/package.json
+++ b/packages/@openmaic/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/storage",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "The MAIC pluggable persistence layer: document / runtime / KV / asset primitives with browser and HTTP backends, depending only on @openmaic/dsl.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

The build/clean scripts in 6 workspace packages used the Unix `rm -rf dist` command, which fails on Windows (cmd.exe has no `rm`), breaking `pnpm install` on Windows at the postinstall step.

This PR replaces `rm -rf dist` with Node's built-in `fs.rmSync`, which is cross-platform (Node >= 20.9 is already required by this repo). No dependencies changed; the lockfile is untouched.

## Packages changed

- packages/@openmaic/dsl
- packages/@openmaic/generation
- packages/@openmaic/storage
- packages/@openmaic/importer
- packages/@openmaic/renderer
- packages/@openmaic/editor

## Verification

`pnpm install` completes successfully on Windows (postinstall builds all packages).