### PR TITLE
fix(generation): carry slide remark onto the canvas as script

### DIFF
--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/src/scene-builder.ts
+++ b/packages/@openmaic/generation/src/scene-builder.ts
@@ -49,6 +49,7 @@ export function buildCompleteScene(
       theme: defaultTheme,
       elements: content.elements,
       background: content.background,
+      ...(content.remark ? { script: content.remark } : {}),
     };
     return {
       id: sceneId,

--- a/packages/@openmaic/generation/test/scene-builder.test.ts
+++ b/packages/@openmaic/generation/test/scene-builder.test.ts
@@ -32,6 +32,26 @@ describe('buildCompleteScene', () => {
     expect(first?.id).not.toBe(second?.id);
   });
 
+  it('carries the generated remark onto the canvas as speaker notes', () => {
+    const scene = buildCompleteScene(
+      slideOutline(),
+      { ...content, remark: 'Explain why constructor injection keeps tests honest.' },
+      [],
+      'stage-1',
+    );
+    expect(scene?.type).toBe('slide');
+    const canvas = scene?.content.type === 'slide' ? scene.content.canvas : undefined;
+    expect(canvas?.script).toBe('Explain why constructor injection keeps tests honest.');
+    expect(validateScene(scene)).toEqual({ valid: true });
+  });
+
+  it('leaves script unset when no remark was generated', () => {
+    const scene = buildCompleteScene(slideOutline(), content, [], 'stage-1');
+    const canvas = scene?.content.type === 'slide' ? scene.content.canvas : undefined;
+    expect(canvas).toBeDefined();
+    expect(canvas).not.toHaveProperty('script');
+  });
+
   it('honors an injected id across retries/upserts', () => {
     const first = buildCompleteScene(slideOutline(), content, [], 'stage-1', {
       sceneId: 'stable-scene-id',


### PR DESCRIPTION
## Summary

`buildCompleteScene` assembled the slide canvas from `elements` and `background` only, so the `remark` that slide-content generation produces (the slide's narration / speaker notes) was discarded at assembly and never reached the persisted scene. This carries it onto the canvas as `Slide.script`, the field `@openmaic/dsl` already defines for speaker notes and that the PPTX importer populates.

AI-assisted PR (Claude Code); reviewed and tested locally by @apetcu.

## Related Issues

Fixes #1383

## Changes

- `packages/@openmaic/generation/src/scene-builder.ts`: set `canvas.script` from `content.remark` when a remark was generated. When there is none, the canvas is unchanged (no `script` key), so existing documents and validators see no difference.
- `packages/@openmaic/generation/test/scene-builder.test.ts`: two tests. One asserts a generated remark lands in `canvas.script` and the scene still passes `validateScene`; it fails on `main` with `expected undefined to be 'Explain why…'`. The other pins that no `script` key appears when no remark exists.
- `packages/@openmaic/generation/package.json`: `0.3.6` → `0.3.7` (patch: compatible change to a published package, per CONTRIBUTING).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

### Steps to reproduce / test

1. `cd packages/@openmaic/generation && pnpm vitest run test/scene-builder.test.ts` on `main` — the new remark test fails (`canvas.script` is `undefined`).
2. Same command on this branch — 4 tests pass.
3. Build any slide scene through `buildCompleteScene` with content that has `remark` set and inspect `scene.content.canvas.script`.

### What you personally verified

- `pnpm test` in `packages/@openmaic/generation`: 26 files, 147 tests pass.
- `pnpm typecheck` in the package (src and test tsconfigs): clean.
- `node scripts/check-package-version-bumps.mjs <upstream/main sha>`: "Package version check passed."
- `prettier --check` and `eslint` on the touched files: clean.
- Not verified: end-to-end classroom playback. The change only adds a field the DSL already accepts; `validateScene` passes with it set, matching what the reporter observed when setting it manually.

### Evidence

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`) — package-level typecheck/lint/format run locally as listed above; repo CI will confirm.
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (no UI change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (none required; the field is already documented in `@openmaic/dsl`)
- [x] My changes do not introduce new warnings

---
Prepared with AI assistance (Claude Code); reviewed and tested locally by @apetcu.
