### PR TITLE
fix: filter out bookmarked courses from @ mention

### DIFF
--- a/components/workbench/workspace/WorkspaceShell.tsx
+++ b/components/workbench/workspace/WorkspaceShell.tsx
@@ -952,6 +952,7 @@ function WorkspaceShellController({ initialPanes }: { readonly initialPanes: Wor
   const courseOptions = useMemo(
     () =>
       [...courses.classrooms]
+        .filter((course) => course.isOwner !== false)
         .sort((a, b) => b.updatedAt - a.updatedAt)
         .map((course) => ({ id: course.id, name: course.name })),
     [courses.classrooms],


### PR DESCRIPTION
  ## Problem Description

  The original @ feature displays all courses, including:
  - Courses created by the user (isOwner: true)
  - Courses bookmarked from other users (isOwner: false)

  ## Original Drawbacks

  1. Poor User Experience:
     → Bookmarked courses cannot be modified
     → Selecting them leads to confusion as they cannot be edited

  2. Inconsistent Functionality:
     → Displays non-operable options
     → Violates the "only show operable content" design principle

  3. Low Efficiency:
     → Users need to manually identify which courses can be modified
     → Increases cognitive burden

  ## Fix

  Added filter condition in courseOptions calculation:
  .filter((course) => course.isOwner !== false)

  Filters out courses where isOwner is false,
  only displays courses created by the user.

  ## User Benefits

  1. Clearer:
     → Only shows modifiable courses
     → Reduces user confusion

  2. More Efficient:
     → Users don't need to identify course types
     → Can directly select and operate

  3. More Consistent:
     → All displayed courses can be modified
     → Meets user expectations

  ## Modified File

  components/workbench/workspace/WorkspaceShell.tsx