### PR TITLE
feat(token-plan): add ASR modality and Xiaomi MiMo Token Plan preset

### DIFF
--- a/components/settings/token-plan-settings.tsx
+++ b/components/settings/token-plan-settings.tsx
@@ -14,6 +14,7 @@ import {
   Image as ImageIcon,
   Video,
   Volume2,
+  Mic,
   Search,
   type LucideIcon,
 } from 'lucide-react';
@@ -42,6 +43,7 @@ const MODALITY_LABEL_KEYS: Record<TokenPlanModality, string> = {
   image: 'settings.imageSettings',
   video: 'settings.videoSettings',
   tts: 'settings.ttsSettings',
+  asr: 'settings.asrSettings',
   webSearch: 'settings.webSearchSettings',
 };
 
@@ -50,6 +52,7 @@ const MODALITY_ICONS: Record<TokenPlanModality, LucideIcon> = {
   image: ImageIcon,
   video: Video,
   tts: Volume2,
+  asr: Mic,
   webSearch: Search,
 };
 
@@ -68,6 +71,7 @@ export function TokenPlanSettings() {
   const setImageProviderConfig = useSettingsStore((s) => s.setImageProviderConfig);
   const setVideoProviderConfig = useSettingsStore((s) => s.setVideoProviderConfig);
   const setTTSProviderConfig = useSettingsStore((s) => s.setTTSProviderConfig);
+  const setASRProviderConfig = useSettingsStore((s) => s.setASRProviderConfig);
   const setWebSearchProviderConfig = useSettingsStore((s) => s.setWebSearchProviderConfig);
   const setImageProvider = useSettingsStore((s) => s.setImageProvider);
   const setImageModelId = useSettingsStore((s) => s.setImageModelId);
@@ -105,6 +109,7 @@ export function TokenPlanSettings() {
       setImageProviderConfig,
       setVideoProviderConfig,
       setTTSProviderConfig,
+      setASRProviderConfig,
       setWebSearchProviderConfig,
     });
   };
@@ -128,6 +133,7 @@ export function TokenPlanSettings() {
       setImageProviderConfig,
       setVideoProviderConfig,
       setTTSProviderConfig,
+      setASRProviderConfig,
       setWebSearchProviderConfig,
       setImageProvider,
       setImageModelId,
@@ -141,6 +147,7 @@ export function TokenPlanSettings() {
     setImageProviderConfig,
     setVideoProviderConfig,
     setTTSProviderConfig,
+    setASRProviderConfig,
     setWebSearchProviderConfig,
     setImageProvider,
     setImageModelId,

--- a/lib/config/apply-token-plan.ts
+++ b/lib/config/apply-token-plan.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from '@/lib/types/provider';
 import type { ImageProviderId, VideoProviderId } from '@/lib/media/types';
-import type { TTSProviderId } from '@/lib/audio/types';
+import type { TTSProviderId, ASRProviderId } from '@/lib/audio/types';
 import type { WebSearchProviderId } from '@/lib/web-search/types';
 import type {
   TokenPlanModality,
@@ -42,6 +42,10 @@ export interface TokenPlanActions {
   ) => void;
   setTTSProviderConfig: (
     id: TTSProviderId,
+    config: Partial<{ apiKey: string; baseUrl: string; enabled: boolean; modelId: string }>,
+  ) => void;
+  setASRProviderConfig: (
+    id: ASRProviderId,
     config: Partial<{ apiKey: string; baseUrl: string; enabled: boolean; modelId: string }>,
   ) => void;
   setWebSearchProviderConfig: (
@@ -211,6 +215,14 @@ function applyModality(
         ...(target.defaultModelId ? { modelId: target.defaultModelId } : {}),
       });
       break;
+    case 'asr':
+      actions.setASRProviderConfig(target.providerId as ASRProviderId, {
+        apiKey,
+        baseUrl: target.baseUrl,
+        enabled: true,
+        ...(target.defaultModelId ? { modelId: target.defaultModelId } : {}),
+      });
+      break;
     case 'webSearch':
       actions.setWebSearchProviderConfig(target.providerId as WebSearchProviderId, {
         apiKey,
@@ -305,6 +317,13 @@ function removeModality(
       break;
     case 'tts':
       actions.setTTSProviderConfig(target.providerId as TTSProviderId, {
+        apiKey: '',
+        baseUrl: '',
+        enabled: false,
+      });
+      break;
+    case 'asr':
+      actions.setASRProviderConfig(target.providerId as ASRProviderId, {
         apiKey: '',
         baseUrl: '',
         enabled: false,

--- a/lib/config/token-plan-presets.ts
+++ b/lib/config/token-plan-presets.ts
@@ -16,8 +16,8 @@ import type { ProviderType } from '@/lib/types/provider';
 /** Loose grouping for the preset list UI. */
 export type PresetCategory = 'official' | 'aggregator' | 'token_plan' | 'third_party';
 
-/** The modalities a token plan can be applied to. ASR is omitted = not adapted. */
-export type TokenPlanModality = 'llm' | 'image' | 'video' | 'tts' | 'webSearch';
+/** The modalities a token plan can be applied to. */
+export type TokenPlanModality = 'llm' | 'image' | 'video' | 'tts' | 'asr' | 'webSearch';
 
 /** Where a token plan maps in one modality's provider registry. */
 export interface TokenPlanModalityTarget {
@@ -59,7 +59,14 @@ export interface TokenPlanPreset {
 }
 
 /** Human-facing order of modalities in the apply result. */
-export const MODALITY_ORDER: TokenPlanModality[] = ['llm', 'image', 'video', 'tts', 'webSearch'];
+export const MODALITY_ORDER: TokenPlanModality[] = [
+  'llm',
+  'image',
+  'video',
+  'tts',
+  'asr',
+  'webSearch',
+];
 
 /**
  * Built-in token plans.
@@ -123,6 +130,41 @@ export const TOKEN_PLAN_PRESETS: TokenPlanPreset[] = [
         ],
       },
       webSearch: { providerId: 'minimax', baseUrl: 'https://api.minimaxi.com' },
+    },
+  },
+
+  // ── Xiaomi MiMo Token Plan ────────────────────────────────────────────────
+  {
+    // Xiaomi MiMo Token Plan: one tp-... key spans LLM + TTS + ASR. tp- keys
+    // authenticate ONLY against the regional Token Plan hosts (verified: the
+    // pay-as-you-go api.xiaomimimo.com host rejects them), so every modality
+    // points at the CN cluster by default — users in other regions switch the
+    // base URL to the SGP/AMS cluster in each provider's settings afterwards.
+    // MiMo audio models speak the chat/completions protocol (text/audio ride
+    // in messages), adapted by the built-in xiaomi-tts / xiaomi-asr providers.
+    id: 'xiaomi-mimo',
+    name: 'Xiaomi MiMo Token Plan',
+    websiteUrl: 'https://mimo.mi.com',
+    apiKeyPlaceholder: 'tp-...',
+    icon: '/logos/xiaomi.svg',
+    category: 'token_plan',
+    modalities: {
+      llm: {
+        providerId: 'xiaomi',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+        apiFormat: 'openai',
+        defaultModels: ['mimo-v2.5-pro', 'mimo-v2.5'],
+      },
+      tts: {
+        providerId: 'xiaomi-tts',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+        defaultModelId: 'mimo-v2.5-tts',
+      },
+      asr: {
+        providerId: 'xiaomi-asr',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+        defaultModelId: 'mimo-v2.5-asr',
+      },
     },
   },
 

--- a/tests/config/apply-token-plan.test.ts
+++ b/tests/config/apply-token-plan.test.ts
@@ -12,6 +12,7 @@ function makeActions(): TokenPlanActions {
     setImageProviderConfig: vi.fn(),
     setVideoProviderConfig: vi.fn(),
     setTTSProviderConfig: vi.fn(),
+    setASRProviderConfig: vi.fn(),
     setWebSearchProviderConfig: vi.fn(),
   };
 }
@@ -80,10 +81,51 @@ describe('applyTokenPlan', () => {
     expect(actions.setImageProviderConfig).not.toHaveBeenCalled();
     expect(actions.setVideoProviderConfig).not.toHaveBeenCalled();
     expect(actions.setTTSProviderConfig).not.toHaveBeenCalled();
+    expect(actions.setASRProviderConfig).not.toHaveBeenCalled();
     expect(actions.setWebSearchProviderConfig).not.toHaveBeenCalled();
 
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({ modality: 'llm', status: 'lit' });
+  });
+
+  it('fills LLM + TTS + ASR for the Xiaomi MiMo Token Plan', () => {
+    const actions = makeActions();
+    const xiaomi = TOKEN_PLAN_PRESETS.find((p) => p.id === 'xiaomi-mimo')!;
+    const results = applyTokenPlan(xiaomi, 'tp-test', actions);
+
+    expect(actions.setProviderConfig).toHaveBeenCalledWith(
+      'xiaomi',
+      expect.objectContaining({
+        apiKey: 'tp-test',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+        type: 'openai',
+        models: expect.arrayContaining([expect.objectContaining({ id: 'mimo-v2.5-pro' })]),
+      }),
+    );
+    expect(actions.setTTSProviderConfig).toHaveBeenCalledWith(
+      'xiaomi-tts',
+      expect.objectContaining({
+        apiKey: 'tp-test',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+        enabled: true,
+        modelId: 'mimo-v2.5-tts',
+      }),
+    );
+    expect(actions.setASRProviderConfig).toHaveBeenCalledWith(
+      'xiaomi-asr',
+      expect.objectContaining({
+        apiKey: 'tp-test',
+        baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+        enabled: true,
+        modelId: 'mimo-v2.5-asr',
+      }),
+    );
+    expect(actions.setImageProviderConfig).not.toHaveBeenCalled();
+    expect(actions.setVideoProviderConfig).not.toHaveBeenCalled();
+    expect(actions.setWebSearchProviderConfig).not.toHaveBeenCalled();
+
+    const lit = results.filter((r) => r.status === 'lit').map((r) => r.modality);
+    expect(lit).toEqual(['llm', 'tts', 'asr']);
   });
 
   it('passes modelsUrl through to the LLM provider config when present', () => {

--- a/tests/config/token-plan-apply-persist.test.ts
+++ b/tests/config/token-plan-apply-persist.test.ts
@@ -37,6 +37,7 @@ describe('token plan apply + probe model write', () => {
       setImageProviderConfig: store.setImageProviderConfig,
       setVideoProviderConfig: store.setVideoProviderConfig,
       setTTSProviderConfig: store.setTTSProviderConfig,
+      setASRProviderConfig: store.setASRProviderConfig,
       setWebSearchProviderConfig: store.setWebSearchProviderConfig,
     });
 


### PR DESCRIPTION
## What

Adds an **ASR modality** to the Token Plan framework and ships a new **Xiaomi MiMo Token Plan** preset whose single `tp-...` key lights up LLM + TTS + ASR in one click.

## Why

`TokenPlanModality` previously stopped at `llm | image | video | tts | webSearch`, with ASR explicitly marked as not adapted. MiMo's Token Plan spans LLM + TTS + ASR under one key, making it the natural first preset to exercise an ASR modality — without it, one third of the plan is unreachable through the one-click apply flow.

## How

- `lib/config/token-plan-presets.ts` — `TokenPlanModality` and `MODALITY_ORDER` gain `'asr'`; new `xiaomi-mimo` preset:
  - `llm` → provider `xiaomi`, `https://token-plan-cn.xiaomimimo.com/v1`, curated models `mimo-v2.5-pro` / `mimo-v2.5`
  - `tts` → provider `xiaomi-tts`, same base URL, default model `mimo-v2.5-tts`
  - `asr` → provider `xiaomi-asr`, same base URL, default model `mimo-v2.5-asr`
  - `apiKeyPlaceholder: 'tp-...'`, icon `/logos/xiaomi.svg`, `category: 'token_plan'`
  - A comment documents that `tp-` keys authenticate only against Token Plan hosts, and that other regions can switch to the SGP/AMS cluster after applying.
- `lib/config/apply-token-plan.ts` — `TokenPlanActions` gains `setASRProviderConfig`; apply/remove handle `asr` symmetrically to `tts`.
- `components/settings/token-plan-settings.tsx` — ASR tab (mic icon, existing `settings.asrSettings` label) with actions wired through.
- `tests/config/apply-token-plan.test.ts` — new Xiaomi preset case (LLM+TTS+ASR filled; image/video/webSearch untouched); DeepSeek case asserts ASR is not called. `token-plan-apply-persist.test.ts` actions updated for the new required field.

Note: the preset references `xiaomi-tts` / `xiaomi-asr` by string id, so this branch compiles independently — but applying the preset is only meaningful once #1432 lands. Suggested merge order: after #1432.

## Test plan

- `pnpm format` ✅
- `npx eslint <changed files> --fix` ✅ (0 errors)
- `npx tsc --noEmit -p tsconfig.json` ✅
- `npx vitest run tests/config` ✅ (4 files / 52 tests passed)

Screenshots: the new ASR tab in Token Plan settings is a small UI addition; screenshots can be added on request.

Closes #1430
