### PR TITLE
fix(tts): treat Add-dialog default URL as a configured credential path

### DIFF
--- a/lib/audio/provider-enablement.ts
+++ b/lib/audio/provider-enablement.ts
@@ -31,6 +31,11 @@ export const BROWSER_NATIVE_TTS_PROVIDER_ID = 'browser-native-tts' as const;
 export interface TTSEnablementConfig {
   apiKey?: string;
   baseUrl?: string;
+  /**
+   * Dialog-supplied default URL for custom providers. `addCustomTTSProvider`
+   * writes this and leaves `baseUrl` empty; Test TTS already falls back to it.
+   */
+  customDefaultBaseUrl?: string;
   /** User-level per-provider toggle. Absent / true ⇒ allowed; false ⇒ hidden. */
   enabled?: boolean;
   isServerConfigured?: boolean;
@@ -69,7 +74,10 @@ export function isTTSProviderConfigured(
     // A custom provider is usable once it has a credential path or any voices
     // the user defined for it (its existing visibility rule).
     return (
-      hasText(config.apiKey) || hasText(config.baseUrl) || (config.customVoices?.length ?? 0) > 0
+      hasText(config.apiKey) ||
+      hasText(config.baseUrl) ||
+      hasText(config.customDefaultBaseUrl) ||
+      (config.customVoices?.length ?? 0) > 0
     );
   }
 

--- a/tests/audio/provider-enablement.test.ts
+++ b/tests/audio/provider-enablement.test.ts
@@ -50,9 +50,30 @@ describe('isTTSProviderConfigured', () => {
   it('custom provider is configured once it has a credential path or voices', () => {
     expect(isTTSProviderConfigured('custom-tts-foo', {})).toBe(false);
     expect(isTTSProviderConfigured('custom-tts-foo', { apiKey: 'k' })).toBe(true);
+    expect(isTTSProviderConfigured('custom-tts-foo', { baseUrl: 'http://127.0.0.1:8020/v1' })).toBe(
+      true,
+    );
     expect(
       isTTSProviderConfigured('custom-tts-foo', { customVoices: [{ id: 'v', name: 'V' }] }),
     ).toBe(true);
+  });
+
+  it('treats the Add-dialog default base URL as a credential path', () => {
+    // addCustomTTSProvider persists the dialog URL on customDefaultBaseUrl and
+    // leaves baseUrl empty. Test TTS already honours that fallback; generation
+    // must too, or isTTSProviderEnabled stays false and narration is skipped.
+    expect(
+      isTTSProviderConfigured('custom-tts-foo', {
+        customDefaultBaseUrl: 'http://127.0.0.1:8020/v1',
+      }),
+    ).toBe(true);
+    expect(
+      isTTSProviderEnabled('custom-tts-foo', {
+        customDefaultBaseUrl: 'http://127.0.0.1:8020/v1',
+        enabled: true,
+      }),
+    ).toBe(true);
+    expect(isTTSProviderConfigured('custom-tts-foo', { customDefaultBaseUrl: '   ' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible TTS providers added through Settings → TTS → + Add stored the dialog Base URL in `customDefaultBaseUrl` and left `baseUrl` empty. `isTTSProviderConfigured()` only looked at `apiKey` / `baseUrl` / custom voices, so generation treated the provider as unconfigured and silently skipped narration — even after Test TTS succeeded using the same dialog URL.

This PR accepts `customDefaultBaseUrl` as a credential path so already-saved custom providers start working without retyping the panel Base URL field.

## Related Issues

Fixes #1471

## Changes

- Include `customDefaultBaseUrl` in `TTSEnablementConfig` and the custom-provider configured predicate
- Add a regression test for the Add-dialog persistence shape (URL only on `customDefaultBaseUrl`, empty `baseUrl`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. Settings → TTS → + Add; fill Name and Default Base URL only (no API key, no custom voices)
2. Do not retype the URL into the panel Base URL input
3. Click Test TTS — it already succeeds today
4. Generate a classroom or regenerate narration with this provider selected
5. Confirm `/api/generate/tts` is called and speech actions receive audio

### What you personally verified

- Wrote a failing unit test first: `isTTSProviderConfigured('custom-tts-foo', { customDefaultBaseUrl: 'http://127.0.0.1:8020/v1' })` returned `false` on `main`
- After the predicate change, `pnpm exec vitest run tests/audio/provider-enablement.test.ts` is 12/12 green
- Whitespace-only `customDefaultBaseUrl` still counts as unconfigured
- Sibling sweep: ASR uses the same store write (`baseUrl: ''` + `customDefaultBaseUrl`) but has no equivalent enablement gate that would drop the request; ASR request paths already fall back to `customDefaultBaseUrl`. Left unchanged.
- Did **not** run a full classroom generation against a live TTS server (no local TTS endpoint in this environment)

### Evidence

- [x] Focused unit test red → green (`tests/audio/provider-enablement.test.ts`)
- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings


Made with [Cursor](https://cursor.com)