### PR TITLE
feat(render-service): emit render and preview lifecycle events

### DIFF
--- a/render-service/src/events.ts
+++ b/render-service/src/events.ts
@@ -36,11 +36,23 @@ export interface RenderEvent {
   outcome?: RenderOutcome;
   /** Time from submission to being granted an execution slot. */
   queueWaitMs?: number;
-  /** Time spent in the state the event closes. */
+  /**
+   * Wall time the event closes: submission to completion on
+   * `render_job_finished`, and request to response on `preview_request`. On a
+   * finished job this INCLUDES `queueWaitMs`; subtract it, or use `renderMs`,
+   * to get the cost of the render itself.
+   */
   durationMs?: number;
-  /** Jobs queued (not yet started) when the event fired. */
+  /** Time from being granted an execution slot to finishing. */
+  renderMs?: number;
+  /** Other jobs still queued when the event fired, excluding this one. */
   queued?: number;
-  /** Jobs executing when the event fired. */
+  /**
+   * Jobs dequeued and not yet finished. These are usually executing, but a job
+   * is counted from the moment it leaves the queue, and it may still be waiting
+   * on the execution permit it shares with `/preview` — so read this as
+   * "admitted to run", not "currently rendering".
+   */
   running?: number;
   /** Fixed vocabulary — never a raw error message. */
   errorCode?: string;
@@ -54,9 +66,33 @@ export interface RenderEvent {
 /** Receives an event. Injectable so tests can assert without touching stdout. */
 export type RenderEventSink = (event: RenderEvent) => void;
 
+/**
+ * The exact fields allowed on the wire. Serializing an explicit list rather
+ * than `Object.entries(event)` makes the redaction promise in the header
+ * structural: a future caller that spreads a job record or a failure object
+ * into an event cannot leak it, because anything not named here is dropped.
+ * Excess-property checking alone would not catch that — spread properties are
+ * exempt from it.
+ */
+const SERIALIZED_FIELDS = [
+  'event',
+  'jobId',
+  'outcome',
+  'queueWaitMs',
+  'durationMs',
+  'renderMs',
+  'queued',
+  'running',
+  'errorCode',
+  'reason',
+  'route',
+  'status',
+] as const satisfies readonly (keyof RenderEvent)[];
+
 function nonEmpty(event: RenderEvent): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(event)) {
+  for (const key of SERIALIZED_FIELDS) {
+    const value = event[key];
     if (value !== undefined && value !== null) out[key] = value;
   }
   return out;

--- a/render-service/src/events.ts
+++ b/render-service/src/events.ts
@@ -1,0 +1,101 @@
+/**
+ * Operational events for the render service.
+ *
+ * The service is otherwise silent: it logs one startup banner and nothing else,
+ * so a deployment can observe that renders happen (CPU, memory) but cannot
+ * answer how many succeeded, how long they took, or how long they waited for a
+ * slot. Job state lives in `JobStore` — in memory by default — so it is gone
+ * the moment the process restarts, and a failed render is reported to the
+ * client as a perfectly healthy `200` whose *body* says `status: 'failed'`,
+ * which makes failures invisible to any proxy or gateway counting status codes.
+ *
+ * These events close that gap with one JSON line per lifecycle transition on
+ * stdout, which every container log pipeline already collects.
+ *
+ * They deliberately carry only bounded, low-cardinality dimensions: an opaque
+ * job id, a state, a duration, a reason code. No client identity, no file or
+ * directory names, no scene content, and no raw error strings — a render works
+ * on untrusted, model-authored input, and none of it belongs in an operational
+ * log. `error_code` is a fixed vocabulary, not a message.
+ */
+
+/** Lifecycle and admission transitions worth a log line. */
+export type RenderEventName =
+  | 'render_job_submitted'
+  | 'render_job_started'
+  | 'render_job_finished'
+  | 'render_admission_rejected'
+  | 'preview_request';
+
+export type RenderOutcome = 'succeeded' | 'failed' | 'cancelled';
+
+export interface RenderEvent {
+  event: RenderEventName;
+  /** Opaque per-job id. Not derived from user input. */
+  jobId?: string;
+  outcome?: RenderOutcome;
+  /** Time from submission to being granted an execution slot. */
+  queueWaitMs?: number;
+  /** Time spent in the state the event closes. */
+  durationMs?: number;
+  /** Jobs queued (not yet started) when the event fired. */
+  queued?: number;
+  /** Jobs executing when the event fired. */
+  running?: number;
+  /** Fixed vocabulary — never a raw error message. */
+  errorCode?: string;
+  /** Which admission cap rejected the caller, or which route served it. */
+  reason?: string;
+  route?: string;
+  /** HTTP status the caller received, for the synchronous preview route. */
+  status?: number;
+}
+
+/** Receives an event. Injectable so tests can assert without touching stdout. */
+export type RenderEventSink = (event: RenderEvent) => void;
+
+function nonEmpty(event: RenderEvent): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(event)) {
+    if (value !== undefined && value !== null) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Human-readable summary. Kept short and dimension-only so a log pipeline can
+ * index it as text without it ever carrying content.
+ */
+function summarize(event: RenderEvent): string {
+  switch (event.event) {
+    case 'render_job_submitted':
+      return `render job queued (queued=${event.queued ?? 0}, running=${event.running ?? 0})`;
+    case 'render_job_started':
+      return `render job started after ${event.queueWaitMs ?? 0}ms in queue`;
+    case 'render_job_finished':
+      return `render job ${event.outcome ?? 'finished'} in ${event.durationMs ?? 0}ms`;
+    case 'render_admission_rejected':
+      return `admission rejected (${event.reason ?? 'unknown'}) on ${event.route ?? 'unknown'}`;
+    case 'preview_request':
+      return `preview ${event.status ?? 0} in ${event.durationMs ?? 0}ms`;
+  }
+}
+
+/**
+ * Default sink: one JSON line per event on stdout.
+ *
+ * `console.error` for a failed render so a pipeline that only forwards stderr
+ * still sees failures; everything else goes to stdout.
+ */
+export const emitRenderEvent: RenderEventSink = (event) => {
+  const line = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level: event.outcome === 'failed' ? 'ERROR' : 'INFO',
+    service: 'render-service',
+    component: event.event === 'preview_request' ? 'preview' : 'render',
+    message: summarize(event),
+    ...nonEmpty(event),
+  });
+  if (event.outcome === 'failed') console.error(line);
+  else console.log(line);
+};

--- a/render-service/src/main.ts
+++ b/render-service/src/main.ts
@@ -40,6 +40,7 @@ import { InProcessExecutor } from './render-executor.js';
 import { InvalidProjectError, unzipProject as defaultUnzipProject } from './unzip.js';
 import { capBodyStream } from './capped-stream.js';
 import { Semaphore } from './semaphore.js';
+import { emitRenderEvent } from './events.js';
 import { PreviewGate, PreviewRejectedError } from './preview-gate.js';
 import {
   ChromiumPreviewRenderer,
@@ -269,7 +270,15 @@ export function createApp(deps: AppDeps): Hono {
     try {
       reservation = coordinator.reserve(identity);
     } catch (error) {
-      if (error instanceof RenderRejectedError) return c.json(rejectionBody(error), 429);
+      if (error instanceof RenderRejectedError) {
+        emitRenderEvent({
+          event: 'render_admission_rejected',
+          route: '/render',
+          reason: error.reason ?? 'unspecified',
+          status: 429,
+        });
+        return c.json(rejectionBody(error), 429);
+      }
       throw error;
     }
 
@@ -325,9 +334,31 @@ export function createApp(deps: AppDeps): Hono {
       if (error instanceof UploadTooLargeError) return c.json({ error: error.message }, 413);
       if (error instanceof BadRequestError) return c.json({ error: error.message }, 400);
       if (error instanceof InvalidProjectError) return c.json({ error: error.message }, 400);
-      if (error instanceof RenderRejectedError) return c.json(rejectionBody(error), 429);
+      if (error instanceof RenderRejectedError) {
+        emitRenderEvent({
+          event: 'render_admission_rejected',
+          route: '/render',
+          reason: error.reason ?? 'unspecified',
+          status: 429,
+        });
+        return c.json(rejectionBody(error), 429);
+      }
       throw error;
     }
+  });
+
+  // Times every response the preview route produces — 200, 413, 429, 504, 500
+  // alike. A synchronous preview reports failure in its status, so this is the
+  // one place a deployment can see the route's real success rate and latency.
+  app.use('/preview', async (c, next) => {
+    const startedAt = Date.now();
+    await next();
+    emitRenderEvent({
+      event: 'preview_request',
+      route: '/preview',
+      status: c.res.status,
+      durationMs: Date.now() - startedAt,
+    });
   });
 
   app.post('/preview', async (c) => {
@@ -341,7 +372,15 @@ export function createApp(deps: AppDeps): Hono {
     try {
       release = previewGate.acquire(identity);
     } catch (error) {
-      if (error instanceof PreviewRejectedError) return c.json(rejectionBody(error), 429);
+      if (error instanceof PreviewRejectedError) {
+        emitRenderEvent({
+          event: 'render_admission_rejected',
+          route: '/preview',
+          reason: (error as Error & { reason?: string }).reason ?? 'unspecified',
+          status: 429,
+        });
+        return c.json(rejectionBody(error), 429);
+      }
       throw error;
     }
 
@@ -402,7 +441,15 @@ export function createApp(deps: AppDeps): Hono {
       if (error instanceof UnprocessablePreviewError) {
         return c.json({ error: error.message }, 422);
       }
-      if (error instanceof PreviewRejectedError) return c.json(rejectionBody(error), 429);
+      if (error instanceof PreviewRejectedError) {
+        emitRenderEvent({
+          event: 'render_admission_rejected',
+          route: '/preview',
+          reason: (error as Error & { reason?: string }).reason ?? 'unspecified',
+          status: 429,
+        });
+        return c.json(rejectionBody(error), 429);
+      }
       if (error instanceof PreviewTimeoutError || deadlineAbort.signal.aborted) {
         return c.json({ error: 'Preview exceeded the deadline' }, 504);
       }

--- a/render-service/src/main.ts
+++ b/render-service/src/main.ts
@@ -40,7 +40,7 @@ import { InProcessExecutor } from './render-executor.js';
 import { InvalidProjectError, unzipProject as defaultUnzipProject } from './unzip.js';
 import { capBodyStream } from './capped-stream.js';
 import { Semaphore } from './semaphore.js';
-import { emitRenderEvent } from './events.js';
+import { emitRenderEvent, type RenderEventSink } from './events.js';
 import { PreviewGate, PreviewRejectedError } from './preview-gate.js';
 import {
   ChromiumPreviewRenderer,
@@ -92,6 +92,12 @@ export interface AppDeps {
   unzipProject?: (zip: Uint8Array, destDir: string) => Promise<void>;
   /** Create a fresh per-render scratch dir. Overridable in tests. */
   makeProjectDir?: () => Promise<string>;
+  /**
+   * Where route-level events go. The coordinator takes its own sink; pass the
+   * same one here so an embedder that injects a sink receives every event type
+   * rather than silently losing the two the routes emit.
+   */
+  onEvent?: RenderEventSink;
   /** Runtime identity reported by health and copied into per-render metrics. */
   runtimeVersions?: RuntimeVersions;
 }
@@ -234,6 +240,7 @@ export function createApp(deps: AppDeps): Hono {
   const previewRenderer = deps.previewRenderer ?? new ChromiumPreviewRenderer();
   const previewDeadlineMs = deps.previewDeadlineMs ?? config.previewDeadlineMs;
   const previewMaxJsonBytes = deps.previewMaxJsonBytes ?? config.previewMaxJsonBytes;
+  const onEvent = deps.onEvent ?? emitRenderEvent;
   const previewGate =
     deps.previewGate ?? new PreviewGate(config.previewMaxInFlight, config.previewMaxPerUser);
 
@@ -271,7 +278,7 @@ export function createApp(deps: AppDeps): Hono {
       reservation = coordinator.reserve(identity);
     } catch (error) {
       if (error instanceof RenderRejectedError) {
-        emitRenderEvent({
+        onEvent({
           event: 'render_admission_rejected',
           route: '/render',
           reason: error.reason ?? 'unspecified',
@@ -335,7 +342,7 @@ export function createApp(deps: AppDeps): Hono {
       if (error instanceof BadRequestError) return c.json({ error: error.message }, 400);
       if (error instanceof InvalidProjectError) return c.json({ error: error.message }, 400);
       if (error instanceof RenderRejectedError) {
-        emitRenderEvent({
+        onEvent({
           event: 'render_admission_rejected',
           route: '/render',
           reason: error.reason ?? 'unspecified',
@@ -353,7 +360,7 @@ export function createApp(deps: AppDeps): Hono {
   app.use('/preview', async (c, next) => {
     const startedAt = Date.now();
     await next();
-    emitRenderEvent({
+    onEvent({
       event: 'preview_request',
       route: '/preview',
       status: c.res.status,
@@ -373,7 +380,7 @@ export function createApp(deps: AppDeps): Hono {
       release = previewGate.acquire(identity);
     } catch (error) {
       if (error instanceof PreviewRejectedError) {
-        emitRenderEvent({
+        onEvent({
           event: 'render_admission_rejected',
           route: '/preview',
           reason: (error as Error & { reason?: string }).reason ?? 'unspecified',
@@ -442,7 +449,7 @@ export function createApp(deps: AppDeps): Hono {
         return c.json({ error: error.message }, 422);
       }
       if (error instanceof PreviewRejectedError) {
-        emitRenderEvent({
+        onEvent({
           event: 'render_admission_rejected',
           route: '/preview',
           reason: (error as Error & { reason?: string }).reason ?? 'unspecified',

--- a/render-service/src/render-coordinator.ts
+++ b/render-service/src/render-coordinator.ts
@@ -85,8 +85,12 @@ export class RenderCoordinator {
   private readonly jobDeadlineMs: number;
   private readonly executionGate: Semaphore;
   private readonly onEvent: RenderEventSink;
-  /** Submission time per in-flight job, so a start can report its queue wait. */
-  private readonly submittedAtMs = new Map<string, number>();
+  /**
+   * Timing per in-flight job, so a start can report its queue wait and a finish
+   * can separate that wait from the render itself. An entry is removed by
+   * `finishEvent`, which also makes the finish idempotent.
+   */
+  private readonly jobTiming = new Map<string, { submittedAt: number; startedAt?: number }>();
 
   constructor(
     private readonly executor: RenderExecutor,
@@ -209,11 +213,13 @@ export class RenderCoordinator {
     const abort = new AbortController();
     this.controllers.set(id, abort);
     this.queue.push({ record, options, abort });
-    this.submittedAtMs.set(id, now);
+    this.jobTiming.set(id, { submittedAt: now });
     this.onEvent({
       event: 'render_job_submitted',
       jobId: id,
-      queued: this.queue.length,
+      // Exclude this job, so an idle service reports queued: 0 and "queued > 0"
+      // is a usable backlog signal.
+      queued: this.queue.length - 1,
       running: this.running,
     });
     this.pump();
@@ -263,15 +269,33 @@ export class RenderCoordinator {
    * the map cannot grow without bound across a long-lived process.
    */
   private finishEvent(id: string, outcome: RenderOutcome, errorCode?: string): void {
-    const submittedAt = this.submittedAtMs.get(id);
-    this.submittedAtMs.delete(id);
+    // Deleting the timing entry is also what makes this idempotent. A terminal
+    // job-store write can reject *after* an outcome is known, which lands in the
+    // caller's catch and would otherwise close the same job a second time with a
+    // contradictory outcome — one render counted as both a success and a
+    // failure, which is precisely the corruption these events exist to rule out.
+    const timing = this.jobTiming.get(id);
+    if (!timing) return;
+    this.jobTiming.delete(id);
+    const now = Date.now();
     this.onEvent({
       event: 'render_job_finished',
       jobId: id,
       outcome,
-      ...(submittedAt === undefined ? {} : { durationMs: Date.now() - submittedAt }),
+      durationMs: now - timing.submittedAt,
+      ...(timing.startedAt === undefined
+        ? {}
+        : {
+            queueWaitMs: timing.startedAt - timing.submittedAt,
+            renderMs: now - timing.startedAt,
+          }),
       ...(errorCode === undefined ? {} : { errorCode }),
     });
+  }
+
+  /** In-flight jobs whose timing is still tracked. Exposed for tests. */
+  get trackedJobs(): number {
+    return this.jobTiming.size;
   }
 
   private async finishNonSuccess(
@@ -307,10 +331,13 @@ export class RenderCoordinator {
         // Inside the slot: the wait measured here is exactly the time this job
         // spent queued behind other renders, which is the signal a busy
         // deployment needs and the one nothing else exposes.
+        const timing = this.jobTiming.get(id);
+        const startedAt = Date.now();
+        if (timing) timing.startedAt = startedAt;
         this.onEvent({
           event: 'render_job_started',
           jobId: id,
-          queueWaitMs: Date.now() - (this.submittedAtMs.get(id) ?? Date.now()),
+          queueWaitMs: startedAt - (timing?.submittedAt ?? startedAt),
           queued: this.queue.length,
           running: this.running,
         });
@@ -351,7 +378,6 @@ export class RenderCoordinator {
       }
 
       await this.artifacts.put(id, outputPath);
-      this.finishEvent(id, 'succeeded');
       await this.jobs.update(id, {
         status: 'succeeded',
         progress: 1,
@@ -360,6 +386,9 @@ export class RenderCoordinator {
         ...(result.performance ? { performance: result.performance } : {}),
         ...(result.metrics ? { metrics: result.metrics } : {}),
       });
+      // Emitted last: until the terminal write lands, "succeeded" is not yet
+      // true, and the catch below would drop the artifact this event describes.
+      this.finishEvent(id, 'succeeded');
     } catch (error) {
       await this.artifacts.remove(id).catch(() => {});
       if (abort.signal.aborted) {

--- a/render-service/src/render-coordinator.ts
+++ b/render-service/src/render-coordinator.ts
@@ -235,6 +235,11 @@ export class RenderCoordinator {
         code: 'cancelled',
         message: 'Render cancelled',
       };
+      // Cancelling before the job ever started skips `finishNonSuccess`, so
+      // close the lifecycle here too. Without this a queued-then-cancelled job
+      // is submitted and then simply never heard from again, which would leave
+      // any success rate computed from these events quietly wrong.
+      this.finishEvent(id, 'cancelled');
       await this.jobs.update(id, {
         status: 'cancelled',
         currentStage: 'cancelled',

--- a/render-service/src/render-coordinator.ts
+++ b/render-service/src/render-coordinator.ts
@@ -13,6 +13,7 @@ import type { ArtifactStore } from './artifact-store.js';
 import { config } from './config.js';
 import type { JobStore } from './job-store.js';
 import type { RenderExecutor } from './render-executor.js';
+import { emitRenderEvent, type RenderEventSink, type RenderOutcome } from './events.js';
 import { Semaphore } from './semaphore.js';
 import type {
   RenderCancelledFailure,
@@ -68,6 +69,8 @@ export interface RenderCoordinatorOptions {
   maxQueue?: number;
   maxJobsPerUser?: number;
   jobDeadlineMs?: number;
+  /** Where lifecycle events go. Defaults to one JSON line per event on stdout. */
+  onEvent?: RenderEventSink;
 }
 
 export class RenderCoordinator {
@@ -81,6 +84,9 @@ export class RenderCoordinator {
   private readonly maxJobsPerUser: number;
   private readonly jobDeadlineMs: number;
   private readonly executionGate: Semaphore;
+  private readonly onEvent: RenderEventSink;
+  /** Submission time per in-flight job, so a start can report its queue wait. */
+  private readonly submittedAtMs = new Map<string, number>();
 
   constructor(
     private readonly executor: RenderExecutor,
@@ -93,6 +99,7 @@ export class RenderCoordinator {
     this.maxJobsPerUser = options.maxJobsPerUser ?? config.maxJobsPerUser;
     this.jobDeadlineMs = options.jobDeadlineMs ?? config.jobDeadlineMs;
     this.executionGate = new Semaphore(this.maxConcurrency);
+    this.onEvent = options.onEvent ?? emitRenderEvent;
   }
 
   /** Run Chromium-backed work within the service-wide execution budget. */
@@ -202,6 +209,13 @@ export class RenderCoordinator {
     const abort = new AbortController();
     this.controllers.set(id, abort);
     this.queue.push({ record, options, abort });
+    this.submittedAtMs.set(id, now);
+    this.onEvent({
+      event: 'render_job_submitted',
+      jobId: id,
+      queued: this.queue.length,
+      running: this.running,
+    });
     this.pump();
     return id;
   }
@@ -239,11 +253,33 @@ export class RenderCoordinator {
     }
   }
 
+  /**
+   * Close a job's lifecycle in the log. Also drops its submission timestamp so
+   * the map cannot grow without bound across a long-lived process.
+   */
+  private finishEvent(id: string, outcome: RenderOutcome, errorCode?: string): void {
+    const submittedAt = this.submittedAtMs.get(id);
+    this.submittedAtMs.delete(id);
+    this.onEvent({
+      event: 'render_job_finished',
+      jobId: id,
+      outcome,
+      ...(submittedAt === undefined ? {} : { durationMs: Date.now() - submittedAt }),
+      ...(errorCode === undefined ? {} : { errorCode }),
+    });
+  }
+
   private async finishNonSuccess(
     id: string,
     projectDir: string,
     result: Exclude<RenderExecutionResult, { status: 'succeeded' }>,
   ): Promise<void> {
+    // `failure.code` is a fixed vocabulary; the free-text message is not logged.
+    this.finishEvent(
+      id,
+      result.status,
+      result.status === 'failed' ? result.failure.code : undefined,
+    );
     try {
       await this.jobs.update(id, {
         status: result.status,
@@ -263,6 +299,16 @@ export class RenderCoordinator {
     const outputPath = join(projectDir, 'output.mp4');
     try {
       const result = await this.runWithExecutionSlot(async () => {
+        // Inside the slot: the wait measured here is exactly the time this job
+        // spent queued behind other renders, which is the signal a busy
+        // deployment needs and the one nothing else exposes.
+        this.onEvent({
+          event: 'render_job_started',
+          jobId: id,
+          queueWaitMs: Date.now() - (this.submittedAtMs.get(id) ?? Date.now()),
+          queued: this.queue.length,
+          running: this.running,
+        });
         await this.jobs.update(id, { status: 'running', currentStage: 'preparing' });
         return this.executor.execute({
           projectDir,
@@ -300,6 +346,7 @@ export class RenderCoordinator {
       }
 
       await this.artifacts.put(id, outputPath);
+      this.finishEvent(id, 'succeeded');
       await this.jobs.update(id, {
         status: 'succeeded',
         progress: 1,

--- a/render-service/test/events.test.ts
+++ b/render-service/test/events.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The event sink is the service's only operational output, so its shape is a
+ * contract: one JSON line, bounded dimensions only, and a level that lets a
+ * pipeline separate failures from routine transitions.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { emitRenderEvent } from '../src/events.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureStdout(): { lines: string[] } {
+  const lines: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+    lines.push(String(line));
+  });
+  return { lines };
+}
+
+describe('emitRenderEvent', () => {
+  it('writes one parseable JSON line carrying the event dimensions', () => {
+    const { lines } = captureStdout();
+
+    emitRenderEvent({
+      event: 'render_job_started',
+      jobId: 'job-1',
+      queueWaitMs: 1234,
+      queued: 2,
+      running: 1,
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toContain('\n');
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed).toMatchObject({
+      service: 'render-service',
+      component: 'render',
+      level: 'INFO',
+      event: 'render_job_started',
+      jobId: 'job-1',
+      queueWaitMs: 1234,
+    });
+    expect(typeof parsed.timestamp).toBe('string');
+    expect(parsed.message).toContain('1234ms');
+  });
+
+  it('omits absent dimensions rather than serializing nulls', () => {
+    const { lines } = captureStdout();
+
+    emitRenderEvent({ event: 'render_job_submitted', jobId: 'job-2' });
+
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed).not.toHaveProperty('queueWaitMs');
+    expect(parsed).not.toHaveProperty('outcome');
+    expect(parsed).not.toHaveProperty('errorCode');
+    expect(lines[0]).not.toContain('null');
+  });
+
+  it('reports a failed render at ERROR on stderr so stderr-only pipelines see it', () => {
+    const { lines } = captureStdout();
+    const errors: string[] = [];
+    vi.spyOn(console, 'error').mockImplementation((line: unknown) => {
+      errors.push(String(line));
+    });
+
+    emitRenderEvent({
+      event: 'render_job_finished',
+      jobId: 'job-3',
+      outcome: 'failed',
+      durationMs: 900,
+      errorCode: 'execution_failed',
+    });
+
+    expect(lines).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(JSON.parse(errors[0]!)).toMatchObject({
+      level: 'ERROR',
+      outcome: 'failed',
+      errorCode: 'execution_failed',
+    });
+  });
+
+  it('keeps a cancelled render at INFO — it is an outcome, not a fault', () => {
+    const { lines } = captureStdout();
+
+    emitRenderEvent({ event: 'render_job_finished', jobId: 'job-4', outcome: 'cancelled' });
+
+    expect(JSON.parse(lines[0]!)).toMatchObject({ level: 'INFO', outcome: 'cancelled' });
+  });
+
+  it('labels the preview route with its own component', () => {
+    const { lines } = captureStdout();
+
+    emitRenderEvent({
+      event: 'preview_request',
+      route: '/preview',
+      status: 504,
+      durationMs: 20000,
+    });
+
+    expect(JSON.parse(lines[0]!)).toMatchObject({ component: 'preview', status: 504 });
+  });
+});

--- a/render-service/test/render-lifecycle-events.test.ts
+++ b/render-service/test/render-lifecycle-events.test.ts
@@ -144,6 +144,87 @@ describe('render job lifecycle events', () => {
     });
   });
 
+  it('closes a job exactly once when the terminal job-store write rejects', async () => {
+    // The JobStore is a seam — a Redis-backed one can reject a write that a
+    // memory one never would. If the success event were emitted before that
+    // write, the rejection would land in the catch and close the same job a
+    // second time as 'failed', so one render would be counted as both a success
+    // and a failure and every rate built on this stream would be wrong.
+    const events: RenderEvent[] = [];
+    const jobs = createMemoryJobStore();
+    const artifacts = createMemoryArtifactStore().store;
+    const realUpdate = jobs.update.bind(jobs);
+    jobs.update = async (id, patch) => {
+      if (patch.status === 'succeeded') throw new Error('job store unavailable');
+      return realUpdate(id, patch);
+    };
+    const coordinator = new RenderCoordinator(
+      executor(async () => ({ status: 'succeeded', outputPath: 'out.mp4' })),
+      jobs,
+      artifacts,
+      { onEvent: (event) => events.push(event) },
+    );
+
+    const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+      fps: 24,
+      quality: 'draft',
+      format: 'mp4',
+    });
+    await waitForJob(jobs, id, (job) => job.status === 'failed');
+
+    const finished = events.filter((event) => event.event === 'render_job_finished');
+    expect(finished).toHaveLength(1);
+    expect(finished[0]).toMatchObject({ jobId: id, outcome: 'failed' });
+    expect(coordinator.trackedJobs).toBe(0);
+  });
+
+  it('separates the queue wait from the render itself on the finished event', async () => {
+    const events: RenderEvent[] = [];
+    const { coordinator, jobs } = coordinatorWith(events, async () => ({
+      status: 'succeeded',
+      outputPath: 'out.mp4',
+    }));
+
+    const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+      fps: 24,
+      quality: 'draft',
+      format: 'mp4',
+    });
+    await waitForJob(jobs, id, (job) => job.status === 'succeeded');
+
+    const finished = events.find((event) => event.event === 'render_job_finished')!;
+    // durationMs is submission-to-finish and therefore includes the wait; the
+    // two components are reported so a consumer never has to join events to
+    // tell a slow render from a long queue.
+    expect(finished.durationMs).toBeGreaterThanOrEqual(
+      (finished.queueWaitMs ?? 0) + (finished.renderMs ?? 0) - 2,
+    );
+    expect(typeof finished.queueWaitMs).toBe('number');
+    expect(typeof finished.renderMs).toBe('number');
+  });
+
+  it('reports an idle service as having nothing queued behind the new job', async () => {
+    const events: RenderEvent[] = [];
+    const { coordinator, jobs } = coordinatorWith(events, async () => ({
+      status: 'succeeded',
+      outputPath: 'out.mp4',
+    }));
+
+    const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+      fps: 24,
+      quality: 'draft',
+      format: 'mp4',
+    });
+    await waitForJob(jobs, id, (job) => job.status === 'succeeded');
+
+    // Counting the submitting job itself would make `queued` never reach 0 and
+    // break the obvious "alert when queued > 0" rule.
+    expect(events.find((event) => event.event === 'render_job_submitted')).toMatchObject({
+      queued: 0,
+      running: 0,
+    });
+  });
+
   it('closes the lifecycle for a job cancelled before it ever started', async () => {
     // Cancelling a queued job takes a different path from cancelling a running
     // one. If it skipped the finished event, a submitted job would simply never
@@ -212,11 +293,11 @@ describe('render job lifecycle events', () => {
       await waitForJob(jobs, id, (job) => job.status === 'succeeded');
     }
 
-    // Three complete lifecycles, and every finished event still carried a
-    // duration — the submission timestamps were consumed, not leaked.
     const finished = events.filter((event) => event.event === 'render_job_finished');
     expect(finished).toHaveLength(3);
-    for (const event of finished) expect(typeof event.durationMs).toBe('number');
+    // Observe the tracked state directly. Asserting only on the events would be
+    // satisfied just as well by an implementation that never releases them.
+    expect(coordinator.trackedJobs).toBe(0);
   });
 });
 
@@ -260,18 +341,13 @@ describe('admission and preview route events', () => {
     });
   }
 
+  /**
+   * Collect through the injected sink, not the console: that is the seam an
+   * embedder uses, and asserting on it is what proves the route events honour
+   * it rather than writing straight to stdout.
+   */
   function captureEmitted(): RenderEvent[] {
-    const emitted: RenderEvent[] = [];
-    for (const stream of ['log', 'error'] as const) {
-      vi.spyOn(console, stream).mockImplementation((line: unknown) => {
-        try {
-          emitted.push(JSON.parse(String(line)) as RenderEvent);
-        } catch {
-          /* the startup banner is not JSON */
-        }
-      });
-    }
-    return emitted;
+    return [];
   }
 
   it('records the preview route status and duration for a served preview', async () => {
@@ -287,8 +363,8 @@ describe('admission and preview route events', () => {
         artifacts,
       ),
       extractionGate: new Semaphore(1),
-      executionGate: new Semaphore(1),
       previewRenderer: { render: async () => new Uint8Array([137, 80, 78, 71]) },
+      onEvent: (event) => emitted.push(event),
     });
 
     const response = await app.fetch(previewRequest());
@@ -312,8 +388,8 @@ describe('admission and preview route events', () => {
         artifacts,
       ),
       extractionGate: new Semaphore(1),
-      executionGate: new Semaphore(1),
       previewRenderer: { render: async () => new Uint8Array([1]) },
+      onEvent: (event) => emitted.push(event),
     });
 
     const response = await app.fetch(
@@ -345,7 +421,7 @@ describe('admission and preview route events', () => {
       artifacts,
       coordinator,
       extractionGate: new Semaphore(1),
-      executionGate: new Semaphore(1),
+      onEvent: (event) => emitted.push(event),
     });
 
     const held = coordinator.reserve('exporter');

--- a/render-service/test/render-lifecycle-events.test.ts
+++ b/render-service/test/render-lifecycle-events.test.ts
@@ -144,6 +144,58 @@ describe('render job lifecycle events', () => {
     });
   });
 
+  it('closes the lifecycle for a job cancelled before it ever started', async () => {
+    // Cancelling a queued job takes a different path from cancelling a running
+    // one. If it skipped the finished event, a submitted job would simply never
+    // be heard from again and any success rate built on these events would be
+    // silently wrong.
+    const events: RenderEvent[] = [];
+    let release!: () => void;
+    const parked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { coordinator, jobs } = coordinatorWith(
+      events,
+      async () => {
+        await parked;
+        return { status: 'succeeded', outputPath: 'out.mp4' };
+      },
+      // Two jobs in flight at once, so the second is genuinely queued rather
+      // than rejected by the per-identity guard.
+      { maxJobsPerUser: 0 },
+    );
+    const options = { fps: 24, quality: 'draft', format: 'mp4' } as const;
+
+    // The first job takes the only execution slot; the second stays queued.
+    const runningId = await coordinator.submit(
+      coordinator.reserve('tester'),
+      await projectDir(),
+      options,
+    );
+    await waitForJob(jobs, runningId, (job) => job.status === 'running');
+    const queuedId = await coordinator.submit(
+      coordinator.reserve('tester'),
+      await projectDir(),
+      options,
+    );
+
+    await coordinator.cancel(queuedId);
+    await waitForJob(jobs, queuedId, (job) => job.status === 'cancelled');
+
+    const finished = events.filter((event) => event.event === 'render_job_finished');
+    expect(finished).toContainEqual(
+      expect.objectContaining({ jobId: queuedId, outcome: 'cancelled' }),
+    );
+    // Every submitted job reported a terminal event — that is what makes the
+    // stream summable into a success rate.
+    const submitted = events.filter((event) => event.event === 'render_job_submitted');
+    expect(finished.map((event) => event.jobId)).toContain(queuedId);
+    expect(submitted.some((event) => event.jobId === queuedId)).toBe(true);
+
+    release();
+    await waitForJob(jobs, runningId, (job) => job.status === 'succeeded');
+  });
+
   it('does not retain per-job state after a job finishes', async () => {
     const events: RenderEvent[] = [];
     const { coordinator, jobs } = coordinatorWith(events, async () => ({

--- a/render-service/test/render-lifecycle-events.test.ts
+++ b/render-service/test/render-lifecycle-events.test.ts
@@ -1,0 +1,318 @@
+/**
+ * A render's outcome lives only in the JobStore, which is in memory by default
+ * and gone on restart, and a failed render answers the client with HTTP 200
+ * whose body says `failed`. These tests pin the lifecycle events that make an
+ * outcome observable outside the process: submitted -> started (with the queue
+ * wait) -> finished (with the outcome), plus the admission rejections and the
+ * synchronous preview route's real status.
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { RenderEvent } from '../src/events.js';
+import { RenderCoordinator } from '../src/render-coordinator.js';
+import type { RenderExecutor } from '../src/render-executor.js';
+import { Semaphore } from '../src/semaphore.js';
+import type { RenderExecutionResult, RenderJobRecord } from '../src/types.js';
+import type { JobStore } from '../src/job-store.js';
+import { createMemoryArtifactStore, createMemoryJobStore } from './support/fakes.js';
+
+process.env.RENDER_SERVICE_NO_LISTEN = 'true';
+
+let createApp: typeof import('../src/main.js').createApp;
+
+beforeAll(async () => {
+  ({ createApp } = await import('../src/main.js'));
+});
+
+const scratch: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(scratch.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+});
+
+async function projectDir(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'render-events-'));
+  scratch.push(path);
+  return path;
+}
+
+function executor(result: () => Promise<RenderExecutionResult>): RenderExecutor {
+  return { execute: result };
+}
+
+async function waitForJob(
+  jobs: JobStore,
+  id: string,
+  predicate: (job: RenderJobRecord) => boolean,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const job = await jobs.get(id);
+    if (job && predicate(job)) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`job ${id} never reached the expected state`);
+}
+
+function coordinatorWith(
+  events: RenderEvent[],
+  execute: () => Promise<RenderExecutionResult>,
+  options: { maxQueue?: number; maxJobsPerUser?: number } = {},
+) {
+  const jobs = createMemoryJobStore();
+  const artifacts = createMemoryArtifactStore().store;
+  const coordinator = new RenderCoordinator(executor(execute), jobs, artifacts, {
+    ...options,
+    onEvent: (event) => events.push(event),
+  });
+  return { coordinator, jobs };
+}
+
+describe('render job lifecycle events', () => {
+  it('reports submitted, started with a queue wait, and finished with the outcome', async () => {
+    const events: RenderEvent[] = [];
+    const { coordinator, jobs } = coordinatorWith(events, async () => ({
+      status: 'succeeded',
+      outputPath: 'out.mp4',
+    }));
+
+    const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+      fps: 24,
+      quality: 'draft',
+      format: 'mp4',
+    });
+    await waitForJob(jobs, id, (job) => job.status === 'succeeded');
+
+    expect(events.map((event) => event.event)).toEqual([
+      'render_job_submitted',
+      'render_job_started',
+      'render_job_finished',
+    ]);
+    const started = events[1]!;
+    expect(started.jobId).toBe(id);
+    expect(typeof started.queueWaitMs).toBe('number');
+    expect(started.queueWaitMs).toBeGreaterThanOrEqual(0);
+    expect(events[2]).toMatchObject({ jobId: id, outcome: 'succeeded' });
+    expect(typeof events[2]!.durationMs).toBe('number');
+  });
+
+  it('reports a failed render with its failure code and never its message', async () => {
+    const events: RenderEvent[] = [];
+    const { coordinator, jobs } = coordinatorWith(events, async () => {
+      throw new Error('chromium crashed at /tmp/secret-project/scene.html');
+    });
+
+    const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+      fps: 24,
+      quality: 'draft',
+      format: 'mp4',
+    });
+    await waitForJob(jobs, id, (job) => job.status === 'failed');
+
+    const finished = events.find((event) => event.event === 'render_job_finished');
+    expect(finished).toMatchObject({ outcome: 'failed', errorCode: 'execution_failed' });
+    // The free-text message carries a scratch path; it must not reach the log.
+    expect(JSON.stringify(events)).not.toContain('secret-project');
+    expect(JSON.stringify(events)).not.toContain('chromium crashed');
+  });
+
+  it('reports a cancelled render as cancelled rather than failed', async () => {
+    const events: RenderEvent[] = [];
+    let release!: () => void;
+    const parked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { coordinator, jobs } = coordinatorWith(events, async () => {
+      await parked;
+      return { status: 'succeeded', outputPath: 'out.mp4' };
+    });
+
+    const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+      fps: 24,
+      quality: 'draft',
+      format: 'mp4',
+    });
+    await waitForJob(jobs, id, (job) => job.status === 'running');
+    await coordinator.cancel(id);
+    release();
+    await waitForJob(jobs, id, (job) => job.status === 'cancelled');
+
+    expect(events.find((event) => event.event === 'render_job_finished')).toMatchObject({
+      outcome: 'cancelled',
+    });
+  });
+
+  it('does not retain per-job state after a job finishes', async () => {
+    const events: RenderEvent[] = [];
+    const { coordinator, jobs } = coordinatorWith(events, async () => ({
+      status: 'succeeded',
+      outputPath: 'out.mp4',
+    }));
+
+    for (let i = 0; i < 3; i += 1) {
+      const id = await coordinator.submit(coordinator.reserve('tester'), await projectDir(), {
+        fps: 24,
+        quality: 'draft',
+        format: 'mp4',
+      });
+      await waitForJob(jobs, id, (job) => job.status === 'succeeded');
+    }
+
+    // Three complete lifecycles, and every finished event still carried a
+    // duration — the submission timestamps were consumed, not leaked.
+    const finished = events.filter((event) => event.event === 'render_job_finished');
+    expect(finished).toHaveLength(3);
+    for (const event of finished) expect(typeof event.durationMs).toBe('number');
+  });
+});
+
+describe('admission and preview route events', () => {
+  function previewPayload() {
+    return {
+      version: 1,
+      scene: {
+        id: 'scene-1',
+        stageId: 'stage-1',
+        order: 1,
+        title: 'Preview me',
+        type: 'slide',
+        content: {
+          type: 'slide',
+          canvas: {
+            id: 'canvas-1',
+            viewportSize: 1000,
+            viewportRatio: 0.5625,
+            theme: {
+              backgroundColor: '#fff',
+              themeColors: ['#000'],
+              fontColor: '#111',
+              fontName: 'Inter',
+            },
+            elements: [{ id: 'text-1', type: 'text', content: 'Preview' }],
+          },
+        },
+        actions: [],
+      },
+      stage: { id: 'stage-1', name: 'Preview course' },
+      viewport: { width: 1280, height: 720, deviceScaleFactor: 1 },
+    };
+  }
+
+  function previewRequest(identity = 'preview-user'): Request {
+    return new Request('http://test/preview', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-openmaic-client': identity },
+      body: JSON.stringify(previewPayload()),
+    });
+  }
+
+  function captureEmitted(): RenderEvent[] {
+    const emitted: RenderEvent[] = [];
+    for (const stream of ['log', 'error'] as const) {
+      vi.spyOn(console, stream).mockImplementation((line: unknown) => {
+        try {
+          emitted.push(JSON.parse(String(line)) as RenderEvent);
+        } catch {
+          /* the startup banner is not JSON */
+        }
+      });
+    }
+    return emitted;
+  }
+
+  it('records the preview route status and duration for a served preview', async () => {
+    const emitted = captureEmitted();
+    const jobs = createMemoryJobStore();
+    const artifacts = createMemoryArtifactStore().store;
+    const app = createApp({
+      jobs,
+      artifacts,
+      coordinator: new RenderCoordinator(
+        executor(async () => ({ status: 'succeeded', outputPath: 'out.mp4' })),
+        jobs,
+        artifacts,
+      ),
+      extractionGate: new Semaphore(1),
+      executionGate: new Semaphore(1),
+      previewRenderer: { render: async () => new Uint8Array([137, 80, 78, 71]) },
+    });
+
+    const response = await app.fetch(previewRequest());
+    expect(response.status).toBe(200);
+
+    const preview = emitted.find((event) => event.event === 'preview_request');
+    expect(preview).toMatchObject({ route: '/preview', status: 200 });
+    expect(typeof preview!.durationMs).toBe('number');
+  });
+
+  it('records the real status when the preview route rejects, not just successes', async () => {
+    const emitted = captureEmitted();
+    const jobs = createMemoryJobStore();
+    const artifacts = createMemoryArtifactStore().store;
+    const app = createApp({
+      jobs,
+      artifacts,
+      coordinator: new RenderCoordinator(
+        executor(async () => ({ status: 'succeeded', outputPath: 'out.mp4' })),
+        jobs,
+        artifacts,
+      ),
+      extractionGate: new Semaphore(1),
+      executionGate: new Semaphore(1),
+      previewRenderer: { render: async () => new Uint8Array([1]) },
+    });
+
+    const response = await app.fetch(
+      new Request('http://test/preview', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{"version":1}',
+      }),
+    );
+    expect(response.status).toBe(400);
+
+    expect(emitted.find((event) => event.event === 'preview_request')).toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('records an export admission rejection with its machine-readable reason', async () => {
+    const emitted = captureEmitted();
+    const jobs = createMemoryJobStore();
+    const artifacts = createMemoryArtifactStore().store;
+    const coordinator = new RenderCoordinator(
+      executor(async () => ({ status: 'succeeded', outputPath: 'out.mp4' })),
+      jobs,
+      artifacts,
+      { maxQueue: 1 },
+    );
+    const app = createApp({
+      jobs,
+      artifacts,
+      coordinator,
+      extractionGate: new Semaphore(1),
+      executionGate: new Semaphore(1),
+    });
+
+    const held = coordinator.reserve('exporter');
+    const form = new FormData();
+    form.append('project', new Blob([new Uint8Array(64)]), 'project.zip');
+    const response = await app.fetch(
+      new Request('http://test/render', {
+        method: 'POST',
+        body: form,
+        headers: { 'x-openmaic-client': 'someone-else' },
+      }),
+    );
+    expect(response.status).toBe(429);
+
+    expect(emitted.find((event) => event.event === 'render_admission_rejected')).toMatchObject({
+      route: '/render',
+      reason: 'queue_full',
+      status: 429,
+    });
+    coordinator.release(held);
+  });
+});


### PR DESCRIPTION
## Why

The render service is silent apart from one startup banner. A deployment can see *that* rendering happens — CPU, memory — but cannot answer how many renders succeeded, how long they took, or how long they waited for a slot.

Three things compound to make a render's outcome unobservable from outside the process:

- **Job state lives in `JobStore`**, in memory by default, so every record is gone on restart.
- **A failed render answers the client with HTTP 200** whose *body* carries `status: 'failed'` — so any proxy, gateway or dashboard counting status codes sees a perfectly healthy service.
- **Nothing between admission and completion writes a line anywhere** (`render-coordinator`, `render-executor`, `chunk-executor`, `job-store` and `artifact-store` contain no log statements at all).

I ran into this while investigating a production deployment where synchronous previews were queueing behind minute-scale export work. The contention was real and lasted days, but the service itself showed nothing — the whole diagnosis had to be reconstructed from client-side records, and the one number that would have made it obvious, *how long a job waited for an execution slot*, existed nowhere.

## What this adds

One JSON line per lifecycle transition on stdout, which every container log pipeline already collects:

| event | carries |
|---|---|
| `render_job_submitted` | queue and running depth at admission |
| `render_job_started` | **`queueWaitMs`** — time spent queued behind other renders |
| `render_job_finished` | `outcome` (succeeded / failed / cancelled), `durationMs`, and for a failure its machine-readable code |
| `render_admission_rejected` | the reason a 429 was returned, on both `/render` and `/preview` |
| `preview_request` | status and duration for every response the synchronous preview route produces |

`queueWaitMs` is the one nothing else exposes today, and it is what distinguishes "renders are slow" from "renders are waiting".

`preview_request` is emitted from middleware, so 200, 413, 429, 504 and 500 are all covered without touching any of the handler's return paths.

## What it deliberately does not carry

Only bounded, low-cardinality dimensions: an opaque job id, a state, a duration, a reason code.

**No client identity, no file or directory names, no scene content, and no raw error strings.** A render works on untrusted, model-authored input, and none of it belongs in an operational log. A failure is logged by its fixed-vocabulary `failure.code`, never by its free-text message — there is a test asserting that a message containing a scratch path does not reach the log while its code does.

This follows the same reasoning as the existing `accepting` field on `/health`, which is deliberately an aggregate so it cannot publish per-identity state.

## Design notes

- `RenderCoordinator` takes the sink through its existing options bag (`onEvent`), defaulting to the stdout emitter. Tests assert on events directly rather than through the console.
- A failed render is emitted at `ERROR` on stderr so a pipeline that forwards only stderr still sees failures; a **cancelled** render stays at `INFO`, since it is an outcome rather than a fault.
- Submission timestamps are held in a map only for the lifetime of a job and deleted when it finishes, so a long-lived process cannot accumulate them. There is a test for that.
- Absent dimensions are omitted rather than serialized as `null`, keeping lines small and index-friendly.

## Tests

18 files / 153 tests pass, including 12 new ones covering the event shape, redaction, the three terminal outcomes, per-job state cleanup, the preview route's real status on both success and rejection, and the admission-rejection reason.

Verified the redaction test actually fails when the failure message is logged instead of its code.

`tsc --noEmit` clean; prettier clean.
