### PR TITLE
fix: bound model discovery response body timeout

### DIFF
--- a/lib/server/model-fetch.ts
+++ b/lib/server/model-fetch.ts
@@ -7,8 +7,6 @@
  * suffix-strip fallback) and try each until one returns a model list.
  */
 
-import { fetchWithTimeout } from './fetch-with-timeout';
-
 /** A model id discovered from a provider's /models endpoint. */
 export interface FetchedModel {
   id: string;
@@ -33,6 +31,13 @@ const KNOWN_COMPAT_SUFFIXES = [
 ] as const;
 
 const FETCH_TIMEOUT_MS = 15_000;
+// Preserve the existing per-attempt allowance, with one retry and a finite
+// budget shared by every candidate and attempt in a discovery operation.
+const DISCOVERY_TIMEOUT_MS = 2 * FETCH_TIMEOUT_MS;
+
+function discoveryTimeout(): DOMException {
+  return new DOMException('Model discovery timed out', 'TimeoutError');
+}
 
 /** Whether the URL's last path segment is an OpenAI-style version segment `/v{N}`. */
 function endsWithVersionSegment(url: string): boolean {
@@ -118,38 +123,76 @@ export async function fetchModels(
 ): Promise<FetchedModel[]> {
   const candidates = buildModelsUrlCandidates(baseUrl, opts);
 
+  const deadline = Date.now() + DISCOVERY_TIMEOUT_MS;
+  let retried = false;
+
   for (const url of candidates) {
-    const res = await fetchWithTimeout(
-      url,
-      {
-        method: 'GET',
-        headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
-        redirect: 'manual',
-      },
-      FETCH_TIMEOUT_MS,
-    );
-
-    if (res.status >= 300 && res.status < 400) {
-      throw new ModelFetchError(res.status, 'Redirects are not allowed');
+    let body: ModelsApiResponse | null;
+    for (;;) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) throw discoveryTimeout();
+      try {
+        body = await fetchModelsCandidate(url, apiKey, Math.min(FETCH_TIMEOUT_MS, remaining));
+        break;
+      } catch (error) {
+        // HTTP errors and malformed JSON are terminal. Only a transport failure
+        // or our deadline gets one retry, shared across all candidate URLs.
+        if (
+          retried ||
+          Date.now() >= deadline ||
+          !(
+            error instanceof TypeError ||
+            (error instanceof DOMException && error.name === 'TimeoutError')
+          )
+        ) {
+          throw error;
+        }
+        retried = true;
+      }
     }
-
-    if (res.ok) {
-      const body = (await res.json()) as ModelsApiResponse;
-      return (body.data ?? [])
-        .map((m) => ({ id: m.id, ownedBy: m.owned_by }))
-        .sort((a, b) => a.id.localeCompare(b.id));
-    }
-
-    if (res.status === 404 || res.status === 405) {
-      continue;
-    }
-
-    // Other statuses (401/403/5xx) are terminal — surface the body for context.
-    const text = await res.text().catch(() => '');
-    throw new ModelFetchError(res.status, `HTTP ${res.status}: ${text.slice(0, 512)}`);
+    if (body === null) continue;
+    return (body.data ?? [])
+      .map((m) => ({ id: m.id, ownedBy: m.owned_by }))
+      .sort((a, b) => a.id.localeCompare(b.id));
   }
 
   throw new ModelFetchError(404, `No /models endpoint found (tried: ${candidates.join(', ')})`);
+}
+
+/** The timer owns the entire finite response, including JSON/error-body reads. */
+async function fetchModelsCandidate(
+  url: string,
+  apiKey: string,
+  timeoutMs: number,
+): Promise<ModelsApiResponse | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(discoveryTimeout()), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+    if (res.status >= 300 && res.status < 400) {
+      throw new ModelFetchError(res.status, 'Redirects are not allowed');
+    }
+    if (res.ok) return (await res.json()) as ModelsApiResponse;
+    if (res.status === 404 || res.status === 405) return null;
+
+    // A stalled error body must not hide an already-known authentication/HTTP
+    // status, or turn a terminal HTTP error into a retryable timeout.
+    const text = await res.text().catch(() => '');
+    throw new ModelFetchError(res.status, `HTTP ${res.status}: ${text.slice(0, 512)}`);
+  } catch (error) {
+    if (error instanceof ModelFetchError) throw error;
+    if (controller.signal.aborted) throw controller.signal.reason;
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    // Release unread redirect/404/405 bodies before trying another endpoint.
+    controller.abort();
+  }
 }
 
 /** Error carrying the upstream HTTP status so the route can map it (401 vs 404). */

--- a/tests/server/model-fetch-http.test.ts
+++ b/tests/server/model-fetch-http.test.ts
@@ -1,0 +1,37 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { expect, it } from 'vitest';
+import { fetchModels } from '@/lib/server/model-fetch';
+
+it('aborts a real stalled response body before succeeding on one retry', async () => {
+  let requests = 0;
+  let closedFirstResponse = false;
+  const server = createServer((_req, res) => {
+    requests += 1;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    if (requests === 1) {
+      res.on('close', () => {
+        closedFirstResponse = true;
+      });
+      res.write('{"data":['); // Headers and partial JSON arrive, but the body never ends.
+    } else {
+      res.end('{"data":[{"id":"recovered"}]}');
+    }
+  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address() as AddressInfo;
+    const started = Date.now();
+    const models = await fetchModels(`http://127.0.0.1:${address.port}`, '');
+    expect(models).toEqual([{ id: 'recovered', ownedBy: undefined }]);
+    expect(requests).toBe(2);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(14_900);
+    await expect.poll(() => closedFirstResponse).toBe(true);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}, 25_000);

--- a/tests/server/model-fetch-timeout.test.ts
+++ b/tests/server/model-fetch-timeout.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchModels, ModelFetchError } from '@/lib/server/model-fetch';
+
+function stalled(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) reject(signal.reason);
+    else signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+}
+
+function successful() {
+  return { ok: true, status: 200, json: async () => ({ data: [{ id: 'model' }] }) };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('model discovery deadlines and retries', () => {
+  it.each(['headers', 'body'])(
+    'bounds stalled %s across both attempts to 30 seconds',
+    async (phase) => {
+      vi.useFakeTimers();
+      const signals: AbortSignal[] = [];
+      const fetchMock = vi.fn((_url, init) => {
+        const signal = init.signal as AbortSignal;
+        signals.push(signal);
+        if (phase === 'headers') return stalled(signal);
+        return Promise.resolve({ ok: true, status: 200, json: () => stalled(signal) });
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const result = fetchModels('https://example.com', '').catch((error) => error);
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(signals[0].aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(signals[0].aborted).toBe(true);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(await result).toMatchObject({ name: 'TimeoutError' });
+      expect(signals.every((s) => s.aborted)).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it('uses one deadline for headers plus body, and succeeds on its single retry', async () => {
+    vi.useFakeTimers();
+    const signals: AbortSignal[] = [];
+    const fetchMock = vi.fn(async (_url, init) => {
+      signals.push(init.signal);
+      if (signals.length === 2) return successful();
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
+      return { ok: true, status: 200, json: () => stalled(init.signal) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = fetchModels('https://example.com', '');
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(await result).toEqual([{ id: 'model', ownedBy: undefined }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('allows a slow successful body within the original 15-second allowance', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: () =>
+        new Promise((resolve) => setTimeout(() => resolve({ data: [{ id: 'slow' }] }), 14_999)),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const result = fetchModels('https://example.com', '');
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(await result).toEqual([{ id: 'slow', ownedBy: undefined }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([401, 403, 500])(
+    'preserves terminal HTTP %i when its error body stalls',
+    async (status) => {
+      vi.useFakeTimers();
+      const fetchMock = vi.fn(async (_url, init) => ({
+        ok: false,
+        status,
+        text: () => stalled(init.signal),
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+      const result = fetchModels('https://example.com', '').catch((error) => error);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(await result).toBeInstanceOf(ModelFetchError);
+      expect(await result).toMatchObject({ status });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it('retries a transport failure once', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(successful());
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await fetchModels('https://example.com', '')).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry malformed JSON', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('bad JSON');
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(fetchModels('https://example.com', '')).rejects.toBeInstanceOf(SyntaxError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restart the total budget when moving to a fallback URL', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (_url, init) => {
+      if (fetchMock.mock.calls.length === 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        return { ok: false, status: 404 };
+      }
+      return { ok: true, status: 200, json: () => stalled(init.signal) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = fetchModels('https://example.com/anthropic', '').catch((error) => error);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(await result).toMatchObject({ name: 'TimeoutError' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      'https://example.com/anthropic/v1/models',
+      'https://example.com/v1/models',
+      'https://example.com/v1/models',
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fix model discovery requests that receive response headers but stall while reading the response body.

The existing 15-second timeout was cleared as soon as `fetch()` returned a `Response`, so `response.json()` or `response.text()` could remain pending indefinitely.

## Related Issues

Fixes #1449

## Changes

- Keep the timeout active through model-list response-body consumption.
- Retry one transport or timeout failure.
- Preserve the existing per-candidate timeout budget.
- Preserve 404/405 endpoint fallback behavior.
- Preserve redirect rejection and terminal HTTP error handling.
- Abort stalled requests and release their connections.
- Add regression coverage for stalled headers, stalled bodies, retries, malformed JSON, terminal HTTP errors, fallback candidates, and a real stalled HTTP response.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

- 34 focused model discovery and route tests passed.
- Real loopback HTTP test passed: a partial JSON response was aborted after the timeout and the retry succeeded.
- Prettier passed.
- ESLint passed for all changed files.
- Full TypeScript checking still reports existing repository baseline errors; the error output is unchanged by this PR.