### PR TITLE
fix(audio): normalize OpenAI Whisper ASR language to ISO-639-1 base subtag (#1082)

### DIFF
--- a/lib/audio/asr-providers.ts
+++ b/lib/audio/asr-providers.ts
@@ -380,6 +380,26 @@ async function transcribeCustomOpenAICompatibleASR(
 }
 
 /**
+ * Normalize an ASR language setting for OpenAI Whisper.
+ *
+ * The OpenAI Whisper transcription API expects an ISO-639-1 two-letter language code
+ * (e.g. 'pt', 'zh', 'en'). The app's global ASR language setting may carry region or
+ * script subtags (e.g. 'pt-BR', 'zh-CN', 'en-US') from browser-native ASR, which
+ * causes OpenAI to reject the request with "unsupported language" (#1082).
+ *
+ * Reduces region-tagged codes to their base language, maps Cantonese ('yue') to
+ * Chinese ('zh'), and maps 'auto' to undefined for Whisper auto-detection.
+ */
+export function normalizeWhisperLanguage(language?: string): string | undefined {
+  if (!language) return undefined;
+  const trimmed = language.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'auto') return undefined;
+  const base = trimmed.split(/[-_]/)[0].toLowerCase();
+  if (base === 'yue') return 'zh';
+  return base || undefined;
+}
+
+/**
  * OpenAI Whisper implementation (using Vercel AI SDK)
  */
 async function transcribeOpenAIWhisper(
@@ -408,7 +428,7 @@ async function transcribeOpenAIWhisper(
       audio: audioData,
       providerOptions: {
         openai: {
-          language: config.language === 'auto' ? undefined : config.language,
+          language: normalizeWhisperLanguage(config.language),
         },
       },
     });

--- a/tests/audio/whisper-asr.test.ts
+++ b/tests/audio/whisper-asr.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { normalizeWhisperLanguage, transcribeAudio } from '@/lib/audio/asr-providers';
+
+const mockTranscribe = vi.fn();
+const mockOpenAITranscription = vi.fn();
+const mockCreateOpenAI = vi.fn();
+
+vi.mock('ai', () => ({
+  experimental_transcribe: (...args: unknown[]) => mockTranscribe(...args),
+}));
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: (...args: unknown[]) => {
+    mockCreateOpenAI(...args);
+    return {
+      transcription: (...tArgs: unknown[]) => mockOpenAITranscription(...tArgs),
+    };
+  },
+}));
+
+function dummyAudioBuffer(): Buffer {
+  return Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00]);
+}
+
+describe('OpenAI Whisper language normalization (#1082)', () => {
+  describe('normalizeWhisperLanguage', () => {
+    it('returns undefined when language is undefined, null, or empty', () => {
+      expect(normalizeWhisperLanguage(undefined)).toBeUndefined();
+      expect(normalizeWhisperLanguage('')).toBeUndefined();
+      expect(normalizeWhisperLanguage('   ')).toBeUndefined();
+    });
+
+    it('maps "auto" (case-insensitive) to undefined for auto-detection', () => {
+      expect(normalizeWhisperLanguage('auto')).toBeUndefined();
+      expect(normalizeWhisperLanguage('AUTO')).toBeUndefined();
+      expect(normalizeWhisperLanguage(' Auto ')).toBeUndefined();
+    });
+
+    it('preserves clean ISO-639-1 two-letter codes', () => {
+      expect(normalizeWhisperLanguage('en')).toBe('en');
+      expect(normalizeWhisperLanguage('zh')).toBe('zh');
+      expect(normalizeWhisperLanguage('pt')).toBe('pt');
+      expect(normalizeWhisperLanguage('ja')).toBe('ja');
+      expect(normalizeWhisperLanguage('ko')).toBe('ko');
+      expect(normalizeWhisperLanguage('es')).toBe('es');
+      expect(normalizeWhisperLanguage('de')).toBe('de');
+      expect(normalizeWhisperLanguage('fr')).toBe('fr');
+    });
+
+    it('strips region subtags to base language code', () => {
+      expect(normalizeWhisperLanguage('pt-BR')).toBe('pt');
+      expect(normalizeWhisperLanguage('pt-PT')).toBe('pt');
+      expect(normalizeWhisperLanguage('zh-CN')).toBe('zh');
+      expect(normalizeWhisperLanguage('zh-TW')).toBe('zh');
+      expect(normalizeWhisperLanguage('en-US')).toBe('en');
+      expect(normalizeWhisperLanguage('en-GB')).toBe('en');
+      expect(normalizeWhisperLanguage('es-ES')).toBe('es');
+      expect(normalizeWhisperLanguage('es-MX')).toBe('es');
+      expect(normalizeWhisperLanguage('de-DE')).toBe('de');
+      expect(normalizeWhisperLanguage('fr-FR')).toBe('fr');
+      expect(normalizeWhisperLanguage('ja-JP')).toBe('ja');
+      expect(normalizeWhisperLanguage('ko-KR')).toBe('ko');
+    });
+
+    it('handles underscore-separated tags and mixed case', () => {
+      expect(normalizeWhisperLanguage('pt_BR')).toBe('pt');
+      expect(normalizeWhisperLanguage('ZH_CN')).toBe('zh');
+      expect(normalizeWhisperLanguage('EN-us')).toBe('en');
+      expect(normalizeWhisperLanguage(' zh-Hans-CN ')).toBe('zh');
+    });
+
+    it('maps Cantonese (yue / yue-Hant-HK) to Chinese (zh)', () => {
+      expect(normalizeWhisperLanguage('yue')).toBe('zh');
+      expect(normalizeWhisperLanguage('yue-Hant-HK')).toBe('zh');
+      expect(normalizeWhisperLanguage('YUE-HK')).toBe('zh');
+    });
+  });
+
+  describe('transcribeAudio with openai-whisper', () => {
+    beforeEach(() => {
+      mockTranscribe.mockReset();
+      mockOpenAITranscription.mockReset();
+      mockCreateOpenAI.mockReset();
+
+      mockOpenAITranscription.mockReturnValue('mock-model-instance');
+      mockTranscribe.mockResolvedValue({ text: 'transcribed speech' });
+    });
+
+    it('passes stripped base language to providerOptions.openai.language when given a region subtag', async () => {
+      const result = await transcribeAudio(
+        {
+          providerId: 'openai-whisper',
+          apiKey: 'sk-test',
+          language: 'pt-BR',
+        },
+        dummyAudioBuffer(),
+      );
+
+      expect(mockTranscribe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerOptions: {
+            openai: {
+              language: 'pt',
+            },
+          },
+        }),
+      );
+      expect(result).toEqual({ text: 'transcribed speech' });
+    });
+
+    it('passes undefined for "auto" language', async () => {
+      await transcribeAudio(
+        {
+          providerId: 'openai-whisper',
+          apiKey: 'sk-test',
+          language: 'auto',
+        },
+        dummyAudioBuffer(),
+      );
+
+      expect(mockTranscribe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerOptions: {
+            openai: {
+              language: undefined,
+            },
+          },
+        }),
+      );
+    });
+
+    it('passes standard ISO-639-1 language code unchanged', async () => {
+      await transcribeAudio(
+        {
+          providerId: 'openai-whisper',
+          apiKey: 'sk-test',
+          language: 'zh',
+        },
+        dummyAudioBuffer(),
+      );
+
+      expect(mockTranscribe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerOptions: {
+            openai: {
+              language: 'zh',
+            },
+          },
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Normalizes language parameters passed to OpenAI Whisper ASR by extracting the ISO-639-1 base language code (and mapping Cantonese `yue` to `zh`). This prevents upstream API rejections with `unsupported language` when the user's active speech recognition language carries a region or script subtag (e.g. `pt-BR`, `zh-CN`, `en-US`, `yue-Hant-HK`) from browser-native settings.

## Related Issues

Fixes #1082

## Changes

- Added `normalizeWhisperLanguage` in `lib/audio/asr-providers.ts` to reduce region-tagged codes to their base subtag, map `yue` to `zh`, and map `'auto'` (case-insensitive) to `undefined`.
- Updated `transcribeOpenAIWhisper` to pass normalized language through `providerOptions.openai.language`.
- Added comprehensive unit tests in `tests/audio/whisper-asr.test.ts` covering normalization edge cases (whitespace, empty, uppercase, underscores, region subtags, Cantonese) and `transcribeAudio` integration.
- Completed local AI code review per repository contributing guidelines for AI-assisted PRs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Set ASR language to a region-tagged value (e.g. `pt-BR` or `zh-CN`).
2. Select `openai-whisper` and trigger audio transcription.
3. Previously, the request was rejected with `unsupported language: pt-BR`. With this change, the base code `pt` is sent and accepted.

### What you personally verified

- Ran unit tests: `pnpm test tests/audio/whisper-asr.test.ts` (9/9 passed).
- Ran full audio test suite: `pnpm test tests/audio/` (34 test files, 244/244 passed).
- Code style and lint: `pnpm eslint` clean, `pnpm prettier --check` clean.

### Evidence

- [x] CI passes (`pnpm test tests/audio/ && pnpm eslint lib/audio/asr-providers.ts tests/audio/whisper-asr.test.ts`)
- [x] Manually tested locally

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
