### PR TITLE
fix(generation): tolerate non-array mediaGenerations in generated outlines

### DIFF
--- a/packages/@openmaic/generation/package.json
+++ b/packages/@openmaic/generation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmaic/generation",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Pure generation pipeline contracts and packaged prompt assets for MAIC consumers.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/@openmaic/generation/src/outline-generator.ts
+++ b/packages/@openmaic/generation/src/outline-generator.ts
@@ -172,6 +172,9 @@ export async function generateSceneOutlinesFromRequirements(
       ...outline,
       id: outline.id || nanoid(),
       order: index + 1,
+      // LLMs occasionally emit mediaGenerations as a string or object; every
+      // downstream consumer requires an array, so drop non-array values here.
+      ...(Array.isArray(outline.mediaGenerations) ? null : { mediaGenerations: undefined }),
     }));
 
     const result = uniquifyMediaElementIds(enriched);

--- a/packages/@openmaic/generation/src/outline-media.ts
+++ b/packages/@openmaic/generation/src/outline-media.ts
@@ -3,10 +3,12 @@ import type { SceneOutline } from './outline-types.js';
 
 /** Give every generated-media request its own globally unique ID. */
 export function uniquifyMediaElementIds(outlines: SceneOutline[]): SceneOutline[] {
-  if (!outlines.some((outline) => outline.mediaGenerations?.length)) return outlines;
+  if (!outlines.some((outline) => outline.mediaGenerations !== undefined)) return outlines;
 
   return outlines.map((outline) => {
-    if (!outline.mediaGenerations) return outline;
+    if (!Array.isArray(outline.mediaGenerations)) {
+      return { ...outline, mediaGenerations: undefined };
+    }
     return {
       ...outline,
       mediaGenerations: outline.mediaGenerations.map((mediaGeneration) => {

--- a/tests/generation/outline-media-uniquify.test.ts
+++ b/tests/generation/outline-media-uniquify.test.ts
@@ -6,16 +6,15 @@ import type { SceneOutline } from '@openmaic/generation';
 function makeOutline(mediaGenerations?: unknown): SceneOutline {
   return {
     id: 'scene-1',
-    order: 1,
-    sceneType: 'slide',
+    type: 'slide',
     title: 'Scene',
     description: '',
     keyPoints: [],
-    estimatedDuration: 60,
+    order: 1,
     ...(mediaGenerations !== undefined
       ? { mediaGenerations: mediaGenerations as SceneOutline['mediaGenerations'] }
       : {}),
-  } as SceneOutline;
+  };
 }
 
 describe('uniquifyMediaElementIds', () => {

--- a/tests/generation/outline-media-uniquify.test.ts
+++ b/tests/generation/outline-media-uniquify.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+
+import { uniquifyMediaElementIds } from '@openmaic/generation';
+import type { SceneOutline } from '@openmaic/generation';
+
+function makeOutline(mediaGenerations?: unknown): SceneOutline {
+  return {
+    id: 'scene-1',
+    order: 1,
+    sceneType: 'slide',
+    title: 'Scene',
+    description: '',
+    keyPoints: [],
+    estimatedDuration: 60,
+    ...(mediaGenerations !== undefined
+      ? { mediaGenerations: mediaGenerations as SceneOutline['mediaGenerations'] }
+      : {}),
+  } as SceneOutline;
+}
+
+describe('uniquifyMediaElementIds', () => {
+  test('assigns unique prefixed element ids to array-shaped media generations', () => {
+    const outlines = [
+      makeOutline([
+        { type: 'image', prompt: 'a diagram' },
+        { type: 'image', prompt: 'a photo' },
+      ]),
+      makeOutline([{ type: 'video', prompt: 'an animation' }]),
+    ];
+
+    const result = uniquifyMediaElementIds(outlines);
+
+    const [first, second] = result.map((outline) => outline.mediaGenerations ?? []);
+    expect(first).toHaveLength(2);
+    expect(second).toHaveLength(1);
+    const ids = [...first, ...second].map((mg) => mg.elementId);
+    expect(new Set(ids).size).toBe(3);
+    ids.forEach((id) => expect(id).toMatch(/^gen_(img|vid)_[A-Za-z0-9_-]{8}$/));
+  });
+
+  test('drops non-array mediaGenerations instead of throwing', () => {
+    const outlines = [makeOutline('generate a diagram'), makeOutline({ type: 'image' })];
+
+    expect(() => uniquifyMediaElementIds(outlines)).not.toThrow();
+
+    const result = uniquifyMediaElementIds(outlines);
+    result.forEach((outline) => expect(outline.mediaGenerations).toBeUndefined());
+  });
+
+  test('keeps valid arrays in mixed outlines while dropping malformed ones', () => {
+    const valid = [
+      { type: 'image' as const, prompt: 'a chart' },
+      { type: 'video' as const, prompt: 'a clip' },
+    ];
+    const outlines = [makeOutline(valid), makeOutline(42), makeOutline(true)];
+
+    const result = uniquifyMediaElementIds(outlines);
+
+    expect(result[0].mediaGenerations).toHaveLength(2);
+    expect(result[1].mediaGenerations).toBeUndefined();
+    expect(result[2].mediaGenerations).toBeUndefined();
+  });
+
+  test('passes through outlines without media generations untouched', () => {
+    const outlines = [makeOutline(), makeOutline([])];
+
+    const result = uniquifyMediaElementIds(outlines);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].mediaGenerations).toBeUndefined();
+    expect(result[1].mediaGenerations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Course outline generation crashes with `outline.mediaGenerations.map is not a function` when the LLM returns an outline whose `mediaGenerations` field is not an array (e.g. a string or an object). Hit on a self-hosted deployment: a single malformed outline aborted the whole course generation.

## Root cause

- LLM output is parsed via `parseJsonResponse`, but the shape of `mediaGenerations` is never validated afterwards.
- `uniquifyMediaElementIds` guards with a falsy check (`if (!outline.mediaGenerations)`), so strings reach `.map()` (TypeError) and objects escape sanitization entirely (downstream `for...of` consumers then throw).
- The early-return guard `outlines.some((o) => o.mediaGenerations?.length)` also short-circuits when no outline carries a valid array, letting malformed values through unsanitized.

## Fix

- `outline-generator.ts`: after parsing, drop non-array `mediaGenerations` from every enriched outline so all downstream consumers see array-or-undefined.
- `outline-media.ts`: `uniquifyMediaElementIds` now treats non-array values as absent (strips them), and the early-return guard opens on field presence so all-malformed outline sets are still sanitized.

## Testing

- New unit tests `tests/generation/outline-media-uniquify.test.ts`: valid arrays still get unique `gen_img_`/`gen_vid_` ids; string/object/number/boolean shapes no longer throw and are stripped; mixed valid+malformed outlines; missing-field pass-through.
- `pnpm vitest run tests/generation/outline-media-uniquify.test.ts` -> 4 passed
- `npx tsc --noEmit` clean; prettier/eslint clean on touched files.

---


---

## 中文说明（问题描述翻译）

### 问题

课程大纲生成时，如果 LLM 返回的大纲 JSON 中某个场景的 `mediaGenerations` 字段不是数组（例如字符串或对象），整个课程生成会直接崩溃，报错 `outline.mediaGenerations.map is not a function`。此问题在自部署环境中实际触发：一条畸形大纲导致整门课程生成失败。

### 根因

- LLM 输出经 `parseJsonResponse` 解析后，`mediaGenerations` 的形状从未被校验；
- `uniquifyMediaElementIds` 只做了假值检查（`if (!outline.mediaGenerations)`），字符串会继续传到 `.map()`（TypeError），对象则完全绕过消毒，下游 `for...of` 消费者随后也会抛错；
- 早退守卫 `outlines.some((o) => o.mediaGenerations?.length)` 在没有任何大纲携带合法数组时直接短路，让畸形值未经清洗地通过。

### 修复

- `outline-generator.ts`：解析完成后，从每条大纲中丢弃非数组的 `mediaGenerations`，使所有下游消费者只会见到数组或 undefined；
- `outline-media.ts`：`uniquifyMediaElementIds` 将非数组值视为缺失（剔除），并把早退守卫改为按"字段是否存在"判断，使全部畸形的大纲集合同样会被清洗。

### 测试

- 新增单元测试 `tests/generation/outline-media-uniquify.test.ts`：合法数组仍会获得唯一的 `gen_img_` / `gen_vid_` 前缀 id；字符串/对象/数字/布尔形状不再抛错并被剔除；合法与畸形混合的大纲；缺失字段的原样透传。
- `pnpm vitest run tests/generation/outline-media-uniquify.test.ts` → 4 项全部通过
- `npx tsc --noEmit` 无错误；改动文件 prettier / eslint 干净。
