### PR TITLE
feat: auto-detect Vietnamese for browser-native TTS narration

### DIFF
--- a/lib/audio/browser-tts-preview.ts
+++ b/lib/audio/browser-tts-preview.ts
@@ -18,9 +18,27 @@ function createAbortError(): Error {
 }
 
 function inferPreviewLang(text: string): string {
-  const cjkCount = (text.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length;
-  const ratio = text.length > 0 ? cjkCount / text.length : 0;
-  return ratio > CJK_LANG_THRESHOLD ? 'zh-CN' : 'en-US';
+  return detectSpeechLang(text);
+}
+
+// U+0110/0111 (đ), U+01A0/01A1 (ơ), U+01AF/01B0 (ư) and the U+1EA0–U+1EF9
+// precomposed block (ớ, ừ, ồ, ế, ấ, …) never occur in French or Romanian
+// Latin, so one occurrence marks Vietnamese. Bare ă/â/ê/ô do occur in
+// Romanian (and ê/ô in lone French words like "fête"), so they only count
+// toward a ratio — this does not fully exclude Romanian prose, which is
+// acceptable because narration chunks follow the course language.
+const VI_DECIDER_RE = /[đĐơƠưƯ\u1EA0-\u1EF9]/;
+const VI_BROAD_RE = /[ăâêôĂÂÊÔ]/g;
+const VI_BROAD_THRESHOLD = 0.02;
+
+/** Language tag for a narration chunk: zh-CN, vi-VN, or en-US fallback. */
+export function detectSpeechLang(text: string): string {
+  if (!text) return 'en-US';
+  const cjkRatio = (text.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length / text.length;
+  if (cjkRatio > CJK_LANG_THRESHOLD) return 'zh-CN';
+  if (VI_DECIDER_RE.test(text)) return 'vi-VN';
+  if ((text.match(VI_BROAD_RE) || []).length / text.length > VI_BROAD_THRESHOLD) return 'vi-VN';
+  return 'en-US';
 }
 
 export function isBrowserTTSAbortError(error: unknown): boolean {

--- a/lib/playback/engine.ts
+++ b/lib/playback/engine.ts
@@ -48,16 +48,10 @@ import {
 import { useCanvasStore } from '@/lib/store/canvas';
 import { useSettingsStore } from '@/lib/store/settings';
 import { isTTSProviderEnabled } from '@/lib/audio/provider-enablement';
+import { detectSpeechLang } from '@/lib/audio/browser-tts-preview';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('PlaybackEngine');
-
-/**
- * If more than 30% of characters are CJK, treat the text as Chinese.
- * Intentionally low: mixed Chinese text often contains punctuation,
- * numbers, and short Latin fragments (e.g. "AI课堂").
- */
-const CJK_LANG_THRESHOLD = 0.3;
 
 export class PlaybackEngine {
   private scenes: Scene[] = [];
@@ -818,12 +812,17 @@ export class PlaybackEngine {
     }
     if (!voiceFound) {
       // No usable voice configured — detect text language so the browser
-      // auto-selects an appropriate voice.
-      const cjkRatio =
-        chunkText.length > 0
-          ? (chunkText.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length / chunkText.length
-          : 0;
-      utterance.lang = cjkRatio > CJK_LANG_THRESHOLD ? 'zh-CN' : 'en-US';
+      // auto-selects an appropriate voice. For Vietnamese additionally bind an
+      // installed vi voice when one exists, since browsers otherwise fall back
+      // to an English voice reading Vietnamese text.
+      utterance.lang = detectSpeechLang(chunkText);
+      if (utterance.lang === 'vi-VN') {
+        const viVoice = voices.find((v) => v.lang?.toLowerCase().startsWith('vi'));
+        if (viVoice) {
+          utterance.voice = viVoice;
+          utterance.lang = viVoice.lang;
+        }
+      }
     }
 
     utterance.onend = () => {

--- a/tests/audio/detect-speech-lang.test.ts
+++ b/tests/audio/detect-speech-lang.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+import { detectSpeechLang } from '@/lib/audio/browser-tts-preview';
+
+describe('detectSpeechLang', () => {
+  it('detects Chinese by CJK ratio', () => {
+    expect(detectSpeechLang('光合作用是植物生长的基础')).toBe('zh-CN');
+  });
+
+  it('detects Vietnamese by decisive letters (đ/ơ/ư/ê/ô)', () => {
+    expect(detectSpeechLang('Xin chào cả lớp!')).toBe('vi-VN');
+    expect(detectSpeechLang('Quang hợp ở thực vật diễn ra như thế nào?')).toBe('vi-VN');
+    expect(detectSpeechLang('Hôm nay thầy rất vui được đồng hành cùng các em')).toBe('vi-VN');
+  });
+
+  it('detects Vietnamese by ă/â density without decisive letters', () => {
+    expect(detectSpeechLang('Anh ăn cơm với cá và canh chua')).toBe('vi-VN');
+  });
+
+  it('falls back to en-US for plain English', () => {
+    expect(detectSpeechLang('Photosynthesis is how plants grow')).toBe('en-US');
+    expect(detectSpeechLang('OK.')).toBe('en-US');
+    expect(detectSpeechLang('')).toBe('en-US');
+  });
+
+  it('does not misclassify French as Vietnamese', () => {
+    expect(detectSpeechLang('Bonjour le monde')).toBe('en-US');
+    expect(detectSpeechLang('café au lait')).toBe('en-US');
+  });
+});


### PR DESCRIPTION
## Summary

Browser-native TTS auto-detection only distinguished Chinese (CJK ratio) from everything else (`en-US`), so Vietnamese narration was read by an English voice. This PR adds Vietnamese auto-detection to the shared language helper and binds an installed `vi` voice in the playback engine when the user has not picked one explicitly.

## Problem

`playBrowserTTSChunk` in the playback engine set:

```ts
utterance.lang = cjkRatio > CJK_LANG_THRESHOLD ? 'zh-CN' : 'en-US';
```

Vietnamese text therefore got `lang='en-US'` with the auto voice — macOS/Safari reads Vietnamese with English phonetics (near-unintelligible for learners). The "Test TTS" preview path (`inferPreviewLang` in `browser-tts-preview.ts`) had the same CJK-only logic, so the preview was equally wrong.

## Solution

### 1. Shared `detectSpeechLang()` (`lib/audio/browser-tts-preview.ts`)

Returns `zh-CN` / `vi-VN` / `en-US` fallback, used by both the preview path and the playback engine:

- CJK ratio check first (unchanged behavior).
- A hit on `đ/Đ`, `ơ/Ơ`, `ư/Ư`, or the U+1EA0–U+1EF9 precomposed block (`ớ`, `ừ`, `ồ`, `ế`, `ấ`, …) — codepoints that never occur in French or Romanian Latin — marks Vietnamese immediately. (This distinction matters: tone-marked variants are *different codepoints* from their base letters, so a naive `[đơưêô]` class misses them — caught by test.)
- Bare `ă/â/ê/ô` (which do occur in Romanian, and `ê/ô` in French) only count toward a low ratio (> 2%). Known limitation, documented in code: lone French words like `"fête"` or Romanian prose will still misclassify — acceptable because narration chunks follow the course language.

### 2. Playback engine (`lib/playback/engine.ts`)

- Uses the shared `detectSpeechLang()` instead of the inline CJK-only check (the duplicated `CJK_LANG_THRESHOLD` is removed).
- When the detected language is `vi-VN` and no explicit voice is configured, binds the first installed `vi-*` voice (`utterance.voice` + `utterance.lang`), since browsers otherwise fall back to an English voice reading Vietnamese text. An explicitly configured voice still wins (that path is untouched).

## Changes

| File | Change |
| --- | --- |
| `lib/audio/browser-tts-preview.ts` | New exported `detectSpeechLang()`; existing `inferPreviewLang()` delegates to it |
| `lib/playback/engine.ts` | Use shared helper; auto-bind installed `vi` voice; drop duplicated CJK constant |
| `tests/audio/detect-speech-lang.test.ts` | New: zh, Vietnamese (decisive / broad / real narration lines), English, French non-regression cases |

## Testing

- **Unit**: 5/5 pass — including a case (`"Xin chào cả lớp!"`) that failed on the first implementation and exposed the tone-marked-codepoint gap.
- **Production build**: `docker compose build` passes (Next.js compile + `tsc` clean).
- **End-to-end** (Playwright WebKit against a local Docker deployment, browser-native TTS, no explicit voice): every narration utterance carries `lang: "vi-VN"` with an installed Vietnamese voice auto-selected (`"Linh"`), advancing through all lines with `onend` firing — previously `lang` was `"en-US"` with the auto voice.

## Notes

- Default behavior for Chinese and English is byte-identical to before; only text matching Vietnamese rules changes (from `en-US` to `vi-VN` + voice binding).
- No new dependencies, no schema/migration changes.
- Requires an installed `vi` voice on the listener's OS for the voice binding to take effect (e.g. macOS `System Settings → Accessibility → Spoken Content → Vietnamese`); without one, only the `lang` tag improves, and the browser picks its closest voice.

## Checklist

- [x] Code follows the existing style of the repository
- [x] No new dependencies
- [x] New unit tests added and passing
- [x] Docker production build passes
- [x] Verified end-to-end in a real browser engine (WebKit)
