### PR TITLE
feat(chat): mature learner handoff flow

### DIFF
--- a/components/canvas/canvas-toolbar.tsx
+++ b/components/canvas/canvas-toolbar.tsx
@@ -16,6 +16,7 @@ import {
   Maximize2,
   Minimize2,
   Quote,
+  BookOpen,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useStageStore } from '@/lib/store';
@@ -42,6 +43,8 @@ export interface CanvasToolbarProps {
   readonly showStopDiscussion?: boolean;
   readonly onStopDiscussion?: () => void;
   readonly onContinueDiscussion?: () => void;
+  readonly showResumeLesson?: boolean;
+  readonly onResumeLesson?: () => void;
   readonly isPresenting?: boolean;
   readonly onTogglePresentation?: () => void;
   readonly className?: string;
@@ -108,6 +111,8 @@ export function CanvasToolbar({
   showStopDiscussion,
   onStopDiscussion,
   onContinueDiscussion,
+  showResumeLesson,
+  onResumeLesson,
   isPresenting,
   onTogglePresentation,
   className,
@@ -307,6 +312,22 @@ export function CanvasToolbar({
           )}
 
           {/* Play / Pause / Stop Discussion */}
+          {showResumeLesson && onResumeLesson && (
+            <button
+              type="button"
+              data-testid="cue-user-resume-lesson"
+              onClick={(event) => {
+                event.stopPropagation();
+                onResumeLesson();
+              }}
+              className="flex h-6 items-center gap-1.5 whitespace-nowrap rounded-md bg-violet-500/10 px-2.5 text-[11px] font-semibold text-violet-600 transition-all hover:bg-violet-500/20 active:scale-95 dark:bg-violet-400/10 dark:text-violet-300 dark:hover:bg-violet-400/20"
+              title={t('roundtable.resumeLesson')}
+            >
+              <BookOpen className="size-3.5" />
+              {t('roundtable.resumeLesson')}
+            </button>
+          )}
+
           {showStopDiscussion && onStopDiscussion ? (
             <div className="flex items-center gap-1.5">
               <button

--- a/components/chat/chat-area.tsx
+++ b/components/chat/chat-area.tsx
@@ -39,7 +39,7 @@ interface ChatAreaProps {
   onLiveSpeech?: (text: string | null, agentId?: string | null) => void;
   onSpeechProgress?: (ratio: number | null) => void;
   onThinking?: (state: { stage: string; agentId?: string } | null) => void;
-  onCueUser?: (fromAgentId?: string, prompt?: string) => void;
+  onCueUser?: (fromAgentId?: string, prompt?: string, options?: string[]) => void;
   onLiveSessionError?: () => void;
   onSoftCloseSession?: (payload: SessionCleanupPayload) => void;
   onSoftClosingChange?: (softClosing: boolean, deadline?: number) => void;
@@ -63,6 +63,7 @@ export interface ChatAreaRef {
   endSession: (sessionId: string, options?: EndSessionOptions) => Promise<void>;
   endActiveSession: (options?: EndSessionOptions) => Promise<void>;
   stopActiveSession: () => Promise<void>;
+  resumeLesson: () => Promise<boolean>;
   continueActiveSoftClosingSession: () => boolean;
   softPauseActiveSession: () => Promise<void>;
   resumeActiveSession: () => Promise<void>;
@@ -113,6 +114,10 @@ export const ChatArea = forwardRef<ChatAreaRef, ChatAreaProps>(
   ) => {
     const { t } = useI18n();
     const scenes = useStageStore((s) => s.scenes);
+    const onCueUserRef = useRef(onCueUser);
+    useEffect(() => {
+      onCueUserRef.current = onCueUser;
+    }, [onCueUser]);
     const {
       sessions,
       activeSessionType,
@@ -161,9 +166,25 @@ export const ChatArea = forwardRef<ChatAreaRef, ChatAreaProps>(
 
     // Whether there's an active discussion/QA session (for amber dot on Chat tab)
     const hasActiveChatSession = useMemo(
-      () => chatSessions.some((s) => s.status === 'active'),
+      () => chatSessions.some((s) => s.status === 'active' || s.status === 'waiting-user'),
       [chatSessions],
     );
+
+    const waitingUserSession = useMemo(
+      () => chatSessions.find((session) => session.status === 'waiting-user'),
+      [chatSessions],
+    );
+
+    // Re-hydrate the learner hand-off after a reload/course restore. The
+    // stream callback handles the live path; this effect handles persistence.
+    useEffect(() => {
+      if (!waitingUserSession) return;
+      onCueUserRef.current?.(
+        waitingUserSession.cueUser?.fromAgentId,
+        waitingUserSession.cueUser?.prompt,
+        waitingUserSession.cueUser?.options,
+      );
+    }, [waitingUserSession]);
 
     const softClosingChatSession = useMemo(
       () => chatSessions.find((s) => s.status === 'soft-closing'),
@@ -194,10 +215,31 @@ export const ChatArea = forwardRef<ChatAreaRef, ChatAreaProps>(
 
     const handleStopActiveSession = useCallback(async () => {
       const active = chatSessions.find(
-        (session) => session.status === 'active' || session.status === 'soft-closing',
+        (session) =>
+          session.status === 'active' ||
+          session.status === 'waiting-user' ||
+          session.status === 'soft-closing',
       );
       if (active) await handleEndSession(active.id);
     }, [chatSessions, handleEndSession]);
+
+    const handleResumeLesson = useCallback(async (): Promise<boolean> => {
+      const active = chatSessions.find(
+        (session) =>
+          session.status === 'active' ||
+          session.status === 'waiting-user' ||
+          session.status === 'soft-closing',
+      );
+      if (!active) return false;
+
+      await endSession(active.id, { source: 'resume_lesson' });
+      onStopSession?.({
+        sessionId: active.id,
+        endReason: 'back_to_lesson',
+        source: 'resume_lesson',
+      });
+      return true;
+    }, [chatSessions, endSession, onStopSession]);
 
     const handleContinueActiveSoftClosingSession = useCallback((): boolean => {
       const softClosing = chatSessions.find((session) => session.status === 'soft-closing');
@@ -213,6 +255,7 @@ export const ChatArea = forwardRef<ChatAreaRef, ChatAreaProps>(
       endSession,
       endActiveSession,
       stopActiveSession: handleStopActiveSession,
+      resumeLesson: handleResumeLesson,
       continueActiveSoftClosingSession: handleContinueActiveSoftClosingSession,
       softPauseActiveSession,
       resumeActiveSession,

--- a/components/chat/chat-session.tsx
+++ b/components/chat/chat-session.tsx
@@ -172,7 +172,10 @@ export function ChatSessionComponent({
   const isDiscussion = session.type === 'discussion';
   const isQA = session.type === 'qa';
   const canEnd =
-    (isDiscussion || isQA) && (session.status === 'active' || session.status === 'soft-closing');
+    (isDiscussion || isQA) &&
+    (session.status === 'active' ||
+      session.status === 'waiting-user' ||
+      session.status === 'soft-closing');
   const isEnded = session.status === 'completed' && (isDiscussion || isQA);
   const isSoftClosing = session.status === 'soft-closing' && (isDiscussion || isQA);
   const remainingSoftCloseSeconds = useSoftCloseCountdown(session.softCloseDeadline);

--- a/components/chat/session-list.tsx
+++ b/components/chat/session-list.tsx
@@ -29,6 +29,8 @@ function getStatusIcon(status: SessionStatus) {
   switch (status) {
     case 'active':
       return <Circle className="size-2.5 fill-green-500 text-green-500" />;
+    case 'waiting-user':
+      return <Circle className="size-2.5 fill-amber-500 text-amber-500 animate-pulse" />;
     case 'soft-closing':
       return <Circle className="size-2.5 fill-amber-500 text-amber-500 animate-pulse" />;
     case 'interrupted':
@@ -57,7 +59,10 @@ export function SessionList({
     <>
       {sessions.map((session) => {
         const isExpanded = expandedSessionIds.has(session.id);
-        const isActive = session.status === 'active' || session.status === 'soft-closing';
+        const isActive =
+          session.status === 'active' ||
+          session.status === 'waiting-user' ||
+          session.status === 'soft-closing';
         const dotColor =
           session.type === 'lecture'
             ? 'bg-purple-500'

--- a/components/chat/use-chat-sessions.ts
+++ b/components/chat/use-chat-sessions.ts
@@ -127,7 +127,7 @@ interface UseChatSessionsOptions {
   onLiveSpeech?: (text: string | null, agentId?: string | null) => void;
   onSpeechProgress?: (ratio: number | null) => void;
   onThinking?: (state: { stage: string; agentId?: string } | null) => void;
-  onCueUser?: (fromAgentId?: string, prompt?: string) => void;
+  onCueUser?: (fromAgentId?: string, prompt?: string, options?: string[]) => void;
   onActiveBubble?: (messageId: string | null) => void;
   onLiveSessionError?: () => void;
   /** Called immediately when the server semantically closes a QA/Discussion session. */
@@ -308,8 +308,38 @@ function isLiveSessionType(session: Pick<ChatSession, 'type'>): boolean {
 
 export function isOpenLiveSession(session: Pick<ChatSession, 'type' | 'status'>): boolean {
   return (
-    isLiveSessionType(session) && (session.status === 'active' || session.status === 'soft-closing')
+    isLiveSessionType(session) &&
+    (session.status === 'active' ||
+      session.status === 'waiting-user' ||
+      session.status === 'soft-closing')
   );
+}
+
+export function parkSessionForUser(
+  session: ChatSession,
+  fromAgentId?: string,
+  prompt?: string,
+  options?: string[],
+  now = Date.now(),
+): ChatSession {
+  const normalizedPrompt = prompt?.trim() || undefined;
+  const normalizedOptions = options
+    ?.map((option) => option.trim())
+    .filter((option, index, all) => option.length > 0 && all.indexOf(option) === index)
+    .slice(0, 4);
+  return {
+    ...session,
+    status: 'waiting-user',
+    cueUser: {
+      fromAgentId,
+      prompt: normalizedPrompt,
+      options: normalizedOptions && normalizedOptions.length >= 2 ? normalizedOptions : undefined,
+      parkedAt: now,
+    },
+    endReason: undefined,
+    softCloseDeadline: undefined,
+    updatedAt: nextChatUpdatedAt(session, now),
+  };
 }
 
 export function resumeSoftClosingSessionForFollowUp(
@@ -321,6 +351,7 @@ export function resumeSoftClosingSessionForFollowUp(
     ...session,
     messages: [...session.messages, userMessage],
     status: 'active' as SessionStatus,
+    cueUser: undefined,
     endReason: undefined,
     softCloseDeadline: undefined,
     updatedAt: nextChatUpdatedAt(session, now),
@@ -335,6 +366,7 @@ export function resumeSoftClosingSessionWithoutMessage(
   return {
     ...session,
     status: 'active',
+    cueUser: undefined,
     endReason: undefined,
     softCloseDeadline: undefined,
     updatedAt: nextChatUpdatedAt(session, now),
@@ -553,8 +585,15 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
     const stored = useStageStore.getState().chats;
     return normalizeStoredSessionsForRestore(stored);
   });
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
-  const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(new Set());
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(() => {
+    const restored = normalizeStoredSessionsForRestore(useStageStore.getState().chats);
+    return restored.find((session) => session.status === 'waiting-user')?.id ?? null;
+  });
+  const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(() => {
+    const restored = normalizeStoredSessionsForRestore(useStageStore.getState().chats);
+    const waitingId = restored.find((session) => session.status === 'waiting-user')?.id;
+    return waitingId ? new Set([waitingId]) : new Set();
+  });
   const [isStreaming, setIsStreaming] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamingSessionIdRef = useRef<string | null>(null);
@@ -590,9 +629,11 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
     softCloseLifecycleRef.current.clear();
     // Stage changed — reload sessions from store (already populated by loadFromStorage)
     const stored = useStageStore.getState().chats;
-    setSessions(normalizeStoredSessionsForRestore(stored));
-    setActiveSessionId(null);
-    setExpandedSessionIds(new Set());
+    const restored = normalizeStoredSessionsForRestore(stored);
+    const waitingId = restored.find((session) => session.status === 'waiting-user')?.id;
+    setSessions(restored);
+    setActiveSessionId(waitingId ?? null);
+    setExpandedSessionIds(waitingId ? new Set([waitingId]) : new Set());
     previousLiveSessionRef.current = undefined;
     piSessionBoundariesRef.current.clear();
   }, [stageId]);
@@ -700,6 +741,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
                 updatedAt: Date.now(),
                 endReason: data?.endReason ?? s.endReason,
                 softCloseDeadline: undefined,
+                cueUser: undefined,
                 directorState: data?.directorState ?? s.directorState,
               }
             : s,
@@ -773,6 +815,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
                 updatedAt: Date.now(),
                 endReason: data.endReason ?? s.endReason,
                 softCloseDeadline: deadline,
+                cueUser: undefined,
                 directorState: data.directorState ?? s.directorState,
               }
             : s,
@@ -841,6 +884,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
                 ...s,
                 status: 'error' as SessionStatus,
                 softCloseDeadline: undefined,
+                cueUser: undefined,
                 updatedAt: nextChatUpdatedAt(s, now),
                 messages: [
                   ...s.messages,
@@ -1048,7 +1092,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
             onThinkingRef.current?.(data);
           },
 
-          onCueUser(fromAgentId?: string, prompt?: string) {
+          onCueUser(fromAgentId?: string, prompt?: string, options?: string[]) {
             // Track cue_user for agent loop
             if (loopDoneDataRef.current) {
               loopDoneDataRef.current.cueUserReceived = true;
@@ -1058,7 +1102,17 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
                 cueUserReceived: true,
               };
             }
-            onCueUserRef.current?.(fromAgentId, prompt);
+            const now = Date.now();
+            setSessions((prev) =>
+              prev.map((session) =>
+                session.id === sessionId
+                  ? parkSessionForUser(session, fromAgentId, prompt, options, now)
+                  : session,
+              ),
+            );
+            setActiveSessionId(sessionId);
+            setExpandedSessionIds((prev) => new Set([...prev, sessionId]));
+            onCueUserRef.current?.(fromAgentId, prompt, options);
           },
 
           onDone(data: {
@@ -1332,6 +1386,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
                       ...s,
                       status: 'completed' as SessionStatus,
                       updatedAt: nextChatUpdatedAt(s),
+                      cueUser: undefined,
                     }
                   : s,
               ),
@@ -1477,6 +1532,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               ...withChatSessionStatus(s, 'completed'),
               messages,
               softCloseDeadline: undefined,
+              cueUser: undefined,
             };
           }),
         );
@@ -1490,6 +1546,7 @@ export function useChatSessions(options: UseChatSessionsOptions = {}) {
               ? {
                   ...withChatSessionStatus(s, 'completed'),
                   softCloseDeadline: undefined,
+                  cueUser: undefined,
                 }
               : s,
           ),

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -184,8 +184,14 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       agentId?: string;
     } | null>(null);
 
-    // Cue user state (Issue 7)
-    const [isCueUser, setIsCueUser] = useState(false);
+    // Durable learner hand-off metadata. The session hook rehydrates this
+    // after reload, while live cue_user events update it immediately.
+    const [cueUser, setCueUser] = useState<{
+      fromAgentId?: string;
+      prompt?: string;
+      options?: string[];
+    } | null>(null);
+    const isCueUser = cueUser !== null;
 
     // End flash state (Issue 3)
     const [showEndFlash, setShowEndFlash] = useState(false);
@@ -414,7 +420,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       setSpeakingAgentId(null);
       setSpeechProgress(null);
       setThinkingState(null);
-      setIsCueUser(false);
+      setCueUser(null);
       setIsTopicPending(false);
       setChatIsStreaming(false);
       setChatIsSoftClosing(false);
@@ -479,6 +485,10 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
         setChatIsSoftClosing(false);
         setSoftCloseDeadline(undefined);
       }
+    }, []);
+
+    const handleResumeLesson = useCallback(async () => {
+      await chatAreaRef.current?.resumeLesson();
     }, []);
 
     /**
@@ -1581,6 +1591,8 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
                 endFlashSessionType={endFlashSessionType}
                 thinkingState={thinkingState}
                 isCueUser={isCueUser}
+                cueUserPrompt={cueUser?.prompt}
+                cueUserOptions={cueUser?.options}
                 isSoftClosing={chatIsSoftClosing}
                 softCloseDeadline={softCloseDeadline}
                 isTopicPending={isTopicPending}
@@ -1631,7 +1643,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
                   }
                   // Auto-switch to chat tab when user sends a message
                   chatAreaRef.current?.switchToTab('chat');
-                  setIsCueUser(false);
+                  setCueUser(null);
                   // Immediately mark streaming for synchronized stop button
                   setChatIsStreaming(true);
                   setChatSessionType(chatSessionType || 'qa');
@@ -1647,6 +1659,9 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
                 onDiscussionSkip={() => {
                   // User clicks "Skip" on ProactiveCard
                   engineRef.current?.skipDiscussion();
+                }}
+                onResumeLesson={() => {
+                  void handleResumeLesson();
                 }}
                 onStopDiscussion={handleStopDiscussion}
                 onContinueDiscussion={handleContinueDiscussion}
@@ -1777,14 +1792,14 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
                 setThinkingState(state);
               });
             }}
-            onCueUser={(_fromAgentId, _prompt) => {
-              setIsCueUser(true);
+            onCueUser={(fromAgentId, prompt, options) => {
+              setCueUser({ fromAgentId, prompt: prompt?.trim() || undefined, options });
             }}
             onLiveSessionError={handleLiveSessionError}
             onSoftCloseSession={() => {
               setThinkingState(null);
               setSpeechProgress(null);
-              setIsCueUser(false);
+              setCueUser(null);
               setActiveBubbleId(null);
             }}
             onSoftClosingChange={(softClosing, deadline) => {

--- a/components/roundtable/index.tsx
+++ b/components/roundtable/index.tsx
@@ -160,114 +160,208 @@ function VoiceWaveformBars({ barClassName }: { readonly barClassName: string }) 
   ));
 }
 
-function CueUserCard({
+function CueUserTurn({
   label,
   prompt,
   options,
   voiceEnabled,
+  canResumeLesson,
   textLabel,
   voiceLabel,
-  resumeLessonLabel,
   onOpenText,
   onOpenVoice,
-  onResumeLesson,
   onSelect,
+  inputValue,
+  onInputChange,
+  onSend,
+  isInputOpen,
+  isVoiceOpen,
+  isRecording,
+  isProcessing,
+  inputRef,
+  onInputActivity,
   presentation = false,
 }: {
   readonly label: string;
   readonly prompt?: string;
   readonly options?: readonly string[];
   readonly voiceEnabled: boolean;
+  readonly canResumeLesson: boolean;
   readonly textLabel: string;
   readonly voiceLabel: string;
-  readonly resumeLessonLabel: string;
   readonly onOpenText: () => void;
   readonly onOpenVoice: () => void;
-  readonly onResumeLesson?: () => void;
   readonly onSelect: (answer: string) => void;
+  readonly inputValue: string;
+  readonly onInputChange: (value: string) => void;
+  readonly onSend: () => void;
+  readonly isInputOpen: boolean;
+  readonly isVoiceOpen: boolean;
+  readonly isRecording: boolean;
+  readonly isProcessing: boolean;
+  readonly inputRef?: React.RefObject<HTMLTextAreaElement | null>;
+  readonly onInputActivity?: (kind: 'text_input' | 'composition_start') => void;
   readonly presentation?: boolean;
 }) {
+  const { t } = useI18n();
   const quickReplies =
     options
       ?.filter(Boolean)
-      .filter((option) => !onResumeLesson || !isResumeLessonOption(option))
+      .filter((option) => !canResumeLesson || !isResumeLessonOption(option))
       .slice(0, 4) ?? [];
+
   return (
     <div
       data-testid="cue-user-card"
+      data-cue-side="user"
       role="group"
       aria-label={label}
       aria-live="polite"
+      onClick={(event) => event.stopPropagation()}
       className={cn(
-        'w-[min(560px,calc(100vw-2rem))] overflow-hidden rounded-[24px] border border-violet-200/90 bg-white/95 shadow-[0_24px_80px_-28px_rgba(76,29,149,0.45),0_8px_28px_-16px_rgba(15,23,42,0.28)] ring-1 ring-white/80 backdrop-blur-2xl dark:border-violet-800/70 dark:bg-gray-950/92 dark:ring-white/10',
-        presentation && 'w-[min(600px,calc(100vw-3rem))] bg-white/90 dark:bg-black/75',
+        'relative ml-auto flex min-h-0 flex-col overflow-visible border border-violet-200/80 bg-white/90 shadow-[0_16px_44px_-24px_rgba(76,29,149,0.38)] backdrop-blur-xl dark:border-violet-800/70 dark:bg-gray-900/90',
+        presentation
+          ? 'w-[min(560px,calc(100vw-3rem))] rounded-[24px] rounded-br-md'
+          : 'h-full w-[min(760px,calc(100%-0.5rem))] rounded-[2rem] rounded-br-lg',
       )}
     >
-      <div className="flex items-start gap-3.5 px-5 pb-3.5 pt-4.5">
-        <span className="relative mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-violet-500 to-indigo-600 text-white shadow-lg shadow-violet-500/20">
-          <span className="absolute -inset-1 animate-pulse rounded-[18px] border border-violet-400/35" />
-          <MessageSquare className="size-4" />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-[10px] font-bold uppercase tracking-[0.18em] text-violet-600 dark:text-violet-300">
-            {label}
-          </span>
-          {prompt && (
-            <span className="mt-1 block text-[15px] font-medium leading-relaxed text-gray-900 dark:text-gray-50">
-              {prompt}
+      <span
+        data-testid="cue-user-bubble-tail"
+        aria-hidden="true"
+        className="absolute -right-[6px] bottom-7 size-3 rotate-45 border-r border-t border-violet-200/80 bg-white/90 dark:border-violet-800/70 dark:bg-gray-900/90"
+      />
+
+      <div className={cn('flex min-h-0 flex-1 flex-col', presentation ? 'p-4' : 'px-5 py-3')}>
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="min-w-0 flex-1">
+            <span className="flex items-center gap-2 text-[10px] font-bold tracking-[0.12em] text-violet-600 dark:text-violet-300">
+              <span className="relative flex size-1.5 rounded-full bg-violet-500 after:absolute after:-inset-1 after:animate-pulse after:rounded-full after:border after:border-violet-400/30" />
+              {label}
             </span>
+            {prompt && (
+              <span className="mt-1 block line-clamp-2 text-sm font-medium leading-relaxed text-gray-900 dark:text-gray-50">
+                {prompt}
+              </span>
+            )}
+          </span>
+
+          {!isInputOpen && !isVoiceOpen && (
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                onClick={onOpenText}
+                aria-label={textLabel}
+                className="flex size-8 items-center justify-center rounded-xl text-gray-400 transition-colors hover:bg-violet-50 hover:text-violet-700 dark:text-gray-500 dark:hover:bg-violet-950/40 dark:hover:text-violet-300"
+              >
+                <MessageSquare className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={onOpenVoice}
+                disabled={!voiceEnabled}
+                aria-label={voiceLabel}
+                className="flex size-8 items-center justify-center rounded-xl text-gray-400 transition-colors hover:bg-violet-50 hover:text-violet-700 disabled:cursor-not-allowed disabled:opacity-30 dark:text-gray-500 dark:hover:bg-violet-950/40 dark:hover:text-violet-300"
+              >
+                {voiceEnabled ? <Mic className="size-3.5" /> : <MicOff className="size-3.5" />}
+              </button>
+            </div>
           )}
-        </span>
-      </div>
-      {quickReplies.length > 0 && (
-        <div className="grid max-h-48 grid-cols-1 gap-2 overflow-y-auto px-4 pb-3 sm:grid-cols-2">
-          {quickReplies.map((option, index) => (
-            <button
-              key={`${index}:${option}`}
-              type="button"
-              onClick={() => onSelect(option)}
-              className="group flex min-h-11 min-w-0 items-center gap-2.5 rounded-2xl border border-gray-200/90 bg-gray-50/85 px-3 py-2.5 text-left text-xs font-semibold text-gray-700 transition-all hover:-translate-y-0.5 hover:border-violet-300 hover:bg-violet-50 hover:text-violet-800 hover:shadow-sm active:translate-y-0 dark:border-gray-700 dark:bg-gray-900/80 dark:text-gray-200 dark:hover:border-violet-700 dark:hover:bg-violet-950/35 dark:hover:text-violet-100"
-            >
-              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-white text-[10px] font-bold text-gray-400 shadow-sm ring-1 ring-gray-200 transition-colors group-hover:text-violet-600 group-hover:ring-violet-200 dark:bg-gray-800 dark:ring-gray-700 dark:group-hover:text-violet-300 dark:group-hover:ring-violet-700">
-                {index + 1}
-              </span>
-              <span className="line-clamp-2 min-w-0 flex-1 leading-relaxed">{option}</span>
-              <span className="shrink-0 text-gray-300 transition-transform group-hover:translate-x-0.5 group-hover:text-violet-400 dark:text-gray-600">
-                →
-              </span>
-            </button>
-          ))}
         </div>
-      )}
-      <div className="flex flex-wrap items-center gap-2 border-t border-gray-100/90 bg-gray-50/55 px-3 py-2.5 dark:border-gray-800 dark:bg-gray-900/55">
-        <button
-          type="button"
-          onClick={onOpenText}
-          className="inline-flex h-8 items-center gap-1.5 rounded-xl px-2.5 text-xs font-semibold text-gray-600 transition-colors hover:bg-white hover:text-violet-700 hover:shadow-sm dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-violet-200"
-        >
-          <MessageSquare className="size-3.5" />
-          {textLabel}
-        </button>
-        <button
-          type="button"
-          onClick={onOpenVoice}
-          disabled={!voiceEnabled}
-          className="inline-flex h-8 items-center gap-1.5 rounded-xl px-2.5 text-xs font-semibold text-gray-600 transition-colors hover:bg-white hover:text-violet-700 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-35 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-violet-200"
-        >
-          {voiceEnabled ? <Mic className="size-3.5" /> : <MicOff className="size-3.5" />}
-          {voiceLabel}
-        </button>
-        {onResumeLesson && (
-          <button
-            type="button"
-            data-testid="cue-user-resume-lesson"
-            onClick={onResumeLesson}
-            className="ml-auto inline-flex h-8 items-center gap-1.5 rounded-xl bg-violet-600 px-3 text-xs font-semibold text-white shadow-sm shadow-violet-500/20 transition-all hover:bg-violet-700 hover:shadow-md active:scale-[0.98] dark:bg-violet-500 dark:hover:bg-violet-400"
-          >
-            <BookOpen className="size-3.5" />
-            {resumeLessonLabel}
-          </button>
-        )}
+
+        <div className="mt-auto min-h-0 border-t border-gray-100/90 pt-2 dark:border-gray-800">
+          {isInputOpen ? (
+            <div className="flex items-end gap-2">
+              <textarea
+                ref={inputRef}
+                value={inputValue}
+                onChange={(event) => onInputChange(event.target.value)}
+                onBeforeInput={() => onInputActivity?.('text_input')}
+                onCompositionStart={() => onInputActivity?.('composition_start')}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
+                    event.preventDefault();
+                    onSend();
+                  }
+                }}
+                placeholder={textLabel}
+                autoFocus
+                rows={1}
+                className="min-h-10 max-h-[100px] min-w-0 flex-1 resize-none overflow-y-auto rounded-xl border border-gray-200 bg-gray-50/80 px-3 py-2 text-sm text-gray-800 outline-none transition focus:border-violet-300 focus:ring-2 focus:ring-violet-200/50 dark:border-gray-700 dark:bg-gray-800/80 dark:text-gray-100 dark:focus:border-violet-700 dark:focus:ring-violet-800/40"
+              />
+              <button
+                type="button"
+                onClick={onOpenVoice}
+                disabled={!voiceEnabled}
+                aria-label={voiceLabel}
+                className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-gray-500 transition hover:bg-violet-50 hover:text-violet-700 disabled:cursor-not-allowed disabled:opacity-30 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-violet-950/40 dark:hover:text-violet-300"
+              >
+                {voiceEnabled ? <Mic className="size-4" /> : <MicOff className="size-4" />}
+              </button>
+              <button
+                type="button"
+                onClick={onSend}
+                disabled={!inputValue.trim()}
+                aria-label={t('roundtable.send')}
+                className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-violet-600 text-white shadow-sm transition hover:bg-violet-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:bg-violet-500 dark:hover:bg-violet-400 dark:disabled:bg-gray-700"
+              >
+                <Send className="size-4" />
+              </button>
+            </div>
+          ) : isVoiceOpen ? (
+            <div className="flex min-h-10 items-center gap-3">
+              <div className="flex h-8 flex-1 items-center gap-1 overflow-hidden rounded-xl bg-violet-50/70 px-3 dark:bg-violet-950/30">
+                <div className="flex h-6 items-center gap-0.5">
+                  <VoiceWaveformBars barClassName="bg-gradient-to-t from-violet-500 to-indigo-500 dark:from-violet-400 dark:to-indigo-400" />
+                </div>
+                <span className="ml-2 text-[11px] font-semibold text-violet-600 dark:text-violet-300">
+                  {isProcessing ? t('roundtable.processing') : t('roundtable.listening')}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={onOpenVoice}
+                aria-label={
+                  isRecording ? t('roundtable.stopRecording') : t('roundtable.startRecording')
+                }
+                className="relative flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-600 text-white shadow-md shadow-violet-500/20 transition hover:scale-105 dark:bg-violet-500"
+              >
+                <Mic className="size-4" />
+                {isRecording && (
+                  <span className="absolute -inset-1 animate-ping rounded-full border border-violet-400/50" />
+                )}
+              </button>
+            </div>
+          ) : quickReplies.length > 0 ? (
+            <div
+              className={cn(
+                'grid max-h-[78px] grid-cols-[repeat(auto-fit,minmax(min(140px,100%),1fr))] gap-1.5 overflow-y-auto',
+              )}
+            >
+              {quickReplies.map((option, index) => (
+                <button
+                  key={`${index}:${option}`}
+                  type="button"
+                  onClick={() => onSelect(option)}
+                  className="group flex min-h-10 min-w-0 items-center justify-center gap-2 rounded-xl border border-transparent bg-gray-50/90 px-3 py-2 text-center text-xs font-semibold text-gray-700 transition-colors hover:border-violet-200 hover:bg-violet-50 hover:text-violet-800 dark:bg-gray-800/80 dark:text-gray-200 dark:hover:border-violet-800 dark:hover:bg-violet-950/35 dark:hover:text-violet-100"
+                >
+                  <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-white text-[9px] font-bold text-gray-400 ring-1 ring-gray-200 transition-colors group-hover:text-violet-600 group-hover:ring-violet-200 dark:bg-gray-900 dark:ring-gray-700 dark:group-hover:text-violet-300 dark:group-hover:ring-violet-700">
+                    {index + 1}
+                  </span>
+                  <span className="line-clamp-2 min-w-0 leading-relaxed">{option}</span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={onOpenText}
+              className="flex min-h-10 w-full items-center justify-center gap-2 rounded-xl bg-gray-50/90 px-3 text-xs font-semibold text-gray-600 transition-colors hover:bg-violet-50 hover:text-violet-700 dark:bg-gray-800/80 dark:text-gray-300 dark:hover:bg-violet-950/35 dark:hover:text-violet-200"
+            >
+              <MessageSquare className="size-3.5" />
+              {textLabel}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -727,6 +821,8 @@ export function Roundtable({
           ? 'teacher'
           : 'idle';
 
+  const showCueUserTurn = !!isCueUser && !bubbleRole && !thinkingState;
+
   // Enriched playbackView that includes userMessage overlay for bubbleRole/sourceText
   const enrichedPlaybackView: PlaybackView = playbackView
     ? { ...playbackView, bubbleRole, sourceText, activeRole: activeRole ?? playbackView.activeRole }
@@ -827,6 +923,8 @@ export function Roundtable({
       showStopDiscussion={showStopButton}
       onStopDiscussion={onStopDiscussion}
       onContinueDiscussion={handleContinueSoftClosing}
+      showResumeLesson={showCueUserTurn}
+      onResumeLesson={onResumeLesson}
       ttsEnabled={ttsEnabled}
       ttsMuted={ttsMuted}
       ttsVolume={ttsVolume}
@@ -898,7 +996,9 @@ export function Roundtable({
         <div
           className={cn(
             'fixed bottom-0 left-0 z-[40] pointer-events-none flex items-center justify-center transition-all duration-300',
-            controlsVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2',
+            controlsVisible || showCueUserTurn
+              ? 'opacity-100 translate-y-0'
+              : 'opacity-0 translate-y-2',
           )}
           style={{ right: chatCollapsed === false ? (chatAreaWidth ?? 320) : 0 }}
         >
@@ -943,7 +1043,7 @@ export function Roundtable({
           {referencePill}
           {/* Input panel */}
           <AnimatePresence>
-            {isInputOpen && (
+            {isInputOpen && !showCueUserTurn && (
               <motion.div
                 key="presentation-input-stage"
                 initial={{ opacity: 0, scale: 0.95, y: 15, filter: 'blur(4px)' }}
@@ -994,7 +1094,7 @@ export function Roundtable({
 
           {/* Voice panel */}
           <AnimatePresence>
-            {isVoiceOpen && (
+            {isVoiceOpen && !showCueUserTurn && (
               <motion.div
                 key="presentation-voice-stage"
                 initial={{ opacity: 0, scale: 0.9, y: 20, filter: 'blur(4px)' }}
@@ -1025,35 +1125,6 @@ export function Roundtable({
                     <div className="absolute inset-0 rounded-full border-2 border-purple-500 opacity-40 animate-[ping_2s_ease-in-out_infinite]" />
                   </button>
                 </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* "Your turn" cue prompt — clickable, opens input panel */}
-          <AnimatePresence>
-            {isCueUser && !bubbleRole && !thinkingState && !isInputOpen && !isVoiceOpen && (
-              <motion.div
-                key="presentation-cue-user"
-                initial={{ opacity: 0, scale: 0.92, y: 8 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
-                exit={{ opacity: 0, scale: 0.92, y: 8 }}
-                transition={{ duration: 0.22, ease: [0.21, 1, 0.36, 1] }}
-                className="pointer-events-auto"
-              >
-                <CueUserCard
-                  label={t('roundtable.yourTurn')}
-                  prompt={cueUserPrompt}
-                  options={cueUserOptions}
-                  voiceEnabled={asrEnabled}
-                  textLabel={t('roundtable.textInput')}
-                  voiceLabel={t('roundtable.voiceInput')}
-                  resumeLessonLabel={t('roundtable.resumeLesson')}
-                  onOpenText={handleToggleInput}
-                  onOpenVoice={handleToggleVoice}
-                  onResumeLesson={onResumeLesson}
-                  onSelect={submitUserMessage}
-                  presentation
-                />
               </motion.div>
             )}
           </AnimatePresence>
@@ -1090,6 +1161,42 @@ export function Roundtable({
           className="fixed bottom-5 z-[48] flex flex-col items-end gap-3 pointer-events-none transition-[right] duration-300"
           style={{ right: chatCollapsed ? 20 : 20 + (chatAreaWidth ?? 320) }}
         >
+          <AnimatePresence>
+            {showCueUserTurn && (
+              <motion.div
+                key="presentation-cue-user"
+                data-testid="cue-user-presentation-turn"
+                initial={{ opacity: 0, scale: 0.96, x: 12 }}
+                animate={{ opacity: 1, scale: 1, x: 0 }}
+                exit={{ opacity: 0, scale: 0.96, x: 12 }}
+                transition={{ duration: 0.22, ease: [0.21, 1, 0.36, 1] }}
+                className="pointer-events-auto"
+              >
+                <CueUserTurn
+                  label={t('roundtable.yourTurn')}
+                  prompt={cueUserPrompt}
+                  options={cueUserOptions}
+                  voiceEnabled={asrEnabled}
+                  canResumeLesson={!!onResumeLesson}
+                  textLabel={t('roundtable.textInput')}
+                  voiceLabel={t('roundtable.voiceInput')}
+                  onOpenText={handleToggleInput}
+                  onOpenVoice={handleToggleVoice}
+                  onSelect={submitUserMessage}
+                  inputValue={inputValue}
+                  onInputChange={setInputValue}
+                  onSend={handleSendMessage}
+                  isInputOpen={isInputOpen}
+                  isVoiceOpen={isVoiceOpen}
+                  isRecording={isRecording}
+                  isProcessing={isProcessing}
+                  onInputActivity={onUserInputActivity}
+                  presentation
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+
           {/* Right-side speech bubble (flows above dock via flex) */}
           <PresentationSpeechOverlay
             playbackView={enrichedPlaybackView}
@@ -1284,38 +1391,6 @@ export function Roundtable({
           : 'border-t border-gray-100 dark:border-gray-800 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md',
       )}
     >
-      {/* Parked learner hand-off floats over the lower canvas instead of being
-          squeezed into the 192px roundtable interaction slot. */}
-      <AnimatePresence>
-        {isCueUser && !bubbleRole && !thinkingState && !isInputOpen && !isVoiceOpen && (
-          <motion.div
-            key="cue-user-floating-panel"
-            data-testid="cue-user-floating-panel"
-            initial={{ opacity: 0, scale: 0.96, y: 14 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: 10 }}
-            transition={{ duration: 0.24, ease: [0.21, 1, 0.36, 1] }}
-            className="pointer-events-none absolute bottom-[calc(100%_-_10px)] left-1/2 z-[70] -translate-x-1/2 px-4"
-          >
-            <div className="pointer-events-auto">
-              <CueUserCard
-                label={t('roundtable.yourTurn')}
-                prompt={cueUserPrompt}
-                options={cueUserOptions}
-                voiceEnabled={asrEnabled}
-                textLabel={t('roundtable.textInput')}
-                voiceLabel={t('roundtable.voiceInput')}
-                resumeLessonLabel={t('roundtable.resumeLesson')}
-                onOpenText={handleToggleInput}
-                onOpenVoice={handleToggleVoice}
-                onResumeLesson={onResumeLesson}
-                onSelect={submitUserMessage}
-              />
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
       {/* ── Toolbar strip — merged from CanvasArea ── */}
       <div
         className={cn(
@@ -1490,14 +1565,55 @@ export function Roundtable({
                 if (isRecording || isProcessing) cancelRecording();
               }
             }}
-            className="relative w-full h-full rounded-[2.5rem] bg-gradient-to-b from-white/40 to-white/80 dark:from-gray-800/40 dark:to-gray-800/80 backdrop-blur-xl border border-white/50 dark:border-gray-700/50 shadow-[0_20px_60px_-15px_rgba(0,0,0,0.05),inset_0_1px_0_0_rgba(255,255,255,0.9)] dark:shadow-[0_20px_60px_-15px_rgba(0,0,0,0.3)] flex flex-col justify-center px-6 overflow-hidden group transition-all duration-700 cursor-default"
+            className={cn(
+              'relative flex h-full w-full flex-col justify-center transition-all duration-500',
+              showCueUserTurn
+                ? 'overflow-visible bg-transparent px-0 shadow-none'
+                : 'group cursor-default overflow-hidden rounded-[2.5rem] border border-white/50 bg-gradient-to-b from-white/40 to-white/80 px-6 shadow-[0_20px_60px_-15px_rgba(0,0,0,0.05),inset_0_1px_0_0_rgba(255,255,255,0.9)] backdrop-blur-xl dark:border-gray-700/50 dark:from-gray-800/40 dark:to-gray-800/80 dark:shadow-[0_20px_60px_-15px_rgba(0,0,0,0.3)]',
+            )}
           >
             {elementReferencePill && (
               <div className="absolute left-1/2 top-2 z-30 -translate-x-1/2">{referencePill}</div>
             )}
+            <AnimatePresence mode="wait">
+              {showCueUserTurn && (
+                <motion.div
+                  key="cue-user-embedded-turn"
+                  data-testid="cue-user-embedded-turn"
+                  initial={{ opacity: 0, scale: 0.98, x: 14 }}
+                  animate={{ opacity: 1, scale: 1, x: 0 }}
+                  exit={{ opacity: 0, scale: 0.98, x: 10 }}
+                  transition={{ duration: 0.24, ease: [0.21, 1, 0.36, 1] }}
+                  className="h-full w-full"
+                >
+                  <CueUserTurn
+                    label={t('roundtable.yourTurn')}
+                    prompt={cueUserPrompt}
+                    options={cueUserOptions}
+                    voiceEnabled={asrEnabled}
+                    canResumeLesson={!!onResumeLesson}
+                    textLabel={t('roundtable.textInput')}
+                    voiceLabel={t('roundtable.voiceInput')}
+                    onOpenText={handleToggleInput}
+                    onOpenVoice={handleToggleVoice}
+                    onSelect={submitUserMessage}
+                    inputValue={inputValue}
+                    onInputChange={setInputValue}
+                    onSend={handleSendMessage}
+                    isInputOpen={isInputOpen}
+                    isVoiceOpen={isVoiceOpen}
+                    isRecording={isRecording}
+                    isProcessing={isProcessing}
+                    inputRef={nonPresentationInputRef}
+                    onInputActivity={onUserInputActivity}
+                  />
+                </motion.div>
+              )}
+            </AnimatePresence>
+
             {/* Text input box */}
             <AnimatePresence>
-              {isInputOpen && (
+              {isInputOpen && !showCueUserTurn && (
                 <motion.div
                   key="input-stage"
                   data-testid="roundtable-non-presentation-input-stage"
@@ -1556,7 +1672,7 @@ export function Roundtable({
               )}
 
               {/* Audio recording status */}
-              {isVoiceOpen && (
+              {isVoiceOpen && !showCueUserTurn && (
                 <motion.div
                   key="voice-stage"
                   initial={{

--- a/components/roundtable/index.tsx
+++ b/components/roundtable/index.tsx
@@ -61,6 +61,8 @@ interface RoundtableProps {
   readonly endFlashSessionType?: 'qa' | 'discussion';
   readonly thinkingState?: { stage: string; agentId?: string } | null;
   readonly isCueUser?: boolean;
+  readonly cueUserPrompt?: string;
+  readonly cueUserOptions?: readonly string[];
   /** Session entered the soft-closing grace window (client-side, ~15s). */
   readonly isSoftClosing?: boolean;
   readonly softCloseDeadline?: number;
@@ -70,6 +72,8 @@ interface RoundtableProps {
   readonly onDiscussionSkip?: () => void;
   readonly onStopDiscussion?: () => void;
   readonly onContinueDiscussion?: () => void;
+  /** Deterministic escape from a parked Q&A back to lecture playback. */
+  readonly onResumeLesson?: () => void;
   readonly onInputActivate?: () => void;
   readonly onUserInputActivity?: (
     kind: 'text_input' | 'composition_start' | 'recording_start',
@@ -130,6 +134,13 @@ const VOICE_WAVE_BARS = [
   { peak: 14, duration: 0.53 },
 ] as const;
 
+const RESUME_LESSON_OPTION_PATTERN =
+  /^(?:(?:不用|不需要|不了|先不用)[，,、。!！\s]*)?(?:继续(?:课程|上课|学习)|回到(?:课程|课堂)|返回(?:课程|课堂))$|^(?:(?:no thanks|not now)[,!.\s]*)?(?:(?:continue|resume)(?:\s+(?:the))?|return to|back to)\s+(?:lesson|course|class)$/i;
+
+export function isResumeLessonOption(option: string): boolean {
+  return RESUME_LESSON_OPTION_PATTERN.test(option.trim());
+}
+
 function VoiceWaveformBars({ barClassName }: { readonly barClassName: string }) {
   return VOICE_WAVE_BARS.map((bar, i) => (
     <motion.div
@@ -147,6 +158,119 @@ function VoiceWaveformBars({ barClassName }: { readonly barClassName: string }) 
       className={cn('w-1 rounded-full', barClassName)}
     />
   ));
+}
+
+function CueUserCard({
+  label,
+  prompt,
+  options,
+  voiceEnabled,
+  textLabel,
+  voiceLabel,
+  resumeLessonLabel,
+  onOpenText,
+  onOpenVoice,
+  onResumeLesson,
+  onSelect,
+  presentation = false,
+}: {
+  readonly label: string;
+  readonly prompt?: string;
+  readonly options?: readonly string[];
+  readonly voiceEnabled: boolean;
+  readonly textLabel: string;
+  readonly voiceLabel: string;
+  readonly resumeLessonLabel: string;
+  readonly onOpenText: () => void;
+  readonly onOpenVoice: () => void;
+  readonly onResumeLesson?: () => void;
+  readonly onSelect: (answer: string) => void;
+  readonly presentation?: boolean;
+}) {
+  const quickReplies =
+    options
+      ?.filter(Boolean)
+      .filter((option) => !onResumeLesson || !isResumeLessonOption(option))
+      .slice(0, 4) ?? [];
+  return (
+    <div
+      data-testid="cue-user-card"
+      role="group"
+      aria-label={label}
+      aria-live="polite"
+      className={cn(
+        'w-[min(560px,calc(100vw-2rem))] overflow-hidden rounded-[24px] border border-violet-200/90 bg-white/95 shadow-[0_24px_80px_-28px_rgba(76,29,149,0.45),0_8px_28px_-16px_rgba(15,23,42,0.28)] ring-1 ring-white/80 backdrop-blur-2xl dark:border-violet-800/70 dark:bg-gray-950/92 dark:ring-white/10',
+        presentation && 'w-[min(600px,calc(100vw-3rem))] bg-white/90 dark:bg-black/75',
+      )}
+    >
+      <div className="flex items-start gap-3.5 px-5 pb-3.5 pt-4.5">
+        <span className="relative mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-violet-500 to-indigo-600 text-white shadow-lg shadow-violet-500/20">
+          <span className="absolute -inset-1 animate-pulse rounded-[18px] border border-violet-400/35" />
+          <MessageSquare className="size-4" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[10px] font-bold uppercase tracking-[0.18em] text-violet-600 dark:text-violet-300">
+            {label}
+          </span>
+          {prompt && (
+            <span className="mt-1 block text-[15px] font-medium leading-relaxed text-gray-900 dark:text-gray-50">
+              {prompt}
+            </span>
+          )}
+        </span>
+      </div>
+      {quickReplies.length > 0 && (
+        <div className="grid max-h-48 grid-cols-1 gap-2 overflow-y-auto px-4 pb-3 sm:grid-cols-2">
+          {quickReplies.map((option, index) => (
+            <button
+              key={`${index}:${option}`}
+              type="button"
+              onClick={() => onSelect(option)}
+              className="group flex min-h-11 min-w-0 items-center gap-2.5 rounded-2xl border border-gray-200/90 bg-gray-50/85 px-3 py-2.5 text-left text-xs font-semibold text-gray-700 transition-all hover:-translate-y-0.5 hover:border-violet-300 hover:bg-violet-50 hover:text-violet-800 hover:shadow-sm active:translate-y-0 dark:border-gray-700 dark:bg-gray-900/80 dark:text-gray-200 dark:hover:border-violet-700 dark:hover:bg-violet-950/35 dark:hover:text-violet-100"
+            >
+              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-white text-[10px] font-bold text-gray-400 shadow-sm ring-1 ring-gray-200 transition-colors group-hover:text-violet-600 group-hover:ring-violet-200 dark:bg-gray-800 dark:ring-gray-700 dark:group-hover:text-violet-300 dark:group-hover:ring-violet-700">
+                {index + 1}
+              </span>
+              <span className="line-clamp-2 min-w-0 flex-1 leading-relaxed">{option}</span>
+              <span className="shrink-0 text-gray-300 transition-transform group-hover:translate-x-0.5 group-hover:text-violet-400 dark:text-gray-600">
+                →
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-2 border-t border-gray-100/90 bg-gray-50/55 px-3 py-2.5 dark:border-gray-800 dark:bg-gray-900/55">
+        <button
+          type="button"
+          onClick={onOpenText}
+          className="inline-flex h-8 items-center gap-1.5 rounded-xl px-2.5 text-xs font-semibold text-gray-600 transition-colors hover:bg-white hover:text-violet-700 hover:shadow-sm dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-violet-200"
+        >
+          <MessageSquare className="size-3.5" />
+          {textLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onOpenVoice}
+          disabled={!voiceEnabled}
+          className="inline-flex h-8 items-center gap-1.5 rounded-xl px-2.5 text-xs font-semibold text-gray-600 transition-colors hover:bg-white hover:text-violet-700 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-35 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-violet-200"
+        >
+          {voiceEnabled ? <Mic className="size-3.5" /> : <MicOff className="size-3.5" />}
+          {voiceLabel}
+        </button>
+        {onResumeLesson && (
+          <button
+            type="button"
+            data-testid="cue-user-resume-lesson"
+            onClick={onResumeLesson}
+            className="ml-auto inline-flex h-8 items-center gap-1.5 rounded-xl bg-violet-600 px-3 text-xs font-semibold text-white shadow-sm shadow-violet-500/20 transition-all hover:bg-violet-700 hover:shadow-md active:scale-[0.98] dark:bg-violet-500 dark:hover:bg-violet-400"
+          >
+            <BookOpen className="size-3.5" />
+            {resumeLessonLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function Roundtable({
@@ -169,6 +293,8 @@ export function Roundtable({
   endFlashSessionType = 'discussion',
   thinkingState,
   isCueUser,
+  cueUserPrompt,
+  cueUserOptions,
   isSoftClosing,
   softCloseDeadline,
   isTopicPending,
@@ -177,6 +303,7 @@ export function Roundtable({
   onDiscussionSkip,
   onStopDiscussion,
   onContinueDiscussion,
+  onResumeLesson,
   onInputActivate,
   onUserInputActivity,
 
@@ -374,6 +501,22 @@ export function Roundtable({
   const teacherName = teacherParticipant?.name || t('roundtable.teacher');
   const userAvatar = userParticipant?.avatar || DEFAULT_USER_AVATAR;
 
+  const submitUserMessage = useCallback(
+    (message: string) => {
+      const normalized = message.trim();
+      if (!normalized || isSendCooldownRef.current) return false;
+      showLocalUserMessage(normalized);
+      onMessageSend?.(normalized);
+      setIsSendCooldown(true);
+      isSendCooldownRef.current = true;
+      setInputValue('');
+      setIsInputOpen(false);
+      setIsVoiceOpen(false);
+      return true;
+    },
+    [onMessageSend, showLocalUserMessage],
+  );
+
   // Audio recording
   const { isRecording, isProcessing, startRecording, stopRecording, cancelRecording } =
     useAudioRecorder({
@@ -388,11 +531,7 @@ export function Roundtable({
           setIsVoiceOpen(false);
           return;
         }
-        showLocalUserMessage(text);
-        onMessageSend?.(text);
-        setIsSendCooldown(true);
-        isSendCooldownRef.current = true;
-        setIsVoiceOpen(false);
+        submitUserMessage(text);
       },
       onError: (error) => {
         toast.error(error);
@@ -401,14 +540,8 @@ export function Roundtable({
     });
 
   const handleSendMessage = () => {
-    if (!inputValue.trim() || isSendCooldown) return;
-
-    showLocalUserMessage(inputValue);
-    onMessageSend?.(inputValue);
-    setIsSendCooldown(true);
-    isSendCooldownRef.current = true;
-    setInputValue('');
-    setIsInputOpen(false);
+    if (isSendCooldown) return;
+    submitUserMessage(inputValue);
   };
 
   const handleToggleInput = () => {
@@ -907,13 +1040,20 @@ export function Roundtable({
                 transition={{ duration: 0.22, ease: [0.21, 1, 0.36, 1] }}
                 className="pointer-events-auto"
               >
-                <button
-                  onClick={() => (asrEnabled ? handleToggleVoice() : handleToggleInput())}
-                  className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/70 dark:bg-black/50 backdrop-blur-xl border border-amber-400/50 dark:border-amber-500/50 shadow-[0_0_16px_rgba(245,158,11,0.2),0_8px_32px_rgba(0,0,0,0.06)] dark:shadow-[0_0_16px_rgba(245,158,11,0.25),0_8px_32px_rgba(0,0,0,0.4)] text-amber-600 dark:text-amber-400 text-sm font-semibold tracking-wide hover:bg-gray-100/80 dark:hover:bg-black/60 hover:border-amber-500/70 dark:hover:border-amber-400/70 hover:shadow-[0_0_24px_rgba(245,158,11,0.25)] dark:hover:shadow-[0_0_24px_rgba(245,158,11,0.35)] transition-all active:scale-95 animate-pulse"
-                >
-                  {asrEnabled ? <Mic className="w-4 h-4" /> : <MessageSquare className="w-4 h-4" />}
-                  {t('roundtable.yourTurn')}
-                </button>
+                <CueUserCard
+                  label={t('roundtable.yourTurn')}
+                  prompt={cueUserPrompt}
+                  options={cueUserOptions}
+                  voiceEnabled={asrEnabled}
+                  textLabel={t('roundtable.textInput')}
+                  voiceLabel={t('roundtable.voiceInput')}
+                  resumeLessonLabel={t('roundtable.resumeLesson')}
+                  onOpenText={handleToggleInput}
+                  onOpenVoice={handleToggleVoice}
+                  onResumeLesson={onResumeLesson}
+                  onSelect={submitUserMessage}
+                  presentation
+                />
               </motion.div>
             )}
           </AnimatePresence>
@@ -1144,6 +1284,38 @@ export function Roundtable({
           : 'border-t border-gray-100 dark:border-gray-800 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md',
       )}
     >
+      {/* Parked learner hand-off floats over the lower canvas instead of being
+          squeezed into the 192px roundtable interaction slot. */}
+      <AnimatePresence>
+        {isCueUser && !bubbleRole && !thinkingState && !isInputOpen && !isVoiceOpen && (
+          <motion.div
+            key="cue-user-floating-panel"
+            data-testid="cue-user-floating-panel"
+            initial={{ opacity: 0, scale: 0.96, y: 14 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 10 }}
+            transition={{ duration: 0.24, ease: [0.21, 1, 0.36, 1] }}
+            className="pointer-events-none absolute bottom-[calc(100%_-_10px)] left-1/2 z-[70] -translate-x-1/2 px-4"
+          >
+            <div className="pointer-events-auto">
+              <CueUserCard
+                label={t('roundtable.yourTurn')}
+                prompt={cueUserPrompt}
+                options={cueUserOptions}
+                voiceEnabled={asrEnabled}
+                textLabel={t('roundtable.textInput')}
+                voiceLabel={t('roundtable.voiceInput')}
+                resumeLessonLabel={t('roundtable.resumeLesson')}
+                onOpenText={handleToggleInput}
+                onOpenVoice={handleToggleVoice}
+                onResumeLesson={onResumeLesson}
+                onSelect={submitUserMessage}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* ── Toolbar strip — merged from CanvasArea ── */}
       <div
         className={cn(
@@ -1467,150 +1639,6 @@ export function Roundtable({
                   <span className="text-[10px] text-gray-400 dark:text-gray-500 font-medium">
                     {t('roundtable.thinking')}
                   </span>
-                </motion.div>
-              )}
-            </AnimatePresence>
-
-            {/* Cue user: centered indicator when waiting for user input */}
-            <AnimatePresence>
-              {isCueUser && !bubbleRole && !thinkingState && !isInputOpen && !isVoiceOpen && (
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.85 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.85 }}
-                  transition={{ duration: 0.35, ease: [0.21, 1, 0.36, 1] }}
-                  className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20 flex flex-col items-center gap-2.5"
-                >
-                  {/* Button with ripple effect */}
-                  <div className="relative flex items-center justify-center">
-                    {/* Soft background glow */}
-                    <div
-                      className={cn(
-                        'absolute w-24 h-24 rounded-full blur-2xl',
-                        asrEnabled
-                          ? 'bg-amber-400/[0.08] dark:bg-amber-500/[0.06]'
-                          : 'bg-purple-400/[0.08] dark:bg-purple-500/[0.06]',
-                      )}
-                    />
-
-                    {/* Expanding ripple 1 */}
-                    <motion.div
-                      animate={{ scale: [1, 2.2], opacity: [0.25, 0] }}
-                      transition={{
-                        repeat: Infinity,
-                        duration: 2.2,
-                        ease: 'easeOut',
-                      }}
-                      className={cn(
-                        'absolute w-11 h-11 rounded-full border',
-                        asrEnabled
-                          ? 'border-amber-400/50 dark:border-amber-500/35'
-                          : 'border-purple-400/50 dark:border-purple-500/35',
-                      )}
-                    />
-                    {/* Expanding ripple 2 */}
-                    <motion.div
-                      animate={{ scale: [1, 2.2], opacity: [0.25, 0] }}
-                      transition={{
-                        repeat: Infinity,
-                        duration: 2.2,
-                        ease: 'easeOut',
-                        delay: 0.7,
-                      }}
-                      className={cn(
-                        'absolute w-11 h-11 rounded-full border',
-                        asrEnabled
-                          ? 'border-amber-300/40 dark:border-amber-400/25'
-                          : 'border-purple-300/40 dark:border-purple-400/25',
-                      )}
-                    />
-
-                    {/* Action circle — voice (ASR on) or text input (ASR off) */}
-                    <motion.button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (asrEnabled) handleToggleVoice();
-                        else handleToggleInput();
-                      }}
-                      animate={{ scale: [1, 1.05, 1] }}
-                      transition={{
-                        repeat: Infinity,
-                        duration: 2,
-                        ease: 'easeInOut',
-                      }}
-                      className={cn(
-                        'relative w-11 h-11 rounded-full flex items-center justify-center shadow-lg cursor-pointer hover:shadow-xl active:scale-95 z-10 bg-gradient-to-br',
-                        asrEnabled
-                          ? 'from-amber-400 to-orange-500 dark:from-amber-500 dark:to-orange-600 shadow-amber-400/30 dark:shadow-amber-600/20 hover:shadow-amber-400/40 dark:hover:shadow-amber-600/30'
-                          : 'from-purple-400 to-indigo-500 dark:from-purple-500 dark:to-indigo-600 shadow-purple-400/30 dark:shadow-purple-600/20 hover:shadow-purple-400/40 dark:hover:shadow-purple-600/30',
-                      )}
-                    >
-                      {asrEnabled ? (
-                        <Mic className="w-[18px] h-[18px] text-white drop-shadow-sm" />
-                      ) : (
-                        <MessageSquare className="w-[18px] h-[18px] text-white drop-shadow-sm" />
-                      )}
-                    </motion.button>
-                  </div>
-
-                  {/* Visual indicator below button */}
-                  {asrEnabled ? (
-                    <div className="flex items-center justify-center gap-[3px] h-3">
-                      {[0, 1, 2, 3, 4, 3, 2, 1, 0].map((intensity, i) => (
-                        <motion.div
-                          key={i}
-                          animate={{
-                            scaleY: [0.3, 0.5 + intensity * 0.15, 0.3],
-                            opacity: [0.3, 0.7, 0.3],
-                          }}
-                          transition={{
-                            repeat: Infinity,
-                            duration: 0.8 + (i % 3) * 0.1,
-                            delay: i * 0.08,
-                            ease: 'easeInOut',
-                          }}
-                          className="w-[2.5px] h-full origin-center rounded-full bg-amber-400/70 dark:bg-amber-500/60"
-                        />
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="flex items-center justify-center gap-[3px] h-3">
-                      {[0, 1, 2, 3, 2, 1, 0].map((intensity, i) => (
-                        <motion.div
-                          key={i}
-                          animate={{
-                            scaleY: [0.3, 0.45 + intensity * 0.15, 0.3],
-                            opacity: [0.25, 0.6, 0.25],
-                          }}
-                          transition={{
-                            repeat: Infinity,
-                            duration: 1.0 + (i % 3) * 0.15,
-                            delay: i * 0.12,
-                            ease: 'easeInOut',
-                          }}
-                          className="w-[2.5px] h-full origin-center rounded-full bg-purple-400/60 dark:bg-purple-500/50"
-                        />
-                      ))}
-                    </div>
-                  )}
-
-                  {/* Label */}
-                  <motion.span
-                    animate={{ opacity: [0.5, 0.9, 0.5] }}
-                    transition={{
-                      repeat: Infinity,
-                      duration: 2.5,
-                      ease: 'easeInOut',
-                    }}
-                    className={cn(
-                      'text-[10px] font-medium tracking-wider',
-                      asrEnabled
-                        ? 'text-amber-600/70 dark:text-amber-400/60'
-                        : 'text-purple-600/70 dark:text-purple-400/60',
-                    )}
-                  >
-                    {t('roundtable.yourTurn')}
-                  </motion.span>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/lib/buffer/stream-buffer.ts
+++ b/lib/buffer/stream-buffer.ts
@@ -63,6 +63,7 @@ export interface CueUserItem {
   kind: 'cue_user';
   fromAgentId?: string;
   prompt?: string;
+  options?: string[];
 }
 
 export interface DoneItem {
@@ -119,7 +120,7 @@ export interface StreamBufferCallbacks {
    */
   onSpeechProgress(ratio: number | null): void;
   onThinking(data: { stage: string; agentId?: string } | null): void;
-  onCueUser(fromAgentId?: string, prompt?: string): void;
+  onCueUser(fromAgentId?: string, prompt?: string, options?: string[]): void;
   onDone(data: {
     totalActions: number;
     totalAgents: number;
@@ -270,7 +271,7 @@ export class StreamBuffer {
     this.items.push({ kind: 'thinking', ...data });
   }
 
-  pushCueUser(data: { fromAgentId?: string; prompt?: string }): void {
+  pushCueUser(data: { fromAgentId?: string; prompt?: string; options?: string[] }): void {
     if (this._disposed) return;
     this.items.push({ kind: 'cue_user', ...data });
   }
@@ -404,7 +405,7 @@ export class StreamBuffer {
             this.cb.onThinking(item);
             break;
           case 'cue_user':
-            this.cb.onCueUser(item.fromAgentId, item.prompt);
+            this.cb.onCueUser(item.fromAgentId, item.prompt, item.options);
             break;
           case 'done':
             this.cb.onLiveSpeech(null, null);
@@ -625,7 +626,7 @@ export class StreamBuffer {
         break;
 
       case 'cue_user':
-        this.cb.onCueUser(item.fromAgentId, item.prompt);
+        this.cb.onCueUser(item.fromAgentId, item.prompt, item.options);
         this.readIndex++;
         this.charCursor = 0;
         this.advanceNonText();
@@ -686,7 +687,7 @@ export class StreamBuffer {
           this.cb.onThinking(next);
           break;
         case 'cue_user':
-          this.cb.onCueUser(next.fromAgentId, next.prompt);
+          this.cb.onCueUser(next.fromAgentId, next.prompt, next.options);
           break;
         case 'done':
           this.cb.onLiveSpeech(null, null);

--- a/lib/chat/pi/prompts.ts
+++ b/lib/chat/pi/prompts.ts
@@ -107,6 +107,8 @@ export function buildDirectorPrompt(
     '# Terminal Tool Policy',
     'Use exactly one terminal tool per loop.',
     'Use `cue_user` when the classroom should wait for the user to continue, ask something new, or answer a visible follow-up.',
+    'When calling `cue_user`, include a concise learner-facing `prompt`. If the response can be expressed as 2-4 clear, mutually exclusive choices, also include `options`; omit options for open-ended replies.',
+    'The cue prompt and options must match the last visible classroom-agent turn; do not introduce a new question or teaching content only inside the tool call.',
     'Use `close_session` when the latest user message or immediate history clearly indicates goodbye, no more, thanks-and-done, conclusion, wrap-up, an explicit end, or a request to return to the lesson.',
     '`close_session` closes only the current Q&A/discussion side session. It does NOT mean the whole class is over unless the user explicitly says the lesson/class is over.',
     'When ending a Q&A/discussion, keep the visible agent response brief and avoid saying "class dismissed", "下课", "再见", or equivalent whole-class farewell language unless the user explicitly asks to end the entire class.',

--- a/lib/chat/pi/tools/cue-user.ts
+++ b/lib/chat/pi/tools/cue-user.ts
@@ -5,7 +5,17 @@ import type { StatelessEvent } from '@/lib/types/chat';
 const CueUserParams = Type.Object({
   prompt: Type.Optional(
     Type.String({
-      description: 'Optional short prompt for handing the turn back to the user.',
+      description:
+        'A concise, learner-facing question that makes it clear what response is expected.',
+      maxLength: 240,
+    }),
+  ),
+  options: Type.Optional(
+    Type.Array(Type.String({ minLength: 1, maxLength: 60 }), {
+      description:
+        'Two to four short, mutually exclusive replies when the learner can answer with one tap. Omit for open-ended questions.',
+      minItems: 2,
+      maxItems: 4,
     }),
   ),
 });
@@ -62,9 +72,14 @@ export function buildCueUserTool(opts: {
         };
       }
 
+      const options = params.options
+        ?.map((option) => option.trim())
+        .filter((option, index, all) => option.length > 0 && all.indexOf(option) === index)
+        .slice(0, 4);
       const emitted = await opts.cueUser({
         fromAgentId: opts.getLastAgentId(),
-        prompt: params.prompt,
+        prompt: params.prompt?.trim() || undefined,
+        ...(options && options.length >= 2 ? { options } : {}),
       });
       return {
         content: [

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -719,6 +719,7 @@
     "softClosing": "متابعة النقاش",
     "thinking": "يفكر",
     "yourTurn": "دورك",
+    "resumeLesson": "متابعة الدرس",
     "stopDiscussion": "إيقاف النقاش",
     "autoPlay": "تشغيل تلقائي",
     "autoPlayOff": "إيقاف التشغيل التلقائي",

--- a/lib/i18n/locales/de-DE.json
+++ b/lib/i18n/locales/de-DE.json
@@ -718,6 +718,7 @@
     "qaEnded": "Fragerunde beendet",
     "thinking": "Denkt nach",
     "yourTurn": "Du bist dran",
+    "resumeLesson": "Unterricht fortsetzen",
     "stopDiscussion": "Diskussion beenden",
     "softClosing": "Diskussion fortsetzen",
     "autoPlay": "Automatische Wiedergabe",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -718,6 +718,7 @@
     "qaEnded": "Q&A ended",
     "thinking": "Thinking",
     "yourTurn": "Your turn",
+    "resumeLesson": "Continue lesson",
     "stopDiscussion": "Stop Discussion",
     "softClosing": "Continue discussion",
     "autoPlay": "Auto-play",

--- a/lib/i18n/locales/es-MX.json
+++ b/lib/i18n/locales/es-MX.json
@@ -718,6 +718,7 @@
     "qaEnded": "Preguntas y respuestas finalizadas",
     "thinking": "Pensando",
     "yourTurn": "Tu turno",
+    "resumeLesson": "Continuar la lección",
     "stopDiscussion": "Detener discusión",
     "softClosing": "Continuar discusión",
     "autoPlay": "Reproducción automática",

--- a/lib/i18n/locales/fr-FR.json
+++ b/lib/i18n/locales/fr-FR.json
@@ -718,6 +718,7 @@
     "qaEnded": "Questions terminées",
     "thinking": "Réflexion",
     "yourTurn": "À vous",
+    "resumeLesson": "Reprendre le cours",
     "stopDiscussion": "Arrêter la discussion",
     "softClosing": "Poursuivre la discussion",
     "autoPlay": "Lecture auto",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -719,6 +719,7 @@
     "softClosing": "話し合いを続ける",
     "thinking": "思考中",
     "yourTurn": "あなたの番です",
+    "resumeLesson": "授業に戻る",
     "stopDiscussion": "ディスカッションを終了",
     "autoPlay": "自動再生",
     "autoPlayOff": "自動再生を停止",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -719,6 +719,7 @@
     "softClosing": "토론 계속하기",
     "thinking": "생각 중",
     "yourTurn": "내 차례",
+    "resumeLesson": "수업 계속하기",
     "stopDiscussion": "토론 중단",
     "autoPlay": "자동 재생",
     "autoPlayOff": "자동 재생 끄기",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -719,6 +719,7 @@
     "softClosing": "Continuar discussão",
     "thinking": "Pensando",
     "yourTurn": "Sua vez",
+    "resumeLesson": "Continuar a aula",
     "stopDiscussion": "Encerrar Discussão",
     "autoPlay": "Reprodução automática",
     "autoPlayOff": "Parar reprodução automática",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -719,6 +719,7 @@
     "softClosing": "Продолжить обсуждение",
     "thinking": "Размышляет",
     "yourTurn": "Ваша очередь",
+    "resumeLesson": "Продолжить урок",
     "stopDiscussion": "Завершить обсуждение",
     "autoPlay": "Автовоспр.",
     "autoPlayOff": "Остановить",

--- a/lib/i18n/locales/vi-VN.json
+++ b/lib/i18n/locales/vi-VN.json
@@ -718,6 +718,7 @@
     "qaEnded": "Phần hỏi đáp đã kết thúc",
     "thinking": "Đang suy nghĩ",
     "yourTurn": "Đến lượt bạn",
+    "resumeLesson": "Tiếp tục bài học",
     "stopDiscussion": "Dừng thảo luận",
     "softClosing": "Tiếp tục thảo luận",
     "autoPlay": "Tự động phát",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -718,6 +718,7 @@
     "qaEnded": "问答已结束",
     "thinking": "思考中",
     "yourTurn": "轮到你发言了",
+    "resumeLesson": "继续课程",
     "stopDiscussion": "结束讨论",
     "softClosing": "继续讨论",
     "autoPlay": "自动播放",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -703,6 +703,7 @@
     "qaEnded": "問答已結束",
     "thinking": "思考中",
     "yourTurn": "輪到你發言了",
+    "resumeLesson": "繼續課程",
     "stopDiscussion": "結束討論",
     "softClosing": "繼續討論",
     "autoPlay": "自動播放",

--- a/lib/playback/auto-resume.ts
+++ b/lib/playback/auto-resume.ts
@@ -1,13 +1,14 @@
 import type { EngineMode } from './types';
 
 /**
- * Where a chat-session cleanup originated. A confirmed or timed-out soft close
- * may auto-resume an interrupted lecture; other sources must not.
+ * Where a chat-session cleanup originated. A confirmed/timed-out soft close or
+ * the explicit resume-lesson control may resume lecture playback.
  */
 export type CleanupSource =
   | 'soft_close_enter'
   | 'soft_close_confirmed'
   | 'soft_close_timeout'
+  | 'resume_lesson'
   | 'manual_stop'
   | 'scene_switch'
   | 'error'
@@ -31,12 +32,22 @@ export interface AutoResumeArgs {
 /**
  * Decide whether an ended Q&A/discussion should auto-resume the lecture it
  * interrupted. Pure and conservative: it only returns true for the narrow
- * "completed soft close after a satisfied/back-to-lesson Q&A" case, and
- * requires the engine to be idle with content still remaining.
+ * "completed soft close after a satisfied/back-to-lesson Q&A" case or the
+ * explicit resume-lesson action, and requires the engine to be idle with
+ * content still remaining.
  */
 export function shouldAutoResumeLecture(args: AutoResumeArgs): boolean {
-  if (args.source !== 'soft_close_confirmed' && args.source !== 'soft_close_timeout') return false;
-  if (!args.hadLectureInterruption) return false;
+  const isExplicitResume = args.source === 'resume_lesson';
+  if (
+    args.source !== 'soft_close_confirmed' &&
+    args.source !== 'soft_close_timeout' &&
+    !isExplicitResume
+  ) {
+    return false;
+  }
+  // An explicit classroom control is authoritative even when the Q&A began
+  // before playback, so it can start the lesson instead of leaving the engine idle.
+  if (!isExplicitResume && !args.hadLectureInterruption) return false;
   if (args.endReason !== 'user_done' && args.endReason !== 'back_to_lesson') return false;
   if (args.engineMode !== 'idle') return false;
   if (args.isExhausted || args.playbackCompleted) return false;

--- a/lib/types/chat.ts
+++ b/lib/types/chat.ts
@@ -14,10 +14,20 @@ export type SessionType = 'qa' | 'discussion' | 'lecture';
 export type SessionStatus =
   | 'idle'
   | 'active'
+  | 'waiting-user'
   | 'soft-closing'
   | 'interrupted'
   | 'completed'
   | 'error';
+
+/** A durable hand-off from the classroom agents to the learner. */
+export interface CueUserState {
+  fromAgentId?: string;
+  prompt?: string;
+  /** Optional short replies rendered as one-tap actions. */
+  options?: string[];
+  parkedAt: number;
+}
 
 /**
  * Metadata attached to chat messages
@@ -63,6 +73,8 @@ export interface ChatSession {
   /** Absolute deadline for the client-side soft-closing grace window. */
   softCloseDeadline?: number;
   directorState?: DirectorState;
+  /** Present while the session is parked and waiting for the learner. */
+  cueUser?: CueUserState;
 }
 
 export interface PiSessionBoundaryContext {
@@ -470,7 +482,10 @@ export type StatelessEvent =
           }
         | { kind: 'projection'; stageId: string; lastSeq: number };
     }
-  | { type: 'cue_user'; data: { fromAgentId?: string; prompt?: string } }
+  | {
+      type: 'cue_user';
+      data: { fromAgentId?: string; prompt?: string; options?: string[] };
+    }
   | {
       type: 'done';
       data: {

--- a/lib/utils/chat-storage-core.ts
+++ b/lib/utils/chat-storage-core.ts
@@ -41,6 +41,8 @@ export interface ChatSessionStatePayload extends ChatMessageSkeleton {
   updatedAt: number;
   sceneId?: string;
   lastActionIndex?: number;
+  cueUser?: ChatSession['cueUser'];
+  directorState?: ChatSession['directorState'];
 }
 
 export interface FoldedChat {
@@ -126,6 +128,22 @@ export type ChatSyncPlan =
       finalStatus?: 'active' | 'completed';
     };
 
+function isCueUserState(value: unknown): value is NonNullable<ChatSession['cueUser']> {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<NonNullable<ChatSession['cueUser']>>;
+  return (
+    (candidate.fromAgentId === undefined || typeof candidate.fromAgentId === 'string') &&
+    (candidate.prompt === undefined || typeof candidate.prompt === 'string') &&
+    (candidate.options === undefined ||
+      (Array.isArray(candidate.options) &&
+        candidate.options.length >= 2 &&
+        candidate.options.length <= 4 &&
+        candidate.options.every((option) => typeof option === 'string'))) &&
+    typeof candidate.parkedAt === 'number' &&
+    Number.isFinite(candidate.parkedAt)
+  );
+}
+
 function isLegacyRecord(record: unknown): record is ChatSessionRecord {
   if (typeof record !== 'object' || record === null) return false;
   const candidate = record as Partial<ChatSessionRecord>;
@@ -135,6 +153,7 @@ function isLegacyRecord(record: unknown): record is ChatSessionRecord {
     typeof candidate.title === 'string' &&
     (candidate.status === 'idle' ||
       candidate.status === 'active' ||
+      candidate.status === 'waiting-user' ||
       candidate.status === 'soft-closing' ||
       candidate.status === 'interrupted' ||
       candidate.status === 'completed' ||
@@ -154,7 +173,10 @@ function isLegacyRecord(record: unknown): record is ChatSessionRecord {
     candidate.config !== null &&
     Array.isArray(candidate.toolCalls) &&
     typeof candidate.createdAt === 'number' &&
-    typeof candidate.updatedAt === 'number'
+    typeof candidate.updatedAt === 'number' &&
+    (candidate.cueUser === undefined || isCueUserState(candidate.cueUser)) &&
+    (candidate.directorState === undefined ||
+      (typeof candidate.directorState === 'object' && candidate.directorState !== null))
   );
 }
 
@@ -197,6 +219,8 @@ export function fromLegacyRecord(record: ChatSessionRecord): ChatSession {
     ...(Number.isInteger(record.lastActionIndex)
       ? { lastActionIndex: record.lastActionIndex }
       : {}),
+    ...(record.cueUser ? { cueUser: record.cueUser } : {}),
+    ...(record.directorState ? { directorState: record.directorState } : {}),
   };
 }
 
@@ -332,6 +356,8 @@ export function statePayload(session: ChatSession): ChatSessionStatePayload {
     ...(Number.isInteger(session.lastActionIndex)
       ? { lastActionIndex: session.lastActionIndex }
       : {}),
+    ...(session.cueUser ? { cueUser: session.cueUser } : {}),
+    ...(session.directorState ? { directorState: session.directorState } : {}),
   };
 }
 
@@ -360,6 +386,7 @@ function isStatePayload(payload: unknown): payload is ChatSessionStatePayload {
     typeof candidate.title === 'string' &&
     (candidate.status === 'idle' ||
       candidate.status === 'active' ||
+      candidate.status === 'waiting-user' ||
       candidate.status === 'soft-closing' ||
       candidate.status === 'interrupted' ||
       candidate.status === 'completed' ||
@@ -374,7 +401,10 @@ function isStatePayload(payload: unknown): payload is ChatSessionStatePayload {
     typeof candidate.updatedAt === 'number' &&
     Number.isFinite(candidate.updatedAt) &&
     (candidate.sceneId === undefined || typeof candidate.sceneId === 'string') &&
-    (candidate.lastActionIndex === undefined || Number.isInteger(candidate.lastActionIndex))
+    (candidate.lastActionIndex === undefined || Number.isInteger(candidate.lastActionIndex)) &&
+    (candidate.cueUser === undefined || isCueUserState(candidate.cueUser)) &&
+    (candidate.directorState === undefined ||
+      (typeof candidate.directorState === 'object' && candidate.directorState !== null))
   );
 }
 
@@ -427,6 +457,8 @@ export function foldRecords(records: RuntimeRecord[]): FoldedChat {
       updatedAt: state.updatedAt,
       sceneId: state.sceneId,
       lastActionIndex: state.lastActionIndex,
+      cueUser: state.cueUser,
+      directorState: state.directorState,
     },
   };
 }

--- a/lib/utils/database.ts
+++ b/lib/utils/database.ts
@@ -173,6 +173,8 @@ export interface ChatSessionRecord {
   updatedAt: number;
   sceneId?: string;
   lastActionIndex?: number;
+  cueUser?: ChatSession['cueUser'];
+  directorState?: ChatSession['directorState'];
 }
 
 /** Compatibility-only shape for the retired editor right-rail table. The

--- a/tests/chat/roundtable-cue-user.test.ts
+++ b/tests/chat/roundtable-cue-user.test.ts
@@ -8,8 +8,8 @@ vi.mock('@/lib/hooks/use-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
 }));
 
-describe('Roundtable cue-user card', () => {
-  it('shows the learner-facing prompt and structured quick replies', () => {
+describe('Roundtable cue-user turn', () => {
+  it('embeds the learner-facing prompt beside the user with structured quick replies', () => {
     const html = renderToStaticMarkup(
       createElement(Roundtable, {
         isCueUser: true,
@@ -21,7 +21,10 @@ describe('Roundtable cue-user card', () => {
     );
 
     expect(html).toContain('data-testid="cue-user-card"');
-    expect(html).toContain('data-testid="cue-user-floating-panel"');
+    expect(html).toContain('data-testid="cue-user-embedded-turn"');
+    expect(html).toContain('data-cue-side="user"');
+    expect(html).toContain('data-testid="cue-user-bubble-tail"');
+    expect(html).not.toContain('data-testid="cue-user-floating-panel"');
     expect(html).toContain('data-testid="cue-user-resume-lesson"');
     expect(html).toContain('roundtable.yourTurn');
     expect(html).toContain('roundtable.textInput');

--- a/tests/chat/roundtable-cue-user.test.ts
+++ b/tests/chat/roundtable-cue-user.test.ts
@@ -1,0 +1,42 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { isResumeLessonOption, Roundtable } from '@/components/roundtable';
+
+vi.mock('@/lib/hooks/use-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+describe('Roundtable cue-user card', () => {
+  it('shows the learner-facing prompt and structured quick replies', () => {
+    const html = renderToStaticMarkup(
+      createElement(Roundtable, {
+        isCueUser: true,
+        cueUserPrompt: 'Which path should we explore next?',
+        cueUserOptions: ['Show an example', 'Let me practice'],
+        onMessageSend: vi.fn(),
+        onResumeLesson: vi.fn(),
+      }),
+    );
+
+    expect(html).toContain('data-testid="cue-user-card"');
+    expect(html).toContain('data-testid="cue-user-floating-panel"');
+    expect(html).toContain('data-testid="cue-user-resume-lesson"');
+    expect(html).toContain('roundtable.yourTurn');
+    expect(html).toContain('roundtable.textInput');
+    expect(html).toContain('roundtable.voiceInput');
+    expect(html).toContain('roundtable.resumeLesson');
+    expect(html).toContain('Which path should we explore next?');
+    expect(html).toContain('Show an example');
+    expect(html).toContain('Let me practice');
+  });
+
+  it('recognizes resume-lesson replies so they can bypass another LLM round', () => {
+    expect(isResumeLessonOption('继续课程')).toBe(true);
+    expect(isResumeLessonOption('不用，继续课程')).toBe(true);
+    expect(isResumeLessonOption('回到课堂')).toBe(true);
+    expect(isResumeLessonOption('Continue the lesson')).toBe(true);
+    expect(isResumeLessonOption('继续讲讲装饰器')).toBe(false);
+  });
+});

--- a/tests/components/edit/playback-chrome-root-element-reference-owner.test.ts
+++ b/tests/components/edit/playback-chrome-root-element-reference-owner.test.ts
@@ -230,6 +230,7 @@ vi.mock('@/components/chat/chat-area', async () => {
         resumeActiveLiveBuffer: vi.fn(),
         pauseActiveLiveBuffer: vi.fn(),
         stopActiveSession: vi.fn(),
+        resumeLesson: vi.fn().mockResolvedValue(true),
         continueActiveSoftClosingSession: vi.fn(),
         getActiveSessionType: vi.fn(),
         pauseBuffer: vi.fn(),

--- a/tests/lib/chat/pi/cue-user.test.ts
+++ b/tests/lib/chat/pi/cue-user.test.ts
@@ -16,13 +16,20 @@ describe('Pi chat cue_user tool', () => {
       },
     });
 
-    const first = await tool.execute('cue-1', { prompt: 'Any follow-up?' });
+    const first = await tool.execute('cue-1', {
+      prompt: ' Any follow-up? ',
+      options: [' Show an example ', 'Let me practice', 'Let me practice'],
+    });
     const second = await tool.execute('cue-2', { prompt: 'Again?' });
 
     expect(events).toEqual([
       {
         type: 'cue_user',
-        data: { fromAgentId: 'default-1', prompt: 'Any follow-up?' },
+        data: {
+          fromAgentId: 'default-1',
+          prompt: 'Any follow-up?',
+          options: ['Show an example', 'Let me practice'],
+        },
       },
     ]);
     expect(first.details).toEqual({ emitted: true });

--- a/tests/lib/chat/pi/prompts.test.ts
+++ b/tests/lib/chat/pi/prompts.test.ts
@@ -272,6 +272,9 @@ describe('Pi director prompt closure routing', () => {
 
     expect(prompt).toContain('Terminal Tool Policy');
     expect(prompt).toContain('Use exactly one terminal tool per loop');
+    expect(prompt).toContain('include a concise learner-facing `prompt`');
+    expect(prompt).toContain('2-4 clear, mutually exclusive choices');
+    expect(prompt).toContain('must match the last visible classroom-agent turn');
     expect(prompt).toContain('`cue_user` and `close_session` are mutually exclusive');
     expect(prompt).toContain('If you call `close_session`, do not call `cue_user` afterward');
     expect(prompt).toContain('close_session.endReason');

--- a/tests/lib/chat/use-chat-sessions.test.ts
+++ b/tests/lib/chat/use-chat-sessions.test.ts
@@ -9,6 +9,7 @@ import {
   getPiSingleRequestOutcome,
   isOpenLiveSession,
   normalizeStoredSessionsForRestore,
+  parkSessionForUser,
   retireLiveRequestResources,
   resumeSoftClosingSessionForFollowUp,
   resumeSoftClosingSessionWithoutMessage,
@@ -45,12 +46,18 @@ describe('normalizeStoredSessionsForRestore', () => {
   it('does not restore transient active or soft-closing statuses', () => {
     const restored = normalizeStoredSessionsForRestore([
       makeSession({ id: 'active', status: 'active' }),
+      makeSession({
+        id: 'waiting-user',
+        status: 'waiting-user',
+        cueUser: { prompt: 'Which example should we try?', parkedAt: 10 },
+      }),
       makeSession({ id: 'soft-closing', status: 'soft-closing', endReason: 'user_goodbye' }),
       makeSession({ id: 'completed', status: 'completed' }),
     ]);
 
     expect(restored.map((session) => [session.id, session.status, session.endReason])).toEqual([
       ['active', 'interrupted', undefined],
+      ['waiting-user', 'waiting-user', undefined],
       ['soft-closing', 'completed', 'user_goodbye'],
       ['completed', 'completed', undefined],
     ]);
@@ -134,9 +141,33 @@ describe('Pi live-session context lifecycle', () => {
 describe('isOpenLiveSession', () => {
   it('treats soft-closing QA/discussion sessions as still open for live controls', () => {
     expect(isOpenLiveSession({ type: 'qa', status: 'active' })).toBe(true);
+    expect(isOpenLiveSession({ type: 'qa', status: 'waiting-user' })).toBe(true);
     expect(isOpenLiveSession({ type: 'discussion', status: 'soft-closing' })).toBe(true);
     expect(isOpenLiveSession({ type: 'qa', status: 'completed' })).toBe(false);
     expect(isOpenLiveSession({ type: 'lecture', status: 'soft-closing' })).toBe(false);
+  });
+});
+
+describe('parkSessionForUser', () => {
+  it('persists a normalized learner hand-off with one-tap replies', () => {
+    const parked = parkSessionForUser(
+      makeSession(),
+      'default-1',
+      '  Which path should we explore?  ',
+      [' Examples ', 'Practice', 'Practice', ''],
+      99,
+    );
+
+    expect(parked).toMatchObject({
+      status: 'waiting-user',
+      updatedAt: 99,
+      cueUser: {
+        fromAgentId: 'default-1',
+        prompt: 'Which path should we explore?',
+        options: ['Examples', 'Practice'],
+        parkedAt: 99,
+      },
+    });
   });
 });
 
@@ -158,6 +189,7 @@ describe('resumeSoftClosingSessionForFollowUp', () => {
         status: 'soft-closing',
         endReason: 'user_done',
         softCloseDeadline: 123,
+        cueUser: { prompt: 'Continue?', parkedAt: 90 },
         messages: [wrapUpMessage],
       }),
       followUpMessage,
@@ -167,6 +199,7 @@ describe('resumeSoftClosingSessionForFollowUp', () => {
     expect(next.status).toBe('active');
     expect(next.endReason).toBeUndefined();
     expect(next.softCloseDeadline).toBeUndefined();
+    expect(next.cueUser).toBeUndefined();
     expect(next.updatedAt).toBe(99);
     expect(next.messages).toEqual([wrapUpMessage, followUpMessage]);
   });

--- a/tests/lib/playback/auto-resume.test.ts
+++ b/tests/lib/playback/auto-resume.test.ts
@@ -30,6 +30,17 @@ describe('shouldAutoResumeLecture', () => {
     ).toBe(false);
   });
 
+  it('resumes immediately for the explicit continue-lesson action', () => {
+    expect(
+      shouldAutoResumeLecture({
+        ...base,
+        source: 'resume_lesson',
+        endReason: 'back_to_lesson',
+        hadLectureInterruption: false,
+      }),
+    ).toBe(true);
+  });
+
   it('never resumes for a non-soft-close cleanup source', () => {
     expect(shouldAutoResumeLecture({ ...base, source: 'soft_close_enter' })).toBe(false);
     expect(shouldAutoResumeLecture({ ...base, source: 'manual_stop' })).toBe(false);

--- a/tests/runtime/chat-storage-core.test.ts
+++ b/tests/runtime/chat-storage-core.test.ts
@@ -8,6 +8,7 @@ import {
   fromLegacyRecords,
   normalizeSession,
   planChatSync,
+  statePayload as chatStatePayload,
 } from '@/lib/utils/chat-storage-core';
 
 const STAGE_ID = 'stage-core';
@@ -282,5 +283,29 @@ describe('normalizeSession', () => {
   );
   it('preserves terminal statuses', () => {
     expect(normalizeSession(session({ status: 'completed' })).status).toBe('completed');
+  });
+
+  it('preserves a durable learner park and its prompt metadata', () => {
+    const parked = session({
+      status: 'waiting-user',
+      cueUser: {
+        fromAgentId: 'default-1',
+        prompt: 'Choose the next activity',
+        options: ['Example', 'Practice'],
+        parkedAt: 1_150,
+      },
+      directorState: { turnCount: 1, agentResponses: [], whiteboardLedger: [] },
+    });
+
+    expect(normalizeSession(parked)).toMatchObject({
+      status: 'waiting-user',
+      cueUser: parked.cueUser,
+      directorState: parked.directorState,
+    });
+    expect(chatStatePayload(parked)).toMatchObject({
+      status: 'waiting-user',
+      cueUser: parked.cueUser,
+      directorState: parked.directorState,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Turn the classroom `cue_user` handoff into a durable learner park state and present it as a native roundtable turn instead of a detached overlay.

## Related Issues

None.

## Changes

- Persist the cue prompt, quick replies, origin agent, and parked timestamp across reloads.
- Restore parked Q&A/discussion sessions without replaying an LLM request.
- Render the learner handoff inside the existing roundtable conversation stage, right-aligned with a bubble tail pointing to the learner avatar.
- Keep quick replies, free-text composition, and voice-recording feedback in the same dialogue surface.
- Move Continue lesson into the course toolbar and resume playback immediately without another LLM round or the soft-close delay.
- Apply the same learner-side ownership in presentation mode by anchoring the handoff above the right-side user dock.
- Collapse model-generated variants such as 不用，继续课程 into the deterministic Continue lesson action.
- Tighten Pi director guidance around `cue_user` versus `close_session` and carry structured options through the SSE buffer.
- Add storage migration, session-state, prompt/tool, playback-resume, and roundtable rendering coverage.
- Add the new UI label to all 12 locales.

## UI change

**Before:** the parked learner prompt appeared as a second floating card over the slide, separate from the existing dialogue and input surfaces.

**After:** the roundtable dialogue itself changes ownership to the learner. The surface moves to the user side, points to the user avatar, and swaps its response dock between quick replies, text input, and voice feedback without opening another card. Continue lesson stays with the course controls in the toolbar.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Start a lesson, interrupt playback with a Q&A, and wait for the teacher to cue the learner.
2. Verify the learner prompt appears inside the roundtable dialogue area, attached to the user side, with quick replies and text/voice entry points.
3. Open text or voice input and verify the response dock changes in place rather than opening a second overlay.
4. Choose a quick reply and verify it is appended as a user message.
5. Choose Continue lesson in the toolbar and verify playback resumes immediately without a soft-close countdown.
6. Reload while parked and verify the same prompt/options are restored without another model request.

### What you personally verified

- Browser-rendered the learner-side roundtable state at desktop width and checked the bubble alignment, tail, response dock, toolbar action, and active user avatar.
- Verified the local application compiles and loads without browser console errors.
- `pnpm exec tsc --noEmit --pretty false` passes.
- Focused cue-user rendering tests pass.
- Full Vitest suite passes: 660 files and 7,416 tests passed; 9 files and 26 tests skipped.
- All GitHub CI checks pass, including E2E and the PostgreSQL storage contract.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [x] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
