### PR TITLE
test(security): isolate image URL guard environment

### DIFF
--- a/tests/server/generate-image-unconditional-url-guard.test.ts
+++ b/tests/server/generate-image-unconditional-url-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // A client-supplied provider base URL must be validated in every environment,
@@ -37,13 +37,16 @@ const IMAGE_ENV_PREFIXES = [
   'IMAGE_COMFYUI',
 ];
 
-function clearImageEnv() {
+function stubImageEnvAbsent() {
   for (const prefix of IMAGE_ENV_PREFIXES) {
-    delete process.env[`${prefix}_API_KEY`];
-    delete process.env[`${prefix}_BASE_URL`];
-    delete process.env[`${prefix}_MODELS`];
-    delete process.env[`${prefix}_ENABLED`];
+    vi.stubEnv(`${prefix}_API_KEY`, undefined);
+    vi.stubEnv(`${prefix}_BASE_URL`, undefined);
+    vi.stubEnv(`${prefix}_MODELS`, undefined);
+    vi.stubEnv(`${prefix}_ENABLED`, undefined);
   }
+  // OpenAI also has a generic image fallback outside the IMAGE_* namespace.
+  vi.stubEnv('OPENAI_API_KEY', undefined);
+  vi.stubEnv('OPENAI_BASE_URL', undefined);
 }
 
 function imageRequest(headers: Record<string, string> = {}): NextRequest {
@@ -56,12 +59,16 @@ function imageRequest(headers: Record<string, string> = {}): NextRequest {
 
 describe('generate image — client-supplied base URL guard applies in every environment', () => {
   beforeEach(() => {
-    vi.resetModules();
     vi.unstubAllEnvs();
-    clearImageEnv();
-    delete process.env.ALLOW_LOCAL_NETWORKS;
+    stubImageEnvAbsent();
+    vi.stubEnv('ALLOW_LOCAL_NETWORKS', undefined);
+    vi.resetModules();
     mocks.generateImage.mockReset();
     mocks.generateImage.mockResolvedValue({ url: 'https://example.com/img.png' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('rejects a private-network base URL when NODE_ENV is not production', async () => {
@@ -101,6 +108,7 @@ describe('generate image — client-supplied base URL guard applies in every env
     expect(mocks.generateImage).toHaveBeenCalledWith(
       expect.objectContaining({
         providerId: 'openai-image',
+        apiKey: 'client-key',
         model: 'gpt-image-2',
         baseUrl: 'http://192.168.1.10/v1/',
       }),


### PR DESCRIPTION
## Summary

Makes the image URL-guard regression tests deterministic when a contributor or CI worker exports generic OpenAI credentials. This is a test-only change; production provider selection and SSRF behavior are unchanged.

This PR was AI-assisted. I reviewed the complete diff, reproduced the failure before the change, and ran the validation listed below before requesting maintainer review.

## Related Issues

Fixes #1475
Related to #1302

## Changes

- Treat both `IMAGE_*` provider variables and the generic `OPENAI_API_KEY` / `OPENAI_BASE_URL` fallback as absent through restorable Vitest stubs.
- Restore environment stubs after every test instead of deleting inherited process environment values.
- Assert that the opt-in local-network path forwards the client-supplied API key, model, and base URL.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Export `OPENAI_API_KEY=openmaic-test-sentinel`.
2. On pre-fix `main`, run `pnpm exec vitest run tests/server/generate-image-unconditional-url-guard.test.ts`: both cases fail because the generic server fallback replaces the client provider configuration.
3. On this branch, run the same focused test and the full suite: both pass while the sentinel remains exported.

### What you personally verified

- Pre-fix focused reproduction: 2 failed / 2 tests with the sentinel exported.
- Focused security/provider surface: 6 files, 120 tests passed with the sentinel exported.
- Root suite: 702 files passed, 9 skipped; 7,894 tests passed, 81 skipped with the sentinel exported.
- `pnpm check`, `pnpm lint`, `tsc --noEmit`, and `pnpm check:i18n-keys` passed. ESLint reported only the 18 warnings already present on `main`; no errors.
- Production `pnpm build` passed.
- Package-version, internal-dependency-range, and Node-engine contract checks passed.
- AI-assisted self-review confirmed the diff is limited to one test file and does not alter production behavior.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (no documentation change is needed for this test-isolation fix)
- [x] My changes do not introduce new warnings
