### PR TITLE
fix(slide): keep bottom table rows visible in classroom playback

### DIFF
--- a/components/slide-renderer/components/element/TableElement/StaticTable.tsx
+++ b/components/slide-renderer/components/element/TableElement/StaticTable.tsx
@@ -95,47 +95,64 @@ export function StaticTable({ elementInfo }: StaticTableProps) {
         ))}
       </colgroup>
       <tbody>
-        {tableData.map((row, rowIdx) => (
-          <tr
-            key={rowIdx}
-            style={{
-              height: `${Number.isFinite(tableRowHeights[rowIdx]) ? tableRowHeights[rowIdx] : safeCellMinHeight}px`,
-            }}
-          >
-            {(Array.isArray(row) ? row : []).map((cell, colIdx) => {
-              if (hiddenCells.has(`${rowIdx}_${colIdx}`)) return null;
-              if (!cell) return null;
+        {tableData.map((row, rowIdx) => {
+          const rowHeight = Number.isFinite(tableRowHeights[rowIdx])
+            ? tableRowHeights[rowIdx]
+            : safeCellMinHeight;
 
-              const bgColor = getCellBg(rowIdx, colIdx, cell.style?.backcolor);
-              const headerColor = getHeaderTextColor(rowIdx);
-              const textStyle = getTextStyle(cell.style);
-              const colspan = Number.isFinite(cell.colspan) && cell.colspan > 0 ? cell.colspan : 1;
-              const rowspan = Number.isFinite(cell.rowspan) && cell.rowspan > 0 ? cell.rowspan : 1;
+          return (
+            <tr key={rowIdx} style={{ height: `${rowHeight}px` }}>
+              {(Array.isArray(row) ? row : []).map((cell, colIdx) => {
+                if (hiddenCells.has(`${rowIdx}_${colIdx}`)) return null;
+                if (!cell) return null;
 
-              // Header text color should be overridden only if cell doesn't have its own color
-              if (headerColor && !cell.style?.color) {
-                textStyle.color = headerColor;
-              }
+                const bgColor = getCellBg(rowIdx, colIdx, cell.style?.backcolor);
+                const headerColor = getHeaderTextColor(rowIdx);
+                const textStyle = getTextStyle(cell.style);
+                const colspan =
+                  Number.isFinite(cell.colspan) && cell.colspan > 0 ? cell.colspan : 1;
+                const rowspan =
+                  Number.isFinite(cell.rowspan) && cell.rowspan > 0 ? cell.rowspan : 1;
 
-              return (
-                <td
-                  key={cell.id || `${rowIdx}-${colIdx}`}
-                  colSpan={colspan > 1 ? colspan : undefined}
-                  rowSpan={rowspan > 1 ? rowspan : undefined}
-                  style={{
-                    border: borderStyle,
-                    backgroundColor: bgColor,
-                    padding: '5px',
-                    verticalAlign: 'middle',
-                    wordBreak: 'break-word',
-                    ...textStyle,
-                  }}
-                  dangerouslySetInnerHTML={{ __html: formatText(cell.text) }}
-                />
-              );
-            })}
-          </tr>
-        ))}
+                // Header text color should be overridden only if cell doesn't have its own color
+                if (headerColor && !cell.style?.color) {
+                  textStyle.color = headerColor;
+                }
+
+                return (
+                  <td
+                    key={cell.id || `${rowIdx}-${colIdx}`}
+                    colSpan={colspan > 1 ? colspan : undefined}
+                    rowSpan={rowspan > 1 ? rowspan : undefined}
+                    style={{
+                      border: borderStyle,
+                      backgroundColor: bgColor,
+                      wordBreak: 'break-word',
+                      ...textStyle,
+                    }}
+                  >
+                    <div
+                      style={{
+                        minHeight: `${rowHeight - 4}px`,
+                        padding: cell.padding,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        lineHeight: 1,
+                        justifyContent:
+                          cell.vAlign === 'top'
+                            ? 'flex-start'
+                            : cell.vAlign === 'bottom'
+                              ? 'flex-end'
+                              : 'center',
+                      }}
+                      dangerouslySetInnerHTML={{ __html: formatText(cell.text) }}
+                    />
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/components/slide-renderer/components/element/TableElement/StaticTable.tsx
+++ b/components/slide-renderer/components/element/TableElement/StaticTable.tsx
@@ -127,6 +127,7 @@ export function StaticTable({ elementInfo }: StaticTableProps) {
                     style={{
                       border: borderStyle,
                       backgroundColor: bgColor,
+                      verticalAlign: cell.vAlign ?? 'middle',
                       wordBreak: 'break-word',
                       ...textStyle,
                     }}

--- a/components/slide-renderer/components/element/TableElement/StaticTable.tsx
+++ b/components/slide-renderer/components/element/TableElement/StaticTable.tsx
@@ -127,7 +127,6 @@ export function StaticTable({ elementInfo }: StaticTableProps) {
                     style={{
                       border: borderStyle,
                       backgroundColor: bgColor,
-                      verticalAlign: cell.vAlign ?? 'middle',
                       wordBreak: 'break-word',
                       ...textStyle,
                     }}

--- a/e2e/tests/table-playback-clipping-1365.spec.ts
+++ b/e2e/tests/table-playback-clipping-1365.spec.ts
@@ -1,0 +1,183 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/base';
+import { createSettingsStorage } from '../fixtures/test-data/settings';
+import { defaultTheme } from '../fixtures/test-data/scene-content';
+
+const STAGE_ID = 'e2e-table-clipping-1365';
+const FINAL_ROW_TEXT = 'Issue1365FinalRow';
+const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+async function seedTableClassroom(page: Page) {
+  await page.addInitScript(
+    ({ settings }) => {
+      localStorage.setItem('maic:account:settings-storage', settings);
+      localStorage.setItem('locale', 'en-US');
+    },
+    { settings: SETTINGS_STORAGE },
+  );
+
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  await page.evaluate(
+    ({ stageId, finalRowText, theme }) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('MAIC-Database');
+
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
+          const now = Date.now();
+          const labels = ['Header', 'Route', 'Hypothesis', 'Evidence', finalRowText];
+
+          tx.objectStore('stages').put({
+            id: stageId,
+            name: 'Table clipping regression',
+            description: '',
+            language: 'en-US',
+            style: 'professional',
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('scenes').put({
+            id: 'scene-table',
+            stageId,
+            type: 'slide',
+            title: 'Table clipping regression',
+            order: 0,
+            content: {
+              type: 'slide',
+              canvas: {
+                id: 'slide-table',
+                viewportSize: 1000,
+                viewportRatio: 0.5625,
+                background: { type: 'solid', color: '#ffffff' },
+                theme,
+                elements: [
+                  {
+                    id: 'table-near-bottom',
+                    type: 'table',
+                    left: 50,
+                    top: 460,
+                    width: 900,
+                    height: 100,
+                    rotate: 0,
+                    colWidths: [0.5, 0.5],
+                    rowHeights: [20, 20, 20, 20, 20],
+                    cellMinHeight: 20,
+                    outline: { width: 1, color: '#334155', style: 'solid' },
+                    data: labels.map((label, rowIndex) => [
+                      {
+                        id: `label-${rowIndex}`,
+                        colspan: 1,
+                        rowspan: 1,
+                        text: label,
+                        style: { fontsize: '14px' },
+                      },
+                      {
+                        id: `value-${rowIndex}`,
+                        colspan: 1,
+                        rowspan: 1,
+                        text: `Value${rowIndex + 1}`,
+                        style: { fontsize: '14px' },
+                      },
+                    ]),
+                  },
+                ],
+              },
+            },
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.objectStore('stageOutlines').put({
+            stageId,
+            outlines: [],
+            createdAt: now,
+            updatedAt: now,
+          });
+
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+        request.onerror = () => reject(request.error);
+      }),
+    { stageId: STAGE_ID, finalRowText: FINAL_ROW_TEXT, theme: defaultTheme },
+  );
+}
+
+test('keeps every table row visible in the thumbnail and default classroom canvas', async ({
+  page,
+}, testInfo) => {
+  await seedTableClassroom(page);
+  await page.goto(`/classroom/${STAGE_ID}`);
+  await page.getByText('Loading classroom...').waitFor({ state: 'hidden', timeout: 15_000 });
+
+  const renderedTables = page.locator('.base-element-table').filter({ hasText: FINAL_ROW_TEXT });
+  await expect(renderedTables).toHaveCount(2);
+
+  const metrics = await renderedTables.evaluateAll((tables) =>
+    tables
+      .map((element) => {
+        const table = element.querySelector('table');
+        if (!table) throw new Error('Could not resolve the rendered HTML table');
+
+        const rows = Array.from(table.querySelectorAll('tr'));
+        const finalRow = rows.at(-1);
+        const tableRect = table.getBoundingClientRect();
+        const rowRect = finalRow?.getBoundingClientRect();
+
+        let clippingBoundary = element.parentElement;
+        while (clippingBoundary) {
+          const style = getComputedStyle(clippingBoundary);
+          if (
+            style.overflow === 'hidden' ||
+            style.overflowX === 'hidden' ||
+            style.overflowY === 'hidden'
+          ) {
+            break;
+          }
+          clippingBoundary = clippingBoundary.parentElement;
+        }
+
+        if (!rowRect || !clippingBoundary) {
+          throw new Error('Could not resolve the rendered table row and slide clipping boundary');
+        }
+
+        const boundaryRect = clippingBoundary.getBoundingClientRect();
+        const visibleTop = Math.max(rowRect.top, boundaryRect.top);
+        const visibleBottom = Math.min(rowRect.bottom, boundaryRect.bottom);
+
+        return {
+          width: tableRect.width,
+          rowCount: rows.length,
+          tableBottom: tableRect.bottom,
+          boundaryBottom: boundaryRect.bottom,
+          finalRowHeight: rowRect.height,
+          finalRowVisibleHeight: Math.max(0, visibleBottom - visibleTop),
+        };
+      })
+      .sort((left, right) => right.width - left.width),
+  );
+
+  await testInfo.attach('table clipping metrics', {
+    body: JSON.stringify(metrics, null, 2),
+    contentType: 'application/json',
+  });
+  await testInfo.attach('table clipping classroom', {
+    body: await page.screenshot(),
+    contentType: 'image/png',
+  });
+
+  const [classroom, thumbnail] = metrics;
+  expect(classroom.rowCount).toBe(5);
+  expect(thumbnail.rowCount).toBe(classroom.rowCount);
+
+  for (const surface of [classroom, thumbnail]) {
+    expect(surface.tableBottom).toBeLessThanOrEqual(surface.boundaryBottom + 1);
+    expect(surface.finalRowVisibleHeight).toBeGreaterThanOrEqual(surface.finalRowHeight - 1);
+  }
+});

--- a/e2e/tests/table-playback-clipping-1365.spec.ts
+++ b/e2e/tests/table-playback-clipping-1365.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '../fixtures/base';
 import { createSettingsStorage } from '../fixtures/test-data/settings';
 import { defaultTheme } from '../fixtures/test-data/scene-content';
@@ -6,6 +6,20 @@ import { defaultTheme } from '../fixtures/test-data/scene-content';
 const STAGE_ID = 'e2e-table-clipping-1365';
 const FINAL_ROW_TEXT = 'Issue1365FinalRow';
 const SETTINGS_STORAGE = createSettingsStorage({ sidebarCollapsed: false });
+
+// At this width every first-column cell wraps to two lines. The element height
+// sits between the old legacy table (~266px) and both aligned renderers (~146px).
+const TABLE_WIDTH = 600;
+const TABLE_HEIGHT = 180;
+const TABLE_TOP = 370;
+const TABLE_ROTATE = 0;
+const ROW_TEXTS = [
+  '课堂播放渲染链与缩略图渲染链必须在同一份幻灯片数据上给出一致的表格高度',
+  '当单元格文本折行时旧实现的内边距与行高会把整张表格撑出元素盒子之外',
+  '本行用于验证表格底部内容在教室视图中不会被幻灯片视口裁掉的回归场景',
+  '两个渲染实现的行高都应由该行最高的单元格决定而不是由声明高度决定',
+  '最后一行是报告者截图里丢失的那一行必须在两条渲染链中完整可见',
+];
 
 async function seedTableClassroom(page: Page) {
   await page.addInitScript(
@@ -19,7 +33,7 @@ async function seedTableClassroom(page: Page) {
   await page.goto('/', { waitUntil: 'networkidle' });
 
   await page.evaluate(
-    ({ stageId, finalRowText, theme }) =>
+    ({ stageId, finalRowText, rowTexts, theme, geometry }) =>
       new Promise<void>((resolve, reject) => {
         const request = indexedDB.open('MAIC-Database');
 
@@ -27,13 +41,12 @@ async function seedTableClassroom(page: Page) {
           const db = (event.target as IDBOpenDBRequest).result;
           const tx = db.transaction(['stages', 'scenes', 'stageOutlines'], 'readwrite');
           const now = Date.now();
-          const labels = ['Header', 'Route', 'Hypothesis', 'Evidence', finalRowText];
 
           tx.objectStore('stages').put({
             id: stageId,
             name: 'Table clipping regression',
             description: '',
-            language: 'en-US',
+            language: 'zh-CN',
             style: 'professional',
             createdAt: now,
             updatedAt: now,
@@ -58,27 +71,28 @@ async function seedTableClassroom(page: Page) {
                     id: 'table-near-bottom',
                     type: 'table',
                     left: 50,
-                    top: 460,
-                    width: 900,
-                    height: 100,
-                    rotate: 0,
+                    top: geometry.top,
+                    width: geometry.width,
+                    height: geometry.height,
+                    rotate: geometry.rotate,
                     colWidths: [0.5, 0.5],
                     rowHeights: [20, 20, 20, 20, 20],
                     cellMinHeight: 20,
                     outline: { width: 1, color: '#334155', style: 'solid' },
-                    data: labels.map((label, rowIndex) => [
+                    data: rowTexts.map((text, rowIndex) => [
                       {
                         id: `label-${rowIndex}`,
                         colspan: 1,
                         rowspan: 1,
-                        text: label,
+                        text,
                         style: { fontsize: '14px' },
                       },
                       {
                         id: `value-${rowIndex}`,
                         colspan: 1,
                         rowspan: 1,
-                        text: `Value${rowIndex + 1}`,
+                        text:
+                          rowIndex === rowTexts.length - 1 ? finalRowText : `Value${rowIndex + 1}`,
                         style: { fontsize: '14px' },
                       },
                     ]),
@@ -105,82 +119,87 @@ async function seedTableClassroom(page: Page) {
         };
         request.onerror = () => reject(request.error);
       }),
-    { stageId: STAGE_ID, finalRowText: FINAL_ROW_TEXT, theme: defaultTheme },
+    {
+      stageId: STAGE_ID,
+      finalRowText: FINAL_ROW_TEXT,
+      rowTexts: ROW_TEXTS,
+      theme: defaultTheme,
+      geometry: {
+        top: TABLE_TOP,
+        width: TABLE_WIDTH,
+        height: TABLE_HEIGHT,
+        rotate: TABLE_ROTATE,
+      },
+    },
   );
 }
 
-test('keeps the final table row visible in the thumbnail and default classroom canvas', async ({
+async function readSurface(locator: Locator) {
+  await expect(locator).toHaveCount(1);
+
+  return locator.evaluate((element) => {
+    const table = element.querySelector('table');
+    if (!table) throw new Error('Could not resolve the rendered HTML table');
+
+    const rows = Array.from(table.querySelectorAll('tr'));
+    const finalRow = rows.at(-1);
+    if (!finalRow) throw new Error('Could not resolve the final table row');
+
+    const wrappedRowCount = rows.filter((row) => {
+      const firstCell = row.querySelector('td');
+      if (!firstCell) return false;
+
+      const walker = document.createTreeWalker(firstCell, NodeFilter.SHOW_TEXT);
+      let fragments = 0;
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        if (!node.textContent?.trim()) continue;
+        const range = document.createRange();
+        range.selectNodeContents(node);
+        fragments += Array.from(range.getClientRects()).filter(
+          (rect) => rect.width > 0 && rect.height > 0,
+        ).length;
+      }
+      return fragments >= 2;
+    }).length;
+
+    const elementRect = element.getBoundingClientRect();
+    const tableRect = table.getBoundingClientRect();
+    const finalRowRect = finalRow.getBoundingClientRect();
+    const overflowRatio = (bottom: number) =>
+      Math.max(0, bottom - elementRect.bottom) / elementRect.height;
+
+    return {
+      rowCount: rows.length,
+      wrappedRowCount,
+      finalRowHeight: finalRowRect.height,
+      tableOverflowRatio: overflowRatio(tableRect.bottom),
+      finalRowOverflowRatio: overflowRatio(finalRowRect.bottom),
+    };
+  });
+}
+
+test('keeps wrapped table rows visible in the thumbnail and default classroom canvas', async ({
   page,
 }, testInfo) => {
+  expect(TABLE_ROTATE, 'bounding-box assertions require an unrotated fixture').toBe(0);
+
   await seedTableClassroom(page);
   await page.goto(`/classroom/${STAGE_ID}`);
   await page.getByText('Loading classroom...').waitFor({ state: 'hidden', timeout: 15_000 });
 
-  const renderedTables = page.locator('.base-element-table').filter({ hasText: FINAL_ROW_TEXT });
-  await expect(renderedTables).toHaveCount(2);
-
-  const metrics = await renderedTables.evaluateAll((tables) =>
-    tables
-      .map((element) => {
-        const table = element.querySelector('table');
-        if (!table) throw new Error('Could not resolve the rendered HTML table');
-
-        const rows = Array.from(table.querySelectorAll('tr'));
-        const finalRow = rows.at(-1);
-        const finalCell = finalRow?.querySelector('td');
-        const finalCellInner = finalCell?.firstElementChild;
-        const tableRect = table.getBoundingClientRect();
-        const rowRect = finalRow?.getBoundingClientRect();
-        const cellRect = finalCell?.getBoundingClientRect();
-        const cellInnerRect = finalCellInner?.getBoundingClientRect();
-        const textRange = document.createRange();
-        if (finalCellInner) textRange.selectNodeContents(finalCellInner);
-        const textRect = textRange.getBoundingClientRect();
-
-        let clippingBoundary = element.parentElement;
-        while (clippingBoundary) {
-          const style = getComputedStyle(clippingBoundary);
-          if (
-            style.overflow === 'hidden' ||
-            style.overflowX === 'hidden' ||
-            style.overflowY === 'hidden'
-          ) {
-            break;
-          }
-          clippingBoundary = clippingBoundary.parentElement;
-        }
-
-        if (!rowRect || !cellRect || !cellInnerRect || !clippingBoundary) {
-          throw new Error(
-            'Could not resolve the rendered table row, cell, inner content, and slide clipping boundary',
-          );
-        }
-
-        const boundaryRect = clippingBoundary.getBoundingClientRect();
-        const visibleTop = Math.max(rowRect.top, boundaryRect.top);
-        const visibleBottom = Math.min(rowRect.bottom, boundaryRect.bottom);
-
-        return {
-          width: tableRect.width,
-          rowCount: rows.length,
-          tableBottom: tableRect.bottom,
-          boundaryBottom: boundaryRect.bottom,
-          finalRowHeight: rowRect.height,
-          finalRowVisibleHeight: Math.max(0, visibleBottom - visibleTop),
-          finalTextHeight: textRect.height,
-          finalTextVisibleHeight: Math.max(
-            0,
-            Math.min(textRect.bottom, boundaryRect.bottom) -
-              Math.max(textRect.top, boundaryRect.top),
-          ),
-          renderer: element.closest('.screen-element') ? 'legacy' : 'package',
-        };
-      })
-      .sort((left, right) => right.width - left.width),
-  );
+  const legacyTable = page
+    .locator('.screen-element .base-element-table')
+    .filter({ hasText: FINAL_ROW_TEXT });
+  const thumbnailTable = page
+    .locator('.thumbnail-slide .base-element-table')
+    .filter({ hasText: FINAL_ROW_TEXT });
+  const surfaces = {
+    legacy: await readSurface(legacyTable),
+    package: await readSurface(thumbnailTable),
+  };
 
   await testInfo.attach('table clipping metrics', {
-    body: JSON.stringify(metrics, null, 2),
+    body: JSON.stringify(surfaces, null, 2),
     contentType: 'application/json',
   });
   await testInfo.attach('table clipping classroom', {
@@ -188,16 +207,18 @@ test('keeps the final table row visible in the thumbnail and default classroom c
     contentType: 'image/png',
   });
 
-  const [classroom, thumbnail] = metrics;
-  expect(classroom.renderer).toBe('legacy');
-  expect(thumbnail.renderer).toBe('package');
-  expect(classroom.rowCount).toBe(5);
-  expect(thumbnail.rowCount).toBe(classroom.rowCount);
-
-  for (const surface of [classroom, thumbnail]) {
-    expect(surface.tableBottom).toBeLessThanOrEqual(surface.boundaryBottom + 1);
-    expect(surface.finalRowVisibleHeight).toBeGreaterThanOrEqual(surface.finalRowHeight - 1);
-    expect(surface.finalTextHeight).toBeGreaterThan(0);
-    expect(surface.finalTextVisibleHeight).toBeGreaterThanOrEqual(surface.finalTextHeight - 1);
+  for (const [name, surface] of Object.entries(surfaces)) {
+    expect(surface.rowCount, `${name}: row count`).toBe(ROW_TEXTS.length);
+    expect(surface.wrappedRowCount, `${name}: wrapped row count`).toBe(ROW_TEXTS.length);
+    expect(surface.finalRowHeight, `${name}: final row has visible geometry`).toBeGreaterThan(0);
+    expect(surface.tableOverflowRatio, `${name}: table escapes its element`).toBeLessThanOrEqual(
+      0.01,
+    );
+    expect(
+      surface.finalRowOverflowRatio,
+      `${name}: final row escapes its element`,
+    ).toBeLessThanOrEqual(0.01);
   }
+
+  expect(surfaces.package.rowCount).toBe(surfaces.legacy.rowCount);
 });

--- a/e2e/tests/table-playback-clipping-1365.spec.ts
+++ b/e2e/tests/table-playback-clipping-1365.spec.ts
@@ -58,9 +58,9 @@ async function seedTableClassroom(page: Page) {
                     id: 'table-near-bottom',
                     type: 'table',
                     left: 50,
-                    top: 460,
+                    top: 440,
                     width: 900,
-                    height: 100,
+                    height: 120,
                     rotate: 0,
                     colWidths: [0.5, 0.5],
                     rowHeights: [20, 20, 20, 20, 20],
@@ -109,7 +109,7 @@ async function seedTableClassroom(page: Page) {
   );
 }
 
-test('keeps every table row visible in the thumbnail and default classroom canvas', async ({
+test('keeps table rows visible and cell content aligned in both renderers', async ({
   page,
 }, testInfo) => {
   await seedTableClassroom(page);
@@ -127,8 +127,12 @@ test('keeps every table row visible in the thumbnail and default classroom canva
 
         const rows = Array.from(table.querySelectorAll('tr'));
         const finalRow = rows.at(-1);
+        const finalCell = finalRow?.querySelector('td');
+        const finalCellInner = finalCell?.firstElementChild;
         const tableRect = table.getBoundingClientRect();
         const rowRect = finalRow?.getBoundingClientRect();
+        const cellRect = finalCell?.getBoundingClientRect();
+        const cellInnerRect = finalCellInner?.getBoundingClientRect();
 
         let clippingBoundary = element.parentElement;
         while (clippingBoundary) {
@@ -143,8 +147,10 @@ test('keeps every table row visible in the thumbnail and default classroom canva
           clippingBoundary = clippingBoundary.parentElement;
         }
 
-        if (!rowRect || !clippingBoundary) {
-          throw new Error('Could not resolve the rendered table row and slide clipping boundary');
+        if (!rowRect || !cellRect || !cellInnerRect || !clippingBoundary) {
+          throw new Error(
+            'Could not resolve the rendered table row, cell, inner content, and slide clipping boundary',
+          );
         }
 
         const boundaryRect = clippingBoundary.getBoundingClientRect();
@@ -158,6 +164,11 @@ test('keeps every table row visible in the thumbnail and default classroom canva
           boundaryBottom: boundaryRect.bottom,
           finalRowHeight: rowRect.height,
           finalRowVisibleHeight: Math.max(0, visibleBottom - visibleTop),
+          finalCellHeight: cellRect.height,
+          finalCellInnerHeight: cellInnerRect.height,
+          finalCellInnerCenterOffset:
+            (cellInnerRect.top + cellInnerRect.bottom - cellRect.top - cellRect.bottom) / 2,
+          renderer: element.closest('.screen-element') ? 'legacy' : 'package',
         };
       })
       .sort((left, right) => right.width - left.width),
@@ -173,6 +184,8 @@ test('keeps every table row visible in the thumbnail and default classroom canva
   });
 
   const [classroom, thumbnail] = metrics;
+  expect(classroom.renderer).toBe('legacy');
+  expect(thumbnail.renderer).toBe('package');
   expect(classroom.rowCount).toBe(5);
   expect(thumbnail.rowCount).toBe(classroom.rowCount);
 
@@ -180,4 +193,10 @@ test('keeps every table row visible in the thumbnail and default classroom canva
     expect(surface.tableBottom).toBeLessThanOrEqual(surface.boundaryBottom + 1);
     expect(surface.finalRowVisibleHeight).toBeGreaterThanOrEqual(surface.finalRowHeight - 1);
   }
+
+  // The table is taller than the sum of its declared row heights, so Chromium
+  // expands the rows. Default vertical centering must still use the full cell,
+  // not only the inner rowHeight - 4 wrapper.
+  expect(classroom.finalCellHeight).toBeGreaterThan(classroom.finalCellInnerHeight + 1);
+  expect(Math.abs(classroom.finalCellInnerCenterOffset)).toBeLessThanOrEqual(1);
 });

--- a/e2e/tests/table-playback-clipping-1365.spec.ts
+++ b/e2e/tests/table-playback-clipping-1365.spec.ts
@@ -145,22 +145,21 @@ async function readSurface(locator: Locator) {
     const finalRow = rows.at(-1);
     if (!finalRow) throw new Error('Could not resolve the final table row');
 
-    const wrappedRowCount = rows.filter((row) => {
-      const firstCell = row.querySelector('td');
-      if (!firstCell) return false;
-
-      const walker = document.createTreeWalker(firstCell, NodeFilter.SHOW_TEXT);
-      let fragments = 0;
-      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-        if (!node.textContent?.trim()) continue;
-        const range = document.createRange();
-        range.selectNodeContents(node);
-        fragments += Array.from(range.getClientRects()).filter(
-          (rect) => rect.width > 0 && rect.height > 0,
-        ).length;
-      }
-      return fragments >= 2;
-    }).length;
+    const wrappedRowCount = rows.filter((row) =>
+      Array.from(row.querySelectorAll('td')).some((cell) => {
+        const walker = document.createTreeWalker(cell, NodeFilter.SHOW_TEXT);
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+          if (!node.textContent?.trim()) continue;
+          const range = document.createRange();
+          range.selectNodeContents(node);
+          const fragments = Array.from(range.getClientRects()).filter(
+            (rect) => rect.width > 0 && rect.height > 0,
+          );
+          if (fragments.length >= 2) return true;
+        }
+        return false;
+      }),
+    ).length;
 
     const elementRect = element.getBoundingClientRect();
     const tableRect = table.getBoundingClientRect();

--- a/e2e/tests/table-playback-clipping-1365.spec.ts
+++ b/e2e/tests/table-playback-clipping-1365.spec.ts
@@ -58,9 +58,9 @@ async function seedTableClassroom(page: Page) {
                     id: 'table-near-bottom',
                     type: 'table',
                     left: 50,
-                    top: 440,
+                    top: 460,
                     width: 900,
-                    height: 120,
+                    height: 100,
                     rotate: 0,
                     colWidths: [0.5, 0.5],
                     rowHeights: [20, 20, 20, 20, 20],
@@ -109,7 +109,7 @@ async function seedTableClassroom(page: Page) {
   );
 }
 
-test('keeps table rows visible and cell content aligned in both renderers', async ({
+test('keeps the final table row visible in the thumbnail and default classroom canvas', async ({
   page,
 }, testInfo) => {
   await seedTableClassroom(page);
@@ -133,6 +133,9 @@ test('keeps table rows visible and cell content aligned in both renderers', asyn
         const rowRect = finalRow?.getBoundingClientRect();
         const cellRect = finalCell?.getBoundingClientRect();
         const cellInnerRect = finalCellInner?.getBoundingClientRect();
+        const textRange = document.createRange();
+        if (finalCellInner) textRange.selectNodeContents(finalCellInner);
+        const textRect = textRange.getBoundingClientRect();
 
         let clippingBoundary = element.parentElement;
         while (clippingBoundary) {
@@ -164,10 +167,12 @@ test('keeps table rows visible and cell content aligned in both renderers', asyn
           boundaryBottom: boundaryRect.bottom,
           finalRowHeight: rowRect.height,
           finalRowVisibleHeight: Math.max(0, visibleBottom - visibleTop),
-          finalCellHeight: cellRect.height,
-          finalCellInnerHeight: cellInnerRect.height,
-          finalCellInnerCenterOffset:
-            (cellInnerRect.top + cellInnerRect.bottom - cellRect.top - cellRect.bottom) / 2,
+          finalTextHeight: textRect.height,
+          finalTextVisibleHeight: Math.max(
+            0,
+            Math.min(textRect.bottom, boundaryRect.bottom) -
+              Math.max(textRect.top, boundaryRect.top),
+          ),
           renderer: element.closest('.screen-element') ? 'legacy' : 'package',
         };
       })
@@ -192,11 +197,7 @@ test('keeps table rows visible and cell content aligned in both renderers', asyn
   for (const surface of [classroom, thumbnail]) {
     expect(surface.tableBottom).toBeLessThanOrEqual(surface.boundaryBottom + 1);
     expect(surface.finalRowVisibleHeight).toBeGreaterThanOrEqual(surface.finalRowHeight - 1);
+    expect(surface.finalTextHeight).toBeGreaterThan(0);
+    expect(surface.finalTextVisibleHeight).toBeGreaterThanOrEqual(surface.finalTextHeight - 1);
   }
-
-  // The table is taller than the sum of its declared row heights, so Chromium
-  // expands the rows. Default vertical centering must still use the full cell,
-  // not only the inner rowHeight - 4 wrapper.
-  expect(classroom.finalCellHeight).toBeGreaterThan(classroom.finalCellInnerHeight + 1);
-  expect(Math.abs(classroom.finalCellInnerCenterOffset)).toBeLessThanOrEqual(1);
 });

--- a/skills/agent-runtime/slide-dsl/SKILL.md
+++ b/skills/agent-runtime/slide-dsl/SKILL.md
@@ -298,8 +298,8 @@ always the same: **write for the intersection.** The known divergences are
   playback (see [the HTML section](#the-rendering-truth-of-content-html));
 - **`paragraphSpace` on a text element** — honoured by the preview renderer, inert
   in playback;
-- **`vAlign` on a text element and `vAlign` / `padding` / `borders` on a table
-  cell** — honoured by the preview renderer, ignored in playback;
+- **`vAlign` on a text element and per-side `borders` on a table cell** — honoured
+  by the preview renderer, ignored in playback;
 - **a plain-text `content` with newlines** — the preview renderer sets
   `white-space: pre-line` when the string contains no markup at all, so the
   newlines become line breaks; playback does not, so they collapse to spaces;
@@ -568,9 +568,9 @@ white text; `rowFooter` does the same to the last row; `colHeader` / `colFooter`
 paint the first / last column in `theme.color` at 30 % alpha; every other even row
 gets it at 10 %. A cell's own `style.backcolor` and `style.color` beat all of it.
 
-**Fields playback ignores** (preview renderer honours them): `cell.vAlign` —
-playback always centres vertically; `cell.padding` — playback always uses 5 px;
-`cell.borders` — playback always draws the table-level `outline` on all four sides.
+**Field playback ignores** (preview renderer honours it): `cell.borders` — playback
+always draws the table-level `outline` on all four sides. Both renderers honour
+`cell.padding` and `cell.vAlign`.
 
 **Merged cells are fragile.** Both renderers expect `data[r]` to contain only the
 top-left cell of each merge, with the spanned positions absent, and playback's

--- a/skills/agent-runtime/slide-dsl/SKILL.md
+++ b/skills/agent-runtime/slide-dsl/SKILL.md
@@ -571,7 +571,9 @@ gets it at 10 %. A cell's own `style.backcolor` and `style.color` beat all of it
 
 **Field playback ignores** (preview renderer honours it): `cell.borders` — playback
 always draws the table-level `outline` on all four sides. Both renderers honour
-`cell.padding` and `cell.vAlign`.
+`cell.padding`. `cell.vAlign` only aligns text inside the declared row-height
+content box; if the browser stretches the row, that box remains centred in the
+full cell.
 
 `cell.padding` has no implicit default: omit it for no inset, or provide a CSS
 padding string such as `5px` or `3px 6px`. Both renderers use `line-height: 1`

--- a/skills/agent-runtime/slide-dsl/SKILL.md
+++ b/skills/agent-runtime/slide-dsl/SKILL.md
@@ -529,7 +529,7 @@ geometry.
 | --------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `colWidths`     | number[]                                                             | **Ratios that sum to 1.** Column px = `colWidths[i] × element width`          |
 | `cellMinHeight` | number (px)                                                          | Row height fallback; content taller than it still expands the row             |
-| `rowHeights`    | number[] (optional)                                                  | Per-row height, overriding `cellMinHeight` for that row                       |
+| `rowHeights`    | number[] (optional)                                                  | Per-row minimum, overriding `cellMinHeight`; wrapped content can expand it    |
 | `outline`       | `{ style?, width?, color? }`                                         | The uniform grid border. Missing `width` → **1 px**, missing `color` → **black** |
 | `theme`         | `{ color, rowHeader, rowFooter, colHeader, colFooter }` (optional)    | Banding — see below                                                          |
 | `data`          | `TableCell[][]`                                                      | Row-major grid                                                               |
@@ -555,8 +555,9 @@ becomes `&nbsp;`**. That has three consequences you must design around:
    becomes `style="color:&nbsp;red"`, which is not a valid declaration, so the colour
    is dropped. Same for any attribute value with a space in it, and for a
    two-class `class`. Cell appearance comes from `cell.style`, not from markup.
-3. Text with spaces will **not wrap** at those spaces. Long prose in a cell
-   overflows sideways instead of re-flowing.
+3. Text with spaces will **not wrap** at those spaces. Playback's
+   `word-break: break-word` can still re-flow long prose, but it may break in the
+   middle of a word instead of at the spaces as the preview renderer does.
 
 So: put plain text in a cell, use `\n` for breaks, use `cell.style` for appearance,
 and reach for attribute-free tags (`<strong>`, `<br/>`) only if you must. The preview
@@ -571,6 +572,10 @@ gets it at 10 %. A cell's own `style.backcolor` and `style.color` beat all of it
 **Field playback ignores** (preview renderer honours it): `cell.borders` — playback
 always draws the table-level `outline` on all four sides. Both renderers honour
 `cell.padding` and `cell.vAlign`.
+
+`cell.padding` has no implicit default: omit it for no inset, or provide a CSS
+padding string such as `5px` or `3px 6px`. Both renderers use `line-height: 1`
+for cell text.
 
 **Merged cells are fragile.** Both renderers expect `data[r]` to contain only the
 top-left cell of each merge, with the spanned positions absent, and playback's

--- a/tests/slide-renderer/edit-elements-render-contract.test.ts
+++ b/tests/slide-renderer/edit-elements-render-contract.test.ts
@@ -111,7 +111,7 @@ describe('edit_elements renderer contracts', () => {
     }
   });
 
-  it('renders explicit table row heights in the app renderer', () => {
+  it('renders explicit row heights and package-aligned cell geometry in the app renderer', () => {
     const table = {
       id: 'table-1',
       type: 'table',
@@ -120,7 +120,10 @@ describe('edit_elements renderer contracts', () => {
       width: 200,
       height: 100,
       rotate: 0,
-      data: [[{ id: 'a', text: 'A' }], [{ id: 'b', text: 'B' }]],
+      data: [
+        [{ id: 'a', text: 'A', padding: '2px 4px', vAlign: 'bottom' }],
+        [{ id: 'b', text: 'B' }],
+      ],
       colWidths: [1],
       rowHeights: [20, 80],
       cellMinHeight: 36,
@@ -129,6 +132,11 @@ describe('edit_elements renderer contracts', () => {
     const markup = renderToStaticMarkup(React.createElement(StaticTable, { elementInfo: table }));
     expect(markup).toContain('height:20px');
     expect(markup).toContain('height:80px');
+    expect(markup).toContain('min-height:16px');
+    expect(markup).toContain('padding:2px 4px');
+    expect(markup).toContain('line-height:1');
+    expect(markup).toContain('justify-content:flex-end');
+    expect(markup).not.toContain('padding:5px');
   });
 
   it('fills the element height in the package table fallback path', () => {

--- a/tests/slide-renderer/edit-elements-render-contract.test.ts
+++ b/tests/slide-renderer/edit-elements-render-contract.test.ts
@@ -136,6 +136,8 @@ describe('edit_elements renderer contracts', () => {
     expect(markup).toContain('padding:2px 4px');
     expect(markup).toContain('line-height:1');
     expect(markup).toContain('justify-content:flex-end');
+    expect(markup).toContain('vertical-align:bottom');
+    expect(markup).toContain('vertical-align:middle');
     expect(markup).not.toContain('padding:5px');
   });
 

--- a/tests/slide-renderer/edit-elements-render-contract.test.ts
+++ b/tests/slide-renderer/edit-elements-render-contract.test.ts
@@ -111,7 +111,7 @@ describe('edit_elements renderer contracts', () => {
     }
   });
 
-  it('renders explicit row heights and package-aligned cell geometry in the app renderer', () => {
+  it('uses the same compact table cell geometry in both renderers', () => {
     const table = {
       id: 'table-1',
       type: 'table',
@@ -129,16 +129,16 @@ describe('edit_elements renderer contracts', () => {
       cellMinHeight: 36,
       outline: { width: 1, color: '#000000' },
     } as PPTTableElement;
-    const markup = renderToStaticMarkup(React.createElement(StaticTable, { elementInfo: table }));
-    expect(markup).toContain('height:20px');
-    expect(markup).toContain('height:80px');
-    expect(markup).toContain('min-height:16px');
-    expect(markup).toContain('padding:2px 4px');
-    expect(markup).toContain('line-height:1');
-    expect(markup).toContain('justify-content:flex-end');
-    expect(markup).toContain('vertical-align:bottom');
-    expect(markup).toContain('vertical-align:middle');
-    expect(markup).not.toContain('padding:5px');
+    for (const Component of [StaticTable, PackageStaticTable]) {
+      const markup = renderToStaticMarkup(React.createElement(Component, { elementInfo: table }));
+      expect(markup).toContain('height:20px');
+      expect(markup).toContain('height:80px');
+      expect(markup).toContain('min-height:16px');
+      expect(markup).toContain('padding:2px 4px');
+      expect(markup).toContain('line-height:1');
+      expect(markup).toContain('justify-content:flex-end');
+      expect(markup).not.toContain('padding:5px');
+    }
   });
 
   it('fills the element height in the package table fallback path', () => {


### PR DESCRIPTION
## Summary

- align the legacy classroom table geometry with `@openmaic/renderer`
- use DSL-provided cell padding and a deterministic compact line-height instead of legacy host-page defaults
- add a real-browser regression that compares the default classroom canvas with the package-rendered thumbnail
- document that row heights are minimums and clarify the two renderers' text-wrapping behavior

## Root cause

Thumbnails and default classroom playback render the same slide through different table implementations. The legacy table put a fixed `5px` padding directly on every `<td>` and inherited line-height from the host page. HTML row heights are minimums, not hard caps, so those intrinsic cell dimensions expanded every row beyond the slide data's `rowHeights`. Near the bottom of the canvas, the enlarged table crossed the existing clipping boundary and its final rows disappeared.

The slide data is not changed. The legacy path now reuses the package renderer's existing inner-cell geometry: `rowHeight - 4` minimum height, `cell.padding`, `line-height: 1`, and flex-based `cell.vAlign`.

## Scope

This deliberately does not remove canvas clipping, constrain legitimately overfull tables, auto-fit text, migrate stored slide data, or change `@openmaic/renderer`. Those would solve different problems or alter the already-correct thumbnail output.

## User-level regression

The Chromium test opens the real classroom route with a five-row table near the bottom of a 1000 × 562.5 slide. Each row is verified to contain a softly wrapped cell, and the table element is 180px high: between the old legacy intrinsic height (~266px) and the aligned legacy/package height (~146px).

The test locates each renderer explicitly, checks that both render all five wrapped rows, and compares transformed browser rectangles using scale-independent overflow ratios. Its measurements do not depend on the new inner wrapper, so the old implementation fails for the actual geometry defect: the legacy table extends **47.78%** beyond its element. With the fix, both the default classroom canvas and thumbnail keep the table and final row within the element.

## Visual verification

Captured from the same real classroom E2E fixture (not a component-level mock):

| Before: legacy classroom renderer | After: this PR |
| --- | --- |
| <img width="1280" height="720" alt="Legacy classroom renderer clips the final table row" src="https://github.com/user-attachments/assets/325e9f59-f3a5-4b97-8a06-a7d4c749b868" /> | <img width="1280" height="720" alt="Fixed classroom renderer shows all five table rows" src="https://github.com/user-attachments/assets/626d1d92-bdcd-4ad3-983b-585b6a527804" /> |

## Verification

- GitHub CI: all 4 required checks passed
- Node 22 Chromium classroom regression: 1 passed
- controlled pre-fix run: failed at the table-overflow assertion (47.78%)
- Node 22 renderer contract tests: 6 passed
- Node 22 TypeScript check: passed
- focused ESLint and Prettier: passed
- Node engine, package-version, and internal-dependency checks: passed
- `git diff --check`: passed

Fixes #1365
