### PR TITLE
feat(tts): allow custom endpoint path for custom TTS providers

### DIFF
--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -182,7 +182,9 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
               ...(ttsProvidersConfig[selectedProviderId]?.providerOptions || {}),
               ...(await getVoxCPMProviderOptions(effectiveVoice, { role: 'teacher', locale })),
             }
-          : undefined;
+          : isCustom
+            ? ttsProvidersConfig[selectedProviderId]?.providerOptions
+            : undefined;
       await startPreview({
         text: testText,
         providerId: selectedProviderId,
@@ -220,7 +222,14 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
     (isCustom ? providerConfig?.customDefaultBaseUrl : ttsProvider?.defaultBaseUrl) ||
     '';
   const endpointPath = (() => {
-    if (isCustom) return '/audio/speech';
+    if (isCustom) {
+      const customPath = ttsProvidersConfig[selectedProviderId]?.providerOptions?.endpointPath;
+      if (typeof customPath === 'string' && customPath.trim()) {
+        const trimmed = customPath.trim();
+        return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+      }
+      return '/audio/speech';
+    }
     switch (selectedProviderId) {
       case 'openai-tts':
       case 'glm-tts':
@@ -506,6 +515,35 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
                 />
               </div>
             </div>
+            {isCustom && (
+              <div className="space-y-2">
+                <Label className="text-sm">{t('settings.ttsEndpointPath')}</Label>
+                <Input
+                  name={`tts-endpoint-path-${selectedProviderId}`}
+                  autoComplete="off"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  placeholder="/audio/speech"
+                  value={
+                    typeof ttsProvidersConfig[selectedProviderId]?.providerOptions?.endpointPath ===
+                    'string'
+                      ? (ttsProvidersConfig[selectedProviderId]?.providerOptions
+                          ?.endpointPath as string)
+                      : ''
+                  }
+                  onChange={(e) =>
+                    setTTSProviderConfig(selectedProviderId, {
+                      providerOptions: {
+                        ...(ttsProvidersConfig[selectedProviderId]?.providerOptions || {}),
+                        endpointPath: e.target.value,
+                      },
+                    })
+                  }
+                  className="font-mono text-sm"
+                />
+              </div>
+            )}
             {requestUrl && (
               <p className="break-all text-xs text-muted-foreground">
                 {t('settings.requestUrl')}: {requestUrl}

--- a/lib/audio/agent-voice.ts
+++ b/lib/audio/agent-voice.ts
@@ -76,7 +76,12 @@ export async function resolveAgentVoiceOptions(
   agent: AgentConfig | undefined,
   opts: AgentVoiceResolveOptions,
 ): Promise<Record<string, unknown> | undefined> {
-  if (opts.providerId !== VOXCPM_TTS_PROVIDER_ID) return undefined;
+  if (opts.providerId !== VOXCPM_TTS_PROVIDER_ID) {
+    // Pass through stored provider options (e.g. a custom provider's
+    // endpointPath) so every TTS flow honors them, not just the settings test.
+    const stored = opts.providerConfig?.providerOptions;
+    return stored && Object.keys(stored).length > 0 ? { ...stored } : undefined;
+  }
   return {
     ...(opts.providerConfig?.providerOptions || {}),
     ...(await getVoxCPMProviderOptions(

--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -276,10 +276,23 @@ async function generateOpenAITTS(
   text: string,
   signal: AbortSignal,
 ): Promise<TTSGenerationResult> {
-  const baseUrl = config.baseUrl || TTS_PROVIDERS['openai-tts'].defaultBaseUrl;
+  const baseUrl = (config.baseUrl || TTS_PROVIDERS['openai-tts'].defaultBaseUrl || '').replace(
+    /\/+$/,
+    '',
+  );
+
+  // Custom providers may override the request path suffix via
+  // providerOptions.endpointPath (default: OpenAI-compatible /audio/speech).
+  const rawEndpointPath = config.providerOptions?.endpointPath;
+  const endpointPath =
+    typeof rawEndpointPath === 'string' && rawEndpointPath.trim()
+      ? rawEndpointPath.trim().startsWith('/')
+        ? rawEndpointPath.trim()
+        : `/${rawEndpointPath.trim()}`
+      : '/audio/speech';
 
   // Use gpt-4o-mini-tts for best quality and intelligent realtime applications
-  const response = await fetch(`${baseUrl}/audio/speech`, {
+  const response = await fetch(`${baseUrl}${endpointPath}`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${config.apiKey}`,

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Token Plan أوروبا"
     },
     "requestUrl": "عنوان الطلب",
+    "ttsEndpointPath": "مسار الطلب",
     "models": "النماذج",
     "comfyuiWorkflows": "سير العمل",
     "comfyuiRefresh": "تحديث",

--- a/lib/i18n/locales/de-DE.json
+++ b/lib/i18n/locales/de-DE.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Token-Tarif EU"
     },
     "requestUrl": "Anfrage-URL",
+    "ttsEndpointPath": "Anfragepfad",
     "models": "Modelle",
     "comfyuiWorkflows": "Workflows",
     "comfyuiRefresh": "Aktualisieren",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Token Plan EU"
     },
     "requestUrl": "Request URL",
+    "ttsEndpointPath": "Request path",
     "models": "Models",
     "comfyuiWorkflows": "Workflows",
     "comfyuiRefresh": "Refresh",

--- a/lib/i18n/locales/es-MX.json
+++ b/lib/i18n/locales/es-MX.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Plan de tokens EU"
     },
     "requestUrl": "URL de solicitud",
+    "ttsEndpointPath": "Ruta de la solicitud",
     "models": "Modelos",
     "comfyuiWorkflows": "Flujos de trabajo",
     "comfyuiRefresh": "Actualizar",

--- a/lib/i18n/locales/fr-FR.json
+++ b/lib/i18n/locales/fr-FR.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Forfait de jetons EU"
     },
     "requestUrl": "URL de la requête",
+    "ttsEndpointPath": "Chemin de la requête",
     "models": "Modèles",
     "comfyuiWorkflows": "Flux de travail",
     "comfyuiRefresh": "Actualiser",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Token Plan 欧州"
     },
     "requestUrl": "リクエストURL",
+    "ttsEndpointPath": "リクエストパス",
     "models": "モデル",
     "comfyuiWorkflows": "ワークフロー",
     "comfyuiRefresh": "更新",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "토큰 플랜 EU"
     },
     "requestUrl": "요청 URL",
+    "ttsEndpointPath": "요청 경로",
     "models": "모델",
     "comfyuiWorkflows": "워크플로",
     "comfyuiRefresh": "새로고침",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Plano de Tokens EU"
     },
     "requestUrl": "URL da Requisição",
+    "ttsEndpointPath": "Caminho da requisição",
     "models": "Modelos",
     "comfyuiWorkflows": "Fluxos de trabalho",
     "comfyuiRefresh": "Atualizar",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Token Plan Европа"
     },
     "requestUrl": "URL запроса",
+    "ttsEndpointPath": "Путь запроса",
     "models": "Модели",
     "comfyuiWorkflows": "Рабочие процессы",
     "comfyuiRefresh": "Обновить",

--- a/lib/i18n/locales/vi-VN.json
+++ b/lib/i18n/locales/vi-VN.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Gói token châu Âu"
     },
     "requestUrl": "Địa chỉ yêu cầu",
+    "ttsEndpointPath": "Đường dẫn yêu cầu",
     "models": "Các model",
     "comfyuiWorkflows": "Luồng công việc",
     "comfyuiRefresh": "Tải lại",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -1268,6 +1268,7 @@
       "xiaomiTokenPlanEU": "Token Plan 欧洲"
     },
     "requestUrl": "请求地址",
+    "ttsEndpointPath": "请求路径",
     "models": "模型",
     "comfyuiWorkflows": "工作流",
     "comfyuiRefresh": "刷新",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -1253,6 +1253,7 @@
       "xiaomiTokenPlanEU": "Token Plan 歐洲"
     },
     "requestUrl": "請求位址",
+    "ttsEndpointPath": "請求路徑",
     "models": "模型",
     "comfyuiWorkflows": "工作流程",
     "comfyuiRefresh": "重新整理",


### PR DESCRIPTION
## What

Adds an optional, configurable **request endpoint path** for custom (OpenAI-compatible) TTS providers, instead of the hard-coded `/audio/speech` suffix.

## Why

Custom TTS providers previously had their request path hard-coded to `/audio/speech` in both the server-side synthesis path (`generateOpenAITTS`) and the settings-panel "Request URL" preview. Relays, gateways, or self-hosted engines that mount their speech API under a different suffix (e.g. `/v1/tts`, or per-tenant path prefixes) could not be integrated at all — configuring the base URL alone was not enough.

## How

- `lib/audio/tts-providers.ts` — `generateOpenAITTS` reads `providerOptions.endpointPath` (default `/audio/speech`; a leading slash is added when missing) and strips trailing slashes from the base URL before joining.
- `lib/audio/agent-voice.ts` — `resolveAgentVoiceOptions` now passes stored `providerOptions` through for non-VoxCPM providers, so the option takes effect on **every** TTS path (scene generation, multi-agent discussion, agent bar), not just the settings test.
- `components/settings/tts-settings.tsx` — a "Request path" input rendered only for custom providers; the "Request URL" preview and the settings test both honor it.
- 12 locale files — new `settings.ttsEndpointPath` string.

No API contract change: `/api/generate/tts` already forwarded `ttsProviderOptions` into the provider config.

## Test plan

- `pnpm format` ✅
- `npx eslint <changed files> --fix` ✅ (0 errors)
- `npx tsc --noEmit -p tsconfig.json` ✅
- `npx vitest run tests/audio tests/i18n` ✅ (40 files / 299 tests passed)

Screenshots: the new settings field is a small UI addition; screenshots can be added on request.

Closes #1428
