### PR TITLE
test: fix PlaybackChromeRoot browser TTS mock

### DIFF
--- a/tests/components/edit/playback-chrome-root-element-reference-owner.test.ts
+++ b/tests/components/edit/playback-chrome-root-element-reference-owner.test.ts
@@ -109,6 +109,7 @@ const settingsState = {
   setChatAreaCollapsed: vi.fn(),
   setTTSMuted: vi.fn(),
   setTTSVolume: vi.fn(),
+  ensureBrowserNativeTTSEnabled: vi.fn(),
   selectedAgentIds: [],
   ttsMuted: false,
   ttsEnabled: false,


### PR DESCRIPTION
## Summary

Fix the PlaybackChromeRoot ownership tests by adding the missing browser-native TTS action to the settings mock.

## Related Issues

Fixes the quality pipeline failure:

`TypeError: ensureBrowserNativeTTSEnabled is not a function`

## Changes

- Add `ensureBrowserNativeTTSEnabled: vi.fn()` to the PlaybackChromeRoot test settings mock.
- No production code changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run the PlaybackChromeRoot ownership test before this change.
2. Observe `TypeError: ensureBrowserNativeTTSEnabled is not a function`.
3. Add the missing mock and rerun the test.

### What you personally verified

- Targeted test passes: 8/8.
- `pnpm check` passes.
- `pnpm lint` passes with 0 errors.
- `npx tsc --noEmit` passes with Node 24 and a 4096 MB heap.
- No production code was changed.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

Test command:

```bash
pnpm vitest run tests/components/edit/playback-chrome-root-element-reference-owner.test.ts
```
Result:

Test Files  1 passed
Tests       8 passed

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings