### PR TITLE
fix(importer): escape Windows paths in rollup-synthesized virtual modules

### DIFF
--- a/packages/@openmaic/importer/rollup.config.js
+++ b/packages/@openmaic/importer/rollup.config.js
@@ -11,9 +11,29 @@ const onwarn = (warning) => {
   console.warn(`(!) ${warning.message}`);
 };
 
+// Windows fix: plugins like @rollup/plugin-commonjs synthesize virtual modules
+// (e.g. for `import.meta.url` in the emscripten jpegxr glue) whose content embeds
+// a raw absolute path like `export default 'C:\Users\...'`. The backslashes are
+// invalid escape sequences in strict mode, so rollup fails to parse the module.
+// Escape them and normalize to forward slashes before rollup parses the module.
+const fixWindowsPathStrings = () => ({
+  name: 'fix-windows-path-strings',
+  transform(code) {
+    if (!code.includes('\\')) return null;
+    let changed = false;
+    const fixed = code.replace(/export default '([^'\n]*)'/g, (match, raw) => {
+      if (!raw.includes('\\')) return match;
+      changed = true;
+      return `export default ${JSON.stringify(raw.replaceAll('\\', '/'))}`;
+    });
+    return changed ? { code: fixed, map: null } : null;
+  },
+});
+
 const plugins = [
   nodeResolve({ browser: true, preferBuiltins: false }),
   commonjs(),
+  fixWindowsPathStrings(),
   json(),
   typescript({ tsconfig: './tsconfig.json' }),
   terser(),


### PR DESCRIPTION
## Summary

`pnpm install` fails on Windows in the root postinstall chain: the `@openmaic/importer` rollup build aborts with `RollupError: Octal literal in strict mode`, which leaves `@openmaic/importer`, `@openmaic/renderer` and `@openmaic/editor` unbuilt and prevents `scripts/sync-maic-importer.mjs` from running.

## Root cause

`jpegxr` ships Emscripten glue code that references `import.meta.url`. `@rollup/plugin-commonjs` synthesizes a virtual module for it whose content embeds the resolved absolute path raw inside a single-quoted string:

```js
export default '/Users/<user>\OpenMAIC\node_modules\.pnpm\jpegxr@0.3.0\node_modules\jpegxr\wasm\jpegxr.js'
```

On POSIX, forward slashes parse fine. On Windows the path contains unescaped backslashes, so `\229` (from a path like `C:\Users\22975\...`) is parsed as an octal escape — invalid in strict mode — and rollup fails to parse the synthesized module:

```
[!] RollupError: Octal literal in strict mode (Note that you need plugins to import files that are not JavaScript)
9da56c03f5f63c21b23e8110b74466 (1:22)
1: export default '/Users\22975\OpenMAIC\node_modules\.pnpm\jpegxr@0.3.0\...'
                         ^
```

## Fix

Add a tiny transform plugin right after `commonjs()` in `packages/@openmaic/importer/rollup.config.js` that rewrites backslashes to forward slashes (with safe re-quoting) inside these generated `export default '...'` strings before rollup parses them. It is a no-op on POSIX, where generated paths contain no backslashes.

## Verification (Windows 11, Node 22.18, pnpm 10.28.0)

- `pnpm install` completes: all 9 workspace projects build — importer now emits `dist/index.umd.js`, `dist/index.cjs` and `dist/index.js`, renderer and editor build, and `sync-maic-importer.mjs` copies the bundle to `public/vendor/maic-importer`
- `pnpm dev` (Next.js 16 / Turbopack) boots successfully