### PR TITLE
fix(settings): read data.error for image/video provider test results

### DIFF
--- a/components/settings/image-settings.tsx
+++ b/components/settings/image-settings.tsx
@@ -135,7 +135,7 @@ export function ImageSettings({ selectedProviderId }: ImageSettingsProps) {
         setTestMessage(t('settings.imageConnectivitySuccess'));
       } else {
         setTestStatus('error');
-        setTestMessage(`${t('settings.imageConnectivityFailed')}: ${data.message}`);
+        setTestMessage(`${t('settings.imageConnectivityFailed')}: ${data.error}`);
       }
     } catch (err) {
       setTestStatus('error');

--- a/components/settings/video-settings.tsx
+++ b/components/settings/video-settings.tsx
@@ -97,7 +97,7 @@ export function VideoSettings({ selectedProviderId }: VideoSettingsProps) {
         setTestMessage(t('settings.videoConnectivitySuccess'));
       } else {
         setTestStatus('error');
-        setTestMessage(`${t('settings.videoConnectivityFailed')}: ${data.message}`);
+        setTestMessage(`${t('settings.videoConnectivityFailed')}: ${data.error}`);
       }
     } catch (err) {
       setTestStatus('error');


### PR DESCRIPTION
Fixes #1457

The verify routes (`/api/verify-image-provider`, `/api/verify-video-provider`, ...) return errors via `apiError()`, which serializes `{ success: false, errorCode, error }`. The image and video settings panels read `data.message` instead, so every failed connectivity test renders `failed: undefined` and the real upstream error is hidden from the user.

All other settings panels (ASR, PDF, `provider-config-panel`, `model-edit-dialog`) already read `data.error` — this brings the two remaining panels in line.

### Testing
- Self-hosted `pnpm dev`, macOS arm64
- With a wrong API key, the image provider test now shows e.g. `Seedream auth failed (401): {"error":{"code":"AuthenticationError",...}}` instead of `undefined`
- `pnpm lint` / type check pass on the touched files (2-line change)

Happy to adjust if you'd rather normalize the API error body shape instead of the client readers.