### PR TITLE
fix(render): enforce chunk worker cap

### DIFF
--- a/render-service/src/chunk-executor.ts
+++ b/render-service/src/chunk-executor.ts
@@ -25,6 +25,7 @@ import { config } from './config.js';
 export const CHUNK_PLAN_SCHEMA_VERSION = 1 as const;
 export const DEFAULT_CHUNK_COUNT = 1;
 export const DEFAULT_CHUNK_WORKERS = 1;
+const SERIAL_CAPTURE_MIN_PARALLEL_FRAMES = String(Number.MAX_SAFE_INTEGER);
 
 export type ChunkFailureCode =
   | 'missing_chunk'
@@ -619,7 +620,11 @@ export async function createRenderPlan(
   await mkdir(planDir, { recursive: true });
   const dimensions = await readCompositionDimensions(projectDir);
   const previousWorkers = process.env.PRODUCER_MAX_WORKERS;
+  const previousMinParallelFrames = process.env.PRODUCER_MIN_PARALLEL_FRAMES;
   process.env.PRODUCER_MAX_WORKERS = String(chunkWorkers);
+  if (chunkWorkers === 1) {
+    process.env.PRODUCER_MIN_PARALLEL_FRAMES = SERIAL_CAPTURE_MIN_PARALLEL_FRAMES;
+  }
   let result: PlanResult;
   try {
     result = await (dependencies.plan ?? defaultDeps.plan)(
@@ -638,6 +643,8 @@ export async function createRenderPlan(
   } finally {
     if (previousWorkers === undefined) delete process.env.PRODUCER_MAX_WORKERS;
     else process.env.PRODUCER_MAX_WORKERS = previousWorkers;
+    if (previousMinParallelFrames === undefined) delete process.env.PRODUCER_MIN_PARALLEL_FRAMES;
+    else process.env.PRODUCER_MIN_PARALLEL_FRAMES = previousMinParallelFrames;
   }
   const resolvedChunkCount = result.chunkCount;
   const chunksJson = JSON.parse(
@@ -814,7 +821,14 @@ export async function executeRenderChunks(
   const plan = await createRenderPlan(request, dependencies);
   const planMs = Date.now() - planStartedAt;
   const previousWorkers = process.env.PRODUCER_MAX_WORKERS;
+  const previousMinParallelFrames = process.env.PRODUCER_MIN_PARALLEL_FRAMES;
   process.env.PRODUCER_MAX_WORKERS = String(plan.chunkWorkers);
+  if (plan.chunkWorkers === 1) {
+    // Producer's distributed renderChunk path does not accept an explicit
+    // worker count. Disable its two-worker minimum so the configured cap is
+    // also honored by forked chunk workers.
+    process.env.PRODUCER_MIN_PARALLEL_FRAMES = SERIAL_CAPTURE_MIN_PARALLEL_FRAMES;
+  }
   const results = new Array<ChunkResult>(plan.chunks.length);
   try {
     const chunksStartedAt = Date.now();
@@ -869,6 +883,8 @@ export async function executeRenderChunks(
   } finally {
     if (previousWorkers === undefined) delete process.env.PRODUCER_MAX_WORKERS;
     else process.env.PRODUCER_MAX_WORKERS = previousWorkers;
+    if (previousMinParallelFrames === undefined) delete process.env.PRODUCER_MIN_PARALLEL_FRAMES;
+    else process.env.PRODUCER_MIN_PARALLEL_FRAMES = previousMinParallelFrames;
   }
 }
 

--- a/render-service/src/render-executor.ts
+++ b/render-service/src/render-executor.ts
@@ -231,13 +231,14 @@ export class InProcessExecutor implements RenderExecutor {
         ];
         const actualCaptureMode =
           observedModes.length === 1 ? observedModes[0]! : result.plan.captureMode;
+        const actualWorkers = Math.max(...result.chunks.map((chunk) => chunk.workers));
         const chunkMetrics: RenderExecutionMetrics = {
           resourceProfile: config.resourceProfile.name,
           capturePolicy: config.resourceProfile.capturePolicy,
           requestedCaptureMode: config.resourceProfile.requestedCaptureMode,
           actualCaptureMode,
           requestedWorkers: config.producerWorkers,
-          actualWorkers: result.plan.chunkWorkers,
+          actualWorkers,
           versions: this.runtimeVersions,
         };
         if (
@@ -260,7 +261,7 @@ export class InProcessExecutor implements RenderExecutor {
           performance: {
             totalElapsedMs: result.totalElapsedMs,
             stages: { ...result.stages },
-            workers: result.plan.chunkWorkers,
+            workers: actualWorkers,
             totalFrames: result.plan.totalFrames,
           },
           metrics: chunkMetrics,

--- a/render-service/test/chunk-executor.test.ts
+++ b/render-service/test/chunk-executor.test.ts
@@ -66,6 +66,8 @@ async function fakePlan(
   await writeFile(join(planDir, 'compiled', 'assets', 'fonts', 'test.woff2'), 'font');
   await writeFile(
     join(planDir, 'meta', 'encoder.json'),
+    // Match the producer snapshot contract: only PRODUCER_RUNTIME_* and
+    // PRODUCER_RENDER_* values are persisted in encoder.json.runtimeEnv.
     JSON.stringify({ runtimeEnv: { PRODUCER_RUNTIME_TEST: '1' } }),
   );
   await writeFile(
@@ -175,7 +177,12 @@ describe('local bounded chunk executor', () => {
     let active = 0;
     let peak = 0;
     let calls = 0;
+    let plans = 0;
     const dependencies = deps({
+      plan: async (...args) => {
+        plans += 1;
+        return fakePlan(...args);
+      },
       onChunkStarted: async () => {
         active += 1;
         peak = Math.max(peak, active);
@@ -211,6 +218,59 @@ describe('local bounded chunk executor', () => {
       dependencies,
     );
     expect(calls).toBe(3);
+    expect(plans).toBe(1);
+  });
+
+  it('propagates the one-worker cap into chunk capture sizing and restores the environment', async () => {
+    const paths = setup();
+    await materializeProject(paths.projectDir);
+    const previousMaxWorkers = process.env.PRODUCER_MAX_WORKERS;
+    const previousMinParallelFrames = process.env.PRODUCER_MIN_PARALLEL_FRAMES;
+    process.env.PRODUCER_MAX_WORKERS = '7';
+    process.env.PRODUCER_MIN_PARALLEL_FRAMES = '120';
+    let planEnvironment: { maxWorkers?: string; minParallelFrames?: string } | undefined;
+    const observed: Array<{ maxWorkers?: string; minParallelFrames?: string }> = [];
+    const renderChunk = deps().renderChunk!;
+
+    try {
+      await executeRenderChunks(
+        { ...paths, options, chunkCount: 3, chunkWorkers: 1, maxParallelChunks: 2 },
+        deps({
+          plan: async (...args) => {
+            planEnvironment = {
+              maxWorkers: process.env.PRODUCER_MAX_WORKERS,
+              minParallelFrames: process.env.PRODUCER_MIN_PARALLEL_FRAMES,
+            };
+            return fakePlan(...args);
+          },
+          renderChunk: async (...args) => {
+            observed.push({
+              maxWorkers: process.env.PRODUCER_MAX_WORKERS,
+              minParallelFrames: process.env.PRODUCER_MIN_PARALLEL_FRAMES,
+            });
+            return renderChunk(...args);
+          },
+        }),
+      );
+
+      expect(planEnvironment).toEqual({
+        maxWorkers: '1',
+        minParallelFrames: String(Number.MAX_SAFE_INTEGER),
+      });
+      expect(observed).toEqual(
+        Array.from({ length: 3 }, () => ({
+          maxWorkers: '1',
+          minParallelFrames: String(Number.MAX_SAFE_INTEGER),
+        })),
+      );
+      expect(process.env.PRODUCER_MAX_WORKERS).toBe('7');
+      expect(process.env.PRODUCER_MIN_PARALLEL_FRAMES).toBe('120');
+    } finally {
+      if (previousMaxWorkers === undefined) delete process.env.PRODUCER_MAX_WORKERS;
+      else process.env.PRODUCER_MAX_WORKERS = previousMaxWorkers;
+      if (previousMinParallelFrames === undefined) delete process.env.PRODUCER_MIN_PARALLEL_FRAMES;
+      else process.env.PRODUCER_MIN_PARALLEL_FRAMES = previousMinParallelFrames;
+    }
   });
 
   it('drains sibling chunks after one worker fails', async () => {

--- a/render-service/test/render-executor.test.ts
+++ b/render-service/test/render-executor.test.ts
@@ -98,7 +98,7 @@ describe('InProcessExecutor', () => {
           sessionBootMs: 1,
           captureStageMs: 5,
           encodeStageMs: 3,
-          workers: 1,
+          workers: 2,
           captureMode: 'beginframe' as const,
           perfPath: '/tmp/chunk-0.mp4.perf.json',
         },
@@ -112,7 +112,7 @@ describe('InProcessExecutor', () => {
           sessionBootMs: 1,
           captureStageMs: 6,
           encodeStageMs: 4,
-          workers: 1,
+          workers: 2,
           captureMode: 'beginframe' as const,
           perfPath: '/tmp/chunk-1.mp4.perf.json',
         },
@@ -131,7 +131,8 @@ describe('InProcessExecutor', () => {
 
     expect(result).toMatchObject({
       status: 'succeeded',
-      performance: { totalFrames: 60, workers: 1 },
+      performance: { totalFrames: 60, workers: 2 },
+      metrics: { requestedWorkers: 1, actualWorkers: 2 },
     });
     expect(chunkExecutor).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- Keep one-worker chunk renders at one capture worker even above the producer's parallelization threshold.
- Report the maximum worker count observed in chunk results instead of echoing the plan setting.
- Preserve reusable plans when the producer omits executor-only worker controls from `encoder.json.runtimeEnv`.

AI-assisted and self-reviewed before submission.

## Related Issues

Fixes #1353

## Changes

- Apply and restore the producer's serial-capture threshold around one-worker chunk execution.
- Derive chunked render metrics and performance data from observed chunk worker counts.
- Keep plan reuse keyed by the executor-owned `chunkWorkers` field rather than expecting non-snapshotted environment variables in producer metadata.
- Add regression coverage using the real producer runtime snapshot shape.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run `pnpm --dir render-service test`.
2. Run `pnpm --dir render-service typecheck`.
3. Run `pnpm exec prettier --check render-service/src/chunk-executor.ts render-service/src/render-executor.ts render-service/test/chunk-executor.test.ts render-service/test/render-executor.test.ts`.

### What you personally verified

- The original worker-cap regression failed on the PR base: chunk execution retained `PRODUCER_MIN_PARALLEL_FRAMES=120`, and metrics reported configured workers `1` when chunk results observed `2`.
- The cache-reuse regression failed before the review fix with two planner calls instead of one when `encoder.json.runtimeEnv` matched producer 0.7.107's actual filtered shape.
- The same regression passes after removing the invalid runtime snapshot predicates while retaining the executor-owned `chunkWorkers` cache key.
- The current-main render-service suite passes: 142 tests.
- Render-service type checking, Prettier 3.8.1, and `git diff --check` pass for the complete rebased patch.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
