### PR TITLE
fix(agent-runtime): resolve VoxCPM Auto Voice for generate_tts

### DIFF
--- a/lib/server/agent-runtime/scene-tts.ts
+++ b/lib/server/agent-runtime/scene-tts.ts
@@ -1,6 +1,13 @@
 import { DEFAULT_TTS_MODELS, DEFAULT_TTS_VOICES, TTS_PROVIDERS } from '@/lib/audio/constants';
 import { generateTTS, TTSRequestTimeoutError } from '@/lib/audio/tts-providers';
 import type { TTSProviderId } from '@/lib/audio/types';
+import { getDeterministicVoiceId, type VoiceDesign } from '@/lib/audio/voice-design';
+import { getVoiceRegistrationAdapter } from '@/lib/audio/voice-registration';
+import {
+  buildAutoVoxCPMVoicePrompt,
+  VOXCPM_AUTO_VOICE_ID,
+  VOXCPM_TTS_PROVIDER_ID,
+} from '@/lib/audio/voxcpm';
 import { BROWSER_NATIVE_TTS_PROVIDER_ID } from '@/lib/audio/provider-enablement';
 import type { LegacySpeechAction, SpeechAction } from '@/lib/types/action';
 import type { GeneratedAgentConfig, Scene } from '@/lib/types/stage';
@@ -33,8 +40,63 @@ function enabledProviderIds(): TTSProviderId[] {
     .map(([id]) => id as TTSProviderId);
 }
 
-function narratorVoice(roster: SceneTtsInput['roster']) {
-  return roster?.find((agent) => agent.role === 'teacher' && agent.voiceConfig)?.voiceConfig;
+function narratorAgent(roster: SceneTtsInput['roster']) {
+  return roster?.find((agent) => agent.role === 'teacher' && agent.voiceConfig);
+}
+
+function effectiveVoiceDesign(agent: ReturnType<typeof narratorAgent>): VoiceDesign | undefined {
+  if (agent?.voiceDesign) return agent.voiceDesign;
+  const persona = agent?.persona?.trim();
+  return persona ? { identity: persona, texture: '', delivery: '' } : undefined;
+}
+
+async function resolveVoxCPMAutoVoiceOptions(params: {
+  providerId: TTSProviderId;
+  voice: string;
+  agent: ReturnType<typeof narratorAgent>;
+  baseUrl?: string;
+  apiKey: string;
+  modelId: string;
+  signal?: AbortSignal;
+}): Promise<Record<string, unknown> | undefined> {
+  if (params.providerId !== VOXCPM_TTS_PROVIDER_ID || params.voice !== VOXCPM_AUTO_VOICE_ID) {
+    return undefined;
+  }
+
+  const voicePrompt = buildAutoVoxCPMVoicePrompt({
+    agentName: params.agent?.name,
+    role: params.agent?.role,
+    persona: params.agent?.persona,
+    voiceDesign: params.agent?.voiceDesign,
+  });
+  const design = effectiveVoiceDesign(params.agent);
+  const adapter = getVoiceRegistrationAdapter(params.providerId);
+  if (!design || !params.baseUrl || !adapter?.supportsRegistration()) return { voicePrompt };
+
+  const config = {
+    baseUrl: params.baseUrl,
+    apiKey: params.apiKey,
+    model: params.modelId,
+  };
+  const voiceId = await getDeterministicVoiceId(design, {
+    providerId: params.providerId,
+    model: params.modelId,
+  });
+  if (await adapter.voiceExists(config, voiceId, params.signal)) {
+    return { registeredVoiceId: voiceId };
+  }
+
+  const clip = await adapter.bootstrapReferenceClip(config, { design }, params.signal);
+  const registeredVoiceId = await adapter.registerVoice(
+    config,
+    {
+      voiceId,
+      referenceAudioBase64: clip.referenceAudioBase64,
+      mimeType: clip.mimeType,
+    },
+    params.signal,
+  );
+  return { registeredVoiceId };
 }
 
 function audioMime(format: string) {
@@ -44,7 +106,8 @@ function audioMime(format: string) {
 /** Server-configured narration synthesis into the stage's classroom-media path. */
 export async function synthesizeSceneNarration(input: SceneTtsInput): Promise<SceneTtsSummary> {
   const enabled = enabledProviderIds();
-  const bound = narratorVoice(input.roster);
+  const narrator = narratorAgent(input.roster);
+  const bound = narrator?.voiceConfig;
   const providerId = (
     bound?.providerId && enabled.includes(bound.providerId as TTSProviderId)
       ? bound.providerId
@@ -68,6 +131,16 @@ export async function synthesizeSceneNarration(input: SceneTtsInput): Promise<Sc
       DEFAULT_TTS_MODELS[providerId as keyof typeof DEFAULT_TTS_MODELS] || '',
       voice,
     ) || '';
+  const baseUrl = resolveTTSBaseUrl(providerId);
+  const providerOptions = await resolveVoxCPMAutoVoiceOptions({
+    providerId,
+    voice,
+    agent: narrator,
+    baseUrl,
+    apiKey,
+    modelId,
+    signal: input.signal,
+  });
   let generated = 0;
   let skipped = 0;
   const failed: string[] = [];
@@ -85,10 +158,11 @@ export async function synthesizeSceneNarration(input: SceneTtsInput): Promise<Sc
           providerId,
           modelId,
           apiKey,
-          baseUrl: resolveTTSBaseUrl(providerId),
+          baseUrl,
           voice,
           speed: speech.speed,
           signal: input.signal,
+          ...(providerOptions ? { providerOptions } : {}),
         },
         speech.text,
       );

--- a/tests/agent-runtime/scene-tts.test.ts
+++ b/tests/agent-runtime/scene-tts.test.ts
@@ -2,18 +2,35 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   providers: vi.fn(),
+  baseUrl: vi.fn(),
+  model: vi.fn(),
   generate: vi.fn(),
   persist: vi.fn(),
+  voiceId: vi.fn(),
+  getAdapter: vi.fn(),
+  adapter: {
+    supportsRegistration: vi.fn(),
+    voiceExists: vi.fn(),
+    bootstrapReferenceClip: vi.fn(),
+    registerVoice: vi.fn(),
+  },
 }));
 
 vi.mock('@/lib/server/provider-config', () => ({
   getServerTTSProviders: mocks.providers,
   resolveTTSApiKey: vi.fn(() => ''),
-  resolveTTSBaseUrl: vi.fn(() => undefined),
-  resolveTTSModel: vi.fn(() => ''),
+  resolveTTSBaseUrl: mocks.baseUrl,
+  resolveTTSModel: mocks.model,
 }));
 
 vi.mock('@/lib/audio/tts-providers', () => ({ generateTTS: mocks.generate }));
+vi.mock('@/lib/audio/voice-design', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/audio/voice-design')>()),
+  getDeterministicVoiceId: mocks.voiceId,
+}));
+vi.mock('@/lib/audio/voice-registration', () => ({
+  getVoiceRegistrationAdapter: mocks.getAdapter,
+}));
 
 vi.mock('@/lib/server/classroom-media-bytes', () => ({
   persistClassroomMediaBytes: mocks.persist,
@@ -33,7 +50,12 @@ const scene = {
 } as Scene;
 
 describe('scene TTS capability routing', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.baseUrl.mockReturnValue(undefined);
+    mocks.model.mockReturnValue('');
+    mocks.getAdapter.mockReturnValue(undefined);
+  });
 
   it('honors the server capability force-off before synthesis', async () => {
     mocks.providers.mockReturnValue({ 'configured-tts': { disabled: true } });
@@ -64,6 +86,59 @@ describe('scene TTS capability routing', () => {
     });
     expect(mocks.persist).toHaveBeenCalledWith(
       expect.objectContaining({ stageId: 'stage-a', mime: 'audio/mpeg' }),
+    );
+  });
+
+  it('registers and reuses VoxCPM Auto Voice from the server-side roster', async () => {
+    mocks.providers.mockReturnValue({ 'voxcpm-tts': {} });
+    mocks.baseUrl.mockReturnValue('http://voxcpm.test/v1');
+    mocks.model.mockReturnValue('voxcpm2');
+    mocks.voiceId.mockResolvedValue('auto-stable-voice');
+    mocks.getAdapter.mockReturnValue(mocks.adapter);
+    mocks.adapter.supportsRegistration.mockReturnValue(true);
+    mocks.adapter.voiceExists.mockResolvedValue(false);
+    mocks.adapter.bootstrapReferenceClip.mockResolvedValue({
+      referenceAudioBase64: 'UklGRg==',
+      mimeType: 'audio/wav',
+    });
+    mocks.adapter.registerVoice.mockResolvedValue('auto-stable-voice');
+    mocks.generate.mockResolvedValue({ audio: new Uint8Array([1, 2]), format: 'wav' });
+    mocks.persist.mockResolvedValue('/api/classroom-media/stage-a/media/tts-speech-a.wav');
+
+    const summary = await synthesizeSceneNarration({
+      scene: structuredClone(scene),
+      force: false,
+      roster: [
+        {
+          id: 'teacher',
+          name: 'Teacher',
+          role: 'teacher',
+          persona: 'patient mentor',
+          avatar: '',
+          color: '',
+          priority: 10,
+          voiceConfig: { providerId: 'voxcpm-tts', voiceId: 'voxcpm:auto' },
+          voiceDesign: {
+            identity: 'adult teacher',
+            texture: 'clear and warm',
+            delivery: 'calm and steady',
+          },
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({ changed: true, generated: 1, failed: [] });
+    expect(mocks.adapter.registerVoice).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'http://voxcpm.test/v1', model: 'voxcpm2' }),
+      expect.objectContaining({ voiceId: 'auto-stable-voice' }),
+      undefined,
+    );
+    expect(mocks.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        voice: 'voxcpm:auto',
+        providerOptions: { registeredVoiceId: 'auto-stable-voice' },
+      }),
+      'Hello',
     );
   });
 });


### PR DESCRIPTION
## Summary
- resolve VoxCPM `voxcpm:auto` from the Agent Runtime's persisted teacher roster
- reuse the existing deterministic voice ID and voice-registration adapter, registering the bootstrap clip only when absent
- pass `registeredVoiceId` into server-side `generateTTS` so Workbench `generate_tts` matches the browser narration path

## Root cause
Agent Workbench's `scene-tts.ts` was added after the Auto Voice register-once flow. It forwarded `voice: voxcpm:auto` without `voicePrompt` or `registeredVoiceId`, so `generateVoxCPMTTS` rejected every speech action before making an HTTP request.

## Verification
- `pnpm exec vitest run tests/agent-runtime/scene-tts.test.ts`
- `pnpm exec next typegen && pnpm exec tsc --noEmit`
- `pnpm exec eslint lib/server/agent-runtime/scene-tts.ts tests/agent-runtime/scene-tts.test.ts`
- `pnpm exec prettier lib/server/agent-runtime/scene-tts.ts tests/agent-runtime/scene-tts.test.ts --check`
- `pnpm build`