### PR TITLE
fix(importer): pnpm install fails on Windows

### DIFF
--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/importer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A javascript tool for parsing .pptx file",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/@openmaic/importer/rollup.config.js
+++ b/packages/@openmaic/importer/rollup.config.js
@@ -17,7 +17,7 @@ const plugins = [
   json(),
   typescript({ tsconfig: './tsconfig.json' }),
   terser(),
-  globals(),
+  globals({ dirname: false, filename: false }),
   builtins(),
 ];
 


### PR DESCRIPTION
## Summary

Fix `@openmaic/importer` failing to build on Windows. The importer is a browser bundle, so the Node-only `__filename` / `__dirname` shims from `rollup-plugin-node-globals` are disabled.

## Related Issues

Fixes [#1371](https://github.com/THU-MAIC/OpenMAIC/issues/1371)

## Changes

- In `packages/@openmaic/importer/rollup.config.js`, configure `globals({ dirname: false, filename: false })` to stop generating the broken `export default '<path>'` virtual modules that contain unescaped Windows backslashes.
- Bump `@openmaic/importer` to a patch version, since `rollup.config.js` is a publishable input.

## Type of Change

<!-- Check the relevant options: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1.On Windows, run `pnpm run build` in `packages/@openmaic/importer`.
2.Confirm the build completes without the `Bad character escape sequence` error.

### What you personally verified

- `pnpm run build` in `packages/@openmaic/importer` now succeeds and emits `dist/index.umd.js`, `dist/index.cjs`, `dist/index.js`, and the `.d.ts` files.

### Evidence

<!-- Attach at least one: logs, screenshots, recordings, or before/after comparisons. -->

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
