### PR TITLE
fix(tts): speak an Azure voice in its own language, not always zh-CN

### DIFF
--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -653,9 +653,14 @@ async function generateAzureTTS(
 
   // Build SSML
   const rate = config.speed ? `${((config.speed - 1) * 100).toFixed(0)}%` : '0%';
+  // An Azure voice id carries the locale it speaks (`en-US-JennyNeural`), so the
+  // first two segments say which language to pronounce. Hardcoding zh-CN made
+  // Azure read every other voice in the catalog — `en-US-JennyNeural` and
+  // `en-US-GuyNeural` are both offered above — with Chinese phonetics.
+  const voiceLocale = /^[a-z]{2,3}-[A-Za-z]{2,4}/.exec(config.voice ?? '')?.[0] ?? 'en-US';
   const ssml = `
-    <speak version='1.0' xml:lang='zh-CN'>
-      <voice xml:lang='zh-CN' name='${config.voice}'>
+    <speak version='1.0' xml:lang='${voiceLocale}'>
+      <voice xml:lang='${voiceLocale}' name='${config.voice}'>
         <prosody rate='${rate}'>${escapeXml(text)}</prosody>
       </voice>
     </speak>


### PR DESCRIPTION
`generateWithAzureTTS` builds its SSML with `xml:lang='zh-CN'` hardcoded on both the `<speak>` and the `<voice>` element, regardless of which voice was selected.

This is reachable from the built-in catalog rather than only from a custom configuration: `AZURE_TTS_VOICES` ships `en-US-JennyNeural` and `en-US-GuyNeural` alongside the Simplified Chinese voices. Selecting either tells Azure the text is Chinese, and it applies Chinese phonetics to English.

An Azure voice id begins with the locale it speaks (`en-US-JennyNeural`, `zh-CN-XiaoxiaoNeural`), so the tag can come from `config.voice` instead of a constant. Falls back to `en-US` only if the id does not match that shape.

```diff
-    <speak version='1.0' xml:lang='zh-CN'>
-      <voice xml:lang='zh-CN' name='${config.voice}'>
+    <speak version='1.0' xml:lang='${voiceLocale}'>
+      <voice xml:lang='${voiceLocale}' name='${config.voice}'>
```

One file, no new dependencies, no behaviour change for the Simplified Chinese voices — they resolve to `zh-CN` exactly as before.

Found while running OpenMAIC with a non-Chinese UI language. Happy to adjust the fallback or the regex if you would rather it were stricter.
