### PR TITLE
fix(docker): copy prebuilt @img native libs in runner stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,17 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Next.js standalone file tracing misses native shared libraries (.so) required by sharp.
+# Copy all prebuilt @img packages from deps to guarantee libvips and sharp native bindings are present.
+RUN --mount=type=bind,from=deps,source=/app/node_modules,target=/deps_node_modules \
+    if [ -d /deps_node_modules/.pnpm ]; then \
+      cp -a /deps_node_modules/.pnpm/@img* ./node_modules/.pnpm/ 2>/dev/null || true; \
+    fi && \
+    if [ -d /deps_node_modules/@img ]; then \
+      cp -a /deps_node_modules/@img ./node_modules/ 2>/dev/null || true; \
+    fi && \
+    chown -R nextjs:nodejs ./node_modules/.pnpm/@img* ./node_modules/@img 2>/dev/null || true
+
 USER nextjs
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Copy prebuilt `@img*` native packages (containing `libvips-cpp.so`) from the `deps` stage into the `runner` stage via Docker BuildKit bind mount.
- Resolves `ERR_DLOPEN_FAILED: Error loading shared library libvips-cpp.so.8.18.6` when using Sharp in the Next.js standalone Docker runner.

## Related Issues
Related to #1357 (bumped `sharp` to `0.35.4`).

## Changes
- In `Dockerfile` Stage 4 (`runner`), add a bind mount copying `./node_modules/.pnpm/@img*` and `./node_modules/@img` from the `deps` stage to ensure native `.so` shared libraries are present in the standalone runner image.
- Set appropriate `nextjs:nodejs` ownership for the copied native packages.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD or build changes

## Verification

### Steps to reproduce / test
1. Build the production Docker image: `docker compose build openmaic`
2. Start the container: `docker compose up -d openmaic`
3. Verify Sharp native bindings load without missing library errors:
   `docker exec openmaic node -e "require('sharp')"`

### What you personally verified
- Verified that `libvips-cpp.so.8.18.6` is preserved in the runner stage's `node_modules`.
- Confirmed `require('sharp')` succeeds inside the container and course material parsing with images no longer crashes with `ERR_DLOPEN_FAILED`.

### Evidence
- [x] Manually tested locally

## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code