### PR TITLE
fix(generation): assign unique IDs per media request

### DIFF
--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/src/outline-media.ts
+++ b/packages/@openmaic/generation/src/outline-media.ts
@@ -1,30 +1,18 @@
 import { nanoid } from 'nanoid';
 import type { SceneOutline } from './outline-types.js';
 
-/** Replace course-local generated-media IDs with globally unique IDs. */
+/** Give every generated-media request its own globally unique ID. */
 export function uniquifyMediaElementIds(outlines: SceneOutline[]): SceneOutline[] {
-  const idMap = new Map<string, string>();
-
-  for (const outline of outlines) {
-    if (!outline.mediaGenerations) continue;
-    for (const mediaGeneration of outline.mediaGenerations) {
-      if (!idMap.has(mediaGeneration.elementId)) {
-        const prefix = mediaGeneration.type === 'video' ? 'gen_vid_' : 'gen_img_';
-        idMap.set(mediaGeneration.elementId, `${prefix}${nanoid(8)}`);
-      }
-    }
-  }
-
-  if (idMap.size === 0) return outlines;
+  if (!outlines.some((outline) => outline.mediaGenerations?.length)) return outlines;
 
   return outlines.map((outline) => {
     if (!outline.mediaGenerations) return outline;
     return {
       ...outline,
-      mediaGenerations: outline.mediaGenerations.map((mediaGeneration) => ({
-        ...mediaGeneration,
-        elementId: idMap.get(mediaGeneration.elementId) || mediaGeneration.elementId,
-      })),
+      mediaGenerations: outline.mediaGenerations.map((mediaGeneration) => {
+        const prefix = mediaGeneration.type === 'video' ? 'gen_vid_' : 'gen_img_';
+        return { ...mediaGeneration, elementId: `${prefix}${nanoid(8)}` };
+      }),
     };
   });
 }

--- a/packages/@openmaic/generation/test/outline-media.test.ts
+++ b/packages/@openmaic/generation/test/outline-media.test.ts
@@ -1,9 +1,17 @@
-// Behavior-parity coverage for uniquifyMediaElementIds from lib/generation/scene-builder.ts.
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { uniquifyMediaElementIds, type SceneOutline } from '@openmaic/generation';
 
+const nanoid = vi.hoisted(() => vi.fn());
+
+vi.mock('nanoid', () => ({ nanoid }));
+
 describe('uniquifyMediaElementIds', () => {
-  test('replaces colliding generated IDs consistently without mutating the input', () => {
+  beforeEach(() => {
+    let sequence = 0;
+    nanoid.mockImplementation(() => String(++sequence).padStart(8, '0'));
+  });
+
+  test('assigns every generation request a globally unique ID without mutating the input', () => {
     const outlines: SceneOutline[] = [1, 2].map((order) => ({
       id: `scene_${order}`,
       type: 'slide',
@@ -12,18 +20,28 @@ describe('uniquifyMediaElementIds', () => {
       keyPoints: [],
       order,
       mediaGenerations: [
-        { type: 'image', prompt: 'A diagram', elementId: 'gen_img_1' },
-        { type: 'video', prompt: 'A clip', elementId: `custom_${order}` },
+        { type: 'image', prompt: `Diagram ${order}`, elementId: 'gen_img_1' },
+        { type: 'video', prompt: `Clip ${order}`, elementId: `custom_${order}` },
       ],
     }));
 
     const result = uniquifyMediaElementIds(outlines);
-    const firstId = result[0]?.mediaGenerations?.[0]?.elementId;
+    const resultIds = result.flatMap((outline) =>
+      (outline.mediaGenerations ?? []).map((request) => request.elementId),
+    );
 
-    expect(firstId).toMatch(/^gen_img_[A-Za-z0-9_-]{8}$/);
-    expect(result[1]?.mediaGenerations?.[0]?.elementId).toBe(firstId);
-    expect(result[0]?.mediaGenerations?.[1]?.elementId).toMatch(/^gen_vid_[A-Za-z0-9_-]{8}$/);
-    expect(outlines[0]?.mediaGenerations?.[0]?.elementId).toBe('gen_img_1');
+    expect(resultIds).toEqual([
+      'gen_img_00000001',
+      'gen_vid_00000002',
+      'gen_img_00000003',
+      'gen_vid_00000004',
+    ]);
+    expect(new Set(resultIds).size).toBe(resultIds.length);
+    expect(
+      outlines.flatMap((outline) =>
+        (outline.mediaGenerations ?? []).map((request) => request.elementId),
+      ),
+    ).toEqual(['gen_img_1', 'custom_1', 'gen_img_1', 'custom_2']);
   });
 
   test('returns the original array when no media IDs exist', () => {


### PR DESCRIPTION
## Summary

Give every generated-media request its own globally unique ID instead of reusing one replacement for repeated model-supplied placeholders. This prevents distinct image or video generations from overwriting each other in task state, IndexedDB, server files, manifests, and media maps.

## Related Issues

Fixes #1367

## Root Cause

`uniquifyMediaElementIds` previously built an `oldId -> newId` map. When the outline model emitted two distinct requests with the same placeholder, both requests received the same replacement even though every downstream consumer treats `elementId` as a unique key.

The prompt contract defines reuse differently: one generation request may be referenced from later content, but a later scene must not add another `mediaGenerations` entry for the same ID.

## Changes

- allocate a fresh type-prefixed ID for each `mediaGenerations` request
- keep the input immutable and preserve the original array when there are no media requests
- make the existing regression deterministic and cover distinct requests that repeat an incoming ID
- bump `@openmaic/generation` from `0.3.5` to `0.3.6`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Pass two scene outlines with different prompts but the same incoming `elementId` to `uniquifyMediaElementIds`.
2. On `main`, observe that both output requests receive one shared ID.
3. On this branch, observe that each request receives a separate ID with the prefix matching its media type.

### What you personally verified

- focused regression passes on Node.js 22.19.0 and Node.js 24
- related browser-orchestrator and video-manifest tests: 15/15 passed
- related generation prompt/manifest tests: 9/9 passed
- generation typecheck and package build passed
- Prettier, root TypeScript, i18n, Node engine, package-version, and internal-dependency checks passed
- ESLint completed with 0 errors and the existing 18 warnings
- production build and the generation Node consumer smoke passed
- full generation suite: 144 passed; the only failure is the existing Windows path-separator assertion in `test/assets.test.ts`
- full root suite on Windows: 7,334 passed; remaining failures are existing Windows-only path/shell assumptions and load-sensitive timeouts; the complete Linux CI suite passed

### Evidence

Before, two distinct requests such as `Diagram 1 / gen_img_1` and `Diagram 2 / gen_img_1` received the same random replacement within a run. The deterministic regression now produces:

```text
gen_img_00000001
gen_vid_00000002
gen_img_00000003
gen_vid_00000004
```

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (no UI change)

## AI Assistance

AI-assisted. The final diff was self-reviewed separately against repository standards, Issue #1367, and adversarial correctness/compatibility concerns; all three reviews reported no findings.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings