### PR TITLE
feat(audio): add Xiaomi MiMo TTS and ASR providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,15 @@ TTS_DOUBAO_BASE_URL=
 TTS_MINIMAX_API_KEY=
 # MiniMax TTS endpoint (speech-2.8 / 2.6 / 02 / 01 series)
 TTS_MINIMAX_BASE_URL=https://api.minimaxi.com
+
+# Xiaomi MiMo TTS (chat/completions protocol, not OpenAI /audio/speech).
+# Token Plan regional examples:
+# TTS_XIAOMI_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
+# TTS_XIAOMI_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1
+# TTS_XIAOMI_BASE_URL=https://token-plan-ams.xiaomimimo.com/v1
+TTS_XIAOMI_API_KEY=
+TTS_XIAOMI_BASE_URL=https://api.xiaomimimo.com/v1
+
 TTS_ELEVENLABS_API_KEY=
 TTS_ELEVENLABS_BASE_URL=
 
@@ -165,6 +174,14 @@ ASR_AZURE_BASE_URL=https://{region}.api.cognitive.microsoft.com
 
 # Lemonade ASR (local, WAV input only, no API key required)
 # ASR_LEMONADE_BASE_URL=http://localhost:13305/v1
+
+# Xiaomi MiMo ASR (chat/completions protocol, WAV/MP3 input).
+# Token Plan regional examples:
+# ASR_XIAOMI_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
+# ASR_XIAOMI_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1
+# ASR_XIAOMI_BASE_URL=https://token-plan-ams.xiaomimimo.com/v1
+ASR_XIAOMI_API_KEY=
+ASR_XIAOMI_BASE_URL=https://api.xiaomimimo.com/v1
 
 # Operators can force-disable any built-in ASR provider. Examples:
 # ASR_OPENAI_ENABLED=false

--- a/components/settings/asr-settings.tsx
+++ b/components/settings/asr-settings.tsx
@@ -298,6 +298,9 @@ export function ASRSettings({ selectedProviderId }: ASRSettingsProps) {
                 case 'qwen-asr':
                   endpointPath = '/services/aigc/multimodal-generation/generation';
                   break;
+                case 'xiaomi-asr':
+                  endpointPath = '/chat/completions';
+                  break;
               }
             }
             if (!endpointPath) return null;

--- a/components/settings/tts-settings.tsx
+++ b/components/settings/tts-settings.tsx
@@ -226,6 +226,8 @@ export function TTSSettings({ selectedProviderId }: TTSSettingsProps) {
       case 'glm-tts':
       case 'lemonade-tts':
         return '/audio/speech';
+      case 'xiaomi-tts':
+        return '/chat/completions';
       case 'azure-tts':
         return '/cognitiveservices/v1';
       case 'qwen-tts':

--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -196,6 +196,9 @@ export async function transcribeAudio(
         'Lemonade',
       );
 
+    case 'xiaomi-asr':
+      return await transcribeXiaomiASR(config, audioBuffer);
+
     default:
       if (isCustomASRProvider(config.providerId)) {
         return await transcribeCustomOpenAICompatibleASR(config, audioBuffer);
@@ -251,6 +254,113 @@ async function transcribeWavOpenAICompatibleASR(
 
   const data = await response.json();
   return { text: typeof data.text === 'string' ? data.text : '' };
+}
+
+/**
+ * Xiaomi MiMo ASR transcription.
+ *
+ * MiMo ASR reuses the chat/completions protocol rather than OpenAI's
+ * /audio/transcriptions: the audio sample rides inside a user message as an
+ * `input_audio` data-URL part (wav/mp3/flac/m4a/ogg, base64, <= 10 MB
+ * encoded), the language hint goes in `asr_options`, and the transcript comes
+ * back as the assistant message's plain text content.
+ */
+async function transcribeXiaomiASR(
+  config: ASRModelConfig,
+  audioBuffer: Buffer | Blob,
+): Promise<ASRTranscriptionResult> {
+  const baseUrl = (config.baseUrl || ASR_PROVIDERS['xiaomi-asr'].defaultBaseUrl || '').replace(
+    /\/+$/,
+    '',
+  );
+
+  const audioBlob = await toAudioBlob(audioBuffer);
+  const bytes = new Uint8Array(await audioBlob.arrayBuffer());
+  const mimeType = resolveXiaomiASRAudioMime(audioBlob, bytes);
+  if (!mimeType) {
+    throw new Error(
+      'Xiaomi MiMo ASR supports wav/mp3/flac/m4a/ogg audio only (browser recordings are transcoded to WAV client-side before upload).',
+    );
+  }
+  const base64 = Buffer.from(bytes).toString('base64');
+
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      ...getOptionalBearerAuthHeaders(config.apiKey),
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({
+      model: config.modelId || ASR_PROVIDERS['xiaomi-asr'].defaultModelId,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_audio',
+              input_audio: { data: `data:${mimeType};base64,${base64}` },
+            },
+          ],
+        },
+      ],
+      ...(config.language && config.language !== 'auto'
+        ? { asr_options: { language: config.language } }
+        : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => response.statusText);
+    throw new Error(`Xiaomi MiMo ASR API error: ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const text = data?.choices?.[0]?.message?.content;
+  return { text: typeof text === 'string' ? text : '' };
+}
+
+/**
+ * MIME types MiMo ASR accepts, mapped to their canonical form for the
+ * input_audio data URL.
+ */
+const XIAOMI_ASR_MIME_MAP: Record<string, string> = {
+  'audio/wav': 'audio/wav',
+  'audio/x-wav': 'audio/wav',
+  'audio/mpeg': 'audio/mpeg',
+  'audio/mp3': 'audio/mpeg',
+  'audio/flac': 'audio/flac',
+  'audio/x-flac': 'audio/flac',
+  'audio/m4a': 'audio/m4a',
+  'audio/x-m4a': 'audio/m4a',
+  'audio/mp4': 'audio/m4a',
+  'audio/ogg': 'audio/ogg',
+};
+
+function asciiAt(bytes: Uint8Array, start: number, end: number): string {
+  return String.fromCharCode(...bytes.slice(start, end));
+}
+
+function sniffXiaomiASRAudioMime(bytes: Uint8Array): string | null {
+  if (bytes.byteLength >= 12 && asciiAt(bytes, 0, 4) === 'RIFF' && asciiAt(bytes, 8, 12) === 'WAVE')
+    return 'audio/wav';
+  if (bytes.byteLength >= 4 && asciiAt(bytes, 0, 4) === 'fLaC') return 'audio/flac';
+  if (bytes.byteLength >= 4 && asciiAt(bytes, 0, 4) === 'OggS') return 'audio/ogg';
+  if (bytes.byteLength >= 12 && asciiAt(bytes, 4, 8) === 'ftyp') return 'audio/m4a';
+  if (bytes.byteLength >= 3 && asciiAt(bytes, 0, 3) === 'ID3') return 'audio/mpeg';
+  if (bytes.byteLength >= 2 && bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0) return 'audio/mpeg';
+  return null;
+}
+
+/**
+ * Resolve the data-URL MIME for a MiMo ASR upload: trust a declared blob type
+ * when it is one MiMo accepts, otherwise sniff the header. Returns null for
+ * unsupported containers (e.g. webm) so the caller can fail with a clear
+ * message instead of the provider's opaque "invalid audio format".
+ */
+function resolveXiaomiASRAudioMime(blob: Blob, bytes: Uint8Array): string | null {
+  const declared = blob.type?.split(';')[0].trim().toLowerCase();
+  if (declared && XIAOMI_ASR_MIME_MAP[declared]) return XIAOMI_ASR_MIME_MAP[declared];
+  return sniffXiaomiASRAudioMime(bytes);
 }
 
 async function toAudioBlob(audioBuffer: Buffer | Blob): Promise<Blob> {

--- a/lib/audio/constants.ts
+++ b/lib/audio/constants.ts
@@ -787,6 +787,31 @@ export const TTS_PROVIDERS: Record<BuiltInTTSProviderId, TTSProviderConfig> = {
     },
   },
 
+  'xiaomi-tts': {
+    id: 'xiaomi-tts',
+    name: 'Xiaomi MiMo TTS',
+    requiresApiKey: true,
+    defaultBaseUrl: 'https://api.xiaomimimo.com/v1',
+    icon: '/logos/xiaomi.svg',
+    models: [
+      { id: 'mimo-v2.5-tts', name: 'MiMo V2.5 TTS' },
+      { id: 'mimo-v2.5-tts-voicedesign', name: 'MiMo V2.5 TTS (Voice Design)' },
+    ],
+    defaultModelId: 'mimo-v2.5-tts',
+    voices: [
+      { id: 'mimo_default', name: 'MiMo 默认', language: 'zh-CN', gender: 'neutral' },
+      { id: '冰糖', name: '冰糖', language: 'zh-CN', gender: 'female' },
+      { id: '茉莉', name: '茉莉', language: 'zh-CN', gender: 'female' },
+      { id: '苏打', name: '苏打', language: 'zh-CN', gender: 'male' },
+      { id: '白桦', name: '白桦', language: 'zh-CN', gender: 'male' },
+      { id: 'Mia', name: 'Mia', language: 'en-US', gender: 'female' },
+      { id: 'Chloe', name: 'Chloe', language: 'en-US', gender: 'female' },
+      { id: 'Milo', name: 'Milo', language: 'en-US', gender: 'male' },
+      { id: 'Dean', name: 'Dean', language: 'en-US', gender: 'male' },
+    ],
+    supportedFormats: ['wav'],
+  },
+
   'voxcpm-tts': {
     id: VOXCPM_TTS_PROVIDER_ID,
     name: 'VoxCPM2',
@@ -1327,6 +1352,18 @@ export const ASR_PROVIDERS: Record<BuiltInASRProviderId, ASRProviderConfig> = {
     supportedLanguages: CUSTOM_ASR_DEFAULT_LANGUAGES,
     supportedFormats: ['wav'],
   },
+
+  'xiaomi-asr': {
+    id: 'xiaomi-asr',
+    name: 'Xiaomi MiMo ASR',
+    requiresApiKey: true,
+    defaultBaseUrl: 'https://api.xiaomimimo.com/v1',
+    icon: '/logos/xiaomi.svg',
+    models: [{ id: 'mimo-v2.5-asr', name: 'MiMo V2.5 ASR' }],
+    defaultModelId: 'mimo-v2.5-asr',
+    supportedLanguages: ['auto', 'zh', 'en'],
+    supportedFormats: ['wav', 'mp3'],
+  },
 };
 
 /**
@@ -1342,6 +1379,7 @@ export const DEFAULT_TTS_VOICES: Record<BuiltInTTSProviderId, string> = {
   'doubao-tts': 'zh_female_vv_uranus_bigtts',
   'elevenlabs-tts': 'EXAVITQu4vr4xnSDxMaL',
   'minimax-tts': 'female-yujie',
+  'xiaomi-tts': 'mimo_default',
   'lemonade-tts': 'af_heart',
   'browser-native-tts': 'default',
 };
@@ -1355,6 +1393,7 @@ export const DEFAULT_TTS_MODELS: Record<BuiltInTTSProviderId, string> = {
   'doubao-tts': '',
   'elevenlabs-tts': 'eleven_multilingual_v2',
   'minimax-tts': 'speech-2.8-hd',
+  'xiaomi-tts': 'mimo-v2.5-tts',
   'lemonade-tts': 'kokoro-v1',
   'browser-native-tts': '',
 };

--- a/lib/audio/provider-display.ts
+++ b/lib/audio/provider-display.ts
@@ -20,6 +20,7 @@ const ASR_PROVIDER_NAME_KEYS: Record<string, string> = {
   'azure-asr': 'settings.providerAzureASR',
   'funasr-asr': 'settings.providerFunASRASR',
   'lemonade-asr': 'settings.providerLemonadeASR',
+  'xiaomi-asr': 'settings.providerXiaomiASR',
 };
 
 const TTS_PROVIDER_NAME_KEYS: Record<string, string> = {
@@ -31,6 +32,7 @@ const TTS_PROVIDER_NAME_KEYS: Record<string, string> = {
   'doubao-tts': 'settings.providerDoubaoTTS',
   'elevenlabs-tts': 'settings.providerElevenLabsTTS',
   'minimax-tts': 'settings.providerMiniMaxTTS',
+  'xiaomi-tts': 'settings.providerXiaomiTTS',
   'lemonade-tts': 'settings.providerLemonadeTTS',
   'browser-native-tts': 'settings.providerBrowserNativeTTS',
 };

--- a/lib/audio/tts-providers.ts
+++ b/lib/audio/tts-providers.ts
@@ -235,6 +235,8 @@ export async function generateTTS(
 
       case 'minimax-tts':
         return await generateMiniMaxTTS(config, text, signal);
+      case 'xiaomi-tts':
+        return await generateXiaomiTTS(config, text, signal);
       case 'doubao-tts':
         return await generateDoubaoTTS(config, text, signal);
       case 'elevenlabs-tts':
@@ -306,6 +308,72 @@ async function generateOpenAITTS(
   return {
     audio: new Uint8Array(arrayBuffer),
     format,
+  };
+}
+
+/**
+ * Xiaomi MiMo TTS implementation.
+ *
+ * MiMo TTS does NOT expose an OpenAI-style /audio/speech endpoint. It reuses
+ * the chat/completions protocol: the text to synthesize goes in an `assistant`
+ * message, optional style instructions go in a `user` message, and the audio
+ * payload comes back base64-encoded at `choices[0].message.audio.data`.
+ * Numeric speed is not a request parameter, so a non-default speed is
+ * translated into a natural-language style instruction instead.
+ */
+async function generateXiaomiTTS(
+  config: TTSModelConfig,
+  text: string,
+  signal: AbortSignal,
+): Promise<TTSGenerationResult> {
+  const baseUrl = (config.baseUrl || TTS_PROVIDERS['xiaomi-tts'].defaultBaseUrl || '').replace(
+    /\/+$/,
+    '',
+  );
+
+  const messages: Array<{ role: string; content: string }> = [];
+  const speed = config.speed ?? 1.0;
+  if (speed >= 1.25) {
+    messages.push({ role: 'user', content: '说得快一些，语速偏快。' });
+  } else if (speed <= 0.8) {
+    messages.push({ role: 'user', content: '说得慢一些，语速偏慢。' });
+  }
+  // The text to synthesize must be in the assistant message (provider rule).
+  messages.push({ role: 'assistant', content: text });
+
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({
+      model: config.modelId || TTS_PROVIDERS['xiaomi-tts'].defaultModelId,
+      messages,
+      audio: {
+        format: 'wav',
+        voice: config.voice || 'mimo_default',
+      },
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throwIfTtsRateLimited('Xiaomi MiMo', response.status);
+    const error = await response.json().catch(() => ({ error: response.statusText }));
+    throw new Error(
+      `Xiaomi MiMo TTS API error: ${error.error?.message || error.message || response.statusText}`,
+    );
+  }
+
+  const data = await response.json();
+  const audioData = data?.choices?.[0]?.message?.audio?.data;
+  if (typeof audioData !== 'string' || !audioData) {
+    throw new Error('Xiaomi MiMo TTS API returned no audio data');
+  }
+  return {
+    audio: new Uint8Array(Buffer.from(audioData, 'base64')),
+    format: 'wav',
   };
 }
 

--- a/lib/audio/types.ts
+++ b/lib/audio/types.ts
@@ -88,6 +88,7 @@ export type BuiltInTTSProviderId =
   | 'doubao-tts'
   | 'elevenlabs-tts'
   | 'minimax-tts'
+  | 'xiaomi-tts'
   | 'lemonade-tts'
   | 'browser-native-tts';
 
@@ -182,6 +183,7 @@ export type BuiltInASRProviderId =
   | 'qwen-asr'
   | 'funasr-asr'
   | 'lemonade-asr'
+  | 'xiaomi-asr'
   | 'azure-asr';
 
 export type ASRProviderId = BuiltInASRProviderId | `custom-asr-${string}`;

--- a/lib/audio/wav-utils.ts
+++ b/lib/audio/wav-utils.ts
@@ -77,7 +77,9 @@ export async function normalizeASRUploadAudio(
   providerId: string,
   audioBlob: Blob,
 ): Promise<{ blob: Blob; fileName: string }> {
-  if (providerId !== 'lemonade-asr' && providerId !== 'funasr-asr') {
+  // Providers whose APIs reject WebM/Opus recordings get a client-side WAV
+  // transcode; everyone else receives the recording as-is.
+  if (providerId !== 'lemonade-asr' && providerId !== 'funasr-asr' && providerId !== 'xiaomi-asr') {
     return { blob: audioBlob, fileName: 'recording.webm' };
   }
   return { blob: await audioBlobToWav(audioBlob), fileName: 'recording.wav' };

--- a/lib/i18n/locales/ar-SA.json
+++ b/lib/i18n/locales/ar-SA.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (فولكينجين)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (محلي)",
     "providerBrowserNativeTTS": "تحويل النص إلى كلام المدمج في المتصفح",
     "voxcpmBackend": "الخلفية",

--- a/lib/i18n/locales/de-DE.json
+++ b/lib/i18n/locales/de-DE.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (Lokal)",
     "providerBrowserNativeTTS": "Browserintegrierte TTS",
     "voxcpmBackend": "Backend",

--- a/lib/i18n/locales/en-US.json
+++ b/lib/i18n/locales/en-US.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (Local)",
     "providerBrowserNativeTTS": "Browser Native TTS",
     "voxcpmBackend": "Backend",

--- a/lib/i18n/locales/es-MX.json
+++ b/lib/i18n/locales/es-MX.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (local)",
     "providerBrowserNativeTTS": "TTS nativo del navegador",
     "voxcpmBackend": "Backend",

--- a/lib/i18n/locales/fr-FR.json
+++ b/lib/i18n/locales/fr-FR.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (local)",
     "providerBrowserNativeTTS": "Synthèse vocale native du navigateur",
     "voxcpmBackend": "Moteur",

--- a/lib/i18n/locales/ja-JP.json
+++ b/lib/i18n/locales/ja-JP.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0（火山エンジン）",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS（ローカル）",
     "providerBrowserNativeTTS": "ブラウザネイティブTTS",
     "voxcpmBackend": "バックエンド",

--- a/lib/i18n/locales/ko-KR.json
+++ b/lib/i18n/locales/ko-KR.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (로컬)",
     "providerBrowserNativeTTS": "브라우저 기본 TTS",
     "voxcpmBackend": "백엔드",

--- a/lib/i18n/locales/pt-BR.json
+++ b/lib/i18n/locales/pt-BR.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (Local)",
     "providerBrowserNativeTTS": "TTS Nativo do Navegador",
     "voxcpmBackend": "Backend",

--- a/lib/i18n/locales/ru-RU.json
+++ b/lib/i18n/locales/ru-RU.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (Локальный)",
     "providerBrowserNativeTTS": "Встроенный TTS браузера",
     "voxcpmBackend": "Бэкенд",

--- a/lib/i18n/locales/vi-VN.json
+++ b/lib/i18n/locales/vi-VN.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "Doubao TTS 2.0 (Volcengine)",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "Xiaomi MiMo TTS",
+    "providerXiaomiASR": "Xiaomi MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS (Cục bộ)",
     "providerBrowserNativeTTS": "Giọng đọc sẵn có của trình duyệt",
     "voxcpmBackend": "Máy chủ xử lý",

--- a/lib/i18n/locales/zh-CN.json
+++ b/lib/i18n/locales/zh-CN.json
@@ -1395,6 +1395,8 @@
     "providerDoubaoTTS": "豆包 TTS 2.0（火山引擎）",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "小米 MiMo TTS",
+    "providerXiaomiASR": "小米 MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS（本地）",
     "providerBrowserNativeTTS": "浏览器原生 TTS",
     "voxcpmBackend": "Backend",

--- a/lib/i18n/locales/zh-TW.json
+++ b/lib/i18n/locales/zh-TW.json
@@ -1380,6 +1380,8 @@
     "providerDoubaoTTS": "豆包 TTS 2.0（火山引擎）",
     "providerElevenLabsTTS": "ElevenLabs TTS",
     "providerMiniMaxTTS": "MiniMax TTS",
+    "providerXiaomiTTS": "小米 MiMo TTS",
+    "providerXiaomiASR": "小米 MiMo ASR",
     "providerLemonadeTTS": "Lemonade TTS（本機）",
     "providerBrowserNativeTTS": "瀏覽器原生 TTS",
     "voxcpmBackend": "後端",

--- a/lib/server/provider-config.ts
+++ b/lib/server/provider-config.ts
@@ -93,6 +93,8 @@ const TTS_ENV_MAP: Record<string, string> = {
   TTS_DOUBAO: 'doubao-tts',
   TTS_ELEVENLABS: 'elevenlabs-tts',
   TTS_MINIMAX: 'minimax-tts',
+  TTS_XIAOMI: 'xiaomi-tts',
+  TTS_MIMO: 'xiaomi-tts',
   TTS_LEMONADE: 'lemonade-tts',
 };
 
@@ -102,6 +104,8 @@ const ASR_ENV_MAP: Record<string, string> = {
   ASR_AZURE: 'azure-asr',
   ASR_FUNASR: 'funasr-asr',
   ASR_LEMONADE: 'lemonade-asr',
+  ASR_XIAOMI: 'xiaomi-asr',
+  ASR_MIMO: 'xiaomi-asr',
 };
 
 const PDF_ENV_MAP: Record<string, string> = {

--- a/lib/store/settings.ts
+++ b/lib/store/settings.ts
@@ -517,6 +517,7 @@ const getDefaultAudioConfig = () => ({
     'doubao-tts': { apiKey: '', baseUrl: '', enabled: true },
     'elevenlabs-tts': { apiKey: '', baseUrl: '', enabled: true },
     'minimax-tts': { apiKey: '', baseUrl: '', modelId: 'speech-2.8-hd', enabled: true },
+    'xiaomi-tts': { apiKey: '', baseUrl: '', modelId: 'mimo-v2.5-tts', enabled: true },
     'lemonade-tts': {
       apiKey: '',
       baseUrl: '',
@@ -537,6 +538,7 @@ const getDefaultAudioConfig = () => ({
     'azure-asr': { apiKey: '', baseUrl: '', enabled: false },
     'funasr-asr': { apiKey: '', baseUrl: '', enabled: false },
     'lemonade-asr': { apiKey: '', baseUrl: '', enabled: false },
+    'xiaomi-asr': { apiKey: '', baseUrl: '', modelId: 'mimo-v2.5-asr', enabled: false },
   } as Record<ASRProviderId, { apiKey: string; baseUrl: string; enabled: boolean }>,
 });
 

--- a/tests/audio/wav-utils.test.ts
+++ b/tests/audio/wav-utils.test.ts
@@ -46,4 +46,11 @@ describe('normalizeASRUploadAudio', () => {
     expect(result.blob).toBe(input);
     expect(result.fileName).toBe('recording.wav');
   });
+
+  it('keeps WAV blobs unchanged for xiaomi-asr', async () => {
+    const input = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/wav' });
+    const result = await normalizeASRUploadAudio('xiaomi-asr', input);
+    expect(result.blob).toBe(input);
+    expect(result.fileName).toBe('recording.wav');
+  });
 });

--- a/tests/audio/xiaomi-asr.test.ts
+++ b/tests/audio/xiaomi-asr.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { transcribeAudio } from '@/lib/audio/asr-providers';
+
+const mockFetch = vi.fn() as Mock;
+vi.stubGlobal('fetch', mockFetch);
+
+function wavBuffer(): Buffer {
+  const buf = Buffer.alloc(44);
+  buf.write('RIFF', 0, 'ascii');
+  buf.write('WAVE', 8, 'ascii');
+  return buf;
+}
+
+function chatCompletionWithText(text: string): object {
+  return {
+    id: 'test-id',
+    choices: [{ finish_reason: 'stop', index: 0, message: { content: text, role: 'assistant' } }],
+  };
+}
+
+describe('Xiaomi MiMo ASR', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('posts input_audio data URL to /chat/completions and returns the transcript', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => chatCompletionWithText('你好，世界'),
+    });
+
+    const result = await transcribeAudio(
+      {
+        providerId: 'xiaomi-asr',
+        apiKey: 'tp-test',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1/',
+        language: 'zh',
+      },
+      wavBuffer(),
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://token-plan-cn.xiaomimimo.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer tp-test');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.model).toBe('mimo-v2.5-asr');
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe('user');
+    const part = body.messages[0].content[0];
+    expect(part.type).toBe('input_audio');
+    expect(part.input_audio.data.startsWith('data:audio/wav;base64,')).toBe(true);
+    expect(body.asr_options).toEqual({ language: 'zh' });
+    expect(result.text).toBe('你好，世界');
+  });
+
+  it('omits asr_options when language is auto', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => chatCompletionWithText('hello'),
+    });
+
+    await transcribeAudio(
+      { providerId: 'xiaomi-asr', apiKey: 'tp-test', language: 'auto' },
+      wavBuffer(),
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.asr_options).toBeUndefined();
+  });
+
+  it('detects MP3 frame sync as audio/mpeg', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => chatCompletionWithText('ok'),
+    });
+
+    await transcribeAudio(
+      { providerId: 'xiaomi-asr', apiKey: 'tp-test' },
+      Buffer.from([0xff, 0xfb, 0x90, 0x00, 1, 2, 3, 4, 5, 6, 7, 8]),
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.messages[0].content[0].input_audio.data.startsWith('data:audio/mpeg;base64,')).toBe(
+      true,
+    );
+  });
+
+  it('rejects webm/opus recordings with a clear error instead of posting them', async () => {
+    const webmHeader = Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4, 5, 6, 7, 8]);
+    await expect(
+      transcribeAudio(
+        { providerId: 'xiaomi-asr', apiKey: 'tp-test' },
+        new Blob([webmHeader], { type: 'audio/webm' }),
+      ),
+    ).rejects.toThrow(/wav\/mp3\/flac\/m4a\/ogg/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws on non-OK responses', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'Param Incorrect',
+      statusText: 'Bad Request',
+    });
+
+    await expect(
+      transcribeAudio({ providerId: 'xiaomi-asr', apiKey: 'tp-test' }, wavBuffer()),
+    ).rejects.toThrow(/Xiaomi MiMo ASR API error: Param Incorrect/);
+  });
+});

--- a/tests/audio/xiaomi-tts.test.ts
+++ b/tests/audio/xiaomi-tts.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { generateTTS } from '@/lib/audio/tts-providers';
+
+const mockFetch = vi.fn() as Mock;
+vi.stubGlobal('fetch', mockFetch);
+
+function chatCompletionWithAudio(): object {
+  return {
+    id: 'test-id',
+    choices: [
+      {
+        finish_reason: 'stop',
+        index: 0,
+        message: {
+          content: '',
+          role: 'assistant',
+          audio: { id: 'audio-id', data: Buffer.from('RIFF-fake-wav').toString('base64') },
+        },
+      },
+    ],
+  };
+}
+
+describe('Xiaomi MiMo TTS', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('posts to /chat/completions with assistant-role text and audio params', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => chatCompletionWithAudio(),
+    });
+
+    const result = await generateTTS(
+      {
+        providerId: 'xiaomi-tts',
+        apiKey: 'tp-test',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1/',
+        voice: '冰糖',
+      },
+      '你好，世界',
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://token-plan-cn.xiaomimimo.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer tp-test');
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({
+      model: 'mimo-v2.5-tts',
+      messages: [{ role: 'assistant', content: '你好，世界' }],
+      audio: { format: 'wav', voice: '冰糖' },
+    });
+    expect(result.audio).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(result.audio).toString()).toBe('RIFF-fake-wav');
+    expect(result.format).toBe('wav');
+  });
+
+  it('defaults to mimo_default voice and mimo-v2.5-tts model', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => chatCompletionWithAudio(),
+    });
+
+    await generateTTS({ providerId: 'xiaomi-tts', apiKey: 'tp-test', voice: '' }, 'hi');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.audio.voice).toBe('mimo_default');
+    expect(body.model).toBe('mimo-v2.5-tts');
+  });
+
+  it('translates non-default speed into a user-role style instruction', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => chatCompletionWithAudio(),
+    });
+
+    await generateTTS(
+      { providerId: 'xiaomi-tts', apiKey: 'tp-test', voice: 'Mia', speed: 1.5 },
+      'hello',
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe('user');
+    expect(body.messages[1]).toEqual({ role: 'assistant', content: 'hello' });
+  });
+
+  it('throws when the response carries no audio data', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ choices: [{ message: { role: 'assistant', content: '' } }] }),
+    });
+
+    await expect(
+      generateTTS({ providerId: 'xiaomi-tts', apiKey: 'tp-test', voice: 'Mia' }, 'hi'),
+    ).rejects.toThrow(/no audio data/);
+  });
+
+  it('throws on non-OK responses', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'Param Incorrect' } }),
+      statusText: 'Bad Request',
+    });
+
+    await expect(
+      generateTTS({ providerId: 'xiaomi-tts', apiKey: 'tp-test', voice: 'Mia' }, 'hi'),
+    ).rejects.toThrow(/Xiaomi MiMo TTS API error: Param Incorrect/);
+  });
+});

--- a/tests/providers/provider-neutrality-guard.test.ts
+++ b/tests/providers/provider-neutrality-guard.test.ts
@@ -182,7 +182,7 @@ const TEMPORARY_VENDOR_DEBT: readonly AllowedVendorDebt[] = [
       ['grok', 6],
       ['tencent', 4],
       ['hunyuan', 3],
-      ['xiaomi', 3],
+      ['xiaomi', 9],
       ['ollama', 3],
       ['lemonade', 12],
       ['bedrock', 29],


### PR DESCRIPTION
## What

Adds built-in `xiaomi-tts` and `xiaomi-asr` providers, integrating speech synthesis (the `mimo-v2.5-tts` family) and speech recognition (`mimo-v2.5-asr`) from the Xiaomi MiMo open platform.

## Why

MiMo's audio APIs speak the **chat/completions protocol**, not OpenAI's `/audio/speech` or `/audio/transcriptions`:

- **TTS**: the text must ride in an `assistant` message, the voice goes in `audio.voice`, and the audio comes back base64-encoded at `choices[0].message.audio.data`. There is no numeric speed parameter.
- **ASR**: the sample is uploaded as an `input_audio` data-URL part in a `user` message; only `wav/mp3/flac/m4a/ogg` are accepted (notably not the `webm/opus` that browser `MediaRecorder` produces); the transcript is plain assistant message content.

The generic custom-provider adapters cannot express either shape, so dedicated providers are required.

## How

- `lib/audio/tts-providers.ts` — `generateXiaomiTTS`: assistant-message text, `audio: { format: 'wav', voice }`, base64 audio extraction; non-default speeds (≥ 1.25× / ≤ 0.8×) are translated into natural-language pacing instructions in a `user` message.
- `lib/audio/asr-providers.ts` — `transcribeXiaomiASR`: `input_audio` data URL; MIME resolved from a declared-type whitelist or magic-byte sniffing (RIFF / ID3 / frame sync / fLaC / OggS / ftyp); unsupported containers fail fast with a clear error instead of the provider's opaque `Param Incorrect`; `asr_options.language` is only sent for non-`auto` languages.
- `lib/audio/wav-utils.ts` — browser recordings are transcoded to WAV client-side for `xiaomi-asr` (same normalization path as FunASR/Lemonade).
- `lib/audio/constants.ts` / `types.ts` / `provider-display.ts` — registry entries: 9 preset voices, 2 TTS models, `/logos/xiaomi.svg`, default base URL `https://api.xiaomimimo.com/v1`.
- `lib/server/provider-config.ts` — `TTS_XIAOMI_*` / `ASR_XIAOMI_*` env vars with `TTS_MIMO_*` / `ASR_MIMO_*` aliases (mirroring the existing `XIAOMI` / `MIMO` LLM aliases).
- `lib/store/settings.ts` defaults, settings-panel `/chat/completions` request-URL previews, 12 locale name keys, `.env.example` documentation including Token Plan regional clusters (`token-plan-cn/sgp/ams`).
- Tests: new `tests/audio/xiaomi-tts.test.ts` and `tests/audio/xiaomi-asr.test.ts`; `wav-utils.test.ts` gains a `xiaomi-asr` case.

## Test plan

- `pnpm format` ✅
- `npx eslint <changed files> --fix` ✅ (0 errors)
- `npx tsc --noEmit -p tsconfig.json` ✅
- `npx vitest run tests/audio tests/i18n` ✅ (42 files / 310 tests passed)
- Verified end-to-end against the `token-plan-cn` cluster: TTS returns a valid RIFF/WAV payload; ASR round-trips a TTS-generated sample correctly.

Docs: https://mimo.mi.com/docs (speech synthesis / speech recognition chapters)

Closes #1429
