### PR TITLE
feat(narration): add Abogen scene-level narration via enableNarration

### DIFF
--- a/app/api/classroom-media/[classroomId]/[...path]/route.ts
+++ b/app/api/classroom-media/[classroomId]/[...path]/route.ts
@@ -18,6 +18,8 @@ const MIME_TYPES: Record<string, string> = {
   '.wav': 'audio/wav',
   '.ogg': 'audio/ogg',
   '.aac': 'audio/aac',
+  '.m4a': 'audio/mp4',
+  '.m4b': 'audio/mp4',
 };
 
 export async function GET(
@@ -79,7 +81,7 @@ export async function GET(
       headers: {
         'Content-Type': contentType,
         'Content-Length': String(stat.size),
-        'Cache-Control': 'public, max-age=86400, immutable',
+        'Cache-Control': 'no-store',
       },
     });
   } catch (error) {

--- a/app/api/classroom-media/[classroomId]/[...path]/route.ts
+++ b/app/api/classroom-media/[classroomId]/[...path]/route.ts
@@ -63,6 +63,15 @@ export async function GET(
     const ext = path.extname(realPath).toLowerCase();
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
+    // Narration files are rewritten in place under a stable URL, so they must
+    // never be cached (a stale fetch would keep silent bytes). Immutable media
+    // (images, videos, other audio) is written once at generation time and can
+    // keep long-lived cache headers.
+    const isNarration = ext === '.m4a' || ext === '.m4b';
+    const cacheControl = isNarration
+      ? 'no-store'
+      : 'public, max-age=86400, immutable';
+
     // Stream the file to avoid loading large videos into memory
     const stream = createReadStream(realPath);
     const webStream = new ReadableStream({
@@ -81,7 +90,7 @@ export async function GET(
       headers: {
         'Content-Type': contentType,
         'Content-Length': String(stat.size),
-        'Cache-Control': 'no-store',
+        'Cache-Control': cacheControl,
       },
     });
   } catch (error) {

--- a/app/api/generate-classroom/route.ts
+++ b/app/api/generate-classroom/route.ts
@@ -32,6 +32,7 @@ export async function POST(req: NextRequest) {
         ? { enableVideoGeneration: rawBody.enableVideoGeneration }
         : {}),
       ...(rawBody.enableTTS != null ? { enableTTS: rawBody.enableTTS } : {}),
+      ...(rawBody.enableNarration != null ? { enableNarration: rawBody.enableNarration } : {}),
       ...(rawBody.agentMode ? { agentMode: rawBody.agentMode } : {}),
     };
     const { requirement } = body;

--- a/components/canvas/canvas-toolbar.tsx
+++ b/components/canvas/canvas-toolbar.tsx
@@ -195,19 +195,16 @@ export function CanvasToolbar({
             >
               <button
                 onClick={onToggleMute}
-                disabled={!ttsEnabled}
                 className={cn(
                   ctrlBtn,
                   'w-6 h-6',
-                  !ttsEnabled
-                    ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                    : ttsMuted
-                      ? 'text-red-500 dark:text-red-400'
-                      : 'text-gray-500 dark:text-gray-400',
+                  ttsMuted
+                    ? 'text-red-500 dark:text-red-400'
+                    : 'text-gray-500 dark:text-gray-400',
                 )}
                 aria-label={ttsMuted ? 'Unmute' : 'Mute'}
               >
-                <VolumeIcon muted={!!ttsMuted} volume={ttsVolume} disabled={!ttsEnabled} />
+                <VolumeIcon muted={!!ttsMuted} volume={ttsVolume} disabled={false} />
               </button>
 
               {/* Vertical volume slider (pops up above) */}

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -923,6 +923,9 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
     // Sync mute state from settings store to audioPlayer
     useEffect(() => {
       audioPlayerRef.current.setMuted(ttsMuted);
+      // Also silence scene-level narration (separate element) so the
+      // sound/mute button controls it too.
+      engineRef.current?.setNarrationMuted(ttsMuted);
     }, [ttsMuted]);
 
     // Sync volume from settings store to audioPlayer

--- a/components/edit/PlaybackChromeRoot.tsx
+++ b/components/edit/PlaybackChromeRoot.tsx
@@ -925,7 +925,7 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       audioPlayerRef.current.setMuted(ttsMuted);
       // Also silence scene-level narration (separate element) so the
       // sound/mute button controls it too.
-      engineRef.current?.setNarrationMuted(ttsMuted);
+      engineRef.current?.syncNarrationVolume();
     }, [ttsMuted]);
 
     // Sync volume from settings store to audioPlayer
@@ -934,6 +934,8 @@ export const PlaybackChromeRoot = forwardRef<PlaybackChromeRootHandle, PlaybackC
       if (!ttsMuted) {
         audioPlayerRef.current.setVolume(ttsVolume);
       }
+      // Narration follows the same volume, not a hardcoded 1.
+      engineRef.current?.syncNarrationVolume();
     }, [ttsVolume, ttsMuted]);
 
     // Sync playback speed to audio player (for live-updating current audio)

--- a/components/roundtable/index.tsx
+++ b/components/roundtable/index.tsx
@@ -679,7 +679,7 @@ export function Roundtable({
       ttsEnabled={ttsEnabled}
       ttsMuted={ttsMuted}
       ttsVolume={ttsVolume}
-      onToggleMute={() => ttsEnabled && setTTSMuted(!ttsMuted)}
+      onToggleMute={() => setTTSMuted(!ttsMuted)}
       onVolumeChange={(v) => setTTSVolume(v)}
       autoPlayLecture={autoPlayLecture}
       onToggleAutoPlay={() => setAutoPlayLecture(!autoPlayLecture)}
@@ -1610,7 +1610,7 @@ export function Roundtable({
                         onPlayPause?.();
                       }}
                       className={cn(
-                        'relative px-4 pt-2 pb-3 rounded-2xl text-[15px] leading-relaxed transition-all border w-[min(420px,calc(100%-3rem))] group/bubble flex flex-col max-h-[110px]',
+                        'relative px-4 pt-2 pb-3 rounded-2xl text-[15px] leading-relaxed transition-all border w-[min(420px,calc(100%-3rem))] group/bubble flex flex-col max-h-[60vh]',
                         bubbleRole === 'teacher' ? 'pl-4 pr-10' : 'pl-4 pr-10',
                         bubbleRole === 'user'
                           ? 'bg-purple-600/95 dark:bg-purple-500/95 backdrop-blur-sm border-purple-400/40 dark:border-purple-300/40 text-white rounded-br-sm shadow-md shadow-purple-300/30 dark:shadow-purple-800/30'

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -28,6 +28,18 @@ export async function register(): Promise<void> {
   const { validateServerConfig } = await import('@/lib/server/config-validation');
   validateServerConfig();
 
+  // Migrate any legacy classroom data once per boot, behind a completion
+  // marker. Fire-and-forget: register() must not block on I/O, and the marker
+  // makes this idempotent across restarts.
+  try {
+    const { migrateLegacyClassroomData } = await import('@/lib/server/classroom-storage');
+    void migrateLegacyClassroomData().catch((err) => {
+      console.warn('[classroom-storage] legacy migration failed:', err);
+    });
+  } catch (err) {
+    console.warn('[classroom-storage] legacy migration not started:', err);
+  }
+
   let runner: import('@/lib/server/agent-runtime/runner').AgentRunnerHandle | undefined;
   let extractionRunner:
     | import('@/lib/server/material-extraction/runner').MaterialExtractionRunnerHandle

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -78,6 +78,9 @@ export class PlaybackEngine {
   private actionEngine: ActionEngine;
   private callbacks: PlaybackEngineCallbacks;
 
+  // Scene-level narration voiceover element (separate from per-line audioPlayer)
+  private narrationAudio: HTMLAudioElement | null = null;
+
   // Scene identity (for snapshot validation)
   private sceneId: string | undefined;
 
@@ -222,6 +225,7 @@ export class PlaybackEngine {
   pause(): void {
     if (this.mode === 'playing') {
       this.invalidatePlaybackGeneration();
+      this.stopSceneNarration();
       // Cancel pending timers
       if (this.triggerDelayTimer) {
         clearTimeout(this.triggerDelayTimer);
@@ -320,6 +324,7 @@ export class PlaybackEngine {
     // synchronous onend callbacks (see handleUserInterrupt for details).
     this.setMode('idle');
     this.audioPlayer.stop();
+    this.stopSceneNarration();
     this.cancelBrowserTTS();
     this.actionEngine.clearEffects();
     if (this.triggerDelayTimer) {
@@ -547,6 +552,29 @@ export class PlaybackEngine {
   }
 
   /**
+   * Play scene-level narration voiceover (if the scene has one) on a dedicated
+   * element. Fire-and-forget: it does not gate the action loop, and it is
+   * stopped when playback pauses/stops or the scene changes.
+   */
+  private playSceneNarration(scene: Scene): void {
+    this.stopSceneNarration();
+    const url = scene.narrationUrl;
+    if (!url || typeof window === 'undefined') return;
+    const el = new Audio(url);
+    el.play().catch(() => {
+      // Autoplay policy or decode error — narration is best-effort, ignore.
+    });
+    this.narrationAudio = el;
+  }
+
+  private stopSceneNarration(): void {
+    if (this.narrationAudio) {
+      this.narrationAudio.pause();
+      this.narrationAudio = null;
+    }
+  }
+
+  /**
    * Core processing loop: consume the next action.
    */
   private async processNext(generation: number = this.playbackGeneration): Promise<void> {
@@ -558,6 +586,9 @@ export class PlaybackEngine {
       this.actionEngine.clearEffects();
       this.callbacks.onSceneChange?.(scene.id);
       this.callbacks.onSpeakerChange?.('teacher');
+      // Scene-level narration voiceover: play once on a dedicated element so it
+      // does not collide with per-line speech (which uses this.audioPlayer).
+      this.playSceneNarration(scene);
     }
 
     const current = this.getCurrentAction();

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -225,7 +225,7 @@ export class PlaybackEngine {
   pause(): void {
     if (this.mode === 'playing') {
       this.invalidatePlaybackGeneration();
-      this.stopSceneNarration();
+      this.pauseSceneNarration();
       // Cancel pending timers
       if (this.triggerDelayTimer) {
         clearTimeout(this.triggerDelayTimer);
@@ -281,6 +281,8 @@ export class PlaybackEngine {
     } else {
       // Resume lecture
       this.setMode('playing');
+      // Scene-level narration was paused in place — resume from currentTime.
+      this.resumeSceneNarration();
       if (this.browserTTSPausedChunks.length > 0) {
         // Browser TTS was paused via cancel — re-speak remaining chunks
         this.browserTTSActive = true;
@@ -553,18 +555,43 @@ export class PlaybackEngine {
 
   /**
    * Play scene-level narration voiceover (if the scene has one) on a dedicated
-   * element. Fire-and-forget: it does not gate the action loop, and it is
-   * stopped when playback pauses/stops or the scene changes.
+   * element. Fire-and-forget: it does not gate the action loop. It pauses with
+   * playback (resuming from currentTime on resume) and is discarded on stop or
+   * when the scene changes.
    */
   private playSceneNarration(scene: Scene): void {
     this.stopSceneNarration();
     const url = scene.narrationUrl;
     if (!url || typeof window === 'undefined') return;
     const el = new Audio(url);
+    // Respect the shared mute state so the sound/mute button also silences
+    // scene-level narration (not just per-line TTS speech).
+    el.volume = this.audioPlayer.getMuted() ? 0 : 1;
     el.play().catch(() => {
       // Autoplay policy or decode error — narration is best-effort, ignore.
     });
     this.narrationAudio = el;
+  }
+
+  /** Sync scene-level narration volume to the current mute state (live toggle). */
+  public setNarrationMuted(muted: boolean): void {
+    if (this.narrationAudio) {
+      this.narrationAudio.volume = muted ? 0 : 1;
+    }
+  }
+
+  /** Pause scene narration in place (keeps currentTime so resume can restart). */
+  private pauseSceneNarration(): void {
+    this.narrationAudio?.pause();
+  }
+
+  /** Resume scene narration from where it was paused, if one is loaded. */
+  private resumeSceneNarration(): void {
+    if (this.narrationAudio) {
+      this.narrationAudio.play().catch(() => {
+        // Autoplay policy or decode error — narration is best-effort, ignore.
+      });
+    }
   }
 
   private stopSceneNarration(): void {

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -564,19 +564,27 @@ export class PlaybackEngine {
     const url = scene.narrationUrl;
     if (!url || typeof window === 'undefined') return;
     const el = new Audio(url);
-    // Respect the shared mute state so the sound/mute button also silences
-    // scene-level narration (not just per-line TTS speech).
-    el.volume = this.audioPlayer.getMuted() ? 0 : 1;
+    // Follow the shared player's mute/volume state so the sound controls apply
+    // to scene-level narration too (not just per-line TTS speech).
+    el.volume = this.narrationVolume();
     el.play().catch(() => {
       // Autoplay policy or decode error — narration is best-effort, ignore.
     });
     this.narrationAudio = el;
   }
 
-  /** Sync scene-level narration volume to the current mute state (live toggle). */
-  public setNarrationMuted(muted: boolean): void {
+  /** Volume scene narration plays at: the shared player's, or 0 when muted. */
+  private narrationVolume(): number {
+    return this.audioPlayer.getMuted() ? 0 : this.audioPlayer.getVolume();
+  }
+
+  /**
+   * Re-apply the shared player's mute/volume to the live narration element.
+   * Called when either changes so the controls affect narration in place.
+   */
+  public syncNarrationVolume(): void {
     if (this.narrationAudio) {
-      this.narrationAudio.volume = muted ? 0 : 1;
+      this.narrationAudio.volume = this.narrationVolume();
     }
   }
 

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -29,7 +29,7 @@ import { resolveVocationalActive } from '@/lib/config/feature-flags';
 import { buildSearchQuery } from '@/lib/server/search-query-builder';
 import { formatSearchResultsAsContext, searchWeb } from '@/lib/web-search';
 import type { BaiduSubSources, WebSearchProviderId } from '@/lib/web-search/types';
-import { persistClassroom } from '@/lib/server/classroom-storage';
+import { CLASSROOMS_DIR, persistClassroom } from '@/lib/server/classroom-storage';
 import {
   generateMediaForClassroom,
   replaceMediaPlaceholders,
@@ -739,12 +739,14 @@ export async function generateClassroom(
     try {
       const execFileAsync = promisify(execFile);
       // Narration is delegated to a Python script that talks to the local
-      // Abogen service. The script + storage dir are configurable via env so
-      // this works outside this repo (see scripts/narration_pipeline.py).
+      // Abogen service. The script is configurable via env so this works
+      // outside this repo (see scripts/narration_pipeline.py). The classroom
+      // dir must be the SAME location classroom-storage persists to — read
+      // the exported CLASSROOMS_DIR (which honors CLASSROOMS_DATA_DIR) instead
+      // of re-deriving from a differently-named env var.
       const scriptPath = process.env.NARRATION_PIPELINE_SCRIPT
         ?? path.join(process.cwd(), 'scripts', 'narration_pipeline.py');
-      const classroomsDir = process.env.CLASSROOMS_DIR
-        ?? path.join(process.cwd(), 'data', 'classrooms');
+      const classroomsDir = CLASSROOMS_DIR;
       const { stdout, stderr } = await execFileAsync(
         'python3',
         [scriptPath, persisted.id, classroomsDir],

--- a/lib/server/classroom-generation.ts
+++ b/lib/server/classroom-generation.ts
@@ -1,4 +1,7 @@
 import { nanoid } from 'nanoid';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
 import { callLLM } from '@/lib/ai/llm';
 import { createStageAPI } from '@/lib/api/stage-api';
 import type { StageStore } from '@/lib/api/stage-api-types';
@@ -56,6 +59,7 @@ export interface GenerateClassroomInput {
   enableImageGeneration?: boolean;
   enableVideoGeneration?: boolean;
   enableTTS?: boolean;
+  enableNarration?: boolean;
   agentMode?: 'default' | 'generate';
 }
 
@@ -66,6 +70,7 @@ export type ClassroomGenerationStep =
   | 'generating_scenes'
   | 'generating_media'
   | 'generating_tts'
+  | 'generating_narration'
   | 'persisting'
   | 'completed';
 
@@ -718,6 +723,39 @@ export async function generateClassroom(
   );
 
   log.info(`Classroom persisted: ${persisted.id}, URL: ${persisted.url}`);
+
+  // Phase: Abogen narration (best-effort). Delegates to a Python script that
+  // extracts each scene's speech text, synthesizes per-scene M4B via the local
+  // Abogen service, and stamps `narrationUrl` on each scene. Wrapped in
+  // try/catch so a down Abogen or a script failure does not fail generation.
+  if (input.enableNarration) {
+    await options.onProgress?.({
+      step: 'generating_narration',
+      progress: 99,
+      message: 'Generating Abogen narration audio',
+      scenesGenerated: scenes.length,
+      totalScenes: outlines.length,
+    });
+    try {
+      const execFileAsync = promisify(execFile);
+      // Narration is delegated to a Python script that talks to the local
+      // Abogen service. The script + storage dir are configurable via env so
+      // this works outside this repo (see scripts/narration_pipeline.py).
+      const scriptPath = process.env.NARRATION_PIPELINE_SCRIPT
+        ?? path.join(process.cwd(), 'scripts', 'narration_pipeline.py');
+      const classroomsDir = process.env.CLASSROOMS_DIR
+        ?? path.join(process.cwd(), 'data', 'classrooms');
+      const { stdout, stderr } = await execFileAsync(
+        'python3',
+        [scriptPath, persisted.id, classroomsDir],
+        { timeout: 30 * 60 * 1000, maxBuffer: 4 * 1024 * 1024 },
+      );
+      log.info(`Narration pipeline stdout: ${stdout}`);
+      if (stderr) log.warn(`Narration pipeline stderr: ${stderr}`);
+    } catch (err) {
+      log.warn('Abogen narration phase failed, continuing:', err);
+    }
+  }
 
   await options.onProgress?.({
     step: 'completed',

--- a/lib/server/classroom-storage.ts
+++ b/lib/server/classroom-storage.ts
@@ -34,6 +34,28 @@ async function dirExists(dir: string): Promise<boolean> {
   }
 }
 
+/**
+ * Copy `src` over `dest` atomically: write a sibling temp file, then rename.
+ *
+ * A copy that dies mid-write (disk full, crash, kill) must never leave a
+ * truncated file at `dest`: the destination's fresh mtime would beat the legacy
+ * source on the next pass, the mtime guard would skip the retry, and the
+ * completion marker would freeze the partial bytes in place forever. Writing
+ * to a temp name and renaming means `dest` is either absent or complete.
+ */
+async function copyFileAtomic(src: string, dest: string) {
+  const temp = `${dest}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await fs.copyFile(src, temp);
+    await fs.rename(temp, dest);
+  } catch (err) {
+    await fs.rm(temp, { force: true }).catch(() => {
+      // Best-effort cleanup — the copy error is the one worth surfacing.
+    });
+    throw err;
+  }
+}
+
 async function copyDirRecursive(src: string, dest: string) {
   await ensureDir(dest);
   const entries = await fs.readdir(src, { withFileTypes: true });
@@ -52,7 +74,7 @@ async function copyDirRecursive(src: string, dest: string) {
       } catch {
         // Destination missing (or stat raced) — fall through to the copy.
       }
-      await fs.copyFile(s, d);
+      await copyFileAtomic(s, d);
     }
   }
 }

--- a/lib/server/classroom-storage.ts
+++ b/lib/server/classroom-storage.ts
@@ -3,18 +3,70 @@ import path from 'path';
 import type { NextRequest } from 'next/server';
 import type { Scene, Stage } from '@/lib/types/stage';
 
-export const CLASSROOMS_DIR = path.join(process.cwd(), 'data', 'classrooms');
-export const CLASSROOM_JOBS_DIR = path.join(process.cwd(), 'data', 'classroom-jobs');
+// Classroom storage location. Override with CLASSROOMS_DATA_DIR env to land on
+// a large drive; otherwise defaults to <project>/data (stock behavior).
+const STORAGE_ROOT = process.env.CLASSROOMS_DATA_DIR ?? path.join(process.cwd(), 'data');
+export const CLASSROOMS_DIR = path.join(STORAGE_ROOT, 'classrooms');
+export const CLASSROOM_JOBS_DIR = path.join(STORAGE_ROOT, 'classroom-jobs');
+
+// Legacy storage location (pre-env-config). Classrooms were previously written
+// to <project>/data/classrooms. When the storage path moved to a non-project
+// CLASSROOMS_DATA_DIR, the JSON made it to the new location but the per-classroom
+// media subdirectories (written by the external narration pipeline) did not
+// follow — stranding the audio. This migration copies any legacy data (including
+// media dirs) into the current location so a future path change can never split
+// the data again.
+const LEGACY_CLASSROOMS_DIR = path.join(process.cwd(), 'data', 'classrooms');
+const LEGACY_CLASSROOM_JOBS_DIR = path.join(process.cwd(), 'data', 'classroom-jobs');
 
 async function ensureDir(dir: string) {
   await fs.mkdir(dir, { recursive: true });
 }
 
+async function dirExists(dir: string): Promise<boolean> {
+  try {
+    return (await fs.stat(dir)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function copyDirRecursive(src: string, dest: string) {
+  await ensureDir(dest);
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirRecursive(s, d);
+    } else {
+      await fs.copyFile(s, d);
+    }
+  }
+}
+
+/**
+ * Migrate any legacy classroom data into the current storage location.
+ * Idempotent and non-destructive: copies (never deletes) legacy JSON + media
+ * subdirectories into CLASSROOMS_DIR / CLASSROOM_JOBS_DIR. Safe to call on
+ * every startup — it no-ops when no legacy data exists.
+ */
+export async function migrateLegacyClassroomData(): Promise<void> {
+  if (await dirExists(LEGACY_CLASSROOMS_DIR)) {
+    await copyDirRecursive(LEGACY_CLASSROOMS_DIR, CLASSROOMS_DIR);
+  }
+  if (await dirExists(LEGACY_CLASSROOM_JOBS_DIR)) {
+    await copyDirRecursive(LEGACY_CLASSROOM_JOBS_DIR, CLASSROOM_JOBS_DIR);
+  }
+}
+
 export async function ensureClassroomsDir() {
+  await migrateLegacyClassroomData();
   await ensureDir(CLASSROOMS_DIR);
 }
 
 export async function ensureClassroomJobsDir() {
+  await migrateLegacyClassroomData();
   await ensureDir(CLASSROOM_JOBS_DIR);
 }
 
@@ -46,6 +98,7 @@ export function isValidClassroomId(id: string): boolean {
 }
 
 export async function readClassroom(id: string): Promise<PersistedClassroomData | null> {
+  await migrateLegacyClassroomData();
   const filePath = path.join(CLASSROOMS_DIR, `${id}.json`);
   try {
     const content = await fs.readFile(filePath, 'utf-8');

--- a/lib/server/classroom-storage.ts
+++ b/lib/server/classroom-storage.ts
@@ -19,6 +19,9 @@ export const CLASSROOM_JOBS_DIR = path.join(STORAGE_ROOT, 'classroom-jobs');
 const LEGACY_CLASSROOMS_DIR = path.join(process.cwd(), 'data', 'classrooms');
 const LEGACY_CLASSROOM_JOBS_DIR = path.join(process.cwd(), 'data', 'classroom-jobs');
 
+/** Marker file: written once after the first successful legacy migration. */
+const LEGACY_MIGRATION_MARKER = '.legacy-migration-complete';
+
 async function ensureDir(dir: string) {
   await fs.mkdir(dir, { recursive: true });
 }
@@ -40,6 +43,15 @@ async function copyDirRecursive(src: string, dest: string) {
     if (entry.isDirectory()) {
       await copyDirRecursive(s, d);
     } else {
+      // Never overwrite a newer destination: after a storage move, a classroom
+      // regenerated into the new location must not be reverted by the stale
+      // legacy copy on the next migration pass.
+      try {
+        const [srcStat, dstStat] = await Promise.all([fs.stat(s), fs.stat(d)]);
+        if (dstStat.mtimeMs >= srcStat.mtimeMs) continue;
+      } catch {
+        // Destination missing (or stat raced) — fall through to the copy.
+      }
       await fs.copyFile(s, d);
     }
   }
@@ -47,17 +59,34 @@ async function copyDirRecursive(src: string, dest: string) {
 
 /**
  * Migrate any legacy classroom data into the current storage location.
- * Idempotent and non-destructive: copies (never deletes) legacy JSON + media
- * subdirectories into CLASSROOMS_DIR / CLASSROOM_JOBS_DIR. Safe to call on
- * every startup — it no-ops when no legacy data exists.
+ * Runs at most once per storage root (guarded by a marker file), copies (never
+ * deletes) legacy JSON + media subdirectories into CLASSROOMS_DIR /
+ * CLASSROOM_JOBS_DIR, and never overwrites a newer destination file. In the
+ * default same-path configuration it no-ops entirely (source === destination,
+ * where fs.copyFile is platform-dependent).
  */
 export async function migrateLegacyClassroomData(): Promise<void> {
-  if (await dirExists(LEGACY_CLASSROOMS_DIR)) {
-    await copyDirRecursive(LEGACY_CLASSROOMS_DIR, CLASSROOMS_DIR);
+  await ensureDir(STORAGE_ROOT);
+  const marker = path.join(STORAGE_ROOT, LEGACY_MIGRATION_MARKER);
+  try {
+    await fs.access(marker);
+    return; // Already migrated once — never rescan on every read.
+  } catch {
+    // No marker yet — first pass.
   }
-  if (await dirExists(LEGACY_CLASSROOM_JOBS_DIR)) {
-    await copyDirRecursive(LEGACY_CLASSROOM_JOBS_DIR, CLASSROOM_JOBS_DIR);
+
+  if (path.resolve(LEGACY_CLASSROOMS_DIR) !== path.resolve(CLASSROOMS_DIR)) {
+    if (await dirExists(LEGACY_CLASSROOMS_DIR)) {
+      await copyDirRecursive(LEGACY_CLASSROOMS_DIR, CLASSROOMS_DIR);
+    }
   }
+  if (path.resolve(LEGACY_CLASSROOM_JOBS_DIR) !== path.resolve(CLASSROOM_JOBS_DIR)) {
+    if (await dirExists(LEGACY_CLASSROOM_JOBS_DIR)) {
+      await copyDirRecursive(LEGACY_CLASSROOM_JOBS_DIR, CLASSROOM_JOBS_DIR);
+    }
+  }
+
+  await fs.writeFile(marker, new Date().toISOString(), 'utf-8');
 }
 
 export async function ensureClassroomsDir() {
@@ -98,7 +127,6 @@ export function isValidClassroomId(id: string): boolean {
 }
 
 export async function readClassroom(id: string): Promise<PersistedClassroomData | null> {
-  await migrateLegacyClassroomData();
   const filePath = path.join(CLASSROOMS_DIR, `${id}.json`);
   try {
     const content = await fs.readFile(filePath, 'utf-8');

--- a/lib/types/stage.ts
+++ b/lib/types/stage.ts
@@ -107,6 +107,14 @@ export type AppScene = DslScene<Action, SceneContent> & {
    * scene-derived outline.
    */
   outlineId?: string;
+
+  /**
+   * Optional scene-level narration audio (relative /api/classroom-media/... path).
+   * Played once as voiceover when the scene starts, independent of per-line
+   * speech actions. Absent when a scene has no narration. App-layer annotation
+   * only — not part of the `@openmaic/dsl` Scene contract.
+   */
+  narrationUrl?: string;
 };
 export type Scene = AppScene;
 

--- a/lib/utils/audio-player.ts
+++ b/lib/utils/audio-player.ts
@@ -270,6 +270,11 @@ export class AudioPlayer {
     return this.muted;
   }
 
+  /** Current volume (used to sync scene-level narration volume). */
+  public getVolume(): number {
+    return this.volume;
+  }
+
   /**
    * Set volume (0-1)
    */

--- a/lib/utils/audio-player.ts
+++ b/lib/utils/audio-player.ts
@@ -265,6 +265,11 @@ export class AudioPlayer {
     }
   }
 
+  /** Current mute state (used to sync scene-level narration volume). */
+  public getMuted(): boolean {
+    return this.muted;
+  }
+
   /**
    * Set volume (0-1)
    */

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gen:video-export-noto-cjk": "node scripts/generate-video-export-noto-cjk.mjs",
     "gen:video-export-noto-script-fonts": "node scripts/generate-video-export-noto-script-fonts.mjs",
     "dev": "next dev",
-    "build": "node scripts/assert-vendor-maic-importer.mjs && next build",
+    "build": "node scripts/assert-vendor-maic-importer.mjs && next build && cp -r .next/static .next/standalone/.next/static",
     "start": "next start",
     "lint": "eslint",
     "check:i18n-keys": "node scripts/check-i18n-keys.mjs",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gen:video-export-noto-cjk": "node scripts/generate-video-export-noto-cjk.mjs",
     "gen:video-export-noto-script-fonts": "node scripts/generate-video-export-noto-script-fonts.mjs",
     "dev": "next dev",
-    "build": "node scripts/assert-vendor-maic-importer.mjs && next build && cp -r .next/static .next/standalone/.next/static",
+    "build": "node scripts/assert-vendor-maic-importer.mjs && next build && node -e \"require('node:fs').cpSync('.next/static', '.next/standalone/.next/static', { recursive: true })\"",
     "start": "next start",
     "lint": "eslint",
     "check:i18n-keys": "node scripts/check-i18n-keys.mjs",

--- a/scripts/narration_pipeline.py
+++ b/scripts/narration_pipeline.py
@@ -14,7 +14,7 @@ Configuration (all optional):
 Usage:
   narration_pipeline.py <classroomId> <classroomsDir>
 """
-import glob, json, os, shutil, sys, time
+import json, os, sys, time
 import requests
 
 ABOGEN = os.environ.get("ABOGEN_URL", "http://localhost:8808")
@@ -92,44 +92,34 @@ def finish_job(s, pending_id):
     return r.json().get("job_id", "?")
 
 
-def newest_m4b():
-    cands = glob.glob(os.path.join(ABOGEN_OUT, "*", "*.m4b"))
-    return max(cands, key=os.path.getmtime) if cands else None
+def has_moov(data):
+    return b"moov" in data[:4096]
 
 
-def is_complete_m4b(path, min_stable_checks=2, stability_s=3.0):
-    """True only when the M4B has a moov atom and its size is stable.
+def wait_for_job_audio(s, job_id, dest, timeout_s=900):
+    """Download the finished M4B for this job by id.
 
-    Abogen encodes with ffmpeg -movflags +faststart, so the moov atom is
-    written LAST. A file that appears on disk mid-encode has no moov (or a
-    placeholder) and grows in size; copying it yields an unplayable clip.
-    This is the root-cause fix for silent narration.
+    Polls the job-scoped download endpoint (GET /jobs/<id>/download/audio),
+    which Abogen only serves once the job is COMPLETED, so the audio is fully
+    encoded and playable. Correlating by job id (rather than scavenging the
+    newest file in the shared output dir) makes the pipeline immune to any
+    concurrent Abogen job. The moov check is belt-and-braces on the bytes we
+    actually copy.
     """
-    try:
-        with open(path, "rb") as f:
-            head = f.read(64)
-        if b"moov" not in head:
-            return False
-    except OSError:
-        return False
-    # size stable across a short window
-    sz0 = os.path.getsize(path)
-    time.sleep(stability_s)
-    sz1 = os.path.getsize(path)
-    if sz0 != sz1:
-        return False
-    return is_complete_m4b(path, min_stable_checks - 1, 0.5) if min_stable_checks > 0 else True
-
-
-def wait_for_m4b(before, timeout_s=900):
-    """Wait for a NEW, COMPLETE M4B (moov present, size stable)."""
+    url = ABOGEN + f"/jobs/{job_id}/download/audio"
     deadline = time.time() + timeout_s
     while time.time() < deadline:
-        cur = newest_m4b()
-        if cur and cur != before and is_complete_m4b(cur):
-            return cur
+        r = s.get(url, timeout=30)
+        if r.status_code == 200 and r.content and has_moov(r.content):
+            tmp = dest + ".part"
+            with open(tmp, "wb") as f:
+                f.write(r.content)
+            os.replace(tmp, dest)
+            return dest
+        if r.status_code not in (200, 404):
+            raise RuntimeError(f"job download failed: HTTP {r.status_code}: {r.text[:200]}")
         time.sleep(5)
-    raise TimeoutError("no complete m4b produced")
+    raise TimeoutError(f"no complete m4b for job {job_id}")
 
 
 def main():
@@ -155,15 +145,13 @@ def main():
         if not text:
             continue
         title = f"scene-{i+1:02d}"
-        before = newest_m4b()
         pend = upload_text(s, text, title)
-        finish_job(s, pend)
-        m4b = wait_for_m4b(before)
+        job_id = finish_job(s, pend)
         dest = os.path.join(media_dir, f"scene-{i+1:02d}.m4b")
-        shutil.copy2(m4b, dest)
+        wait_for_job_audio(s, job_id, dest)
         scene["narrationUrl"] = f"/api/classroom-media/{cid}/media/scene-{i+1:02d}.m4b"
         wired += 1
-        print(f"wired scene {i+1}: {m4b}")
+        print(f"wired scene {i+1}: {job_id} -> {dest}")
 
     with open(cf, "w") as f:
         json.dump(data, f, indent=2)

--- a/scripts/narration_pipeline.py
+++ b/scripts/narration_pipeline.py
@@ -96,6 +96,26 @@ def has_moov(data):
     return b"moov" in data[:4096]
 
 
+def job_is_dead(s, job_id):
+    """True when Abogen says this job is gone or terminally failed.
+
+    /jobs/<id>/download/audio answers 404 both while a job is still running and
+    when it will never produce audio, so a 404 alone cannot be acted on. The job
+    page distinguishes them: unknown jobs render "Job Not Found" (Abogen answers
+    200 there, not 404, to spare stale browser tabs) and finished ones carry a
+    failed/cancelled status badge.
+    """
+    r = s.get(f"{ABOGEN}/jobs/{job_id}", timeout=30)
+    if r.status_code != 200:
+        return False
+    body = r.text
+    return (
+        "Job Not Found" in body
+        or "badge--failed" in body
+        or "badge--cancelled" in body
+    )
+
+
 def wait_for_job_audio(s, job_id, dest, timeout_s=900):
     """Download the finished M4B for this job by id.
 
@@ -104,7 +124,8 @@ def wait_for_job_audio(s, job_id, dest, timeout_s=900):
     encoded and playable. Correlating by job id (rather than scavenging the
     newest file in the shared output dir) makes the pipeline immune to any
     concurrent Abogen job. The moov check is belt-and-braces on the bytes we
-    actually copy.
+    actually copy. A job that Abogen reports dead fails immediately instead of
+    burning the whole timeout.
     """
     url = ABOGEN + f"/jobs/{job_id}/download/audio"
     deadline = time.time() + timeout_s
@@ -116,7 +137,10 @@ def wait_for_job_audio(s, job_id, dest, timeout_s=900):
                 f.write(r.content)
             os.replace(tmp, dest)
             return dest
-        if r.status_code not in (200, 404):
+        if r.status_code == 404:
+            if job_is_dead(s, job_id):
+                raise RuntimeError(f"abogen job {job_id} is gone or failed")
+        elif r.status_code != 200:
             raise RuntimeError(f"job download failed: HTTP {r.status_code}: {r.text[:200]}")
         time.sleep(5)
     raise TimeoutError(f"no complete m4b for job {job_id}")

--- a/scripts/narration_pipeline.py
+++ b/scripts/narration_pipeline.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Auto-narration pipeline for an OpenMAIC classroom.
+
+Reads a persisted classroom JSON, synthesizes one M4B per scene via the local
+Abogen service (Kokoro TTS), copies each M4B into the classroom media dir, and
+stamps `scenes[i].narrationUrl` with the relative serving path. Re-persists the
+JSON. Invoked by the OpenMAIC generation job when `enableNarration` is set.
+
+Configuration (all optional):
+  ABOGEN_URL        base URL of Abogen service       (default http://localhost:8808)
+  ABOGEN_OUTPUT_DIR Abogen output directory          (default /var/lib/abogen/output)
+  ABOGEN_VOICE      Kokoro voice for narration        (default bm_george)
+
+Usage:
+  narration_pipeline.py <classroomId> <classroomsDir>
+"""
+import glob, json, os, shutil, sys, time
+import requests
+
+ABOGEN = os.environ.get("ABOGEN_URL", "http://localhost:8808")
+ABOGEN_OUT = os.environ.get("ABOGEN_OUTPUT_DIR", "/var/lib/abogen/output")
+VOICE = os.environ.get("ABOGEN_VOICE", "bm_george")
+
+NORM = {
+    "normalization_apostrophe_mode": "spacy",
+    "normalization_numbers": "true", "normalization_currency": "true",
+    "normalization_titles": "true", "normalization_footnotes": "true",
+    "normalization_terminal": "true", "normalization_caps_quotes": "true",
+    "normalization_apostrophes_contractions": "true",
+    "normalization_apostrophes_plural_possessives": "true",
+    "normalization_apostrophes_sibilant_possessives": "true",
+    "normalization_apostrophes_decades": "true",
+    "normalization_apostrophes_leading_elisions": "true",
+    "normalization_phoneme_hints": "true",
+    "normalization_contraction_aux_be": "true",
+    "normalization_contraction_aux_have": "true",
+    "normalization_contraction_modal_will": "true",
+    "normalization_contraction_modal_would": "true",
+    "normalization_contraction_negation_not": "true",
+    "normalization_contraction_let_us": "true",
+}
+
+
+def scene_speech_text(scene):
+    """Concatenate a scene's speech-action texts in order."""
+    parts = []
+    for a in scene.get("actions", []):
+        if isinstance(a, dict) and a.get("type") == "speech" and a.get("text", "").strip():
+            parts.append(a["text"].strip())
+    return "\n\n".join(parts)
+
+
+def upload_text(s, text, title):
+    data = {
+        "text": text, "title": title, "language": "b", "voice": VOICE,
+        "voice_profile": "__standard", "speed": "1.0", "subtitle_mode": "Disabled",
+        "output_format": "m4b", "save_mode": "default_output",
+        "merge_chapters_at_end": "true", "save_chapters_separately": "false",
+        "silence_between_chapters": "2.0", "chapter_intro_delay": "0.5",
+        "read_title_intro": "false", "read_closing_outro": "true",
+        "auto_prefix_chapter_titles": "true", "normalize_chapter_opening_caps": "true",
+        "chunk_level": "paragraph", "speaker_analysis_threshold": 3,
+        "remove_cover": "false", "generate_epub3": "false", "json": "1",
+    }
+    data.update(NORM)
+    r = s.post(ABOGEN + "/wizard/text", data=data,
+               headers={"Accept": "application/json"}, timeout=120)
+    j = r.json()
+    if "pending_id" not in j:
+        raise RuntimeError(f"no pending_id: {j}")
+    return j["pending_id"]
+
+
+def finish_job(s, pending_id):
+    chapters_j = s.get(f"{ABOGEN}/wizard/chapters?pending_id={pending_id}",
+                       headers={"Accept": "application/json"}).json()
+    nch = len(chapters_j.get("chapters", [])) or 1
+    fin = {
+        "pending_id": pending_id, "json": "1", "chunk_level": "paragraph",
+        "speaker_analysis_threshold": 3, "generate_epub3": "false",
+        "applied_speaker_config": "", "apply_speaker_config": "",
+        "save_speaker_config": "", "speaker-narrator-voice": VOICE,
+        "speaker-narrator-pronunciation": "", "speaker-narrator-formula": "",
+    }
+    for i in range(nch):
+        fin[f"chapter-{i}-enabled"] = "on"
+        fin[f"chapter-{i}-title"] = ""
+        fin[f"chapter-{i}-voice"] = "__default"
+        fin[f"chapter-{i}-formula"] = ""
+    r = s.post(ABOGEN + "/wizard/finish", data=fin,
+               headers={"Accept": "application/json"}, timeout=120)
+    return r.json().get("job_id", "?")
+
+
+def newest_m4b():
+    cands = glob.glob(os.path.join(ABOGEN_OUT, "*", "*.m4b"))
+    return max(cands, key=os.path.getmtime) if cands else None
+
+
+def is_complete_m4b(path, min_stable_checks=2, stability_s=3.0):
+    """True only when the M4B has a moov atom and its size is stable.
+
+    Abogen encodes with ffmpeg -movflags +faststart, so the moov atom is
+    written LAST. A file that appears on disk mid-encode has no moov (or a
+    placeholder) and grows in size; copying it yields an unplayable clip.
+    This is the root-cause fix for silent narration.
+    """
+    try:
+        with open(path, "rb") as f:
+            head = f.read(64)
+        if b"moov" not in head:
+            return False
+    except OSError:
+        return False
+    # size stable across a short window
+    sz0 = os.path.getsize(path)
+    time.sleep(stability_s)
+    sz1 = os.path.getsize(path)
+    if sz0 != sz1:
+        return False
+    return is_complete_m4b(path, min_stable_checks - 1, 0.5) if min_stable_checks > 0 else True
+
+
+def wait_for_m4b(before, timeout_s=900):
+    """Wait for a NEW, COMPLETE M4B (moov present, size stable)."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        cur = newest_m4b()
+        if cur and cur != before and is_complete_m4b(cur):
+            return cur
+        time.sleep(5)
+    raise TimeoutError("no complete m4b produced")
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("usage: narration_pipeline.py <classroomId> <classroomsDir>")
+    cid, cdir = sys.argv[1], sys.argv[2]
+    cf = os.path.join(cdir, f"{cid}.json")
+    if not os.path.exists(cf):
+        sys.exit(f"classroom json not found: {cf}")
+    with open(cf) as f:
+        data = json.load(f)
+
+    media_dir = os.path.join(cdir, cid, "media")
+    os.makedirs(media_dir, exist_ok=True)
+
+    s = requests.Session()
+    s.get(ABOGEN + "/")
+
+    scenes = data.get("scenes", [])
+    wired = 0
+    for i, scene in enumerate(scenes):
+        text = scene_speech_text(scene)
+        if not text:
+            continue
+        title = f"scene-{i+1:02d}"
+        before = newest_m4b()
+        pend = upload_text(s, text, title)
+        finish_job(s, pend)
+        m4b = wait_for_m4b(before)
+        dest = os.path.join(media_dir, f"scene-{i+1:02d}.m4b")
+        shutil.copy2(m4b, dest)
+        scene["narrationUrl"] = f"/api/classroom-media/{cid}/media/scene-{i+1:02d}.m4b"
+        wired += 1
+        print(f"wired scene {i+1}: {m4b}")
+
+    with open(cf, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"narration wired for {wired}/{len(scenes)} scenes")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/openmaic/SKILL.md
+++ b/skills/openmaic/SKILL.md
@@ -95,6 +95,12 @@ Load [references/generate-flow.md](references/generate-flow.md).
 
 Use this only after the service is healthy. Confirm before reading local PDFs. If the user has already clearly asked to generate, do not ask for a second confirmation before submitting the generation job, and then follow the polling loop until it succeeds or fails. Only send the supported content fields for generation requests. For long-running jobs, prefer sparse polling and tell the user to check back later if the turn ends before completion.
 
+After the classroom is generated, if the user wants voiceover audio, follow the
+**Narration Wiring (Abogen audio)** section in [references/generate-flow.md](references/generate-flow.md) —
+it documents generating per-scene M4B audio with the local Abogen service and
+wiring it into the classroom as scene-level narration (including the critical
+"rebuild wipes classroom data" gotcha).
+
 ## Response Style
 
 - Keep each step short and explicit.

--- a/skills/openmaic/references/generate-flow.md
+++ b/skills/openmaic/references/generate-flow.md
@@ -168,20 +168,21 @@ If the error suggests a provider or model configuration problem, explicitly tell
 ## Narration Wiring (Abogen audio)
 
 OpenMAIC's built-in TTS is often disabled (health shows `"tts": false`). To give a
-generated classroom voiceover, generate per-scene audio with the local **Abogen**
-service (Kokoro TTS, `http://localhost:8808`) and wire it in as scene-level
+generated classroom voiceover, generate per-scene audio with a local **Abogen**
+service (Kokoro TTS, e.g. `http://localhost:8808`) and wire it in as scene-level
 narration.
 
 ### Automatic (recommended)
 
 Set `enableNarration: true` in the generation request. After the classroom is
-persisted, the server runs `~/.local/bin/narration_pipeline.py <classroomId>
-<classroomsDir>` which extracts each scene's speech text, synthesizes one M4B per
-scene via Abogen, copies it into the classroom media dir, stamps
-`scenes[i].narrationUrl`, and re-persists the JSON. The job reports
-`generating_narration` at 99% while this runs, and only reports `succeeded` once
-narration is wired. Best-effort: a down Abogen or script failure logs a warning
-and the job still succeeds (without narration).
+persisted, the server runs the repo's narration script
+(`scripts/narration_pipeline.py <classroomId> <classroomsDir>` — path
+overridable via `NARRATION_PIPELINE_SCRIPT`) which extracts each scene's speech
+text, synthesizes one M4B per scene via Abogen, copies it into the classroom
+media dir, stamps `scenes[i].narrationUrl`, and re-persists the JSON. The job
+reports `generating_narration` at 99% while this runs, and only reports
+`succeeded` once narration is wired. Best-effort: a down Abogen or script
+failure logs a warning and the job still succeeds (without narration).
 
 ### Manual (fallback)
 
@@ -189,35 +190,30 @@ If `enableNarration` is not available (older codebase) or you want to wire
 pre-generated M4Bs:
 
 1. **Extract scene scripts.** Each scene's speech text lives in the classroom
-   JSON at `data/classrooms/<id>.json` under `scenes[].actions[]` where
+   JSON at `<classroomsDir>/<id>.json` under `scenes[].actions[]` where
    `type === 'speech'`. Write one `.txt` per scene (concatenate its speech
-   actions) into a scratch dir, e.g. `~/scratch/scene-audio/`.
+   actions) into a scratch dir.
 
-2. **Generate audio via Abogen.** Use `~/.local/bin/abogen_scenes.py` (or the
-   `abogen` skill's `/wizard/text` → `/wizard/finish` flow) to produce one M4B
-   per scene. Default voice `bm_george` (British male, good for technical math).
-   Output lands under `<ABOGEN_OUTPUT_DIR>/<job>/<name>.m4b` (env-configurable).
+2. **Generate audio via Abogen.** Use the Abogen `/wizard/text` →
+   `/wizard/finish` flow to produce one M4B per scene (the pipeline script
+   shows the exact request shape). Default voice `bm_george` (British male,
+   good for technical math). Output lands under Abogen's configured output
+   dir.
 
-3. **Wire narration into the classroom.** Run `~/.local/bin/wire_narration.py`
-   (edit `CLASSROOM_ID` / `AUDIO_DIR` at the top). It copies each scene's M4B
-   into the classroom media dir and stamps `scenes[i].narrationUrl` with the
-   relative `/api/classroom-media/<id>/media/scene-NN.m4b` path, then rewrites
-   the JSON. It backs up the JSON to `<your backup dir>/openmaic-classrooms/`
-   first.
+3. **Wire narration into the classroom.** `scripts/narration_pipeline.py` does
+   this end to end; to wire pre-generated files instead, copy each M4B into the
+   classroom media dir and stamp `scenes[i].narrationUrl` with the relative
+   `/api/classroom-media/<id>/media/scene-NN.m4b` path, then rewrite the JSON.
 
-4. **Rebuild + restart.** `cd ~/OpenMAIC && pnpm build` (or `npm run build`),
-   then `systemctl --user restart openmaic.service`.
+4. **Rebuild + restart.** `cd <repo> && pnpm build` (or `npm run build`), then
+   restart the server process.
 
 ### CRITICAL: the build wipes classroom data
 
-`next build` regenerates `.next/` and **deletes
-`.next/standalone/data/classrooms/`** — the stored classroom JSON and its media
-are lost. This is the #1 gotcha. Always:
-
-- Back up `data/classrooms/<id>.json` (and `media/`) to
-  `<your backup dir>/openmaic-classrooms/` **before** any rebuild.
-- After a rebuild, restore the JSON from backup, then re-run `wire_narration.py`
-  (it re-copies the M4Bs from the source audio dir, so it's idempotent).
+`next build` regenerates `.next/` and **deletes** the stored classroom JSON and
+media that live under `.next/standalone/` when serving from the standalone
+build. If your deployment keeps classroom data inside the build output, back up
+the classroom JSON (and `media/`) before any rebuild and restore it after.
 
 ### Verify
 
@@ -239,32 +235,30 @@ machine** (server and clients alike) even though:
 - `file` reports `ISO Media, Apple iTunes ALAC/AAC-LC (.M4A) Audio`
 - `ffprobe` fails with `moov atom not found`
 
-`narration_pipeline.py::wait_for_m4b` MUST wait for a **complete** M4B:
-`moov` present in the file head AND size stable across a short window, before
-`shutil.copy2`. The classroom copies must have `moov` — verify with
-`python3 -c "d=open('...scene-01.m4b','rb').read(); print(d.find(b'moov'))"`
-(must be `>= 0`). A valid copy is ~1.5MB+ (the old corrupt ones were 256KB with
-only `ftyp`+`mdat`). If narration is already wired but silent, re-run the
-pipeline (it's idempotent — re-copies valid M4Bs).
+The pipeline downloads each scene's finished audio from the job-scoped endpoint
+(`GET /jobs/<id>/download/audio`, only served once the Abogen job is
+COMPLETED), which guarantees a fully-encoded file, and additionally checks for
+`moov` in the bytes before stamping the narration URL. If narration is already
+wired but silent, re-run the pipeline (it's idempotent — re-downloads valid
+M4Bs).
 
 ### CRITICAL: browser caches the corrupt M4B (silent on clients, works on server)
 
-The media route previously sent `Cache-Control: public, max-age=86400, immutable`.
 Because the narration URL is stable (`/api/classroom-media/<id>/media/scene-NN.m4b`),
-a client that fetched the OLD corrupt file cached it under that URL and, with
-`immutable`, never revalidated — so it kept playing the stale silent bytes even
-after the file was fixed. The server (ryzen9) played fine because it fetched
-fresh; LAN clients stayed silent with the play icon showing.
-
-Fix: the media route must send `Cache-Control: no-store` (never cache — the
-files are small and rewritten in place). After changing it, rebuild + restart.
-Clients that already cached the corrupt file must hard-refresh (Ctrl+Shift+R)
+a client that fetched a corrupt file could cache it under that URL and keep
+playing the stale silent bytes. The media route therefore sends
+`Cache-Control: no-store` for narration files (`.m4a`/`.m4b`) so they are never
+cached; immutable media (images, videos) keeps long-lived cache headers.
+Clients that already cached a corrupt file must hard-refresh (Ctrl+Shift+R)
 once to drop it.
 
-### Known ceiling
+### Combination with per-line TTS
 
-Scene narration is fire-and-forget: it plays once at scene start and does not
-pause/resume with the playback controls. Add pause/resume sync if that matters.
+Narration is scene-level voiceover that plays in addition to the action loop. If
+`enableTTS` is also enabled, the per-line speech audio and the scene narration
+play at the same time. They are designed to be alternatives: enable
+`enableNarration` for voiceover (TTS off), or keep `enableTTS` for per-line
+speech (narration off).
 
 ## Confirmation Requirements
 

--- a/skills/openmaic/references/generate-flow.md
+++ b/skills/openmaic/references/generate-flow.md
@@ -39,6 +39,7 @@ Only send supported content fields:
 - optional `enableImageGeneration` (boolean) — allow image generation metadata in outlines
 - optional `enableVideoGeneration` (boolean) — allow video generation metadata in outlines
 - optional `enableTTS` (boolean) — enable server-side TTS audio generation for speech actions
+- optional `enableNarration` (boolean) — after generation, synthesize per-scene M4B narration via the local **Abogen** service and wire it in as scene-level `narrationUrl` (see "Narration Wiring" below). Best-effort: a down Abogen or a script failure logs a warning and does not fail the job.
 - optional `agentMode` (`"default"` | `"generate"`) — controls agent profile strategy:
   - `"default"` (or omitted): uses built-in default agents
   - `"generate"`: uses LLM to generate custom agent profiles tailored to the course content
@@ -163,6 +164,107 @@ If the job fails, return the job ID plus the server error.
 If generation fails, surface the server error directly instead of paraphrasing it away.
 
 If the error suggests a provider or model configuration problem, explicitly tell the user to update `.env.local` or `server-providers.yml` instead of attempting a runtime override.
+
+## Narration Wiring (Abogen audio)
+
+OpenMAIC's built-in TTS is often disabled (health shows `"tts": false`). To give a
+generated classroom voiceover, generate per-scene audio with the local **Abogen**
+service (Kokoro TTS, `http://localhost:8808`) and wire it in as scene-level
+narration.
+
+### Automatic (recommended)
+
+Set `enableNarration: true` in the generation request. After the classroom is
+persisted, the server runs `~/.local/bin/narration_pipeline.py <classroomId>
+<classroomsDir>` which extracts each scene's speech text, synthesizes one M4B per
+scene via Abogen, copies it into the classroom media dir, stamps
+`scenes[i].narrationUrl`, and re-persists the JSON. The job reports
+`generating_narration` at 99% while this runs, and only reports `succeeded` once
+narration is wired. Best-effort: a down Abogen or script failure logs a warning
+and the job still succeeds (without narration).
+
+### Manual (fallback)
+
+If `enableNarration` is not available (older codebase) or you want to wire
+pre-generated M4Bs:
+
+1. **Extract scene scripts.** Each scene's speech text lives in the classroom
+   JSON at `data/classrooms/<id>.json` under `scenes[].actions[]` where
+   `type === 'speech'`. Write one `.txt` per scene (concatenate its speech
+   actions) into a scratch dir, e.g. `~/scratch/scene-audio/`.
+
+2. **Generate audio via Abogen.** Use `~/.local/bin/abogen_scenes.py` (or the
+   `abogen` skill's `/wizard/text` → `/wizard/finish` flow) to produce one M4B
+   per scene. Default voice `bm_george` (British male, good for technical math).
+   Output lands under `<ABOGEN_OUTPUT_DIR>/<job>/<name>.m4b` (env-configurable).
+
+3. **Wire narration into the classroom.** Run `~/.local/bin/wire_narration.py`
+   (edit `CLASSROOM_ID` / `AUDIO_DIR` at the top). It copies each scene's M4B
+   into the classroom media dir and stamps `scenes[i].narrationUrl` with the
+   relative `/api/classroom-media/<id>/media/scene-NN.m4b` path, then rewrites
+   the JSON. It backs up the JSON to `<your backup dir>/openmaic-classrooms/`
+   first.
+
+4. **Rebuild + restart.** `cd ~/OpenMAIC && pnpm build` (or `npm run build`),
+   then `systemctl --user restart openmaic.service`.
+
+### CRITICAL: the build wipes classroom data
+
+`next build` regenerates `.next/` and **deletes
+`.next/standalone/data/classrooms/`** — the stored classroom JSON and its media
+are lost. This is the #1 gotcha. Always:
+
+- Back up `data/classrooms/<id>.json` (and `media/`) to
+  `<your backup dir>/openmaic-classrooms/` **before** any rebuild.
+- After a rebuild, restore the JSON from backup, then re-run `wire_narration.py`
+  (it re-copies the M4Bs from the source audio dir, so it's idempotent).
+
+### Verify
+
+- `curl -s -o /dev/null -w "%{http_code} %{content_type}" \
+  http://localhost:3000/api/classroom-media/<id>/media/scene-01.m4b` → `200 audio/mp4`.
+- Open the classroom, start playback: each scene's M4B plays as voiceover on a
+  dedicated element (separate from per-line speech). Speech text still shows and
+  advances on the reading timer.
+
+### CRITICAL: incomplete M4B (silent narration) — the #2 gotcha
+
+Abogen encodes with `ffmpeg -movflags +faststart`, so the `moov` atom is written
+**last**. If the pipeline copies the `.m4b` the moment the file *appears*, it
+copies a mid-write, truncated file that has NO `moov` atom. Browsers cannot
+decode an M4A/AAC stream without `moov`, so the classroom is **silent on every
+machine** (server and clients alike) even though:
+- the stream returns `200`
+- `Content-Length` is present
+- `file` reports `ISO Media, Apple iTunes ALAC/AAC-LC (.M4A) Audio`
+- `ffprobe` fails with `moov atom not found`
+
+`narration_pipeline.py::wait_for_m4b` MUST wait for a **complete** M4B:
+`moov` present in the file head AND size stable across a short window, before
+`shutil.copy2`. The classroom copies must have `moov` — verify with
+`python3 -c "d=open('...scene-01.m4b','rb').read(); print(d.find(b'moov'))"`
+(must be `>= 0`). A valid copy is ~1.5MB+ (the old corrupt ones were 256KB with
+only `ftyp`+`mdat`). If narration is already wired but silent, re-run the
+pipeline (it's idempotent — re-copies valid M4Bs).
+
+### CRITICAL: browser caches the corrupt M4B (silent on clients, works on server)
+
+The media route previously sent `Cache-Control: public, max-age=86400, immutable`.
+Because the narration URL is stable (`/api/classroom-media/<id>/media/scene-NN.m4b`),
+a client that fetched the OLD corrupt file cached it under that URL and, with
+`immutable`, never revalidated — so it kept playing the stale silent bytes even
+after the file was fixed. The server (ryzen9) played fine because it fetched
+fresh; LAN clients stayed silent with the play icon showing.
+
+Fix: the media route must send `Cache-Control: no-store` (never cache — the
+files are small and rewritten in place). After changing it, rebuild + restart.
+Clients that already cached the corrupt file must hard-refresh (Ctrl+Shift+R)
+once to drop it.
+
+### Known ceiling
+
+Scene narration is fire-and-forget: it plays once at scene start and does not
+pause/resume with the playback controls. Add pause/resume sync if that matters.
 
 ## Confirmation Requirements
 

--- a/tests/server/classroom-storage-migration.test.ts
+++ b/tests/server/classroom-storage-migration.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Unit tests for the legacy classroom-data migration (review finding 2):
+ *  - runs at most once per storage root (marker-gated)
+ *  - never overwrites a newer destination file
+ *  - no-ops entirely when legacy path === current path (default config)
+ *
+ * The legacy dir is hardcoded to <cwd>/data/classrooms, so each test chdirs
+ * into a sandboxed project root and points CLASSROOMS_DATA_DIR at a separate
+ * "current" root to exercise the copy path.
+ */
+
+const TMP = fsSync.realpathSync(os.tmpdir());
+const ROOT = path.join(TMP, 'openmaic-classroom-storage-test');
+const PROJECT = path.join(ROOT, 'project'); // legacy = <cwd>/data
+const CURRENT = path.join(ROOT, 'current'); // CLASSROOMS_DATA_DIR
+
+const originalCwd = process.cwd();
+
+async function writeFile(p: string, content: string, mtimeMs: number) {
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, content);
+  await fs.utimes(p, new Date(mtimeMs), new Date(mtimeMs));
+}
+
+async function readFile(p: string): Promise<string | null> {
+  try {
+    return await fs.readFile(p, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function legacyClassrooms() {
+  return path.join(PROJECT, 'data', 'classrooms');
+}
+
+describe('migrateLegacyClassroomData', () => {
+  beforeEach(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(PROJECT, { recursive: true });
+    process.env.CLASSROOMS_DATA_DIR = CURRENT;
+    process.chdir(PROJECT);
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    delete process.env.CLASSROOMS_DATA_DIR;
+    await fs.rm(ROOT, { recursive: true, force: true });
+  });
+
+  test('copies legacy data once and marks completion', async () => {
+    await writeFile(
+      path.join(legacyClassrooms(), 'abc.json'),
+      '{"legacy":true}',
+      Date.now(),
+    );
+
+    const { migrateLegacyClassroomData, CLASSROOMS_DIR } = await import(
+      '@/lib/server/classroom-storage'
+    );
+
+    await migrateLegacyClassroomData();
+    expect(CLASSROOMS_DIR).toBe(path.join(CURRENT, 'classrooms'));
+    expect(await readFile(path.join(CLASSROOMS_DIR, 'abc.json'))).toBe('{"legacy":true}');
+    expect(
+      await readFile(path.join(CURRENT, '.legacy-migration-complete')),
+    ).not.toBeNull();
+  });
+
+  test('second call is a no-op even if legacy data changed', async () => {
+    await writeFile(path.join(legacyClassrooms(), 'abc.json'), '{"v":1}', Date.now());
+
+    const { migrateLegacyClassroomData, CLASSROOMS_DIR } = await import(
+      '@/lib/server/classroom-storage'
+    );
+
+    await migrateLegacyClassroomData();
+    // Simulate a NEWER classroom regenerated into the current location.
+    await writeFile(path.join(CLASSROOMS_DIR, 'abc.json'), '{"v":2}', Date.now() + 100_000);
+
+    // Stale legacy copy now differs — a non-marker-gated migration would revert v2.
+    await writeFile(
+      path.join(legacyClassrooms(), 'abc.json'),
+      '{"v":1,"stale":true}',
+      Date.now() + 50_000,
+    );
+
+    await migrateLegacyClassroomData();
+    expect(await readFile(path.join(CLASSROOMS_DIR, 'abc.json'))).toBe('{"v":2}');
+  });
+
+  test('never overwrites a newer destination in the copy pass', async () => {
+    const current = path.join(CURRENT, 'classrooms');
+    // Destination exists and is NEWER than the legacy source. Marker-gating is
+    // bypassed by deleting the marker so the copy guard itself is exercised.
+    await writeFile(path.join(current, 'abc.json'), '{"new":true}', Date.now());
+    await writeFile(
+      path.join(legacyClassrooms(), 'abc.json'),
+      '{"legacy":true}',
+      Date.now() - 100_000,
+    );
+
+    const { migrateLegacyClassroomData, CLASSROOMS_DIR } = await import(
+      '@/lib/server/classroom-storage'
+    );
+
+    await migrateLegacyClassroomData();
+    // First pass: marker absent, dest newer → still guarded.
+    expect(await readFile(path.join(CLASSROOMS_DIR, 'abc.json'))).toBe('{"new":true}');
+  });
+
+  test('same-path default configuration does not copy onto itself', async () => {
+    // Simulate the default layout (env var unset): legacy and current both
+    // resolve to <cwd>/data/classrooms, where copyFile(src, src) is undefined.
+    delete process.env.CLASSROOMS_DATA_DIR;
+    await fs.mkdir(legacyClassrooms(), { recursive: true });
+
+    const { migrateLegacyClassroomData, CLASSROOMS_DIR } = await import(
+      '@/lib/server/classroom-storage'
+    );
+    expect(CLASSROOMS_DIR).toBe(legacyClassrooms());
+
+    await migrateLegacyClassroomData(); // must not throw on same-path copy
+    expect(
+      await readFile(path.join(PROJECT, 'data', '.legacy-migration-complete')),
+    ).not.toBeNull();
+  });
+});

--- a/tests/server/classroom-storage-migration.test.ts
+++ b/tests/server/classroom-storage-migration.test.ts
@@ -132,4 +132,43 @@ describe('migrateLegacyClassroomData', () => {
       await readFile(path.join(PROJECT, 'data', '.legacy-migration-complete')),
     ).not.toBeNull();
   });
+
+  test('a copy that dies mid-write leaves no partial destination behind', async () => {
+    // Review finding: copyFile wrote destinations in place, so a crash mid-copy
+    // left a truncated file whose fresh mtime beat the legacy source. The next
+    // pass skipped it via the mtime guard and the completion marker froze the
+    // partial bytes in place permanently. Copying via temp + rename means the
+    // destination is only ever absent or complete.
+    await writeFile(
+      path.join(legacyClassrooms(), 'abc.json'),
+      '{"legacy":true}',
+      Date.now(),
+    );
+
+    const { migrateLegacyClassroomData, CLASSROOMS_DIR } = await import(
+      '@/lib/server/classroom-storage'
+    );
+
+    // Simulate the crash: bytes land, then the write throws (disk full).
+    const spy = vi
+      .spyOn(fs, 'copyFile')
+      .mockImplementation(async (_src: fsSync.PathLike, dest: fsSync.PathLike) => {
+        await fs.writeFile(dest, '{"legacy":'); // truncated
+        throw Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' });
+      });
+
+    await expect(migrateLegacyClassroomData()).rejects.toThrow('ENOSPC');
+    spy.mockRestore();
+
+    // No truncated destination and no temp litter, and the marker was NOT
+    // written — so the next boot retries instead of freezing the partial file.
+    expect(await readFile(path.join(CLASSROOMS_DIR, 'abc.json'))).toBeNull();
+    expect((await fs.readdir(CLASSROOMS_DIR)).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+    expect(await readFile(path.join(CURRENT, '.legacy-migration-complete'))).toBeNull();
+
+    // The retry on the next pass completes the copy for real.
+    await migrateLegacyClassroomData();
+    expect(await readFile(path.join(CLASSROOMS_DIR, 'abc.json'))).toBe('{"legacy":true}');
+    expect(await readFile(path.join(CURRENT, '.legacy-migration-complete'))).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds optional per-scene **Abogen narration** to OpenMAIC classrooms. When `enableNarration: true` is set on `POST /api/generate-classroom`, after the classroom is persisted the server runs `scripts/narration_pipeline.py`, which for each scene:

1. extracts the scene's speech text,
2. synthesizes one M4B via a local **Abogen** (Kokoro TTS) service,
3. waits for the M4B to be **complete** (moov atom present + stable size) so browsers can decode it,
4. copies it into the classroom media dir and stamps `scenes[i].narrationUrl`,
5. re-persists the classroom JSON.

Narration plays once per scene as a voiceover on a dedicated element, separate from per-line speech. It is **best-effort**: a down Abogen or script failure logs a warning and does not fail generation.

## Changes

- `enableNarration` input flag + `generating_narration` progress step
- `scripts/narration_pipeline.py` (env-configurable: `ABOGEN_URL`, `ABOGEN_OUTPUT_DIR`, `ABOGEN_VOICE`)
- `lib/server/classroom-storage.ts` — storage root now env-configurable via `CLASSROOMS_DATA_DIR`; best-effort migration from legacy `<cwd>/data`. Migrated files are copied to a sibling temp name and renamed into place, so a copy that dies mid-write (disk full, crash) can never leave a truncated destination that the mtime guard would then skip forever
- `app/api/classroom-media/[...path]/route.ts` — serve `.m4a`/`.m4b` as `audio/mp4` with `Cache-Control: no-store` (a stable narration URL + `immutable` caching left clients playing stale silent bytes)
- `package.json` build — copy `.next/static` into standalone output (Next.js build does not do this)
- Skill docs in `skills/openmaic/`

## Notes

Requires a **local Abogen** service, e.g. `http://localhost:8808`. For contributors, point `ABOGEN_URL` / `ABOGEN_OUTPUT_DIR` / `CLASSROOMS_DATA_DIR` via `.env.local` (gitignored).

### Known limitation: the boot window

Legacy migration is fired from `instrumentation.register()` as **fire-and-forget** (boot must not block on I/O), so on the *first* boot of a deployment that (a) sets `CLASSROOMS_DATA_DIR` to a new location and (b) has a legacy `<cwd>/data` directory, there is a short window — the first seconds after boot, until the copy finishes — where a classroom that exists only in the legacy directory reads as missing (`readClassroom` → `null` → 404). It is self-healing: the migration completes, writes its marker, and every later read finds the data. The window only exists on the first boot after a storage-path change; the marker makes subsequent boots no-ops.

Accepted as-is rather than making `readClassroom` migrate synchronously on a first miss, because that would put the full copy on the request path and race the marker the background pass is already writing.

### Known behavior: the sound button

The sound/mute button is actionable in classrooms that have neither TTS nor scene narration (it is the existing shared TTS control; there is simply nothing for it to silence).

## Review follow-ups

- **Partial copies can survive forever** — fixed: `copyFileAtomic` (temp + rename, temp removed on failure) with a regression test that fails against the previous in-place `copyFile`.
- **Job download 404 polls to the full timeout** — fixed: `narration_pipeline.py` probes the job page on a 404 and fails immediately when Abogen reports the job gone/failed/cancelled.
- **Narration volume hardcoded to 1** — fixed: scene narration now takes the shared player's volume (and mute), so the volume slider affects it.
