### PR TITLE
fix(ai): enable streaming compatibility for OpenAI protocol providers

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1835,7 +1835,7 @@ function usesCustomOpenAIBaseUrl(baseUrl?: string): boolean {
 
 function shouldUseOpenAIStreamingChatCompat(providerId: ProviderId, baseUrl?: string): boolean {
   return (
-    providerId === 'openai' &&
+    PROVIDERS[providerId]?.type === 'openai' &&
     usesCustomOpenAIBaseUrl(baseUrl) &&
     process.env.OPENAI_COMPAT_USE_STREAMING_CHAT === 'true'
   );

--- a/tests/ai/openai-provider.test.ts
+++ b/tests/ai/openai-provider.test.ts
@@ -206,6 +206,23 @@ describe('OpenAI provider defaults', () => {
     expect(openAiMock.responses).not.toHaveBeenCalled();
   });
 
+  it('routes OpenAI-compatible built-in providers through Chat Completions when enabled', () => {
+    vi.stubEnv('OPENAI_COMPAT_USE_STREAMING_CHAT', 'true');
+
+    getModel({
+      providerId: 'glm',
+      modelId: 'glm-5',
+      apiKey: 'sk-test',
+    });
+
+    const options = openAiMock.createOpenAI.mock.calls.at(-1)?.[0] as
+      | { fetch?: typeof fetch }
+      | undefined;
+    expect(options?.fetch).toBeTypeOf('function');
+    expect(openAiMock.chat).toHaveBeenCalledWith('glm-5');
+    expect(openAiMock.responses).not.toHaveBeenCalled();
+  });
+
   it.each([
     'https://api.openai.com/v1/',
     ' https://API.openai.com/v1 ',


### PR DESCRIPTION
Closes #847

## Executive Summary

Long-running scene generation can fail after approximately five minutes when an OpenAI-compatible provider with a custom endpoint withholds response headers until its non-streaming response is complete. This change lets the existing opt-in streaming compatibility path apply to every registered provider using the OpenAI protocol, including GLM and Qwen, while preserving default behavior.

AI-assisted PR; the implementation and diff were self-reviewed before submission.

## Technical Design Document

### Problem and root cause

The compatibility gate in lib/ai/providers.ts only matched providerId openai. Built-in providers such as glm and qwen use the same OpenAI protocol and custom endpoints, but could not opt into the existing streaming Chat Completions adapter. Their non-streaming calls could reach the upstream undici headers timeout before any response headers arrived.

### Design

Change the gate predicate from a literal provider ID check to the provider registry protocol type check:

Provider registry entry -> type=openai -> custom base URL -> opt-in environment flag -> streaming Chat Completions adapter

The environment flag remains OPENAI_COMPAT_USE_STREAMING_CHAT=true, custom OpenAI endpoints remain required, and the default false path is unchanged. The OpenAI Responses API selection remains limited to OpenAI provider IDs and is unaffected.

### Compatibility and risk

This is non-breaking and opt-in. Providers without type=openai, requests using the official OpenAI endpoint, and deployments without the flag retain their prior model routing. The regression test verifies GLM uses Chat Completions and does not use Responses.

## Changes

- Generalize the existing streaming compatibility gate to registered OpenAI-protocol providers.
- Add a GLM regression test for the provider routing decision.
- No API response, UI, configuration default, or user-facing text changes.

## Visual Proof

```text
Before: glm + custom endpoint + flag -> Responses/non-streaming path -> headers timeout risk
After:  glm + custom endpoint + flag -> Chat Completions streaming path -> headers arrive promptly
Default: any provider + flag unset/false -> existing routing behavior
```

## Verification

### Steps to reproduce / test

1. Configure GLM or another OpenAI-compatible provider with a custom base URL.
2. Set OPENAI_COMPAT_USE_STREAMING_CHAT=true.
3. Generate a long scene-content response and verify the provider uses the streaming Chat Completions path.
4. Run pnpm exec vitest run tests/ai/openai-provider.test.ts.

### What was personally verified

- Focused provider suite: 51 passed.
- pnpm check: passed.
- pnpm lint: 0 errors; 18 existing warnings remain in unrelated files.
- npx tsc --noEmit: passed.
- Full pnpm test: 7,346 passed, 26 skipped, 5 unrelated failures in chat-storage and workspace-rail-session-rename tests due their existing timeout/menu assertions.
- git diff --check: passed.
- No live provider credentials were used; the long-running upstream request was not exercised against GLM.

### Evidence

- [x] CI-relevant formatting check passed
- [x] Focused automated regression test passed
- [x] TypeScript check passed
- [x] Self-review completed
- [ ] Manual live-provider verification (requires provider credentials)
- [ ] Screenshots/recordings (not applicable; no UI changes)

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (no user-facing behavior or configuration change)
- [x] My changes do not introduce new warnings
