### PR TITLE
fix(importer): convert Equation.3 OLE formulas via MTEF v3, surface degrade telemetry

### DIFF
--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/importer",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "A javascript tool for parsing .pptx file",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/@openmaic/importer/package.json
+++ b/packages/@openmaic/importer/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@openmaic/dsl": "workspace:^",
     "@xmldom/xmldom": "^0.9.9",
+    "cfb": "1.2.2",
     "jpegxr": "^0.3.0",
     "jszip": "^3.10.1",
     "katex": "^0.16.33",

--- a/packages/@openmaic/importer/src/adapter/types.ts
+++ b/packages/@openmaic/importer/src/adapter/types.ts
@@ -298,6 +298,9 @@ export interface Math {
   picBase64: string;
   order: number;
   text?: string;
+  /** MTEF conversion succeeded but approximated a construct (PILE/MATRIX …);
+   *  the LaTeX renders but is semantically flattened — surfaces a warning. */
+  degraded?: boolean;
 }
 
 export type BaseElement = Shape | Text | Image | Table | Chart | Video | Audio | Diagram | Math;

--- a/packages/@openmaic/importer/src/import-pipeline/index.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/index.ts
@@ -20,7 +20,7 @@ import type { Output } from '../adapter/types';
 import { parseZip } from '../parser/ZipParser';
 import { buildPresentation } from '../model/Presentation';
 import { toPptxtojsonFormat } from '../adapter/toPptxtojson';
-import type { ImportContext } from './types';
+import type { ImportContext, ImportWarning } from './types';
 import { transformParsedToSlides } from './transformParsedToSlides';
 import { createMockImportContext } from './mockContext';
 
@@ -42,6 +42,13 @@ export interface ImportPptxOptions {
    * keeps an in-memory `blob:` URL (valid only for the current tab).
    */
   upload?: OssUpload;
+  /**
+   * Degrade-not-fail telemetry sink. The import never fails on partial
+   * content loss by design; this is the only channel through which callers
+   * can learn it happened (formulas degraded to placeholders, unconvertible
+   * WMF/EMF media, elements dropped by DSL normalization).
+   */
+  onWarning?: (warning: ImportWarning) => void;
 }
 
 /**
@@ -57,7 +64,7 @@ export async function parsedToSlides(
   json: Output,
   options: ImportPptxOptions = {},
 ): Promise<Slide[]> {
-  const baseCtx = createMockImportContext(buildContextOverrides(options.upload));
+  const baseCtx = createMockImportContext(buildContextOverrides(options.upload, options.onWarning));
   // Drive the transform-time width clamp from the deck's own pixel width
   // (pt → px via ratio) so 16:9 widescreen decks (960pt → 1280px) don't
   // get text elements truncated to the legacy 4:3 default of 960.
@@ -79,7 +86,7 @@ export async function parsedToSlides(
   // viewportRatio / theme are filled at construction); the contract's
   // `normalize` pass at this output boundary is the safety net for anything the
   // transform missed on an exotic deck, mirroring the generator's wiring.
-  return normalizeImportedSlides(slides);
+  return normalizeImportedSlides(slides, options.onWarning);
 }
 
 /**
@@ -109,8 +116,34 @@ const normalizeImportedSlide = normalizeSlideWith({
   },
 });
 
-export function normalizeImportedSlides(slides: Slide[]): Slide[] {
-  return slides.map(normalizeImportedSlide);
+export function normalizeImportedSlides(
+  slides: Slide[],
+  onWarning?: (warning: ImportWarning) => void,
+): Slide[] {
+  if (!onWarning) return slides.map(normalizeImportedSlide);
+  return slides.map((slide, slideIndex) =>
+    normalizeSlideWith({
+      onInvalid: 'drop',
+      onDropped: (element, error) => {
+        console.warn(
+          `[@openmaic/importer] dropping element that fails DSL normalization: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        try {
+          onWarning({
+            code: 'element-dropped',
+            slideIndex,
+            message: `A ${String((element as { type?: string }).type ?? 'unknown')} element failed DSL normalization and was dropped: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
+        } catch (sinkErr) {
+          console.error('[@openmaic/importer] onWarning sink threw (ignored):', sinkErr);
+        }
+      },
+    })(slide),
+  );
 }
 
 /**
@@ -131,15 +164,20 @@ export async function importPptx(
   return parsedToSlides(json, options);
 }
 
-function buildContextOverrides(upload: OssUpload | undefined): Partial<ImportContext> {
-  if (!upload) return {};
-  return {
-    uploadBase64Image: async (base64, filename, dir) => {
+function buildContextOverrides(
+  upload: OssUpload | undefined,
+  onWarning?: (warning: ImportWarning) => void,
+): Partial<ImportContext> {
+  const overrides: Partial<ImportContext> = {};
+  if (upload) {
+    overrides.uploadBase64Image = async (base64, filename, dir) => {
       const blob = await dataUrlToBlob(base64);
       return upload(blob, filename, dir);
-    },
-    uploadBlobMedia: (blob, filename, dir) => upload(blob, filename, dir),
-  };
+    };
+    overrides.uploadBlobMedia = (blob, filename, dir) => upload(blob, filename, dir);
+  }
+  if (onWarning) overrides.onWarning = onWarning;
+  return overrides;
 }
 
 async function toArrayBuffer(input: File | Blob | ArrayBuffer): Promise<ArrayBuffer> {
@@ -152,7 +190,7 @@ async function dataUrlToBlob(dataUrl: string): Promise<Blob> {
   return response.blob();
 }
 
-export type { ImportContext, TransformResult } from './types';
+export type { ImportContext, ImportWarning, TransformResult } from './types';
 export { transformParsedToSlides } from './transformParsedToSlides';
 export { createMockImportContext } from './mockContext';
 export type { Output } from '../adapter/types';

--- a/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
@@ -914,6 +914,7 @@ export async function transformParsedToSlides(
             autoplay: false,
             poster: el.src || '',
           };
+          warnUnconvertibleMedia(ctx, slideIndex, 'A video poster', el.src);
           slide.elements.push(videoElement);
 
           // 上传到 OSS

--- a/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/transformParsedToSlides.ts
@@ -29,6 +29,7 @@ import type {
 import { SHAPE_PATH_FORMULAS } from '../openmaic/configs/shapes';
 import { getSvgPathRange } from '../openmaic/utils/svgPathParser';
 import { parseVideoCodec, isVideoCodecSupported } from '../openmaic/utils/videoCodec';
+import { isPlaceholderDataUrl } from '../utils/mediaWebConvert';
 import type { ImportContext, TransformResult } from './types';
 
 type ParsedPptxJson = Awaited<ReturnType<typeof parsePptxDefault>>;
@@ -364,6 +365,46 @@ const shouldPreserveRotatedTextFrame = (
   );
 };
 
+/**
+ * Degrade-not-fail telemetry: report media that arrived as the blank
+ * placeholder (WMF / vector-only EMF cannot be converted in this environment).
+ * No-op unless the caller wired `ctx.onWarning`.
+ */
+/** Telemetry must never fail the import: a throwing sink is logged and swallowed. */
+function emitWarning(
+  ctx: ImportContext,
+  warning: { code: string; slideIndex: number; message: string },
+): void {
+  if (!ctx.onWarning) return;
+  try {
+    ctx.onWarning(warning);
+  } catch (err) {
+    console.error('[@openmaic/importer] onWarning sink threw (ignored):', err);
+  }
+}
+
+function warnUnconvertibleMedia(
+  ctx: ImportContext,
+  slideIndex: number,
+  what: string,
+  src: string | undefined,
+): void {
+  if (!isPlaceholderDataUrl(src)) return;
+  emitWarning(ctx, {
+    code: 'media-unconvertible',
+    slideIndex,
+    message: `${what} uses a media format that cannot be converted (WMF / vector EMF); it stays a blank placeholder`,
+  });
+}
+
+function escapeHtmlText(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 export async function transformParsedToSlides(
   json: ParsedPptxJson,
   ctx: ImportContext,
@@ -392,7 +433,7 @@ export async function transformParsedToSlides(
   // base64 图片上传改为并发
   const limitUpload = createConcurrencyLimiter(6);
   const uploadTasks: Promise<unknown>[] = [];
-  for (const item of json.slides) {
+  for (const [slideIndex, item] of json.slides.entries()) {
     const { type, value } = item.fill;
     let background: SlideBackground;
     if (type === 'image') {
@@ -404,6 +445,7 @@ export async function transformParsedToSlides(
           size: 'cover',
         },
       };
+      warnUnconvertibleMedia(ctx, slideIndex, 'Slide background image', value.picBase64);
       if (value.picBase64 && value.picBase64.startsWith('data:')) {
         const bg = background.image!;
         uploadTasks.push(
@@ -536,6 +578,7 @@ export async function transformParsedToSlides(
             let pattern: string | undefined;
             if (el.fill.type === 'image') {
               pattern = el.fill.value.picBase64;
+              warnUnconvertibleMedia(ctx, slideIndex, 'A text frame image fill', pattern);
             }
             const shapeEl: PPTShapeElement = {
               type: 'shape',
@@ -618,6 +661,7 @@ export async function transformParsedToSlides(
           }
         } else if (el.type === 'image') {
           const imageSrc = el.src;
+          warnUnconvertibleMedia(ctx, slideIndex, 'An image element', imageSrc);
 
           const element: PPTImageElement = {
             type: 'image',
@@ -745,37 +789,78 @@ export async function transformParsedToSlides(
                 rotate: 0,
               };
               slide.elements.push(latexElement);
+              if ((el as { degraded?: boolean }).degraded) {
+                emitWarning(ctx, {
+                  code: 'formula-degraded',
+                  slideIndex,
+                  message:
+                    'A formula was converted from its OLE equation but some constructs were approximated (e.g. pile/matrix flattened); review the rendered formula',
+                });
+              }
               usedKatex = true;
             } catch (error) {
               console.warn('[PPTX导入] KaTeX 无法渲染公式，回退为图片:', error);
             }
           }
           if (!usedKatex) {
-            const mathElement: PPTImageElement = {
-              type: 'image',
-              id: nanoid(10),
-              src: el.picBase64,
-              width: el.width,
-              height: el.height,
-              left: el.left,
-              top: el.top,
-              fixedRatio: true,
-              rotate: 0,
-            };
-            slide.elements.push(mathElement);
-            if (el.picBase64 && el.picBase64.startsWith('data:')) {
-              uploadTasks.push(
-                limitUpload(() =>
-                  ctx.uploadBase64Image(el.picBase64, `math_${Date.now()}.png`, 'a2m'),
-                )
-                  .then((url) => {
-                    mathElement.src = url;
-                  })
-                  .catch((error) => {
-                    console.error('数学公式图片上传失败:', error);
-                  }),
-              );
+            // Degrade ladder: when the fallback picture carries real pixels
+            // (e.g. an EMF with an embedded bitmap), keep it. When even the
+            // fallback is the blank placeholder — the common case for legacy
+            // OLE equation objects whose preview is WMF — and the math node
+            // kept its plain text, emit a text element so the formula content
+            // survives at all instead of a stretched placeholder pixel.
+            const fallbackIsPlaceholder = isPlaceholderDataUrl(el.picBase64);
+            if (fallbackIsPlaceholder && el.text) {
+              const textElement: PPTTextElement = {
+                type: 'text',
+                id: nanoid(10),
+                width: el.width,
+                height: el.height,
+                left: el.left,
+                top: el.top,
+                rotate: 0,
+                defaultFontName: theme.fontName,
+                defaultColor: theme.fontColor,
+                content: `<div><p style="line-height: 1; white-space: nowrap;">${escapeHtmlText(el.text)}</p></div>`,
+                fill: '',
+              };
+              slide.elements.push(textElement);
+            } else {
+              const mathElement: PPTImageElement = {
+                type: 'image',
+                id: nanoid(10),
+                src: el.picBase64,
+                width: el.width,
+                height: el.height,
+                left: el.left,
+                top: el.top,
+                fixedRatio: true,
+                rotate: 0,
+              };
+              slide.elements.push(mathElement);
+              if (el.picBase64 && el.picBase64.startsWith('data:')) {
+                uploadTasks.push(
+                  limitUpload(() =>
+                    ctx.uploadBase64Image(el.picBase64, `math_${Date.now()}.png`, 'a2m'),
+                  )
+                    .then((url) => {
+                      mathElement.src = url;
+                    })
+                    .catch((error) => {
+                      console.error('数学公式图片上传失败:', error);
+                    }),
+                );
+              }
             }
+            emitWarning(ctx, {
+              code: 'formula-fallback-image',
+              slideIndex,
+              message: fallbackIsPlaceholder
+                ? el.text
+                  ? 'A formula could not be converted to LaTeX and its fallback picture is unconvertible (WMF); kept its plain text instead'
+                  : 'A formula could not be converted to LaTeX and its fallback picture is unconvertible (WMF); it stays a blank placeholder'
+                : 'A formula could not be converted to LaTeX; the original fallback picture is used',
+            });
           }
         } else if (el.type === 'audio') {
           console.log('🔍 音频元素完整信息:', JSON.stringify(el, null, 2));
@@ -902,6 +987,7 @@ export async function transformParsedToSlides(
             if (el.fill?.type === 'image') {
               pattern = el.fill.value.picBase64;
               opacity = el.fill.value.opacity;
+              warnUnconvertibleMedia(ctx, slideIndex, 'A shape image fill', pattern);
             }
             const fill = el.fill?.type === 'color' ? el.fill.value : '';
 

--- a/packages/@openmaic/importer/src/import-pipeline/types.ts
+++ b/packages/@openmaic/importer/src/import-pipeline/types.ts
@@ -12,6 +12,22 @@ export interface ImportContext {
   uploadBlobMedia: (blob: Blob, filename: string, dir: string) => Promise<string>;
   /** 当前未被 transform 使用，poster 提取仍由 hook 侧 extractVideoPosters 负责，预留给后续迁移 */
   extractVideoFirstFrame: (videoUrl: string) => Promise<string | null>;
+  /**
+   * Degrade-not-fail telemetry: emitted when content survives the import only
+   * partially — e.g. a formula that could not be converted to LaTeX, or media
+   * in an unconvertible format (WMF / vector-only EMF) replaced by the blank
+   * placeholder. Optional so existing callers keep compiling unchanged.
+   */
+  onWarning?: (warning: ImportWarning) => void;
+}
+
+/** A single content-degradation event surfaced to the importing caller. */
+export interface ImportWarning {
+  /** Stable machine code, e.g. `media-unconvertible` | `formula-fallback-image` | `element-dropped`. */
+  code: string;
+  /** 0-based index of the slide the warning belongs to. */
+  slideIndex: number;
+  message: string;
 }
 
 export interface TransformResult {

--- a/packages/@openmaic/importer/src/index.ts
+++ b/packages/@openmaic/importer/src/index.ts
@@ -47,6 +47,8 @@ export type {
   OssUpload,
   ImportPptxOptions,
   ImportContext,
+  ImportWarning,
   TransformResult,
 } from './import-pipeline';
 export type { Slide as CanvasSlide } from '@openmaic/dsl';
+export { isPlaceholderDataUrl } from './utils/mediaWebConvert';

--- a/packages/@openmaic/importer/src/model/Slide.ts
+++ b/packages/@openmaic/importer/src/model/Slide.ts
@@ -16,6 +16,7 @@ import {
   MathNodeData,
   parseMathNode,
   parseOleDocxMathNode,
+  parseOleEquationMathNode,
   isMathAlternateContent,
 } from './nodes/MathNode';
 
@@ -77,6 +78,30 @@ function tryParseOleDocxMath(graphicFrame: SafeXmlNode): MathNodeData | undefine
   if (!progId.startsWith('Word.Document')) return undefined;
 
   return parseOleDocxMathNode(graphicFrame);
+}
+
+/**
+ * Detect graphicFrame with oleObj progId="Equation.3" / "MathType.*" and
+ * delegate to parseOleEquationMathNode. The embedding's `Equation Native`
+ * stream carries MTEF v3 data convertible to LaTeX (utils/mtef.ts); without
+ * this branch the object falls through to its WMF preview picture, which
+ * cannot be converted and degrades to the blank placeholder.
+ */
+function tryParseOleEquationMath(graphicFrame: SafeXmlNode): MathNodeData | undefined {
+  const graphicData = graphicFrame.child('graphic').child('graphicData');
+  const uri = graphicData.attr('uri') || '';
+  if (!uri.includes('ole')) return undefined;
+
+  const altContent = graphicData.child('AlternateContent');
+  if (!altContent.exists()) return undefined;
+
+  const oleObj = altContent.child('Choice').child('oleObj');
+  if (!oleObj.exists()) return undefined;
+
+  const progId = oleObj.attr('progId') || '';
+  if (!progId.startsWith('Equation.') && !progId.startsWith('MathType')) return undefined;
+
+  return parseOleEquationMathNode(graphicFrame);
 }
 
 /**
@@ -397,6 +422,11 @@ export function parseChildNode(
       {
         const oleDocxMath = tryParseOleDocxMath(child);
         if (oleDocxMath) return oleDocxMath;
+      }
+      // Equation.3 / MathType OLE → math node (MTEF v3 in `Equation Native`)
+      {
+        const oleEquationMath = tryParseOleEquationMath(child);
+        if (oleEquationMath) return oleEquationMath;
       }
       // OLE object with fallback picture (e.g. embedded PDF preview on slide 34)
       {

--- a/packages/@openmaic/importer/src/model/nodes/MathNode.ts
+++ b/packages/@openmaic/importer/src/model/nodes/MathNode.ts
@@ -34,6 +34,12 @@ export interface MathNodeData extends BaseNodeData {
   plainText: string;
   /** rId of embedded .docx package (Word.Document OLE — contains EQ field math). */
   oleDocxRId?: string;
+  /**
+   * rId of the embedded OLE binary for `Equation.3` / MathType objects. The
+   * binary is an OLE compound file whose `Equation Native` stream holds MTEF
+   * v3 data convertible to LaTeX (see utils/mtef.ts).
+   */
+  oleEquationRId?: string;
 }
 
 /**
@@ -162,6 +168,46 @@ export function parseOleDocxMathNode(graphicFrame: SafeXmlNode): MathNodeData | 
     nodeType: 'math' as const,
     ommlXml: '',
     oleDocxRId: docxRId,
+    fallbackBlipEmbed,
+    plainText: '',
+  };
+}
+
+/**
+ * Parse a graphicFrame whose oleObj has progId "Equation.3" / "MathType.*".
+ * The embedding is an OLE compound file with an `Equation Native` (MTEF v3)
+ * stream; conversion to LaTeX is deferred to the serializer, which needs the
+ * embeddings map. Structure mirrors {@link parseOleDocxMathNode}.
+ */
+export function parseOleEquationMathNode(graphicFrame: SafeXmlNode): MathNodeData | undefined {
+  const base = parseBaseProps(graphicFrame);
+
+  const graphicData = graphicFrame.child('graphic').child('graphicData');
+  const altContent = graphicData.child('AlternateContent');
+  if (!altContent.exists()) return undefined;
+
+  const oleObj = altContent.child('Choice').child('oleObj');
+  const equationRId = oleObj.attr('r:id') ?? oleObj.attr('id');
+  if (!equationRId) return undefined;
+
+  let fallbackBlipEmbed: string | undefined;
+  const fallback = altContent.child('Fallback');
+  if (fallback.exists()) {
+    const fbOle = fallback.child('oleObj');
+    const fbPic = fbOle.exists() ? fbOle.child('pic') : fallback.child('pic');
+    if (fbPic.exists()) {
+      const blip = fbPic.child('blipFill').child('blip');
+      if (blip.exists()) {
+        fallbackBlipEmbed = blip.attr('embed') ?? blip.attr('r:embed');
+      }
+    }
+  }
+
+  return {
+    ...base,
+    nodeType: 'math' as const,
+    ommlXml: '',
+    oleEquationRId: equationRId,
     fallbackBlipEmbed,
     plainText: '',
   };

--- a/packages/@openmaic/importer/src/serializer/mathSerializer.ts
+++ b/packages/@openmaic/importer/src/serializer/mathSerializer.ts
@@ -14,7 +14,9 @@ import { resolveMediaPath } from '../utils/media';
 import { resolveColorToCss } from './StyleResolver';
 import { DOMParser } from '@xmldom/xmldom';
 import { parseDocxMathContent } from '../utils/eqFieldParser';
+import { equationNativeToLatex } from '../utils/mtef';
 import JSZip from 'jszip';
+import * as CFB from 'cfb';
 
 // @ts-expect-error — omml2mathml has no type declarations
 import omml2mathml from 'omml2mathml';
@@ -393,6 +395,40 @@ async function resolveFallbackImage(
  * Resolve an embedded .docx package from the slide's rels + presentation embeddings.
  * Returns the word/document.xml content string, or null.
  */
+/**
+ * Resolve an `Equation.3` / MathType OLE embedding and convert its
+ * `Equation Native` stream (MTEF v3) to LaTeX. Returns null when the binary
+ * is missing, not a compound file, or MTEF parsing fails — the caller then
+ * falls back to the preview-picture path.
+ */
+function resolveOleEquationLatex(
+  rId: string,
+  ctx: RenderContext,
+): { latex: string; plainText: string; degraded: boolean } | null {
+  const rel = ctx.slide.rels.get(rId);
+  if (!rel) return null;
+
+  const fileName = rel.target.split('/').pop() || '';
+  const embeddingPath = `ppt/embeddings/${fileName}`;
+  const data = ctx.presentation.embeddings.get(embeddingPath);
+  if (!data) return null;
+
+  try {
+    const cfb = CFB.read(data, { type: 'buffer' });
+    const stream = CFB.find(cfb, 'Equation Native');
+    if (!stream?.content) return null;
+    const converted = equationNativeToLatex(new Uint8Array(stream.content));
+    return {
+      latex: converted.latex,
+      plainText: converted.plainText,
+      degraded: converted.degraded,
+    };
+  } catch (err) {
+    console.warn('[mathSerializer] Equation Native MTEF→LaTeX failed:', err);
+    return null;
+  }
+}
+
 async function resolveOleDocxContent(rId: string, ctx: RenderContext): Promise<string | null> {
   const rel = ctx.slide.rels.get(rId);
   if (!rel) return null;
@@ -428,7 +464,16 @@ export async function mathToElement(
   let latex = '';
   let plainText = node.plainText || '';
 
-  if (node.oleDocxRId) {
+  let mtefDegraded = false;
+  if (node.oleEquationRId) {
+    // Equation.3 / MathType OLE: `Equation Native` MTEF v3 → LaTeX
+    const converted = resolveOleEquationLatex(node.oleEquationRId, ctx);
+    if (converted) {
+      latex = converted.latex;
+      plainText = converted.plainText || plainText;
+      mtefDegraded = converted.degraded;
+    }
+  } else if (node.oleDocxRId) {
     // OLE Word.Document with EQ field math
     const docXml = await resolveOleDocxContent(node.oleDocxRId, ctx);
     if (docXml) {
@@ -476,5 +521,6 @@ export async function mathToElement(
     picBase64,
     order,
     text: plainText || undefined,
+    ...(mtefDegraded ? { degraded: true } : {}),
   };
 }

--- a/packages/@openmaic/importer/src/utils/mediaWebConvert.ts
+++ b/packages/@openmaic/importer/src/utils/mediaWebConvert.ts
@@ -83,9 +83,30 @@ function tiffToRgba(
   }
 }
 
-/** 1×1 transparent PNG — fallback when conversion is not possible */
+/**
+ * 1×1 fully transparent PNG — fallback when conversion is not possible.
+ * Decodes to RGBA(0,0,0,0): unlike a colored pixel, stretching it over the
+ * original frame's geometry renders as nothing instead of a colored block.
+ */
 const TRANSPARENT_PNG_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=';
+
+/**
+ * The placeholder shipped through 0.1.4: a 1×1 PNG whose single pixel is
+ * RGBA(255,0,0,127) — 50%-alpha red, despite the "transparent" name. Stretched
+ * over a formula frame it renders as a pink block. Kept so placeholder
+ * detection also matches data URLs produced by those versions (and decks
+ * re-imported from them).
+ */
+const LEGACY_PLACEHOLDER_PNG_DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const PLACEHOLDER_DATA_URLS = new Set([TRANSPARENT_PNG_DATA_URL, LEGACY_PLACEHOLDER_PNG_DATA_URL]);
+
+/** Whether a media src is an unconvertible-format placeholder emitted by this module. */
+export function isPlaceholderDataUrl(src: string | undefined | null): boolean {
+  return !!src && PLACEHOLDER_DATA_URLS.has(src);
+}
 
 // ---------------------------------------------------------------------------
 // WDP (JPEG XR) → PNG

--- a/packages/@openmaic/importer/src/utils/mtef.ts
+++ b/packages/@openmaic/importer/src/utils/mtef.ts
@@ -1,0 +1,871 @@
+/**
+ * MTEF v.3 → LaTeX converter for Microsoft Equation 3.0 OLE objects.
+ *
+ * Legacy courseware embeds formulas as OLE equation objects
+ * (`progId="Equation.3"` / MathType). Their only renderable form inside the
+ * .pptx is a WMF preview picture, which cannot be rasterized in this
+ * environment — but the OLE binary also carries an `Equation Native` stream
+ * whose payload, behind a 28-byte EQNOLEFILEHDR, is MTEF v3: a compact
+ * record tree (CHAR / TMPL / LINE / EMBELL / typesize records) that fully
+ * describes the equation. This module parses that binary into LaTeX so those
+ * formulas import as editable `latex` elements instead of blank placeholders.
+ *
+ * Grammar reference: MathType MTEF v.3 (archived spec, rtf2latex2e). Tag byte
+ * = record type in the low nibble, option flags in the high nibble
+ * (flag 0x01 → 0x10, 0x02 → 0x20, 0x04 → 0x40, 0x08 → 0x80). All 16-bit
+ * values are little-endian; v3 CHAR records always store a 16-bit character.
+ *
+ * Empirical notes from Equation Editor 3.x streams (validated against real
+ * courseware decks): tmROOT emits slots as [radicand, null-degree] for square
+ * roots; tmSCRIPT emits a null LINE for its unused slot, ordered [sub, sup];
+ * fence templates carry their left/right fence CHARs at the END of their own
+ * sub-object list, AFTER the main slot LINE.
+ *
+ * Scope note: this targets the record set Equation Editor 3.x actually emits
+ * (CHAR, LINE, TMPL fences/fraction/root/scripts/big-ops, EMBELL, typesize,
+ * PILE, MATRIX). Newer MathType MTEF v5 streams are rejected and fall back to
+ * the picture path. Unknown constructs degrade to their slot contents rather
+ * than failing the whole equation.
+ */
+
+export interface MtefConversion {
+  latex: string;
+  /** Flat character content, used as degrade-text when LaTeX is not viable. */
+  plainText: string;
+  /** True when at least one construct was skipped or approximated. */
+  degraded: boolean;
+}
+
+/** Thrown when the stream is not MTEF v3 or the bytes cannot be walked. */
+export class MtefParseError extends Error {}
+
+// ---------------------------------------------------------------------------
+// Record grammar (tag = type | options<<4)
+// ---------------------------------------------------------------------------
+
+const TAG_END = 0x0;
+const TAG_LINE = 0x1;
+const TAG_CHAR = 0x2;
+const TAG_TMPL = 0x3;
+const TAG_PILE = 0x4;
+const TAG_MATRIX = 0x5;
+const TAG_EMBELL = 0x6;
+const TAG_RULER = 0x7;
+const TAG_FONT = 0x8;
+const TAG_SIZE = 0x9;
+
+const OPT_LMOVE = 0x8; // nudge follows (LINE/CHAR/TMPL/PILE/MATRIX/EMBELL)
+const OPT_NULL = 0x1; // LINE: placeholder only, no object list
+const OPT_LSPACE = 0x4; // LINE: line-spacing value follows
+const OPT_RULER = 0x2; // LINE/PILE: RULER record follows
+const OPT_EMBELL = 0x2; // CHAR: embellishment list follows
+
+// Template selectors (MTEF v3).
+const TM_PAREN = 1;
+const TM_BRACE = 2;
+const TM_BRACK = 3;
+const TM_BAR = 4;
+const TM_DBAR = 5;
+const TM_FLOOR = 6;
+const TM_CEILING = 7;
+const TM_ROOT = 13;
+const TM_FRACT = 14;
+const TM_SCRIPT = 15;
+const TM_UBAR = 16;
+const TM_OBAR = 17;
+const TM_LARROW = 18;
+const TM_RARROW = 19;
+const TM_BARROW = 20;
+// TM_BIGOP_FIRST selectors are now encoded in bigOpLimits() 21; // tmSINT .. tmIINTER: operators with limit slots
+// TM_BIGOP_LAST selectors are now encoded in bigOpLimits() 38;
+const TM_LIM = 39;
+const TM_SLFRACT = 41;
+const TM_INTOP = 42;
+const TM_LSCRIPT = 44;
+const TM_DIRAC = 45;
+const TM_UARROW = 46;
+const TM_OARROW = 47;
+const TM_OARC = 48;
+
+const FENCE_PAIRS: Record<number, [string, string]> = {
+  [TM_PAREN]: ['\\left ( ', '\\right ) '],
+  0: ['\\left \\langle ', '\\right \\rangle '], // tmANGLE
+  8: ['\\left [ ', '\\right [ '], // tmLBLB
+  9: ['\\left ] ', '\\right ] '], // tmRBRB
+  10: ['\\left ] ', '\\right [ '], // tmRBLB
+  11: ['\\left [ ', '\\right ) '], // tmLBRP
+  12: ['\\left ( ', '\\right ] '], // tmLPRB
+  [TM_BRACE]: ['\\left \\{ ', '\\right \\} '],
+  [TM_BRACK]: ['\\left [ ', '\\right ] '],
+  [TM_BAR]: ['\\left | ', '\\right | '],
+  [TM_DBAR]: ['\\left \\| ', '\\right \\| '],
+  [TM_FLOOR]: ['\\left \\lfloor ', '\\right \\rfloor '],
+  [TM_CEILING]: ['\\left \\lceil ', '\\right \\rceil '],
+  [TM_DIRAC]: ['\\left \\langle ', '\\right \\rangle '],
+};
+
+// v3 selectors 24/25/26 are tmSSINT/tmDSINT/tmTSINT ("summation-style"
+// integrals — limits above/below); contour integrals come from tmSINT
+// variations 3/4, not from separate selectors.
+const BIG_OPS: Record<number, string> = {
+  21: '\\int ',
+  22: '\\iint ',
+  23: '\\iiint ',
+  24: '\\int \\limits ',
+  25: '\\iint \\limits ',
+  26: '\\iiint \\limits ',
+  29: '\\sum ',
+  30: '\\sum ',
+  31: '\\prod ',
+  32: '\\prod ',
+  33: '\\coprod ',
+  34: '\\coprod ',
+  35: '\\bigcup ',
+  36: '\\bigcup ',
+  37: '\\bigcap ',
+  38: '\\bigcap ',
+  [TM_INTOP]: '\\int ',
+  43: '\\sum ',
+};
+
+/** Per-selector variation → which limit slots exist (v3 variation tables). */
+function bigOpLimits(selector: number, variation: number): { lower: boolean; upper: boolean } {
+  switch (selector) {
+    case 21:
+      return {
+        lower: variation === 1 || variation === 2 || variation === 4,
+        upper: variation === 2,
+      };
+    case 22:
+    case 23:
+      return { lower: variation === 1 || variation === 3, upper: false };
+    case 24:
+      return { lower: true, upper: variation === 0 };
+    case 25:
+    case 26:
+      return { lower: true, upper: false };
+    case 29:
+    case 31:
+    case 33:
+    case 35:
+    case 37:
+      return { lower: variation === 0 || variation === 1, upper: variation === 1 };
+    case 30:
+    case 32:
+    case 34:
+    case 36:
+    case 38:
+      // This family has only tvL* (0, lower-only) and tvB* (1, both).
+      return { lower: variation === 0 || variation === 1, upper: variation === 1 };
+    case TM_INTOP:
+    case 43:
+      return {
+        lower: variation === 1 || variation === 2,
+        upper: variation === 0 || variation === 2,
+      };
+    default:
+      return { lower: false, upper: false };
+  }
+}
+
+const EMBELL_LATEX: Record<number, string> = {
+  2: '\\dot ',
+  3: '\\ddot ',
+  4: '\\dddot ',
+  5: "'",
+  6: "''",
+  7: '`',
+  18: "'''",
+  8: '\\tilde ',
+  9: '\\hat ',
+  10: '\\not ',
+  11: '\\overrightarrow ',
+  12: '\\overleftarrow ',
+  13: '\\overleftrightarrow ',
+  14: '\\overrightarrow ',
+  15: '\\overleftarrow ',
+  17: '\\bar ',
+};
+
+/**
+ * Unicode operator/symbol codepoints with direct LaTeX commands. Values carry
+ * a trailing space when letter-terminated: KaTeX absorbs a following letter
+ * into the command name otherwise (`\cdotb`).
+ */
+const SYMBOL_LATEX: Record<number, string> = {
+  0x22c5: '\\cdot ',
+  0x00d7: '\\times ',
+  0x00f7: '\\div ',
+  0x00b1: '\\pm ',
+  0x2213: '\\mp ',
+  0x2264: '\\le ',
+  0x2265: '\\ge ',
+  0x2260: '\\ne ',
+  0x2248: '\\approx ',
+  0x2261: '\\equiv ',
+  0x223c: '\\sim ',
+  0x221d: '\\propto ',
+  0x221e: '\\infty ',
+  0x2208: '\\in ',
+  0x2209: '\\notin ',
+  0x2282: '\\subset ',
+  0x2286: '\\subseteq ',
+  0x2283: '\\supset ',
+  0x2287: '\\supseteq ',
+  0x222a: '\\cup ',
+  0x2229: '\\cap ',
+  0x2227: '\\land ',
+  0x2228: '\\lor ',
+  0x2200: '\\forall ',
+  0x2203: '\\exists ',
+  0x2205: '\\emptyset ',
+  0x2202: '\\partial ',
+  0x2211: '\\sum ',
+  0x220f: '\\prod ',
+  0x222b: '\\int ',
+  0x2192: '\\to ',
+  0x21d2: '\\Rightarrow ',
+  0x21d4: '\\Leftrightarrow ',
+  0x2026: '\\ldots ',
+  0x22ef: '\\cdots ',
+  0x226a: '\\ll ',
+  0x226b: '\\gg ',
+  0x00b0: '^{\\circ}',
+};
+
+// ---------------------------------------------------------------------------
+// Binary cursor
+// ---------------------------------------------------------------------------
+
+class Cursor {
+  pos: number;
+  constructor(
+    private readonly data: Uint8Array,
+    startPos: number,
+    private readonly endPos: number,
+  ) {
+    this.pos = startPos;
+  }
+
+  get eof(): boolean {
+    return this.pos >= this.endPos;
+  }
+
+  byte(): number {
+    if (this.eof) throw new MtefParseError('unexpected end of MTEF stream');
+    return this.data[this.pos++]!;
+  }
+
+  uint16(): number {
+    const lo = this.byte();
+    return lo | (this.byte() << 8);
+  }
+
+  skipNudge(): void {
+    const dx = this.byte();
+    const dy = this.byte();
+    if (dx === 128 && dy === 128) {
+      this.uint16();
+      this.uint16();
+    }
+  }
+
+  /**
+   * RULER body (tag already consumed): n_stops, then per stop a 1-byte tab
+   * type followed by a 16-bit offset (v3 spec).
+   */
+  skipRulerBody(): void {
+    const nStops = this.byte();
+    for (let i = 0; i < nStops; i++) {
+      this.byte(); // tab-stop type
+      this.uint16(); // offset
+    }
+  }
+
+  /**
+   * A complete RULER record (tag included) — what xfRULER promises. Real
+   * streams occasionally omit the RULER tag (see rtf2latex2e's eqn.c); a
+   * non-RULER first byte is left in place and treated as a zero-stop ruler.
+   */
+  skipRulerRecord(): void {
+    if ((this.data[this.pos]! & 0x0f) === 0x7) {
+      this.byte();
+      this.skipRulerBody();
+    }
+  }
+}
+
+const MAX_RECORDS = 20_000;
+
+interface CharNode {
+  kind: 'char';
+  code: number;
+  typeface: number;
+  embellishments: number[];
+}
+interface TmplNode {
+  kind: 'tmpl';
+  selector: number;
+  variation: number;
+  options: number;
+  children: Node[];
+}
+interface LineNode {
+  kind: 'line';
+  content: Node[];
+}
+type Node = CharNode | TmplNode | LineNode | { kind: 'other' };
+
+function parseObjectList(cur: Cursor, budget: { count: number }, depth = 0): Node[] {
+  const nodes: Node[] = [];
+  while (!cur.eof) {
+    if (++budget.count > MAX_RECORDS) throw new MtefParseError('MTEF stream too large');
+    const tag = cur.byte();
+    const type = tag & 0x0f;
+    const options = (tag >> 4) & 0x0f;
+    if (type === TAG_END) return nodes;
+    switch (type) {
+      case TAG_LINE: {
+        if (options & OPT_LMOVE) cur.skipNudge();
+        if (options & OPT_LSPACE) cur.byte();
+        if (options & OPT_RULER) cur.skipRulerRecord();
+        if (options & OPT_NULL) {
+          nodes.push({ kind: 'line', content: [] });
+        } else {
+          nodes.push({ kind: 'line', content: parseObjectList(cur, budget, depth + 1) });
+        }
+        break;
+      }
+      case TAG_CHAR: {
+        if (options & OPT_LMOVE) cur.skipNudge();
+        const typeface = cur.byte();
+        const code = cur.uint16();
+        const embellishments: number[] = [];
+        if (options & OPT_EMBELL) {
+          for (;;) {
+            const etag = cur.byte();
+            const etype = etag & 0x0f;
+            const eopts = (etag >> 4) & 0x0f;
+            if (etype === TAG_END) break;
+            if (etype !== TAG_EMBELL)
+              throw new MtefParseError('non-EMBELL inside embellishment list');
+            if (eopts & OPT_LMOVE) cur.skipNudge();
+            embellishments.push(cur.byte());
+          }
+        }
+        nodes.push({ kind: 'char', code, typeface, embellishments });
+        break;
+      }
+      case TAG_TMPL: {
+        if (options & OPT_LMOVE) cur.skipNudge();
+        const selector = cur.byte();
+        const variation = cur.byte();
+        const tmplOptions = cur.byte();
+        const children = parseObjectList(cur, budget, depth + 1);
+        nodes.push({ kind: 'tmpl', selector, variation, options: tmplOptions, children });
+        break;
+      }
+      case TAG_PILE: {
+        // v3 field order: nudge → halign → valign → [complete RULER record].
+        if (options & OPT_LMOVE) cur.skipNudge();
+        cur.byte(); // halign
+        cur.byte(); // valign
+        if (options & OPT_RULER) cur.skipRulerRecord();
+        const children = parseObjectList(cur, budget, depth + 1);
+        nodes.push({ kind: 'tmpl', selector: -1, variation: 0, options: 0, children });
+        break;
+      }
+      case TAG_MATRIX: {
+        // v3 uses single-byte fields (16-bit valign_2 is an MTEF v5 field).
+        if (options & OPT_LMOVE) cur.skipNudge();
+        cur.byte(); // valign
+        cur.byte(); // h_just
+        cur.byte(); // v_just
+        const rows = cur.byte();
+        const cols = cur.byte();
+        // Partition lines: 2 bits per line (rows+1 / cols+1), byte-rounded.
+        const partBytes = Math.ceil(((rows + 1) * 2) / 8) + Math.ceil(((cols + 1) * 2) / 8);
+        for (let i = 0; i < partBytes; i++) cur.byte();
+        const children = parseObjectList(cur, budget, depth + 1);
+        nodes.push({ kind: 'tmpl', selector: -2, variation: 0, options: 0, children });
+        break;
+      }
+      case TAG_EMBELL: {
+        // Bare embellishment outside a CHAR list (unexpected); skip payload.
+        if (options & OPT_LMOVE) cur.skipNudge();
+        cur.byte();
+        break;
+      }
+      case TAG_RULER:
+        cur.skipRulerBody();
+        break;
+      case TAG_FONT:
+        cur.byte(); // tface
+        cur.byte(); // style
+        for (;;) {
+          if (cur.eof) break;
+          if (cur.byte() === 0) break; // null-terminated font name
+        }
+        break;
+      case TAG_SIZE: {
+        // v3 has three forms (spec): "9, 101, -lsize(16)" explicit point size;
+        // "9, 100, lsize, dsize(16)" large delta; "9, lsize, dsize+128" small
+        // delta. The first byte discriminates.
+        const form = cur.byte();
+        if (form === 101) cur.uint16();
+        else if (form === 100) {
+          cur.byte();
+          cur.uint16();
+        } else {
+          cur.byte(); // dsize + 128
+        }
+        break;
+      }
+      default:
+        // FULL/SUB/SUB2/SYM/SUBSYM (10-14) carry no payload.
+        if (type < 10 || type > 14) throw new MtefParseError(`unknown MTEF record type ${type}`);
+        break;
+    }
+  }
+  // Nested lists are END-terminated; reaching EOF below the top level means
+  // the stream was truncated mid-equation and the tree would silently lose
+  // content — fail loud so the caller falls back to the picture path.
+  if (depth > 0) throw new MtefParseError('truncated MTEF stream (unterminated nested list)');
+  return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Tree → LaTeX
+// ---------------------------------------------------------------------------
+
+interface RenderState {
+  degraded: boolean;
+}
+
+/**
+ * Adobe Symbol-font code → LaTeX for font-local 8-bit codes. The Greek and
+ * symbol typefaces (fnLCGREEK/fnUCGREEK/fnSYMBOL) store glyphs in the Symbol
+ * font encoding (0x61 = α, 0x71 = θ …), NOT ASCII/Unicode — decoding them as
+ * text turns α into `a`. Codes ≥ 0x100 are MTCode/Unicode and skip this table.
+ */
+const SYMBOL_FONT_LATEX: Record<number, string> = {
+  0x2a: '\\ast ',
+  0x2d: '-',
+  0x3c: '\\le ',
+  0x3e: '\\ge ',
+  0x5b: '\\leftarrow ',
+  0x5d: '\\rightarrow ',
+  0x5e: '\\uparrow ',
+  0x5f: '\\downarrow ',
+  0x60: '\\equiv ',
+  0x7e: '\\simeq ',
+  0x61: '\\alpha ',
+  0x62: '\\beta ',
+  0x63: '\\chi ',
+  0x64: '\\delta ',
+  0x65: '\\epsilon ',
+  0x66: '\\phi ',
+  0x67: '\\gamma ',
+  0x68: '\\eta ',
+  0x69: '\\iota ',
+  0x6a: '\\phi ',
+  0x6b: '\\kappa ',
+  0x6c: '\\lambda ',
+  0x6d: '\\mu ',
+  0x6e: '\\nu ',
+  0x6f: 'o',
+  0x70: '\\pi ',
+  0x71: '\\theta ',
+  0x72: '\\rho ',
+  0x73: '\\sigma ',
+  0x74: '\\tau ',
+  0x75: '\\upsilon ',
+  0x76: '\\varpi ',
+  0x77: '\\omega ',
+  0x78: '\\xi ',
+  0x79: '\\psi ',
+  0x7a: '\\zeta ',
+  0x41: 'A',
+  0x42: 'B',
+  0x44: '\\Delta ',
+  0x45: 'E',
+  0x46: '\\Phi ',
+  0x47: '\\Gamma ',
+  0x48: 'H',
+  0x49: 'I',
+  0x4b: 'K',
+  0x4c: '\\Lambda ',
+  0x4d: 'M',
+  0x4e: 'N',
+  0x4f: 'O',
+  0x50: '\\Pi ',
+  0x51: '\\Theta ',
+  0x52: 'P',
+  0x53: '\\Sigma ',
+  0x54: 'T',
+  0x55: '\\Upsilon ',
+  0x57: '\\Omega ',
+  0x58: '\\Xi ',
+  0x59: '\\Psi ',
+  0x5a: 'Z',
+};
+
+const TF_LCGREEK = 4;
+const TF_UCGREEK = 5;
+const TF_SYMBOL = 6;
+
+function charLatex(node: CharNode, state: RenderState): string {
+  let out: string;
+  const fontLocal =
+    node.code < 0x100 &&
+    (node.typeface === TF_LCGREEK + 128 ||
+      node.typeface === TF_UCGREEK + 128 ||
+      node.typeface === TF_SYMBOL + 128);
+  const symbol = fontLocal
+    ? (SYMBOL_FONT_LATEX[node.code] ?? escapeLatexChar(node.code))
+    : SYMBOL_LATEX[node.code];
+  if (symbol) {
+    out = symbol;
+  } else if (node.code >= 32 && node.code < 127) {
+    out = escapeLatexChar(node.code);
+  } else if (node.code > 127) {
+    out = String.fromCharCode(node.code);
+  } else {
+    out = ' ';
+  }
+  for (const embell of node.embellishments) {
+    const mark = EMBELL_LATEX[embell];
+    if (mark === undefined) {
+      state.degraded = true;
+      continue;
+    }
+    out = applyEmbellishment(out, mark);
+  }
+  return out;
+}
+
+function escapeLatexChar(code: number): string {
+  switch (code) {
+    case 0x23:
+      return '\\#';
+    case 0x24:
+      return '\\$';
+    case 0x25:
+      return '\\%';
+    case 0x26:
+      return '\\&';
+    case 0x5c:
+      return '\\backslash ';
+    case 0x5e:
+      return '\\hat{}';
+    case 0x5f:
+      return '\\_';
+    case 0x7b:
+      return '\\{';
+    case 0x7d:
+      return '\\}';
+    case 0x7e:
+      return '\\sim ';
+    default:
+      return String.fromCharCode(code);
+  }
+}
+
+function applyEmbellishment(base: string, mark: string): string {
+  if (mark === "'" || mark === "''" || mark === '`' || mark === "'''") {
+    return `${base}${mark}`;
+  }
+  return `${mark}{${base}}`;
+}
+
+interface Rendered {
+  latex: string;
+  plainText: string;
+}
+
+function renderList(nodes: Node[], state: RenderState): Rendered {
+  const latex: string[] = [];
+  const text: string[] = [];
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
+    if (node.kind === 'char' || node.kind === 'tmpl') {
+      // Render each atom exactly once — a second recursive render here made
+      // deep nesting exponential (depth 26 ≈ 50s).
+      let rendered: string;
+      let renderedText: string;
+      if (node.kind === 'char') {
+        rendered = charLatex(node, state);
+        renderedText = plainChar(node);
+      } else {
+        const out = renderTmpl(node, state);
+        rendered = out.latex;
+        renderedText = out.plainText;
+      }
+      // A following tmSCRIPT attaches to this atom (e.g. (a/2)²: the script
+      // template trails the paren template as a sibling in the same list).
+      const next = nodes[i + 1];
+      if (next?.kind === 'tmpl' && (next.selector === TM_SCRIPT || next.selector === TM_LSCRIPT)) {
+        const combo = renderScript(next, rendered, renderedText, state);
+        latex.push(combo.latex);
+        text.push(combo.plainText);
+        i++;
+        continue;
+      }
+      latex.push(rendered);
+      text.push(renderedText);
+    } else if (node.kind === 'line') {
+      const rendered = renderList(node.content, state);
+      latex.push(rendered.latex);
+      text.push(rendered.plainText);
+    } else {
+      state.degraded = true;
+    }
+  }
+  return { latex: latex.join(''), plainText: text.join('') };
+}
+
+function plainChar(node: CharNode): string {
+  if (node.code === 0x22c5) return '·';
+  if (node.code === 0x2264) return '≤';
+  if (node.code === 0x2265) return '≥';
+  return node.code >= 32 ? String.fromCharCode(node.code) : '';
+}
+
+function lineContents(children: Node[], state: RenderState): Rendered[] {
+  return children
+    .filter((child): child is LineNode => child.kind === 'line')
+    .map((line) => renderList(line.content, state));
+}
+
+function renderTmpl(node: TmplNode, state: RenderState): Rendered {
+  const { selector, variation, children } = node;
+
+  if (selector === TM_DIRAC) {
+    // DiracBox: [left slot, right slot, ⟨ | ⟩ chars]. Variations 0/1/2 =
+    // both / left-only / right-only.
+    const parts = lineContents(children, state);
+    const left = parts[0]?.latex ?? '';
+    const right = variation === 2 ? '' : (parts[1]?.latex ?? '');
+    if (variation === 0 && !right) state.degraded = true;
+    return {
+      latex: `\\langle ${variation === 1 ? left : `${left} \\mid ${right}`}\\rangle `,
+      plainText: `<${parts.map((p) => p.plainText).join('|')}>`,
+    };
+  }
+
+  const fence = FENCE_PAIRS[selector];
+  if (fence) {
+    // The fence CHARs at the end of the template's own list are structural;
+    // the \left/\right pair already renders them, so only the slot matters.
+    // Variations: 0 = both sides, 1 = left only, 2 = right only.
+    const [inner] = lineContents(children, state);
+    const open = variation === 2 ? '' : fence[0];
+    const close = variation === 1 ? '' : fence[1];
+    return {
+      latex: `${open}${inner?.latex ?? ''}${close}`,
+      plainText: `(${inner?.plainText ?? ''})`,
+    };
+  }
+
+  if (selector === TM_FRACT || selector === TM_SLFRACT) {
+    const parts = lineContents(children, state);
+    const num = parts[0]?.latex ?? '';
+    const den = parts[1]?.latex ?? '';
+    const plain = `${parts[0]?.plainText ?? ''}/${parts[1]?.plainText ?? ''}`;
+    if (!num || !den) {
+      state.degraded = true;
+      return { latex: `${num}${den}`, plainText: plain };
+    }
+    if (selector === TM_SLFRACT) {
+      return { latex: `${num}/${den}`, plainText: plain };
+    }
+    return { latex: `\\frac{${num}}{${den}}`, plainText: plain };
+  }
+
+  if (selector === TM_ROOT) {
+    // Equation 3.0 emits [radicand, degree?] — square roots carry a null
+    // second slot; take the first non-empty line as the radicand and the
+    // remaining non-empty line (if any) as the degree.
+    const parts = lineContents(children, state).filter((part) => part.latex);
+    if (variation === 1 && parts.length >= 2) {
+      const [radicand, degree] = parts;
+      return {
+        latex: `\\sqrt[${degree!.latex}]{${radicand!.latex}}`,
+        plainText: `${radicand!.plainText}^${degree!.plainText}`,
+      };
+    }
+    const radicand = parts[0];
+    return {
+      latex: `\\sqrt{${radicand?.latex ?? ''}}`,
+      plainText: `√(${radicand?.plainText ?? ''})`,
+    };
+  }
+
+  if (selector === TM_SCRIPT) {
+    return renderScript(node, '', '', state);
+  }
+
+  if (selector === TM_LSCRIPT) {
+    // Leading script: slots are [sub, sup] (ScrBoxClass order); variation
+    // picks which exist. tvLSUPER=0, tvLSUB=1, tvLSUBSUP=2.
+    const parts = lineContents(children, state);
+    const sub = variation === 0 ? '' : (parts[0]?.latex ?? '');
+    const sup = variation === 1 ? '' : (parts[1]?.latex ?? '');
+    return {
+      latex: `{}${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}{${parts[2]?.latex ?? parts[1]?.latex ?? parts[0]?.latex ?? ''}}`,
+      plainText: parts.map((p) => p.plainText).join(''),
+    };
+  }
+
+  if (selector === TM_UBAR || selector === TM_OBAR) {
+    const [inner] = lineContents(children, state);
+    // Spec: 16 = tmUBAR (underbar), 17 = tmOBAR (overbar).
+    const cmd = selector === TM_UBAR ? '\\underline' : '\\overline';
+    return { latex: `${cmd}{${inner?.latex ?? ''}}`, plainText: inner?.plainText ?? '' };
+  }
+
+  if (selector === TM_LARROW || selector === TM_RARROW || selector === TM_BARROW) {
+    const [inner] = lineContents(children, state);
+    const cmd =
+      selector === TM_RARROW
+        ? '\\overrightarrow'
+        : selector === TM_LARROW
+          ? '\\overleftarrow'
+          : '\\overleftrightarrow';
+    return { latex: `${cmd}{${inner?.latex ?? ''}}`, plainText: inner?.plainText ?? '' };
+  }
+
+  if (selector === TM_OARC) {
+    // KaTeX has no arc accent command; approximate with a frown overset and
+    // flag degraded so callers know the rendering is approximate.
+    const [inner] = lineContents(children, state);
+    state.degraded = true;
+    return {
+      latex: `\\overset{\\frown }{${inner?.latex ?? ''}}`,
+      plainText: inner?.plainText ?? '',
+    };
+  }
+  if (selector === TM_UARROW || selector === TM_OARROW) {
+    // U/O prefix = under/over, same convention as tmUBAR/tmOBAR.
+    const [inner] = lineContents(children, state);
+    const cmd = selector === TM_UARROW ? '\\underrightarrow' : '\\overrightarrow';
+    return { latex: `${cmd}{${inner?.latex ?? ''}}`, plainText: inner?.plainText ?? '' };
+  }
+
+  if (selector === TM_LIM) {
+    // Slots [main, lower, upper]; variation 0/1/2 = lower / upper / both.
+    const parts = lineContents(children, state);
+    const sub = variation === 1 ? '' : (parts[1]?.latex ?? '');
+    const sup = variation === 0 ? '' : (parts[2]?.latex ?? '');
+    return {
+      latex: `\\lim${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}${parts[0]?.latex ?? ''}`,
+      plainText: `lim${parts.map((p) => p.plainText).join('')}`,
+    };
+  }
+
+  const isContour =
+    (selector === 21 && (variation === 3 || variation === 4)) ||
+    (selector === 24 && variation === 2);
+  const bigOp = isContour ? '\\oint ' : BIG_OPS[selector];
+  if (bigOp) {
+    // v3 BigOpBox sub-object order: [main slot (summand), upper, lower, op
+    // CHAR]. The operand renders AFTER the operator and its limits.
+    const parts = lineContents(children, state);
+    const main = parts[0]?.latex ?? '';
+    const { lower, upper } = bigOpLimits(selector, variation);
+    // Real streams (reference rtf2latex2e + MathType decks) order the slots
+    // [main, LOWER, upper] — the archived spec prose says upper-first, but
+    // the 20-year reference implementation reads sub then sup. When only the
+    // upper limit exists some writers omit the lower slot entirely, leaving
+    // the upper value at position 1 — fall back to it.
+    const sub = lower ? (parts[1]?.latex ?? '') : '';
+    let sup = '';
+    if (upper) {
+      sup = parts[2]?.latex ?? (lower ? '' : (parts[1]?.latex ?? ''));
+    }
+    const limits = `${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}`;
+    const plainMain = parts[0]?.plainText ?? '';
+    if (parts.length > 3) {
+      // More slots than the family allows: keep everything, flag degrade.
+      state.degraded = true;
+    }
+    return {
+      latex: `${bigOp}${limits}${main}`,
+      plainText: `${bigOp.trim()}${sub}${sup}${plainMain}`,
+    };
+  }
+
+  // Unknown template (incl. PILE/-1, MATRIX/-2): concatenate slot contents so
+  // the characters survive; mark degraded so callers can warn.
+  state.degraded = true;
+  const all = lineContents(children, state);
+  return {
+    latex: all.map((part) => part.latex).join(''),
+    plainText: all.map((part) => part.plainText).join(''),
+  };
+}
+
+function renderScript(
+  node: TmplNode,
+  baseLatex: string,
+  baseText: string,
+  state: RenderState,
+): Rendered {
+  const parts = lineContents(node.children, state);
+  let sub = '';
+  let sup = '';
+  switch (node.variation) {
+    case 0: // tvSUPER — slots are [sub, sup] with the unused one null/omitted
+      if (parts.length >= 2) sup = parts[1]?.latex ?? '';
+      else sup = parts[0]?.latex ?? '';
+      break;
+    case 1: // tvSUB — writer emits [real, null]
+      sub = parts.find((part) => part.latex)?.latex ?? '';
+      break;
+    case 2: // tvSUBSUP
+      sub = parts[0]?.latex ?? '';
+      sup = parts[1]?.latex ?? '';
+      break;
+    default:
+      state.degraded = true;
+      break;
+  }
+  const scripts = `${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}`;
+  return {
+    latex: `${baseLatex}${scripts}`,
+    plainText: `${baseText}${sub}${sup}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an `Equation Native` stream (EQNOLEFILEHDR + MTEF v3) to LaTeX.
+ * Throws {@link MtefParseError} for non-v3 streams or malformed bytes —
+ * callers should fall back to the picture path on throw.
+ */
+export function equationNativeToLatex(stream: Uint8Array): MtefConversion {
+  if (stream.byteLength < 34) throw new MtefParseError('Equation Native stream too short');
+  const view = new DataView(stream.buffer, stream.byteOffset, stream.byteLength);
+  const hdrLen = view.getUint16(0, true);
+  const mtefStart = hdrLen > 0 && hdrLen < stream.byteLength ? hdrLen : 28;
+  if (stream[mtefStart] !== 3) {
+    throw new MtefParseError(`unsupported MTEF version ${stream[mtefStart] ?? '?'}`);
+  }
+  if (stream[mtefStart + 1] !== 1) {
+    // Mac-generated streams store 8-bit characters; only the Windows encoding
+    // is handled here.
+    throw new MtefParseError('unsupported MTEF platform (Windows only)');
+  }
+
+  const cur = new Cursor(stream, mtefStart + 5, stream.byteLength);
+  const budget = { count: 0 };
+  const root = parseObjectList(cur, budget);
+  const state = { degraded: false };
+  const rendered = renderList(root, state);
+  const latex = rendered.latex.replace(/\s+/g, ' ').trim();
+  if (!latex) throw new MtefParseError('MTEF stream produced empty equation');
+  return { latex, plainText: rendered.plainText.trim(), degraded: state.degraded };
+}

--- a/packages/@openmaic/importer/src/utils/mtef.ts
+++ b/packages/@openmaic/importer/src/utils/mtef.ts
@@ -522,10 +522,11 @@ const SYMBOL_FONT_LATEX: Record<number, string> = {
   0x58: '\\Xi ',
   0x59: '\\Psi ',
   0x5a: 'Z',
-  // Adobe Symbol high half (0xA0–0xFF from the URW AFM); positions not listed
+  // Adobe Symbol high half (~50 of ~70 defined 0xA0–0xFF positions from the
+  // URW AFM; excluded: suits, ®/©/™, fraktur, extrema pieces → throw); positions not listed
   // here throw MtefParseError so the formula falls back to its picture. Font-local
   // codes here are glyph indices into the Symbol font; unmapped ones must
-  // NOT pass through as Latin-1 (0xF7 is ∫-extension, not ÷). Structural
+  // NOT pass through as Latin-1 (0xF4 is integralex, not a blank). Structural
   // pieces (big-paren/large-op extenders) map to their base operators;
   // playing-card suits and serif-mark glyphs are excluded — they flag
   // degraded via the unmapped path.
@@ -617,7 +618,7 @@ function charLatex(node: CharNode, state: RenderState): string {
       node.typeface === TF_UCGREEK + 128 ||
       node.typeface === TF_SYMBOL + 128);
   // Unmapped font-local Symbol glyph. Codes >= 0xA0 and the known-divergent
-  // low positions must NOT pass through as Latin-1 (0xF7 is an integral
+  // low positions must NOT pass through as Latin-1 (0xF4 is the integral
   // extender, not ÷; 0x60 is radicalex, not a backtick; 0x80-0x9F are C1
   // controls) — refuse the conversion so the picture fallback takes over.
   // Printable ASCII positions where Symbol matches ASCII (= + ( ) etc.) are

--- a/packages/@openmaic/importer/src/utils/mtef.ts
+++ b/packages/@openmaic/importer/src/utils/mtef.ts
@@ -346,6 +346,7 @@ function parseObjectList(cur: Cursor, budget: { count: number }, depth = 0): Nod
         const embellishments: number[] = [];
         if (options & OPT_EMBELL) {
           for (;;) {
+            if (++budget.count > MAX_RECORDS) throw new MtefParseError('MTEF stream too large');
             const etag = cur.byte();
             const etype = etag & 0x0f;
             const eopts = (etag >> 4) & 0x0f;
@@ -521,19 +522,86 @@ const SYMBOL_FONT_LATEX: Record<number, string> = {
   0x58: '\\Xi ',
   0x59: '\\Psi ',
   0x5a: 'Z',
-  // Adobe Symbol high half: the operator block real Equation 3.0 decks use.
+  // Adobe Symbol high half, complete (0xA0–0xFF from the URW AFM). Font-local
+  // codes here are glyph indices into the Symbol font; unmapped ones must
+  // NOT pass through as Latin-1 (0xF7 is ∫-extension, not ÷). Structural
+  // pieces (big-paren/large-op extenders) map to their base operators;
+  // playing-card suits and serif-mark glyphs are excluded — they flag
+  // degraded via the unmapped path.
+  0xa2: "' ",
   0xa3: '\\le ',
+  0xa4: '/',
+  0xa5: '\\infty ',
+  0xa6: 'f',
+  0xab: '\\leftrightarrow ',
+  0xac: '\\leftarrow ',
+  0xad: '\\uparrow ',
+  0xae: '\\to ',
+  0xaf: '\\downarrow ',
+  0xb0: '^{\\circ}',
+  0xb1: '\\pm ',
+  0xb2: "''",
   0xb3: '\\ge ',
   0xb4: '\\times ',
+  0xb5: '\\propto ',
+  0xb6: '\\partial ',
+  0xb7: '\\bullet ',
   0xb8: '\\div ',
-  0xa5: '\\infty ',
-  0xae: '\\to ',
   0xb9: '\\ne ',
-  0xd6: '\\surd ',
-  0xb1: '\\pm ',
-  0xac: '\\leftarrow ',
-  0xbb: '\\approx ',
   0xba: '\\equiv ',
+  0xbb: '\\approx ',
+  0xbc: '\\ldots ',
+  0xc0: '\\aleph ',
+  0xc4: '\\otimes ',
+  0xc5: '\\oplus ',
+  0xc6: '\\emptyset ',
+  0xc7: '\\cap ',
+  0xc8: '\\cup ',
+  0xc9: '\\supset ',
+  0xca: '\\supseteq ',
+  0xcb: '\\not\\subset ',
+  0xcc: '\\subset ',
+  0xcd: '\\subseteq ',
+  0xce: '\\in ',
+  0xcf: '\\notin ',
+  0xd0: '\\angle ',
+  0xd1: '\\nabla ',
+  0xd5: '\\prod ',
+  0xd6: '\\surd ',
+  0xd7: '\\cdot ',
+  0xd8: '\\neg ',
+  0xd9: '\\wedge ',
+  0xda: '\\vee ',
+  0xdb: '\\Leftrightarrow ',
+  0xdc: '\\Leftarrow ',
+  0xdd: '\\Uparrow ',
+  0xde: '\\Rightarrow ',
+  0xdf: '\\Downarrow ',
+  0xe0: '\\lozenge ',
+  0xe1: '\\langle ',
+  0xe5: '\\sum ',
+  0xf1: '\\rangle ',
+  0xf2: '\\int ',
+  0xf3: '\\int ',
+  0xe6: '(',
+  0xe7: '|',
+  0xe8: '(',
+  0xe9: '[',
+  0xea: '|',
+  0xeb: '[',
+  0xec: '\\{ ',
+  0xed: '\\{ ',
+  0xee: '\\{ ',
+  0xef: '|',
+  0xf6: ')',
+  0xf7: ')',
+  0xf8: ')',
+  0xf9: ']',
+  0xfa: '|',
+  0xfb: ']',
+  0xfc: '\\} ',
+  0xfd: '\\} ',
+  0xfe: '\\} ',
 };
 
 const TF_LCGREEK = 4;
@@ -547,10 +615,19 @@ function charLatex(node: CharNode, state: RenderState): string {
     (node.typeface === TF_LCGREEK + 128 ||
       node.typeface === TF_UCGREEK + 128 ||
       node.typeface === TF_SYMBOL + 128);
-  if (fontLocal && node.code >= 0xa0 && SYMBOL_FONT_LATEX[node.code] === undefined) {
-    // Unmapped Symbol operator position: passing the raw Latin-1 byte through
-    // is at best approximate — flag it so callers can warn.
-    state.degraded = true;
+  // Unmapped font-local Symbol glyph. Codes >= 0xA0 and the known-divergent
+  // low positions must NOT pass through as Latin-1 (0xF7 is an integral
+  // extender, not ÷; 0x60 is radicalex, not a backtick; 0x80-0x9F are C1
+  // controls) — refuse the conversion so the picture fallback takes over.
+  // Printable ASCII positions where Symbol matches ASCII (= + ( ) etc.) are
+  // safe to pass through.
+  const FONT_LOCAL_PASSTHROUGH = node.code >= 0x20 && node.code < 0x7f;
+  if (fontLocal && SYMBOL_FONT_LATEX[node.code] === undefined && !FONT_LOCAL_PASSTHROUGH) {
+    throw new MtefParseError(`unmapped Symbol font glyph 0x${node.code.toString(16)}`);
+  }
+  if (fontLocal && node.code === 0x60) {
+    // radicalex — the radical extension bar, not renderable standalone.
+    throw new MtefParseError('unmapped Symbol font glyph 0x60 (radicalex)');
   }
   const symbol = fontLocal
     ? (SYMBOL_FONT_LATEX[node.code] ?? escapeLatexChar(node.code))
@@ -675,14 +752,20 @@ function renderTmpl(node: TmplNode, state: RenderState): Rendered {
   const { selector, variation, children } = node;
 
   if (selector === TM_DIRAC) {
-    // DiracBox: [left slot, right slot, ⟨ | ⟩ chars]. Variations 0/1/2 =
-    // both / left-only / right-only.
+    // DiracBox: [left slot, right slot, ⟨ | ⟩ chars]. Variations per the
+    // rtf2latex2e reference: 0 = ⟨L|R⟩, 1 = bra ⟨L|, 2 = ket |R⟩.
     const parts = lineContents(children, state);
     const left = parts[0]?.latex ?? '';
     const right = variation === 2 ? '' : (parts[1]?.latex ?? '');
     if (variation === 0 && !right) state.degraded = true;
+    const body =
+      variation === 1
+        ? `\\left\\langle ${left}\\right| `
+        : variation === 2
+          ? `\\left| ${right || left}\\right\\rangle `
+          : `\\left\\langle ${left}\\mid ${right}\\right\\rangle `;
     return {
-      latex: `\\langle ${variation === 1 ? left : `${left} \\mid ${right}`}\\rangle `,
+      latex: body,
       plainText: `<${parts.map((p) => p.plainText).join('|')}>`,
     };
   }
@@ -796,8 +879,12 @@ function renderTmpl(node: TmplNode, state: RenderState): Rendered {
   if (selector === TM_LIM) {
     // Slots [main, lower, upper]. Variations (spec + rtf2latex2e eqn.c):
     // 0 = tvULIM upper limit, 1 = tvLLIM lower limit, 2 = tvBLIM both.
-    // Single-limit writers emit two slots — the lone limit sits at position 1
-    // regardless of role — fall back like the big-operator branch does.
+    // The reference emits `main` FIRST, then the limits, and injects NO
+    // function name — Equation Editor users type the function ("lim", "max",
+    // "min"…) into the main slot, so hardcoding \lim both duplicates it and
+    // glues to a letter-leading main slot (\limx → KaTeX undefined control
+    // sequence). Single-limit writers emit two slots — the lone limit sits at
+    // position 1 regardless of role — falling back like the big-op branch.
     const parts = lineContents(children, state);
     const sub = variation === 1 || variation === 2 ? (parts[1]?.latex ?? '') : '';
     const sup =
@@ -806,9 +893,13 @@ function renderTmpl(node: TmplNode, state: RenderState): Rendered {
         : variation === 2
           ? (parts[2]?.latex ?? '')
           : '';
+    const main = parts[0]?.latex ?? '';
+    // KaTeX needs a base before the scripts: an empty main slot (writer put
+    // the function in the limit slots only) gets \lim as a neutral default.
+    const base = main || '\\lim ';
     return {
-      latex: `\\lim${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}${parts[0]?.latex ?? ''}`,
-      plainText: `lim${parts.map((p) => p.plainText).join('')}`,
+      latex: `${base}${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}`,
+      plainText: parts.map((p) => p.plainText).join(''),
     };
   }
 

--- a/packages/@openmaic/importer/src/utils/mtef.ts
+++ b/packages/@openmaic/importer/src/utils/mtef.ts
@@ -296,6 +296,8 @@ class Cursor {
 }
 
 const MAX_RECORDS = 20_000;
+const MAX_DEPTH = 200;
+const MAX_LATEX_LENGTH = 64 * 1024;
 
 interface CharNode {
   kind: 'char';
@@ -317,6 +319,7 @@ interface LineNode {
 type Node = CharNode | TmplNode | LineNode | { kind: 'other' };
 
 function parseObjectList(cur: Cursor, budget: { count: number }, depth = 0): Node[] {
+  if (depth > MAX_DEPTH) throw new MtefParseError('MTEF nesting too deep');
   const nodes: Node[] = [];
   while (!cur.eof) {
     if (++budget.count > MAX_RECORDS) throw new MtefParseError('MTEF stream too large');
@@ -449,22 +452,29 @@ interface RenderState {
  * text turns α into `a`. Codes ≥ 0x100 are MTCode/Unicode and skip this table.
  */
 const SYMBOL_FONT_LATEX: Record<number, string> = {
+  // Adobe Symbol font encoding (verified against URW StandardSymbolsPS AFM
+  // + Adobe AGL): covers the Greek block and every punctuation/operator
+  // position where Symbol differs from ASCII. Unmapped font-local bytes
+  // >= 0xA0 pass through and flag degraded (see charLatex).
+  0x22: '\\forall ',
+  0x24: '\\exists ',
+  0x27: '\\ni ',
   0x2a: '\\ast ',
   0x2d: '-',
-  0x3c: '\\le ',
-  0x3e: '\\ge ',
-  0x5b: '\\leftarrow ',
-  0x5d: '\\rightarrow ',
-  0x5e: '\\uparrow ',
-  0x5f: '\\downarrow ',
-  0x60: '\\equiv ',
-  0x7e: '\\simeq ',
+  0x5e: '\\perp ',
+  0x3c: '<',
+  0x3e: '>',
+  0x5b: '[',
+  0x5d: ']',
+  0x5c: '\\therefore ',
+  0x40: '\\cong ',
+  0x7e: '\\sim ',
   0x61: '\\alpha ',
   0x62: '\\beta ',
   0x63: '\\chi ',
   0x64: '\\delta ',
   0x65: '\\epsilon ',
-  0x66: '\\phi ',
+  0x66: '\\varphi ',
   0x67: '\\gamma ',
   0x68: '\\eta ',
   0x69: '\\iota ',
@@ -487,12 +497,14 @@ const SYMBOL_FONT_LATEX: Record<number, string> = {
   0x7a: '\\zeta ',
   0x41: 'A',
   0x42: 'B',
+  0x43: 'X',
   0x44: '\\Delta ',
   0x45: 'E',
   0x46: '\\Phi ',
   0x47: '\\Gamma ',
   0x48: 'H',
   0x49: 'I',
+  0x4a: '\\vartheta ',
   0x4b: 'K',
   0x4c: '\\Lambda ',
   0x4d: 'M',
@@ -504,10 +516,24 @@ const SYMBOL_FONT_LATEX: Record<number, string> = {
   0x53: '\\Sigma ',
   0x54: 'T',
   0x55: '\\Upsilon ',
+  0x56: '\\varsigma ',
   0x57: '\\Omega ',
   0x58: '\\Xi ',
   0x59: '\\Psi ',
   0x5a: 'Z',
+  // Adobe Symbol high half: the operator block real Equation 3.0 decks use.
+  0xa3: '\\le ',
+  0xb3: '\\ge ',
+  0xb4: '\\times ',
+  0xb8: '\\div ',
+  0xa5: '\\infty ',
+  0xae: '\\to ',
+  0xb9: '\\ne ',
+  0xd6: '\\surd ',
+  0xb1: '\\pm ',
+  0xac: '\\leftarrow ',
+  0xbb: '\\approx ',
+  0xba: '\\equiv ',
 };
 
 const TF_LCGREEK = 4;
@@ -521,6 +547,11 @@ function charLatex(node: CharNode, state: RenderState): string {
     (node.typeface === TF_LCGREEK + 128 ||
       node.typeface === TF_UCGREEK + 128 ||
       node.typeface === TF_SYMBOL + 128);
+  if (fontLocal && node.code >= 0xa0 && SYMBOL_FONT_LATEX[node.code] === undefined) {
+    // Unmapped Symbol operator position: passing the raw Latin-1 byte through
+    // is at best approximate — flag it so callers can warn.
+    state.degraded = true;
+  }
   const symbol = fontLocal
     ? (SYMBOL_FONT_LATEX[node.code] ?? escapeLatexChar(node.code))
     : SYMBOL_LATEX[node.code];
@@ -604,7 +635,10 @@ function renderList(nodes: Node[], state: RenderState): Rendered {
       // A following tmSCRIPT attaches to this atom (e.g. (a/2)²: the script
       // template trails the paren template as a sibling in the same list).
       const next = nodes[i + 1];
-      if (next?.kind === 'tmpl' && (next.selector === TM_SCRIPT || next.selector === TM_LSCRIPT)) {
+      // Only tmSCRIPT attaches backwards; tmLSCRIPT is a LEADING script whose
+      // base is the atom AFTER it — routing it through renderScript would
+      // steal the previous atom as its base.
+      if (next?.kind === 'tmpl' && next.selector === TM_SCRIPT) {
         const combo = renderScript(next, rendered, renderedText, state);
         latex.push(combo.latex);
         text.push(combo.plainText);
@@ -657,10 +691,12 @@ function renderTmpl(node: TmplNode, state: RenderState): Rendered {
   if (fence) {
     // The fence CHARs at the end of the template's own list are structural;
     // the \left/\right pair already renders them, so only the slot matters.
-    // Variations: 0 = both sides, 1 = left only, 2 = right only.
+    // Variations: 0 = both sides, 1 = left only, 2 = right only — the missing
+    // side becomes a null delimiter (\left. / \right.) so the output is
+    // always a matched KaTeX pair (piecewise-function braces are var 1).
     const [inner] = lineContents(children, state);
-    const open = variation === 2 ? '' : fence[0];
-    const close = variation === 1 ? '' : fence[1];
+    const open = variation === 2 ? '\\left. ' : fence[0];
+    const close = variation === 1 ? '\\right. ' : fence[1];
     return {
       latex: `${open}${inner?.latex ?? ''}${close}`,
       plainText: `(${inner?.plainText ?? ''})`,
@@ -707,12 +743,17 @@ function renderTmpl(node: TmplNode, state: RenderState): Rendered {
 
   if (selector === TM_LSCRIPT) {
     // Leading script: slots are [sub, sup] (ScrBoxClass order); variation
-    // picks which exist. tvLSUPER=0, tvLSUB=1, tvLSUBSUP=2.
+    // picks which exist (tvLSUPER=0, tvLSUB=1, tvLSUBSUP=2). The BASE is the
+    // next sibling in the parent list — this template emits the scripts only;
+    // re-emitting a slot as a base group would duplicate it.
     const parts = lineContents(children, state);
     const sub = variation === 0 ? '' : (parts[0]?.latex ?? '');
-    const sup = variation === 1 ? '' : (parts[1]?.latex ?? '');
+    // tvLSUPER writers may emit the sup slot alone; fall back like the
+    // big-operator branch does.
+    const sup =
+      variation === 1 ? '' : (parts[1]?.latex ?? (variation === 0 ? (parts[0]?.latex ?? '') : ''));
     return {
-      latex: `{}${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}{${parts[2]?.latex ?? parts[1]?.latex ?? parts[0]?.latex ?? ''}}`,
+      latex: `{}${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}`,
       plainText: parts.map((p) => p.plainText).join(''),
     };
   }
@@ -753,10 +794,18 @@ function renderTmpl(node: TmplNode, state: RenderState): Rendered {
   }
 
   if (selector === TM_LIM) {
-    // Slots [main, lower, upper]; variation 0/1/2 = lower / upper / both.
+    // Slots [main, lower, upper]. Variations (spec + rtf2latex2e eqn.c):
+    // 0 = tvULIM upper limit, 1 = tvLLIM lower limit, 2 = tvBLIM both.
+    // Single-limit writers emit two slots — the lone limit sits at position 1
+    // regardless of role — fall back like the big-operator branch does.
     const parts = lineContents(children, state);
-    const sub = variation === 1 ? '' : (parts[1]?.latex ?? '');
-    const sup = variation === 0 ? '' : (parts[2]?.latex ?? '');
+    const sub = variation === 1 || variation === 2 ? (parts[1]?.latex ?? '') : '';
+    const sup =
+      variation === 0
+        ? (parts[2]?.latex ?? parts[1]?.latex ?? '')
+        : variation === 2
+          ? (parts[2]?.latex ?? '')
+          : '';
     return {
       latex: `\\lim${sub ? `_{${sub}}` : ''}${sup ? `^{${sup}}` : ''}${parts[0]?.latex ?? ''}`,
       plainText: `lim${parts.map((p) => p.plainText).join('')}`,
@@ -867,5 +916,8 @@ export function equationNativeToLatex(stream: Uint8Array): MtefConversion {
   const rendered = renderList(root, state);
   const latex = rendered.latex.replace(/\s+/g, ' ').trim();
   if (!latex) throw new MtefParseError('MTEF stream produced empty equation');
+  if (latex.length > MAX_LATEX_LENGTH) {
+    throw new MtefParseError('MTEF stream produced oversized LaTeX output');
+  }
   return { latex, plainText: rendered.plainText.trim(), degraded: state.degraded };
 }

--- a/packages/@openmaic/importer/src/utils/mtef.ts
+++ b/packages/@openmaic/importer/src/utils/mtef.ts
@@ -522,7 +522,8 @@ const SYMBOL_FONT_LATEX: Record<number, string> = {
   0x58: '\\Xi ',
   0x59: '\\Psi ',
   0x5a: 'Z',
-  // Adobe Symbol high half, complete (0xA0–0xFF from the URW AFM). Font-local
+  // Adobe Symbol high half (0xA0–0xFF from the URW AFM); positions not listed
+  // here throw MtefParseError so the formula falls back to its picture. Font-local
   // codes here are glyph indices into the Symbol font; unmapped ones must
   // NOT pass through as Latin-1 (0xF7 is ∫-extension, not ÷). Structural
   // pieces (big-paren/large-op extenders) map to their base operators;

--- a/packages/@openmaic/importer/test/mathSerializer.oleEquation.test.ts
+++ b/packages/@openmaic/importer/test/mathSerializer.oleEquation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import * as CFB from 'cfb';
+
+import { mathToElement } from '../src/serializer/mathSerializer';
+import type { MathNodeData } from '../src/model/nodes/MathNode';
+import { minimalCtx } from './helpers';
+import type { RenderContext } from '../src/serializer/RenderContext';
+
+/** Build an OLE compound file whose `Equation Native` stream is hdr+records. */
+function equationBin(records: number[]): Uint8Array {
+  const hdr = new Uint8Array(28); // EQNOLEFILEHDR, cbHdr = 0x1c
+  new DataView(hdr.buffer).setUint16(0, 0x1c, true);
+  const body = Uint8Array.from([0x03, 0x01, 0x01, 0x03, 0x0a, ...records]);
+  const cfb = CFB.utils.cfb_new();
+  CFB.utils.cfb_add(cfb, '/Equation Native', new Uint8Array([...hdr, ...body]));
+  return new Uint8Array(CFB.write(cfb, { type: 'buffer' }));
+}
+
+const A_EQUALS_A_DOT_B = [
+  0x0a,
+  0x01, // FULL, LINE
+  0x12,
+  0x83,
+  0x41,
+  0x00, // A
+  0x02,
+  0x86,
+  0x3d,
+  0x00, // =
+  0x12,
+  0x83,
+  0x61,
+  0x00, // a
+  0x02,
+  0x86,
+  0xc5,
+  0x22, // ⋅
+  0x12,
+  0x83,
+  0x62,
+  0x00, // b
+  0x00,
+  0x00,
+];
+
+function ctxWithEmbedding(bytes: Uint8Array | null): RenderContext {
+  const slide = {
+    index: 0,
+    rels: new Map([['rId5', { target: '../embeddings/oleObject1.bin' }]]),
+  };
+  const presentation = bytes
+    ? { embeddings: new Map([['ppt/embeddings/oleObject1.bin', bytes]]) }
+    : { embeddings: new Map() };
+  return minimalCtx({ slide, presentation } as unknown as Partial<RenderContext>);
+}
+
+function oleEquationNode(): MathNodeData {
+  return {
+    nodeType: 'math',
+    id: 'n1',
+    position: { x: 100, y: 200 },
+    size: { w: 300, h: 60 },
+    xmlOrder: 1,
+    ommlXml: '',
+    plainText: '',
+    oleEquationRId: 'rId5',
+    fallbackBlipEmbed: undefined,
+  } as unknown as MathNodeData;
+}
+
+describe('mathSerializer · Equation.3 OLE (MTEF)', () => {
+  it('resolves the embedding and converts MTEF v3 to LaTeX', async () => {
+    const ctx = ctxWithEmbedding(equationBin(A_EQUALS_A_DOT_B));
+    const el = await mathToElement(oleEquationNode(), ctx, 1);
+    expect(el.latex).toBe('A=a\\cdot b');
+    expect(el.text).toBe('A=a·b');
+  });
+
+  it('falls back to empty latex when the rel is unknown', async () => {
+    const ctx = minimalCtx(); // no rels at all
+    const el = await mathToElement(oleEquationNode(), ctx, 1);
+    expect(el.latex).toBe('');
+  });
+
+  it('falls back to empty latex when the embedding bytes are missing', async () => {
+    const ctx = ctxWithEmbedding(null);
+    const el = await mathToElement(oleEquationNode(), ctx, 1);
+    expect(el.latex).toBe('');
+  });
+
+  it('falls back to empty latex when the binary is not an OLE compound file', async () => {
+    const ctx = ctxWithEmbedding(Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]));
+    const el = await mathToElement(oleEquationNode(), ctx, 1);
+    expect(el.latex).toBe('');
+  });
+});

--- a/packages/@openmaic/importer/test/mediaWebConvert.placeholder.test.ts
+++ b/packages/@openmaic/importer/test/mediaWebConvert.placeholder.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { inflateSync } from 'node:zlib';
+import { isPlaceholderDataUrl } from '../src/utils/mediaWebConvert';
+
+const TRANSPARENT_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=';
+const LEGACY_RED_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+interface PngScanline {
+  filter: number;
+  rgba: number[];
+}
+
+/** Minimal PNG reader: returns the first scanline of a 1×1 RGBA PNG. */
+function decodeSinglePixelPng(dataUrl: string): PngScanline {
+  const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+  // PNG magic
+  expect(bytes.slice(0, 8)).toEqual(
+    Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  );
+
+  let pos = 8;
+  let width = 0;
+  let height = 0;
+  let colorType = 0;
+  const idat: number[] = [];
+  while (pos < bytes.length) {
+    const length =
+      (bytes[pos] << 24) | (bytes[pos + 1] << 16) | (bytes[pos + 2] << 8) | bytes[pos + 3];
+    const type = String.fromCharCode(
+      bytes[pos + 4],
+      bytes[pos + 5],
+      bytes[pos + 6],
+      bytes[pos + 7],
+    );
+    const data = bytes.slice(pos + 8, pos + 8 + length);
+    if (type === 'IHDR') {
+      width = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+      height = (data[4] << 24) | (data[5] << 16) | (data[6] << 8) | data[7];
+      colorType = data[9];
+    } else if (type === 'IDAT') {
+      idat.push(...data);
+    }
+    pos += 12 + length;
+  }
+
+  expect(width).toBe(1);
+  expect(height).toBe(1);
+  expect(colorType).toBe(6); // RGBA
+
+  // Tests run in Node; zlib handles the IDAT stream without extra deps.
+  const raw = inflateSync(Buffer.from(idat));
+  return { filter: raw[0], rgba: Array.from(raw.slice(1, 5)) };
+}
+
+describe('mediaWebConvert · placeholder constant', () => {
+  it('current placeholder is a 1×1 RGBA PNG with alpha 0 (fully transparent)', () => {
+    const { filter, rgba } = decodeSinglePixelPng(TRANSPARENT_PLACEHOLDER);
+    expect(filter).toBe(0);
+    expect(rgba[3]).toBe(0);
+  });
+
+  it('legacy 0.1.4 placeholder is still 1×1 (red 50% pixel) and detected as placeholder', () => {
+    const { rgba } = decodeSinglePixelPng(LEGACY_RED_PLACEHOLDER);
+    expect(rgba).toEqual([255, 0, 0, 127]);
+    expect(isPlaceholderDataUrl(LEGACY_RED_PLACEHOLDER)).toBe(true);
+  });
+
+  it('isPlaceholderDataUrl matches the current placeholder', () => {
+    expect(isPlaceholderDataUrl(TRANSPARENT_PLACEHOLDER)).toBe(true);
+  });
+
+  it('isPlaceholderDataUrl rejects real media sources', () => {
+    expect(isPlaceholderDataUrl(undefined)).toBe(false);
+    expect(isPlaceholderDataUrl('')).toBe(false);
+    expect(isPlaceholderDataUrl('https://cdn.example.com/shares/media/abc.png')).toBe(false);
+    expect(
+      isPlaceholderDataUrl(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/@openmaic/importer/test/mtef.test.ts
+++ b/packages/@openmaic/importer/test/mtef.test.ts
@@ -1,0 +1,643 @@
+import { describe, expect, it } from 'vitest';
+import katex from 'katex';
+
+import { equationNativeToLatex, MtefParseError } from '../src/utils/mtef';
+
+/**
+ * Synthetic MTEF v3 streams, built record by record from the spec (tag =
+ * type | options<<4). The streams below replicate equations found in real
+ * Equation 3.0 courseware decks, byte-for-byte in structure.
+ */
+function mtefStream(records: number[]): Uint8Array {
+  const header = [0x03, 0x01, 0x01, 0x03, 0x0a]; // MTEF v3, Windows, Equation Editor 3.10
+  const hdr = new Uint8Array(28); // EQNOLEFILEHDR, cbHdr = 0x1c
+  new DataView(hdr.buffer).setUint16(0, 0x1c, true);
+  const body = Uint8Array.from([...header, ...records]);
+  return new Uint8Array([...hdr, ...body]);
+}
+
+/** CHAR(fnVARIABLE, code, embellished?) — typeface 3 = fnVARIABLE. */
+function varChar(code: number, options = 0x10): number[] {
+  return [0x02 | options, 0x83, code & 0xff, code >> 8];
+}
+
+/** CHAR(fnSYMBOL, code) — typeface 6 carries operators like = · ≤ +. */
+function symChar(code: number): number[] {
+  return [0x02, 0x86, code & 0xff, code >> 8];
+}
+
+/** CHAR(fnNUMBER, code) — typeface 8. */
+function numChar(code: number): number[] {
+  return [0x02, 0x88, code & 0xff, code >> 8];
+}
+
+const FULL = [0x0a];
+const SUB = [0x0b];
+const LINE = [0x01];
+const LINE_NULL = [0x11];
+const END = [0x00];
+
+describe('mtef · equationNativeToLatex', () => {
+  it('converts A = a·b (CHAR stream with dot operator)', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      ...varChar(0x41), // A
+      ...symChar(0x3d), // =
+      ...varChar(0x61), // a
+      ...symChar(0x22c5), // ⋅
+      ...varChar(0x62), // b
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('A=a\\cdot b');
+    expect(conv.plainText).toBe('A=a·b');
+    expect(conv.degraded).toBe(false);
+    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+  });
+
+  it('converts R′ = √((a/2)²+(b/2)²) ≤ R (prime, fences, fraction, root, scripts)', () => {
+    // Structure from a real Equation 3.0 deck: the root template's slot is
+    // [paren{frac a 2} script², +, paren{frac b 2} script²], followed by a
+    // null degree slot; ≤ R sits OUTSIDE the root, in the top-level line.
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      ...[0x32, 0x83, 0x52, 0x00], // CHAR R (embellished)
+      ...[0x06, 0x05], // EMBELL prime
+      ...END, // ends embellishment list
+      ...symChar(0x3d), // =
+      // TMPL tmROOT(tvSQROOT)
+      0x03,
+      0x0d,
+      0x00,
+      0x00,
+      ...LINE, // radicand slot
+      // TMPL tmPAREN
+      0x03,
+      0x01,
+      0x00,
+      0x00,
+      ...LINE, // paren slot
+      // TMPL tmFRACT(tvFFRACT)
+      0x03,
+      0x0e,
+      0x00,
+      0x00,
+      ...LINE,
+      ...varChar(0x61),
+      ...END, // numerator: a
+      ...LINE,
+      ...numChar(0x32),
+      ...END, // denominator: 2
+      ...END, // ends fraction slots
+      ...END, // ends paren slot
+      ...[0x02, 0x96, 0x28, 0x00], // fence char (
+      ...[0x02, 0x96, 0x29, 0x00], // fence char )
+      ...END, // ends paren template
+      // TMPL tmSCRIPT(tvSUPER)
+      0x03,
+      0x0f,
+      0x00,
+      0x00,
+      ...SUB,
+      ...LINE_NULL, // unused sub slot
+      ...LINE,
+      ...numChar(0x32),
+      ...END, // superscript: 2
+      ...END, // ends script slots
+      ...symChar(0x2b), // +
+      // second (b/2)² — same shape
+      0x03,
+      0x01,
+      0x00,
+      0x00,
+      ...LINE,
+      0x03,
+      0x0e,
+      0x00,
+      0x00,
+      ...LINE,
+      ...varChar(0x62),
+      ...END,
+      ...LINE,
+      ...numChar(0x32),
+      ...END,
+      ...END,
+      ...END,
+      ...[0x02, 0x96, 0x28, 0x00],
+      ...[0x02, 0x96, 0x29, 0x00],
+      ...END,
+      0x03,
+      0x0f,
+      0x00,
+      0x00,
+      ...SUB,
+      ...LINE_NULL,
+      ...LINE,
+      ...numChar(0x32),
+      ...END,
+      ...END,
+      ...END, // ends radicand slot
+      ...LINE_NULL, // null degree slot
+      ...END, // ends root template
+      ...symChar(0x2264), // ≤
+      ...varChar(0x52), // R
+      ...END, // ends top line
+      ...END, // ends equation
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe(
+      "R'=\\sqrt{\\left ( \\frac{a}{2}\\right ) ^{2}+\\left ( \\frac{b}{2}\\right ) ^{2}}\\le R",
+    );
+    expect(conv.degraded).toBe(false);
+    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+  });
+
+  it('attaches a tvSUB script to the preceding char (Dᵢ)', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      ...varChar(0x44), // D
+      0x03,
+      0x0f,
+      0x01,
+      0x00, // TMPL tmSCRIPT(tvSUB)
+      ...SUB,
+      ...LINE,
+      ...varChar(0x69),
+      ...END, // subscript: i
+      ...LINE_NULL,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('D_{i}');
+  });
+
+  it('degrades unknown templates to slot contents and flags degraded', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      0x63,
+      0x00,
+      0x00, // selector 0x63 — beyond the v3 table
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('x');
+    expect(conv.degraded).toBe(true);
+  });
+
+  it('rejects non-v3 MTEF streams', () => {
+    const hdr = new Uint8Array(28);
+    new DataView(hdr.buffer).setUint16(0, 0x1c, true);
+    const stream = new Uint8Array([...hdr, 0x05, 0x01, 0x00, 0x05, 0x00, 0x00, 0x00]);
+    expect(() => equationNativeToLatex(stream)).toThrow(MtefParseError);
+  });
+
+  it('throws on truncated streams instead of looping', () => {
+    const hdr = new Uint8Array(28);
+    const stream = new Uint8Array([...hdr, 0x03, 0x01, 0x01, 0x03, 0x0a, 0x01, 0x12, 0x83]);
+    expect(() => equationNativeToLatex(stream)).toThrow(MtefParseError);
+  });
+});
+
+describe('mtef · spec-conformance (cross-review round 2)', () => {
+  it('BigOp tmSUM(tvBSUM) renders [main, upper, lower] in the right roles', () => {
+    // Slots per spec: main=summand k, upper=n, lower=i=1.
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      29,
+      1,
+      0, // TMPL tmSUM tvBSUM (both limits)
+      ...LINE,
+      ...varChar(0x6b),
+      ...END, // main: k
+      ...LINE,
+      ...varChar(0x69),
+      ...symChar(0x3d),
+      ...varChar(0x31),
+      ...END, // lower: i=1 (real streams order [main, lower, upper])
+      ...LINE,
+      ...varChar(0x6e),
+      ...END, // upper: n
+      ...END, // ends template
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('\\sum _{i=1}^{n}k');
+    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+  });
+
+  it('BigOp tmSUM(tvLSUM) is lower-only; main is not eaten by limits', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      29,
+      0,
+      0,
+      ...LINE,
+      ...varChar(0x6b),
+      ...END, // main
+      ...LINE,
+      ...varChar(0x6a),
+      ...END, // lower: j (upper slot omitted)
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('\\sum _{j}k');
+  });
+
+  it('BigOp tmINTOP(tvUINTOP) renders the upper limit slot', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      42,
+      0,
+      0,
+      ...LINE,
+      ...varChar(0x64),
+      ...varChar(0x78),
+      ...END, // main: dx (fnVARIABLE — fnSYMBOL d/x would decode as δ/ξ)
+      ...LINE,
+      ...varChar(0x6e),
+      ...END, // upper: n
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('\\int ^{n}dx');
+  });
+
+  it('SIZE records in all three v3 forms parse without derailing the stream', () => {
+    const explicit = mtefStream([
+      0x09,
+      101,
+      0x10,
+      0x00,
+      ...FULL,
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(explicit).latex).toBe('x');
+    const delta = mtefStream([0x09, 1, 0x90, ...FULL, ...LINE, ...varChar(0x78), ...END, ...END]);
+    expect(equationNativeToLatex(delta).latex).toBe('x');
+    const large = mtefStream([
+      0x09,
+      100,
+      1,
+      0x20,
+      0x00,
+      ...FULL,
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(large).latex).toBe('x');
+  });
+
+  it('LINE xfRULER consumes a complete RULER record (tag + typed stops)', () => {
+    const stream = mtefStream([
+      ...FULL,
+      0x21, // LINE with xfRULER
+      0x07,
+      0x01,
+      0x00,
+      0x00,
+      0x01, // RULER: 1 stop, type left, offset 0x0100
+      ...varChar(0x78),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(stream).latex).toBe('x');
+  });
+
+  it('PILE reads nudge→halign→valign→RULER order and keeps its lines', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x24,
+      0x00,
+      0x01, // PILE with xfRULER: halign 0, valign 1
+      0x07,
+      0x00, // RULER: no stops
+      ...LINE,
+      ...varChar(0x61),
+      ...END,
+      ...LINE,
+      ...varChar(0x62),
+      ...END,
+      ...END, // ends pile
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('ab');
+    expect(conv.degraded).toBe(true); // PILE is flattened — flagged
+  });
+
+  it('MATRIX (v3 single-byte fields) keeps every cell', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x05,
+      0x00,
+      0x01,
+      0x00,
+      0x01,
+      0x02,
+      0x00,
+      0x00, // valign,h_just,v_just,rows=1,cols=2,parts bytes
+      ...LINE,
+      ...varChar(0x61),
+      ...END,
+      ...LINE,
+      ...varChar(0x62),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('ab');
+    expect(conv.degraded).toBe(true);
+  });
+
+  it('tmUBAR(16) renders underbar, tmOBAR(17) renders overbar', () => {
+    const under = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      16,
+      0,
+      0,
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(under).latex).toBe('\\underline{x}');
+    const over = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      17,
+      0,
+      0,
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(over).latex).toBe('\\overline{x}');
+  });
+
+  it('fence variations render only the present side', () => {
+    const leftOnly = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      1,
+      1,
+      0,
+      ...LINE,
+      ...varChar(0x61),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(leftOnly).latex).toBe('\\left ( a');
+    const rightOnly = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      1,
+      2,
+      0,
+      ...LINE,
+      ...varChar(0x61),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(rightOnly).latex).toBe('a\\right )');
+  });
+
+  it('tmDIRAC renders ⟨left|right⟩ and degrades on a missing right slot', () => {
+    const both = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      45,
+      0,
+      0,
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...LINE,
+      ...varChar(0x79),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(both);
+    expect(conv.latex).toBe('\\langle x \\mid y\\rangle');
+    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+  });
+
+  it('tmLSCRIPT(tvLSUB) renders a leading subscript, not superscript', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      44,
+      1,
+      0,
+      ...LINE,
+      ...varChar(0x31),
+      ...END,
+      ...LINE_NULL,
+      ...END,
+      ...varChar(0x53),
+      ...END,
+      ...END,
+    ]);
+    // leading script template + following base char S
+    const conv = equationNativeToLatex(stream);
+    expect(conv.latex).toBe('{}_{1}{}S');
+  });
+
+  it('deeply nested fences render in linear time (perf guard)', () => {
+    function nested(depth: number): number[] {
+      let rec: number[] = [...varChar(0x78)];
+      for (let i = 0; i < depth; i++) {
+        rec = [0x03, 1, 0, 0, 0x01, ...rec, 0x00, 0x00];
+      }
+      return [...FULL, ...LINE, ...rec, ...END, ...END];
+    }
+    const t0 = Date.now();
+    const conv = equationNativeToLatex(mtefStream(nested(80)));
+    const ms = Date.now() - t0;
+    expect(conv.latex).toContain('x');
+    expect(ms).toBeLessThan(2000);
+  });
+
+  it('truncated nested list throws instead of silently losing content', () => {
+    // A fraction whose denominator LINE is never terminated.
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      14,
+      0,
+      0, // tmFRACT
+      ...LINE,
+      ...varChar(0x61),
+      ...END, // numerator closed
+      ...LINE,
+      ...varChar(0x62), // denominator unterminated → EOF
+    ]);
+    expect(() => equationNativeToLatex(stream)).toThrow(MtefParseError);
+  });
+
+  it('tmOARC output stays KaTeX-renderable and flags degraded', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      48,
+      0,
+      0,
+      ...LINE,
+      ...varChar(0x41),
+      ...varChar(0x42),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const conv = equationNativeToLatex(stream);
+    expect(conv.degraded).toBe(true);
+    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+  });
+});
+
+describe('mtef · round-3 fixes', () => {
+  it('tmISUM(tvBISUM) renders both limits (variation 1 = both, not upper-only)', () => {
+    const stream = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      30,
+      1,
+      0, // tmISUM tvBISUM
+      ...LINE,
+      ...varChar(0x6b),
+      ...END, // main
+      ...LINE,
+      ...varChar(0x6a),
+      ...END, // lower
+      ...LINE,
+      ...varChar(0x6e),
+      ...END, // upper
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(stream).latex).toBe('\\sum _{j}^{n}k');
+  });
+
+  it('contour integral variations render \\oint (tmSINT var 3/4, tmSSINT var 2)', () => {
+    const mk = (sel: number, variation: number) =>
+      mtefStream([
+        ...FULL,
+        ...LINE,
+        0x03,
+        sel,
+        variation,
+        0,
+        ...LINE,
+        ...varChar(0x64),
+        ...varChar(0x78),
+        ...END, // main dx
+        ...LINE,
+        ...varChar(0x30),
+        ...END, // lower 0
+        ...END,
+        ...END,
+        ...END,
+      ]);
+    expect(equationNativeToLatex(mk(21, 3)).latex).toBe('\\oint dx');
+    expect(equationNativeToLatex(mk(21, 4)).latex).toBe('\\oint _{0}dx');
+    expect(equationNativeToLatex(mk(24, 2)).latex).toBe('\\oint _{0}dx');
+  });
+
+  it('decodes font-local Symbol encoding: fnLCGREEK q → \\theta, fnSYMBOL = stays =', () => {
+    const theta = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x02,
+      0x84,
+      0x71,
+      0x00, // CHAR fnLCGREEK code 0x71 (Symbol 'q' = θ)
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(theta).latex).toBe('\\theta');
+    const stillEq = mtefStream([
+      ...FULL,
+      ...LINE,
+      ...symChar(0x3d),
+      ...varChar(0x61),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(stillEq).latex).toBe('=a');
+  });
+
+  it('rejects Mac-platform MTEF streams (8-bit chars unsupported)', () => {
+    const hdr = new Uint8Array(28);
+    new DataView(hdr.buffer).setUint16(0, 0x1c, true);
+    const stream = new Uint8Array([...hdr, 0x03, 0x00, 0x01, 0x03, 0x0a, 0x0a, 0x01, 0x00, 0x00]);
+    expect(() => equationNativeToLatex(stream)).toThrow(MtefParseError);
+  });
+
+  it('tagless RULER after xfRULER is tolerated', () => {
+    const stream = mtefStream([
+      ...FULL,
+      0x21, // LINE with xfRULER
+      // no RULER tag follows — next record goes straight into the object list
+      ...varChar(0x78),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(stream).latex).toBe('x');
+  });
+});

--- a/packages/@openmaic/importer/test/mtef.test.ts
+++ b/packages/@openmaic/importer/test/mtef.test.ts
@@ -213,7 +213,7 @@ describe('mtef · equationNativeToLatex', () => {
 
 describe('mtef · spec-conformance (cross-review round 2)', () => {
   it('BigOp tmSUM(tvBSUM) renders [main, upper, lower] in the right roles', () => {
-    // Slots per real streams: [main=k, lower=i=1, upper=n].
+    // Slots: [main=k, lower=i=1, upper=n] per real streams + eqn.c.
     const stream = mtefStream([
       ...FULL,
       ...LINE,
@@ -472,7 +472,39 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
     expect(() => katex.renderToString(brace.latex, { throwOnError: true })).not.toThrow();
   });
 
-  it('tmDIRAC renders ⟨left|right⟩ and degrades on a missing right slot', () => {
+  it('tmDIRAC: var1 = bra ⟨L|, var2 = ket |R⟩ (reference semantics)', () => {
+    const bra = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      45,
+      1,
+      0,
+      ...LINE,
+      ...varChar(0x61),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(bra).latex).toBe('\\left\\langle a\\right|');
+    const ket = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      45,
+      2,
+      0,
+      ...LINE,
+      ...varChar(0x61),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(ket).latex).toBe('\\left| a\\right\\rangle');
     const both = mtefStream([
       ...FULL,
       ...LINE,
@@ -489,10 +521,11 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
       ...END,
       ...END,
       ...END,
+      ...END,
     ]);
-    const conv = equationNativeToLatex(both);
-    expect(conv.latex).toBe('\\langle x \\mid y\\rangle');
-    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+    const outB = equationNativeToLatex(both);
+    expect(outB.latex).toBe('\\left\\langle x\\mid y\\right\\rangle');
+    expect(() => katex.renderToString(outB.latex, { throwOnError: true })).not.toThrow();
   });
 
   it('tmLSCRIPT emits only the leading scripts; the base is the next sibling', () => {
@@ -715,8 +748,10 @@ describe('mtef · round-3 fixes', () => {
 describe('mtef · real Equation 3.0 fixtures (round-tripped from a legacy deck)', () => {
   // Raw `Equation Native` streams from a real 消防 courseware deck
   // (Equation.3 OLE objects), base64-encoded. These pin the font-local
-  // Symbol encoding and the [main, lower, upper] big-op claims against
-  // bytes a real writer produced.
+  // Symbol encoding (fnSYMBOL = / + / ⋅ / ≤ as real writers emit them)
+  // against bytes a real writer produced. None of the three contains a
+  // big-operator selector (21–43); that reading is pinned by the
+  // spec-conformance tests above instead.
   const OLE_A_EQ_A_DOT_B =
     'HAAAAAIA5sEdAAAAAAAAAFAlGACMMBgAAAAAAAMBAQMKCgESg0EAAoY9ABKDYQAChsUiEoNiAAAA';
   const OLE_R_PRIME_LE_R =
@@ -753,45 +788,95 @@ describe('mtef · real Equation 3.0 fixtures (round-tripped from a legacy deck)'
 });
 
 describe('mtef · review round fixes', () => {
-  it('tmLIM variations map roles correctly (0=upper, 1=lower)', () => {
-    // Single-limit writers emit two slots [main, limit]; the role comes from
-    // the variation, not the position (spec + rtf2latex2e eqn.c).
-    const upperOnly = mtefStream([
-      ...FULL,
-      ...LINE,
-      0x03,
-      39,
-      0,
-      0, // tmLIM tvULIM
-      ...LINE,
-      ...varChar(0x78),
-      ...END, // main: x
-      ...LINE,
-      ...varChar(0x6e),
-      ...END, // the lone limit
-      ...END,
-      ...END,
-      ...END,
-    ]);
-    expect(equationNativeToLatex(upperOnly).latex).toBe('\\lim^{n}x');
-    const lowerOnly = mtefStream([
+  it('tmLIM: main slot first, no injected operator name; empty main gets \lim', () => {
+    // Reference emits `main` followed by limits and injects NO function
+    // name — the function lives in the main slot (probes from review).
+    const limLower = mtefStream([
       ...FULL,
       ...LINE,
       0x03,
       39,
       1,
-      0, // tmLIM tvLLIM
+      0,
+      ...LINE,
+      ...varChar(0x6c),
+      ...varChar(0x69),
+      ...varChar(0x6d),
+      ...END, // main: "lim"
+      ...LINE,
+      ...varChar(0x6e),
+      ...END, // lower: n
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const outL = equationNativeToLatex(limLower);
+    expect(outL.latex).toBe('lim_{n}');
+    expect(() => katex.renderToString(outL.latex, { throwOnError: true })).not.toThrow();
+    const maxLower = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      39,
+      1,
+      0,
+      ...LINE,
+      ...varChar(0x6d),
+      ...varChar(0x61),
+      ...varChar(0x78),
+      ...END, // main: "max"
+      ...LINE,
+      ...varChar(0x69),
+      ...END, // lower: i
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(maxLower).latex).toBe('max_{i}');
+    // Empty main slot + letter-leading content must not glue to \lim.
+    const emptyMain = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      39,
+      1,
+      0,
+      ...LINE,
+      ...END, // main: empty
       ...LINE,
       ...varChar(0x78),
+      ...END, // lower: x
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    const outE = equationNativeToLatex(emptyMain);
+    expect(outE.latex).toBe('\\lim _{x}');
+    expect(() => katex.renderToString(outE.latex, { throwOnError: true })).not.toThrow();
+    // Both limits.
+    const both = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      39,
+      2,
+      0,
+      ...LINE,
+      ...varChar(0x6c),
+      ...varChar(0x69),
+      ...varChar(0x6d),
       ...END,
       ...LINE,
       ...varChar(0x6e),
+      ...END,
+      ...LINE,
+      ...varChar(0x32),
       ...END,
       ...END,
       ...END,
       ...END,
     ]);
-    expect(equationNativeToLatex(lowerOnly).latex).toBe('\\lim_{n}x');
+    expect(equationNativeToLatex(both).latex).toBe('lim_{n}^{2}');
   });
 
   it('Adobe Symbol operator block maps correctly (≤ × → ∞ ≠)', () => {
@@ -823,5 +908,96 @@ describe('mtef · review round fixes', () => {
       return [...FULL, ...LINE, ...rec, ...END, ...END];
     }
     expect(() => equationNativeToLatex(mtefStream(nestedFences(500)))).toThrow(MtefParseError);
+  });
+});
+
+describe('mtef · round-6 fixes (wyuc review 2)', () => {
+  it('unmapped Symbol high-half codes throw MtefParseError (picture fallback), not Latin-1', () => {
+    // 0xF7 is parenrightex (a big-paren extender). Before the full-table fix
+    // it passed through as ÷ — wrong but plausible-looking math.
+    const probe = (code: number) =>
+      mtefStream([...FULL, ...LINE, ...symChar(code), ...END, ...END]);
+    // 0xA0 = Euro (unmapped — excluded category)
+    expect(() => equationNativeToLatex(probe(0xa0))).toThrow(MtefParseError);
+    // 0xC1 Ifraktur (unmapped)
+    expect(() => equationNativeToLatex(probe(0xc1))).toThrow(MtefParseError);
+  });
+
+  it('previously-dangerous unmapped codes now map correctly from the AFM', () => {
+    const mk = (code: number) =>
+      equationNativeToLatex(mtefStream([...FULL, ...LINE, ...symChar(code), ...END, ...END])).latex;
+    expect(mk(0xf2)).toBe('\\int'); // was ÷
+    expect(mk(0xd7)).toBe('\\cdot'); // was ×
+    expect(mk(0xe5)).toBe('\\sum'); // was å
+    expect(mk(0xd5)).toBe('\\prod'); // was Õ
+    expect(mk(0xce)).toBe('\\in'); // was Î
+    expect(mk(0xe1)).toBe('\\langle'); // was á
+    expect(mk(0xf1)).toBe('\\rangle'); // was ö
+    expect(mk(0xb6)).toBe('\\partial'); // was ¶
+    expect(mk(0xd1)).toBe('\\nabla'); // was Ñ
+    expect(mk(0xde)).toBe('\\Rightarrow'); // was Þ
+    expect(mk(0xdb)).toBe('\\Leftrightarrow'); // was Û
+    expect(mk(0xa2)).toBe("'"); // was ¢
+    for (const code of [0xf2, 0xd7, 0xe5, 0xd5, 0xce, 0xe1, 0xf1, 0xb6, 0xd1, 0xde, 0xdb, 0xa2]) {
+      const latex = mk(code);
+      expect(() => katex.renderToString(latex, { throwOnError: true })).not.toThrow();
+    }
+  });
+
+  it('MAX_LATEX_LENGTH: 15,000 sibling macro CHARs throw (width case)', () => {
+    const records: number[] = [...FULL, ...LINE];
+    // Each CHAR is 4 bytes; macro commands like \alpha produce ~7 chars of
+    // LaTeX from 4 input bytes — 15k of them exceeds the 64 KiB output cap.
+    for (let i = 0; i < 15_000; i++) records.push(...[0x02, 0x84, 0x61, 0x00]);
+    records.push(...END, ...END);
+    expect(() => equationNativeToLatex(mtefStream(records))).toThrow(
+      'MTEF stream produced oversized LaTeX output',
+    );
+    // A small count passes.
+    const small: number[] = [...FULL, ...LINE];
+    for (let i = 0; i < 100; i++) small.push(...[0x02, 0x84, 0x61, 0x00]);
+    small.push(...END, ...END);
+    expect(() => equationNativeToLatex(mtefStream(small))).not.toThrow();
+  });
+
+  it('MAX_RECORDS: 20,001 sibling CHARs throw', () => {
+    const records: number[] = [...FULL, ...LINE];
+    for (let i = 0; i < 20_001; i++) records.push(...varChar(0x61));
+    records.push(...END, ...END);
+    expect(() => equationNativeToLatex(mtefStream(records))).toThrow('MTEF stream too large');
+  });
+
+  it('embellishment records count against the budget (P3)', () => {
+    // One CHAR with >MAX_RECORDS embellishments.
+    const records: number[] = [...FULL, ...LINE, 0x22, 0x83, 0x61, 0x00]; // CHAR xfEMBELL 'a'
+    for (let i = 0; i < 20_001; i++) records.push(0x06, 0x11); // EMBELL (bar)
+    records.push(0x00, ...END, ...END);
+    expect(() => equationNativeToLatex(mtefStream(records))).toThrow('MTEF stream too large');
+  });
+
+  it('tmDIRAC KaTeX-validity for all variations', () => {
+    for (const v of [0, 1, 2]) {
+      const conv = equationNativeToLatex(
+        mtefStream([
+          ...FULL,
+          ...LINE,
+          0x03,
+          45,
+          v,
+          0,
+          ...LINE,
+          ...varChar(0x61),
+          ...END,
+          ...LINE,
+          ...varChar(0x62),
+          ...END,
+          ...END,
+          ...END,
+          ...END,
+          ...END,
+        ]),
+      );
+      expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+    }
   });
 });

--- a/packages/@openmaic/importer/test/mtef.test.ts
+++ b/packages/@openmaic/importer/test/mtef.test.ts
@@ -213,7 +213,7 @@ describe('mtef · equationNativeToLatex', () => {
 
 describe('mtef · spec-conformance (cross-review round 2)', () => {
   it('BigOp tmSUM(tvBSUM) renders [main, upper, lower] in the right roles', () => {
-    // Slots per spec: main=summand k, upper=n, lower=i=1.
+    // Slots per real streams: [main=k, lower=i=1, upper=n].
     const stream = mtefStream([
       ...FULL,
       ...LINE,
@@ -416,7 +416,7 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
     expect(equationNativeToLatex(over).latex).toBe('\\overline{x}');
   });
 
-  it('fence variations render only the present side', () => {
+  it('fence variations render matched pairs via null delimiters (KaTeX-valid)', () => {
     const leftOnly = mtefStream([
       ...FULL,
       ...LINE,
@@ -431,7 +431,9 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
       ...END,
       ...END,
     ]);
-    expect(equationNativeToLatex(leftOnly).latex).toBe('\\left ( a');
+    const left = equationNativeToLatex(leftOnly);
+    expect(left.latex).toBe('\\left ( a\\right.');
+    expect(() => katex.renderToString(left.latex, { throwOnError: true })).not.toThrow();
     const rightOnly = mtefStream([
       ...FULL,
       ...LINE,
@@ -446,7 +448,28 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
       ...END,
       ...END,
     ]);
-    expect(equationNativeToLatex(rightOnly).latex).toBe('a\\right )');
+    const right = equationNativeToLatex(rightOnly);
+    expect(right.latex).toBe('\\left. a\\right )');
+    expect(() => katex.renderToString(right.latex, { throwOnError: true })).not.toThrow();
+    // tmBRACE var 1 — the legacy piecewise-function brace.
+    const brace = equationNativeToLatex(
+      mtefStream([
+        ...FULL,
+        ...LINE,
+        0x03,
+        2,
+        1,
+        0,
+        ...LINE,
+        ...varChar(0x61),
+        ...END,
+        ...END,
+        ...END,
+        ...END,
+      ]),
+    );
+    expect(brace.latex).toBe('\\left \\{ a\\right.');
+    expect(() => katex.renderToString(brace.latex, { throwOnError: true })).not.toThrow();
   });
 
   it('tmDIRAC renders ⟨left|right⟩ and degrades on a missing right slot', () => {
@@ -472,7 +495,7 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
     expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
   });
 
-  it('tmLSCRIPT(tvLSUB) renders a leading subscript, not superscript', () => {
+  it('tmLSCRIPT emits only the leading scripts; the base is the next sibling', () => {
     const stream = mtefStream([
       ...FULL,
       ...LINE,
@@ -483,19 +506,68 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
       ...LINE,
       ...varChar(0x31),
       ...END,
-      ...LINE_NULL,
       ...END,
       ...varChar(0x53),
       ...END,
       ...END,
     ]);
-    // leading script template + following base char S
-    const conv = equationNativeToLatex(stream);
-    expect(conv.latex).toBe('{}_{1}{}S');
+    expect(equationNativeToLatex(stream).latex).toBe('{}_{1}S');
+    // tvLSUPER with a single emitted slot (no null-sub line): the lone slot
+    // IS the superscript — it must not vanish.
+    const supOnly = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      44,
+      0,
+      0,
+      ...LINE,
+      ...numChar(0x31),
+      ...numChar(0x32),
+      ...END,
+      ...END,
+      ...varChar(0x43),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(supOnly).latex).toBe('{}^{12}C');
+    // A leading script must NOT steal the previous atom as its base.
+    const trail = mtefStream([
+      ...FULL,
+      ...LINE,
+      ...varChar(0x3d),
+      0x03,
+      44,
+      2,
+      0,
+      ...LINE,
+      ...numChar(0x36),
+      ...END,
+      ...LINE,
+      ...numChar(0x31),
+      ...numChar(0x32),
+      ...END,
+      ...END,
+      ...varChar(0x43),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(trail).latex).toBe('={}_{6}^{12}C');
   });
 
-  it('deeply nested fences render in linear time (perf guard)', () => {
-    function nested(depth: number): number[] {
+  it('deeply nested templates render in linear time and bounded size (perf guard)', () => {
+    // Nest the leading-script template inside its own sup slot — the shape
+    // that doubled per level before the base-duplication fix.
+    function nestedScripts(depth: number): number[] {
+      let rec: number[] = [...varChar(0x78)];
+      for (let i = 0; i < depth; i++) {
+        rec = [0x03, 44, 0, 0, ...LINE_NULL, ...LINE, ...rec, ...END, ...END];
+      }
+      return [...FULL, ...LINE, ...rec, ...END, ...END];
+    }
+    const conv = equationNativeToLatex(mtefStream(nestedScripts(90))); // 2 depth levels each, under the 200 cap
+    expect(conv.latex.length).toBeLessThan(2_000);
+    function nestedFences(depth: number): number[] {
       let rec: number[] = [...varChar(0x78)];
       for (let i = 0; i < depth; i++) {
         rec = [0x03, 1, 0, 0, 0x01, ...rec, 0x00, 0x00];
@@ -503,10 +575,8 @@ describe('mtef · spec-conformance (cross-review round 2)', () => {
       return [...FULL, ...LINE, ...rec, ...END, ...END];
     }
     const t0 = Date.now();
-    const conv = equationNativeToLatex(mtefStream(nested(80)));
-    const ms = Date.now() - t0;
-    expect(conv.latex).toContain('x');
-    expect(ms).toBeLessThan(2000);
+    expect(equationNativeToLatex(mtefStream(nestedFences(80))).latex).toContain('x');
+    expect(Date.now() - t0).toBeLessThan(2000);
   });
 
   it('truncated nested list throws instead of silently losing content', () => {
@@ -639,5 +709,119 @@ describe('mtef · round-3 fixes', () => {
       ...END,
     ]);
     expect(equationNativeToLatex(stream).latex).toBe('x');
+  });
+});
+
+describe('mtef · real Equation 3.0 fixtures (round-tripped from a legacy deck)', () => {
+  // Raw `Equation Native` streams from a real 消防 courseware deck
+  // (Equation.3 OLE objects), base64-encoded. These pin the font-local
+  // Symbol encoding and the [main, lower, upper] big-op claims against
+  // bytes a real writer produced.
+  const OLE_A_EQ_A_DOT_B =
+    'HAAAAAIA5sEdAAAAAAAAAFAlGACMMBgAAAAAAAMBAQMKCgESg0EAAoY9ABKDYQAChsUiEoNiAAAA';
+  const OLE_R_PRIME_LE_R =
+    'HAAAAAIA5sGFAAAAAAAAAJDDFwC87hcAAAAAAAMBAQMKCgEyg1IABgUAAAKGPQADDQAAAQMBAAABAw4AAAESg2EAAAECiDIAAAAAApYoAAKWKQAAAw8AAAsRAQKIMgAAAAoChisAAwEAAAEDDgAAARKDYgAAAQKIMgAAAAACligAApYpAAADDwAACxEBAogyAAAAABEACgKGZCISg1IAAAA=';
+  const OLE_2R_PRIME_LE_D_I =
+    'HAAAAAIAycGmAAAAAAAAAPgxFgD0zRUAAAAAAAMBAQMKCgECiDIAMoNSAAYFAAAChj0AAogyAAMNAAABAwEAAAEDDgAAARKDYQAAAQKIMgAAAAACligAApYpAAADDwAACxEBAogyAAAACgKGKwADAQAAAQMOAAABEoNiAAABAogyAAAAAAKWKAAClikAAAMPAAALEQECiDIAAAAAEQAKAoZkIgKIMgASg1IAAoY9ABKDRAADDwEACwESg2kAABEAAAA=';
+
+  function decode(b64: string): Uint8Array {
+    return new Uint8Array(Buffer.from(b64, 'base64'));
+  }
+
+  it('fixture 1: A = a·b (fnSYMBOL = / ⋅ via MTCode)', () => {
+    const conv = equationNativeToLatex(decode(OLE_A_EQ_A_DOT_B));
+    expect(conv.latex).toBe('A=a\\cdot b');
+    expect(conv.degraded).toBe(false);
+  });
+
+  it("fixture 2: R' = √((a/2)²+(b/2)²) ≤ R", () => {
+    const conv = equationNativeToLatex(decode(OLE_R_PRIME_LE_R));
+    expect(conv.latex).toBe(
+      "R'=\\sqrt{\\left ( \\frac{a}{2}\\right ) ^{2}+\\left ( \\frac{b}{2}\\right ) ^{2}}\\le R",
+    );
+    expect(conv.degraded).toBe(false);
+    expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+  });
+
+  it("fixture 3: 2R' = 2√((a/2)²+(b/2)²) ≤ 2R = Dᵢ", () => {
+    const conv = equationNativeToLatex(decode(OLE_2R_PRIME_LE_D_I));
+    expect(conv.latex).toBe(
+      "2R'=2\\sqrt{\\left ( \\frac{a}{2}\\right ) ^{2}+\\left ( \\frac{b}{2}\\right ) ^{2}}\\le 2R=D_{i}",
+    );
+    expect(conv.degraded).toBe(false);
+  });
+});
+
+describe('mtef · review round fixes', () => {
+  it('tmLIM variations map roles correctly (0=upper, 1=lower)', () => {
+    // Single-limit writers emit two slots [main, limit]; the role comes from
+    // the variation, not the position (spec + rtf2latex2e eqn.c).
+    const upperOnly = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      39,
+      0,
+      0, // tmLIM tvULIM
+      ...LINE,
+      ...varChar(0x78),
+      ...END, // main: x
+      ...LINE,
+      ...varChar(0x6e),
+      ...END, // the lone limit
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(upperOnly).latex).toBe('\\lim^{n}x');
+    const lowerOnly = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x03,
+      39,
+      1,
+      0, // tmLIM tvLLIM
+      ...LINE,
+      ...varChar(0x78),
+      ...END,
+      ...LINE,
+      ...varChar(0x6e),
+      ...END,
+      ...END,
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(lowerOnly).latex).toBe('\\lim_{n}x');
+  });
+
+  it('Adobe Symbol operator block maps correctly (≤ × → ∞ ≠)', () => {
+    const conv = mtefStream([
+      ...FULL,
+      ...LINE,
+      0x02,
+      0x86,
+      0xa3,
+      0x00, // fnSYMBOL 0xA3 = ≤
+      ...varChar(0x61),
+      0x02,
+      0x86,
+      0xb4,
+      0x00, // fnSYMBOL 0xB4 = ×
+      ...varChar(0x62),
+      ...END,
+      ...END,
+    ]);
+    expect(equationNativeToLatex(conv).latex).toBe('\\le a\\times b');
+  });
+
+  it('nesting depth cap throws MtefParseError instead of RangeError', () => {
+    function nestedFences(depth: number): number[] {
+      let rec: number[] = [...varChar(0x78)];
+      for (let i = 0; i < depth; i++) {
+        rec = [0x03, 1, 0, 0, 0x01, ...rec, 0x00, 0x00];
+      }
+      return [...FULL, ...LINE, ...rec, ...END, ...END];
+    }
+    expect(() => equationNativeToLatex(mtefStream(nestedFences(500)))).toThrow(MtefParseError);
   });
 });

--- a/packages/@openmaic/importer/test/mtef.test.ts
+++ b/packages/@openmaic/importer/test/mtef.test.ts
@@ -212,7 +212,7 @@ describe('mtef · equationNativeToLatex', () => {
 });
 
 describe('mtef · spec-conformance (cross-review round 2)', () => {
-  it('BigOp tmSUM(tvBSUM) renders [main, upper, lower] in the right roles', () => {
+  it('BigOp tmSUM(tvBSUM) renders [main, lower, upper] in the right roles', () => {
     // Slots: [main=k, lower=i=1, upper=n] per real streams + eqn.c.
     const stream = mtefStream([
       ...FULL,
@@ -997,6 +997,28 @@ describe('mtef · round-6 fixes (wyuc review 2)', () => {
           ...END,
         ]),
       );
+      expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
+    }
+  });
+});
+
+describe('Symbol-font glyphs that once produced invalid or misleading LaTeX', () => {
+  it('renders 0xD6 (radical) as a standalone \\surd and 0xF3 (integraltp) as \\int, both KaTeX-valid', () => {
+    const sym = (code: number) => [0x02, 0x86, code, 0x00];
+    const chr = (code: number) => [0x02, 0x83, code, 0x00];
+    const stream = (records: number[]) => {
+      const hdr = new Uint8Array(28);
+      new DataView(hdr.buffer).setUint16(0, 0x1c, true);
+      return new Uint8Array([...hdr, 0x03, 0x01, 0x01, 0x03, 0x0a, ...records]);
+    };
+    for (const [records, expected] of [
+      [[0x0a, 0x01, ...sym(0xd6), 0x00, 0x00], '\\surd'],
+      [[0x0a, 0x01, ...chr(0x61), ...sym(0xd6), ...chr(0x62), 0x00, 0x00], 'a\\surd b'],
+      [[0x0a, 0x01, ...chr(0x61), ...sym(0xf3), ...chr(0x62), 0x00, 0x00], 'a\\int b'],
+    ] as [number[], string][]) {
+      const conv = equationNativeToLatex(stream(records));
+      expect(conv.latex).toBe(expected);
+      expect(conv.degraded).toBe(false);
       expect(() => katex.renderToString(conv.latex, { throwOnError: true })).not.toThrow();
     }
   });

--- a/packages/@openmaic/importer/test/transformParsedToSlides.warnings.test.ts
+++ b/packages/@openmaic/importer/test/transformParsedToSlides.warnings.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import { transformParsedToSlides } from '../src/import-pipeline/transformParsedToSlides';
+import { createMockImportContext } from '../src/import-pipeline/mockContext';
+import type { ImportWarning } from '../src/import-pipeline/types';
+
+const LEGACY_RED_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const REAL_IMAGE_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+interface FixtureElement {
+  type: string;
+  [key: string]: unknown;
+}
+
+function buildJson(
+  elements: FixtureElement[],
+  fill: Record<string, unknown> = { type: 'color', value: '#ffffff' },
+) {
+  return {
+    size: { width: 960, height: 540 },
+    themeColors: [],
+    slides: [
+      {
+        fill,
+        note: '',
+        layoutElements: [],
+        elements,
+      },
+    ],
+  };
+}
+
+function baseImageElement(overrides: Record<string, unknown> = {}): FixtureElement {
+  return {
+    type: 'image',
+    left: 10,
+    top: 20,
+    width: 100,
+    height: 50,
+    name: '公式',
+    order: 1,
+    src: LEGACY_RED_PLACEHOLDER,
+    rotate: 0,
+    isFlipH: false,
+    isFlipV: false,
+    ...overrides,
+  };
+}
+
+function mathElement(overrides: Record<string, unknown> = {}): FixtureElement {
+  return {
+    type: 'math',
+    left: 30,
+    top: 40,
+    width: 200,
+    height: 40,
+    order: 1,
+    latex: '',
+    picBase64: LEGACY_RED_PLACEHOLDER,
+    ...overrides,
+  };
+}
+
+async function run(json: unknown) {
+  const warnings: ImportWarning[] = [];
+  const { slides } = await transformParsedToSlides(
+    json as unknown as Parameters<typeof transformParsedToSlides>[0],
+    createMockImportContext({
+      viewportWidth: 1280,
+      onWarning: (w) => warnings.push(w),
+    }),
+  );
+  return { slides, warnings };
+}
+
+describe('transformParsedToSlides · degrade warnings', () => {
+  it('warns media-unconvertible for an image element whose src is the placeholder', async () => {
+    const { slides, warnings } = await run(buildJson([baseImageElement()]));
+    expect(warnings).toEqual([
+      expect.objectContaining({ code: 'media-unconvertible', slideIndex: 0 }),
+    ]);
+    // Upstream does not strip the element — consumers decide via the warning.
+    expect(slides[0].elements.filter((e) => e.type === 'image')).toHaveLength(1);
+  });
+
+  it('does not warn for a real image src', async () => {
+    const { warnings } = await run(buildJson([baseImageElement({ src: REAL_IMAGE_DATA_URL })]));
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps formula plain text when the fallback picture is unconvertible', async () => {
+    const { slides, warnings } = await run(buildJson([mathElement({ text: 'A=a·b' })]));
+    const types = slides[0].elements.map((e) => e.type);
+    expect(types).toContain('text');
+    expect(types).not.toContain('image');
+    const text = slides[0].elements.find((e) => e.type === 'text') as { content: string };
+    expect(text.content).toContain('A=a·b');
+    expect(warnings).toEqual([
+      expect.objectContaining({ code: 'formula-fallback-image', slideIndex: 0 }),
+    ]);
+  });
+
+  it('falls back to the image element (with warning) when no plain text survives', async () => {
+    const { slides, warnings } = await run(buildJson([mathElement({ text: undefined })]));
+    expect(slides[0].elements.map((e) => e.type)).toEqual(['image']);
+    expect(warnings).toEqual([
+      expect.objectContaining({ code: 'formula-fallback-image', slideIndex: 0 }),
+    ]);
+  });
+
+  it('prefers the real fallback picture over plain text when it carries pixels', async () => {
+    const { slides, warnings } = await run(
+      buildJson([mathElement({ text: 'A=a·b', picBase64: REAL_IMAGE_DATA_URL })]),
+    );
+    expect(slides[0].elements.map((e) => e.type)).toEqual(['image']);
+    expect(warnings).toEqual([expect.objectContaining({ code: 'formula-fallback-image' })]);
+  });
+
+  it('warns media-unconvertible for a placeholder background image', async () => {
+    const { warnings } = await run(
+      buildJson([], { type: 'image', value: { picBase64: LEGACY_RED_PLACEHOLDER } }),
+    );
+    expect(warnings).toEqual([
+      expect.objectContaining({ code: 'media-unconvertible', slideIndex: 0 }),
+    ]);
+  });
+
+  it('warns media-unconvertible for a shape image-fill pattern placeholder', async () => {
+    const { warnings } = await run(
+      buildJson([
+        {
+          type: 'shape',
+          left: 10,
+          top: 10,
+          width: 100,
+          height: 100,
+          order: 1,
+          rotate: 0,
+          content: '<div><p>x</p></div>',
+          fill: { type: 'image', value: { picBase64: LEGACY_RED_PLACEHOLDER, opacity: 1 } },
+          borderWidth: 0,
+          borderColor: '#000',
+          borderType: 'solid',
+          borderStrokeDasharray: '0',
+          vAlign: 'mid',
+        },
+      ]),
+    );
+    expect(warnings).toEqual([
+      expect.objectContaining({ code: 'media-unconvertible', slideIndex: 0 }),
+    ]);
+  });
+
+  it('stays silent when no onWarning sink is wired', async () => {
+    const { slides } = await transformParsedToSlides(
+      buildJson([baseImageElement()]) as unknown as Parameters<typeof transformParsedToSlides>[0],
+      createMockImportContext({ viewportWidth: 1280 }),
+    );
+    expect(slides[0].elements.filter((e) => e.type === 'image')).toHaveLength(1);
+  });
+});
+
+describe('transformParsedToSlides · degraded formulas & sink isolation', () => {
+  it('emits formula-degraded when an MTEF conversion was approximated', async () => {
+    const json = buildJson([
+      mathElement({
+        latex: 'x',
+        text: undefined,
+        degraded: true,
+      } as never),
+    ]);
+    const { slides, warnings } = await run(json);
+    // KaTeX succeeds on 'x' → latex element + approximation warning.
+    expect(slides[0].elements.map((e) => e.type)).toEqual(['latex']);
+    expect(warnings).toEqual([
+      expect.objectContaining({ code: 'formula-degraded', slideIndex: 0 }),
+    ]);
+  });
+
+  it('a throwing onWarning sink never fails the import', async () => {
+    const warnings: ImportWarning[] = [];
+    const { slides } = await transformParsedToSlides(
+      buildJson([baseImageElement()]) as unknown as Parameters<typeof transformParsedToSlides>[0],
+      createMockImportContext({
+        viewportWidth: 1280,
+        onWarning: (w) => {
+          warnings.push(w);
+          throw new Error('sink exploded');
+        },
+      }),
+    );
+    expect(slides[0].elements.filter((e) => e.type === 'image')).toHaveLength(1);
+    expect(warnings).toHaveLength(1); // the call happened, the throw was swallowed
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,6 +650,9 @@ importers:
       '@xmldom/xmldom':
         specifier: ^0.9.9
         version: 0.9.10
+      cfb:
+        specifier: 1.2.2
+        version: 1.2.2
       jpegxr:
         specifier: ^0.3.0
         version: 0.3.0
@@ -6098,6 +6101,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   adm-zip@0.5.18:
     resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
     engines: {node: '>=12.0'}
@@ -6650,6 +6657,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -6989,6 +7000,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   create-ecdh@4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
@@ -19217,6 +19233,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   adm-zip@0.5.18: {}
 
   agent-base@7.1.4: {}
@@ -19872,6 +19890,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   chalk@1.1.3:
@@ -20209,6 +20232,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  crc-32@1.2.2: {}
 
   create-ecdh@4.0.4:
     dependencies:
@@ -21084,8 +21109,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.11
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -21107,7 +21132,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -21118,21 +21143,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21143,7 +21168,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21109,8 +21109,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.11
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -21132,7 +21132,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -21143,21 +21143,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21168,7 +21168,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Problem

Legacy courseware stores formulas as Equation 3.0 / MathType OLE objects. Their only renderable form inside the .pptx is a WMF preview picture, which the importer cannot rasterize. Those formulas degraded to a hardcoded 1×1 **`TRANSPARENT_PNG_DATA_URL`** — actually a 50%-alpha red pixel (RGB 255,0,0 α=127) despite the name — rendered as a pink block once stretched over the formula frame, with no way for callers to notice the content loss.

## Changes

1. **Equation.3 / MathType OLE → LaTeX** (new `utils/mtef.ts`): detect the progId, resolve the embedding, parse the OLE compound file (`cfb`), convert its `Equation Native` MTEF v3 stream — fractions, radicals, scripts, fences, big operators with per-family limit variations, embellishments, Symbol-font local character encodings (table verified against URW StandardSymbolsPS AFM + Adobe AGL). Slot orders follow the rtf2latex2e reference implementation and real MathType streams (`[main, lower, upper]`; tmLSCRIPT base = following sibling; tmLIM 0=upper/1=lower), not the archived spec prose. Hardening: 200-deep nesting cap and 64 KiB output cap, both failing loud as `MtefParseError`. Any failure falls back to the existing picture path.
2. **Placeholder fixed**: truly transparent pixel; the legacy red one stays recognized (`isPlaceholderDataUrl` exported).
3. **Degrade telemetry**: optional `ImportPptxOptions.onWarning` receives machine-coded warnings (`media-unconvertible` / `formula-fallback-image` / `formula-degraded` / `element-dropped`) at every placeholder consumption point (image, background, shape/text pattern fills, math fallback, video poster). A throwing sink is isolated so telemetry can never fail an import. A formula whose fallback picture is also a placeholder keeps its plain text as a text element.

## Testing

- **37 new tests** (suite: 85). Highlights: three REAL `Equation Native` stream fixtures round-tripped from a legacy deck (pinning the font-local Symbol encoding and the big-operator slot order); spec-conformance synthetic streams incl. one-sided fences asserted against KaTeX `throwOnError`; script-nesting perf guard (linear, bounded); truncation/depth-cap/`MtefParseError` contract; warning emission and sink isolation.
- Fuzz: 8k random payloads behind a valid v3 header — all rejected as `MtefParseError`, zero other exception types, zero bogus LaTeX.
- End-to-end on a real Equation 3.0 deck: 4 formulas → 4 KaTeX-renderable latex elements, 0 placeholders, 0 warnings; real raster images unaffected.

Review round 1 (thanks @wyuc) findings all addressed in 97909e64 — LSCRIPT base duplication, one-sided fence null delimiters, the Symbol table corrected against the AFM, tmLIM role inversion, depth/output caps.

Version: **0.1.4 → 0.2.0** (new public option/type/export + `Math.degraded` field).

Reviewers please focus on `utils/mtef.ts` (binary grammar) and the warning plumbing in `import-pipeline/`.