### PR TITLE
fix(audio): reuse one narration element so mobile narration survives the first segment

### DIFF
--- a/lib/utils/audio-player.ts
+++ b/lib/utils/audio-player.ts
@@ -32,6 +32,17 @@ async function resolveBytes(audioId: string): Promise<Blob | null> {
  */
 export class AudioPlayer {
   private audio: HTMLAudioElement | null = null;
+  /**
+   * The element narration plays through, created once per player.
+   *
+   * Playback must not mint a new element per line: mobile autoplay policies
+   * only cover an element that a user gesture has reached, so a fresh element
+   * gets its programmatic `play()` refused with NotAllowedError mid-lesson and
+   * the narration goes silent from the second line on, while the lesson keeps
+   * advancing on the reading-time fallback. One element, handed every line,
+   * stays playable for the rest of the lesson.
+   */
+  private element: HTMLAudioElement | null = null;
   private onEndedCallback: (() => void) | null = null;
   private muted: boolean = false;
   private volume: number = 1;
@@ -66,11 +77,39 @@ export class AudioPlayer {
     if (this.blobUrl === blobUrl) this.blobUrl = null;
   }
 
+  /**
+   * The narration element, created on first use and reused by every line.
+   * Deliberately not dropped by stopAudioElement(): discarding it is what made
+   * each following line a fresh element whose play() the policy refuses.
+   */
+  private getAudioElement(): HTMLAudioElement {
+    if (!this.element) {
+      this.element = new Audio();
+      this.element.preload = 'auto';
+    }
+    return this.element;
+  }
+
   private stopAudioElement(): void {
     if (this.audio) {
       this.audio.pause();
-      this.audio.currentTime = 0;
+      try {
+        this.audio.currentTime = 0;
+      } catch {
+        /* Not seekable yet (nothing loaded): there is nothing to rewind. */
+      }
       this.audio = null;
+    }
+    // The element outlives this line now, so the line's own state has to be
+    // released with it: a stale ended handler would report speech that is no
+    // longer playing, and a revoked object URL still loaded keeps the narration
+    // buffer alive until the next play() replaces it.
+    if (this.element) {
+      this.element.onended = null;
+      if (typeof this.element.removeAttribute === 'function') {
+        this.element.removeAttribute('src');
+      }
+      this.element.load?.();
     }
     // Stop or replacement before natural end must not leak the fetched
     // narration: the element is dropped here, so its URL is released with it.
@@ -141,8 +180,10 @@ export class AudioPlayer {
       this.stopAudioElement();
       if (requestToken !== this.requestToken) return false;
 
-      // Create audio element
-      this.audio = new Audio();
+      // Reuse this player's element rather than creating one per line: a new
+      // element's programmatic play() is what mobile autoplay policies refuse,
+      // which left the narration silent from the second line on.
+      this.audio = this.getAudioElement();
 
       // Set audio source
       const blobUrl = blob ? URL.createObjectURL(blob) : undefined;
@@ -156,10 +197,13 @@ export class AudioPlayer {
       this.audio.playbackRate = this.playbackRate;
 
       // Set ended callback
-      this.audio.addEventListener('ended', () => {
+      // Assignment rather than addEventListener: the element is reused, so a
+      // listener would otherwise accumulate once per segment and fire the
+      // callback several times for one line.
+      this.audio.onended = () => {
         this.releaseBlobUrl(blobUrl);
         this.onEndedCallback?.();
-      });
+      };
 
       // Play. If play() rejects (autoplay policy, decode error, interrupted
       // load) the 'ended' listener never fires, so revoke the blob URL here to

--- a/tests/audio/audio-player-element-reuse.test.ts
+++ b/tests/audio/audio-player-element-reuse.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the IndexedDB layer so importing AudioPlayer doesn't pull in Dexie.
+const getMock = vi.fn();
+vi.mock('@/lib/utils/database', () => ({
+  db: { audioFiles: { get: getMock } },
+}));
+
+/** A rejection shaped like the browser's autoplay refusal. */
+function notAllowed(): Error {
+  return Object.assign(new Error('play() failed because the user did not interact'), {
+    name: 'NotAllowedError',
+  });
+}
+
+/** Stub URL.createObjectURL/revokeObjectURL while keeping `new URL(...)` working. */
+function stubObjectUrl() {
+  let next = 0;
+  const createObjectURL = vi.fn(() => `blob:fake-url-${++next}`);
+  const revokeObjectURL = vi.fn();
+  class URLStub extends URL {}
+  Object.assign(URLStub, { createObjectURL, revokeObjectURL });
+  vi.stubGlobal('URL', URLStub);
+  return { createObjectURL, revokeObjectURL };
+}
+
+class AudioStub {
+  play = vi.fn(async () => {});
+  pause = vi.fn();
+  load = vi.fn();
+  removeAttribute = vi.fn();
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  volume = 1;
+  muted = false;
+  preload = 'auto';
+  defaultPlaybackRate = 1;
+  playbackRate = 1;
+  currentTime = 0;
+  duration = 0;
+  src = '';
+  paused = true;
+  readyState = 0;
+  onended: (() => void) | null = null;
+}
+
+/**
+ * Stub Audio, tracking every element the player creates.
+ *
+ * `mobile` applies the autoplay policy the way a phone does: the element the
+ * user's own gesture reached plays, and every element created afterwards is
+ * refused — which is exactly how a player that mints an element per narration
+ * line loses its voice from the second line on while the lesson keeps going.
+ * `permissive` accepts every play, as a desktop browser effectively does.
+ */
+function stubAudio(policy: 'mobile' | 'permissive' = 'permissive') {
+  const instances: AudioStub[] = [];
+  class PolicyAudioStub extends AudioStub {
+    constructor() {
+      super();
+      if (policy === 'mobile' && instances.length > 0) {
+        this.play = vi.fn(async () => Promise.reject(notAllowed()));
+      }
+      instances.push(this);
+    }
+  }
+  vi.stubGlobal('Audio', PolicyAudioStub);
+  return { instances };
+}
+
+describe('AudioPlayer narration element', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    getMock.mockReset();
+    getMock.mockResolvedValue({ blob: new Blob(['audio']) });
+  });
+
+  it('keeps narration audible after the first line, when the policy refuses new elements', async () => {
+    stubObjectUrl();
+    const audio = stubAudio('mobile');
+    const { AudioPlayer } = await import('@/lib/utils/audio-player');
+    const player = new AudioPlayer();
+
+    // Only the first line is covered by the user's gesture; the lines after it
+    // are programmatic, and they are the ones the policy used to refuse.
+    await expect(player.play('audio-1')).resolves.toBe(true);
+    await expect(player.play('audio-2')).resolves.toBe(true);
+    await expect(player.play('audio-3')).resolves.toBe(true);
+
+    expect(audio.instances).toHaveLength(1);
+  });
+
+  it('reuses that one element for every line', async () => {
+    stubObjectUrl();
+    const { instances } = stubAudio('mobile');
+    const { AudioPlayer } = await import('@/lib/utils/audio-player');
+    const player = new AudioPlayer();
+
+    await player.play('audio-1');
+    await player.play('audio-2');
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0].play).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the end of each line through a single assigned handler', async () => {
+    stubObjectUrl();
+    const { instances } = stubAudio('mobile');
+    const { AudioPlayer } = await import('@/lib/utils/audio-player');
+    const player = new AudioPlayer();
+    const onEnded = vi.fn();
+    player.onEnded(onEnded);
+
+    await player.play('audio-1');
+    await player.play('audio-2');
+
+    const element = instances[0];
+    // A listener per line would accumulate on the reused element and call the
+    // engine back several times for a single line.
+    expect(element.addEventListener).not.toHaveBeenCalledWith('ended', expect.anything());
+
+    element.onended?.();
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the line’s state when playback is stopped', async () => {
+    const { revokeObjectURL } = stubObjectUrl();
+    const { instances } = stubAudio('mobile');
+    const { AudioPlayer } = await import('@/lib/utils/audio-player');
+    const player = new AudioPlayer();
+
+    await player.play('audio-1');
+    const element = instances[0];
+    player.stop();
+
+    expect(element.pause).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url-1');
+    // The element outlives the line, so nothing of that line may outlive it too.
+    expect(element.onended).toBeNull();
+    expect(element.removeAttribute).toHaveBeenCalledWith('src');
+    expect(element.load).toHaveBeenCalled();
+  });
+
+  it('still surfaces a failure that is not an autoplay refusal', async () => {
+    stubObjectUrl();
+    const { instances } = stubAudio('permissive');
+    const { AudioPlayer } = await import('@/lib/utils/audio-player');
+    const player = new AudioPlayer();
+    await player.play('audio-1');
+
+    instances[0].play = vi.fn(async () => Promise.reject(new Error('decode error')));
+
+    await expect(player.play('audio-2')).rejects.toThrow('decode error');
+  });
+});


### PR DESCRIPTION
> 🤖 **AI-assisted PR** — written with an AI coding agent and reviewed by a second one (Claude Code) before opening. That review is why this PR is one file: an earlier draft also carried a gesture-retry helper and touched the discussion-TTS path, and both were split out (reasons below). I understand the change and stand behind it.

## Summary

On mobile browsers (iOS Safari, Chrome on Android, and the in-app WebViews that wrap them) classroom narration plays the **first** segment and then goes silent for every following segment, while the player keeps advancing visually. A refresh buys back at most one more segment.

The cause is structural. `lib/utils/audio-player.ts` creates a **new** media element for every narration line. Only the first line is covered by the user's own gesture (the tap on Play); every line after it is programmatic, on a brand-new element, so the autoplay policy refuses it with `NotAllowedError`. The playback engine catches that rejection (as #651 documents) and falls back to the reading-time timer — so the lesson walks on and the voice is gone for the rest of the session. #652 fixed the blob URL **leak** from the same rejection; the user-facing half stayed open, and nothing in this repo tracks it.

An element that a gesture has activated keeps playing afterwards, so the fix is to stop minting elements: **one element per player, handed every line**, stays playable for the rest of the lesson.

## Related Issues

Fixes #1474

Related to #651 / #652 — the same rejection, fixed there only for the leak. Related to #444 (mobile playback).

## Changes

`lib/utils/audio-player.ts` only:

- a per-player `element`, created on first use (`getAudioElement()`) and reused by every line, replaces `new Audio()` inside `play()`;
- `stopAudioElement()` releases the **line's** state instead of the element: `onended` is cleared, `src` is removed and `load()` is called, so a stopped line cannot report speech that is no longer playing and a revoked object URL cannot keep the narration buffer alive until the next `play()`. The element itself is deliberately kept — discarding it is what made each following line a fresh, un-activated element;
- `onended` is **assigned** rather than added with `addEventListener`: the element now outlives a single line, so a listener would accumulate once per segment and call the engine back several times for one line.

`tests/audio/audio-player-element-reuse.test.ts` (new) stubs the mobile policy itself — the first element plays, every element created after it is refused — and asserts lines 2 and 3 still play, that one element is created for three lines, that the end callback is a single assigned handler, that `stop()` releases the line's state, and that a non-autoplay failure still surfaces. **The first two tests fail on `main` and pass with this change** (output below), which is the point: they encode the bug rather than the implementation.

**Deliberately not in this PR** (both from the AI review, and both separable):

- a `playWithGestureRetry` helper that would wait for the next user gesture after a refusal. It has to not hold the engine's `play()` promise open (the reading-timer fallback has a 2 s floor and a typical dwell of 3–10 s, so a long wait turns "silent but advancing" into "silent and stalled"), and it needs cancellation wired to the existing `requestToken`/abort pattern so a pending retry cannot start narration over a paused lesson. That is its own PR, with its own tests, and it is not needed for the fix above: the refusal disappears once the element is reused.
- the discussion-TTS path (`lib/hooks/use-discussion-tts.ts`) — a different player with its own queue lifecycle that does not share the element-reuse half.

No user-facing strings were added (no i18n debt), and nothing under `packages/@openmaic/` changed, so no version bump applies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Self-host, open a classroom with pre-generated narration in a **mobile** browser (or device emulator) with **Auto-play ON**.
2. Tap **Play** once, then leave the page alone.
3. Before: the first segment is audible, every later segment is silent while the scene advances.
4. After: narration continues through consecutive segments with no further interaction.

### What you personally verified

- **The new tests fail on `main` and pass with the change** (shown below) — the regression is encoded, not just described.
- **Live deployment, instrumented**: patched `HTMLMediaElement.prototype.play` and `window.Audio` in the classroom page of a self-hosted instance, clicked **Play once** with a real (trusted) mouse event, then left it running for 3 minutes under the default Chromium autoplay policy: **1 element created, 8+ consecutive `play-OK`, 0 `play-FAIL`**, `currentTime` advancing line by line (29.5s → 20.9s → 25.6s → …) with the scene following. Same page and instrument before the change: the per-line `play()` rejected with `NotAllowedError` and the scene advanced with no audio.
- **Real device**: Android Chrome, Auto-play ON — a 16-scene lesson narrated continuously without touching the screen.
- Desktop behaviour is unchanged by design: the element is reused there too, and a `play()` that succeeds never sees a refusal.
- **Not verified**: iOS Safari and other in-app WebViews were not instrumented. They share the policy and the mechanism, so they are expected to be covered — that is an expectation, not a measurement.

### Evidence

New tests against `main` (no patch) — the bug, reproduced:

```
× keeps narration audible after the first line, when the policy refuses new elements
× reuses that one element for every line
× reports the end of each line through a single assigned handler
× releases the line's state when playback is stopped
× still surfaces a failure that is not an autoplay refusal
Test Files  1 failed (1)     Tests  5 failed (5)
```

The same file with the patch:

```
Test Files  1 passed (1)     Tests  5 passed (5)
```

Live instrumentation, before → after (one initial Play click, 3-minute window):

```
play-FAIL|NotAllowedError|.../tts_s1_action_0nnx3PqX.wav        (before: silence for the rest of the lesson)
play-OK|...tts_s1_link...wav|els=1                              (after: 8+ consecutive lines)
play-OK|...tts_s2_link...wav|els=1
play-OK|...tts_s3_link...wav|els=1   …
```

Local checks (Node 24 / pnpm 10):

```
$ npx prettier --check …   # clean
$ npx eslint …             # clean
$ npx tsc --noEmit         # clean
$ npx vitest run tests/audio tests/playback
  Test Files  43 passed (43)      Tests  329 passed (329)
```

- [x] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (no UI change)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code (plus an AI review; its findings shaped the scope of this PR)
- [x] I have added/updated documentation as needed (the reasoning lives inline; no user-facing docs change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix works — and that fail without it
- [x] New and existing unit tests pass locally
