### PR TITLE
fix(docker): create /app/data with runtime-user ownership so classroom persistence works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,15 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# The app persists classrooms, classroom media, and usage records under
+# ./data, which docker-compose.yml mounts as the openmaic-data named volume.
+# Nothing above creates the directory, so on first run Docker materializes
+# the mountpoint as root:root and every write from the unprivileged runtime
+# user fails with EACCES — classroom persistence silently stores nothing
+# (THU-MAIC/OpenMAIC#1438). Creating it here makes the empty-volume copy-up
+# inherit the runtime user's ownership.
+RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data
+
 USER nextjs
 
 EXPOSE 3000

--- a/packages/docs/content/docs/deployment.mdx
+++ b/packages/docs/content/docs/deployment.mdx
@@ -33,6 +33,12 @@ docker compose up --build
 
 The default Compose deployment starts the OpenMAIC app and mounts the `openmaic-data` volume. Configure other providers and features as needed; see [Configuration](./configuration.mdx).
 
+The image creates the volume's data directory with the runtime user's ownership, so fresh volumes persist classrooms and usage records out of the box. A volume created by an older image may be root-owned, which makes every server-side save fail with `EACCES` while the app keeps serving normally (classrooms silently never reach disk; the log shows `Failed to record usage ... EACCES: permission denied`). Repair such a volume once, then restart the app:
+
+```bash
+docker exec -u root <container> chown -R 1001:1001 /app/data
+```
+
 `NEXT_PUBLIC_*` feature flags are injected at Docker build time and cannot be set only in the runtime `.env.local`. For example, to enable video export and experimental PPTX import:
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #1438. The final stage never creates `/app/data`, while `docker-compose.yml` mounts the `openmaic-data` named volume there. On a fresh volume Docker materializes the mountpoint as `root:root`, so the unprivileged runtime user (`nextjs`, uid 1001) cannot write to the directory the app persists classrooms, classroom media, and usage records into. The build now creates the directory owned by the runtime user before `USER nextjs`.

## Root cause

Verified against the repo:

- `Dockerfile` final stage has only `adduser` + the two `COPY --chown` of the standalone output + `USER nextjs` — no `mkdir`/`chown` for `/app/data`;
- `docker-compose.yml:40` mounts `openmaic-data:/app/data`;
- `lib/server/classroom-storage.ts` resolves `CLASSROOMS_DIR` to `/app/data/classrooms`, so every classroom save lands inside that directory.

Docker creates a named volume's mountpoint as `root:root` when the path is absent from the image; the runtime user then has no write permission. The write failure is non-fatal by design, so the app keeps serving while persisting nothing:

```
[WARN] [UsageStorage] Failed to record usage (ignored): Error: EACCES: permission denied, mkdir '/app/data/usage'
```

## Changes

- `Dockerfile`: `RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data` before `USER nextjs`. Empty-volume copy-up inherits this ownership, so fresh deployments work out of the box — no compose change needed.
- `packages/docs/content/docs/deployment.mdx`: a note plus the one-time repair for volumes already created by an older image (the fix cannot retroactively change an existing volume).

## Verification

Built from this branch and ran end-to-end on Docker (Windows host, Docker Desktop / WSL2, `node:22-alpine` / musl):

1. Image contains the directory with the runtime user's ownership, so an empty volume inherits it:

```
$ docker run --rm --entrypoint ls <image> -ld /app/data
drwxr-xr-x    2 nextjs   nodejs        4096 //app/data
```

2. After deploying with a fresh volume, `docker exec <container> ls -ld /app/data` reports `nextjs nextjs` and writes succeed; the `EACCES` log line is gone from a clean boot.
3. The app boots and serves normally (`GET /` -> 200, `GET /api/agent/skills` -> 200) and a repaired pre-existing volume accepts writes after the documented one-time `chown`.

The `EACCES` line before the fix was reproduced on an unchanged v1.0.1 tree and is attached to #1438, including the empty volume dating back to a 0.2.x deployment.

## Notes

- Scope is intentionally minimal; the broader "persistence failure is invisible in the UI" hardening (e.g. a `/api/health` probe) is a separate concern, as noted on #1438.
- No compose or config changes are required for new deployments; only pre-existing volumes need the documented one-time repair.
