### PR TITLE
fix(render): preserve plan audio during chunk assembly

### DIFF
--- a/render-service/src/chunk-executor.ts
+++ b/render-service/src/chunk-executor.ts
@@ -14,6 +14,7 @@ import {
   plan as producerPlan,
   renderChunk as producerRenderChunk,
   hashProjectDir,
+  resolvePlanAudioPath,
   type AssembleResult,
   type ChunkResult,
   type DistributedRenderConfig,
@@ -844,11 +845,17 @@ export async function executeRenderChunks(
     let assembly: AssembleResult;
     const assembleStartedAt = Date.now();
     try {
-      const audioPath = join(plan.planDir, 'audio.aac');
+      const audioPath = resolvePlanAudioPath(plan.planDir);
+      const producerMetadata = JSON.parse(
+        await readFile(join(plan.planDir, 'plan.json'), 'utf8'),
+      ) as { hasAudio?: boolean };
+      if (producerMetadata.hasAudio && !audioPath) {
+        throw new Error('Plan declares audio but its audio artifact is missing');
+      }
       assembly = await (dependencies.assemble ?? defaultDeps.assemble)(
         plan.planDir,
         results.map((result) => result.outputPath),
-        (await exists(audioPath)) ? audioPath : null,
+        audioPath,
         plan.outputPath,
         { abortSignal: request.signal },
       );

--- a/render-service/src/chunk-executor.ts
+++ b/render-service/src/chunk-executor.ts
@@ -845,10 +845,10 @@ export async function executeRenderChunks(
     let assembly: AssembleResult;
     const assembleStartedAt = Date.now();
     try {
-      const audioPath = resolvePlanAudioPath(plan.planDir);
       const producerMetadata = JSON.parse(
         await readFile(join(plan.planDir, 'plan.json'), 'utf8'),
       ) as { hasAudio?: boolean };
+      const audioPath = producerMetadata.hasAudio ? resolvePlanAudioPath(plan.planDir) : null;
       if (producerMetadata.hasAudio && !audioPath) {
         throw new Error('Plan declares audio but its audio artifact is missing');
       }

--- a/render-service/test/chunk-executor.test.ts
+++ b/render-service/test/chunk-executor.test.ts
@@ -185,6 +185,29 @@ describe('local bounded chunk executor', () => {
     expect(assembled).toBe(false);
   });
 
+  it('ignores stale audio from a failed planning attempt when the current plan has no audio', async () => {
+    const paths = setup();
+    await materializeProject(paths.projectDir);
+    let assembledAudio: string | null | undefined;
+    const dependencies = deps();
+    const assemble = dependencies.assemble!;
+    await executeRenderChunks(
+      { ...paths, options },
+      deps({
+        plan: async (...args) => {
+          const result = await fakePlan(...args);
+          await writeFile(join(paths.planDir, 'audio.m4a'), 'stale-audio');
+          return result;
+        },
+        assemble: async (...args) => {
+          assembledAudio = args[2];
+          return assemble(...args);
+        },
+      }),
+    );
+    expect(assembledAudio).toBeNull();
+  });
+
   it('terminates a real child worker on deadline without crashing the parent', async () => {
     const controller = new AbortController();
     const fixture = join(

--- a/render-service/test/chunk-executor.test.ts
+++ b/render-service/test/chunk-executor.test.ts
@@ -61,6 +61,7 @@ async function fakePlan(
   planDir: string,
 ): Promise<PlanResult> {
   await mkdir(join(planDir, 'meta'), { recursive: true });
+  await writeFile(join(planDir, 'plan.json'), JSON.stringify({ hasAudio: false }));
   await mkdir(join(planDir, 'compiled', 'assets', 'fonts'), { recursive: true });
   await writeFile(join(planDir, 'compiled', 'index.html'), '<html></html>');
   await writeFile(join(planDir, 'compiled', 'assets', 'fonts', 'test.woff2'), 'font');
@@ -128,6 +129,62 @@ function deps(overrides: Partial<ChunkExecutorDependencies> = {}): ChunkExecutor
 }
 
 describe('local bounded chunk executor', () => {
+  it.each(['audio.m4a', 'audio.aac', null])(
+    'passes the plan audio artifact %s to assembly',
+    async (filename) => {
+      const paths = setup();
+      await materializeProject(paths.projectDir);
+      let assembledAudio: string | null | undefined;
+      const dependencies = deps();
+      const assemble = dependencies.assemble!;
+      await executeRenderChunks(
+        { ...paths, options },
+        deps({
+          plan: async (...args) => {
+            const result = await fakePlan(...args);
+            await writeFile(
+              join(paths.planDir, 'plan.json'),
+              JSON.stringify({ hasAudio: filename !== null }),
+            );
+            if (filename) await writeFile(join(paths.planDir, filename), 'mixed-audio');
+            return result;
+          },
+          assemble: async (...args) => {
+            assembledAudio = args[2];
+            return assemble(...args);
+          },
+        }),
+      );
+      expect(assembledAudio).toBe(filename ? join(paths.planDir, filename) : null);
+    },
+  );
+
+  it('rejects a plan whose declared audio artifact is missing before assembly', async () => {
+    const paths = setup();
+    await materializeProject(paths.projectDir);
+    let assembled = false;
+    await expect(
+      executeRenderChunks(
+        { ...paths, options },
+        deps({
+          plan: async (...args) => {
+            const result = await fakePlan(...args);
+            await writeFile(join(paths.planDir, 'plan.json'), JSON.stringify({ hasAudio: true }));
+            return result;
+          },
+          assemble: async () => {
+            assembled = true;
+            throw new Error('Assembly should not be called');
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'assembly_failed',
+      message: expect.stringContaining('audio artifact is missing'),
+    });
+    expect(assembled).toBe(false);
+  });
+
   it('terminates a real child worker on deadline without crashing the parent', async () => {
     const controller = new AbortController();
     const fixture = join(


### PR DESCRIPTION
## Summary
Preserve the producer's audio artifact when assembling rendered chunks. Resolve the artifact through `resolvePlanAudioPath`, so both current `audio.m4a` and legacy `audio.aac` plans retain their soundtrack. Treat `plan.json.hasAudio` as authoritative so a stale artifact from a failed planning attempt is never attached to a later silent plan. Fail explicitly when a plan declares audio but its artifact is missing.

## Related Issues
Fixes #1352

## Changes
- Resolve and pass the producer audio artifact only when `plan.json` declares audio.
- Reject missing declared audio before assembly instead of silently exporting a video without sound.
- Cover M4A, AAC, silent plans, missing declared audio, and stale audio after a partial planning failure.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Verification
Run from `render-service` after rebasing onto current `main`:
- `vitest run test/chunk-executor.test.ts` — 15 tests passed.
- `tsc --noEmit` — passed.
- `git diff --check origin/main...HEAD` — passed.

The regression cases exercise artifact selection and assembly error handling with mocked producer calls, including an `audio.m4a` left in the plan directory while the current `plan.json` contains `hasAudio: false`.

Full application formatting/lint/typecheck, a live Chromium/FFmpeg export, and manual end-to-end regression checks have not been completed. This PR remains a draft pending those checks and human review.

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (not applicable)

## AI assistance and review
AI-assisted contribution: Codex implemented the change and regression tests and performed an additional agent review of the diff. This is not a claim of human review; human review is pending.

## Checklist
- [x] Changed files follow the project's formatting style
- [x] Agent self-review completed
- [x] No documentation change needed for this internal bug fix
- [ ] Full application checks establish no new warnings
