### PR TITLE
fix(media): emit keyframe images as data URLs [AI-assisted]

### DIFF
--- a/lib/document/extractors/local-media.ts
+++ b/lib/document/extractors/local-media.ts
@@ -747,7 +747,7 @@ export async function extractMediaMaterial(
             id: assetId,
             type: 'image',
             mimeType: prepared.mime,
-            data: prepared.buffer.toString('base64'),
+            data: `data:${prepared.mime};base64,${prepared.buffer.toString('base64')}`,
             width: prepared.width,
             height: prepared.height,
             description: `${stem} at ${(timeMs / 1000).toFixed(3)} seconds`,

--- a/lib/server/material-extraction/extract.ts
+++ b/lib/server/material-extraction/extract.ts
@@ -56,6 +56,11 @@ function markerTime(timeMs: number): string {
   return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${seconds}`;
 }
 
+function decodeMediaAssetData(data: string): Buffer {
+  const dataUrl = /^data:[^,]*;base64,([\s\S]*)$/i.exec(data);
+  return Buffer.from(dataUrl?.[1] ?? data, 'base64');
+}
+
 export function mediaArtifactText(artifact: MediaArtifact): string {
   return (artifact.transcript ?? [])
     .filter((segment) => segment.text.trim())
@@ -151,7 +156,7 @@ export async function extractClaimedSessionMaterial(
     const images = [];
     for (const asset of artifact.assets ?? []) {
       if (asset.type !== 'image' || !asset.data) continue;
-      const bytes = Buffer.from(asset.data, 'base64');
+      const bytes = decodeMediaAssetData(asset.data);
       const rawAssetId = await putBytes(source.sessionId, bytes, asset.mimeType ?? 'image/webp');
       images.push({
         id: createMaterialId(),

--- a/tests/agent-runtime/material-extraction.test.ts
+++ b/tests/agent-runtime/material-extraction.test.ts
@@ -184,7 +184,7 @@ describe('uploaded material extraction lifecycle', () => {
               id: 'frame-1',
               type: 'image',
               mimeType: 'image/webp',
-              data: Buffer.from('prepared-webp').toString('base64'),
+              data: `data:image/webp;base64,${Buffer.from('prepared-webp').toString('base64')}`,
             },
           ],
         })),

--- a/tests/document/local-media-extractor.test.ts
+++ b/tests/document/local-media-extractor.test.ts
@@ -142,7 +142,13 @@ describe.skipIf(!ffmpegAvailable)('local media extractor real pipeline', () => {
       ]);
       expect(artifact.transcript?.[0].endMs).toBeGreaterThan(1_500);
       expect(artifact.keyframes?.length).toBeGreaterThan(0);
-      expect(artifact.assets?.[0]).toMatchObject({ type: 'image', mimeType: 'image/webp' });
+      const keyframe = artifact.assets?.[0];
+      expect(keyframe).toMatchObject({ type: 'image', mimeType: 'image/webp' });
+      // Keyframe `data` must be a data URL. `pdf-compat` derives the asset mime
+      // from it, and the document bundle forwards it as the `pdfImages[].src`
+      // that `storeImages` decodes with `decodeBase64DataUrl`. Raw base64 here
+      // makes course generation fail with "Failed to store image bundle".
+      expect(keyframe?.data).toMatch(/^data:image\/webp;base64,[A-Za-z0-9+/]+=*$/);
 
       const deadlineProvider = createLocalMediaExtractorProvider({
         transcribe: vi.fn(() => new Promise<{ text: string }>(() => undefined)),


### PR DESCRIPTION
## Summary

> **Maintainer note (scope):** on current `main`, local keyframe assets are consumed by the agent-runtime material-extraction path only; the browser document-bundle path (`storeImages`) does not receive them, since the media branch of `extract-document` returns no images. This PR therefore aligns `assets[].data` on one data-URL contract across producers and consumers (material extraction now decodes both forms); it does not by itself fix the browser report in #1220, hence `Refs`. A follow-up maintainer commit also rejects malformed or empty data URLs instead of decoding garbage bytes.

Local `ffmpeg` keyframe extraction writes the asset's `data` field as **raw base64** instead of a **base64 data URL**. Every downstream consumer of the document bundle treats `assets[].data` as a data URL, so any course generated from an uploaded video that went through local keyframe extraction fails at image persistence with `Failed to store image bundle at image img_1`.

This PR makes `lib/document/extractors/local-media.ts` emit the same `data:<mime>;base64,<payload>` form that every other producer in `lib/document/` already emits, and adds a regression assertion to the existing real-pipeline keyframe test.

## Related Issues

Refs #1220

## Changes

- `lib/document/extractors/local-media.ts` — keyframe asset `data` is now built as `` `data:${prepared.mime};base64,${...}` `` instead of bare `prepared.buffer.toString('base64')`. One line; no other behavior changes.
- `tests/document/local-media-extractor.test.ts` — the existing ffmpeg-backed pipeline test now asserts the keyframe `data` field matches `/^data:image\/webp;base64,[A-Za-z0-9+/]+=*$/`.

## Root cause

`local-media.ts` was the **only** raw-base64 producer under `lib/document/`. The other three follow the data-URL contract:

| Producer | Emitted form |
| --- | --- |
| `lib/document/pdf-providers.ts` | `data:<mime>;base64,...` |
| `lib/pdf/mineru-cloud.ts` | `data:<mime>;base64,...` |
| `lib/pdf/mineru-parser.ts:21` | `value.startsWith('data:') ? value : \`data:image/png;base64,${value}\`` |
| **`lib/document/extractors/local-media.ts`** | **raw base64 — fixed here** |

The value flows, unchecked, into the image persistence layer:

1. `lib/document/pdf-compat.ts:193` forwards it verbatim: `src: asset.data as string`.
2. `app/generation-preview/page.tsx:420` calls `storeImages(bundle.images)`.
3. `lib/utils/image-storage.ts:74` → `decodeBase64DataUrl(img.src)` does `base64DataUrl.split(',')` and takes `parts[1]`. A raw-base64 string contains no comma, so `base64Data` is `undefined`, and `atob(undefined)` throws `InvalidCharacterError: The string to be decoded is not correctly encoded.` — which is rethrown as `Failed to store image bundle at image img_1`, exactly the message in #1220.

There is a **second, silent** defect from the same root cause: `lib/document/pdf-compat.ts:108,118` derives the asset mime via `dataUrlMimeType(image.src)`, which returns `undefined` for a non-data-URL. So even where persistence did not throw, the declared `image/webp` mime was being dropped on the floor.

## Verification

### Steps to reproduce / test

1. `pnpm install --frozen-lockfile`
2. `npx vitest run tests/document/local-media-extractor.test.ts` (an `ffmpeg`/`ffprobe` on `PATH` is required for the real-pipeline suite to run rather than skip)
3. Before the fix: the keyframe `data` assertion fails with a raw-base64 value. After: it passes with `data:image/webp;base64,...`.

### What you personally verified

- Reproduced the reported failure mechanism directly against `storeImages`. Feeding it `{ id: 'img_1', src: '<raw base64>' }` rejects with `Failed to store image bundle at image img_1` and cause `InvalidCharacterError: The string to be decoded is not correctly encoded.` — byte-for-byte the error in #1220. Feeding the same bytes as a data URL stores successfully (`session_9riZGIzO5k_img_1`).
- Confirmed the fix produces the correct wire form end-to-end through the **real** ffmpeg pipeline: extraction of a generated fixture emits `data:image/webp;base64,UklGRrYGAABXRUJQVlA4IKoGAAAwxQCdASoABdAC...`.
- Confirmed the new assertion is **not vacuous**: with the one-line source change stashed and everything else identical, the test fails on the raw-base64 value; with it restored, the test passes.
- Re-checked the sibling contract consumer `extractOriginalImageId` (`lib/utils/image-storage.ts:133`) while tracing this; its prefix arithmetic (`'session_'.length` + `SESSION_ID_LENGTH` = index 18) is correct, including for nanoids containing underscores. Not changed.

**Not verified:** I did not drive the full browser course-generation flow (upload video → generate) in a real browser session, so I have not observed the end-user-visible success path myself — only the storage-layer contract either side of it.

### Evidence

Commands run locally on Windows, all green, against the parent commit `29735f10d0081859ac3db1a50a0cc92f46436004`:

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
  - `pnpm check` (prettier) → `All matched files use Prettier code style!`
  - `eslint` → no findings
  - `npx tsc --noEmit` → exit 0
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes) — no UI change

Additional repo gates run locally:

- `node scripts/check-package-version-bumps.mjs 29735f10d0081859ac3db1a50a0cc92f46436004` → `Package version check passed.` (no publishable package touched, so no semver bump is required)
- `node scripts/check-i18n-keys.mjs` → `i18n key alignment check passed (12 locale files, source: en-US.json)` (no user-facing string added)
- `npx vitest run` over the focused set (local-media extractor, image-storage, pdf-compat, document bundle, media registry) → 33 passed, 1 skipped

Note on the one skip: `resolveExecutable()` in `local-media.ts` searches `PATH` for an **extensionless** `ffmpeg`, so on Windows (where the binary is `ffmpeg.exe`) the real-pipeline suite self-skips. CI does not install ffmpeg, so this suite also skips there; the CI-run guard for this change is the material-extraction decoder test. To verify the regression assertion on this machine I injected the real `ffmpeg.exe`/`ffprobe.exe` through the provider's `commands` seam.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (none required — no public API or user-facing string change)
- [x] My changes do not introduce new warnings

---

### AI-assisted disclosure

This PR is **AI-assisted** (Claude Code), as required by the AI-Assisted PRs section of `CONTRIBUTING.md`.

Per that policy I ran an AI self-review over the diff before opening this PR. Findings and how they were resolved:

1. *Is one line enough, or is this papering over a laxer contract?* Checked whether the fix belonged at the consumer instead. Rejected: the four producers under `lib/document/` already establish the data-URL contract, three of them explicitly, so the extractor was the outlier rather than the consumer being over-strict. Fixing the producer also repairs the silently-dropped mime in `pdf-compat`, which a consumer-side fix would not.
2. *Could the value already be a data URL in some path, making this a double prefix?* `prepared.buffer` comes from a `sharp` encode of an extracted frame — it is always raw image bytes, never pre-prefixed. Verified there is no other writer of this field in the extractor.
3. *Is the regression test actually exercising the fix, or does it pass either way?* Verified by stash/restore as described above.
4. *Does the new regex over-constrain the webp output?* It asserts only the `data:` prefix, the mime, the base64 marker, and a valid base64 alphabet; it does not pin encoder output length or content, so it will not break on a libwebp version bump.

I understand and take responsibility for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


