### PR TITLE
test(agent-runtime): make the material search budget test deterministic

### DIFF
--- a/lib/server/agent-runtime/material-tools.ts
+++ b/lib/server/agent-runtime/material-tools.ts
@@ -402,7 +402,7 @@ export function buildMaterialTools(deps: MaterialToolDependencies): AgentTool<ne
         throw new Error('search_material query must contain 1 to 200 characters');
       }
       const needle = foldCase(params.query);
-      const deadline = performance.now() + SEARCH_TIME_BUDGET_MS;
+      const deadline = now() + SEARCH_TIME_BUDGET_MS;
       let scannedChars = 0;
       let truncated = false;
       const hits: Array<{
@@ -417,7 +417,7 @@ export function buildMaterialTools(deps: MaterialToolDependencies): AgentTool<ne
       for (const record of records) {
         throwIfAborted(signal);
         if (!isSearchableTextRecord(record)) continue;
-        if (scannedChars >= MAX_SEARCH_CHARS_PER_EXEC || performance.now() >= deadline) {
+        if (scannedChars >= MAX_SEARCH_CHARS_PER_EXEC || now() >= deadline) {
           truncated = true;
           break;
         }
@@ -430,7 +430,7 @@ export function buildMaterialTools(deps: MaterialToolDependencies): AgentTool<ne
         const maxDecodeBytes = Math.min(raw.length, remainingCharsBeforeRead * 4);
         const text = raw.toString('utf8', 0, maxDecodeBytes);
         const sourceWasByteTruncated = maxDecodeBytes < raw.length;
-        if (performance.now() >= deadline) {
+        if (now() >= deadline) {
           truncated = true;
           break;
         }
@@ -443,7 +443,7 @@ export function buildMaterialTools(deps: MaterialToolDependencies): AgentTool<ne
         ) {
           throwIfAborted(signal);
           const remainingChars = MAX_SEARCH_CHARS_PER_EXEC - scannedChars;
-          if (remainingChars <= 0 || performance.now() >= deadline) {
+          if (remainingChars <= 0 || now() >= deadline) {
             truncated = true;
             break;
           }

--- a/tests/agent-runtime/material-tools.test.ts
+++ b/tests/agent-runtime/material-tools.test.ts
@@ -497,6 +497,9 @@ describe('material agent tools', () => {
         sessionId: 'ses_1',
         listMaterials: vi.fn().mockResolvedValue([material()]),
         readTextAsset: singleAsset(Buffer.from('a'.repeat(1_100_000))),
+        // Frozen clock: only the character budget can stop the scan, so the
+        // assertion does not depend on how fast the test machine is.
+        now: () => 0,
       }),
       'search_material',
     );
@@ -504,6 +507,30 @@ describe('material agent tools', () => {
     expect(result.details).toMatchObject({
       mode: 'literal',
       scannedChars: 1_000_000,
+      truncated: true,
+      hits: [],
+    });
+  });
+
+  it('stops at the per-execution time budget and reports truncation', async () => {
+    let clockCalls = 0;
+    const search = tool(
+      buildMaterialTools({
+        sessionId: 'ses_1',
+        listMaterials: vi.fn().mockResolvedValue([material()]),
+        readTextAsset: singleAsset(Buffer.from('a'.repeat(1_100_000))),
+        // Clock reads, in order: deadline (0 + 100), the pre-read check, the
+        // post-decode check, and the first per-chunk check all see 0, so one
+        // 16_384-char chunk is scanned; the second per-chunk check reads 1_000
+        // and trips the time budget with the counter at exactly one chunk.
+        now: () => (clockCalls++ < 4 ? 0 : 1_000),
+      }),
+      'search_material',
+    );
+    const result = await search.execute('call_1', { query: 'not-present' } as never);
+    expect(result.details).toMatchObject({
+      mode: 'literal',
+      scannedChars: 16_384,
       truncated: true,
       hits: [],
     });


### PR DESCRIPTION
## Summary

`tests/agent-runtime/material-tools.test.ts` › "stops at the per-execution character budget and reports truncation" fails intermittently in CI (#1452): `search_material` stops on whichever of `MAX_SEARCH_CHARS_PER_EXEC` (1,000,000) or `SEARCH_TIME_BUDGET_MS` (100 ms wall clock) fires first, and the test asserts the exact character count, which only holds when the scan finishes inside 100 ms. On a loaded runner the time budget wins at a chunk boundary (`scannedChars: 786432`).

## Related Issues

Closes #1452

## Changes

- `lib/server/agent-runtime/material-tools.ts`: the search tool reads the clock through the injectable `now` dependency (`deps.now ?? Date.now`) that `wait_for_materials` already uses, instead of calling `performance.now()` directly at the four deadline checks. No limit or default changes.
- `tests/agent-runtime/material-tools.test.ts`: the character-budget test pins `now: () => 0` so only the character budget can stop the scan; a new time-budget test drives a fake clock that expires after exactly one 16,384-char chunk and asserts `scannedChars: 16_384`, `truncated: true`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

- `vitest run tests/agent-runtime/material-tools.test.ts`: 32/32. The character-budget test looped 20 times with the frozen clock: 20/20.
- Mutation: with `performance.now()` restored in the search path, the new time-budget test fails (`scannedChars` 1,000,000 instead of 16,384), so it pins the injected clock rather than the implementation detail.
- `pnpm exec tsc --noEmit`, eslint and prettier on the two files, and `pnpm check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
