### PR TITLE
fix(generation): restore the quiz option value/label contract

### DIFF
--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/src/scene-generator.ts
+++ b/packages/@openmaic/generation/src/scene-generator.ts
@@ -911,7 +911,14 @@ async function generateQuizContent(
  * AI may generate plain strings ["OptionA", "OptionB"] or QuizOption objects.
  * This normalizes to QuizOption[] format: { value: "A", label: "OptionA" }
  */
-function normalizeQuizOptions(
+const OPTION_LETTER_RE = /^[A-Za-z]$/;
+
+/** True for a bare selection letter such as "A" (whitespace tolerated). */
+function isOptionLetter(text: string): boolean {
+  return OPTION_LETTER_RE.test(text.trim());
+}
+
+export function normalizeQuizOptions(
   options: unknown[] | undefined,
 ): { value: string; label: string }[] | undefined {
   if (!options || !Array.isArray(options)) return undefined;
@@ -925,9 +932,30 @@ function normalizeQuizOptions(
 
     if (typeof opt === 'object' && opt !== null) {
       const obj = opt as Record<string, unknown>;
+      const value = typeof obj.value === 'string' ? obj.value : undefined;
+      const label = typeof obj.label === 'string' ? obj.label : undefined;
+
+      // Some generations fill the two fields the other way round: the
+      // selection letter lands in `label` and the option content in `value`.
+      // QuizView renders `value` as the badge and `label` as the body, so the
+      // swap surfaces as a badge full of content next to a body reading "A".
+      // Restore the documented contract only when the shape says so
+      // unambiguously — `label` is a bare letter and `value` is not. Two bare
+      // letters (an option whose content really is a letter) stay untouched.
+      // The letter is taken from `label` rather than from the index so the
+      // identity the model's answer key refers to is preserved.
+      if (
+        value !== undefined &&
+        label !== undefined &&
+        isOptionLetter(label) &&
+        !isOptionLetter(value)
+      ) {
+        return { value: label.trim(), label: value };
+      }
+
       return {
-        value: typeof obj.value === 'string' ? obj.value : letter,
-        label: typeof obj.label === 'string' ? obj.label : String(obj.value || obj.text || letter),
+        value: value ?? letter,
+        label: label ?? String(obj.value || obj.text || letter),
       };
     }
 

--- a/tests/quiz/option-contract.test.ts
+++ b/tests/quiz/option-contract.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeQuizOptions } from '@/packages/@openmaic/generation/src/scene-generator';
+
+describe('normalizeQuizOptions option contract', () => {
+  it('keeps the documented shape when the model already follows it', () => {
+    expect(
+      normalizeQuizOptions([
+        { value: 'A', label: '梯度是一个标量' },
+        { value: 'B', label: '梯度是一个向量' },
+      ]),
+    ).toEqual([
+      { value: 'A', label: '梯度是一个标量' },
+      { value: 'B', label: '梯度是一个向量' },
+    ]);
+  });
+
+  it('restores the contract when the model swaps value and label (#1375)', () => {
+    // QuizView renders `value` as the badge and `label` as the body, so this
+    // shape used to render a badge reading "(6, 2)" above a body reading "A".
+    expect(
+      normalizeQuizOptions([
+        { value: '(6, 2)', label: 'A' },
+        { value: '(2, -4)', label: 'B' },
+      ]),
+    ).toEqual([
+      { value: 'A', label: '(6, 2)' },
+      { value: 'B', label: '(2, -4)' },
+    ]);
+  });
+
+  it('takes the letter from label, not the index, so answer keys still resolve', () => {
+    expect(normalizeQuizOptions([{ value: 'twelve', label: 'C' }])).toEqual([
+      { value: 'C', label: 'twelve' },
+    ]);
+  });
+
+  it('leaves two bare letters alone — the content may itself be a letter', () => {
+    expect(normalizeQuizOptions([{ value: 'A', label: 'B' }])).toEqual([
+      { value: 'A', label: 'B' },
+    ]);
+  });
+
+  it('still letters plain string options by position', () => {
+    expect(normalizeQuizOptions(['first', 'second'])).toEqual([
+      { value: 'A', label: 'first' },
+      { value: 'B', label: 'second' },
+    ]);
+  });
+
+  it('returns undefined for missing options', () => {
+    expect(normalizeQuizOptions(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Quiz scenes sometimes render a badge full of option content sitting above a body that reads just "A". This restores the documented option contract in `normalizeQuizOptions` so those scenes render the letter as the badge and the content as the body.

## Related Issues

Closes #1375

## Changes

- `normalizeQuizOptions` now repairs a swapped `value`/`label` pair in the object-shaped input path, when the shape is unambiguous.
- Exported the function so it can be unit-tested.
- Added `tests/quiz/option-contract.test.ts` covering the swap, the already-correct shape, the ambiguous case, and the plain-string path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Root cause

`normalizeQuizOptions` documents the contract as `{ value: "A", label: "<content>" }` and enforces it for plain-string options, but the object path passed the model's strings straight through:

```ts
return {
  value: typeof obj.value === 'string' ? obj.value : letter,
  label: typeof obj.label === 'string' ? obj.label : String(obj.value || obj.text || letter),
};
```

So when a generation emits `{ value: "(6, 2)", label: "A" }`, the reversal reaches the renderer intact. `quiz-view.tsx` renders `{opt.value}` as the badge and `<QuizMathText text={opt.label} />` as the body, which is exactly the reported display.

## Design notes

Two judgement calls worth flagging for review:

- **The swap only fires when it is unambiguous** — `label` is a bare A–Z letter and `value` is not. If *both* are bare letters, the option's content may genuinely be a letter ("Which letter follows A?"), and there is no way to tell that apart from a swap, so those are left untouched.
- **The letter comes from `label`, not from the option's index.** If a generation emits its options out of order, taking the index letter would silently re-key the options away from the identity the model's answer key refers to. Taking `label` preserves it.

## Verification

### Steps to reproduce / test

1. Generate a course containing quiz scenes (the report used deepseek-v4-flash); some scenes come out with `value` holding the content and `label` holding the letter.
2. Open such a quiz scene in the classroom.
3. Before: the option badge shows `(6, 2)` and the body shows `A`. After: badge `A`, body `(6, 2)`.

### What you personally verified

- **Red before green.** With the new branch removed but the export kept, exactly the two swap-related tests fail and the other four pass — so the guard tests are genuine regression cover, not tautologies:
  ```
  × restores the contract when the model swaps value and label (#1375)
  × takes the letter from label, not the index, so answer keys still resolve
  Tests  2 failed | 4 passed (6)
  ```
  With the fix: `Tests  6 passed (6)`.
- **Full suite, not just my file:** `vitest run` → **660 files passed, 7362 tests passed, 81 skipped, 0 failures**.
- `npx tsc --noEmit` clean (needs `NODE_OPTIONS=--max-old-space-size=8192` on my machine — the default heap OOMs before it finishes; that is a local limit, not a type error).
- `npx eslint` clean on both changed files; `npx prettier --check` clean after running `--write`.

**What I did not verify:** I did not reproduce end-to-end against a live LLM generation — I do not have a provider key set up here, so the swapped payload in the test is the one quoted in #1375 rather than one I generated myself. I also did not visually confirm the rendered badge/body in the browser; the render mapping is read from `quiz-view.tsx` (`opt.value` → badge, `opt.label` → body).

## Note on overlap with #1328

#1328 is open against the sibling function `normalizeQuizAnswer` and the `normalizeQuizOptions` call site, resolving AI answer keys to option values before grading. It does not change the body of `normalizeQuizOptions`, and #1375 is scoped to the display contract, so the two are complementary — but they touch the same file, and whichever lands second may need a trivial rebase. Happy to rebase on top of #1328 if you would rather take that one first.
