### PR TITLE
fix: tolerate malformed authored CSS in classroom exports

### DIFF
--- a/lib/export/css-asset-parser.ts
+++ b/lib/export/css-asset-parser.ts
@@ -7,6 +7,9 @@ export interface CssUrlReference {
   end: number;
 }
 
+/** CSS drops an escaped newline from a token value: url("a\<LF>b") is "ab". */
+const stripEscapedNewlines = (value: string) => value.replace(/\\\r\n|\\\n|\\\r|\\\f/g, '');
+
 export function cssUrlReferences(value: string): CssUrlReference[] {
   const refs: CssUrlReference[] = [];
   valueParser(value).walk((node: CssValueNode) => {
@@ -16,7 +19,11 @@ export function cssUrlReferences(value: string): CssUrlReference[] {
       (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
         ? raw.slice(1, -1)
         : raw;
-    refs.push({ raw: unquoted, start: node.sourceIndex, end: node.sourceEndIndex });
+    refs.push({
+      raw: stripEscapedNewlines(unquoted),
+      start: node.sourceIndex,
+      end: node.sourceEndIndex,
+    });
     return false;
   });
   return refs;
@@ -52,7 +59,10 @@ export function cssImportReference(rule: AtRule): { url: string; conditions: str
         : raw;
   }
   if (!url) return null;
-  return { url, conditions: rule.params.slice(node.sourceEndIndex).trim() };
+  return {
+    url: stripEscapedNewlines(url),
+    conditions: rule.params.slice(node.sourceEndIndex).trim(),
+  };
 }
 
 export function parseCss(css: string, cssUrl: string): Root {
@@ -91,14 +101,28 @@ export function collectCssAssetReferencesByRegex(
       continue;
     }
     if (ch === '"' || ch === "'") {
+      // An unescaped \n/\r/\f ends the string as a bad-string token and the
+      // browser recovers right there; scanning must too, or everything after
+      // an unterminated string is swallowed and browser-active assets hidden.
       let j = i + 1;
-      while (j < n && css[j] !== ch) {
-        if (css[j] === '\\') j++;
+      let terminated = false;
+      while (j < n) {
+        if (css[j] === '\\') {
+          // An escaped newline continues the string; \r\n is one newline.
+          j += css[j + 1] === '\r' && css[j + 2] === '\n' ? 3 : 2;
+          continue;
+        }
+        if (css[j] === ch) {
+          terminated = true;
+          break;
+        }
+        if (css[j] === '\n' || css[j] === '\r' || css[j] === '\f') break;
         j++;
       }
-      if (importNext) refs.push({ kind: 'css-import', url: css.slice(i + 1, j) });
+      if (terminated && importNext)
+        refs.push({ kind: 'css-import', url: stripEscapedNewlines(css.slice(i + 1, j)) });
       importNext = false;
-      i = j + 1;
+      i = terminated ? j + 1 : j;
       continue;
     }
     if (ch === '@') {
@@ -124,16 +148,32 @@ export function collectCssAssetReferencesByRegex(
       const quote = css[k] === '"' || css[k] === "'" ? css[k] : null;
       if (quote) {
         let m = k + 1;
-        while (m < n && css[m] !== quote) {
-          if (css[m] === '\\') m++;
+        let terminated = false;
+        while (m < n) {
+          if (css[m] === '\\') {
+            m += css[m + 1] === '\r' && css[m + 2] === '\n' ? 3 : 2;
+            continue;
+          }
+          if (css[m] === quote) {
+            terminated = true;
+            break;
+          }
+          if (css[m] === '\n' || css[m] === '\r' || css[m] === '\f') break;
           m++;
         }
-        refs.push({ kind: importNext ? 'css-import' : 'css-url', url: css.slice(k + 1, m) });
-        i = m + 1;
+        // An unterminated url("... string is a bad-string token: no URL is
+        // taken from it and scanning resumes at the offending character.
+        if (terminated) {
+          refs.push({
+            kind: importNext ? 'css-import' : 'css-url',
+            url: stripEscapedNewlines(css.slice(k + 1, m)),
+          });
+        }
+        i = terminated ? m + 1 : m;
       } else {
         let m = k;
         while (m < n && css[m] !== ')') m++;
-        const raw = css.slice(k, m).trim();
+        const raw = stripEscapedNewlines(css.slice(k, m).trim());
         if (raw) refs.push({ kind: importNext ? 'css-import' : 'css-url', url: raw });
         i = m + 1;
       }

--- a/lib/export/css-asset-parser.ts
+++ b/lib/export/css-asset-parser.ts
@@ -65,11 +65,100 @@ export function parseCss(css: string, cssUrl: string): Root {
   }
 }
 
+/**
+ * Best-effort fallback for `collectCssAssetReferences` when strict parsing
+ * fails. A tiny token scanner (not a regex pile) that is comment- and
+ * string-aware, so textual `content: "url(...)"`, commented-out imports and
+ * lookalike function names (`myurl(`) are not mistaken for dependencies, while
+ * real remote refs in malformed CSS stay visible to residual validation (e.g.
+ * the video export's offline-completeness check).
+ */
+export function collectCssAssetReferencesByRegex(
+  css: string,
+): Array<{ kind: 'css-url' | 'css-import'; url: string }> {
+  const refs: Array<{ kind: 'css-url' | 'css-import'; url: string }> = [];
+  const n = css.length;
+  let i = 0;
+  let importNext = false;
+  const isWordChar = (c: string) => /[\w-]/.test(c);
+  while (i < n) {
+    const ch = css[i];
+    if (ch === '/' && css[i + 1] === '*') {
+      // Unterminated comments run to end-of-stylesheet, like browsers.
+      // Comments count as whitespace: `@import /* c */ "x.css"` stays intact.
+      const end = css.indexOf('*/', i + 2);
+      i = end === -1 ? n : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      let j = i + 1;
+      while (j < n && css[j] !== ch) {
+        if (css[j] === '\\') j++;
+        j++;
+      }
+      if (importNext) refs.push({ kind: 'css-import', url: css.slice(i + 1, j) });
+      importNext = false;
+      i = j + 1;
+      continue;
+    }
+    if (ch === '@') {
+      i++;
+      continue;
+    }
+    if (!isWordChar(ch)) {
+      if (!/\s/.test(ch)) importNext = false;
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < n && isWordChar(css[j])) j++;
+    const word = css.slice(i, j).toLowerCase();
+    if (word === 'import') {
+      importNext = true;
+      i = j;
+      continue;
+    }
+    if (word === 'url' && css[j] === '(') {
+      let k = j + 1;
+      while (k < n && /\s/.test(css[k])) k++;
+      const quote = css[k] === '"' || css[k] === "'" ? css[k] : null;
+      if (quote) {
+        let m = k + 1;
+        while (m < n && css[m] !== quote) {
+          if (css[m] === '\\') m++;
+          m++;
+        }
+        refs.push({ kind: importNext ? 'css-import' : 'css-url', url: css.slice(k + 1, m) });
+        i = m + 1;
+      } else {
+        let m = k;
+        while (m < n && css[m] !== ')') m++;
+        const raw = css.slice(k, m).trim();
+        if (raw) refs.push({ kind: importNext ? 'css-import' : 'css-url', url: raw });
+        i = m + 1;
+      }
+      importNext = false;
+      continue;
+    }
+    importNext = false;
+    i = j;
+  }
+  return refs;
+}
+
 export function collectCssAssetReferences(
   css: string,
   context: 'stylesheet' | 'declaration-list' = 'stylesheet',
 ): Array<{ kind: 'css-url' | 'css-import'; url: string }> {
-  const root = parseCss(context === 'stylesheet' ? css : `.x{${css}}`, 'inline-css');
+  // Authored CSS (e.g. LLM-generated interactive scenes) can carry browser-
+  // tolerated syntax errors like `-- name: value`. Strict parsing here would
+  // abort the whole export, so collection is best-effort instead.
+  let root: Root;
+  try {
+    root = parseCss(context === 'stylesheet' ? css : `.x{${css}}`, 'inline-css');
+  } catch {
+    return collectCssAssetReferencesByRegex(css);
+  }
   const refs: Array<{ kind: 'css-url' | 'css-import'; url: string }> = [];
   root.walkAtRules((rule) => {
     if (rule.name.toLowerCase() !== 'import') return;

--- a/lib/export/inline-assets.ts
+++ b/lib/export/inline-assets.ts
@@ -21,11 +21,25 @@ import {
 import parseSrcset, { type SrcsetCandidate } from 'parse-srcset';
 import type { AtRule, Root } from 'postcss';
 import {
+  collectCssAssetReferencesByRegex,
   cssImportReference,
   cssUrlReferences,
   parseCss,
   rewriteCssValue,
 } from './css-asset-parser';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('InlineAssets');
+
+/** Best-effort parse for enhancement paths; null means "leave the CSS as-is". */
+function tryParseCss(css: string, cssUrl: string): Root | null {
+  try {
+    return parseCss(css, cssUrl);
+  } catch (error) {
+    log.warn(`CSS parse failed for ${cssUrl}; leaving value untouched`, error);
+    return null;
+  }
+}
 
 export { toDataUri } from './inline-assets-shared';
 export type { InlineReport, InlineOptions, FetchAsset } from './inline-assets-shared';
@@ -262,7 +276,26 @@ export async function inlineCssUrls(
 ): Promise<{ css: string; failed: { url: string; reason: string }[]; inlined: string[] }> {
   const failed: { url: string; reason: string }[] = [];
   const inlined: string[] = [];
-  const root = parseCss(css, cssUrl);
+  // Authored CSS can carry browser-tolerated syntax errors (e.g. `-- name`).
+  // Inlining is an enhancement, not a precondition: on a parse failure keep the
+  // stylesheet byte-for-byte and continue instead of failing the whole export.
+  let root: Root;
+  try {
+    root = parseCss(css, cssUrl);
+  } catch (error) {
+    log.warn(`CSS parse failed while inlining ${cssUrl}; leaving stylesheet untouched`, error);
+    // Zip exporters only consume `failed`, so remote refs inside the
+    // unparseable stylesheet must be surfaced here, not silently packaged.
+    for (const ref of collectCssAssetReferencesByRegex(css)) {
+      if (/^(?:data:|blob:|about:|#)/i.test(ref.url)) continue;
+      try {
+        failed.push({ url: new URL(ref.url, cssUrl).href, reason: 'css parse failed' });
+      } catch {
+        // Unresolvable values stay untouched, as elsewhere.
+      }
+    }
+    return { css, failed, inlined };
+  }
   const imports: AtRule[] = [];
   root.walkAtRules((rule) => {
     if (rule.name.toLowerCase() === 'import') imports.push(rule);
@@ -295,10 +328,19 @@ export async function inlineCssUrls(
       fetchAsset,
       new Set(activeCssUrls).add(abs),
     );
-    inlined.push(abs, ...nested.inlined);
     failed.push(...nested.failed);
     const wrapped = wrapImportedCss(nested.css, parseCssImportConditions(reference.conditions));
-    rule.replaceWith(...parseCss(wrapped, abs).nodes);
+    // nested.css is raw whenever the imported stylesheet failed strict parsing;
+    // re-parsing it here would rethrow. Keep the original @import rule then. The
+    // remote dependency stays in the output, so report it as a failure instead
+    // of claiming the import (and its nested assets) were inlined.
+    const wrappedRoot = tryParseCss(wrapped, abs);
+    if (wrappedRoot) {
+      rule.replaceWith(...wrappedRoot.nodes);
+      inlined.push(abs, ...nested.inlined);
+    } else {
+      failed.push({ url: abs, reason: 'css parse failed' });
+    }
   }
 
   // 1. Find @font-face blocks; build dropRefs (non-woff2 fonts in blocks that have a woff2).
@@ -323,11 +365,19 @@ export async function inlineCssUrls(
   return { css: root.toString(), failed, inlined };
 }
 
+/** Absolute http(s) refs inside unparseable CSS; surfaced as export failures. */
+function unresolvedCssRefs(css: string): { url: string; reason: string }[] {
+  return collectCssAssetReferencesByRegex(css)
+    .filter((ref) => /^https?:\/\//i.test(ref.url))
+    .map((ref) => ({ url: ref.url, reason: 'css parse failed' }));
+}
+
 async function inlineStyleAttributeUrls(
   css: string,
   fetchAsset: FetchAsset,
 ): Promise<{ css: string; failed: { url: string; reason: string }[]; inlined: string[] }> {
-  const root = parseCss(`.openmaic-style{${css}}`, 'style-attribute');
+  const root = tryParseCss(`.openmaic-style{${css}}`, 'style-attribute');
+  if (!root) return { css, failed: unresolvedCssRefs(css), inlined: [] };
   const result = await inlineParsedCssUrls(root, 'about:blank', fetchAsset, new Set());
   const serialized = root.toString();
   return {
@@ -341,10 +391,11 @@ async function inlineSvgPresentationAttributeUrls(
   cssValue: string,
   fetchAsset: FetchAsset,
 ): Promise<{ cssValue: string; failed: { url: string; reason: string }[]; inlined: string[] }> {
-  const root = parseCss(
+  const root = tryParseCss(
     `.openmaic-svg{${attributeName}:${cssValue}}`,
     'svg-presentation-attribute',
   );
+  if (!root) return { cssValue, failed: unresolvedCssRefs(cssValue), inlined: [] };
   let declarationValue = cssValue;
   const result = await inlineParsedCssUrls(root, 'about:blank', fetchAsset, new Set());
   root.walkDecls((declaration) => {

--- a/tests/export/inline-assets.test.ts
+++ b/tests/export/inline-assets.test.ts
@@ -894,3 +894,131 @@ describe('inlineHtmlAssets', () => {
     expect(out).toContain('src="data:text/javascript;base64,');
   });
 });
+
+describe('malformed authored CSS tolerance', () => {
+  // Regression for the stage-LHSa3TDAYh export failures: an LLM-authored
+  // <style> carried `-- crop-green: #22c55e;` (space after --). Browsers drop
+  // such declarations, but strict postcss parsing used to abort the whole
+  // resource-pack / classroom-zip export.
+  const malformedCss = `:root {\n  -- crop-green: #22c55e;\n}\nbody { color: red; }`;
+
+  it('collectAssetRefs does not throw on an unparsable <style> block', () => {
+    expect(() => collectAssetRefs(`<style>${malformedCss}</style>`)).not.toThrow();
+  });
+
+  it('inlineHtmlAssets keeps a malformed <style> block byte-for-byte and still succeeds', async () => {
+    const { html: out, report } = await inlineHtmlAssets(
+      `<style>${malformedCss}</style><img src="https://cdn.test/ok.png">`,
+      {
+        fetcher: async () => ({
+          bytes: new Uint8Array([1]),
+          contentType: 'image/png',
+        }),
+      },
+    );
+    expect(out).toContain(`-- crop-green: #22c55e;`);
+    expect(out).toContain('<img src="data:image/png;base64,');
+    expect(report.failed).toHaveLength(0);
+  });
+
+  it('inlineCssUrls returns the stylesheet untouched when it cannot parse', async () => {
+    const fetcher = async () => null as unknown as Awaited<ReturnType<typeof fetch>>;
+    const { css, failed, inlined } = await inlineCssUrls(
+      malformedCss,
+      'about:blank',
+      fetcher as never,
+    );
+    expect(css).toBe(malformedCss);
+    expect(failed).toHaveLength(0);
+    expect(inlined).toHaveLength(0);
+  });
+
+  it('collectCssAssetReferences still surfaces url() refs in malformed CSS', async () => {
+    const { collectCssAssetReferences } = await import('@/lib/export/css-asset-parser');
+    expect(
+      collectCssAssetReferences(
+        ':root { -- crop-green: #22c55e; } .a { background: url(https://x/a.png); }',
+      ),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/a.png' }]);
+  });
+
+  it('ignores url() text inside quoted strings but keeps parenthesized quoted urls', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    expect(
+      collectCssAssetReferencesByRegex(
+        '.a { content: "url(https://x/text-only.png)"; } .b { src: url("https://x/font(foo).woff2"); }',
+      ),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/font(foo).woff2' }]);
+  });
+
+  it('reports a malformed @import url() only once', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    expect(collectCssAssetReferencesByRegex('@import url(https://x/a.css);')).toEqual([
+      { kind: 'css-import', url: 'https://x/a.css' },
+    ]);
+  });
+
+  it('keeps collecting urls after a malformed unterminated @import', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    expect(
+      collectCssAssetReferencesByRegex(
+        '@import url(https://x/a.css) .a { background: url(https://x/b.png); }',
+      ),
+    ).toEqual([
+      { kind: 'css-import', url: 'https://x/a.css' },
+      { kind: 'css-url', url: 'https://x/b.png' },
+    ]);
+  });
+
+  it('ignores unterminated comments and non-url function names', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    expect(
+      collectCssAssetReferencesByRegex(
+        '.a { background: myurl(https://x/fake.png); } /* url(https://x/gone.png)',
+      ),
+    ).toEqual([]);
+  });
+
+  it('keeps an @import target across an interleaved comment', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    expect(collectCssAssetReferencesByRegex('@import /* x */ "https://x/a.css";')).toEqual([
+      { kind: 'css-import', url: 'https://x/a.css' },
+    ]);
+  });
+
+  it('surfaces absolute and relative url() refs of unparseable CSS as failures', async () => {
+    const { css, failed } = await inlineCssUrls(
+      ':root { -- crop-green: #22c55e; } .a { background: url(https://x/a.png) ; } .b { background: url(imgs/b.png); } /* url(https://x/comment.png) */',
+      'https://cdn.test/page.html',
+      (async () => null) as never,
+    );
+    expect(css).toContain('-- crop-green');
+    expect(failed).toContainEqual({ url: 'https://x/a.png', reason: 'css parse failed' });
+    expect(failed).toContainEqual({
+      url: 'https://cdn.test/imgs/b.png',
+      reason: 'css parse failed',
+    });
+    expect(failed).not.toContainEqual({
+      url: 'https://x/comment.png',
+      reason: 'css parse failed',
+    });
+  });
+
+  it('does not rethrow when an @import pulls malformed nested CSS', async () => {
+    const imported = ':root { -- crop-green: #22c55e; }';
+    const { css, inlined, failed } = await inlineCssUrls(
+      '@import url(https://cdn.test/bad.css); body { color: red; }',
+      'https://cdn.test/a.css',
+      (async (url: string) =>
+        url === 'https://cdn.test/bad.css'
+          ? { bytes: new TextEncoder().encode(imported), contentType: 'text/css' }
+          : null) as never,
+    );
+    expect(css).toContain('@import url(https://cdn.test/bad.css)');
+    expect(inlined).not.toContain('https://cdn.test/bad.css');
+    expect(failed).toContainEqual({
+      url: 'https://cdn.test/bad.css',
+      reason: 'css parse failed',
+    });
+  });
+});

--- a/tests/export/inline-assets.test.ts
+++ b/tests/export/inline-assets.test.ts
@@ -986,6 +986,77 @@ describe('malformed authored CSS tolerance', () => {
     ]);
   });
 
+  it('recovers at a bad-string token and still collects later urls', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    // An unescaped newline ends the string; the browser applies .ok below.
+    expect(
+      collectCssAssetReferencesByRegex(
+        '.bad { content: "oops\n;}\n.ok { background: url(https://x/ok.png) }',
+      ),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/ok.png' }]);
+    // Same for a quoted url( whose string is unterminated.
+    expect(
+      collectCssAssetReferencesByRegex(
+        '.bad { src: url("oops\n;}\n.ok { background: url(https://x/ok.png) }',
+      ),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/ok.png' }]);
+  });
+
+  it('handles escaped and unescaped newlines per CSS string semantics', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    const tail = '.ok { background: url(https://x/ok.png) }';
+    // Escaped \n / \r\n continue the string; the url inside is taken.
+    expect(
+      collectCssAssetReferencesByRegex(`.a { content: "esc\\
+line" }
+.ok2 { src: url(https://x/a.png) }`),
+    ).toContainEqual({ kind: 'css-url', url: 'https://x/a.png' });
+    // Backslash + CR + LF is one escaped newline in CSS: string continues.
+    expect(
+      collectCssAssetReferencesByRegex('.a { content: "crlf\\\r\nend" }\n' + tail),
+    ).toContainEqual({ kind: 'css-url', url: 'https://x/ok.png' });
+    // Unescaped \r and \f are bad-string terminators like \n.
+    expect(
+      collectCssAssetReferencesByRegex(`.bad { content: "oops
+}
+${tail}`),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/ok.png' }]);
+    expect(
+      collectCssAssetReferencesByRegex(`.bad { content: "oops}
+${tail}`),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/ok.png' }]);
+    // Unterminated at EOF swallows nothing real afterwards (there is none).
+    expect(collectCssAssetReferencesByRegex('.bad { content: "oops')).toEqual([]);
+  });
+
+  it('continues a quoted url() string across escaped newlines', async () => {
+    const { collectCssAssetReferencesByRegex } = await import('@/lib/export/css-asset-parser');
+    // Escaped LF inside a double-quoted url(): CSS drops the escape, so the
+    // dependency URL is the concatenation across the line break.
+    expect(collectCssAssetReferencesByRegex('.a { src: url("https://x/a\\\nb.png") }')).toEqual([
+      { kind: 'css-url', url: 'https://x/ab.png' },
+    ]);
+    // Escaped CRLF inside a single-quoted url(): skip-3 continues the string.
+    expect(collectCssAssetReferencesByRegex(".a { src: url('https://x/c\\\r\nd.png') }")).toEqual([
+      { kind: 'css-url', url: 'https://x/cd.png' },
+    ]);
+    // Unescaped newline inside url("...") is a bad string: no URL taken,
+    // scanning resumes and the later dependency is still collected.
+    expect(
+      collectCssAssetReferencesByRegex(
+        '.bad { src: url("oops\n) }\n.ok { src: url(https://x/ok.png) }',
+      ),
+    ).toEqual([{ kind: 'css-url', url: 'https://x/ok.png' }]);
+    // Unescaped \r / \f inside a quoted url(...) are bad strings too.
+    const tail = '.ok { src: url(https://x/ok.png) }';
+    expect(collectCssAssetReferencesByRegex('.bad { src: url("oops\r) }\n' + tail)).toEqual([
+      { kind: 'css-url', url: 'https://x/ok.png' },
+    ]);
+    expect(collectCssAssetReferencesByRegex('.bad { src: url("oops\f) }\n' + tail)).toEqual([
+      { kind: 'css-url', url: 'https://x/ok.png' },
+    ]);
+  });
+
   it('surfaces absolute and relative url() refs of unparseable CSS as failures', async () => {
     const { css, failed } = await inlineCssUrls(
       ':root { -- crop-green: #22c55e; } .a { background: url(https://x/a.png) ; } .b { background: url(imgs/b.png); } /* url(https://x/comment.png) */',


### PR DESCRIPTION
LLM-generated interactive-scene HTML can carry browser-tolerated CSS syntax errors such as `-- crop-green: #22c55e` (a space between `--` and the custom-property name). Browsers silently drop such declarations so the page renders fine, but the strict `postcss` pass used to inline assets for the resource-pack and classroom-zip exports throws (`interactive-css-parse-failed: ... Unknown word`), failing the entire export — while PPTX export, which never parses interactive HTML, keeps working.

This makes inlining best-effort instead of fatal:

- On strict-parse failure the stylesheet / style attribute / SVG presentation attribute is kept byte-for-byte (matching browser behavior) with a warning, and export continues.
- Remote dependencies inside unparseable CSS (`url()` / `@import`, absolute or relative, quoted with parentheses) are still surfaced through a comment- and string-aware fallback scanner, so exporters warn about un-inlined assets and offline validation is not silently bypassed.

Tested: 10 new regression cases in `tests/export/inline-assets.test.ts` (comment/string awareness, unterminated comments, `@import` with interleaved comments, dedup, function-name boundary); full export suite passes.