### PR TITLE
fix(server): bound skill zip inflation instead of trusting declared sizes

### DIFF
--- a/lib/server/skill-export.ts
+++ b/lib/server/skill-export.ts
@@ -1,6 +1,7 @@
 /** Package installed skills for portable download. */
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import { inflateRawSync } from 'node:zlib';
 import JSZip from 'jszip';
 import { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 import { UserSkillError, validateUserSkillInput, type UserSkillFields } from '@openmaic/storage';
@@ -107,6 +108,56 @@ export function parseUserSkillMarkdown(markdown: string): UserSkillUpload {
   }
 }
 
+/** SKILL.md byte ceiling: the 64 KiB content column plus frontmatter headroom. */
+const maxSkillMdBytes = 70_000;
+
+/**
+ * The JSZip internals surface of one loaded entry — the same surface the
+ * declared-size check below reads. `loadAsync` trusts the central directory
+ * only (the local header's size copies are skipped) and eagerly slices the
+ * entry's compressed bytes into `compressedContent` (jszip 3.10.1
+ * `zipEntry.js`/`compressedObject.js`), so the raw stream is available without
+ * inflating it. In a hand-built zip every field here is attacker controlled.
+ */
+type LoadedZipEntryData = {
+  uncompressedSize?: number;
+  compression?: { magic?: string };
+  compressedContent?: Uint8Array;
+};
+
+/**
+ * Decode the SKILL.md entry with a hard output cap instead of `async()`.
+ * `uncompressedSize` is a declaration, not a measurement: a malicious zip
+ * states a tiny size while its deflate stream expands arbitrarily, and JSZip
+ * inflates the real stream first (its own length comparison fires only on the
+ * stream's end event, after the memory is spent). The upload route caps the
+ * archive at 1 MiB and deflate expands up to ~1032:1, so one request could
+ * otherwise grow ~1 GiB in the server process. `maxOutputLength` makes zlib
+ * abort the moment output crosses the cap, bounding expansion no matter what
+ * the headers claim. STORE entries (the only other method JSZip registers,
+ * magic `\x00\x00`) carry the content verbatim in `compressedContent`, so they
+ * are length checked directly, never inflated.
+ */
+function decodeSkillMdEntry(entry: JSZip.JSZipObject): string {
+  const data = (entry as unknown as { _data?: LoadedZipEntryData })._data;
+  const compressed = data?.compressedContent;
+  if (!compressed) throw new UserSkillUploadError('The skill archive is not a valid zip file.');
+  if (data.compression?.magic === '\u0008\u0000') {
+    try {
+      return inflateRawSync(compressed, { maxOutputLength: maxSkillMdBytes }).toString('utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ERR_BUFFER_TOO_LARGE') {
+        throw new UserSkillUploadError('The archive SKILL.md is too large.');
+      }
+      throw error; // corrupt stream — the caller reports it as an invalid zip
+    }
+  }
+  if (compressed.byteLength > maxSkillMdBytes) {
+    throw new UserSkillUploadError('The archive SKILL.md is too large.');
+  }
+  return Buffer.from(compressed).toString('utf8');
+}
+
 /** Read the single SKILL.md from an exported owner-skill zip. */
 export async function parseUserSkillZip(bytes: Buffer): Promise<UserSkillUpload> {
   try {
@@ -117,11 +168,13 @@ export async function parseUserSkillZip(bytes: Buffer): Promise<UserSkillUpload>
     if (skillFiles.length !== 1) {
       throw new UserSkillUploadError('The archive must contain exactly one SKILL.md file.');
     }
-    const metadata = (skillFiles[0] as unknown as { _data?: { uncompressedSize?: number } })._data;
-    if ((metadata?.uncompressedSize ?? 0) > 70_000) {
+    const metadata = (skillFiles[0] as unknown as { _data?: LoadedZipEntryData })._data;
+    // Honest zips are refused here without inflating; the decode below bounds
+    // the ones whose declared size lies.
+    if ((metadata?.uncompressedSize ?? 0) > maxSkillMdBytes) {
       throw new UserSkillUploadError('The archive SKILL.md is too large.');
     }
-    return parseUserSkillMarkdown(await skillFiles[0]!.async('string'));
+    return parseUserSkillMarkdown(decodeSkillMdEntry(skillFiles[0]!));
   } catch (error) {
     if (error instanceof UserSkillError || error instanceof UserSkillUploadError) throw error;
     throw new UserSkillUploadError('The skill archive is not a valid zip file.');

--- a/tests/server/skill-export.test.ts
+++ b/tests/server/skill-export.test.ts
@@ -24,6 +24,39 @@ function walkRelative(dir: string, base = dir): string[] {
   return out;
 }
 
+/**
+ * Offset of `name`'s record in the zip central directory. JSZip reads entry
+ * sizes only from there (never from the local header), so tests forge declared
+ * sizes at this offset to simulate the lying-header attack.
+ */
+function centralDirectoryEntry(bytes: Buffer, name: string): number {
+  let eocd = -1;
+  for (let i = bytes.length - 22; i >= 0; i -= 1) {
+    if (bytes.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd === -1) throw new Error('test zip has no end-of-central-directory record');
+  let offset = bytes.readUInt32LE(eocd + 16);
+  const count = bytes.readUInt16LE(eocd + 10);
+  for (let entry = 0; entry < count; entry += 1) {
+    if (bytes.readUInt32LE(offset) !== 0x02014b50) {
+      throw new Error('test zip has a broken central directory');
+    }
+    const nameLength = bytes.readUInt16LE(offset + 28);
+    const extraLength = bytes.readUInt16LE(offset + 30);
+    const commentLength = bytes.readUInt16LE(offset + 32);
+    if (bytes.toString('utf8', offset + 46, offset + 46 + nameLength) === name) return offset;
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+  throw new Error(`test zip has no central-directory entry for ${name}`);
+}
+
+function skillMarkdown(body: string): string {
+  return `---\nname: my-skill\ntitle: Title\ndescription: Description\n---\n\n${body}`;
+}
+
 describe('skill export zips', () => {
   it('packages the shipped OpenMAIC skill verbatim under openmaic/', async () => {
     const zip = await buildOpenClawSkillZip();
@@ -88,5 +121,76 @@ describe('skill export zips', () => {
     await expect(
       parseUserSkillZip(await ambiguous.generateAsync({ type: 'nodebuffer' })),
     ).rejects.toThrow(/exactly one SKILL\.md/);
+  });
+
+  it('rejects an honest zip whose SKILL.md exceeds the size cap', async () => {
+    const zip = new JSZip();
+    zip.file('my-skill/SKILL.md', skillMarkdown('x'.repeat(75_000)));
+    await expect(
+      parseUserSkillZip(await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' })),
+    ).rejects.toThrow('The archive SKILL.md is too large.');
+  });
+
+  it('rejects a forged-header zip bomb whose declared size hides the real inflation', async () => {
+    // ~100 KB of body compresses to a few hundred bytes, so the bomb itself
+    // slips under the upload route's 1 MiB archive cap with room to spare.
+    const zip = new JSZip();
+    zip.file('my-skill/SKILL.md', skillMarkdown('x'.repeat(100 * 1024)));
+    const bomb = Buffer.from(
+      await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' }),
+    );
+    // Forge the central directory's declared uncompressedSize (offset 24 in the
+    // entry record) to a small honest-looking value.
+    bomb.writeUInt32LE(123, centralDirectoryEntry(bomb, 'my-skill/SKILL.md') + 24);
+    // The forgery must take, or the test no longer exercises the attack path.
+    const reloaded = await JSZip.loadAsync(bomb);
+    const forged = reloaded.file('my-skill/SKILL.md') as unknown as {
+      _data: { uncompressedSize: number };
+    };
+    expect(forged._data.uncompressedSize).toBe(123);
+    await expect(parseUserSkillZip(bomb)).rejects.toThrow('The archive SKILL.md is too large.');
+  });
+
+  it('parses STORE (uncompressed) skill zips', async () => {
+    const zip = new JSZip();
+    zip.file('my-skill/SKILL.md', skillMarkdown('Stored instructions.'));
+    const stored = await zip.generateAsync({ type: 'nodebuffer', compression: 'STORE' });
+    await expect(parseUserSkillZip(stored)).resolves.toEqual({
+      name: 'my-skill',
+      title: 'Title',
+      description: 'Description',
+      content: 'Stored instructions.',
+    });
+  });
+
+  it('rejects a forged STORE entry whose declared size hides real bytes', async () => {
+    // STORE never inflates, so its only guard is the byte-length check on the
+    // actual slice — the forgery below must not make that check read 123.
+    const zip = new JSZip();
+    zip.file('my-skill/SKILL.md', skillMarkdown('x'.repeat(80_000)));
+    const bomb = Buffer.from(await zip.generateAsync({ type: 'nodebuffer', compression: 'STORE' }));
+    bomb.writeUInt32LE(123, centralDirectoryEntry(bomb, 'my-skill/SKILL.md') + 24);
+    const reloaded = await JSZip.loadAsync(bomb);
+    const forged = reloaded.file('my-skill/SKILL.md') as unknown as {
+      _data: { uncompressedSize: number };
+    };
+    expect(forged._data.uncompressedSize).toBe(123);
+    await expect(parseUserSkillZip(bomb)).rejects.toThrow('The archive SKILL.md is too large.');
+  });
+
+  it('reports a corrupt deflate stream as an invalid zip, not a size refusal', async () => {
+    // Declare DEFLATE over stored markdown bytes: inflateRawSync throws a
+    // plain zlib error (not ERR_BUFFER_TOO_LARGE), which the decoder rethrows
+    // for the outer catch to map — pinning that contract keeps a future
+    // refactor from swallowing every zlib failure as "too large".
+    const zip = new JSZip();
+    zip.file('my-skill/SKILL.md', skillMarkdown('Plainly stored text.'));
+    const lying = Buffer.from(
+      await zip.generateAsync({ type: 'nodebuffer', compression: 'STORE' }),
+    );
+    lying.writeUInt16LE(8, centralDirectoryEntry(lying, 'my-skill/SKILL.md') + 10);
+    await expect(parseUserSkillZip(lying)).rejects.toThrow(
+      'The skill archive is not a valid zip file.',
+    );
   });
 });


### PR DESCRIPTION
Fixes #1361

## Problem

`parseUserSkillZip` (`lib/server/skill-export.ts`, reached from the user skill upload route `POST /api/agent/skills`) enforced the SKILL.md size limit by reading the zip central directory's **self-declared** `uncompressedSize` and then decoded the entry with `entry.async('string')` — which inflates the real deflate stream no matter what the header claims. A crafted archive declaring a tiny size slipped past the guard; JSZip's own uncompressed-length comparison fires only when the inflation stream ends, after the memory has been spent. With the route's 1 MiB archive cap and deflate's ~1032:1 maximum ratio, a single ~1 MiB request could expand ~1 GiB in the Node process, repeatable per request (memory-exhaustion DoS).

## Fix

Decode the SKILL.md entry with a hard output cap instead of trusting declarations:

- DEFLATE entries are inflated directly with `node:zlib` `inflateRawSync(_data.compressedContent, { maxOutputLength: 70_000 })` — zlib aborts the moment output crosses the cap, whatever the headers say. `ERR_BUFFER_TOO_LARGE` maps to the existing `UserSkillUploadError('The archive SKILL.md is too large.')`, so route responses and status codes are unchanged.
- STORE (uncompressed) entries carry the content verbatim in `compressedContent`, so they are byte-length checked directly, never inflated.
- The declared-size check stays as a fast path that refuses honest oversized archives without inflating.
- Corrupt streams (plain zlib errors) still fall through to the existing invalid-zip mapping.

The compressed bytes come from the same JSZip internals surface the old check read (`_data`): jszip 3.10.1's `loadAsync` eagerly slices each entry's `compressedContent` at load time and registers exactly two compression methods, so every reachable branch is bounded.

## Tests

`tests/server/skill-export.test.ts` (5 → 10):

- **forged-header bomb refused** — a real DEFLATE zip whose central directory is patched (Buffer surgery) to declare `uncompressedSize = 123` while the stream really expands ~100 KB; the test first asserts the forgery took on reload (so it can never silently stop exercising the attack path), then asserts refusal with "too large". Red against the pre-fix code (it inflated fully and was only caught afterwards by JSZip's length mismatch), green after.
- honest oversized DEFLATE zip refused by the fast path
- forged STORE entry (declared size hides real bytes) refused by the byte-length check
- STORE zip round-trips through the new path
- corrupt deflate stream still maps to "not a valid zip file", not a size refusal

`pnpm vitest run tests/server/skill-export.test.ts` → 10/10; prettier/eslint clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)