### PR TITLE
fix(ssrf): keep cloud metadata endpoints blocked under ALLOW_LOCAL_NETWORKS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -459,7 +459,10 @@ DEFAULT_MODEL=
 
 # --- Local/Self-hosted Deployment ---------------------------------------------
 # Set to "true" to allow private/local network URLs (e.g. localhost, 192.168.x.x).
-# Required for self-hosted models like Ollama. Do NOT enable on public deployments.
+# Required for self-hosted models like Ollama. This flag never unblocks cloud
+# instance metadata endpoints (169.254.169.254, 100.100.100.200, fd00:ec2::254,
+# metadata.google.internal): those stay blocked even when it is enabled. Do NOT
+# enable on public deployments.
 # ALLOW_LOCAL_NETWORKS=true
 
 # Build-time, space-separated CSP frame-ancestor sources in addition to 'self'.

--- a/.env.example
+++ b/.env.example
@@ -462,9 +462,10 @@ DEFAULT_MODEL=
 # Required for self-hosted models like Ollama. Do NOT enable on public deployments.
 # The known cloud instance-metadata and credential endpoints (169.254.169.254,
 # 169.254.170.2, 169.254.170.23, 100.100.100.200, 168.63.129.16, 192.0.0.192,
-# fd00:ec2::254, fd00:ec2::23, metadata.google.internal) stay blocked even with
-# this flag. That is a fixed address list, not a general link-local block, and a
-# hostname whose DNS lookup fails or times out is still allowed through.
+# fd00:ec2::254, fd00:ec2::23, metadata.google.internal) are blocked with or
+# without this flag. That is a fixed address list, not a general link-local
+# block, and under the flag a hostname whose DNS lookup fails, times out or
+# returns no answer is still allowed through.
 # ALLOW_LOCAL_NETWORKS=true
 
 # Build-time, space-separated CSP frame-ancestor sources in addition to 'self'.

--- a/.env.example
+++ b/.env.example
@@ -459,10 +459,12 @@ DEFAULT_MODEL=
 
 # --- Local/Self-hosted Deployment ---------------------------------------------
 # Set to "true" to allow private/local network URLs (e.g. localhost, 192.168.x.x).
-# Required for self-hosted models like Ollama. This flag never unblocks cloud
-# instance metadata endpoints (169.254.169.254, 100.100.100.200, fd00:ec2::254,
-# metadata.google.internal): those stay blocked even when it is enabled. Do NOT
-# enable on public deployments.
+# Required for self-hosted models like Ollama. Do NOT enable on public deployments.
+# The known cloud instance-metadata and credential endpoints (169.254.169.254,
+# 169.254.170.2, 169.254.170.23, 100.100.100.200, 168.63.129.16, 192.0.0.192,
+# fd00:ec2::254, fd00:ec2::23, metadata.google.internal) stay blocked even with
+# this flag. That is a fixed address list, not a general link-local block, and a
+# hostname whose DNS lookup fails or times out is still allowed through.
 # ALLOW_LOCAL_NETWORKS=true
 
 # Build-time, space-separated CSP frame-ancestor sources in addition to 'self'.

--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -9,7 +9,22 @@ import { isIP } from 'node:net';
 import ipaddr from 'ipaddr.js';
 
 const CLOUD_METADATA_HOSTNAMES = new Set(['metadata.google.internal']);
-const CLOUD_METADATA_ADDRESSES = new Set(['169.254.169.254', '100.100.100.200', 'fd00:ec2::254']);
+// Instance metadata and credential endpoints. A fixed list, not a general
+// link-local block: AWS/Azure/GCP/OCI/DigitalOcean/Hetzner/OpenStack IMDS,
+// AWS ECS task credentials, EKS Pod Identity, AWS IMDS over IPv6, Alibaba
+// Cloud metadata, Azure WireServer and the legacy OCI IMDS address.
+const CLOUD_METADATA_ADDRESSES = new Set([
+  '169.254.169.254',
+  '169.254.170.2',
+  '169.254.170.23',
+  'fd00:ec2::254',
+  'fd00:ec2::23',
+  '100.100.100.200',
+  '168.63.129.16',
+  '192.0.0.192',
+]);
+/** Upper bound on the DNS lookup done under ALLOW_LOCAL_NETWORKS; on expiry the target is allowed. */
+const ALLOW_LOCAL_DNS_TIMEOUT_MS = 3_000;
 
 export class UnsafeNetworkTargetError extends Error {
   constructor(message: string) {
@@ -45,10 +60,55 @@ function canonicalizeIp(value: string): string | null {
   return address.toString().toLowerCase();
 }
 
-/** True when an IP literal (URL host or DNS answer) is a cloud metadata address. */
+/**
+ * IPv4 addresses carried inside an IPv6 literal by a transition mechanism:
+ * 6to4 (2002::/16), Teredo (2001:0::/32, XOR-inverted), ISATAP interface
+ * identifiers and NAT64 (64:ff9b::/96). Empty when none applies.
+ */
+function tunnelEmbeddedIPv4(normalized: string): string[] {
+  const hextets = expandIPv6(normalized);
+  if (!hextets) return [];
+  const dotted = (high: number, low: number) =>
+    `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+  const embedded: string[] = [];
+  if (hextets[0] === 0x2002) embedded.push(dotted(hextets[1], hextets[2]));
+  if (hextets[0] === 0x2001 && hextets[1] === 0x0000) {
+    embedded.push(dotted(hextets[6] ^ 0xffff, hextets[7] ^ 0xffff));
+  }
+  if ((hextets[4] === 0x0000 || hextets[4] === 0x0200) && hextets[5] === 0x5efe) {
+    embedded.push(dotted(hextets[6], hextets[7]));
+  }
+  if (hextets[0] === 0x0064 && hextets[1] === 0xff9b && hextets.slice(2, 6).every((h) => h === 0)) {
+    embedded.push(dotted(hextets[6], hextets[7]));
+  }
+  return embedded;
+}
+
+/**
+ * True when an IP literal (URL host or DNS answer) is a cloud metadata address,
+ * directly, as IPv4-mapped IPv6, or embedded through a tunnel prefix.
+ */
 function isCloudMetadataAddress(value: string): boolean {
   const canonical = canonicalizeIp(value);
-  return canonical !== null && CLOUD_METADATA_ADDRESSES.has(canonical);
+  if (canonical === null) return false;
+  if (CLOUD_METADATA_ADDRESSES.has(canonical)) return true;
+  return tunnelEmbeddedIPv4(canonical).some((embedded) => CLOUD_METADATA_ADDRESSES.has(embedded));
+}
+
+/** dns.lookup bounded by a timer; resolves to null on timeout so the caller decides. */
+async function lookupWithTimeout(
+  hostname: string,
+  timeoutMs: number,
+): Promise<Array<{ address: string; family: number }> | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+  });
+  try {
+    return await Promise.race([dns.lookup(hostname, { all: true, verbatim: true }), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**
@@ -298,18 +358,18 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
     if (isIP(hostname)) {
       return null;
     }
-    // Non-IP hostname: fail open when DNS errors or returns nothing (split-horizon
-    // DNS is an explicit flag use case), but never when an answer is metadata.
-    let resolvedAddresses: Array<{ address: string; family: number }>;
+    // Non-IP hostname: fail open when DNS errors, times out or returns nothing
+    // (split-horizon DNS is an explicit flag use case), but never when an
+    // answer is a metadata address. This is a best-effort check against
+    // misconfiguration, not a defence against DNS rebinding: the provider
+    // fetch resolves the name again.
+    let resolvedAddresses: Array<{ address: string; family: number }> | null;
     try {
-      resolvedAddresses = await dns.lookup(hostname, { all: true, verbatim: true });
+      resolvedAddresses = await lookupWithTimeout(hostname, ALLOW_LOCAL_DNS_TIMEOUT_MS);
     } catch {
       return null;
     }
-    if (
-      resolvedAddresses.length > 0 &&
-      resolvedAddresses.some(({ address }) => isCloudMetadataAddress(address))
-    ) {
+    if (resolvedAddresses?.some(({ address }) => isCloudMetadataAddress(address))) {
       return CLOUD_METADATA_BLOCK_MESSAGE;
     }
     return null;

--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -121,7 +121,7 @@ export function assertSafeIp(value: string): void {
     throw new UnsafeNetworkTargetError(`Unable to classify network address: ${value}`);
   }
   if (
-    CLOUD_METADATA_ADDRESSES.has(canonical) ||
+    isCloudMetadataAddress(canonical) ||
     isPrivateIP(canonical) ||
     ipaddr.parse(canonical).range() !== 'unicast'
   ) {
@@ -291,31 +291,10 @@ export function isPrivateIP(ip: string): boolean {
     return true;
   }
 
-  // 6to4 tunnel: 2002::/16 — embedded IPv4 sits in bits 16-47
-  if (ipv6FirstHextet === 0x2002) {
-    const hextets = expandIPv6(normalized);
-    if (hextets) {
-      const embedded = `${hextets[1] >> 8}.${hextets[1] & 0xff}.${hextets[2] >> 8}.${hextets[2] & 0xff}`;
-      if (isPrivateIP(embedded)) return true;
-    }
-  }
-
-  // Teredo tunnel: 2001:0000::/32 — client IPv4 in last 32 bits, XOR-inverted
-  if (ipv6FirstHextet === 0x2001) {
-    const hextets = expandIPv6(normalized);
-    if (hextets && hextets[1] === 0x0000) {
-      const high = hextets[6] ^ 0xffff;
-      const low = hextets[7] ^ 0xffff;
-      const embedded = `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
-      if (isPrivateIP(embedded)) return true;
-    }
-  }
-
-  // ISATAP interface ID: 0000:5efe:<IPv4> or 0200:5efe:<IPv4>
-  const hextets = expandIPv6(normalized);
-  if (hextets && (hextets[4] === 0x0000 || hextets[4] === 0x0200) && hextets[5] === 0x5efe) {
-    const embedded = `${hextets[6] >> 8}.${hextets[6] & 0xff}.${hextets[7] >> 8}.${hextets[7] & 0xff}`;
-    if (isPrivateIP(embedded)) return true;
+  // Transition mechanisms (6to4, Teredo, ISATAP, NAT64) carry an IPv4
+  // address inside the IPv6 literal; classify by the embedded address.
+  if (tunnelEmbeddedIPv4(normalized).some((embedded) => isPrivateIP(embedded))) {
+    return true;
   }
 
   return false;

--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -27,25 +27,43 @@ function normalizeAddress(value: string): string {
 }
 
 /**
- * Assert that a connection address is globally routable unicast.
- * IPv4-mapped IPv6 is classified as IPv4 so ::ffff:127.0.0.1 cannot hide.
+ * Canonical textual form of an IP literal, unwrapping IPv4-mapped IPv6 so that
+ * `::ffff:169.254.169.254` compares equal to `169.254.169.254`. Returns null
+ * when the value is not a parseable IP literal.
  */
-export function assertSafeIp(value: string): void {
+function canonicalizeIp(value: string): string | null {
   const normalized = normalizeAddress(value);
   let address: ipaddr.IPv4 | ipaddr.IPv6;
   try {
     address = ipaddr.parse(normalized);
   } catch {
-    throw new UnsafeNetworkTargetError(`Unable to classify network address: ${value}`);
+    return null;
   }
   if (address.kind() === 'ipv6' && (address as ipaddr.IPv6).isIPv4MappedAddress()) {
     address = (address as ipaddr.IPv6).toIPv4Address();
   }
-  const canonical = address.toString().toLowerCase();
+  return address.toString().toLowerCase();
+}
+
+/** True when an IP literal (URL host or DNS answer) is a cloud metadata address. */
+function isCloudMetadataAddress(value: string): boolean {
+  const canonical = canonicalizeIp(value);
+  return canonical !== null && CLOUD_METADATA_ADDRESSES.has(canonical);
+}
+
+/**
+ * Assert that a connection address is globally routable unicast.
+ * IPv4-mapped IPv6 is classified as IPv4 so ::ffff:127.0.0.1 cannot hide.
+ */
+export function assertSafeIp(value: string): void {
+  const canonical = canonicalizeIp(value);
+  if (canonical === null) {
+    throw new UnsafeNetworkTargetError(`Unable to classify network address: ${value}`);
+  }
   if (
     CLOUD_METADATA_ADDRESSES.has(canonical) ||
     isPrivateIP(canonical) ||
-    address.range() !== 'unicast'
+    ipaddr.parse(canonical).range() !== 'unicast'
   ) {
     throw new UnsafeNetworkTargetError('Local/private/reserved network URLs are not allowed');
   }
@@ -243,6 +261,9 @@ export function isPrivateIP(ip: string): boolean {
   return false;
 }
 
+const CLOUD_METADATA_BLOCK_MESSAGE =
+  'Cloud instance metadata endpoints are never allowed as outbound targets, even with ALLOW_LOCAL_NETWORKS=true.';
+
 const LOCAL_NETWORK_BLOCK_MESSAGE =
   'Local/private network URLs are not allowed. If this is a self-hosted deployment or internal gateway (including split-horizon DNS), set ALLOW_LOCAL_NETWORKS=true to allow local network targets.';
 
@@ -262,13 +283,38 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
     return 'Only HTTP(S) URLs are allowed';
   }
 
-  // Self-hosted deployments can set ALLOW_LOCAL_NETWORKS=true to skip private-IP checks
-  const allowLocal = process.env.ALLOW_LOCAL_NETWORKS;
-  if (allowLocal === 'true' || allowLocal === '1') {
+  // Self-hosted deployments can set ALLOW_LOCAL_NETWORKS=true to skip private-IP
+  // checks. Cloud instance metadata endpoints stay blocked either way.
+  const allowLocal =
+    process.env.ALLOW_LOCAL_NETWORKS === 'true' || process.env.ALLOW_LOCAL_NETWORKS === '1';
+  const hostname = normalizeAddress(parsed.hostname);
+
+  if (allowLocal) {
+    // The flag is for loopback/RFC1918/.local targets (local Ollama, compose
+    // networks, split-horizon DNS). Cloud metadata endpoints are never allowed.
+    if (CLOUD_METADATA_HOSTNAMES.has(hostname) || isCloudMetadataAddress(hostname)) {
+      return CLOUD_METADATA_BLOCK_MESSAGE;
+    }
+    if (isIP(hostname)) {
+      return null;
+    }
+    // Non-IP hostname: fail open when DNS errors or returns nothing (split-horizon
+    // DNS is an explicit flag use case), but never when an answer is metadata.
+    let resolvedAddresses: Array<{ address: string; family: number }>;
+    try {
+      resolvedAddresses = await dns.lookup(hostname, { all: true, verbatim: true });
+    } catch {
+      return null;
+    }
+    if (
+      resolvedAddresses.length > 0 &&
+      resolvedAddresses.some(({ address }) => isCloudMetadataAddress(address))
+    ) {
+      return CLOUD_METADATA_BLOCK_MESSAGE;
+    }
     return null;
   }
 
-  const hostname = normalizeAddress(parsed.hostname);
   if (
     hostname === 'localhost' ||
     hostname.endsWith('.local') ||
@@ -280,6 +326,11 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
   }
 
   if (isIP(hostname)) {
+    // Metadata addresses that are not RFC1918/link-local (e.g. 100.100.100.200)
+    // are caught here; the private ones were rejected just above.
+    if (isCloudMetadataAddress(hostname)) {
+      return CLOUD_METADATA_BLOCK_MESSAGE;
+    }
     return null;
   }
 
@@ -292,6 +343,10 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
 
   if (resolvedAddresses.length === 0) {
     return 'Unable to verify hostname safety';
+  }
+
+  if (resolvedAddresses.some(({ address }) => isCloudMetadataAddress(address))) {
+    return CLOUD_METADATA_BLOCK_MESSAGE;
   }
 
   if (resolvedAddresses.some(({ address }) => isPrivateIP(address))) {

--- a/lib/server/ssrf-guard.ts
+++ b/lib/server/ssrf-guard.ts
@@ -328,12 +328,14 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
     process.env.ALLOW_LOCAL_NETWORKS === 'true' || process.env.ALLOW_LOCAL_NETWORKS === '1';
   const hostname = normalizeAddress(parsed.hostname);
 
+  // Cloud metadata endpoints are never allowed, with or without the flag.
+  if (CLOUD_METADATA_HOSTNAMES.has(hostname) || isCloudMetadataAddress(hostname)) {
+    return CLOUD_METADATA_BLOCK_MESSAGE;
+  }
+
   if (allowLocal) {
     // The flag is for loopback/RFC1918/.local targets (local Ollama, compose
-    // networks, split-horizon DNS). Cloud metadata endpoints are never allowed.
-    if (CLOUD_METADATA_HOSTNAMES.has(hostname) || isCloudMetadataAddress(hostname)) {
-      return CLOUD_METADATA_BLOCK_MESSAGE;
-    }
+    // networks, split-horizon DNS).
     if (isIP(hostname)) {
       return null;
     }
@@ -365,11 +367,6 @@ export async function validateUrlForSSRF(url: string): Promise<string | null> {
   }
 
   if (isIP(hostname)) {
-    // Metadata addresses that are not RFC1918/link-local (e.g. 100.100.100.200)
-    // are caught here; the private ones were rejected just above.
-    if (isCloudMetadataAddress(hostname)) {
-      return CLOUD_METADATA_BLOCK_MESSAGE;
-    }
     return null;
   }
 

--- a/tests/document/extract-document-route.test.ts
+++ b/tests/document/extract-document-route.test.ts
@@ -508,7 +508,7 @@ describe('POST /api/extract-document (asset-id form)', () => {
       fileName: 'lesson.pdf',
       mimeType: 'application/pdf',
       providerId: 'mineru-cloud',
-      baseUrl: 'http://169.254.169.254/latest/meta-data/',
+      baseUrl: 'http://192.168.1.10/v1/',
     });
     const json = await res.json();
 
@@ -517,7 +517,7 @@ describe('POST /api/extract-document (asset-id form)', () => {
     expect(mocks.parseWithMinerUCloud).toHaveBeenCalledWith(
       expect.objectContaining({
         providerId: 'mineru-cloud',
-        baseUrl: 'http://169.254.169.254/latest/meta-data/',
+        baseUrl: 'http://192.168.1.10/v1/',
       }),
       expect.any(Buffer),
       'lesson.pdf',

--- a/tests/document/extract-document-route.test.ts
+++ b/tests/document/extract-document-route.test.ts
@@ -468,7 +468,7 @@ describe('POST /api/extract-document (asset-id form)', () => {
     expect(mocks.resolveServerAsset).not.toHaveBeenCalled();
   });
 
-  it('rejects a client-supplied JSON path baseUrl pointing at a metadata address in any environment', async () => {
+  it('rejects a client-supplied JSON path baseUrl pointing at a private address in any environment', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('ALLOW_LOCAL_NETWORKS', 'false');
     mocks.resolveServerAsset.mockResolvedValue({
@@ -482,7 +482,7 @@ describe('POST /api/extract-document (asset-id form)', () => {
       fileName: 'lesson.pdf',
       mimeType: 'application/pdf',
       providerId: 'mineru-cloud',
-      baseUrl: 'http://169.254.169.254/latest/meta-data/',
+      baseUrl: 'http://192.168.1.10/v1/',
     });
     const json = await res.json();
 

--- a/tests/server/generate-image-unconditional-url-guard.test.ts
+++ b/tests/server/generate-image-unconditional-url-guard.test.ts
@@ -64,7 +64,7 @@ describe('generate image — client-supplied base URL guard applies in every env
     mocks.generateImage.mockResolvedValue({ url: 'https://example.com/img.png' });
   });
 
-  it('rejects a metadata-address base URL when NODE_ENV is not production', async () => {
+  it('rejects a private-network base URL when NODE_ENV is not production', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     const { POST } = await import('@/app/api/generate/image/route');
 
@@ -73,7 +73,7 @@ describe('generate image — client-supplied base URL guard applies in every env
         'x-image-provider': 'openai-image',
         'x-api-key': 'client-key',
         'x-image-model': 'gpt-image-2',
-        'x-base-url': 'http://169.254.169.254/latest/meta-data/',
+        'x-base-url': 'http://192.168.1.10/v1/',
       }),
     );
     const json = await res.json();

--- a/tests/server/generate-image-unconditional-url-guard.test.ts
+++ b/tests/server/generate-image-unconditional-url-guard.test.ts
@@ -83,7 +83,7 @@ describe('generate image — client-supplied base URL guard applies in every env
     expect(mocks.generateImage).not.toHaveBeenCalled();
   });
 
-  it('still allows the same local base URL when ALLOW_LOCAL_NETWORKS=true', async () => {
+  it('still allows a private-network base URL when ALLOW_LOCAL_NETWORKS=true', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('ALLOW_LOCAL_NETWORKS', 'true');
     const { POST } = await import('@/app/api/generate/image/route');
@@ -93,7 +93,7 @@ describe('generate image — client-supplied base URL guard applies in every env
         'x-image-provider': 'openai-image',
         'x-api-key': 'client-key',
         'x-image-model': 'gpt-image-2',
-        'x-base-url': 'http://169.254.169.254/latest/meta-data/',
+        'x-base-url': 'http://192.168.1.10/v1/',
       }),
     );
 
@@ -102,7 +102,7 @@ describe('generate image — client-supplied base URL guard applies in every env
       expect.objectContaining({
         providerId: 'openai-image',
         model: 'gpt-image-2',
-        baseUrl: 'http://169.254.169.254/latest/meta-data/',
+        baseUrl: 'http://192.168.1.10/v1/',
       }),
       expect.anything(),
     );

--- a/tests/server/resolve-model-url-guard.test.ts
+++ b/tests/server/resolve-model-url-guard.test.ts
@@ -39,7 +39,7 @@ describe('resolveModel — client-supplied base URL guard applies in every envir
     mocks.serverManaged = false;
   });
 
-  it('rejects a metadata-address base URL when NODE_ENV is not production', async () => {
+  it('rejects a private-network base URL when NODE_ENV is not production', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     const { resolveModel } = await import('@/lib/server/resolve-model');
 
@@ -47,7 +47,7 @@ describe('resolveModel — client-supplied base URL guard applies in every envir
       resolveModel({
         modelString: 'openai:gpt-5.4-mini',
         apiKey: 'client-key',
-        baseUrl: 'http://169.254.169.254/latest/meta-data/',
+        baseUrl: 'http://192.168.1.10/v1/',
       }),
     ).rejects.toThrow(/Local\/private network URLs are not allowed/);
     expect(mocks.getModelCalls).toHaveLength(0);

--- a/tests/server/resolve-model-url-guard.test.ts
+++ b/tests/server/resolve-model-url-guard.test.ts
@@ -53,7 +53,7 @@ describe('resolveModel — client-supplied base URL guard applies in every envir
     expect(mocks.getModelCalls).toHaveLength(0);
   });
 
-  it('still allows the same local base URL when ALLOW_LOCAL_NETWORKS=true', async () => {
+  it('still allows a private-network base URL when ALLOW_LOCAL_NETWORKS=true', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('ALLOW_LOCAL_NETWORKS', 'true');
     const { resolveModel } = await import('@/lib/server/resolve-model');
@@ -61,12 +61,12 @@ describe('resolveModel — client-supplied base URL guard applies in every envir
     const result = await resolveModel({
       modelString: 'openai:gpt-5.4-mini',
       apiKey: 'client-key',
-      baseUrl: 'http://169.254.169.254/latest/meta-data/',
+      baseUrl: 'http://192.168.1.10/v1/',
     });
 
     expect(result.modelId).toBe('gpt-5.4-mini');
     expect(mocks.getModelCalls.at(-1)).toMatchObject({
-      baseUrl: 'http://169.254.169.254/latest/meta-data/',
+      baseUrl: 'http://192.168.1.10/v1/',
     });
   });
 });

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -283,6 +283,11 @@ describe('validateUrlForSSRF', () => {
       'http://[2001:0:1234:5678::5601:5601]/',
       'http://[fe80::5efe:a9fe:a9fe]/',
       'http://[64:ff9b::a9fe:a9fe]/',
+      // ISATAP under a globally routable prefix carrying a non-private metadata
+      // address: only the tunnel decoder catches these.
+      'http://[2001:db8::5efe:168.63.129.16]/',
+      'http://[2001:db8::200:5efe:192.0.0.192]/',
+      'http://[2001:db8::5efe:100.100.100.200]/',
     ];
 
     for (const url of urls) {
@@ -290,6 +295,28 @@ describe('validateUrlForSSRF', () => {
     }
 
     // Literals and known metadata hostnames are classified without DNS.
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps allowing tunnel literals that embed public or private IPv4 when ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    const urls = [
+      'http://[2002:808:808::]/', // 6to4 8.8.8.8
+      'http://[2002:c0a8:10a::]/', // 6to4 192.168.1.10
+      'http://[2001:0:1234:5678::f7f7:f7f7]/', // Teredo 8.8.8.8
+      'http://[2001:0:1234:5678::3f57:fef5]/', // Teredo 192.168.1.10
+      'http://[2001:db8::5efe:8.8.8.8]/', // ISATAP 8.8.8.8
+      'http://[fe80::5efe:192.168.1.10]/', // ISATAP 192.168.1.10
+      'http://[64:ff9b::8.8.8.8]/', // NAT64 8.8.8.8
+      'http://[64:ff9b::192.168.1.10]/', // NAT64 192.168.1.10
+    ];
+
+    for (const url of urls) {
+      await expect(validateUrlForSSRF(url)).resolves.toBeNull();
+    }
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
@@ -446,6 +473,25 @@ describe('assertSafeIp', () => {
     const { assertSafeIp } = await import('@/lib/server/ssrf-guard');
     expect(() => assertSafeIp('::ffff:127.0.0.1')).toThrow(STRICT_BLOCK_MESSAGE);
     expect(() => assertSafeIp('::ffff:8.8.8.8')).not.toThrow();
+  });
+
+  it('rejects ISATAP and NAT64 addresses that embed a metadata or private IPv4', async () => {
+    const { assertSafeIp, isPrivateIP, UnsafeNetworkTargetError } =
+      await import('@/lib/server/ssrf-guard');
+
+    expect(() => assertSafeIp('2001:470:1f0b:1:0:5efe:168.63.129.16')).toThrow(
+      UnsafeNetworkTargetError,
+    );
+    expect(() => assertSafeIp('2001:470:1f0b:1:200:5efe:192.0.0.192')).toThrow(
+      UnsafeNetworkTargetError,
+    );
+    expect(() => assertSafeIp('2001:470:1f0b:1:0:5efe:100.100.100.200')).toThrow(
+      UnsafeNetworkTargetError,
+    );
+    expect(() => assertSafeIp('2001:470:1f0b:1:0:5efe:8.8.8.8')).not.toThrow();
+    expect(isPrivateIP('64:ff9b::192.168.1.10')).toBe(true);
+    expect(isPrivateIP('64:ff9b::7f00:1')).toBe(true);
+    expect(isPrivateIP('64:ff9b::8.8.8.8')).toBe(false);
   });
 
   it('rejects ISATAP addresses that embed private IPv4 beneath a public IPv6 prefix', async () => {

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -12,6 +12,8 @@ vi.mock('node:dns', () => ({
 
 const PRIVATE_NETWORK_BLOCK_MESSAGE =
   'Local/private network URLs are not allowed. If this is a self-hosted deployment or internal gateway (including split-horizon DNS), set ALLOW_LOCAL_NETWORKS=true to allow local network targets.';
+const CLOUD_METADATA_BLOCK_MESSAGE =
+  'Cloud instance metadata endpoints are never allowed as outbound targets, even with ALLOW_LOCAL_NETWORKS=true.';
 const ALLOW_LOCAL_NETWORKS_GUIDANCE = 'ALLOW_LOCAL_NETWORKS=true';
 const originalAllowLocalNetworks = process.env.ALLOW_LOCAL_NETWORKS;
 
@@ -254,7 +256,108 @@ describe('validateUrlForSSRF', () => {
 
     await expect(validateUrlForSSRF('http://192.168.1.10')).resolves.toBeNull();
     await expect(validateUrlForSSRF('https://internal.example')).resolves.toBeNull();
+    // Private IP literals skip DNS; non-IP hostnames are resolved so metadata
+    // answers can still be caught while the flag is set.
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    expect(lookupMock).toHaveBeenCalledWith('internal.example', { all: true, verbatim: true });
+  });
+
+  it('still blocks cloud metadata literals when ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    const urls = [
+      'http://169.254.169.254/latest/meta-data/',
+      'http://[::ffff:169.254.169.254]/',
+      'http://100.100.100.200/',
+      'http://[fd00:ec2::254]/',
+      'http://metadata.google.internal/computeMetadata/v1/',
+    ];
+
+    for (const url of urls) {
+      await expect(validateUrlForSSRF(url)).resolves.toBe(CLOUD_METADATA_BLOCK_MESSAGE);
+    }
+
+    // Literals and known metadata hostnames are classified without DNS.
     expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks a hostname under ALLOW_LOCAL_NETWORKS=true when any DNS answer is metadata', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+      { address: '::ffff:100.100.100.200', family: 6 },
+    ]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://metadata.example')).resolves.toBe(
+      CLOUD_METADATA_BLOCK_MESSAGE,
+    );
+    expect(lookupMock).toHaveBeenCalledWith('metadata.example', { all: true, verbatim: true });
+  });
+
+  it('still allows hostnames whose DNS answers are all RFC1918 when ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+    lookupMock.mockResolvedValue([
+      { address: '10.0.0.4', family: 4 },
+      { address: '192.168.1.10', family: 4 },
+    ]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('http://ollama.internal')).resolves.toBeNull();
+    expect(lookupMock).toHaveBeenCalledWith('ollama.internal', { all: true, verbatim: true });
+  });
+
+  it('still allows loopback and private IP targets when ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+    lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('http://localhost:11434/')).resolves.toBeNull();
+    await expect(validateUrlForSSRF('http://192.168.1.10/')).resolves.toBeNull();
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    expect(lookupMock).toHaveBeenCalledWith('localhost', { all: true, verbatim: true });
+  });
+
+  it('fails open when DNS lookup errors under ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+    lookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    await expect(validateUrlForSSRF('https://split-horizon.internal')).resolves.toBeNull();
+  });
+
+  it('still blocks cloud metadata endpoints when ALLOW_LOCAL_NETWORKS is not set', async () => {
+    const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+    // Link-local and ULA metadata literals are private, so they return the generic message.
+    await expect(validateUrlForSSRF('http://169.254.169.254/latest/meta-data/')).resolves.toBe(
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
+    );
+    await expect(validateUrlForSSRF('http://[::ffff:169.254.169.254]/')).resolves.toBe(
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
+    );
+    await expect(validateUrlForSSRF('http://[fd00:ec2::254]/')).resolves.toBe(
+      PRIVATE_NETWORK_BLOCK_MESSAGE,
+    );
+    // 100.100.100.200 is not RFC1918, but it is a metadata address and stays blocked.
+    expect(await validateUrlForSSRF('http://100.100.100.200/')).not.toBeNull();
+
+    // A metadata hostname resolves to a metadata address and is rejected via DNS.
+    lookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    await expect(validateUrlForSSRF('http://metadata.google.internal/')).resolves.toBe(
+      CLOUD_METADATA_BLOCK_MESSAGE,
+    );
+    expect(lookupMock).toHaveBeenCalledWith('metadata.google.internal', {
+      all: true,
+      verbatim: true,
+    });
   });
 
   it('fails closed when DNS lookup errors', async () => {

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -270,9 +270,19 @@ describe('validateUrlForSSRF', () => {
     const urls = [
       'http://169.254.169.254/latest/meta-data/',
       'http://[::ffff:169.254.169.254]/',
+      'http://169.254.170.2/v2/credentials/',
+      'http://169.254.170.23/v1/credentials',
       'http://100.100.100.200/',
+      'http://168.63.129.16/',
+      'http://192.0.0.192/',
       'http://[fd00:ec2::254]/',
+      'http://[fd00:ec2::23]/',
       'http://metadata.google.internal/computeMetadata/v1/',
+      // Tunnel prefixes carrying 169.254.169.254: 6to4, Teredo, ISATAP, NAT64.
+      'http://[2002:a9fe:a9fe::]/',
+      'http://[2001:0:1234:5678::5601:5601]/',
+      'http://[fe80::5efe:a9fe:a9fe]/',
+      'http://[64:ff9b::a9fe:a9fe]/',
     ];
 
     for (const url of urls) {
@@ -322,6 +332,22 @@ describe('validateUrlForSSRF', () => {
     await expect(validateUrlForSSRF('http://192.168.1.10/')).resolves.toBeNull();
     expect(lookupMock).toHaveBeenCalledTimes(1);
     expect(lookupMock).toHaveBeenCalledWith('localhost', { all: true, verbatim: true });
+  });
+
+  it('fails open when DNS lookup hangs past the bound under ALLOW_LOCAL_NETWORKS=true', async () => {
+    process.env.ALLOW_LOCAL_NETWORKS = 'true';
+    vi.useFakeTimers();
+    try {
+      lookupMock.mockReturnValue(new Promise(() => {}));
+
+      const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
+
+      const pending = validateUrlForSSRF('https://slow-resolver.internal');
+      await vi.advanceTimersByTimeAsync(3_000);
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('fails open when DNS lookup errors under ALLOW_LOCAL_NETWORKS=true', async () => {

--- a/tests/server/ssrf-guard.test.ts
+++ b/tests/server/ssrf-guard.test.ts
@@ -91,7 +91,7 @@ describe('validateUrlForSSRF', () => {
       'http://172.16.5.4',
       'http://172.31.255.255',
       'http://192.168.1.10',
-      'http://169.254.169.254',
+      'http://169.254.1.1',
       'http://0.0.0.0',
     ];
 
@@ -389,28 +389,28 @@ describe('validateUrlForSSRF', () => {
   it('still blocks cloud metadata endpoints when ALLOW_LOCAL_NETWORKS is not set', async () => {
     const { validateUrlForSSRF } = await import('@/lib/server/ssrf-guard');
 
-    // Link-local and ULA metadata literals are private, so they return the generic message.
-    await expect(validateUrlForSSRF('http://169.254.169.254/latest/meta-data/')).resolves.toBe(
+    // Metadata literals get the metadata message, not the one that suggests the flag.
+    for (const url of [
+      'http://169.254.169.254/latest/meta-data/',
+      'http://[::ffff:169.254.169.254]/',
+      'http://[fd00:ec2::254]/',
+      'http://100.100.100.200/',
+      'http://168.63.129.16/',
+      'http://192.0.0.192/',
+    ]) {
+      await expect(validateUrlForSSRF(url)).resolves.toBe(CLOUD_METADATA_BLOCK_MESSAGE);
+    }
+    // Other link-local targets still get the generic message.
+    await expect(validateUrlForSSRF('http://169.254.1.1/')).resolves.toBe(
       PRIVATE_NETWORK_BLOCK_MESSAGE,
     );
-    await expect(validateUrlForSSRF('http://[::ffff:169.254.169.254]/')).resolves.toBe(
-      PRIVATE_NETWORK_BLOCK_MESSAGE,
-    );
-    await expect(validateUrlForSSRF('http://[fd00:ec2::254]/')).resolves.toBe(
-      PRIVATE_NETWORK_BLOCK_MESSAGE,
-    );
-    // 100.100.100.200 is not RFC1918, but it is a metadata address and stays blocked.
-    expect(await validateUrlForSSRF('http://100.100.100.200/')).not.toBeNull();
 
-    // A metadata hostname resolves to a metadata address and is rejected via DNS.
-    lookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    // The metadata hostname is rejected by name, before any DNS lookup.
+    lookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
     await expect(validateUrlForSSRF('http://metadata.google.internal/')).resolves.toBe(
       CLOUD_METADATA_BLOCK_MESSAGE,
     );
-    expect(lookupMock).toHaveBeenCalledWith('metadata.google.internal', {
-      all: true,
-      verbatim: true,
-    });
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 
   it('fails closed when DNS lookup errors', async () => {
@@ -492,6 +492,10 @@ describe('assertSafeIp', () => {
     expect(isPrivateIP('64:ff9b::192.168.1.10')).toBe(true);
     expect(isPrivateIP('64:ff9b::7f00:1')).toBe(true);
     expect(isPrivateIP('64:ff9b::8.8.8.8')).toBe(false);
+    // Decoder boundaries: only the exact tunnel prefixes carry an embedded IPv4.
+    expect(isPrivateIP('2001:db8:1:2:3:4:3f57:fef5')).toBe(false); // not Teredo (2001:0::/32)
+    expect(isPrivateIP('64:ff9b:1:2:3:4:c0a8:10a')).toBe(false); // not NAT64 (64:ff9b::/96)
+    expect(isPrivateIP('2003:c0a8:10a::')).toBe(false); // not 6to4 (2002::/16)
   });
 
   it('rejects ISATAP addresses that embed private IPv4 beneath a public IPv6 prefix', async () => {

--- a/tests/server/transcription-unconditional-url-guard.test.ts
+++ b/tests/server/transcription-unconditional-url-guard.test.ts
@@ -66,9 +66,9 @@ describe('transcription — client-supplied base URL guard applies in every envi
     mocks.serverDisabled = false;
   });
 
-  it('rejects a metadata-address base URL when NODE_ENV is not production', async () => {
+  it('rejects a private-network base URL when NODE_ENV is not production', async () => {
     vi.stubEnv('NODE_ENV', 'development');
-    const res = await postTranscription('http://169.254.169.254/latest/meta-data/');
+    const res = await postTranscription('http://192.168.1.10/v1/');
     const json = await res.json();
 
     expect(res.status).toBe(403);

--- a/tests/server/transcription-unconditional-url-guard.test.ts
+++ b/tests/server/transcription-unconditional-url-guard.test.ts
@@ -76,10 +76,10 @@ describe('transcription — client-supplied base URL guard applies in every envi
     expect(mocks.transcribeAudio).not.toHaveBeenCalled();
   });
 
-  it('still lets the same local base URL through when ALLOW_LOCAL_NETWORKS=true', async () => {
+  it('still lets a private-network base URL through when ALLOW_LOCAL_NETWORKS=true', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('ALLOW_LOCAL_NETWORKS', 'true');
-    const res = await postTranscription('http://169.254.169.254/latest/meta-data/');
+    const res = await postTranscription('http://192.168.1.10/v1/');
     const json = await res.json();
 
     expect(res.status).toBe(200);
@@ -87,7 +87,7 @@ describe('transcription — client-supplied base URL guard applies in every envi
     expect(mocks.transcribeAudio).toHaveBeenCalledWith(
       expect.objectContaining({
         providerId: 'openai',
-        baseUrl: 'http://169.254.169.254/latest/meta-data/',
+        baseUrl: 'http://192.168.1.10/v1/',
       }),
       expect.any(File),
     );


### PR DESCRIPTION
## Summary

`ALLOW_LOCAL_NETWORKS=true` is the documented opt-in for self-hosted deployments that need loopback, RFC1918 or split-horizon provider targets. It returned from `validateUrlForSSRF` before any classification, so on such a deployment a client-supplied base URL of `169.254.169.254` (or `metadata.google.internal`, `100.100.100.200`, `fd00:ec2::254`) was accepted. Local networks and cloud instance-metadata endpoints are different things; this keeps the metadata set blocked regardless of the flag.

Hardening follow-up to GHSA-9m7h-vh2h-rc3w / CVE-2026-86259. It is not a new vulnerability: the flag is documented as unsafe for public deployments, and the default deployment never sets it.

## Changes

- `lib/server/ssrf-guard.ts`: under the flag, literal hosts (including IPv4-mapped IPv6) and the known metadata hostname are rejected with a distinct message; non-IP hostnames are resolved and rejected if any answer is a metadata address. DNS failure under the flag still fails open (split-horizon DNS is a flag use case). Without the flag the DNS path now also rejects answers on metadata addresses that are not RFC1918 (`100.100.100.200`). The IP canonicalisation used by `assertSafeIp` is factored into one helper shared with the new check.
- `.env.example`: the flag comment says metadata endpoints stay blocked.
- Tests: new cases in `tests/server/ssrf-guard.test.ts` for every metadata literal, mapped form, DNS answer, RFC1918-only DNS, loopback/private still allowed, DNS error fail-open, and the flag-off path. The four route tests that used the metadata address as their example of a flag-allowed target now use a private-network address.

## Verification

- `pnpm exec vitest run tests/server/ssrf-guard.test.ts tests/server/*url-guard*.test.ts tests/document/extract-document-route.test.ts tests/agent-runtime/fetch-url*.test.ts` → 7 files, 108 tests passed
- `pnpm exec tsc --noEmit`, eslint and prettier on the changed files → clean

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRaNc5E88r41GUWt2Y3uiQ