### PR TITLE
fix(ai): enable streaming compatibility for OpenAI protocol providers [AI-assisted]

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1835,7 +1835,7 @@ function usesCustomOpenAIBaseUrl(baseUrl?: string): boolean {
 
 function shouldUseOpenAIStreamingChatCompat(providerId: ProviderId, baseUrl?: string): boolean {
   return (
-    providerId === 'openai' &&
+    PROVIDERS[providerId]?.type === 'openai' &&
     usesCustomOpenAIBaseUrl(baseUrl) &&
     process.env.OPENAI_COMPAT_USE_STREAMING_CHAT === 'true'
   );

--- a/tests/ai/openai-provider.test.ts
+++ b/tests/ai/openai-provider.test.ts
@@ -206,6 +206,23 @@ describe('OpenAI provider defaults', () => {
     expect(openAiMock.responses).not.toHaveBeenCalled();
   });
 
+  it('routes OpenAI-compatible built-in providers through Chat Completions when enabled', () => {
+    vi.stubEnv('OPENAI_COMPAT_USE_STREAMING_CHAT', 'true');
+
+    getModel({
+      providerId: 'glm',
+      modelId: 'glm-5',
+      apiKey: 'sk-test',
+    });
+
+    const options = openAiMock.createOpenAI.mock.calls.at(-1)?.[0] as
+      | { fetch?: typeof fetch }
+      | undefined;
+    expect(options?.fetch).toBeTypeOf('function');
+    expect(openAiMock.chat).toHaveBeenCalledWith('glm-5');
+    expect(openAiMock.responses).not.toHaveBeenCalled();
+  });
+
   it.each([
     'https://api.openai.com/v1/',
     ' https://API.openai.com/v1 ',


### PR DESCRIPTION
## Summary

Long non-streaming requests from GLM, Qwen, and other OpenAI-compatible providers can hit the 300-second undici headers timeout because the existing compatibility streaming workaround only recognizes provider ID openai. This PR applies the opt-in workaround to every registered provider whose protocol type is openai.

## Related Issues

Closes #847

## Changes

- Widen the compatibility-streaming gate to the provider registry protocol type.
- Preserve the existing custom-base-URL and OPENAI_COMPAT_USE_STREAMING_CHAT feature-flag requirements.
- Preserve native OpenAI and non-OpenAI provider behavior.
- Add a GLM regression test for Chat Completions routing.

## Technical Design Document

### Context
OpenMAIC uses one OpenAI SDK transport for multiple provider entries. The request workaround is transport-specific, but its gate was provider-ID-specific, leaving equivalent OpenAI-compatible endpoints unprotected.

### Decision
Use PROVIDERS[providerId].type === openai as the protocol discriminator. Keep the feature flag opt-in and require a non-native OpenAI base URL, so default behavior remains unchanged.

### Flow

```mermaid
flowchart LR
  A[Provider config] --> B{Protocol type is openai?}
  B -- no --> C[Existing provider transport]
  B -- yes --> D{Custom base URL and flag enabled?}
  D -- no --> E[Existing OpenAI SDK behavior]
  D -- yes --> F[Streaming Chat Completions compatibility fetch]
```

### Compatibility
No public API, provider configuration, persistence, or storage changes. Existing tests for the official OpenAI base URL and default flag behavior remain unchanged.

## Verification

1. Set OPENAI_COMPAT_USE_STREAMING_CHAT=true.
2. Configure the GLM provider and call getModel with the built-in GLM endpoint.
3. Confirm the injected fetch exists and Chat Completions is selected.

What was verified:

- pnpm test -- tests/ai/openai-provider.test.ts: 654 test files passed, 7351 tests passed, 9 files skipped, 26 tests skipped.
- npx tsc --noEmit passed.
- pnpm lint passed with 0 errors and 18 existing warnings outside this change.
- pnpm check passed.
- pnpm check:i18n-keys passed.
- git diff --check passed.

CLI evidence:

    Test Files  654 passed | 9 skipped (663)
    Tests       7351 passed | 26 skipped (7377)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have added or updated documentation as needed in this PR description
- [x] My changes do not introduce new warnings

This PR is AI-assisted; the implementation was self-reviewed and validated locally.