### PR TITLE
fix: add cancellable retry helper for generation

### DIFF
--- a/lib/generation/retry.ts
+++ b/lib/generation/retry.ts
@@ -1,0 +1,47 @@
+export type RetryDecision = 'retry' | 'fail';
+
+export type RetryOptions = {
+  maxRetries?: number;
+  signal?: AbortSignal;
+  baseDelayMs?: number;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+};
+
+function abortError(): Error {
+  return typeof DOMException !== 'undefined'
+    ? new DOMException('Aborted', 'AbortError')
+    : Object.assign(new Error('Aborted'), { name: 'AbortError' });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortError();
+}
+
+const defaultSleep = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    throwIfAborted(signal);
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer);
+      reject(abortError());
+    }, { once: true });
+  });
+
+export async function withRetry<T>(fn: (attempt: number) => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const maxRetries = Math.max(0, options.maxRetries ?? 2);
+  const baseDelayMs = Math.max(0, options.baseDelayMs ?? 300);
+  const shouldRetry = options.shouldRetry ?? (() => true);
+  const sleep = options.sleep ?? defaultSleep;
+  let attempt = 0;
+  while (true) {
+    throwIfAborted(options.signal);
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      if (attempt >= maxRetries || !shouldRetry(error, attempt)) throw error;
+      attempt += 1;
+      await sleep(baseDelayMs * 2 ** (attempt - 1), options.signal);
+    }
+  }
+}

--- a/lib/generation/retry.ts
+++ b/lib/generation/retry.ts
@@ -22,13 +22,20 @@ const defaultSleep = (ms: number, signal?: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
     throwIfAborted(signal);
     const timer = setTimeout(resolve, ms);
-    signal?.addEventListener('abort', () => {
-      clearTimeout(timer);
-      reject(abortError());
-    }, { once: true });
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(abortError());
+      },
+      { once: true },
+    );
   });
 
-export async function withRetry<T>(fn: (attempt: number) => Promise<T>, options: RetryOptions = {}): Promise<T> {
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
   const maxRetries = Math.max(0, options.maxRetries ?? 2);
   const baseDelayMs = Math.max(0, options.baseDelayMs ?? 300);
   const shouldRetry = options.shouldRetry ?? (() => true);

--- a/tests/generation/retry.test.ts
+++ b/tests/generation/retry.test.ts
@@ -3,7 +3,11 @@ import { withRetry } from '@/lib/generation/retry';
 
 describe('withRetry', () => {
   it('retries with exponential delays and returns the eventual result', async () => {
-    const fn = vi.fn().mockRejectedValueOnce(new Error('temporary')).mockRejectedValueOnce(new Error('temporary')).mockResolvedValue('ok');
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary'))
+      .mockRejectedValueOnce(new Error('temporary'))
+      .mockResolvedValue('ok');
     const sleep = vi.fn().mockResolvedValue(undefined);
     await expect(withRetry(fn, { sleep, baseDelayMs: 10 })).resolves.toBe('ok');
     expect(fn).toHaveBeenCalledTimes(3);
@@ -14,7 +18,9 @@ describe('withRetry', () => {
   it('stops at the retry limit and respects a retry predicate', async () => {
     const err = new Error('bad request');
     const fn = vi.fn().mockRejectedValue(err);
-    await expect(withRetry(fn, { maxRetries: 3, shouldRetry: () => false, sleep: vi.fn() })).rejects.toBe(err);
+    await expect(
+      withRetry(fn, { maxRetries: 3, shouldRetry: () => false, sleep: vi.fn() }),
+    ).rejects.toBe(err);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
@@ -22,7 +28,9 @@ describe('withRetry', () => {
     const controller = new AbortController();
     controller.abort();
     const fn = vi.fn().mockResolvedValue('nope');
-    await expect(withRetry(fn, { signal: controller.signal })).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(withRetry(fn, { signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError',
+    });
     expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/tests/generation/retry.test.ts
+++ b/tests/generation/retry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withRetry } from '@/lib/generation/retry';
+
+describe('withRetry', () => {
+  it('retries with exponential delays and returns the eventual result', async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error('temporary')).mockRejectedValueOnce(new Error('temporary')).mockResolvedValue('ok');
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(withRetry(fn, { sleep, baseDelayMs: 10 })).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 10, undefined);
+    expect(sleep).toHaveBeenNthCalledWith(2, 20, undefined);
+  });
+
+  it('stops at the retry limit and respects a retry predicate', async () => {
+    const err = new Error('bad request');
+    const fn = vi.fn().mockRejectedValue(err);
+    await expect(withRetry(fn, { maxRetries: 3, shouldRetry: () => false, sleep: vi.fn() })).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start work after cancellation', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fn = vi.fn().mockResolvedValue('nope');
+    await expect(withRetry(fn, { signal: controller.signal })).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Add a reusable, cancellable retry helper for generation requests.

## Related Issues

Related to #573

## Changes

- Add bounded exponential backoff for retryable operations.
- Respect `AbortSignal` during requests and backoff delays.
- Allow callers to decide which errors are retryable.
- Add unit tests for retry success, retry limits, filtering, and cancellation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Run the generation retry unit tests.
2. Verify transient failures retry with exponential backoff.
3. Verify cancellation stops both the active retry flow and pending delay.

### What you personally verified

- Verified retry success after transient failures.
- Verified retry limits and non-retryable errors.
- Verified `AbortSignal` cancellation.
- Full generation test suite passed locally: 26 test files, 136 tests.
- End-to-end testing against a real external model provider was not performed.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings